### PR TITLE
vault: remove `use_identity` agent config

### DIFF
--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -306,7 +306,6 @@ var basicConfig = &Config{
 		TLSSkipVerify:        &trueValue,
 		TaskTokenTTL:         "1s",
 		Token:                "12345",
-		UseIdentity:          pointer.Of(true),
 		DefaultIdentity: &config.WorkloadIdentityConfig{
 			Audience: []string{"vault.io", "nomad.io"},
 			Env:      pointer.Of(false),
@@ -331,7 +330,6 @@ var basicConfig = &Config{
 			TLSSkipVerify:        &trueValue,
 			TaskTokenTTL:         "1s",
 			Token:                "12345",
-			UseIdentity:          pointer.Of(true),
 			DefaultIdentity: &config.WorkloadIdentityConfig{
 				Audience: []string{"vault.io", "nomad.io"},
 				Env:      pointer.Of(false),
@@ -1097,7 +1095,6 @@ func TestConfig_MultipleVault(t *testing.T) {
 	must.Eq(t, "abracadabra", cfg.Vault.Token)
 
 	must.MapLen(t, 3, cfg.Vaults)
-	must.Equal(t, cfg.Vault, cfg.Vaults["default"])
 	must.Equal(t, cfg.Vault, cfg.Vaults[structs.VaultDefaultCluster])
 
 	must.Eq(t, "alternate", cfg.Vaults["alternate"].Name)

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -271,7 +271,6 @@ vault {
   tls_server_name       = "foobar"
   tls_skip_verify       = true
   create_from_role      = "test_role"
-  use_identity          = true
 
   default_identity {
     aud  = ["vault.io", "nomad.io"]

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -400,8 +400,7 @@
       "task_token_ttl": "1s",
       "tls_server_name": "foobar",
       "tls_skip_verify": true,
-      "token": "12345",
-      "use_identity": true
+      "token": "12345"
     }
   ],
   "reporting":{

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -500,13 +500,6 @@ func (c *Config) UseConsulIdentity() bool {
 		*c.ConsulConfig.UseIdentity
 }
 
-// UseVaultIdentity returns true when Vault workload identity is enabled.
-func (c *Config) UseVaultIdentity() bool {
-	return c.VaultConfig != nil &&
-		c.VaultConfig.UseIdentity != nil &&
-		*c.VaultConfig.UseIdentity
-}
-
 // workloadIdentityFromConfig returns a structs.WorkloadIdentity to be used in
 // a job from a config.WorkloadIdentityConfig parsed from an agent config file.
 func workloadIdentityFromConfig(widConfig *config.WorkloadIdentityConfig) *structs.WorkloadIdentity {

--- a/nomad/job_endpoint_hook_implicit_identities.go
+++ b/nomad/job_endpoint_hook_implicit_identities.go
@@ -108,10 +108,10 @@ func (h jobImplicitIdentitiesHook) handleConsulTasks(t *structs.Task, consul *st
 
 // handleVault injects a workload identity to the task if:
 //  1. The task has a Vault block.
-//  2. The server is configured with `vault.use_identity = true` and a
-//     `vault.default_identity` is provided.
+//  2. The task does not have an identity for the Vault cluster.
+//  3. The server is configured with a `vault.default_identity`.
 func (h jobImplicitIdentitiesHook) handleVault(t *structs.Task) {
-	if !h.srv.config.UseVaultIdentity() || t.Vault == nil {
+	if t.Vault == nil {
 		return
 	}
 

--- a/nomad/job_endpoint_hook_implicit_identities_test.go
+++ b/nomad/job_endpoint_hook_implicit_identities_test.go
@@ -339,7 +339,6 @@ func Test_jobImplicitIndentitiesHook_Mutate_vault(t *testing.T) {
 			},
 			inputConfig: &Config{
 				VaultConfig: &config.VaultConfig{
-					UseIdentity: pointer.Of(true),
 					DefaultIdentity: &config.WorkloadIdentityConfig{
 						Audience: []string{"vault.io"},
 					},
@@ -352,7 +351,7 @@ func Test_jobImplicitIndentitiesHook_Mutate_vault(t *testing.T) {
 			},
 		},
 		{
-			name: "no mutation when vault identity is disabled",
+			name: "no mutation when no default identity is provided",
 			inputJob: &structs.Job{
 				TaskGroups: []*structs.TaskGroup{{
 					Tasks: []*structs.Task{{
@@ -361,34 +360,7 @@ func Test_jobImplicitIndentitiesHook_Mutate_vault(t *testing.T) {
 				}},
 			},
 			inputConfig: &Config{
-				VaultConfig: &config.VaultConfig{
-					UseIdentity: pointer.Of(false),
-					DefaultIdentity: &config.WorkloadIdentityConfig{
-						Audience: []string{"vault.io"},
-					},
-				},
-			},
-			expectedOutputJob: &structs.Job{
-				TaskGroups: []*structs.TaskGroup{{
-					Tasks: []*structs.Task{{
-						Vault: &structs.Vault{},
-					}},
-				}},
-			},
-		},
-		{
-			name: "no mutation when vault identity is enabled but no default identity is configured",
-			inputJob: &structs.Job{
-				TaskGroups: []*structs.TaskGroup{{
-					Tasks: []*structs.Task{{
-						Vault: &structs.Vault{},
-					}},
-				}},
-			},
-			inputConfig: &Config{
-				VaultConfig: &config.VaultConfig{
-					UseIdentity: pointer.Of(true),
-				},
+				VaultConfig: &config.VaultConfig{},
 			},
 			expectedOutputJob: &structs.Job{
 				TaskGroups: []*structs.TaskGroup{{
@@ -415,9 +387,8 @@ func Test_jobImplicitIndentitiesHook_Mutate_vault(t *testing.T) {
 			},
 			inputConfig: &Config{
 				VaultConfig: &config.VaultConfig{
-					UseIdentity: pointer.Of(true),
 					DefaultIdentity: &config.WorkloadIdentityConfig{
-						Audience: []string{"vault.io"},
+						Audience: []string{"vault-from-config.io"},
 					},
 				},
 			},
@@ -436,7 +407,7 @@ func Test_jobImplicitIndentitiesHook_Mutate_vault(t *testing.T) {
 			},
 		},
 		{
-			name: "mutate when task does not have a vault idenity",
+			name: "mutate when task does not have a vault identity",
 			inputJob: &structs.Job{
 				TaskGroups: []*structs.TaskGroup{{
 					Tasks: []*structs.Task{{
@@ -448,7 +419,6 @@ func Test_jobImplicitIndentitiesHook_Mutate_vault(t *testing.T) {
 			},
 			inputConfig: &Config{
 				VaultConfig: &config.VaultConfig{
-					UseIdentity: pointer.Of(true),
 					DefaultIdentity: &config.WorkloadIdentityConfig{
 						Audience: []string{"vault.io"},
 					},

--- a/nomad/structs/config/vault.go
+++ b/nomad/structs/config/vault.go
@@ -87,13 +87,6 @@ type VaultConfig struct {
 
 	// Servers-only fields.
 
-	// UseIdentity defines if workload identities should be used to derive
-	// Vault tokens.
-	//
-	// It is a transitional field used only during the adoption period of
-	// workload identities and will be ignored and removed in future versions.
-	UseIdentity *bool `mapstructure:"use_identity"`
-
 	// DefaultIdentity is the default workload identity configuration used when
 	// a job has a `vault` block but no `identity` named "vault_<name>", where
 	// <name> matches this block `name` parameter.
@@ -135,7 +128,6 @@ func DefaultVaultConfig() *VaultConfig {
 		Addr:                 "https://vault.service.consul:8200",
 		ConnectionRetryIntv:  DefaultVaultConnectRetryIntv,
 		AllowUnauthenticated: pointer.Of(true),
-		UseIdentity:          pointer.Of(false),
 	}
 }
 
@@ -191,8 +183,6 @@ func (c *VaultConfig) Merge(b *VaultConfig) *VaultConfig {
 	if b.TLSServerName != "" {
 		result.TLSServerName = b.TLSServerName
 	}
-
-	result.UseIdentity = pointer.Merge(result.UseIdentity, b.UseIdentity)
 
 	if result.DefaultIdentity == nil && b.DefaultIdentity != nil {
 		sID := *b.DefaultIdentity
@@ -298,9 +288,6 @@ func (c *VaultConfig) Equal(b *VaultConfig) bool {
 		return false
 	}
 
-	if !pointer.Eq(b.UseIdentity, c.UseIdentity) {
-		return false
-	}
 	if !c.DefaultIdentity.Equal(b.DefaultIdentity) {
 		return false
 	}

--- a/nomad/structs/config/vault_test.go
+++ b/nomad/structs/config/vault_test.go
@@ -29,7 +29,6 @@ func TestVaultConfig_Merge(t *testing.T) {
 		TLSKeyFile:           "1",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
-		UseIdentity:          pointer.Of(false),
 		DefaultIdentity:      nil,
 	}
 
@@ -46,7 +45,6 @@ func TestVaultConfig_Merge(t *testing.T) {
 		TLSKeyFile:           "2",
 		TLSSkipVerify:        nil,
 		TLSServerName:        "2",
-		UseIdentity:          pointer.Of(true),
 		DefaultIdentity: &WorkloadIdentityConfig{
 			Audience: []string{"vault.dev"},
 			Env:      pointer.Of(true),
@@ -67,7 +65,6 @@ func TestVaultConfig_Merge(t *testing.T) {
 		TLSKeyFile:           "2",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "2",
-		UseIdentity:          pointer.Of(true),
 		DefaultIdentity: &WorkloadIdentityConfig{
 			Audience: []string{"vault.dev"},
 			Env:      pointer.Of(true),
@@ -99,7 +96,6 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSKeyFile:           "1",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
-		UseIdentity:          pointer.Of(true),
 		DefaultIdentity: &WorkloadIdentityConfig{
 			Audience: []string{"vault.dev"},
 			Env:      pointer.Of(true),
@@ -122,7 +118,6 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSKeyFile:           "1",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
-		UseIdentity:          pointer.Of(true),
 		DefaultIdentity: &WorkloadIdentityConfig{
 			Audience: []string{"vault.dev"},
 			Env:      pointer.Of(true),
@@ -147,7 +142,6 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSKeyFile:           "1",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
-		UseIdentity:          pointer.Of(true),
 		DefaultIdentity: &WorkloadIdentityConfig{
 			Audience: []string{"vault.dev"},
 			Env:      pointer.Of(true),
@@ -170,7 +164,6 @@ func TestVaultConfig_Equals(t *testing.T) {
 		TLSKeyFile:           "1",
 		TLSSkipVerify:        pointer.Of(true),
 		TLSServerName:        "1",
-		UseIdentity:          pointer.Of(false),
 		DefaultIdentity: &WorkloadIdentityConfig{
 			Audience: []string{"vault.io"},
 			Env:      pointer.Of(false),

--- a/website/content/docs/configuration/vault.mdx
+++ b/website/content/docs/configuration/vault.mdx
@@ -28,7 +28,6 @@ information about the Vault integration.
 ```hcl
 vault {
   enabled      = true
-  use_identity = true
 
   default_identity {
     aud = ["vault.io"]
@@ -133,10 +132,6 @@ agents with [`client.enabled`] set to `true`.
 These parameters should only be defined in the configuration file of Nomad
 agents with [`server.enabled`] set to `true`.
 
-- `use_identity` `(bool: false)` - If set to `true`, Nomad uses workload
-  identities to generate Vault ACL tokens. If `false` the deprecated
-  token-based flow is used.
-
 - `default_identity` <code>([Identity](#default_identity-parameters): nil)</code> -
   Specifies the default workload identity configuration to use when a task with
   a `vault` block does not specify an [`identity`][jobspec_identity] block
@@ -237,9 +232,6 @@ vault {
   # Only needed in servers when transioning from the token-based flow to
   # workload identities.
   create_from_role = "nomad-cluster"
-
-  # Generate Vault tokens using workload identities.
-  use_identity = true
 
   # Provide a default workload identity configuration so jobs don't need to
   # specify one.


### PR DESCRIPTION
The initial intention behind the `vault.use_identity` configuration was to indicate to Nomad servers that they would need to sign a workload identities for allocs with a `vault` block.

But in order to support identity renewal, #18262 and #18431 moved the token signing logic to the alloc runner since a new token needs to be signed prior to the TTL expiring.

So #18343 implemented `use_identity` as a flag to indicate that the workload identity JWT flow should be used when deriving Vault tokens for tasks.

But this configuration value is set on servers so it is not available to clients at the time of token derivation, making its meaning not clear: a job may end up using the identity-based flow even when `use_identity` is `false`.

The only reliable signal available to clients at token derivation time is the presence of an `identity` block for Vault, and this is already configured with the `vault.default_identity` configuration block, making `vault.use_identity` redundant.

This commit removes the `vault.use_identity` configuration and simplifies the logic on when an implicit Vault identity is injected into tasks.

```mermaid
flowchart TD
	Start[Job Registered] --> HasVault{Task has vault block?}

    HasVault -->|No| HasVaultIdentityNoVault{Task has vault identity?}
    HasVault -->|Yes| HasVaultIdentityWithVault{Task has vault identity?}

    HasVaultIdentityNoVault -->|Yes| VaultNoIdentityWarn[Warn\nVault identity without vault block]
    HasVaultIdentityNoVault --> |No| NoVault[No Vault]
    VaultNoIdentityWarn --> NoVault

    HasVaultIdentityWithVault -->|Yes| WIDHasPolicies{Vault block has policies?}
    HasVaultIdentityWithVault -->|No| HasDefaultIdentity{Server has default_identity?}

    WIDHasPolicies -->|No| UseWID[Use workload identity]
    WIDHasPolicies -->|Yes| DeprecatePoliciesWarn[Warn\nUsing identity with policies]
    DeprecatePoliciesWarn --> UseWID
    
    HasDefaultIdentity -->|Yes| InjectDefaultIdentity[Inject default identity]
    InjectDefaultIdentity --> WIDHasPolicies
    HasDefaultIdentity -->|No| LegacyHasPolicies{Vault block has policies?}

    LegacyHasPolicies -->|Yes| UseLegacy[Use legacy flow]
    LegacyHasPolicies -->|No| MissingPoliciesError[Error\nLegacy flow without policies]
```