### PR TITLE
lint: fix a missing gofmt -s

### DIFF
--- a/helper/subproc/subproc.go
+++ b/helper/subproc/subproc.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"time"
 	"strings"
+	"time"
 )
 
 const (


### PR DESCRIPTION
I somehow missed this was failing in https://github.com/hashicorp/nomad/pull/18444