### PR TITLE
server: Add reporting configuration to  nomad server

### DIFF
--- a/ci/test-core.json
+++ b/ci/test-core.json
@@ -36,6 +36,7 @@
     "lib/...",
     "nomad/deploymentwatcher/...",
     "nomad/drainer/...",
+    "nomad/reporting/...",
     "nomad/lock/...",
     "nomad/state/...",
     "nomad/stream/...",

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -601,6 +601,8 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	}
 	conf.JobMaxSourceSize = int(jobMaxSourceBytes)
 
+	conf.Reporting = agentConfig.Reporting
+
 	return conf, nil
 }
 

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -429,6 +429,8 @@ type Config struct {
 
 	// JobTrackedVersions is the number of historic Job versions that are kept.
 	JobTrackedVersions int
+
+	Reporting *config.ReportingConfig
 }
 
 func (c *Config) Copy() *Config {

--- a/nomad/reporting/reporting_ce.go
+++ b/nomad/reporting/reporting_ce.go
@@ -1,0 +1,9 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+
+package reporting
+
+type Manager struct {
+}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/nomad/volumewatcher"
+	"github.com/hashicorp/nomad/reporting"
 	"github.com/hashicorp/nomad/scheduler"
 )
 
@@ -289,6 +290,10 @@ type Server struct {
 	// statsFetcher is used by autopilot to check the status of the other
 	// Nomad router.
 	statsFetcher *StatsFetcher
+
+	// reportingManager is used to configure and handle all the license reporting
+	// dependencies.
+	reportingManager *reporting.Manager
 
 	// EnterpriseState is used to fill in state for Pro/Ent builds
 	EnterpriseState

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -42,11 +42,11 @@ import (
 	"github.com/hashicorp/nomad/nomad/deploymentwatcher"
 	"github.com/hashicorp/nomad/nomad/drainer"
 	"github.com/hashicorp/nomad/nomad/lock"
+	"github.com/hashicorp/nomad/nomad/reporting"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/nomad/volumewatcher"
-	"github.com/hashicorp/nomad/reporting"
 	"github.com/hashicorp/nomad/scheduler"
 )
 


### PR DESCRIPTION
To continue with the licensing reporting, the configuration needs to be passed down to the server who will in turn be responsable for the metrics. This PR adds the a reporting manager that will only be populated and used on the enterprise version.

Related: [#1106](https://github.com/hashicorp/nomad-enterprise/issues/1106)