### PR TITLE
cli: use same offset when following single or multiple alloc logs.

### DIFF
--- a/.changelog/18604.txt
+++ b/.changelog/18604.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Use same offset when following single or multiple alloc logs
+```

--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -358,7 +358,7 @@ func (l *AllocLogsCommand) tailMultipleFiles(client *api.Client, alloc *api.Allo
 	defer close(cancel)
 
 	stdoutFrames, stdoutErrCh := client.AllocFS().Logs(
-		alloc, true, l.task, api.FSLogNameStdout, api.OriginEnd, 1, cancel, nil)
+		alloc, true, l.task, api.FSLogNameStdout, api.OriginEnd, 0, cancel, nil)
 
 	// Setting up the logs stream can fail, therefore we need to check the
 	// error channel before continuing further.
@@ -369,7 +369,7 @@ func (l *AllocLogsCommand) tailMultipleFiles(client *api.Client, alloc *api.Allo
 	}
 
 	stderrFrames, stderrErrCh := client.AllocFS().Logs(
-		alloc, true, l.task, api.FSLogNameStderr, api.OriginEnd, 1, cancel, nil)
+		alloc, true, l.task, api.FSLogNameStderr, api.OriginEnd, 0, cancel, nil)
 
 	// Setting up the logs stream can fail, therefore we need to check the
 	// error channel before continuing further.


### PR DESCRIPTION
closes #18550 