### PR TITLE
client: prevent using stale allocs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2359,7 +2359,7 @@ OUTER:
 		//
 		// For full context, please see https://github.com/hashicorp/nomad/issues/18267
 		if resp.Index <= req.MinQueryIndex {
-			c.logger.Debug("Received stale allocation information. Retrying.",
+			c.logger.Debug("received stale allocation information; retrying",
 				"index", resp.Index, "min_index", req.MinQueryIndex)
 			continue OUTER
 		}

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -257,7 +257,7 @@ func (a *Alloc) GetAllocs(args *structs.AllocsGetRequest,
 				reply.Allocs = allocs
 				reply.Index = maxIndex
 			} else {
-				// Use the last index that affected the nodes table
+				// Use the last index that affected the allocs table
 				index, err := state.Index("allocs")
 				if err != nil {
 					return err


### PR DESCRIPTION
Similar to #18269, it is possible that even if Node.GetClientAllocs retrieves fresh allocs that the subsequent Alloc.GetAllocs call retrieves stale allocs. While [`diffAlloc(existing, updated)`](https://github.com/hashicorp/nomad/blob/v1.6.2/client/util.go#L27-L46) properly ignores stale alloc *updates*, alloc deletions have no such check.

So if a client retrieves an alloc created at index 123, and then a subsequent Alloc.GetAllocs call hits a new server which returns results at index 100, the client will stop the alloc created at 123 because it will be missing from the stale response.

This change applies the same logic as #18269 and ensures only fresh responses are used.

Glossary:
* fresh - modified at an index > the query index
* stale - modified at an index <= the query index