### PR TITLE
Add more links from Variables doc to Nomad Variable template examples

### DIFF
--- a/website/content/docs/concepts/variables.mdx
+++ b/website/content/docs/concepts/variables.mdx
@@ -7,12 +7,13 @@ description: Learn about the Nomad Variables feature
 # Nomad Variables
 
 Most Nomad workloads need access to config values or secrets. Nomad has a
-`template` block to provide such configuration to tasks, but prior to Nomad 1.4
-has left the role of storing that configuration to external services such as
-[HashiCorp Consul] and [HashiCorp Vault].
+`template` block to [provide such configuration to tasks](/nomad/docs/job-specification/template#nomad-variables),
+but prior to Nomad 1.4 has left the role of storing that configuration to
+external services such as [HashiCorp Consul] and [HashiCorp Vault].
 
 Nomad Variables provide the option to store configuration at file-like paths
-directly in Nomad's state store. The contents of these variables are encrypted
+directly in Nomad's state store. You can [access these variables](/nomad/docs/job-specification/template#nomad-variables) directly from
+your task `template`s. The contents of these variables are encrypted
 and replicated between servers via raft. Access to variables is controlled by
 ACL policies, and tasks have implicit ACL policies that allow them to access
 their own variables. You can create, read, update, or delete variables via the
@@ -189,7 +190,7 @@ See [Workload Associated ACL Policies] for more details.
 [HashiCorp Vault]: https://www.vaultproject.io/
 [Key Management]: /nomad/docs/operations/key-management
 [ACL policy specification]: /nomad/docs/other-specifications/acl-policy
-[`template`]: /nomad/docs/job-specification/template
+[`template`]: /nomad/docs/job-specification/template#nomad-variables
 [workload identity]: /nomad/docs/concepts/workload-identity
 [Workload Associated ACL Policies]: /nomad/docs/concepts/workload-identity#workload-associated-acl-policies
 [ACL policy namespace rules]: /nomad/docs/other-specifications/acl-policy#namespace-rules


### PR DESCRIPTION
It was not obvious to me that Nomad Variables could themselves be used in templates. I read this page and wasn't exactly sure what they're used for w/o an example.

The timeline was:
1. day 0: read this page
2. day 1-2: monkey with HCL2 variables in job specs
3. day 3: come across this page on [Nomad Variables in templates](https://developer.hashicorp.com/nomad/docs/job-specification/template#nomad-variables) when it dawned on me that... that's how they can be used and it's sick

This PR adds two links and one sentence to try to get that across to Nomad novices like myself so they can go straight from Nomad Variables > "oh this is cool" faster.

I think ideally this doc also has an example like from the Nomad Variables section of the `template` page:

```md
template {
  data        = <<EOH
{{ range nomadVarList "path/to/filter" }}
  {{ . }}
{{ end }}
EOH
}
```