### PR TITLE
Adding timeouts to group and task

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -459,6 +459,7 @@ type TaskGroup struct {
 	MaxClientDisconnect       *time.Duration            `mapstructure:"max_client_disconnect" hcl:"max_client_disconnect,optional"`
 	Scaling                   *ScalingPolicy            `hcl:"scaling,block"`
 	Consul                    *Consul                   `hcl:"consul,block"`
+	Timeout                   *TaskGroupTimeout         `hcl:"timeout,block"`
 }
 
 // NewTaskGroup creates a new TaskGroup.
@@ -723,13 +724,12 @@ type Task struct {
 	KillSignal      string                 `mapstructure:"kill_signal" hcl:"kill_signal,optional"`
 	Kind            string                 `hcl:"kind,optional"`
 	ScalingPolicies []*ScalingPolicy       `hcl:"scaling,block"`
-
 	// Identity is the default Nomad Workload Identity and will be added to
 	// Identities with the name "default"
 	Identity *WorkloadIdentity
-
 	// Workload Identities
 	Identities []*WorkloadIdentity `hcl:"identity,block"`
+	Timeout    *TaskTimeout        `hcl:"timeout,block"`
 }
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
@@ -1049,6 +1049,7 @@ const (
 	TaskStarted                = "Started"
 	TaskTerminated             = "Terminated"
 	TaskKilling                = "Killing"
+	TaskTimedout               = "Timed Out"
 	TaskKilled                 = "Killed"
 	TaskRestarting             = "Restarting"
 	TaskNotRestarting          = "Not Restarting"
@@ -1162,4 +1163,18 @@ type WorkloadIdentity struct {
 	File        bool          `hcl:"file,optional"`
 	ServiceName string        `hcl:"service_name,optional"`
 	TTL         time.Duration `mapstructure:"ttl" hcl:"ttl,optional"`
+}
+
+type TaskTimeout struct {
+	TTL           *time.Duration `hcl:"ttl,optional"`
+	Time          *string        `hcl:"time,optional"`
+	TimeZone      *string        `mapstructure:"time_zone" hcl:"time_zone,optional"`
+	FailOnTimeout bool           `hcl:"fail_on_timeout,optional"`
+}
+
+type TaskGroupTimeout struct {
+	TTL       *time.Duration `hcl:"ttl,optional"`
+	Time      *string        `hcl:"time,optional"`
+	StartFrom *string        `hcl:"start_from,optional"`
+	TimeZone  *string        `mapstructure:"time_zone" hcl:"time_zone,optional"`
 }

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -304,6 +304,11 @@ func (ar *allocRunner) initTaskRunners(tasks []*structs.Task) error {
 			Wranglers:           ar.wranglers,
 			AllocHookResources:  ar.hookResources,
 			WIDMgr:              ar.widmgr,
+			RPCClient:           ar.rpcClient,
+		}
+
+		if ar.cpusetManager != nil {
+			trConfig.CpusetCgroupPathGetter = ar.cpusetManager.CgroupPathFor(ar.id, task.Name)
 		}
 
 		// Create, but do not Run, the task runner

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -137,6 +137,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 		newConsulHTTPSocketHook(hookLogger, alloc, ar.allocDir, config.ConsulConfig),
 		newCSIHook(alloc, hookLogger, ar.csiManager, ar.rpcClient, ar, ar.hookResources, ar.clientConfig.Node.SecretID),
 		newChecksHook(hookLogger, alloc, ar.checkStore, ar),
+		newTimeoutHook(hookLogger, alloc, ar),
 	}
 	if config.ExtraAllocHooks != nil {
 		ar.runnerHooks = append(ar.runnerHooks, config.ExtraAllocHooks...)

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -268,6 +268,9 @@ type TaskRunner struct {
 
 	// widmgr fetches workload identities
 	widmgr IdentitySigner
+	// rpcClient is the RPC Client that should be used by the taskrunner and its
+	// hooks to communicate with Nomad Servers.
+	rpcClient config.RPCer
 }
 
 type Config struct {
@@ -343,6 +346,9 @@ type Config struct {
 
 	// WIDMgr fetches workload identities
 	WIDMgr IdentitySigner
+	// RPCClient is the RPC Client that should be used by the taskrunner and its
+	// hooks to communicate with Nomad Servers.
+	RPCClient config.RPCer
 }
 
 func NewTaskRunner(config *Config) (*TaskRunner, error) {
@@ -405,6 +411,7 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 		getter:                config.Getter,
 		wranglers:             config.Wranglers,
 		widmgr:                config.WIDMgr,
+		rpcClient:             config.RPCClient,
 	}
 
 	// Create the logger based on the allocation ID

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -73,6 +73,7 @@ func (tr *TaskRunner) initHooks() {
 		newDeviceHook(tr.devicemanager, hookLogger),
 		newAPIHook(tr.shutdownCtx, tr.clientConfig.APIListenerRegistrar, hookLogger),
 		newWranglerHook(tr.wranglers, task.Name, alloc.ID, hookLogger),
+		newTimeoutHook(tr, hookLogger),
 	}
 
 	// If the task has a CSI block, add the hook.

--- a/client/allocrunner/taskrunner/timeout_hook.go
+++ b/client/allocrunner/taskrunner/timeout_hook.go
@@ -1,0 +1,268 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package taskrunner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+const (
+	// timeoutHookName is the name of this hook as appears in logs
+	timeoutHookName = "task_timeout_hook"
+)
+
+// timeoutHook manages timeouts
+type timeoutHook struct {
+	logger  hclog.Logger
+	message string
+	tr *TaskRunner
+
+	// fields that get re-initialized on allocation update
+	lock      sync.RWMutex
+	ctx       context.Context
+	stop      context.CancelFunc
+
+	stopTimerChannel chan bool
+}
+
+type saveTimeoutOpts struct {
+	Namespace    string
+	Region       string
+}
+
+func newTimeoutHook(
+	runner *TaskRunner,
+	logger hclog.Logger,
+) *timeoutHook {
+	h := &timeoutHook{
+		logger:  logger.Named(timeoutHookName),
+		tr: runner,
+		stopTimerChannel: make(chan bool),
+	}
+
+	h.ctx, h.stop = context.WithCancel(h.tr.shutdownDelayCtx)
+	return h
+}
+
+func (h *timeoutHook) Name() string {
+	return timeoutHookName
+}
+
+func (h *timeoutHook) Prestart(_ context.Context,
+	_ *interfaces.TaskPrestartRequest, _ *interfaces.TaskPrestartResponse) error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	timeoutConfig := h.tr.task.Timeout
+
+	if timeoutConfig == nil {
+		return nil
+	}
+
+	var timeString string
+	if timeoutConfig.Time != nil {
+		timeString = *timeoutConfig.Time
+	}
+
+	var deadline time.Time
+
+	if timeString != "" {
+		t, err := time.Parse("15:04:05", timeString)
+		if err != nil {
+			return fmt.Errorf("error parsing time: %w", err)
+		}
+
+		currentTime := time.Now()
+		deadline = time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), t.Hour(), t.Minute(), t.Second(), 0, currentTime.Location())
+
+		// handle time's into the next day
+		if deadline.Before(currentTime) {
+			deadline = deadline.Add(24 * time.Hour)
+		}
+
+		h.message = fmt.Sprintf("Timed out because time deadline reached: %v", timeString)
+	} else {
+		deadline = time.Now().Add(*timeoutConfig.TTL)
+		h.message = fmt.Sprintf("Timed out %v from task start", *timeoutConfig.TTL)
+	}
+
+	existingOrNewDeadline, err := h.saveDeadline(deadline)
+	if err != nil {
+		return err
+	}
+
+	// overwrite deadline with new one
+	deadline = *existingOrNewDeadline
+
+	// Now that the deadline is saved
+	// Kick off goroutine to watch for timeout
+	go h.stopTaskAfterDeadline(deadline)
+
+	return nil
+}
+
+func (h *timeoutHook) Stop(_ context.Context, _ *interfaces.TaskStopRequest, _ *interfaces.TaskStopResponse) error{
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	// TODO: Bail out if unused
+
+	h.removeDeadline()
+	h.stop()
+
+	return nil
+}
+
+func (h *timeoutHook) getUniqueId() string {
+	var uniqueId string
+
+	if h.tr.alloc.Job.Type == "system" || h.tr.alloc.Job.Type == "sysbatch" {
+		uniqueId = fmt.Sprintf("system-%v-%v-%v-%v", h.tr.alloc.JobID, h.tr.taskName, h.tr.alloc.NodeID, h.tr.alloc.Job.CreateIndex)
+		} else {
+		uniqueId = fmt.Sprintf("standard-%v-%v-%v-%v", h.tr.alloc.JobID, h.tr.taskName, h.tr.alloc.Index(), h.tr.alloc.Job.CreateIndex)
+	}
+
+	return uniqueId
+}
+
+func (h *timeoutHook) removeDeadline() error {
+	opts := saveTimeoutOpts{
+		Namespace:    h.tr.alloc.Job.Namespace,
+		Region:       h.tr.alloc.Job.Region,
+	}
+
+	uniqueId := h.getUniqueId()
+	var Variable structs.VariableDecrypted
+	Variable.Path = fmt.Sprintf("internal/timeouts/tasks/%s", uniqueId)
+	Variable.VariableMetadata = structs.VariableMetadata{
+		Path: Variable.Path,
+	}
+
+	args := structs.VariablesApplyRequest{
+		Op:  structs.VarOpDelete,
+		Var: &Variable,
+		WriteRequest: structs.WriteRequest{
+			Region:    opts.Region,
+			Namespace: opts.Namespace,
+		},
+	}
+
+	var out structs.VariablesApplyResponse
+	if err := h.tr.rpcClient.RPC(structs.VariablesApplyRPCMethod, &args, &out); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *timeoutHook) saveDeadline(deadline time.Time) (*time.Time, error) {
+	opts := saveTimeoutOpts{
+		Namespace:    h.tr.alloc.Job.Namespace,
+		Region:       h.tr.alloc.Job.Region,
+	}
+
+	var Variable structs.VariableDecrypted
+
+	uniqueId := h.getUniqueId()
+	Variable.Path = fmt.Sprintf("internal/timeouts/tasks/%s", uniqueId)
+	Variable.Items = structs.VariableItems{
+		"deadline": deadline.String(),
+	}
+	Variable.ModifyIndex = 0
+
+	args := structs.VariablesApplyRequest{
+		Op:  structs.VarOpCAS,
+		Var: &Variable,
+		WriteRequest: structs.WriteRequest{
+			Region:    opts.Region,
+			Namespace: opts.Namespace,
+		},
+	}
+
+	var out structs.VariablesApplyResponse
+	if err := h.tr.rpcClient.RPC(structs.VariablesApplyRPCMethod, &args, &out); err != nil {
+		if strings.Contains(err.Error(), "cas error:") && out.Conflict != nil {
+			return nil, fmt.Errorf("conflicting value: %w", err)
+		}
+
+		if out.Conflict != nil {
+			existingDeadline := out.Conflict.Items["deadline"]
+			deadlineMinusClockSkew := strings.Split(existingDeadline, " m=")[0]
+			layout := "2006-01-02 15:04:05.999999 -0700 MST"
+			time, err := time.Parse(layout, deadlineMinusClockSkew)
+			return &time, err
+		}
+
+		return nil, fmt.Errorf("some write error: %w", err)
+	}
+
+	if out.Conflict != nil {
+		existingDeadline := out.Conflict.Items["deadline"]
+		deadlineMinusClockSkew := strings.Split(existingDeadline, " m=")[0]
+		layout := "2006-01-02 15:04:05.999999 -0700 MST"
+		time, err := time.Parse(layout, deadlineMinusClockSkew)
+		return &time, err
+	}
+
+	return &deadline, nil
+}
+
+func (h *timeoutHook) stopTaskAfterDeadline(deadline time.Time) {
+	timer, cancel := helper.NewSafeTimer(time.Second)
+	defer cancel()
+
+	for {
+		select {
+		case <-time.After(time.Minute):
+			fmt.Println("Stopping because of time.After")
+		case <-timer.C:
+			if time.Now().After(deadline) {
+				h.stopTaskForTimeout()
+				return
+			}
+
+			fmt.Println("task timer: tick")
+			timer.Reset(time.Second)
+		case <- h.ctx.Done():
+			fmt.Println("Stopping because context is done")
+			return
+		}
+	}
+
+}
+
+func (h *timeoutHook) stopTaskForTimeout() error {
+	tr := h.tr
+	// Don't emit the event if its dead already
+	state := tr.TaskState().State
+	if state == structs.TaskStatePending || state == structs.TaskStateRunning {
+		e := structs.NewTaskEvent(structs.TaskTimedout)
+		e.Message = h.message
+		tr.EmitEvent(e)
+	}
+
+
+	if h.tr.task.Timeout.FailOnTimeout {
+		tr.MarkFailedKill("Failing on timeout")
+	} else {
+		taskEvent := structs.NewTaskEvent(structs.TaskKilling)
+		taskEvent.SetKillTimeout(tr.Task().KillTimeout, tr.clientConfig.MaxKillTimeout)
+		err := tr.Kill(context.TODO(), taskEvent)
+
+		if err != nil && err != errors.New("Task not running") {
+			tr.logger.Warn("error stopping leader task", "error", err, "task_name", tr.taskName)
+		}
+	}
+
+	return nil
+}

