### PR TITLE
Add role update functionality to acl token update

### DIFF
--- a/.changelog/18532.txt
+++ b/.changelog/18532.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added support for updating the roles for an ACL token
+```

--- a/website/content/docs/commands/acl/token/update.mdx
+++ b/website/content/docs/commands/acl/token/update.mdx
@@ -28,7 +28,16 @@ The `acl token update` command requires an existing token's accessor ID.
 - `-type`: Sets the type of token. Must be one of "client" or "management".
 
 - `-policy`: Specifies a policy to associate with the token. Can be specified
-  multiple times, but only with client type tokens.
+  multiple times, but only with client type tokens. If any policies are
+  specified, they completely replace the policies on the existing token.
+
+- `-role-id`: ID of a role to use for this token. Can be specified multiple
+  times, but only with client type tokens. If any roles are specified, they
+  completely replace the roles on the existing token.
+
+- `-role-name`: Name of a role to use for this token. Can be specified multiple
+  times, but only with client type tokens. If any roles are specified, they
+  completely replace the roles on the existing token.
 
 ## Examples
 


### PR DESCRIPTION
This pull request adds the ability to update roles in the `acl token update` command.

Fixes: #18354