### PR TITLE
services: get Consul token from hook resources

### DIFF
--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -129,6 +129,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 			alloc:             alloc,
 			providerNamespace: alloc.ServiceProviderNamespace(),
 			serviceRegWrapper: ar.serviceRegWrapper,
+			hookResources:     ar.hookResources,
 			restarter:         ar,
 			taskEnvBuilder:    newEnvBuilder(),
 			networkStatus:     ar,

--- a/client/allocrunner/group_service_hook_test.go
+++ b/client/allocrunner/group_service_hook_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
 	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/taskenv"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/pointer"
@@ -52,6 +53,7 @@ func TestGroupServiceHook_NoGroupServices(t *testing.T) {
 		restarter:         agentconsul.NoopRestarter(),
 		taskEnvBuilder:    taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region),
 		logger:            logger,
+		hookResources:     cstructs.NewAllocHookResources(),
 	})
 	must.NoError(t, h.Prerun())
 
@@ -93,6 +95,7 @@ func TestGroupServiceHook_ShutdownDelayUpdate(t *testing.T) {
 		restarter:         agentconsul.NoopRestarter(),
 		taskEnvBuilder:    taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region),
 		logger:            logger,
+		hookResources:     cstructs.NewAllocHookResources(),
 	})
 	must.NoError(t, h.Prerun())
 
@@ -134,6 +137,7 @@ func TestGroupServiceHook_GroupServices(t *testing.T) {
 		restarter:         agentconsul.NoopRestarter(),
 		taskEnvBuilder:    taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region),
 		logger:            logger,
+		hookResources:     cstructs.NewAllocHookResources(),
 	})
 	must.NoError(t, h.Prerun())
 
@@ -179,6 +183,7 @@ func TestGroupServiceHook_GroupServices_Nomad(t *testing.T) {
 		restarter:         agentconsul.NoopRestarter(),
 		taskEnvBuilder:    taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region),
 		logger:            logger,
+		hookResources:     cstructs.NewAllocHookResources(),
 	})
 	must.NoError(t, h.Prerun())
 
@@ -233,6 +238,7 @@ func TestGroupServiceHook_NoNetwork(t *testing.T) {
 		restarter:         agentconsul.NoopRestarter(),
 		taskEnvBuilder:    taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region),
 		logger:            logger,
+		hookResources:     cstructs.NewAllocHookResources(),
 	})
 	must.NoError(t, h.Prerun())
 
@@ -281,6 +287,7 @@ func TestGroupServiceHook_getWorkloadServices(t *testing.T) {
 		restarter:         agentconsul.NoopRestarter(),
 		taskEnvBuilder:    taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region),
 		logger:            logger,
+		hookResources:     cstructs.NewAllocHookResources(),
 	})
 
 	services := h.getWorkloadServicesLocked()

--- a/client/allocrunner/taskrunner/script_check_hook_test.go
+++ b/client/allocrunner/taskrunner/script_check_hook_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/nomad/client/serviceregistration"
 	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
 	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/taskenv"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -260,6 +261,7 @@ func TestScript_TaskEnvInterpolation(t *testing.T) {
 		task:              task,
 		serviceRegWrapper: regWrap,
 		logger:            logger,
+		hookResources:     cstructs.NewAllocHookResources(),
 	})
 	// emulate prestart having been fired
 	svcHook.taskEnv = env

--- a/client/allocrunner/taskrunner/service_hook_test.go
+++ b/client/allocrunner/taskrunner/service_hook_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
 	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/taskenv"
 	agentconsul "github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -43,6 +44,7 @@ func TestUpdate_beforePoststart(t *testing.T) {
 		task:              alloc.LookupTask("web"),
 		serviceRegWrapper: regWrap,
 		logger:            logger,
+		hookResources:     cstructs.NewAllocHookResources(),
 	})
 	require.NoError(t, hook.Update(context.Background(), &interfaces.TaskUpdateRequest{
 		Alloc:   alloc,
@@ -108,6 +110,7 @@ func Test_serviceHook_multipleDeRegisterCall(t *testing.T) {
 		task:              alloc.LookupTask("web"),
 		serviceRegWrapper: regWrap,
 		logger:            logger,
+		hookResources:     cstructs.NewAllocHookResources(),
 	})
 
 	// Interpolating workload services performs a check on the task env, if it
@@ -184,6 +187,7 @@ func Test_serviceHook_Nomad(t *testing.T) {
 		serviceRegWrapper: regWrapper,
 		restarter:         agentconsul.NoopRestarter(),
 		logger:            logger,
+		hookResources:     cstructs.NewAllocHookResources(),
 	})
 
 	// Create a taskEnv builder to use in requests, otherwise interpolation of

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -132,6 +132,7 @@ func (tr *TaskRunner) initHooks() {
 		providerNamespace: serviceProviderNamespace,
 		serviceRegWrapper: tr.serviceRegWrapper,
 		restarter:         tr,
+		hookResources:     tr.allocHookResources,
 		logger:            hookLogger,
 	}))
 

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -28,6 +28,7 @@ import (
 	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
 	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	cstate "github.com/hashicorp/nomad/client/state"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	ctestutil "github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/client/widmgr"
@@ -146,6 +147,7 @@ func testTaskRunnerConfig(t *testing.T, alloc *structs.Allocation, taskName stri
 		Getter:                getter.TestSandbox(t),
 		Wranglers:             proclib.MockWranglers(t),
 		WIDMgr:                widmgr.NewWIDMgr(widsigner, alloc, logger),
+		AllocHookResources:    cstructs.NewAllocHookResources(),
 	}
 
 	return conf, trCleanup

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -22,6 +22,7 @@ import (
 	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
 	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	"github.com/hashicorp/nomad/client/state"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -173,6 +174,7 @@ func TestConsul_Integration(t *testing.T) {
 		StartConditionMetCh: closedCh,
 		ServiceRegWrapper:   wrapper.NewHandlerWrapper(logger, serviceClient, regMock.NewServiceRegistrationHandler(logger)),
 		Wranglers:           proclib.MockWranglers(t),
+		AllocHookResources:  cstructs.NewAllocHookResources(),
 	}
 
 	tr, err := taskrunner.NewTaskRunner(config)


### PR DESCRIPTION
When Workload Identity is being used with Consul, the `consul_hook` will add Consul tokens to the alloc hook resources. Update the `group_service_hook` and `service_hook` to use those tokens when available for registering and deregistering Consul workloads.