### PR TITLE
WI: WIDMgr should expose default identity signatures

### DIFF
--- a/client/widmgr/widmgr.go
+++ b/client/widmgr/widmgr.go
@@ -233,7 +233,6 @@ func (m *WIDMgr) getIdentities() error {
 	}
 
 	// Index initial workload identities by name
-	m.lastToken = make(map[cstructs.TaskIdentity]*structs.SignedWorkloadIdentity, len(signedWIDs))
 	for _, swid := range signedWIDs {
 		id := cstructs.TaskIdentity{
 			TaskName:     swid.TaskName,

--- a/client/widmgr/widmgr.go
+++ b/client/widmgr/widmgr.go
@@ -232,6 +232,11 @@ func (m *WIDMgr) getIdentities() error {
 		return err
 	}
 
+	// Store default identity tokens
+	for id, token := range defaultTokens {
+		m.lastToken[id] = token
+	}
+
 	// Index initial workload identities by name
 	for _, swid := range signedWIDs {
 		id := cstructs.TaskIdentity{
@@ -240,10 +245,6 @@ func (m *WIDMgr) getIdentities() error {
 		}
 
 		m.lastToken[id] = swid
-	}
-	// Store default identity tokens
-	for id, token := range defaultTokens {
-		m.lastToken[id] = token
 	}
 
 	// TODO: Persist signed identity token to client state


### PR DESCRIPTION
Since the `identity_hook` is meant to be the central place that makes signed identities available to other hooks, it should also expose the `default` identity that is signed by the plan applier. 

Ref: https://github.com/hashicorp/team-nomad/issues/404