### PR TITLE
[ui] Bugfix: Wrap the passed path prop as a handlebars tag

### DIFF
--- a/.changelog/18598.txt
+++ b/.changelog/18598.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fix the job auto-linked variable path name when user lacks variable write permissions
+```

--- a/ui/app/components/editable-variable-link.hbs
+++ b/ui/app/components/editable-variable-link.hbs
@@ -13,5 +13,5 @@
     {{/if}}
   {{/with}}
 {{else}}
-  @path
+  {{@path}}
 {{/if}}


### PR DESCRIPTION
On the new /job/:jobid/variables page, we list variables that can be automatically read by the job in question.

In the event that the user does not have `write variable` access, we want to provide the name of the path, not as a link, so it can at least be known to them.

Without the wrapping `{{}}` brackets, this would always output the string "@path", instead of the desired passed path string.