### PR TITLE
consul: allow `consul` block in task scope

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -714,6 +714,7 @@ type Task struct {
 	LogConfig       *LogConfig             `mapstructure:"logs" hcl:"logs,block"`
 	Artifacts       []*TaskArtifact        `hcl:"artifact,block"`
 	Vault           *Vault                 `hcl:"vault,block"`
+	Consul          *Consul                `hcl:"consul,block"`
 	Templates       []*Template            `hcl:"template,block"`
 	DispatchPayload *DispatchPayloadConfig `hcl:"dispatch_payload,block"`
 	VolumeMounts    []*VolumeMount         `hcl:"volume_mount,block"`
@@ -751,6 +752,9 @@ func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
 	}
 	if t.Vault != nil {
 		t.Vault.Canonicalize()
+	}
+	if t.Consul != nil {
+		t.Consul.Canonicalize()
 	}
 	for _, tmpl := range t.Templates {
 		tmpl.Canonicalize()

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -103,7 +103,7 @@ func (tr *TaskRunner) initHooks() {
 	}
 
 	// Get the consul namespace for the TG of the allocation.
-	consulNamespace := tr.alloc.ConsulNamespace()
+	consulNamespace := tr.alloc.ConsulNamespaceForTask(tr.taskName)
 
 	// Identify the service registration provider, which can differ from the
 	// Consul namespace depending on which provider is used.

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1302,6 +1302,10 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 		}
 	}
 
+	if apiTask.Consul != nil {
+		structsTask.Consul = apiConsulToStructs(apiTask.Consul)
+	}
+
 	if len(apiTask.Templates) > 0 {
 		structsTask.Templates = []*structs.Template{}
 		for _, template := range apiTask.Templates {

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -548,6 +548,12 @@ func (t *Task) Diff(other *Task, contextual bool) (*TaskDiff, error) {
 		diff.Objects = append(diff.Objects, vDiff)
 	}
 
+	// Consul diff
+	consulDiff := primitiveObjectDiff(t.Consul, other.Consul, nil, "Consul", contextual)
+	if consulDiff != nil {
+		diff.Objects = append(diff.Objects, consulDiff)
+	}
+
 	// Template diff
 	tmplDiffs := templateDiffs(t.Templates, other.Templates, contextual)
 	if tmplDiffs != nil {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7547,6 +7547,10 @@ type Task struct {
 	// have access to.
 	Vault *Vault
 
+	// Consul configuration specific to this task. If uset, falls back to the
+	// group's Consul field.
+	Consul *Consul
+
 	// Templates are the set of templates to be rendered for the task.
 	Templates []*Template
 
@@ -7684,6 +7688,7 @@ func (t *Task) Copy() *Task {
 	nt.CSIPluginConfig = nt.CSIPluginConfig.Copy()
 
 	nt.Vault = nt.Vault.Copy()
+	nt.Consul = nt.Consul.Copy()
 	nt.Resources = nt.Resources.Copy()
 	nt.LogConfig = nt.LogConfig.Copy()
 	nt.Meta = maps.Clone(nt.Meta)
@@ -10719,6 +10724,16 @@ func (a *Allocation) ReservedCores() *idset.Set[hw.CoreID] {
 // with this allocation.
 func (a *Allocation) ConsulNamespace() string {
 	return a.Job.LookupTaskGroup(a.TaskGroup).Consul.GetNamespace()
+}
+
+func (a *Allocation) ConsulNamespaceForTask(taskName string) string {
+	tg := a.Job.LookupTaskGroup(a.TaskGroup)
+	task := tg.LookupTask(taskName)
+	if task.Consul != nil {
+		return task.Consul.GetNamespace()
+	}
+
+	return tg.Consul.GetNamespace()
 }
 
 func (a *Allocation) JobNamespacedID() NamespacedID {


### PR DESCRIPTION
To support Workload Identity with Consul for templates, we want templates to be able to use the WI created at the task scope (either implicitly or set by the user). But to allow different tasks within a group to be assigned to different clusters as we're doing for Vault, we need to be able to set the `consul` block with its `cluster` field at the task level to override the group.