### PR TITLE
feat: support unix address in api client

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -291,6 +291,14 @@ func (t *TLSConfig) Copy() *TLSConfig {
 func defaultHttpClient() *http.Client {
 	httpClient := cleanhttp.DefaultPooledClient()
 	transport := httpClient.Transport.(*http.Transport)
+
+	unixTransport := httpClient.Transport.(*http.Transport)
+	unixTransport.DialContext = func(_ context.Context, network, address string) (net.Conn, error) {
+		return net.Dial("unix", address)
+	}
+
+	transport.RegisterProtocol("unix", unixTransport)
+
 	transport.TLSHandshakeTimeout = 10 * time.Second
 	transport.TLSClientConfig = &tls.Config{
 		MinVersion: tls.VersionTLS12,

--- a/api/api.go
+++ b/api/api.go
@@ -215,13 +215,13 @@ func (c *Config) ClientConfig(region, address string, tlsEnabled bool) *Config {
 
 	u, err := url.Parse(address)
 	if err != nil && u.Scheme != "" {
-		addressWithScheme := address
+		addressWithScheme = address
 	} else {
 		scheme := "http"
 		if tlsEnabled {
 			scheme = "https"
 		}
-		addressWithScheme := fmt.Sprintf("%s://%s", scheme, address)
+		addressWithScheme = fmt.Sprintf("%s://%s", scheme, address)
 	}
 
 	config := &Config{

--- a/api/api.go
+++ b/api/api.go
@@ -210,12 +210,22 @@ type Config struct {
 // ClientConfig copies the configuration with a new client address, region, and
 // whether the client has TLS enabled.
 func (c *Config) ClientConfig(region, address string, tlsEnabled bool) *Config {
-	scheme := "http"
-	if tlsEnabled {
-		scheme = "https"
+	// Check if the address already contains a scheme.
+	var addressWithScheme string
+
+	u, err := url.Parse(address)
+	if err != nil && u.Scheme != "" {
+		addressWithScheme := address
+	} else {
+		scheme := "http"
+		if tlsEnabled {
+			scheme = "https"
+		}
+		addressWithScheme := fmt.Sprintf("%s://%s", scheme, address)
 	}
+
 	config := &Config{
-		Address:    fmt.Sprintf("%s://%s", scheme, address),
+		Address:    addressWithScheme,
 		Region:     region,
 		Namespace:  c.Namespace,
 		HttpClient: c.HttpClient,


### PR DESCRIPTION
This is another attempt to add Unix address support to the API client.

Inspired by #16872.

The idea is to only apply the minimum required changes:

- [ ] Fix scheme handling in config structure to not add a scheme if one is already present. (This is an improvement even without `unix` support. 
- [ ] Register the `unix` protocol with the default transport so that it is transparently supported.

Disclaimer: I do not speak *Go*