### PR TITLE
feature: Add prune flag for nomad server force-leave command

### DIFF
--- a/.changelog/18463.txt
+++ b/.changelog/18463.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+cli: Add `-prune` flag to `nomad operator force-leave` command
+```

--- a/api/agent.go
+++ b/api/agent.go
@@ -35,6 +35,12 @@ type KeyringRequest struct {
 	Key string
 }
 
+// ForceLeaveOpts are used to configure the ForceLeave method.
+type ForceLeaveOpts struct {
+	// Prune indicates whether to remove a node from the list of members
+	Prune bool
+}
+
 // Agent returns a new agent which can be used to query
 // the agent-specific endpoints.
 func (c *Client) Agent() *Agent {
@@ -162,10 +168,19 @@ func (a *Agent) MembersOpts(opts *QueryOptions) (*ServerMembers, error) {
 }
 
 // ForceLeave is used to eject an existing node from the cluster.
-func (a *Agent) ForceLeave(node string, prune bool) error {
+func (a *Agent) ForceLeave(node string) error {
+	_, err := a.client.put("/v1/agent/force-leave?node="+node, nil, nil, nil)
+	return err
+}
+
+// ForceLeaveWithOptions is used to eject an existing node from the cluster
+// with additional options such as prune.
+func (a *Agent) ForceLeaveWithOptions(node string, opts ForceLeaveOpts) error {
 	v := url.Values{}
 	v.Add("node", node)
-	v.Add("prune", strconv.FormatBool(prune))
+	if opts.Prune {
+		v.Add("prune", "1")
+	}
 	_, err := a.client.put("/v1/agent/force-leave?"+v.Encode(), nil, nil, nil)
 	return err
 }

--- a/api/agent.go
+++ b/api/agent.go
@@ -169,7 +169,9 @@ func (a *Agent) MembersOpts(opts *QueryOptions) (*ServerMembers, error) {
 
 // ForceLeave is used to eject an existing node from the cluster.
 func (a *Agent) ForceLeave(node string) error {
-	_, err := a.client.put("/v1/agent/force-leave?node="+node, nil, nil, nil)
+	v := url.Values{}
+	v.Add("node", node)
+	_, err := a.client.put("/v1/agent/force-leave?"+v.Encode(), nil, nil, nil)
 	return err
 }
 

--- a/api/agent.go
+++ b/api/agent.go
@@ -162,8 +162,11 @@ func (a *Agent) MembersOpts(opts *QueryOptions) (*ServerMembers, error) {
 }
 
 // ForceLeave is used to eject an existing node from the cluster.
-func (a *Agent) ForceLeave(node string) error {
-	_, err := a.client.put("/v1/agent/force-leave?node="+node, nil, nil, nil)
+func (a *Agent) ForceLeave(node string, prune bool) error {
+	v := url.Values{}
+	v.Add("node", node)
+	v.Add("prune", strconv.FormatBool(prune))
+	_, err := a.client.put("/v1/agent/force-leave?"+v.Encode(), nil, nil, nil)
 	return err
 }
 

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -189,8 +189,6 @@ func TestAgent_ForceLeavePrune(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		t.Log("membersBefore", membersBefore.Members)
-		t.Log("membersAfter", membersAfter.Members)
 		if len(membersAfter.Members) == len(membersBefore.Members) {
 			return fmt.Errorf("node did not get pruned")
 		}
@@ -199,7 +197,7 @@ func TestAgent_ForceLeavePrune(t *testing.T) {
 	must.Wait(t, wait.InitialSuccess(
 		wait.ErrorFunc(f),
 		wait.Timeout(5*time.Second),
-		wait.Gap(1*time.Second),
+		wait.Gap(100*time.Millisecond),
 	))
 
 }

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -112,7 +112,7 @@ func TestAgent_ForceLeave(t *testing.T) {
 	a := c.Agent()
 
 	// Force-leave on a nonexistent node does not error
-	err := a.ForceLeave("nope")
+	err := a.ForceLeave("nope", false)
 	must.NoError(t, err)
 
 	// Force-leave on an existing node
@@ -126,9 +126,10 @@ func TestAgent_ForceLeave(t *testing.T) {
 	must.One(t, n)
 
 	membersBefore, err := a.MembersOpts(&QueryOptions{})
+	must.NoError(t, err)
 	must.Eq(t, membersBefore.Members[1].Status, "alive")
 
-	err = a.ForceLeave(membersBefore.Members[1].Name)
+	err = a.ForceLeave(membersBefore.Members[1].Name, false)
 	must.NoError(t, err)
 
 	time.Sleep(3 * time.Second)
@@ -152,6 +153,50 @@ func TestAgent_ForceLeave(t *testing.T) {
 		wait.Timeout(3*time.Second),
 		wait.Gap(100*time.Millisecond),
 	))
+
+}
+
+func TestAgent_ForceLeavePrune(t *testing.T) {
+	testutil.Parallel(t)
+
+	c, s := makeClient(t, nil, nil)
+	defer s.Stop()
+	a := c.Agent()
+
+	nodeName := "foo.global"
+	_, s2 := makeClient(t, nil, func(c *testutil.TestServerConfig) {
+		c.NodeName = nodeName
+		c.Server.BootstrapExpect = 0
+	})
+	defer s2.Stop()
+
+	n, err := a.Join(s2.SerfAddr)
+	must.NoError(t, err)
+	must.One(t, n)
+
+	err = a.ForceLeave(nodeName, true)
+	must.NoError(t, err)
+
+	time.Sleep(3 * time.Second)
+
+	f := func() error {
+		membersAfter, err := a.MembersOpts(&QueryOptions{})
+		if err != nil {
+			return err
+		}
+		for _, node := range membersAfter.Members {
+			if node.Name == nodeName {
+				return fmt.Errorf("node did not get pruned")
+			}
+		}
+		return nil
+	}
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(f),
+		wait.Timeout(3*time.Second),
+		wait.Gap(100*time.Millisecond),
+	))
+
 }
 
 func (a *AgentMember) String() string {

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -332,8 +332,15 @@ func (s *HTTPServer) AgentForceLeaveRequest(resp http.ResponseWriter, req *http.
 		return nil, CodedError(400, "missing node to force leave")
 	}
 
+	_, prune := req.URL.Query()["prune"]
+
 	// Attempt remove
-	err := srv.RemoveFailedNode(node)
+	var err error
+	if prune {
+		err = srv.RemoveFailedNodePrune(node)
+	} else {
+		err = srv.RemoveFailedNode(node)
+	}
 	return nil, err
 }
 

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -332,10 +332,12 @@ func (s *HTTPServer) AgentForceLeaveRequest(resp http.ResponseWriter, req *http.
 		return nil, CodedError(400, "missing node to force leave")
 	}
 
-	prune, _ := parseBool(req, "prune")
+	prune, err := parseBool(req, "prune")
+	if err != nil {
+		return nil, CodedError(400, "invalid prune value")
+	}
 
 	// Attempt remove
-	var err error
 	if prune != nil && *prune {
 		err = srv.RemoveFailedNodePrune(node)
 	} else {

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -332,11 +332,11 @@ func (s *HTTPServer) AgentForceLeaveRequest(resp http.ResponseWriter, req *http.
 		return nil, CodedError(400, "missing node to force leave")
 	}
 
-	_, prune := req.URL.Query()["prune"]
+	prune, _ := parseBool(req, "prune")
 
 	// Attempt remove
 	var err error
-	if prune {
+	if prune != nil && *prune {
 		err = srv.RemoveFailedNodePrune(node)
 	} else {
 		err = srv.RemoveFailedNode(node)

--- a/command/server_force_leave.go
+++ b/command/server_force_leave.go
@@ -36,7 +36,7 @@ Server Force-Leave Options:
 
   -prune
     Removes failed or left server from the Serf member list immediately.
-	This will not work with alive server.
+	If member is actually still alive, it will eventually rejoin the cluster again.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1866,6 +1866,11 @@ func (s *Server) RemoveFailedNode(node string) error {
 	return s.serf.RemoveFailedNode(node)
 }
 
+// RemoveFailedNodePrune immediately removes a failed node from the list of members
+func (s *Server) RemoveFailedNodePrune(node string) error {
+	return s.serf.RemoveFailedNodePrune(node)
+}
+
 // KeyManager returns the Serf keyring manager
 func (s *Server) KeyManager() *serf.KeyManager {
 	return s.serf.KeyManager()

--- a/website/content/api-docs/agent.mdx
+++ b/website/content/api-docs/agent.mdx
@@ -441,13 +441,16 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `node` `(string: <required>)` - Specifies the name of the node to force leave.
+- `prune` `(boolean: <optional>)` - Specifies whether to forcibly remove the node from
+the list of members. Pruning a node in the `left` or `failed` state removes it from the list altogether.
+
 
 ### Sample Request
 
 ```shell-session
 $ curl \
     --request POST \
