### PR TITLE
job endpoint: reorder check for disabled job registrations

### DIFF
--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -2416,7 +2416,7 @@ func TestJobRegister_ACL_RejectedBySchedulerConfig(t *testing.T) {
 			name:          "reject enabled, without a token",
 			token:         "",
 			rejectEnabled: true,
-			errExpected:   structs.ErrPermissionDenied.Error(),
+			errExpected:   structs.ErrJobRegistrationDisabled.Error(),
 		},
 		{
 			name:          "reject enabled, with a management token",


### PR DESCRIPTION
When job registrations are disabled, there's no reason to do the potentially expensive job mutation and admission hooks. Move the ACL resolution and this check before those hooks.