### PR TITLE
sids_hook: read tokens from consul_hook when available

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -142,12 +142,12 @@ func (tr *TaskRunner) initHooks() {
 		// with a consul token, indicating that Consul ACLs are enabled
 		if tr.clientConfig.ConsulConfig.Token != "" {
 			tr.runnerHooks = append(tr.runnerHooks, newSIDSHook(sidsHookConfig{
-				alloc:      tr.Alloc(),
-				task:       tr.Task(),
-				sidsClient: tr.siClient,
-				lifecycle:  tr,
-				logger:     hookLogger,
-				runner:     tr,
+				alloc:              tr.Alloc(),
+				task:               tr.Task(),
+				sidsClient:         tr.siClient,
+				lifecycle:          tr,
+				logger:             hookLogger,
+				allocHookResources: tr.allocHookResources,
 			}))
 		}
 

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -147,6 +147,7 @@ func (tr *TaskRunner) initHooks() {
 				sidsClient: tr.siClient,
 				lifecycle:  tr,
 				logger:     hookLogger,
+				runner:     tr,
 			}))
 		}
 

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -28,6 +28,7 @@ import (
 	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
 	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	cstate "github.com/hashicorp/nomad/client/state"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	ctestutil "github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/client/widmgr"
@@ -146,6 +147,7 @@ func testTaskRunnerConfig(t *testing.T, alloc *structs.Allocation, taskName stri
 		Getter:                getter.TestSandbox(t),
 		Wranglers:             proclib.MockWranglers(t),
 		WIDMgr:                widmgr.NewWIDMgr(widsigner, alloc, logger),
+		AllocHookResources:    cstructs.NewAllocHookResources(),
 	}
 
 	return conf, trCleanup


### PR DESCRIPTION
The `sids_hook` runs for Connect sidecar/gateway tasks and gets Consul Service Identity (SI) tokens for use by the Envoy bootstrap hook. When Workload Identity is being used with Consul, the `consul_hook` will have already added these tokens to the alloc hook resources. Update the `sids_hook` to use those tokens instead and write them to the expected area of the taskdir.