-    https://localhost:4646/v1/agent/force-leave?node=client-ab2e23dc
+    https://localhost:4646/v1/agent/force-leave?node=client-ab2e23dc&prune=true
 ```
 
 ## Health

--- a/website/content/api-docs/agent.mdx
+++ b/website/content/api-docs/agent.mdx
@@ -441,8 +441,9 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `node` `(string: <required>)` - Specifies the name of the node to force leave.
-- `prune` `(boolean: <optional>)` - Specifies whether to forcibly remove the node from
-the list of members. Pruning a node in the `left` or `failed` state removes it from the list altogether.
+- `prune` `(boolean: <optional>)` -  Removes failed or left server from the Serf 
+  member list immediately. If member is actually still alive, it will eventually rejoin 
+  the cluster again.
 
 
 ### Sample Request

--- a/website/content/docs/commands/server/force-leave.mdx
+++ b/website/content/docs/commands/server/force-leave.mdx
@@ -10,7 +10,9 @@ description: >
 
 The `server force-leave` command forces a server to enter the "left" state.
 This can be used to eject server nodes which have failed and will not rejoin
-the cluster. Note that if the server is actually still alive, it will
+the cluster. The failed or left server will be garbage collected after `24h`. 
+
+~> Note that if the server is actually still alive, it will
 eventually rejoin the cluster again.
 
 ## Usage
@@ -22,8 +24,8 @@ nomad server force-leave [options] <node>
 This command expects only one argument - the node which should be forced
 to enter the "left" state.
 
-Additionally, by specifying the `prune` flag, a node can be forcibly removed
-from the list of members entirely.
+Additionally, by specifying the `prune` flag, a failed or left node can be forcibly removed
+from the list of members completely.
 
 If ACLs are enabled, this option requires a token with the `agent:write`
 capability.

--- a/website/content/docs/commands/server/force-leave.mdx
+++ b/website/content/docs/commands/server/force-leave.mdx
@@ -22,6 +22,9 @@ nomad server force-leave [options] <node>
 This command expects only one argument - the node which should be forced
 to enter the "left" state.
 
+Additionally, by specifying the `prune` flag, a node can be forcibly removed
+from the list of members entirely.
+
 If ACLs are enabled, this option requires a token with the `agent:write`
 capability.
 
@@ -29,11 +32,23 @@ capability.
 
 @include 'general_options_no_namespace.mdx'
 
+## Server Force-Leave Options
+
+- `-prune`: Specifies whether to forcibly remove the node from the list of members. 
+Pruning a node in the `left` or `failed` state removes it from the list altogether.
+
 ## Examples
 
 Force-leave the server "node1":
 
 ```shell-session
 $ nomad server force-leave node1
