### PR TITLE
Update consul-connect.mdx

### DIFF
--- a/website/content/docs/integrations/consul-connect.mdx
+++ b/website/content/docs/integrations/consul-connect.mdx
@@ -66,7 +66,7 @@ GRPC port and set `connect` to enabled by adding some additional information to
 your Consul client configurations, depending on format. Consul agents running TLS
 and a version greater than [1.14.0](https://releases.hashicorp.com/consul/1.14.0)
 should set the `grpc_tls` configuration parameter instead of `grpc`. Please see
-the Consul [port documentation](https://nomadproject.io/consul_ports) for further reference material.
+the Consul [port documentation](https://developer.hashicorp.com/consul/docs/install/ports) for further reference material.
 
 For HCL configurations:
 


### PR DESCRIPTION
The hyperlink points to a non-existing URL. I suggest change it for this one (https://developer.hashicorp.com/consul/docs/install/ports) which at least listed the port 8503 (grpc tls)