### PR TITLE
[ui] node eligibilty taken into consideration when clients list filtered to "ready"

### DIFF
--- a/.changelog/18607.txt
+++ b/.changelog/18607.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: change the State filter on clients page to split out eligibility and drain status
+```

--- a/ui/app/components/client-node-row.js
+++ b/ui/app/components/client-node-row.js
@@ -59,35 +59,29 @@ export default class ClientNodeRow extends Component.extend(
 
   @computed('node.compositeStatus')
   get nodeStatusColor() {
-    let compositeStatus = this.get('node.compositeStatus');
-
-    if (compositeStatus === 'draining') {
-      return 'neutral';
-    } else if (compositeStatus === 'ineligible') {
+    let status = this.get('node.status');
+    if (status === 'disconnected') {
       return 'warning';
-    } else if (compositeStatus === 'down') {
+    } else if (status === 'down') {
       return 'critical';
-    } else if (compositeStatus === 'ready') {
+    } else if (status === 'ready') {
       return 'success';
-    } else if (compositeStatus === 'initializing') {
+    } else if (status === 'initializing') {
       return 'neutral';
     } else {
       return 'neutral';
     }
   }
-  @computed('node.compositeStatus')
+  @computed('node.status')
   get nodeStatusIcon() {
-    let compositeStatus = this.get('node.compositeStatus');
-
-    if (compositeStatus === 'draining') {
-      return 'minus-circle';
-    } else if (compositeStatus === 'ineligible') {
+    let status = this.get('node.status');
+    if (status === 'disconnected') {
       return 'skip';
-    } else if (compositeStatus === 'down') {
+    } else if (status === 'down') {
       return 'x-circle';
-    } else if (compositeStatus === 'ready') {
+    } else if (status === 'ready') {
       return 'check-circle';
-    } else if (compositeStatus === 'initializing') {
+    } else if (status === 'initializing') {
       return 'entry-point';
     } else {
       return '';

--- a/ui/app/components/client-node-row.js
+++ b/ui/app/components/client-node-row.js
@@ -57,7 +57,7 @@ export default class ClientNodeRow extends Component.extend(
 
   @watchRelationship('allocations') watch;
 
-  @computed('node.compositeStatus')
+  @computed('node.status')
   get nodeStatusColor() {
     let status = this.get('node.status');
     if (status === 'disconnected') {

--- a/ui/app/controllers/clients/index.js
+++ b/ui/app/controllers/clients/index.js
@@ -237,6 +237,14 @@ export default class IndexController extends Controller.extend(
         return false;
       }
 
+      // Our state dropdown here is an amalgamation of "Status", "Eligibility",
+      // and "Drain Status" in order to simplify filtering options.
+      // While technically an ineligible node may have a state of "ready",
+      // the user's intent when selecting "ready" is probably to see nodes
+      // that are eligible to run jobs. As such, we filter out ineligible nodes
+      // when the user selects "ready".
+      if (statuses?.includes('ready') && !node.get('isEligible')) return false;
+
       if (onlyIneligible && node.get('isEligible')) return false;
       if (onlyDraining && !node.get('isDraining')) return false;
 

--- a/ui/app/controllers/clients/index.js
+++ b/ui/app/controllers/clients/index.js
@@ -123,6 +123,27 @@ export default class IndexController extends Controller.extend(
     ],
   };
 
+  @computed(
+    'state_initializing',
+    'state_ready',
+    'state_down',
+    'state_disconnected',
+    'eligibility_eligible',
+    'eligibility_ineligible',
+    'drain_status_draining',
+    'drain_status_not_draining'
+  )
+  get activeToggles() {
+    return this.allToggles.filter((t) => this[t.qp]);
+  }
+
+  get allToggles() {
+    return Object.values(this.clientFilterToggles).reduce(
+      (acc, filters) => acc.concat(filters),
+      []
+    );
+  }
+
   constructor() {
     super(...arguments);
     this.addDynamicQueryParams();

--- a/ui/app/controllers/clients/index.js
+++ b/ui/app/controllers/clients/index.js
@@ -62,7 +62,6 @@ export default class IndexController extends Controller.extend(
   ];
 
   filterFunc = (node) => {
-    console.log('--ff', node);
     return node.isEligible;
   };
 
@@ -143,6 +142,12 @@ export default class IndexController extends Controller.extend(
       (acc, filters) => acc.concat(filters),
       []
     );
+  }
+
+  // eslint-disable-next-line ember/classic-decorator-hooks
+  constructor() {
+    super(...arguments);
+    this.addDynamicQueryParams();
   }
 
   addDynamicQueryParams() {
@@ -348,6 +353,16 @@ export default class IndexController extends Controller.extend(
 
   setFacetQueryParam(queryParam, selection) {
     this.set(queryParam, serialize(selection));
+  }
+
+  @action
+  handleFilterChange(queryParamValue, option, queryParamLabel) {
+    if (queryParamValue.includes(option)) {
+      queryParamValue.removeObject(option);
+    } else {
+      queryParamValue.addObject(option);
+    }
+    this.set(queryParamLabel, serialize(queryParamValue));
   }
 
   @action

--- a/ui/app/controllers/clients/index.js
+++ b/ui/app/controllers/clients/index.js
@@ -131,7 +131,8 @@ export default class IndexController extends Controller.extend(
     'eligibility_eligible',
     'eligibility_ineligible',
     'drain_status_draining',
-    'drain_status_not_draining'
+    'drain_status_not_draining',
+    'allToggles.[]'
   )
   get activeToggles() {
     return this.allToggles.filter((t) => this[t.qp]);
@@ -142,11 +143,6 @@ export default class IndexController extends Controller.extend(
       (acc, filters) => acc.concat(filters),
       []
     );
-  }
-
-  constructor() {
-    super(...arguments);
-    this.addDynamicQueryParams();
   }
 
   addDynamicQueryParams() {
@@ -283,20 +279,21 @@ export default class IndexController extends Controller.extend(
   }
 
   @computed(
+    'clientFilterToggles',
+    'drain_status_draining',
+    'drain_status_not_draining',
+    'eligibility_eligible',
+    'eligibility_ineligible',
     'nodes.[]',
     'selectionClass',
     'selectionDatacenter',
     'selectionNodePool',
     'selectionVersion',
     'selectionVolume',
-    'state_initializing',
-    'state_ready',
-    'state_down',
     'state_disconnected',
-    'eligibility_eligible',
-    'eligibility_ineligible',
-    'drain_status_draining',
-    'drain_status_not_draining'
+    'state_down',
+    'state_initializing',
+    'state_ready'
   )
   get filteredNodes() {
     const {

--- a/ui/app/styles/core/table.scss
+++ b/ui/app/styles/core/table.scss
@@ -111,9 +111,6 @@
     }
 
     &.node-status-badges {
-      // display: grid;
-      // gap: 0.5rem;
-
       .hds-badge__text {
         white-space: nowrap;
       }

--- a/ui/app/styles/core/table.scss
+++ b/ui/app/styles/core/table.scss
@@ -110,6 +110,15 @@
       white-space: nowrap;
     }
 
+    &.node-status-badges {
+      // display: grid;
+      // gap: 0.5rem;
+
+      .hds-badge__text {
+        white-space: nowrap;
+      }
+    }
+
     &.is-narrow {
       padding: 1.25em 0 1.25em 0.5em;
 

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -20,7 +20,7 @@
       </div>
 
       <Hds::SegmentedGroup as |S|>
-        <S.Dropdown as |dd|>
+        <S.Dropdown data-test-state-facet as |dd|>
           <dd.ToggleButton
             @text="State"
             @color="secondary"
@@ -33,8 +33,9 @@
               @value={{option.label}}
               @count={{get (filter (action option.filter) this.nodes) "length"}}
               checked={{get this option.qp}}
+              data-test-dropdown-option={{option.label}}
             >
-              {{capitalize option.label}}
+              {{option.label}}
             </dd.Checkbox>
           {{/each}}
           <dd.Separator />
@@ -45,8 +46,9 @@
               @value={{option.label}}
               @count={{get (filter (action option.filter) this.nodes) "length"}}
               checked={{get this option.qp}}
+              data-test-dropdown-option={{option.label}}
             >
-              {{capitalize option.label}}
+              {{option.label}}
             </dd.Checkbox>
           {{/each}}
           <dd.Separator />
@@ -57,15 +59,15 @@
               @value={{option.label}}
               @count={{get (filter (action option.filter) this.nodes) "length"}}
               checked={{get this option.qp}}
+              data-test-dropdown-option={{option.label}}
             >
-              {{capitalize option.label}}
+              {{option.label}}
             </dd.Checkbox>
           {{/each}}
         </S.Dropdown>
 
-        <S.Dropdown as |dd|>
+        <S.Dropdown data-test-node-pool-facet as |dd|>
           <dd.ToggleButton
-            data-test-node-pool-facet
             @text="Node Pool"
             @color="secondary"
             @badge={{or this.selectionNodePool.length false}}
@@ -80,6 +82,7 @@
               @value={{option.label}}
               checked={{includes option.label this.selectionNodePool}}
               @count={{get (filter-by 'nodePool' option.label this.nodes) "length"}}
+              data-test-dropdown-option={{option.label}}
             >
               {{option.label}}
             </dd.Checkbox>
@@ -90,9 +93,8 @@
           {{/each}}
         </S.Dropdown>
 
-        <S.Dropdown as |dd|>
+        <S.Dropdown data-test-class-facet as |dd|>
           <dd.ToggleButton
-            data-test-class-facet
             @text="Class"
             @color="secondary"
             @badge={{or this.selectionClass.length false}}
@@ -107,6 +109,7 @@
               @value={{option.label}}
               checked={{includes option.label this.selectionClass}}
               @count={{get (filter-by 'nodeClass' option.label this.nodes) "length"}}
+              data-test-dropdown-option={{option.label}}
             >
               {{option.label}}
             </dd.Checkbox>
@@ -117,9 +120,8 @@
           {{/each}}
         </S.Dropdown>
 
-        <S.Dropdown as |dd|>
+        <S.Dropdown data-test-datacenter-facet as |dd|>
           <dd.ToggleButton
-            data-test-datacenter-facet
             @text="Datacenter"
             @color="secondary"
             @badge={{or this.selectionDatacenter.length false}}
@@ -134,6 +136,7 @@
               @value={{option.label}}
               checked={{includes option.label this.selectionDatacenter}}
               @count={{get (filter-by 'datacenter' option.label this.nodes) "length"}}
+              data-test-dropdown-option={{option.label}}
             >
               {{option.label}}
             </dd.Checkbox>
@@ -145,9 +148,8 @@
 
         </S.Dropdown>
 
-        <S.Dropdown as |dd|>
+        <S.Dropdown data-test-version-facet as |dd|>
           <dd.ToggleButton
-            data-test-version-facet
             @text="Version"
             @color="secondary"
             @badge={{or this.selectionVersion.length false}}
@@ -162,6 +164,7 @@
               @value={{option.label}}
               checked={{includes option.label this.selectionVersion}}
               @count={{get (filter-by 'version' option.label this.nodes) "length"}}
+              data-test-dropdown-option={{option.label}}
             >
               {{option.label}}
             </dd.Checkbox>
@@ -172,9 +175,8 @@
           {{/each}}
         </S.Dropdown>
 
-        <S.Dropdown as |dd|>
+        <S.Dropdown data-test-volume-facet as |dd|>
           <dd.ToggleButton
-            data-test-volume-facet
             @text="Volume"
             @color="secondary"
             @badge={{or this.selectionVolume.length false}}
@@ -189,6 +191,7 @@
               @value={{option.label}}
               checked={{includes option.label this.selectionVolume}}
               @count={{get (filter-by 'volume' option.label this.nodes) "length"}}
+              data-test-dropdown-option={{option.label}}
             >
               {{option.label}}
             </dd.Checkbox>
@@ -221,7 +224,7 @@
               @class="is-200px is-truncatable"
               @prop="name"
             >Name</t.sort-by>
-            <t.sort-by @prop="compositeStatus">State</t.sort-by>
+            <t.sort-by @prop="status">State</t.sort-by>
             <th class="is-200px is-truncatable">Address</th>
             <t.sort-by @prop="nodePool">Node Pool</t.sort-by>
             <t.sort-by @prop="datacenter">Datacenter</t.sort-by>

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 {{page-title "Clients"}}
-<section class="section" {{did-insert (action this.addDynamicQueryParams)}}>
+<section class="section">
   {{#if this.isForbidden}}
     <ForbiddenMessage />
   {{else}}
@@ -22,7 +22,6 @@
       <Hds::SegmentedGroup as |S|>
         <S.Dropdown as |dd|>
           <dd.ToggleButton
-            class="solo-badge-button"
             @text="State"
             @color="secondary"
             @badge={{if (eq this.activeToggles.length this.allToggles.length) false this.activeToggles.length}}
@@ -63,41 +62,142 @@
             </dd.Checkbox>
           {{/each}}
         </S.Dropdown>
-        <MultiSelectDropdown
-          data-test-node-pool-facet
-          @label="Node Pool"
-          @options={{this.optionsNodePool}}
-          @selection={{this.selectionNodePool}}
-          @onSelect={{action this.setFacetQueryParam "qpNodePool"}}
-        />
-        <MultiSelectDropdown
-          data-test-class-facet
-          @label="Class"
-          @options={{this.optionsClass}}
-          @selection={{this.selectionClass}}
-          @onSelect={{action this.setFacetQueryParam "qpClass"}}
-        />
-          <MultiSelectDropdown
+
+        <S.Dropdown as |dd|>
+          <dd.ToggleButton
+            data-test-node-pool-facet
+            @text="Node Pool"
+            @color="secondary"
+            @badge={{or this.selectionNodePool.length false}}
+          />
+          {{#each this.optionsNodePool key="label" as |option|}}
+            <dd.Checkbox
+              {{on "change" (action this.handleFilterChange
+                this.selectionNodePool
+                option.label
+                "qpNodePool"
+              )}}
+              @value={{option.label}}
+              checked={{includes option.label this.selectionNodePool}}
+              @count={{get (filter-by 'nodePool' option.label this.nodes) "length"}}
+            >
+              {{option.label}}
+            </dd.Checkbox>
+          {{else}}
+            <dd.Generic data-test-dropdown-empty>
+              No Node Pool filters
+            </dd.Generic>
+          {{/each}}
+        </S.Dropdown>
+
+        <S.Dropdown as |dd|>
+          <dd.ToggleButton
+            data-test-class-facet
+            @text="Class"
+            @color="secondary"
+            @badge={{or this.selectionClass.length false}}
+          />
+          {{#each this.optionsClass key="label" as |option|}}
+            <dd.Checkbox
+              {{on "change" (action this.handleFilterChange
+                this.selectionClass
+                option.label
+                "qpClass"
+              )}}
+              @value={{option.label}}
+              checked={{includes option.label this.selectionClass}}
+              @count={{get (filter-by 'nodeClass' option.label this.nodes) "length"}}
+            >
+              {{option.label}}
+            </dd.Checkbox>
+          {{else}}
+            <dd.Generic data-test-dropdown-empty>
+              No Class filters
+            </dd.Generic>
+          {{/each}}
+        </S.Dropdown>
+
+        <S.Dropdown as |dd|>
+          <dd.ToggleButton
             data-test-datacenter-facet
-            @label="Datacenter"
-            @options={{this.optionsDatacenter}}
-            @selection={{this.selectionDatacenter}}
-            @onSelect={{action this.setFacetQueryParam "qpDatacenter"}}
+            @text="Datacenter"
+            @color="secondary"
+            @badge={{or this.selectionDatacenter.length false}}
           />
-          <MultiSelectDropdown
+          {{#each this.optionsDatacenter key="label" as |option|}}
+            <dd.Checkbox
+              {{on "change" (action this.handleFilterChange
+                this.selectionDatacenter
+                option.label
+                "qpDatacenter"
+              )}}
+              @value={{option.label}}
+              checked={{includes option.label this.selectionDatacenter}}
+              @count={{get (filter-by 'datacenter' option.label this.nodes) "length"}}
+            >
+              {{option.label}}
+            </dd.Checkbox>
+          {{else}}
+            <dd.Generic data-test-dropdown-empty>
+              No Datacenter filters
+            </dd.Generic>
+          {{/each}}
+
+        </S.Dropdown>
+
+        <S.Dropdown as |dd|>
+          <dd.ToggleButton
             data-test-version-facet
-            @label="Version"
-            @options={{this.optionsVersion}}
-            @selection={{this.selectionVersion}}
-            @onSelect={{action this.setFacetQueryParam "qpVersion"}}
+            @text="Version"
+            @color="secondary"
+            @badge={{or this.selectionVersion.length false}}
           />
-          <MultiSelectDropdown
+          {{#each this.optionsVersion key="label" as |option|}}
+            <dd.Checkbox
+              {{on "change" (action this.handleFilterChange
+                this.selectionVersion
+                option.label
+                "qpVersion"
+              )}}
+              @value={{option.label}}
+              checked={{includes option.label this.selectionVersion}}
+              @count={{get (filter-by 'version' option.label this.nodes) "length"}}
+            >
+              {{option.label}}
+            </dd.Checkbox>
+          {{else}}
+            <dd.Generic data-test-dropdown-empty>
+              No Version filters
+            </dd.Generic>
+          {{/each}}
+        </S.Dropdown>
+
+        <S.Dropdown as |dd|>
+          <dd.ToggleButton
             data-test-volume-facet
-            @label="Volume"
-            @options={{this.optionsVolume}}
-            @selection={{this.selectionVolume}}
-            @onSelect={{action this.setFacetQueryParam "qpVolume"}}
+            @text="Volume"
+            @color="secondary"
+            @badge={{or this.selectionVolume.length false}}
           />
+          {{#each this.optionsVolume key="label" as |option|}}
+            <dd.Checkbox
+              {{on "change" (action this.handleFilterChange
+                this.selectionVolume
+                option.label
+                "qpVolume"
+              )}}
+              @value={{option.label}}
+              checked={{includes option.label this.selectionVolume}}
+              @count={{get (filter-by 'volume' option.label this.nodes) "length"}}
+            >
+              {{option.label}}
+            </dd.Checkbox>
+          {{else}}
+            <dd.Generic data-test-dropdown-empty>
+              No Volume filters
+            </dd.Generic>
+          {{/each}}
+        </S.Dropdown>
       </Hds::SegmentedGroup>
     </div>
     {{#if this.sortedNodes}}

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -20,13 +20,45 @@
       </div>
       <div class="toolbar-item is-right-aligned is-mobile-full-width">
         <div class="button-bar">
-          <MultiSelectDropdown
-            data-test-state-facet
-            @label="State"
-            @options={{this.optionsState}}
-            @selection={{this.selectionState}}
-            @onSelect={{action this.setFacetQueryParam "qpState"}}
-          />
+          <Hds::Dropdown as |dd|>
+            <dd.ToggleButton @text="State" @color="secondary" />
+            <dd.Title @text="Status" />
+            {{#each this.clientFilterToggles.state as |option|}}
+              <dd.Checkbox
+                {{on "change" (toggle option.qp this)}}
+                @value={{option.label}}
+                @count={{get (filter (action option.filter) this.nodes) "length"}}
+                checked={{get this option.qp}}
+              >
+                {{capitalize option.label}}
+              </dd.Checkbox>
+            {{/each}}
+            <dd.Separator />
+            <dd.Title @text="Eligibility" />
+            {{#each this.clientFilterToggles.eligibility as |option|}}
+              <dd.Checkbox
+                {{on "change" (toggle option.qp this)}}
+                @value={{option.label}}
+                @count={{get (filter (action option.filter) this.nodes) "length"}}
+                checked={{get this option.qp}}
+              >
+                {{capitalize option.label}}
+              </dd.Checkbox>
+            {{/each}}
+            <dd.Separator />
+            <dd.Title @text="Drain Status" />
+            {{#each this.clientFilterToggles.drainStatus as |option|}}
+              <dd.Checkbox
+                {{on "change" (toggle option.qp this)}}
+                @value={{option.label}}
+                @count={{get (filter (action option.filter) this.nodes) "length"}}
+                checked={{get this option.qp}}
+              >
+                {{capitalize option.label}}
+              </dd.Checkbox>
+            {{/each}}
+          </Hds::Dropdown>
+
           <MultiSelectDropdown
             data-test-node-pool-facet
             @label="Node Pool"

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -21,7 +21,9 @@
       <div class="toolbar-item is-right-aligned is-mobile-full-width">
         <div class="button-bar">
           <Hds::Dropdown as |dd|>
-            <dd.ToggleButton @text="State" @color="secondary" @badge="{{this.activeToggles.length}} / {{this.allToggles.length}}" />
+            <dd.ToggleButton @text="State" @color="secondary"
+            @badgeIcon="filter-circle"
+            />
             <dd.Title @text="Status" />
             {{#each this.clientFilterToggles.state as |option|}}
               <dd.Checkbox

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 {{page-title "Clients"}}
-<section class="section">
+<section class="section" {{did-insert (action this.addDynamicQueryParams)}}>
   {{#if this.isForbidden}}
     <ForbiddenMessage />
   {{else}}
@@ -18,63 +18,65 @@
           />
         {{/if}}
       </div>
-      <div class="toolbar-item is-right-aligned is-mobile-full-width">
-        <div class="button-bar">
-          <Hds::Dropdown as |dd|>
-            <dd.ToggleButton @text="State" @color="secondary"
-            @badgeIcon="filter-circle"
-            />
-            <dd.Title @text="Status" />
-            {{#each this.clientFilterToggles.state as |option|}}
-              <dd.Checkbox
-                {{on "change" (toggle option.qp this)}}
-                @value={{option.label}}
-                @count={{get (filter (action option.filter) this.nodes) "length"}}
-                checked={{get this option.qp}}
-              >
-                {{capitalize option.label}}
-              </dd.Checkbox>
-            {{/each}}
-            <dd.Separator />
-            <dd.Title @text="Eligibility" />
-            {{#each this.clientFilterToggles.eligibility as |option|}}
-              <dd.Checkbox
-                {{on "change" (toggle option.qp this)}}
-                @value={{option.label}}
-                @count={{get (filter (action option.filter) this.nodes) "length"}}
-                checked={{get this option.qp}}
-              >
-                {{capitalize option.label}}
-              </dd.Checkbox>
-            {{/each}}
-            <dd.Separator />
-            <dd.Title @text="Drain Status" />
-            {{#each this.clientFilterToggles.drainStatus as |option|}}
-              <dd.Checkbox
-                {{on "change" (toggle option.qp this)}}
-                @value={{option.label}}
-                @count={{get (filter (action option.filter) this.nodes) "length"}}
-                checked={{get this option.qp}}
-              >
-                {{capitalize option.label}}
-              </dd.Checkbox>
-            {{/each}}
-          </Hds::Dropdown>
 
-          <MultiSelectDropdown
-            data-test-node-pool-facet
-            @label="Node Pool"
-            @options={{this.optionsNodePool}}
-            @selection={{this.selectionNodePool}}
-            @onSelect={{action this.setFacetQueryParam "qpNodePool"}}
+      <Hds::SegmentedGroup as |S|>
+        <S.Dropdown as |dd|>
+          <dd.ToggleButton
+            class="solo-badge-button"
+            @text="State"
+            @color="secondary"
+            @badge={{if (eq this.activeToggles.length this.allToggles.length) false this.activeToggles.length}}
           />
-          <MultiSelectDropdown
-            data-test-class-facet
-            @label="Class"
-            @options={{this.optionsClass}}
-            @selection={{this.selectionClass}}
-            @onSelect={{action this.setFacetQueryParam "qpClass"}}
-          />
+          <dd.Title @text="Status" />
+          {{#each this.clientFilterToggles.state as |option|}}
+            <dd.Checkbox
+              {{on "change" (toggle option.qp this)}}
+              @value={{option.label}}
+              @count={{get (filter (action option.filter) this.nodes) "length"}}
+              checked={{get this option.qp}}
+            >
+              {{capitalize option.label}}
+            </dd.Checkbox>
+          {{/each}}
+          <dd.Separator />
+          <dd.Title @text="Eligibility" />
+          {{#each this.clientFilterToggles.eligibility as |option|}}
+            <dd.Checkbox
+              {{on "change" (toggle option.qp this)}}
+              @value={{option.label}}
+              @count={{get (filter (action option.filter) this.nodes) "length"}}
+              checked={{get this option.qp}}
+            >
+              {{capitalize option.label}}
+            </dd.Checkbox>
+          {{/each}}
+          <dd.Separator />
+          <dd.Title @text="Drain Status" />
+          {{#each this.clientFilterToggles.drainStatus as |option|}}
+            <dd.Checkbox
+              {{on "change" (toggle option.qp this)}}
+              @value={{option.label}}
+              @count={{get (filter (action option.filter) this.nodes) "length"}}
+              checked={{get this option.qp}}
+            >
+              {{capitalize option.label}}
+            </dd.Checkbox>
+          {{/each}}
+        </S.Dropdown>
+        <MultiSelectDropdown
+          data-test-node-pool-facet
+          @label="Node Pool"
+          @options={{this.optionsNodePool}}
+          @selection={{this.selectionNodePool}}
+          @onSelect={{action this.setFacetQueryParam "qpNodePool"}}
+        />
+        <MultiSelectDropdown
+          data-test-class-facet
+          @label="Class"
+          @options={{this.optionsClass}}
+          @selection={{this.selectionClass}}
+          @onSelect={{action this.setFacetQueryParam "qpClass"}}
+        />
           <MultiSelectDropdown
             data-test-datacenter-facet
             @label="Datacenter"
@@ -96,8 +98,7 @@
             @selection={{this.selectionVolume}}
             @onSelect={{action this.setFacetQueryParam "qpVolume"}}
           />
-        </div>
-      </div>
+      </Hds::SegmentedGroup>
     </div>
     {{#if this.sortedNodes}}
       <ListPagination

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -35,7 +35,7 @@
               checked={{get this option.qp}}
               data-test-dropdown-option={{option.label}}
             >
-              {{option.label}}
+              {{capitalize option.label}}
             </dd.Checkbox>
           {{/each}}
           <dd.Separator />
@@ -48,7 +48,7 @@
               checked={{get this option.qp}}
               data-test-dropdown-option={{option.label}}
             >
-              {{option.label}}
+              {{capitalize option.label}}
             </dd.Checkbox>
           {{/each}}
           <dd.Separator />
@@ -61,7 +61,7 @@
               checked={{get this option.qp}}
               data-test-dropdown-option={{option.label}}
             >
-              {{option.label}}
+              {{capitalize option.label}}
             </dd.Checkbox>
           {{/each}}
         </S.Dropdown>

--- a/ui/app/templates/clients/index.hbs
+++ b/ui/app/templates/clients/index.hbs
@@ -21,7 +21,7 @@
       <div class="toolbar-item is-right-aligned is-mobile-full-width">
         <div class="button-bar">
           <Hds::Dropdown as |dd|>
-            <dd.ToggleButton @text="State" @color="secondary" />
+            <dd.ToggleButton @text="State" @color="secondary" @badge="{{this.activeToggles.length}} / {{this.allToggles.length}}" />
             <dd.Title @text="Status" />
             {{#each this.clientFilterToggles.state as |option|}}
               <dd.Checkbox

--- a/ui/app/templates/components/client-node-row.hbs
+++ b/ui/app/templates/components/client-node-row.hbs
@@ -12,28 +12,24 @@
 </td>
 <td data-test-client-id><LinkTo @route="clients.client" @model={{this.node.id}} class="is-primary">{{this.node.shortId}}</LinkTo></td>
 <td data-test-client-name class="is-200px is-truncatable" title="{{this.node.name}}">{{this.node.name}}</td>
-<td data-test-client-composite-status>
-  <span class="tooltip" aria-label="{{this.node.status}} / {{if this.node.isDraining "draining" "not draining"}} / {{if this.node.isEligible "eligible" "not eligible"}}">
-  </span>
+<td class="node-status-badges" data-test-client-composite-status>
   <Hds::Badge
-    @text={{capitalize this.node.compositeStatus}}
+    @text={{capitalize this.node.status}}
     @icon={{this.nodeStatusIcon}}
     @color={{this.nodeStatusColor}}
-    @size="large"
+    @size="small"
   />
 
   {{#if this.node.isEligible}}
     <Hds::Badge
       @text="Eligible"
-      @icon="check-circle"
-      @color="success"
+      @color="neutral"
       @size="small"
     />
   {{else}}
     <Hds::Badge
       @text="Ineligible"
-      @icon="skip"
-      @color="warning"
+      @color="neutral"
       @size="small"
     />
   {{/if}}
@@ -41,15 +37,13 @@
   {{#if this.node.isDraining}}
     <Hds::Badge
       @text="Draining"
-      @icon="minus-circle"
-      @color="warning"
+      @color="neutral"
       @size="small"
     />
   {{else}}
     <Hds::Badge
       @text="Not Draining"
-      @icon="skip"
-      @color="success"
+      @color="neutral"
       @size="small"
     />
   {{/if}}

--- a/ui/app/templates/components/client-node-row.hbs
+++ b/ui/app/templates/components/client-node-row.hbs
@@ -14,13 +14,45 @@
 <td data-test-client-name class="is-200px is-truncatable" title="{{this.node.name}}">{{this.node.name}}</td>
 <td data-test-client-composite-status>
   <span class="tooltip" aria-label="{{this.node.status}} / {{if this.node.isDraining "draining" "not draining"}} / {{if this.node.isEligible "eligible" "not eligible"}}">
-    <Hds::Badge
-      @text={{capitalize this.node.compositeStatus}}
-      @icon={{this.nodeStatusIcon}}
-      @color={{this.nodeStatusColor}}
-      @size="large"
-    />
   </span>
+  <Hds::Badge
+    @text={{capitalize this.node.compositeStatus}}
+    @icon={{this.nodeStatusIcon}}
+    @color={{this.nodeStatusColor}}
+    @size="large"
+  />
+
+  {{#if this.node.isEligible}}
+    <Hds::Badge
+      @text="Eligible"
+      @icon="check-circle"
+      @color="success"
+      @size="small"
+    />
+  {{else}}
+    <Hds::Badge
+      @text="Ineligible"
+      @icon="skip"
+      @color="warning"
+      @size="small"
+    />
+  {{/if}}
+
+  {{#if this.node.isDraining}}
+    <Hds::Badge
+      @text="Draining"
+      @icon="minus-circle"
+      @color="warning"
+      @size="small"
+    />
+  {{else}}
+    <Hds::Badge
+      @text="Not Draining"
+      @icon="skip"
+      @color="success"
+      @size="small"
+    />
+  {{/if}}
 </td>
 <td data-test-client-address class="is-200px is-truncatable">{{this.node.httpAddr}}</td>
 <td data-test-client-node-pool title="{{this.node.nodePool}}">

--- a/ui/tests/pages/clients/list.js
+++ b/ui/tests/pages/clients/list.js
@@ -16,8 +16,23 @@ import {
   visitable,
 } from 'ember-cli-page-object';
 
-import { multiFacet } from 'nomad-ui/tests/pages/components/facet';
 import pageSizeSelect from 'nomad-ui/tests/pages/components/page-size-select';
+
+const heliosFacet = (scope) => ({
+  scope,
+  toggle: clickable('button'),
+  options: collection(
+    '.hds-menu-primitive__content .hds-dropdown__content .hds-dropdown__list .hds-dropdown-list-item--variant-checkbox',
+    {
+      toggle: clickable('label'),
+      count: text('label .hds-dropdown-list-item__count'),
+      key: attribute(
+        'data-test-dropdown-option',
+        '[data-test-dropdown-option]'
+      ),
+    }
+  ),
+});
 
 export default create({
   pageSize: 25,
@@ -77,11 +92,11 @@ export default create({
   },
 
   facets: {
-    nodePools: multiFacet('[data-test-node-pool-facet]'),
-    class: multiFacet('[data-test-class-facet]'),
-    state: multiFacet('[data-test-state-facet]'),
-    datacenter: multiFacet('[data-test-datacenter-facet]'),
-    version: multiFacet('[data-test-version-facet]'),
-    volume: multiFacet('[data-test-volume-facet]'),
+    nodePools: heliosFacet('[data-test-node-pool-facet]'),
+    class: heliosFacet('[data-test-class-facet]'),
+    state: heliosFacet('[data-test-state-facet]'),
+    datacenter: heliosFacet('[data-test-datacenter-facet]'),
+    version: heliosFacet('[data-test-version-facet]'),
+    volume: heliosFacet('[data-test-volume-facet]'),
   },
 });


### PR DESCRIPTION
On our clients list page, we abstract node readiness, eligibility, and draining status into one `State` filter.

This leads to situations where a user selects "Ready" and expects to see eligible nodes, but a node can technically be "ready" by status and marked ineligible for new tasks.

This seems confusing with the abstraction in place. As such, selecting "Ready" will not filter out any ineligible nodes.

In resolving this, we've made some updates to the way the State filter works, relative to the others:
- It is an "inclusive" filter, with all options selected by default (others are exclusive until something is clicked)
- query parameters from it are individually appended to the URL, where in other dropdowns a stringified array of all checked options is appended
- it includes subsections for Status, Eligibility, and Drain status, where others are single-subject filters.

We realize this creates an inconsistency, but felt like this represents a practical approach to making state filter behaviour here work as expected.

<img width="1194" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/ea0eeeb5-98a6-424c-9d31-f4b94e5df408">



Resolves #18593 