### PR TITLE
CSI: Expand Volume (Node edition)

### DIFF
--- a/client/allocrunner/csi_hook_test.go
+++ b/client/allocrunner/csi_hook_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/csi"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
@@ -496,6 +497,10 @@ func (vm mockVolumeManager) UnmountVolume(ctx context.Context, volID, remoteID, 
 func (vm mockVolumeManager) HasMount(_ context.Context, mountInfo *csimanager.MountInfo) (bool, error) {
 	vm.callCounts.inc("hasMount")
 	return mountInfo != nil && vm.hasMounts, nil
+}
+
+func (vm mockVolumeManager) ExpandVolume(_ context.Context, _, _, _ string, _ *csimanager.UsageOptions, _ *csi.CapacityRange) (int64, error) {
+	return 0, nil
 }
 
 func (vm mockVolumeManager) ExternalID() string {

--- a/client/pluginmanager/csimanager/interface.go
+++ b/client/pluginmanager/csimanager/interface.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/nomad/client/pluginmanager"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/csi"
 )
 
 type MountInfo struct {
@@ -57,6 +58,7 @@ type VolumeManager interface {
 	MountVolume(ctx context.Context, vol *structs.CSIVolume, alloc *structs.Allocation, usageOpts *UsageOptions, publishContext map[string]string) (*MountInfo, error)
 	UnmountVolume(ctx context.Context, volID, remoteID, allocID string, usageOpts *UsageOptions) error
 	HasMount(ctx context.Context, mountInfo *MountInfo) (bool, error)
+	ExpandVolume(ctx context.Context, volID, remoteID, allocID string, usageOpts *UsageOptions, capacity *csi.CapacityRange) (int64, error)
 	ExternalID() string
 }
 

--- a/client/pluginmanager/csimanager/testing.go
+++ b/client/pluginmanager/csimanager/testing.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package csimanager
+
+import (
+	"context"
+
+	"github.com/hashicorp/nomad/client/pluginmanager"
+	nstructs "github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/csi"
+)
+
+var _ Manager = &MockCSIManager{}
+
+type MockCSIManager struct {
+	VM *MockVolumeManager
+
+	NextWaitForPluginErr    error
+	NextManagerForPluginErr error
+}
+
+func (m *MockCSIManager) PluginManager() pluginmanager.PluginManager {
+	panic("implement me")
+}
+
+func (m *MockCSIManager) WaitForPlugin(_ context.Context, pluginType, pluginID string) error {
+	return m.NextWaitForPluginErr
+}
+
+func (m *MockCSIManager) ManagerForPlugin(_ context.Context, pluginID string) (VolumeManager, error) {
+	return m.VM, m.NextManagerForPluginErr
+}
+
+func (m *MockCSIManager) Shutdown() {
+	panic("implement me")
+}
+
+var _ VolumeManager = &MockVolumeManager{}
+
+type MockVolumeManager struct {
+	NextExpandVolumeErr  error
+	LastExpandVolumeCall *MockExpandVolumeCall
+}
+
+func (m *MockVolumeManager) MountVolume(_ context.Context, vol *nstructs.CSIVolume, alloc *nstructs.Allocation, usageOpts *UsageOptions, publishContext map[string]string) (*MountInfo, error) {
+	panic("implement me")
+}
+
+func (m *MockVolumeManager) UnmountVolume(_ context.Context, volID, remoteID, allocID string, usageOpts *UsageOptions) error {
+	panic("implement me")
+}
+
+func (m *MockVolumeManager) HasMount(_ context.Context, mountInfo *MountInfo) (bool, error) {
+	panic("implement me")
+}
+
+func (m *MockVolumeManager) ExpandVolume(_ context.Context, volID, remoteID, allocID string, usageOpts *UsageOptions, capacity *csi.CapacityRange) (int64, error) {
+	m.LastExpandVolumeCall = &MockExpandVolumeCall{
+		volID, remoteID, allocID, usageOpts, capacity,
+	}
+	return capacity.RequiredBytes, m.NextExpandVolumeErr
+}
+
+type MockExpandVolumeCall struct {
+	VolID, RemoteID, AllocID string
+	UsageOpts                *UsageOptions
+	Capacity                 *csi.CapacityRange
+}
+
+func (m *MockVolumeManager) ExternalID() string {
+	return "mock-volume-manager"
+}

--- a/client/structs/csi_test.go
+++ b/client/structs/csi_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package structs
+
+import (
+	"testing"
+
+	"github.com/shoenig/test/must"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func TestClientCSINodeExpandVolumeRequest_Validate(t *testing.T) {
+	req := &ClientCSINodeExpandVolumeRequest{
+		PluginID:   "plug-id",
+		VolumeID:   "vol-id",
+		ExternalID: "ext-id",
+		Claim: &structs.CSIVolumeClaim{
+			AllocationID: "alloc-id",
+		},
+	}
+	err := req.Validate()
+	must.NoError(t, err)
+
+	req.PluginID = ""
+	err = req.Validate()
+	must.ErrorContains(t, err, "PluginID is required")
+
+	req.VolumeID = ""
+	err = req.Validate()
+	must.ErrorContains(t, err, "VolumeID is required")
+
+	req.ExternalID = ""
+	err = req.Validate()
+	must.ErrorContains(t, err, "ExternalID is required")
+
+	req.Claim.AllocationID = ""
+	err = req.Validate()
+	must.ErrorContains(t, err, "Claim.AllocationID is required")
+
+	req.Claim = nil
+	err = req.Validate()
+	must.ErrorContains(t, err, "Claim is required")
+}

--- a/nomad/client_csi_endpoint.go
+++ b/nomad/client_csi_endpoint.go
@@ -224,12 +224,34 @@ func (a *ClientCSI) isRetryable(err error) bool {
 
 func (a *ClientCSI) NodeDetachVolume(args *cstructs.ClientCSINodeDetachVolumeRequest, reply *cstructs.ClientCSINodeDetachVolumeResponse) error {
 	defer metrics.MeasureSince([]string{"nomad", "client_csi_node", "detach_volume"}, time.Now())
+	return a.sendCSINodeRPC(
+		args.NodeID,
+		"CSI.NodeDetachVolume",
+		"ClientCSI.NodeDetachVolume",
+		structs.RateMetricWrite,
+		args,
+		reply,
+	)
+}
 
+func (a *ClientCSI) NodeExpandVolume(args *cstructs.ClientCSINodeExpandVolumeRequest, reply *cstructs.ClientCSINodeExpandVolumeResponse) error {
+	defer metrics.MeasureSince([]string{"nomad", "client_csi_node", "expand_volume"}, time.Now())
+	return a.sendCSINodeRPC(
+		args.Claim.NodeID,
+		"CSI.NodeExpandVolume",
+		"ClientCSI.NodeExpandVolume",
+		structs.RateMetricWrite,
+		args,
+		reply,
+	)
+}
+
+func (a *ClientCSI) sendCSINodeRPC(nodeID, method, fwdMethod, op string, args any, reply any) error {
 	// client requests aren't RequestWithIdentity, so we use a placeholder here
 	// to populate the identity data for metrics
 	identityReq := &structs.GenericRequest{}
 	authErr := a.srv.Authenticate(a.ctx, identityReq)
-	a.srv.MeasureRPCRate("client_csi", structs.RateMetricWrite, identityReq)
+	a.srv.MeasureRPCRate("client_csi", op, identityReq)
 
 	// only servers can send these client RPCs
 	err := validateTLSCertificateLevel(a.srv, a.ctx, tlsCertificateLevelServer)
@@ -243,24 +265,22 @@ func (a *ClientCSI) NodeDetachVolume(args *cstructs.ClientCSINodeDetachVolumeReq
 		return err
 	}
 
-	_, err = getNodeForRpc(snap, args.NodeID)
+	_, err = getNodeForRpc(snap, nodeID)
 	if err != nil {
 		return err
 	}
 
 	// Get the connection to the client
-	state, ok := a.srv.getNodeConn(args.NodeID)
+	state, ok := a.srv.getNodeConn(nodeID)
 	if !ok {
-		return findNodeConnAndForward(a.srv, args.NodeID, "ClientCSI.NodeDetachVolume", args, reply)
+		return findNodeConnAndForward(a.srv, nodeID, fwdMethod, args, reply)
 	}
 
 	// Make the RPC
-	err = NodeRpc(state.Session, "CSI.NodeDetachVolume", args, reply)
-	if err != nil {
-		return fmt.Errorf("node detach volume: %v", err)
+	if err := NodeRpc(state.Session, method, args, reply); err != nil {
+		return fmt.Errorf("%s error: %w", method, err)
 	}
 	return nil
-
 }
 
 // clientIDsForController returns a shuffled list of client IDs where the

--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -45,6 +45,8 @@ type MockClientCSI struct {
 	NextControllerExpandVolumeError    error
 	NextControllerExpandVolumeResponse *cstructs.ClientCSIControllerExpandVolumeResponse
 	NextNodeDetachError                error
+	NextNodeExpandError                error
+	LastNodeExpandRequest              *cstructs.ClientCSINodeExpandVolumeRequest
 }
 
 func newMockClientCSI() *MockClientCSI {
@@ -106,6 +108,11 @@ func (c *MockClientCSI) ControllerExpandVolume(req *cstructs.ClientCSIController
 
 func (c *MockClientCSI) NodeDetachVolume(req *cstructs.ClientCSINodeDetachVolumeRequest, resp *cstructs.ClientCSINodeDetachVolumeResponse) error {
 	return c.NextNodeDetachError
+}
+
+func (c *MockClientCSI) NodeExpandVolume(req *cstructs.ClientCSINodeExpandVolumeRequest, resp *cstructs.ClientCSINodeExpandVolumeResponse) error {
+	c.LastNodeExpandRequest = req
+	return c.NextNodeExpandError
 }
 
 func TestClientCSIController_AttachVolume_Local(t *testing.T) {

--- a/plugins/csi/client_test.go
+++ b/plugins/csi/client_test.go
@@ -1518,3 +1518,163 @@ func TestClient_RPC_NodeUnpublishVolume(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_RPC_NodeExpandVolume(t *testing.T) {
+	// minimum valid request
+	minRequest := &NodeExpandVolumeRequest{
+		ExternalVolumeID: "test-vol",
+		TargetPath:       "/test-path",
+	}
+
+	cases := []struct {
+		Name        string
+		Request     *NodeExpandVolumeRequest
+		ExpectCall  *csipbv1.NodeExpandVolumeRequest
+		ResponseErr error
+		ExpectedErr error
+	}{
+		{
+			Name:    "success min",
+			Request: minRequest,
+			ExpectCall: &csipbv1.NodeExpandVolumeRequest{
+				VolumeId:   "test-vol",
+				VolumePath: "/test-path",
+			},
+		},
+		{
+			Name: "success full",
+			Request: &NodeExpandVolumeRequest{
+				ExternalVolumeID: "test-vol",
+				TargetPath:       "/test-path",
+				StagingPath:      "/test-staging-path",
+				CapacityRange: &CapacityRange{
+					RequiredBytes: 5,
+					LimitBytes:    10,
+				},
+				Capability: &VolumeCapability{
+					AccessType: VolumeAccessTypeMount,
+					AccessMode: VolumeAccessModeMultiNodeSingleWriter,
+					MountVolume: &structs.CSIMountOptions{
+						FSType:     "test-fstype",
+						MountFlags: []string{"test-flags"},
+					},
+				},
+			},
+			ExpectCall: &csipbv1.NodeExpandVolumeRequest{
+				VolumeId:          "test-vol",
+				VolumePath:        "/test-path",
+				StagingTargetPath: "/test-staging-path",
+				CapacityRange: &csipbv1.CapacityRange{
+					RequiredBytes: 5,
+					LimitBytes:    10,
+				},
+				VolumeCapability: &csipbv1.VolumeCapability{
+					AccessType: &csipbv1.VolumeCapability_Mount{
+						Mount: &csipbv1.VolumeCapability_MountVolume{
+							FsType:           "test-fstype",
+							MountFlags:       []string{"test-flags"},
+							VolumeMountGroup: "",
+						}},
+					AccessMode: &csipbv1.VolumeCapability_AccessMode{
+						Mode: csipbv1.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER},
+				},
+			},
+		},
+
+		{
+			Name: "validate missing volume id",
+			Request: &NodeExpandVolumeRequest{
+				TargetPath: "/test-path",
+			},
+			ExpectedErr: errors.New("ExternalVolumeID is required"),
+		},
+		{
+			Name: "validate missing target path",
+			Request: &NodeExpandVolumeRequest{
+				ExternalVolumeID: "test-volume",
+			},
+			ExpectedErr: errors.New("TargetPath is required"),
+		},
+		{
+			Name: "validate min greater than max",
+			Request: &NodeExpandVolumeRequest{
+				ExternalVolumeID: "test-vol",
+				TargetPath:       "/test-path",
+				CapacityRange: &CapacityRange{
+					RequiredBytes: 4,
+					LimitBytes:    2,
+				},
+			},
+			ExpectedErr: errors.New("LimitBytes cannot be less than RequiredBytes"),
+		},
+
+		{
+			Name:        "grpc error default case",
+			Request:     minRequest,
+			ResponseErr: status.Errorf(codes.DataLoss, "misc unspecified error"),
+			ExpectedErr: errors.New("node plugin returned an error: rpc error: code = DataLoss desc = misc unspecified error"),
+		},
+		{
+			Name:        "grpc error invalid argument",
+			Request:     minRequest,
+			ResponseErr: status.Errorf(codes.InvalidArgument, "sad args"),
+			ExpectedErr: errors.New("requested capabilities not compatible with volume \"test-vol\": rpc error: code = InvalidArgument desc = sad args"),
+		},
+		{
+			Name:        "grpc error NotFound",
+			Request:     minRequest,
+			ResponseErr: status.Errorf(codes.NotFound, "does not exist"),
+			ExpectedErr: errors.New("CSI client error (ignorable): volume \"test-vol\" could not be found: rpc error: code = NotFound desc = does not exist"),
+		},
+		{
+			Name:        "grpc error FailedPrecondition",
+			Request:     minRequest,
+			ResponseErr: status.Errorf(codes.FailedPrecondition, "unsupported"),
+			ExpectedErr: errors.New("volume \"test-vol\" cannot be expanded while in use: rpc error: code = FailedPrecondition desc = unsupported"),
+		},
+		{
+			Name:        "grpc error OutOfRange",
+			Request:     minRequest,
+			ResponseErr: status.Errorf(codes.OutOfRange, "too small"),
+			ExpectedErr: errors.New("unsupported capacity_range for volume \"test-vol\": rpc error: code = OutOfRange desc = too small"),
+		},
+		{
+			Name:        "grpc error Internal",
+			Request:     minRequest,
+			ResponseErr: status.Errorf(codes.Internal, "some grpc error"),
+			ExpectedErr: errors.New("node plugin returned an internal error, check the plugin allocation logs for more information: rpc error: code = Internal desc = some grpc error"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, _, nc, client := newTestClient(t)
+
+			nc.NextErr = tc.ResponseErr
+			// the fake client should take ~no time, but set a timeout just in case
+			ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+			defer cancel()
+			resp, err := client.NodeExpandVolume(ctx, tc.Request)
+			if tc.ExpectedErr != nil {
+				must.EqError(t, err, tc.ExpectedErr.Error())
+				return
+			}
+			must.NoError(t, err)
+			must.NotNil(t, resp)
+			must.Eq(t, tc.ExpectCall, nc.LastExpandVolumeRequest)
+
+		})
+	}
+
+	t.Run("connection error", func(t *testing.T) {
+		c := &client{} // induce c.ensureConnected() error
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*50)
+		defer cancel()
+		resp, err := c.NodeExpandVolume(ctx, &NodeExpandVolumeRequest{
+			ExternalVolumeID: "valid-id",
+			TargetPath:       "/some-path",
+		})
+		must.Nil(t, resp)
+		must.EqError(t, err, "address is empty")
+	})
+}

--- a/plugins/csi/testing/client.go
+++ b/plugins/csi/testing/client.go
@@ -150,6 +150,7 @@ type NodeClient struct {
 	NextPublishVolumeResponse   *csipbv1.NodePublishVolumeResponse
 	NextUnpublishVolumeResponse *csipbv1.NodeUnpublishVolumeResponse
 	NextExpandVolumeResponse    *csipbv1.NodeExpandVolumeResponse
+	LastExpandVolumeRequest     *csipbv1.NodeExpandVolumeRequest
 }
 
 // NewNodeClient returns a new stub NodeClient
@@ -193,5 +194,6 @@ func (c *NodeClient) NodeUnpublishVolume(ctx context.Context, in *csipbv1.NodeUn
 }
 
 func (c *NodeClient) NodeExpandVolume(ctx context.Context, in *csipbv1.NodeExpandVolumeRequest, opts ...grpc.CallOption) (*csipbv1.NodeExpandVolumeResponse, error) {
+	c.LastExpandVolumeRequest = in
 	return c.NextExpandVolumeResponse, c.NextErr
 }


### PR DESCRIPTION
Follow-up to #18359, wrapping up the full feature requested in #10324 (sans docs)

After the controller plugin has expanded the disk at e.g. a cloud vendor, it may say that we also need to issue [NodeExpandVolume](https://github.com/container-storage-interface/spec/blob/c918b7f/spec.md#nodeexpandvolume) for the node plugin to make the new disk space available to task(s) that have claims on the volume by e.g. expanding the filesystem on the node.

The main gap in test coverage is `sendCSINodeRPC` which I split out from `ClientCSI.NodeDetachVolume`, which was not actually tested before.  I know that it works, but I'm open to (figuring out how to) add proper coverage there, amongst all the other layers with greater coverage, if it's a considerable concern.