--- a/client/allocrunner/timeout_hook.go
+++ b/client/allocrunner/timeout_hook.go
@@ -1,0 +1,292 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package allocrunner
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+const (
+	// timeoutHookName is the name of this hook as appears in logs
+	timeoutHookName = "alloc_timeout_hook"
+)
+
+// timeoutHook manages timeouts
+type timeoutHook struct {
+	logger  hclog.Logger
+	allocID string
+	message string
+	runner *allocRunner
+
+	// fields that get re-initialized on allocation update
+	lock      sync.RWMutex
+	ctx       context.Context
+	stop      context.CancelFunc
+	alloc     *structs.Allocation
+
+	stopTimerChannel chan bool
+}
+
+type saveTimeoutOpts struct {
+	Namespace    string
+	Region       string
+}
+
+func newTimeoutHook(
+	logger hclog.Logger,
+	alloc *structs.Allocation,
+	runner *allocRunner,
+) *timeoutHook {
+	h := &timeoutHook{
+		logger:  logger.Named(timeoutHookName),
+		allocID: alloc.ID,
+		alloc:   alloc,
+		runner: runner,
+		stopTimerChannel: make(chan bool),
+	}
+	h.initialize(alloc)
+	return h
+}
+
+func (h *timeoutHook) initialize(alloc *structs.Allocation) {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	// fresh context and stop function for this allocation
+	h.ctx, h.stop = context.WithCancel(h.runner.shutdownDelayCtx)
+
+	// set the initial alloc
+	h.alloc = alloc
+}
+
+func (h *timeoutHook) Name() string {
+	return timeoutHookName
+}
+
+func (h *timeoutHook) Prerun() error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	// get task group config
+	tg := h.alloc.Job.LookupTaskGroup(h.alloc.TaskGroup)
+
+	if tg.Timeout == nil {
+		return nil
+	}
+
+	var timeString string
+	if tg.Timeout.Time != nil {
+		timeString = *tg.Timeout.Time
+	}
+
+	var deadline time.Time
+
+	if timeString != "" {
+		t, err := time.Parse("15:04:05", timeString)
+		if err != nil {
+			return fmt.Errorf("error parsing time: %w", err)
+		}
+
+		currentTime := time.Now()
+		deadline = time.Date(currentTime.Year(), currentTime.Month(), currentTime.Day(), t.Hour(), t.Minute(), t.Second(), 0, currentTime.Location())
+
+		// handle time's into the next day
+		if deadline.Before(currentTime) {
+			deadline = deadline.Add(24 * time.Hour)
+		}
+
+		h.message = fmt.Sprintf("Timed out because time deadline reached: %v", timeString)
+	} else {
+
+		if tg.Timeout.StartFrom == nil {
+			deadline = time.Now().Add(*tg.Timeout.TTL)
+			h.message = fmt.Sprintf("Timed out %v from task start", *tg.Timeout.TTL)
+		} else if *tg.Timeout.StartFrom == "scheduled" {
+			deadline = time.Unix(0, h.alloc.CreateTime).Add(*tg.Timeout.TTL)
+			h.message = fmt.Sprintf("Timed out %v from allocation scheduled", *tg.Timeout.TTL)
+		} else if *tg.Timeout.StartFrom == "submit" {
+			deadline = time.Unix(0, h.alloc.Job.SubmitTime).Add(*tg.Timeout.TTL)
+			h.message = fmt.Sprintf("Timed out %v from job submit", *tg.Timeout.TTL)
+		}	else {
+			deadline = time.Now().Add(*tg.Timeout.TTL)
+			h.message = fmt.Sprintf("Timed out %v from task start", *tg.Timeout.TTL)
+		}
+	}
+
+	// save deadline to variable
+	existingOrNewDeadline, err := h.saveDeadline(deadline)
+	if err != nil {
+		return err
+	}
+
+	// overwrite deadline with new one
+	deadline = *existingOrNewDeadline
+
+	// Now that the deadline is saved
+	// Kick off goroutine to watch for timeout
+	go h.stopAllocAfterDeadline(deadline)
+
+	return nil
+}
+
+func (h *timeoutHook) Update(request *interfaces.RunnerUpdateRequest) error {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	// TODO: Nothing happens here?
+
+	return nil
+}
+
+func (h *timeoutHook) PreKill() {
+	h.lock.Lock()
+	defer h.lock.Unlock()
+
+	// TODO: Bail out if not used
+
+	h.removeDeadline()
+	h.stop()
+}
+
+func (h *timeoutHook) getUniqueId() string {
+	var uniqueId string
+	if h.alloc.Job.Type == "system" || h.alloc.Job.Type == "sysbatch" {
+		uniqueId = fmt.Sprintf("system-%v-%v-%v", h.alloc.JobID, h.alloc.NodeID, h.alloc.Job.CreateIndex)
+		} else {
+		uniqueId = fmt.Sprintf("standard-%v-%v-%v", h.alloc.JobID, h.alloc.Index(), h.alloc.Job.CreateIndex)
+	}
+
+	return uniqueId
+}
+
+func (h *timeoutHook) removeDeadline() error {
+	opts := saveTimeoutOpts{
+		Namespace:    h.alloc.Namespace,
+		Region:       h.alloc.Job.Region,
+	}
+
+	uniqueId := h.getUniqueId()
+	var Variable structs.VariableDecrypted
+	Variable.Path = fmt.Sprintf("internal/timeouts/allocs/%s", uniqueId)
+	Variable.VariableMetadata = structs.VariableMetadata{
+		Path: Variable.Path,
+	}
+
+	args := structs.VariablesApplyRequest{
+		Op:  structs.VarOpDelete,
+		Var: &Variable,
+		WriteRequest: structs.WriteRequest{
+			Region:    opts.Region,
+			Namespace: opts.Namespace,
+		},
+	}
+
+	var out structs.VariablesApplyResponse
+	if err := h.runner.rpcClient.RPC(structs.VariablesApplyRPCMethod, &args, &out); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (h *timeoutHook) saveDeadline(deadline time.Time) (*time.Time, error) {
+	opts := saveTimeoutOpts{
+		Namespace:    h.alloc.Namespace,
+		Region:       h.alloc.Job.Region,
+	}
+
+	var Variable structs.VariableDecrypted
+
+	uniqueId := h.getUniqueId()
+	Variable.Path = fmt.Sprintf("internal/timeouts/allocs/%s", uniqueId)
+	Variable.Items = structs.VariableItems{
+		"deadline": deadline.String(),
+	}
+	Variable.ModifyIndex = 0
+
+	args := structs.VariablesApplyRequest{
+		Op:  structs.VarOpCAS,
+		Var: &Variable,
+		WriteRequest: structs.WriteRequest{
+			Region:    opts.Region,
+			Namespace: opts.Namespace,
+		},
+	}
+
+	var out structs.VariablesApplyResponse
+	if err := h.runner.rpcClient.RPC(structs.VariablesApplyRPCMethod, &args, &out); err != nil {
+		if strings.Contains(err.Error(), "cas error:") && out.Conflict != nil {
+			return nil, fmt.Errorf("conflicting value: %w", err)
+		}
+
+		if out.Conflict != nil {
+			existingDeadline := out.Conflict.Items["deadline"]
+			deadlineMinusClockSkew := strings.Split(existingDeadline, " m=")[0]
+			layout := "2006-01-02 15:04:05.999999 -0700 MST"
+			time, err := time.Parse(layout, deadlineMinusClockSkew)
+			return &time, err
+		}
+
+		return nil, fmt.Errorf("some write error: %w", err)
+	}
+
+	if out.Conflict != nil {
+		existingDeadline := out.Conflict.Items["deadline"]
+		deadlineMinusClockSkew := strings.Split(existingDeadline, " m=")[0]
+		layout := "2006-01-02 15:04:05.999999 -0700 MST"
+		time, err := time.Parse(layout, deadlineMinusClockSkew)
+		return &time, err
+	}
+
+	return &deadline, nil
+}
+
+func (h *timeoutHook) stopAllocAfterDeadline(deadline time.Time) {
+	timer, cancel := helper.NewSafeTimer(time.Second)
+	defer cancel()
+
+	for {
+		select {
+		case <-time.After(time.Minute):
+			fmt.Println("Stopping because of time.After")
+		case <-timer.C:
+			if time.Now().After(deadline) {
+				h.stopAllocForTimeout()
+				return
+			}
+
+			fmt.Println("timer: tick")
+			timer.Reset(time.Second)
+		case <- h.ctx.Done():
+			fmt.Println("Stopping because context is done")
+			return
+		}
+	}
+
+}
+
+func (h *timeoutHook) stopAllocForTimeout() error {
+	for _, tr := range h.runner.tasks {
+		// Don't emit the event if its dead already
+		state := tr.TaskState().State
+		if state == structs.TaskStatePending || state == structs.TaskStateRunning {
+			e := structs.NewTaskEvent(structs.TaskTimedout)
+			e.Message = h.message
+			tr.EmitEvent(e)
+		}
+	}
+
+	h.runner.Destroy()
+
+	return nil
+}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1105,6 +1105,14 @@ func ApiTgToStructsTG(job *structs.Job, taskGroup *api.TaskGroup, tg *structs.Ta
 		tg.Scaling = ApiScalingPolicyToStructs(tg.Count, taskGroup.Scaling).TargetTaskGroup(job, tg)
 	}
 
+	if taskGroup.Timeout != nil {
+		tg.Timeout = &structs.TaskGroupTimeout{
+			TTL: taskGroup.Timeout.TTL,
+			Time: taskGroup.Timeout.Time,
+			StartFrom: taskGroup.Timeout.StartFrom,
+		}
+	}
+
 	tg.EphemeralDisk = &structs.EphemeralDisk{
 		Sticky:  *taskGroup.EphemeralDisk.Sticky,
 		SizeMB:  *taskGroup.EphemeralDisk.SizeMB,
@@ -1299,6 +1307,15 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 			DisableFile:  *apiTask.Vault.DisableFile,
 			ChangeMode:   *apiTask.Vault.ChangeMode,
 			ChangeSignal: *apiTask.Vault.ChangeSignal,
+		}
+	}
+
+	if apiTask.Timeout != nil {
+		structsTask.Timeout = &structs.TaskTimeout{
+			TTL:     apiTask.Timeout.TTL,
+			Time:     apiTask.Timeout.Time,
+			TimeZone:     apiTask.Timeout.TimeZone,
+			FailOnTimeout: apiTask.Timeout.FailOnTimeout,
 		}
 	}
 

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -506,6 +506,8 @@ func buildDisplayMessage(event *api.TaskEvent) string {
 		} else {
 			desc = "Sent interrupt"
 		}
