### PR TITLE
[ui] bugfix: when hitting the "start" button on a job page, if it has no submission data, fallback to raw json definition

### DIFF
--- a/.changelog/18621.txt
+++ b/.changelog/18621.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: using start/stop from the job page in the UI will no longer fail when the job lacks HCL submission data
+```

--- a/ui/app/components/job-page/parts/title.js
+++ b/ui/app/components/job-page/parts/title.js
@@ -71,8 +71,17 @@ export default class Title extends Component {
    */
   @task(function* (withNotifications = false) {
     const job = this.job;
-    const specification = yield job.fetchRawSpecification();
-    job.set('_newDefinition', specification.Source);
+
+    // Try to get the submission/hcl sourced specification first.
+    // In the event that this fails, fall back to the raw definition.
+    try {
+      const specification = yield job.fetchRawSpecification();
+      job.set('_newDefinition', specification.Source);
+    } catch {
+      const definition = yield job.fetchRawDefinition();
+      delete definition.Stop;
+      job.set('_newDefinition', JSON.stringify(definition));
+    }
 
     try {
       yield job.parse();


### PR DESCRIPTION
In Nomad 1.6, we introduced HCL-in-the-UI using a new /submissions endpoint among other things.

Shortly after the release, we realized we missed a spot: stop/starting via the UI would not maintain the submission data. My initial fix for this solved the issue of maintaining HCL, but caused a new bug: jobs that lacked submission data (perhaps they were submitted via curl with just the json spec, and without HCL) would 404 on /submission and fail to progress through to /parse and submit.

This PR provides a fallback to the initial method in cases where the /submission request fails.

Resolves #18547 
Resolves #18536 