### PR TITLE
OpenID Configuration Discovery Endpoint

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -388,6 +388,14 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	conf.ClientRPCAdvertise = rpcAddr
 	conf.ServerRPCAdvertise = serverAddr
 
+	// OIDC Issuer address
+	//FIXME(schmichael) seems like a bad way to configure http for servers. will upgrades break?
+	if agentConfig.OIDCIssuer == "" {
+		conf.OIDCIssuer = agentConfig.HTTPAddr()
+	} else {
+		conf.OIDCIssuer = agentConfig.OIDCIssuer
+	}
+
 	// Set up gc threshold and heartbeat grace period
 	if gcThreshold := agentConfig.Server.NodeGCThreshold; gcThreshold != "" {
 		dur, err := time.ParseDuration(gcThreshold)

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -389,12 +389,7 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	conf.ServerRPCAdvertise = serverAddr
 
 	// OIDC Issuer address
-	//FIXME(schmichael) seems like a bad way to configure http for servers. will upgrades break?
-	if agentConfig.OIDCIssuer == "" {
-		conf.OIDCIssuer = agentConfig.HTTPAddr()
-	} else {
-		conf.OIDCIssuer = agentConfig.OIDCIssuer
-	}
+	conf.OIDCIssuer = agentConfig.OIDCIssuer
 
 	// Set up gc threshold and heartbeat grace period
 	if gcThreshold := agentConfig.Server.NodeGCThreshold; gcThreshold != "" {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -202,6 +202,9 @@ type Config struct {
 	// Reporting is used to enable go census reporting
 	Reporting *config.ReportingConfig `hcl:"reporting,block"`
 
+	//FIXME(schmichael) where should this live
+	OIDCIssuer string `hcl:"oidc_issuer"`
+
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
@@ -1381,6 +1384,16 @@ func DefaultConfig() *Config {
 	return cfg
 }
 
+// HTTPAddr returns a URL with the proper scheme (HTTP vs HTTPS) for the
+// advertise address.
+func (c *Config) HTTPAddr() string {
+	if c.TLSConfig.EnableHTTP {
+		return "https://" + c.AdvertiseAddrs.HTTP
+	} else {
+		return "http://" + c.AdvertiseAddrs.HTTP
+	}
+}
+
 // Listener can be used to get a new listener using a custom bind address.
 // If the bind provided address is empty, the BindAddr is used instead.
 func (c *Config) Listener(proto, addr string, port int) (net.Listener, error) {
@@ -1599,6 +1612,10 @@ func (c *Config) Merge(b *Config) *Config {
 	}
 
 	result.Limits = c.Limits.Merge(b.Limits)
+
+	if b.OIDCIssuer != "" {
+		result.OIDCIssuer = b.OIDCIssuer
+	}
 
 	return &result
 }

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -502,8 +502,9 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.Handle("/v1/vars", wrapCORS(s.wrap(s.VariablesListRequest)))
 	s.mux.Handle("/v1/var/", wrapCORSWithAllowedMethods(s.wrap(s.VariableSpecificRequest), "HEAD", "GET", "PUT", "DELETE"))
 
-	// JWKS Handler
+	// OIDC Handlers
 	s.mux.HandleFunc("/.well-known/jwks.json", s.wrap(s.JWKSRequest))
+	s.mux.HandleFunc("/.well-known/openid-configuration", s.wrap(s.OIDCDiscoveryRequest))
 
 	agentConfig := s.agent.GetConfig()
 	uiConfigEnabled := agentConfig.UI != nil && agentConfig.UI.Enabled

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -503,7 +503,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.Handle("/v1/var/", wrapCORSWithAllowedMethods(s.wrap(s.VariableSpecificRequest), "HEAD", "GET", "PUT", "DELETE"))
 
 	// OIDC Handlers
-	s.mux.HandleFunc("/.well-known/jwks.json", s.wrap(s.JWKSRequest))
+	s.mux.HandleFunc(structs.JWKSPath, s.wrap(s.JWKSRequest))
 	s.mux.HandleFunc("/.well-known/openid-configuration", s.wrap(s.OIDCDiscoveryRequest))
 
 	agentConfig := s.agent.GetConfig()

--- a/command/agent/keyring_endpoint.go
+++ b/command/agent/keyring_endpoint.go
@@ -135,7 +135,7 @@ func (s *HTTPServer) OIDCDiscoveryRequest(resp http.ResponseWriter, req *http.Re
 		Keys:                jwksPath,
 		RequestParameter:    false,
 		RequestURIParameter: false,
-		IDTokenAlgs:         []string{structs.PubKeyAlgEdDSA},
+		IDTokenAlgs:         []string{structs.PubKeyAlgRS256, structs.PubKeyAlgEdDSA},
 		ResponseTypes:       []string{"code"},
 		Subjects:            []string{"public"},
 	}

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -583,6 +583,10 @@ func (a *Alloc) SignIdentities(args *structs.AllocIdentitiesRequest, reply *stru
 
 			widFound = true
 			claims := structs.NewIdentityClaims(out.Job, out, idReq.TaskName, wid, now)
+
+			//FIXME(schmichael) its weird to inject this outside of NewIdentityClaims
+			claims.Issuer = a.srv.GetConfig().OIDCIssuer
+
 			token, _, err := a.srv.encrypter.SignClaims(claims)
 			if err != nil {
 				return err

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -432,8 +432,9 @@ type Config struct {
 
 	Reporting *config.ReportingConfig
 
-	// OIDCIssuer is the URL for the OIDC Issuer field in Workload Identity JWTs
-	//FIXME(schmichael) is this the best way to pass it in?
+	// OIDCIssuer is the URL for the OIDC Issuer field in Workload Identity JWTs.
+	// If this is not configured the /.well-known/openid-configuration endpoint
+	// will not be available.
 	OIDCIssuer string
 }
 

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -431,6 +431,10 @@ type Config struct {
 	JobTrackedVersions int
 
 	Reporting *config.ReportingConfig
+
+	// OIDCIssuer is the URL for the OIDC Issuer field in Workload Identity JWTs
+	//FIXME(schmichael) is this the best way to pass it in?
+	OIDCIssuer string
 }
 
 func (c *Config) Copy() *Config {

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -423,3 +423,24 @@ func (k *Keyring) ListPublic(args *structs.GenericRequest, reply *structs.Keyrin
 	}
 	return k.srv.blockingRPC(&opts)
 }
+
+// GetConfig for workload identities. This RPC is used to back an OIDC
+// Discovery endpoint.
+//
+// Unauthenticated because OIDC Discovery endpoints must be publically
+// available.
+func (k *Keyring) GetConfig(args *structs.GenericRequest, reply *structs.KeyringGetConfigResponse) error {
+
+	// JWKS is a public endpoint: intentionally ignore auth errors and only
+	// authenticate to measure rate metrics.
+	k.srv.Authenticate(k.ctx, args)
+	if done, err := k.srv.forward("Keyring.GetConfig", args, args, reply); done {
+		return err
+	}
+	k.srv.MeasureRPCRate("keyring", structs.RateMetricList, args)
+
+	defer metrics.MeasureSince([]string{"nomad", "keyring", "get_config"}, time.Now())
+
+	reply.OIDCDiscovery = k.srv.oidcDisco
+	return nil
+}

--- a/nomad/structs/keyring.go
+++ b/nomad/structs/keyring.go
@@ -255,6 +255,15 @@ type KeyringDeleteRootKeyResponse struct {
 	WriteMeta
 }
 
+// OIDCDiscoveryResponse defines the OIDC Discovery response.
+//
+// Not specific to Nomad's keyring, but included here since public signing keys
+// are exposed in an OIDC compliant way for validation of workload identity
+// JWTs.
+//
+// See https://openid.net/specs/openid-connect-discovery-1_0.html
+type OIDCDiscovery struct{}
+
 // KeyringListPublicResponse lists public key components of signing keys. Used
 // to build a JWKS endpoint.
 type KeyringListPublicResponse struct {


### PR DESCRIPTION
WIP branch to test against AWS

Issuer (and JWKS base address) is configurable with `oidc_issuer = "..."` in your agent config.

Endpoint is at http://localhost:4646/.well-known/openid-configuration