### PR TITLE
Fixes Consul token checking when policies exist within namespaces

### DIFF
--- a/.changelog/18516.txt
+++ b/.changelog/18516.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul: uses token namespace to fetch policies for verification
+```

--- a/e2e/connect/acls.go
+++ b/e2e/connect/acls.go
@@ -102,8 +102,9 @@ func (tc *ConnectACLsE2ETest) AfterEach(f *framework.F) {
 
 // todo(shoenig): follow up refactor with e2eutil.ConsulPolicy
 type consulPolicy struct {
-	Name  string // e.g. nomad-operator
-	Rules string // e.g. service "" { policy="write" }
+	Name      string // e.g. nomad-operator
+	Rules     string // e.g. service "" { policy="write" }
+	Namespace string // e.g. default
 }
 
 // todo(shoenig): follow up refactor with e2eutil.ConsulPolicy
@@ -112,17 +113,31 @@ func (tc *ConnectACLsE2ETest) createConsulPolicy(p consulPolicy, f *framework.F)
 		Name:        p.Name,
 		Description: "test policy " + p.Name,
 		Rules:       p.Rules,
+		Namespace:   p.Namespace,
 	}, &consulapi.WriteOptions{Token: tc.consulManagementToken})
 	f.NoError(err, "failed to create consul policy")
 	tc.consulPolicyIDs = append(tc.consulPolicyIDs, result.ID)
 	return result.ID
 }
 
+func (tc *ConnectACLsE2ETest) createConsulNamespace(namespace string, f *framework.F) string {
+	result, _, err := tc.Consul().Namespaces().Create(&consulapi.Namespace{
+		Name: namespace,
+	}, &consulapi.WriteOptions{Token: tc.consulManagementToken})
+	f.NoError(err, "failed to create consul namespace")
+	return result.Name
+}
+
 // todo(shoenig): follow up refactor with e2eutil.ConsulPolicy
 func (tc *ConnectACLsE2ETest) createOperatorToken(policyID string, f *framework.F) string {
+	return tc.createOperatorTokenNamespaced(policyID, "default", f)
+}
+
+func (tc *ConnectACLsE2ETest) createOperatorTokenNamespaced(policyID string, namespace string, f *framework.F) string {
 	token, _, err := tc.Consul().ACL().TokenCreate(&consulapi.ACLToken{
 		Description: "operator token",
 		Policies:    []*consulapi.ACLTokenPolicyLink{{ID: policyID}},
+		Namespace:   namespace,
 	}, &consulapi.WriteOptions{Token: tc.consulManagementToken})
 	f.NoError(err, "failed to create operator token")
 	tc.consulTokenIDs = append(tc.consulTokenIDs, token.AccessorID)
@@ -230,6 +245,47 @@ func (tc *ConnectACLsE2ETest) TestConnectACLsConnectDemo(f *framework.F) {
 
 	// create a Consul "operator token" blessed with the above policy
 	operatorToken := tc.createOperatorToken(policyID, f)
+	t.Log("created operator token:", operatorToken)
+
+	jobID := connectJobID()
+	tc.jobIDs = append(tc.jobIDs, jobID)
+
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, tc.Nomad(), demoConnectJob, jobID, operatorToken)
+	f.Equal(2, len(allocs), "expected 2 allocs for connect demo", allocs)
+	allocIDs := e2eutil.AllocIDsFromAllocationListStubs(allocs)
+	f.Equal(2, len(allocIDs), "expected 2 allocIDs for connect demo", allocIDs)
+	e2eutil.WaitForAllocsRunning(t, tc.Nomad(), allocIDs)
+
+	// === Check Consul SI tokens were generated for sidecars ===
+	foundSITokens := tc.countSITokens(t)
+	f.Equal(2, len(foundSITokens), "expected 2 SI tokens total: %v", foundSITokens)
+	f.Equal(1, foundSITokens["connect-proxy-count-api"], "expected 1 SI token for connect-proxy-count-api: %v", foundSITokens)
+	f.Equal(1, foundSITokens["connect-proxy-count-dashboard"], "expected 1 SI token for connect-proxy-count-dashboard: %v", foundSITokens)
+
+	t.Log("connect legacy job with ACLs enable finished")
+}
+
+func (tc *ConnectACLsE2ETest) TestConnectACLsConnectDemoNamespaced(f *framework.F) {
+	t := f.T()
+
+	t.Log("test register Connect job w/ ACLs enabled w/ operator token")
+
+	// === Setup ACL policy within a namespace and mint Operator token ===
+
+	// create a namespace
+	namespace := tc.createConsulNamespace("ns-"+uuid.Short(), f)
+	t.Log("created namespace:", namespace)
+
+	// create a policy allowing writes of services "count-api" and "count-dashboard"
+	policyID := tc.createConsulPolicy(consulPolicy{
+		Name:      "nomad-operator-policy-" + uuid.Short(),
+		Rules:     `service "count-api" { policy = "write" } service "count-dashboard" { policy = "write" }`,
+		Namespace: namespace,
+	}, f)
+	t.Log("created operator policy:", policyID)
+
+	// create a Consul "operator token" blessed with the above policy
+	operatorToken := tc.createOperatorTokenNamespaced(policyID, namespace, f)
 	t.Log("created operator token:", operatorToken)
 
 	jobID := connectJobID()


### PR DESCRIPTION
Re: support case #122732

Fixes a bug where Nomad fails to fetch Consul policies whilst checking a Consul token presented when submitting a job, if the policies attached to that token exist within a namespace.

> [ERROR] agent.http: Request error: method=GET url=/v1/acl/policy/83073614-xxxx-xxxx-xxxx-xxxxxxxxxxxx from=127.0.0.1:54668 error="Requested policy does not exist: ACL not found"

 - When querying policies from Consul, use the namespace of the token rather than the default namespace.
   - This should be possible since [rules and policies within a specific namespace are prevented from accessing resources in another namespace](https://developer.hashicorp.com/consul/docs/security/acl/acl-rules#implicit-namespacing), therefore if the token is from a non-default namespace then all of it's policies must also exist within that namespace?
   - We cannot use the namespace from the job spec because tokens created in the "default" Consul namespace _can_ have permissions granted in other namespaces - also job spec Consul namespaces are Enterprise-only.