### PR TITLE
config: apply defaults to extra Consul and Vault

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1612,7 +1612,8 @@ func mergeVaultConfigs(left, right map[string]*config.VaultConfig) map[string]*c
 		if lConfig, ok := left[name]; ok {
 			merged[name] = lConfig.Merge(rConfig)
 		} else {
-			merged[name] = rConfig.Copy()
+			merged[name] = config.DefaultVaultConfig().Merge(rConfig)
+			merged[name].Name = name
 		}
 	}
 	return merged
@@ -1627,7 +1628,8 @@ func mergeConsulConfigs(left, right map[string]*config.ConsulConfig) map[string]
 		if lConfig, ok := left[name]; ok {
 			merged[name] = lConfig.Merge(rConfig)
 		} else {
-			merged[name] = rConfig.Copy()
+			merged[name] = config.DefaultConsulConfig().Merge(rConfig)
+			merged[name].Name = name
 		}
 	}
 	return merged

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -1651,10 +1651,10 @@ func (c *Config) Copy() *Config {
 	nc.ACL = c.ACL.Copy()
 	nc.Telemetry = c.Telemetry.Copy()
 	nc.DisableUpdateCheck = pointer.Copy(c.DisableUpdateCheck)
-	nc.Consul = c.Consul.Copy()
 	nc.Consuls = helper.DeepCopyMap(c.Consuls)
-	nc.Vault = c.Vault.Copy()
+	nc.Consul = nc.Consuls[structs.ConsulDefaultCluster]
 	nc.Vaults = helper.DeepCopyMap(c.Vaults)
+	nc.Vault = nc.Vaults[structs.VaultDefaultCluster]
 	nc.UI = c.UI.Copy()
 
 	nc.NomadConfig = c.NomadConfig.Copy()

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -1110,6 +1110,10 @@ func TestConfig_MultipleVault(t *testing.T) {
 	must.Nil(t, cfg.Vaults["other"].Enabled)
 	must.Eq(t, "127.0.0.1:9502", cfg.Vaults["other"].Addr)
 	must.Eq(t, pointer.Of(4*time.Hour), cfg.Vaults["other"].DefaultIdentity.TTL)
+
+	// check that extra Vault clusters have the defaults applied when not
+	// overridden
+	must.Eq(t, "jwt", cfg.Vaults["other"].JWTAuthBackendPath)
 }
 
 func TestConfig_MultipleConsul(t *testing.T) {
@@ -1161,4 +1165,8 @@ func TestConfig_MultipleConsul(t *testing.T) {
 	must.Eq(t, "other", cfg.Consuls["other"].Name)
 	must.Eq(t, pointer.Of(3*time.Hour), cfg.Consuls["other"].ServiceIdentity.TTL)
 	must.Eq(t, pointer.Of(5*time.Hour), cfg.Consuls["other"].TaskIdentity.TTL)
+
+	// check that extra Consul clusters have the defaults applied when not
+	// overridden
+	must.Eq(t, "nomad-client", cfg.Consuls["other"].ClientServiceName)
 }

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -545,7 +545,19 @@ func TestConfig_Merge(t *testing.T) {
 	result := c0.Merge(c1)
 	result = result.Merge(c2)
 	result = result.Merge(c3)
-	require.Equal(t, c3, result)
+
+	// Apply expected Consuls and Vaults defaults.
+	//
+	// Update pointers so the "default" key also updates expected.Consul and
+	// expected.Vault.
+	expected := c3.Copy()
+	for name, consul := range expected.Consuls {
+		*expected.Consuls[name] = *config.DefaultConsulConfig().Merge(consul)
+	}
+	for name, vault := range expected.Vaults {
+		*expected.Vaults[name] = *config.DefaultVaultConfig().Merge(vault)
+	}
+	require.Equal(t, expected, result)
 }
 
 func TestConfig_ParseConfigFile(t *testing.T) {

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -363,6 +363,7 @@ func (a *TestAgent) config() *Config {
 	conf.BindAddr = "127.0.0.1"
 
 	conf.Consul = sconfig.DefaultConsulConfig()
+	conf.Consuls[structs.ConsulDefaultCluster] = conf.Consul
 	conf.Vault.Enabled = new(bool)
 
 	// Tighten the Serf timing


### PR DESCRIPTION
Apply the expected default values when loading additional Consul and Vault cluster configuration. Without these defaults some fields would be left empty.