### PR TITLE
[f-gh-17449] Locks: Fixes for lock visibility

### DIFF
--- a/api/locks.go
+++ b/api/locks.go
@@ -131,7 +131,14 @@ func (l *Locks) Acquire(ctx context.Context) (string, error) {
 func (l *Locks) Release(ctx context.Context) error {
 	var out Variable
 
-	_, err := l.c.retryPut(ctx, "/v1/var/"+l.variable.Path+"?lock-release", l.variable, &out, &l.WriteOptions)
+	rv := &Variable{
+		Lock: &VariableLock{
+			ID: l.variable.Lock.ID,
+		},
+	}
+
+	_, err := l.c.retryPut(ctx, "/v1/var/"+l.variable.Path+"?lock-release", rv,
+		&out, &l.WriteOptions)
 	if err != nil {
 		callErr, ok := err.(UnexpectedResponseError)
 

--- a/api/retry.go
+++ b/api/retry.go
@@ -39,7 +39,7 @@ func (c *Client) retryPut(ctx context.Context, endpoint string, in, out any, q *
 	var err error
 	var wm *WriteMeta
 
-	attemptDelay := time.Duration(0)
+	attemptDelay := time.Duration(100 * time.Second) // Avoid a tick before starting
 	startTime := time.Now()
 
 	t := time.NewTimer(attemptDelay)

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -309,6 +309,7 @@ func TestVariable_CreateReturnsContent(t *testing.T) {
 }
 
 func TestVariables_LockRenewRelease(t *testing.T) {
+	testutil.Parallel(t)
 
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
@@ -319,7 +320,7 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 	sv1.Items["k1"] = "v1"
 	sv1.Items["k2"] = "v2"
 
-	t.Run("2 create sv1", func(t *testing.T) {
+	t.Run("1 create sv1", func(t *testing.T) {
 		get, _, err := nsv.Create(sv1, nil)
 		must.NoError(t, err)
 		must.NotNil(t, get)
@@ -331,7 +332,7 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 		*sv1 = *get
 	})
 
-	t.Run("3 acquire lock on sv1", func(t *testing.T) {
+	t.Run("2 acquire lock on sv1", func(t *testing.T) {
 		get, _, err := nsv.AcquireLock(sv1, nil)
 		must.NoError(t, err)
 		must.NotNil(t, get)
@@ -342,7 +343,7 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 		*sv1 = *get
 	})
 
-	t.Run("4 renew lock on sv1", func(t *testing.T) {
+	t.Run("3 renew lock on sv1", func(t *testing.T) {
 		get, _, err := nsv.RenewLock(sv1, nil)
 		must.NoError(t, err)
 		must.NotNil(t, get)
@@ -351,14 +352,14 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 		must.Eq(t, sv1.Lock.ID, get.Lock.ID)
 	})
 
-	t.Run("5 list vars", func(t *testing.T) {
+	t.Run("4 list vars", func(t *testing.T) {
 		l, _, err := nsv.List(nil)
 		must.NoError(t, err)
 		must.Len(t, 1, l)
 		must.Nil(t, l[0].Lock)
 	})
 
-	t.Run("6 release lock on sv1", func(t *testing.T) {
+	t.Run("5 release lock on sv1", func(t *testing.T) {
 		get, _, err := nsv.ReleaseLock(sv1, nil)
 		must.NoError(t, err)
 		must.NotNil(t, get)

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -344,7 +344,8 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 	})
 
 	t.Run("3 renew lock on sv1", func(t *testing.T) {
-		get, _, err := nsv.RenewLock(sv1, nil)
+		rlsv := *sv1
+		get, _, err := nsv.RenewLock(&rlsv, nil)
 		must.NoError(t, err)
 		must.NotNil(t, get)
 		must.Eq(t, sv1.ModifyIndex, get.ModifyIndex)
@@ -357,11 +358,12 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 		must.NoError(t, err)
 		must.Len(t, 1, l)
 		must.Nil(t, l[0].Lock)
+		fmt.Println(" ****** list ", sv1, l)
 	})
 
 	t.Run("5 release lock on sv1", func(t *testing.T) {
 		sv1.Items = nil
-
+		fmt.Println(" ****** before release ", sv1)
 		get, _, err := nsv.ReleaseLock(sv1, nil)
 		must.NoError(t, err)
 		must.NotNil(t, get)

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -356,8 +356,7 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 		l, _, err := nsv.List(nil)
 		must.NoError(t, err)
 		must.Len(t, 1, l)
-		must.NotNil(t, l[0].Lock)
-		must.Eq(t, sv1.Lock.ID, l[0].Lock.ID)
+		must.Nil(t, l[0].Lock)
 	})
 
 	t.Run("6 release lock on sv1", func(t *testing.T) {
@@ -365,7 +364,7 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 		must.NoError(t, err)
 		must.NotNil(t, get)
 		must.NotEq(t, sv1.ModifyIndex, get.ModifyIndex)
-		must.Eq(t, sv1.Items, get.Items)
+		must.Nil(t, get.Items)
 		must.Nil(t, get.Lock)
 
 		*sv1 = *get

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -20,7 +20,7 @@ func TestVariables_SimpleCRUD(t *testing.T) {
 	defer s.Stop()
 
 	nsv := c.Variables()
-	sv1 := NewVariable("my/first/variable")
+	sv1 := NewVariable("my/first/variable/SimpleCRUD")
 	sv1.Namespace = "default"
 	sv1.Items["k1"] = "v1"
 	sv1.Items["k2"] = "v2"
@@ -297,7 +297,7 @@ func TestVariable_CreateReturnsContent(t *testing.T) {
 	defer s.Stop()
 
 	nsv := c.Variables()
-	sv1 := NewVariable("my/first/variable")
+	sv1 := NewVariable("my/first/variable/create")
 	sv1.Namespace = "default"
 	sv1.Items["k1"] = "v1"
 	sv1.Items["k2"] = "v2"
@@ -371,7 +371,7 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 		must.NoError(t, err)
 		must.NotNil(t, get)
 		must.NotEq(t, sv1.ModifyIndex, get.ModifyIndex)
-		must.Nil(t, get.Items)
+		must.Zero(t, len(get.Items))
 		must.Nil(t, get.Lock)
 	})
 }

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -360,6 +360,7 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 	})
 
 	t.Run("5 release lock on sv1", func(t *testing.T) {
+		sv1.Items = nil
 		get, _, err := nsv.ReleaseLock(sv1, nil)
 		must.NoError(t, err)
 		must.NotNil(t, get)

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -361,13 +361,12 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 
 	t.Run("5 release lock on sv1", func(t *testing.T) {
 		sv1.Items = nil
+
 		get, _, err := nsv.ReleaseLock(sv1, nil)
 		must.NoError(t, err)
 		must.NotNil(t, get)
 		must.NotEq(t, sv1.ModifyIndex, get.ModifyIndex)
 		must.Nil(t, get.Items)
 		must.Nil(t, get.Lock)
-
-		*sv1 = *get
 	})
 }

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -345,28 +345,23 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 
 	t.Run("3 renew lock on sv1", func(t *testing.T) {
 		rlsv := *sv1
-		fmt.Println(" ****** renew 1", sv1, rlsv)
 		get, _, err := nsv.RenewLock(&rlsv, nil)
 		must.NoError(t, err)
 		must.NotNil(t, get)
 		must.Eq(t, sv1.ModifyIndex, get.ModifyIndex)
 		must.NotNil(t, get.Lock)
 		must.Eq(t, sv1.Lock.ID, get.Lock.ID)
-		fmt.Println(" ****** renew 2", sv1, rlsv)
 	})
 
 	t.Run("4 list vars", func(t *testing.T) {
 		l, _, err := nsv.List(nil)
-		fmt.Println(" ****** list 1 ", sv1, l)
 		must.NoError(t, err)
 		must.Len(t, 1, l)
 		must.Nil(t, l[0].Lock)
-		fmt.Println(" ****** list 2", sv1, l)
 	})
 
 	t.Run("5 release lock on sv1", func(t *testing.T) {
 		sv1.Items = nil
-		fmt.Println(" ****** before release ", sv1)
 		get, _, err := nsv.ReleaseLock(sv1, nil)
 		must.NoError(t, err)
 		must.NotNil(t, get)

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -309,7 +309,6 @@ func TestVariable_CreateReturnsContent(t *testing.T) {
 }
 
 func TestVariables_LockRenewRelease(t *testing.T) {
-	testutil.Parallel(t)
 
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -313,9 +313,9 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 
 	c, s := makeClient(t, nil, nil)
 	defer s.Stop()
-
+	path := fmt.Sprintf("%s-%v", "/first/variable", time.Now().UnixMilli())
 	nsv := c.Variables()
-	sv1 := NewVariable("my/first/variable")
+	sv1 := NewVariable(path)
 	sv1.Namespace = "default"
 	sv1.Items["k1"] = "v1"
 	sv1.Items["k2"] = "v2"
@@ -345,20 +345,23 @@ func TestVariables_LockRenewRelease(t *testing.T) {
 
 	t.Run("3 renew lock on sv1", func(t *testing.T) {
 		rlsv := *sv1
+		fmt.Println(" ****** renew 1", sv1, rlsv)
 		get, _, err := nsv.RenewLock(&rlsv, nil)
 		must.NoError(t, err)
 		must.NotNil(t, get)
 		must.Eq(t, sv1.ModifyIndex, get.ModifyIndex)
 		must.NotNil(t, get.Lock)
 		must.Eq(t, sv1.Lock.ID, get.Lock.ID)
+		fmt.Println(" ****** renew 2", sv1, rlsv)
 	})
 
 	t.Run("4 list vars", func(t *testing.T) {
 		l, _, err := nsv.List(nil)
+		fmt.Println(" ****** list 1 ", sv1, l)
 		must.NoError(t, err)
 		must.Len(t, 1, l)
 		must.Nil(t, l[0].Lock)
-		fmt.Println(" ****** list ", sv1, l)
+		fmt.Println(" ****** list 2", sv1, l)
 	})
 
 	t.Run("5 release lock on sv1", func(t *testing.T) {

--- a/command/agent/variable_endpoint_test.go
+++ b/command/agent/variable_endpoint_test.go
@@ -522,6 +522,7 @@ func TestHTTP_Variables(t *testing.T) {
 			svLR.Items = nil
 			// Make the HTTP request
 			buf := encodeReq(&svLR)
+
 			req, err := http.NewRequest("PUT", "/v1/var/"+svLR.Path+"?"+releaseLockQueryParam, buf)
 			must.NoError(t, err)
 			respW := httptest.NewRecorder()

--- a/command/agent/variable_endpoint_test.go
+++ b/command/agent/variable_endpoint_test.go
@@ -517,9 +517,9 @@ func TestHTTP_Variables(t *testing.T) {
 		})
 
 		t.Run("release_lock", func(t *testing.T) {
-			svLR := sv1
+			svLR := *sv1
 
-			svLR.Items["new"] = "new"
+			svLR.Items = nil
 			// Make the HTTP request
 			buf := encodeReq(&svLR)
 			req, err := http.NewRequest("PUT", "/v1/var/"+svLR.Path+"?"+releaseLockQueryParam, buf)
@@ -540,10 +540,9 @@ func TestHTTP_Variables(t *testing.T) {
 
 			// Check for the lock
 			must.Nil(t, out.VariableMetadata.Lock)
-			must.Zero(t, len(out.LockID()))
 
 			// Check that written variable is equal the input
-			must.Eq(t, sv1.Items, out.Items)
+			must.Zero(t, len(out.Items))
 
 			// Remove the lock information from the mock variable for the following tests
 			sv1.VariableMetadata = out.VariableMetadata

--- a/nomad/state/state_store_variables.go
+++ b/nomad/state/state_store_variables.go
@@ -117,9 +117,6 @@ func (s *StateStore) GetVariable(
 	}
 
 	sv := raw.(*structs.VariableEncrypted)
-
-	// Remove lock information
-	sv.Lock = nil
 	return sv, nil
 }
 

--- a/nomad/state/state_store_variables.go
+++ b/nomad/state/state_store_variables.go
@@ -117,6 +117,9 @@ func (s *StateStore) GetVariable(
 	}
 
 	sv := raw.(*structs.VariableEncrypted)
+
+	// Remove lock information
+	sv.Lock = nil
 	return sv, nil
 }
 
@@ -553,14 +556,14 @@ func (s *StateStore) VarLockRelease(idx uint64,
 		return req.ConflictResponse(idx, zeroVal)
 	}
 
+	// Avoid overwriting the variable data when releasing the lock, to prevent
+	// a delay release to remove customer data.
+
 	updated := sv.Copy()
 	updated.Lock = nil
 	updated.ModifyIndex = idx
 
-	// Avoid overwriting the variable data when releasing the lock, to prevent
-	// a delay release to remove customer data.
-
-	updated.Data = sv.Data
+	//updated.Data = sv.Data
 
 	err = s.updateVarsAndIndexTxn(tx, idx, &updated)
 	if err != nil {

--- a/nomad/state/state_store_variables.go
+++ b/nomad/state/state_store_variables.go
@@ -560,8 +560,6 @@ func (s *StateStore) VarLockRelease(idx uint64,
 	updated.Lock = nil
 	updated.ModifyIndex = idx
 
-	//updated.Data = sv.Data
-
 	err = s.updateVarsAndIndexTxn(tx, idx, &updated)
 	if err != nil {
 		req.ErrorResponse(idx, fmt.Errorf("failed lock release: %s", err))

--- a/nomad/state/state_store_variables_test.go
+++ b/nomad/state/state_store_variables_test.go
@@ -38,6 +38,10 @@ func TestStateStore_UpsertVariables(t *testing.T) {
 		mock.VariableEncrypted(),
 	}
 	svs[0].Path = "aaaaa"
+	svs[0].Lock = &structs.VariableLock{
+		ID: "lock ID",
+	}
+
 	svs[1].Path = "bbbbb"
 
 	insertIndex := uint64(20)
@@ -89,6 +93,7 @@ func TestStateStore_UpsertVariables(t *testing.T) {
 		sve, err := testState.GetVariable(ws, svs[0].Namespace, svs[0].Path)
 		must.NoError(t, err)
 		must.NotNil(t, sve)
+		must.Nil(t, sve.Lock)
 	})
 
 	// Upsert the exact same variables without any modification. In this

--- a/nomad/state/state_store_variables_test.go
+++ b/nomad/state/state_store_variables_test.go
@@ -38,10 +38,6 @@ func TestStateStore_UpsertVariables(t *testing.T) {
 		mock.VariableEncrypted(),
 	}
 	svs[0].Path = "aaaaa"
-	svs[0].Lock = &structs.VariableLock{
-		ID: "lock ID",
-	}
-
 	svs[1].Path = "bbbbb"
 
 	insertIndex := uint64(20)
@@ -93,7 +89,6 @@ func TestStateStore_UpsertVariables(t *testing.T) {
 		sve, err := testState.GetVariable(ws, svs[0].Namespace, svs[0].Path)
 		must.NoError(t, err)
 		must.NotNil(t, sve)
-		must.Nil(t, sve.Lock)
 	})
 
 	// Upsert the exact same variables without any modification. In this

--- a/nomad/structs/variables.go
+++ b/nomad/structs/variables.go
@@ -84,7 +84,7 @@ type VariableMetadata struct {
 	Path      string
 
 	// Lock represents a variable which is used for locking functionality.
-	Lock *VariableLock
+	Lock *VariableLock `json:",omitempty"`
 
 	CreateIndex uint64
 	CreateTime  int64
@@ -110,7 +110,7 @@ type VariableData struct {
 // persisted to disk.
 type VariableDecrypted struct {
 	VariableMetadata
-	Items VariableItems
+	Items VariableItems `json:",omitempty"`
 }
 
 // VariableItems are the actual secrets stored in a variable. They are always

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -32,6 +32,7 @@ var (
 	errMissingLockInfo   = structs.NewErrRPCCoded(http.StatusBadRequest, "missing lock information")
 	errLockOnVarCreation = structs.NewErrRPCCoded(http.StatusBadRequest, "variable should not contain lock definition")
 	errItemsOnRelease    = structs.NewErrRPCCoded(http.StatusBadRequest, "lock release operation doesn't take variable items")
+	errNoPath            = structs.NewErrRPCCoded(http.StatusBadRequest, "delete requires a Path")
 )
 
 type variableTimers interface {
@@ -231,7 +232,7 @@ func canonicalizeAndValidate(args *structs.VariablesApplyRequest) error {
 
 	case structs.VarOpDelete, structs.VarOpDeleteCAS:
 		if args.Var == nil || args.Var.Path == "" {
-			return errMissingLockInfo
+			return errNoPath
 		}
 
 	case structs.VarOpLockRelease:

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -360,15 +360,17 @@ func (sv *Variables) Read(args *structs.VariablesReadRequest, reply *structs.Var
 			// Setup the output
 			reply.Data = nil
 			if out != nil {
+
+				if !(aclObj != nil && aclObj.IsManagement()) {
+					out.Lock = nil
+				}
+
 				dv, err := sv.decrypt(out)
 				if err != nil {
 					return err
 				}
 
 				ov := dv.Copy()
-				if aclObj != nil && !aclObj.IsManagement() {
-					ov.Lock = nil
-				}
 
 				reply.Data = &ov
 				reply.Index = out.ModifyIndex
@@ -460,7 +462,7 @@ func (sv *Variables) List(
 					sv := raw.(*structs.VariableEncrypted)
 					svStub := sv.VariableMetadata
 
-					if aclObj != nil && !aclObj.IsManagement() {
+					if !(aclObj != nil && aclObj.IsManagement()) {
 						svStub.Lock = nil
 					}
 
@@ -553,6 +555,11 @@ func (sv *Variables) listAllVariables(
 				func(raw interface{}) error {
 					v := raw.(*structs.VariableEncrypted)
 					svStub := v.VariableMetadata
+
+					if !(aclObj != nil && aclObj.IsManagement()) {
+						svStub.Lock = nil
+					}
+
 					svs = append(svs, &svStub)
 					return nil
 				})

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -243,7 +243,7 @@ func canonicalizeAndValidate(args *structs.VariablesApplyRequest) error {
 
 		// If the operation is a lock release and there are items on the variable
 		// reject the request, release doesn't update the variable.
-		if args.Var.Items != nil || len(args.Var.Items) == 0 {
+		if args.Var.Items != nil || len(args.Var.Items) != 0 {
 			return errItemsOnRelease
 		}
 

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -366,16 +366,15 @@ func (sv *Variables) Read(args *structs.VariablesReadRequest, reply *structs.Var
 			reply.Data = nil
 			if out != nil {
 
-				if !(aclObj != nil && aclObj.IsManagement()) {
-					out.Lock = nil
-				}
-
 				dv, err := sv.decrypt(out)
 				if err != nil {
 					return err
 				}
 
 				ov := dv.Copy()
+				if !(aclObj != nil && aclObj.IsManagement()) {
+					ov.Lock = nil
+				}
 
 				reply.Data = &ov
 				reply.Index = out.ModifyIndex

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -158,7 +158,7 @@ func (sv *Variables) Apply(args *structs.VariablesApplyRequest, reply *structs.V
 	*reply = *r
 	reply.Index = index
 
-	if out.Result == structs.VarOpResultOk {
+	if out.IsOk() {
 		switch args.Op {
 		case structs.VarOpLockAcquire:
 			sv.timers.CreateVariableLockTTLTimer(ev.Copy())

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -243,7 +243,7 @@ func canonicalizeAndValidate(args *structs.VariablesApplyRequest) error {
 
 		// If the operation is a lock release and there are items on the variable
 		// reject the request, release doesn't update the variable.
-		if args.Var.Items != nil {
+		if args.Var.Items != nil || len(args.Var.Items) == 0 {
 			return errItemsOnRelease
 		}
 

--- a/nomad/variables_endpoint_test.go
+++ b/nomad/variables_endpoint_test.go
@@ -996,6 +996,10 @@ func writeVar(t *testing.T, s *Server, idx uint64, ns, path string) {
 	sv := mock.Variable()
 	sv.Namespace = ns
 	sv.Path = path
+	sv.Lock = &structs.VariableLock{
+		ID: "lockID",
+	}
+
 	bPlain, err := json.Marshal(sv.Items)
 	must.NoError(t, err)
 	bEnc, kID, err := s.encrypter.Encrypt(bPlain)


### PR DESCRIPTION
This PR addresses a 3 of small issues:
-  The logic to not show the lock ID unless a management token was used for the Read and List endpoints only worked if ACL was enabled, by changing `if aclObj != nil && !aclObj.IsManagement() ` to `!(aclObj != nil && aclObj.IsManagement())` the problem is fixed. 

- When a new variable is created and it includes lock parameters, the endpoint returns an error, to avoid creating locks without TTL

- When releasing a lock, the items provided in the variable are ignored because the lock release operation doesn't update the items, in this PR a new type of error is introduces to reject this requests.