+
+```
+
+Force-leave the server "node1" and prune it:
+
+```shell-session
+$ nomad server force-leave -prune node1
 
 ```

--- a/website/content/docs/commands/server/force-leave.mdx
+++ b/website/content/docs/commands/server/force-leave.mdx
@@ -36,8 +36,8 @@ capability.
 
 ## Server Force-Leave Options
 
-- `-prune`: Specifies whether to forcibly remove the node from the list of members. 
-Pruning a node in the `left` or `failed` state removes it from the list altogether.
+- `-prune`: Removes failed or left server from the Serf member list immediately.
+	If member is actually still alive, it will eventually rejoin the cluster again.
 
 ## Examples
 

--- a/website/content/docs/commands/server/force-leave.mdx
+++ b/website/content/docs/commands/server/force-leave.mdx
@@ -25,7 +25,7 @@ This command expects only one argument - the node which should be forced
 to enter the "left" state.
 
 Additionally, by specifying the `prune` flag, a failed or left node can be forcibly removed
-from the list of members completely.
+from the list of members immediately.
 
 If ACLs are enabled, this option requires a token with the `agent:write`
 capability.


### PR DESCRIPTION
This feature will help operator to remove a failed/left node from Serf layer immediately without waiting for 24 hours for the node to be reaped

* Update CLI with prune flag
* Update API /v1/agent/force-leave with prune query string parameter
* Update CLI and API doc
* Add unit test