### PR TITLE
config: fix some issues with workload identity and multi Consul and Vault

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2783,7 +2783,7 @@ func (c *Client) setupVaultClients() error {
 	c.vaultClients = map[string]vaultclient.VaultClient{}
 	vaultConfigs := c.GetConfig().GetVaultConfigs(c.logger)
 	for _, vaultConfig := range vaultConfigs {
-		vaultClient, err := vaultclient.NewVaultClient(c.GetConfig().VaultConfig, c.logger, c.deriveToken)
+		vaultClient, err := vaultclient.NewVaultClient(vaultConfig, c.logger, c.deriveToken)
 		if err != nil {
 			return err
 		}
@@ -2792,7 +2792,6 @@ func (c *Client) setupVaultClients() error {
 			return fmt.Errorf("failed to create vault client for cluster %q", vaultConfig.Name)
 		}
 		c.vaultClients[vaultConfig.Name] = vaultClient
-
 	}
 
 	// Start renewing tokens and secrets only once we've ensured we have created

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -180,6 +180,10 @@ func ParseConfigFile(path string) (*Config, error) {
 	// Since the map of multiple cluster configuration contains a pointer to
 	// the default block we don't need to parse it directly.
 	for name, consulConfig := range c.Consuls {
+		// Capture consulConfig inside the loop so the parse duration function
+		// modifies the right configuration.
+		consulConfig := consulConfig
+
 		if consulConfig.ServiceIdentity != nil {
 			tds = append(tds, durationConversionMap{
 				fmt.Sprintf("consuls.%s.service_identity.ttl", name), nil, &consulConfig.ServiceIdentity.TTLHCL,
@@ -200,6 +204,10 @@ func ParseConfigFile(path string) (*Config, error) {
 	}
 
 	for name, vaultConfig := range c.Vaults {
+		// Capture vaultConfig inside the loop so the parse duration function
+		// modifies the right configuration.
+		vaultConfig := vaultConfig
+
 		if vaultConfig.DefaultIdentity != nil {
 			tds = append(tds, durationConversionMap{
 				fmt.Sprintf("vaults.%s.default_identity.ttl", name), nil, &vaultConfig.DefaultIdentity.TTLHCL,

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -1081,13 +1081,18 @@ func TestConfig_MultipleVault(t *testing.T) {
 	must.Eq(t, "127.0.0.1:9500", cfg.Vault.Addr)
 	must.Eq(t, "abracadabra", cfg.Vault.Token)
 
-	must.MapLen(t, 2, cfg.Vaults)
+	must.MapLen(t, 3, cfg.Vaults)
 	must.Equal(t, cfg.Vault, cfg.Vaults["default"])
 
 	must.Eq(t, "alternate", cfg.Vaults["alternate"].Name)
 	must.True(t, *cfg.Vaults["alternate"].Enabled)
 	must.Eq(t, "127.0.0.1:9501", cfg.Vaults["alternate"].Addr)
 	must.Eq(t, "xyzzy", cfg.Vaults["alternate"].Token)
+
+	must.Eq(t, "other", cfg.Vaults["other"].Name)
+	must.Nil(t, cfg.Vaults["other"].Enabled)
+	must.Eq(t, "127.0.0.1:9502", cfg.Vaults["other"].Addr)
+	must.Eq(t, pointer.Of(4*time.Hour), cfg.Vaults["other"].DefaultIdentity.TTL)
 }
 
 func TestConfig_MultipleConsul(t *testing.T) {
@@ -1128,11 +1133,15 @@ func TestConfig_MultipleConsul(t *testing.T) {
 	must.Eq(t, "127.0.0.1:9501", cfg.Consul.Addr)
 	must.Eq(t, "abracadabra", cfg.Consul.Token)
 
-	must.MapLen(t, 2, cfg.Consuls)
+	must.MapLen(t, 3, cfg.Consuls)
 	must.Eq(t, cfg.Consul, cfg.Consuls["default"])
 
 	must.Eq(t, "alternate", cfg.Consuls["alternate"].Name)
 	must.True(t, *cfg.Consuls["alternate"].AllowUnauthenticated)
 	must.Eq(t, "127.0.0.2:8501", cfg.Consuls["alternate"].Addr)
 	must.Eq(t, "xyzzy", cfg.Consuls["alternate"].Token)
+
+	must.Eq(t, "other", cfg.Consuls["other"].Name)
+	must.Eq(t, pointer.Of(3*time.Hour), cfg.Consuls["other"].ServiceIdentity.TTL)
+	must.Eq(t, pointer.Of(5*time.Hour), cfg.Consuls["other"].TaskIdentity.TTL)
 }

--- a/command/agent/testdata/extra-consul.hcl
+++ b/command/agent/testdata/extra-consul.hcl
@@ -9,7 +9,7 @@ consul {
   timeout               = "20s"
 }
 
-# this alternate config should be added as an extra consul config
+# these alternate configs should be added as an extra consul configs
 consul {
   name                   = "alternate"
   server_service_name    = "nomad"
@@ -22,4 +22,18 @@ consul {
   allow_unauthenticated  = true
   token                  = "xyzzy"
   auth                   = "username:pass"
+}
+
+consul {
+  name = "other"
+
+  service_identity {
+    aud = ["consul-other.io"]
+    ttl = "3h"
+  }
+
+  task_identity {
+    aud = ["consul-other.io"]
+    ttl = "5h"
+  }
 }

--- a/command/agent/testdata/extra-vault.hcl
+++ b/command/agent/testdata/extra-vault.hcl
@@ -7,7 +7,7 @@ vault {
   token   = "abracadabra"
 }
 
-# this alternate config should be added as an extra vault config
+# these alternate configs should be added as an extra vault configs
 vault {
   name                  = "alternate"
   address               = "127.0.0.1:9501"
@@ -22,4 +22,14 @@ vault {
   tls_server_name       = "barbaz"
   tls_skip_verify       = true
   create_from_role      = "test_role2"
+}
+
+vault {
+  name    = "other"
+  address = "127.0.0.1:9502"
+
+  default_identity {
+    aud = ["vault-other.io"]
+    ttl = "4h"
+  }
 }

--- a/nomad/structs/config/workload_id.go
+++ b/nomad/structs/config/workload_id.go
@@ -53,6 +53,9 @@ func (wi *WorkloadIdentityConfig) Copy() *WorkloadIdentityConfig {
 	if wi.File != nil {
 		nwi.File = pointer.Of(*wi.File)
 	}
+	if wi.TTL != nil {
+		nwi.TTL = pointer.Of(*wi.TTL)
+	}
 
 	return nwi
 }

--- a/nomad/structs/config/workload_id_test.go
+++ b/nomad/structs/config/workload_id_test.go
@@ -27,16 +27,22 @@ func TestWorkloadIdentityConfig_Copy(t *testing.T) {
 	clone := original.Copy()
 	must.Eq(t, original, clone)
 	must.NotEqOp(t, original, clone)
+	must.NotEqOp(t, original.Env, clone.Env)
+	must.NotEqOp(t, original.File, clone.File)
+	must.NotEqOp(t, original.TTL, clone.TTL)
 
 	// Verify returned struct does not mutate original.
 	clone.Name = "clone"
-	clone.Audience = []string{"aud", "clone"}
-	clone.Env = pointer.Of(false)
-	clone.File = pointer.Of(true)
-	clone.TTL = pointer.Of(time.Second)
+	clone.Audience[0] = "changed"
+	*clone.Env = false
+	*clone.File = true
+	*clone.TTL = time.Second
 
 	must.NotEq(t, original, clone)
 	must.NotEqOp(t, original, clone)
+	must.NotEqOp(t, original.Env, clone.Env)
+	must.NotEqOp(t, original.File, clone.File)
+	must.NotEqOp(t, original.TTL, clone.TTL)
 }
 
 func TestWorkloadIdentityConfig_Equal(t *testing.T) {


### PR DESCRIPTION
Breaking up #18534 into more manageable pieces, this PR fixes some small bugs in configuration parsing and handling of workload identity and multi Consul and Vault. 

Each commit contains a specific bug fix.