+	case api.TaskTimedout:
+		desc = event.Message
 	case api.TaskKilled:
 		if event.KillError != "" {
 			desc = event.KillError


### PR DESCRIPTION
During a hack week I took a stab at an initial implementation of timeouts for tasks. Pushing up this draft PR as a starting point for discussion. (Also note to anybody external to HashiCorp reading this, I'm a PM, not a full engineer, so don't get too excited just yet 😄)

What this does:
- This creates a new taskrunner hook and new allocrunner hook for timeouts.
- In the jobspec, if a new "timeout" block is set, the runners start a goroutine that waits for the deadline to pass. The allocation or task (depending on the block) is then killed at the deadline.

Open Product Questions:
- I am currently failing the allocations if the group timeout happens, and failing them at the task level if FailOnTimeout is set. It kind of feels like there should be a top level "timed out" status instead? If a task fails due to timeout, should a postStop task get run? If a preStart tails times out, should a main task get run? Do people need customization of this behavior?
- Right now this depends on a Nomad client running. Is that an issue for people?
- I think timezones need to be handled. I *think* you could just pass in a TZ at the jobspec level and us that? If not, default to the client's TZ? To UTC? Could we just not do this initially and always go UTC?
- This includes the functionality on service and system jobs... would that ever make sense?

Open Technical Questions:
- This is saving information about the timeout in Nomad Variables. Its sort of cool that this is inspectable by the user, but I think this should probably be "its own thing" in the Nomad state store. Any disagreement there? What's the "right way" to store this?
- Is there a better way to wait in the goroutine? I feel like this probably checks in too often and is wasting cycles?

I'm sure there are more open questions/issues (and unfortunately I've forgotten a lot since I did this over a month ago), but wanted to get the conversation going!

Fixes https://github.com/hashicorp/nomad/issues/1782