### PR TITLE
job endpoint: implicit constraints for multi-Vault/Consul

### DIFF
--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -69,12 +69,12 @@ func NewJobEndpoints(s *Server, ctx *RPCContext) *Job {
 		logger: s.logger.Named("job"),
 		mutators: []jobMutator{
 			&jobCanonicalizer{srv: s},
+			jobVaultHook{srv: s},
+			jobConsulHook{srv: s},
 			jobConnectHook{},
 			jobExposeCheckHook{},
 			jobImpliedConstraints{},
 			jobNodePoolMutatingHook{srv: s},
-			jobVaultHook{srv: s},
-			jobConsulHook{srv: s},
 			jobImplicitIdentitiesHook{srv: s},
 		},
 		validators: []jobValidator{

--- a/nomad/job_endpoint_hook_consul_ce.go
+++ b/nomad/job_endpoint_hook_consul_ce.go
@@ -59,14 +59,14 @@ func (j jobConsulHook) Mutate(job *structs.Job) (*structs.Job, []error, error) {
 		}
 
 		for _, service := range group.Services {
-			if service.Provider == structs.ServiceProviderConsul && service.Cluster == "" {
+			if service.IsConsul() && service.Cluster == "" {
 				service.Cluster = "default"
 			}
 		}
 
 		for _, task := range group.Tasks {
 			for _, service := range task.Services {
-				if service.Provider == structs.ServiceProviderConsul && service.Cluster == "" {
+				if service.IsConsul() && service.Cluster == "" {
 					service.Cluster = "default"
 				}
 			}

--- a/nomad/structs/consul.go
+++ b/nomad/structs/consul.go
@@ -100,7 +100,7 @@ func (j *Job) ConsulUsages() map[string]*ConsulUsage {
 
 		// Gather group services
 		for _, service := range tg.Services {
-			if service.Provider == ServiceProviderConsul {
+			if service.IsConsul() {
 				m[namespace].Services = append(m[namespace].Services, service.Name)
 			}
 		}
@@ -108,7 +108,7 @@ func (j *Job) ConsulUsages() map[string]*ConsulUsage {
 		// Gather task services and KV usage
 		for _, task := range tg.Tasks {
 			for _, service := range task.Services {
-				if service.Provider == ServiceProviderConsul {
+				if service.IsConsul() {
 					m[namespace].Services = append(m[namespace].Services, service.Name)
 				}
 			}

--- a/nomad/structs/job.go
+++ b/nomad/structs/job.go
@@ -111,7 +111,7 @@ func (j *Job) RequiredConsulServiceDiscovery() map[string]bool {
 // to the function are utilising Consul service discovery.
 func requiresConsulServiceDiscovery(services []*Service) bool {
 	for _, tgService := range services {
-		if tgService.Provider == ServiceProviderConsul || tgService.Provider == "" {
+		if tgService.IsConsul() {
 			return true
 		}
 	}

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -1048,6 +1048,11 @@ func (s *Service) Equal(o *Service) bool {
 	return true
 }
 
+func (s *Service) IsConsul() bool {
+	return s.Provider == ServiceProviderConsul || s.Provider == ""
+
+}
+
 // ConsulConnect represents a Consul Connect jobspec block.
 type ConsulConnect struct {
 	// Native indicates whether the service is Consul Connect Native enabled.


### PR DESCRIPTION
Update the implicit constraint mutating hook to support multiple Vault and Consul clusters in Nomad Enterprise. This requires moving the Vault/Consul mutating hooks earlier in the list as well, because that'll ensure we've canonicalized properly for multiple clusters.