### PR TITLE
client: prevent watching stale alloc state

### DIFF
--- a/client/allocwatcher/alloc_watcher.go
+++ b/client/allocwatcher/alloc_watcher.go
@@ -384,7 +384,8 @@ func (p *remotePrevAlloc) Wait(ctx context.Context) error {
 			}
 		}
 
-		if req.AllowStale && resp.Index <= req.MinQueryIndex {
+		// Ensure that we didn't receive a stale response
+		if req.AllowStale && resp.Index < req.MinQueryIndex {
 			retry := getRemoteRetryIntv + helper.RandomStagger(getRemoteRetryIntv)
 			p.logger.Warn("received stale alloc; retrying",
 				"req_index", req.MinQueryIndex,

--- a/client/client.go
+++ b/client/client.go
@@ -2423,6 +2423,7 @@ OUTER:
 			// Node.GetClientAllocs which returns older results.
 			if allocsResp.Index <= allocsReq.MinQueryIndex {
 				retry := c.retryIntv(getAllocRetryIntv)
+				timer, stop := helper.NewSafeTimer(retry)
 				c.logger.Warn("failed to retrieve updated allocs; retrying",
 					"req_index", allocsReq.MinQueryIndex,
 					"resp_index", allocsResp.Index,
@@ -2430,9 +2431,10 @@ OUTER:
 					"wait", retry,
 				)
 				select {
-				case <-time.After(retry):
+				case <-timer.C:
 					continue
 				case <-c.shutdownCh:
+					stop()
 					return
 				}
 			}


### PR DESCRIPTION
When waiting on a previous alloc we must query against the leader before switching to a stale query with index set.

Also check to ensure the response is fresh before using it like #18269