### PR TITLE
consul: add multi-cluster support to client constructors

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -74,9 +74,9 @@ type allocRunner struct {
 	// registering services and checks
 	consulClient serviceregistration.Handler
 
-	// consulProxiesClient is the client used by the envoy version hook for
+	// consulProxiesClientFunc gets a client used by the envoy version hook for
 	// looking up supported envoy versions of the consul agent.
-	consulProxiesClient consul.SupportedProxiesAPI
+	consulProxiesClientFunc consul.SupportedProxiesAPIFunc
 
 	// sidsClient is the client used by the service identity hook for
 	// managing SI tokens
@@ -226,7 +226,7 @@ func NewAllocRunner(config *config.AllocRunnerConfig) (interfaces.AllocRunner, e
 		alloc:                    alloc,
 		clientConfig:             config.ClientConfig,
 		consulClient:             config.Consul,
-		consulProxiesClient:      config.ConsulProxies,
+		consulProxiesClientFunc:  config.ConsulProxiesFunc,
 		sidsClient:               config.ConsulSI,
 		vaultClientFunc:          config.VaultFunc,
 		tasks:                    make(map[string]*taskrunner.TaskRunner, len(tg.Tasks)),
@@ -302,7 +302,7 @@ func (ar *allocRunner) initTaskRunners(tasks []*structs.Task) error {
 			StateUpdater:        ar,
 			DynamicRegistry:     ar.dynamicRegistry,
 			Consul:              ar.consulClient,
-			ConsulProxies:       ar.consulProxiesClient,
+			ConsulProxiesFunc:   ar.consulProxiesClientFunc,
 			ConsulSI:            ar.sidsClient,
 			VaultFunc:           ar.vaultClientFunc,
 			DeviceStatsReporter: ar.deviceStatsReporter,

--- a/client/allocrunner/taskrunner/envoy_version_hook.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook.go
@@ -84,7 +84,7 @@ func (h *envoyVersionHook) Prestart(_ context.Context, request *ifs.TaskPrestart
 	//
 	// TODO: how do we select the right cluster here if we have multiple
 	// services which could have their own cluster field value?
-	proxies, err := h.proxiesClientFunc("default").Proxies()
+	proxies, err := h.proxiesClientFunc(structs.ConsulDefaultCluster).Proxies()
 	if err != nil {
 		return fmt.Errorf("error retrieving supported Envoy versions from Consul: %w", err)
 	}

--- a/client/allocrunner/taskrunner/envoy_version_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocdir"
 	ifs "github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	clientconsul "github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/command/agent/consul"
 	"github.com/hashicorp/nomad/helper/envoy"
@@ -241,9 +242,10 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_standard(t *testing.T) {
 		},
 		Error: nil,
 	}
+	spAPIFunc := func(_ string) clientconsul.SupportedProxiesAPI { return spAPI }
 
 	// Run envoy_version hook
-	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, spAPI, logger))
+	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, spAPIFunc, logger))
 
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{
@@ -283,9 +285,10 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_custom(t *testing.T) {
 		},
 		Error: nil,
 	}
+	spAPIFunc := func(_ string) clientconsul.SupportedProxiesAPI { return spAPI }
 
 	// Run envoy_version hook
-	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, spAPI, logger))
+	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, spAPIFunc, logger))
 
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{
@@ -327,9 +330,10 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_skip(t *testing.T) {
 		},
 		Error: nil,
 	}
+	spAPIFunc := func(_ string) clientconsul.SupportedProxiesAPI { return spAPI }
 
 	// Run envoy_version hook
-	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, spAPI, logger))
+	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, spAPIFunc, logger))
 
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{
@@ -365,9 +369,10 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_no_fallback(t *testing.T) {
 		Value: nil, // old consul, no .xDS.SupportedProxies
 		Error: nil,
 	}
+	spAPIFunc := func(_ string) clientconsul.SupportedProxiesAPI { return spAPI }
 
 	// Run envoy_version hook
-	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, spAPI, logger))
+	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, spAPIFunc, logger))
 
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{
@@ -400,9 +405,10 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_error(t *testing.T) {
 		Value: nil,
 		Error: errors.New("some consul error"),
 	}
+	spAPIFunc := func(_ string) clientconsul.SupportedProxiesAPI { return spAPI }
 
 	// Run envoy_version hook
-	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, spAPI, logger))
+	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, spAPIFunc, logger))
 
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{
@@ -438,9 +444,10 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_restart(t *testing.T) {
 		},
 		Error: nil,
 	}
+	mockProxiesAPIFunc := func(_ string) clientconsul.SupportedProxiesAPI { return mockProxiesAPI }
 
 	// Run envoy_version hook
-	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, mockProxiesAPI, logger))
+	h := newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, mockProxiesAPIFunc, logger))
 
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -185,10 +185,10 @@ type TaskRunner struct {
 	// registering services and checks
 	consulServiceClient serviceregistration.Handler
 
-	// consulProxiesClient is the client used by the envoy version hook for
+	// consulProxiesClientFunc gets a client used by the envoy version hook for
 	// asking consul what version of envoy nomad should inject into the connect
 	// sidecar or gateway task.
-	consulProxiesClient consul.SupportedProxiesAPI
+	consulProxiesClientFunc consul.SupportedProxiesAPIFunc
 
 	// sidsClient is the client used by the service identity hook for managing
 	// service identity tokens
@@ -282,9 +282,9 @@ type Config struct {
 	// Consul is the client to use for managing Consul service registrations
 	Consul serviceregistration.Handler
 
-	// ConsulProxies is the client to use for looking up supported envoy versions
+	// ConsulProxiesFunc gets a client to use for looking up supported envoy versions
 	// from Consul.
-	ConsulProxies consul.SupportedProxiesAPI
+	ConsulProxiesFunc consul.SupportedProxiesAPIFunc
 
 	// ConsulSI is the client to use for managing Consul SI tokens
 	ConsulSI consul.ServiceIdentityAPI
@@ -369,44 +369,44 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 	}
 
 	tr := &TaskRunner{
-		alloc:                 config.Alloc,
-		allocID:               config.Alloc.ID,
-		clientConfig:          config.ClientConfig,
-		task:                  config.Task,
-		taskDir:               config.TaskDir,
-		taskName:              config.Task.Name,
-		taskLeader:            config.Task.Leader,
-		envBuilder:            envBuilder,
-		dynamicRegistry:       config.DynamicRegistry,
-		consulServiceClient:   config.Consul,
-		consulProxiesClient:   config.ConsulProxies,
-		siClient:              config.ConsulSI,
-		vaultClientFunc:       config.VaultFunc,
-		state:                 tstate,
-		localState:            state.NewLocalState(),
-		allocHookResources:    config.AllocHookResources,
-		stateDB:               config.StateDB,
-		stateUpdater:          config.StateUpdater,
-		deviceStatsReporter:   config.DeviceStatsReporter,
-		killCtx:               killCtx,
-		killCtxCancel:         killCancel,
-		shutdownCtx:           trCtx,
-		shutdownCtxCancel:     trCancel,
-		triggerUpdateCh:       make(chan struct{}, triggerUpdateChCap),
-		restartCh:             make(chan struct{}, restartChCap),
-		waitCh:                make(chan struct{}),
-		csiManager:            config.CSIManager,
-		devicemanager:         config.DeviceManager,
-		driverManager:         config.DriverManager,
-		maxEvents:             defaultMaxEvents,
-		serversContactedCh:    config.ServersContactedCh,
-		startConditionMetCh:   config.StartConditionMetCh,
-		shutdownDelayCtx:      config.ShutdownDelayCtx,
-		shutdownDelayCancelFn: config.ShutdownDelayCancelFn,
-		serviceRegWrapper:     config.ServiceRegWrapper,
-		getter:                config.Getter,
-		wranglers:             config.Wranglers,
-		widmgr:                config.WIDMgr,
+		alloc:                   config.Alloc,
+		allocID:                 config.Alloc.ID,
+		clientConfig:            config.ClientConfig,
+		task:                    config.Task,
+		taskDir:                 config.TaskDir,
+		taskName:                config.Task.Name,
+		taskLeader:              config.Task.Leader,
+		envBuilder:              envBuilder,
+		dynamicRegistry:         config.DynamicRegistry,
+		consulServiceClient:     config.Consul,
+		consulProxiesClientFunc: config.ConsulProxiesFunc,
+		siClient:                config.ConsulSI,
+		vaultClientFunc:         config.VaultFunc,
+		state:                   tstate,
+		localState:              state.NewLocalState(),
+		allocHookResources:      config.AllocHookResources,
+		stateDB:                 config.StateDB,
+		stateUpdater:            config.StateUpdater,
+		deviceStatsReporter:     config.DeviceStatsReporter,
+		killCtx:                 killCtx,
+		killCtxCancel:           killCancel,
+		shutdownCtx:             trCtx,
+		shutdownCtxCancel:       trCancel,
+		triggerUpdateCh:         make(chan struct{}, triggerUpdateChCap),
+		restartCh:               make(chan struct{}, restartChCap),
+		waitCh:                  make(chan struct{}),
+		csiManager:              config.CSIManager,
+		devicemanager:           config.DeviceManager,
+		driverManager:           config.DriverManager,
+		maxEvents:               defaultMaxEvents,
+		serversContactedCh:      config.ServersContactedCh,
+		startConditionMetCh:     config.StartConditionMetCh,
+		shutdownDelayCtx:        config.ShutdownDelayCtx,
+		shutdownDelayCancelFn:   config.ShutdownDelayCancelFn,
+		serviceRegWrapper:       config.ServiceRegWrapper,
+		getter:                  config.Getter,
+		wranglers:               config.Wranglers,
+		widmgr:                  config.WIDMgr,
 	}
 
 	// Create the logger based on the allocation ID

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -154,7 +154,7 @@ func (tr *TaskRunner) initHooks() {
 
 		if task.UsesConnectSidecar() {
 			tr.runnerHooks = append(tr.runnerHooks,
-				newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, tr.consulProxiesClient, hookLogger)),
+				newEnvoyVersionHook(newEnvoyVersionHookConfig(alloc, tr.consulProxiesClientFunc, hookLogger)),
 				newEnvoyBootstrapHook(newEnvoyBootstrapHookConfig(alloc, tr.clientConfig.ConsulConfig, consulNamespace, hookLogger)),
 			)
 		} else if task.Kind.IsConnectNative() {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2108,7 +2108,7 @@ func TestClient_AllocPrerunErrorDuringRestore(t *testing.T) {
 		conf.PluginSingletonLoader = singleton.NewSingletonLoader(logger, c1.config.PluginLoader)
 
 		// actually make and start the client
-		c2, err := NewClient(conf, c1.consulCatalog, nil, c1.consulService, nil)
+		c2, err := NewClient(conf, c1.consulCatalog, nil, c1.consulServices, nil)
 		must.NoError(t, err)
 		t.Cleanup(func() {
 			test.NoError(t, c2.Shutdown())

--- a/client/config/arconfig.go
+++ b/client/config/arconfig.go
@@ -52,9 +52,9 @@ type AllocRunnerConfig struct {
 	// Consul is the Consul client used to register task services and checks
 	Consul serviceregistration.Handler
 
-	// ConsulProxies is the Consul client used to lookup supported envoy versions
-	// of the Consul agent.
-	ConsulProxies consul.SupportedProxiesAPI
+	// ConsulProxiesFunc gets a Consul client used to lookup supported envoy
+	// versions of the Consul agent.
+	ConsulProxiesFunc consul.SupportedProxiesAPIFunc
 
 	// ConsulSI is the Consul client used to manage service identity tokens.
 	ConsulSI consul.ServiceIdentityAPI

--- a/client/consul/consul.go
+++ b/client/consul/consul.go
@@ -38,6 +38,10 @@ type SupportedProxiesAPI interface {
 	Proxies() (map[string][]string, error)
 }
 
+// SupportedProxiesAPIFunc returns an interface that the Nomad client uses for
+// requesting the set of supported proxies from Consul.
+type SupportedProxiesAPIFunc func(string) SupportedProxiesAPI
+
 // JWTLoginRequest is an object representing a login request with JWT
 type JWTLoginRequest struct {
 	JWT            string

--- a/client/serviceregistration/service_registration.go
+++ b/client/serviceregistration/service_registration.go
@@ -48,6 +48,8 @@ type Handler interface {
 	UpdateTTL(id, namespace, output, status string) error
 }
 
+type HandlerFunc func(string) Handler
+
 // WorkloadRestarter allows the checkWatcher to restart tasks or entire task
 // groups.
 type WorkloadRestarter interface {

--- a/client/serviceregistration/wrapper/wrapper.go
+++ b/client/serviceregistration/wrapper/wrapper.go
@@ -18,7 +18,7 @@ import (
 type HandlerWrapper struct {
 	log hclog.Logger
 
-	// consulServiceProvider is the handler for services where Consul is the
+	// consulServiceProvider gets the handler for services where Consul is the
 	// provider. This provider is always created and available.
 	consulServiceProvider serviceregistration.Handler
 
@@ -33,7 +33,7 @@ type HandlerWrapper struct {
 // implementation to allow future flexibility and is initially only intended
 // for use with the alloc and task runner service hooks.
 func NewHandlerWrapper(
-	log hclog.Logger, consulProvider, nomadProvider serviceregistration.Handler) *HandlerWrapper {
+	log hclog.Logger, consulProvider serviceregistration.Handler, nomadProvider serviceregistration.Handler) *HandlerWrapper {
 	return &HandlerWrapper{
 		log:                   log,
 		nomadServiceProvider:  nomadProvider,

--- a/command/agent/consul/catalog_testing.go
+++ b/command/agent/consul/catalog_testing.go
@@ -14,6 +14,14 @@ import (
 	"github.com/hashicorp/go-hclog"
 )
 
+type MockClient struct {
+	MockCatalog
+	MockNamespaces
+}
+
+var _ NamespaceAPI = (*MockClient)(nil)
+var _ CatalogAPI = (*MockClient)(nil)
+
 // MockNamespaces is a mock implementation of NamespaceAPI.
 type MockNamespaces struct {
 	namespaces []*api.Namespace

--- a/command/agent/consul/connect_proxies.go
+++ b/command/agent/consul/connect_proxies.go
@@ -7,7 +7,8 @@ import (
 	"errors"
 )
 
-// ConnectProxies implements SupportedProxiesAPI by using the Consul Agent API.
+// ConnectProxies implements the client/consul.SupportedProxiesAPI interface by
+// using the Consul Agent API.
 type ConnectProxies struct {
 	agentAPI AgentAPI
 }

--- a/nomad/consul.go
+++ b/nomad/consul.go
@@ -509,11 +509,11 @@ func (s *Server) purgeSITokenAccessors(accessors []*structs.SITokenAccessor) err
 type ConsulConfigsAPI interface {
 	// SetIngressCE adds the given ConfigEntry to Consul, overwriting
 	// the previous entry if set.
-	SetIngressCE(ctx context.Context, namespace, service string, entry *structs.ConsulIngressConfigEntry) error
+	SetIngressCE(ctx context.Context, namespace, service, cluster string, entry *structs.ConsulIngressConfigEntry) error
 
 	// SetTerminatingCE adds the given ConfigEntry to Consul, overwriting
 	// the previous entry if set.
-	SetTerminatingCE(ctx context.Context, namespace, service string, entry *structs.ConsulTerminatingConfigEntry) error
+	SetTerminatingCE(ctx context.Context, namespace, service, cluster string, entry *structs.ConsulTerminatingConfigEntry) error
 
 	// Stop is used to stop additional creations of Configuration Entries. Intended to
 	// be used on Nomad Server shutdown.
@@ -521,9 +521,9 @@ type ConsulConfigsAPI interface {
 }
 
 type consulConfigsAPI struct {
-	// configsClient is the API subset of the real Consul client we need for
-	// managing Configuration Entries.
-	configsClient consul.ConfigAPI
+	// configsClientFunc returns an interface that is the API subset of the real
+	// Consul client we need for managing Configuration Entries.
+	configsClientFunc consul.ConfigAPIFunc
 
 	// limiter is used to rate limit requests to Consul
 	limiter *rate.Limiter
@@ -537,11 +537,11 @@ type consulConfigsAPI struct {
 	stopped bool
 }
 
-func NewConsulConfigsAPI(configsClient consul.ConfigAPI, logger hclog.Logger) *consulConfigsAPI {
+func NewConsulConfigsAPI(configsClientFunc consul.ConfigAPIFunc, logger hclog.Logger) *consulConfigsAPI {
 	return &consulConfigsAPI{
-		configsClient: configsClient,
-		limiter:       rate.NewLimiter(configEntriesRequestRateLimit, int(configEntriesRequestRateLimit)),
-		logger:        logger,
+		configsClientFunc: configsClientFunc,
+		limiter:           rate.NewLimiter(configEntriesRequestRateLimit, int(configEntriesRequestRateLimit)),
+		logger:            logger,
 	}
 }
 
@@ -551,16 +551,16 @@ func (c *consulConfigsAPI) Stop() {
 	c.stopped = true
 }
 
-func (c *consulConfigsAPI) SetIngressCE(ctx context.Context, namespace, service string, entry *structs.ConsulIngressConfigEntry) error {
-	return c.setCE(ctx, convertIngressCE(namespace, service, entry))
+func (c *consulConfigsAPI) SetIngressCE(ctx context.Context, namespace, service, cluster string, entry *structs.ConsulIngressConfigEntry) error {
+	return c.setCE(ctx, convertIngressCE(namespace, service, entry), cluster)
 }
 
-func (c *consulConfigsAPI) SetTerminatingCE(ctx context.Context, namespace, service string, entry *structs.ConsulTerminatingConfigEntry) error {
-	return c.setCE(ctx, convertTerminatingCE(namespace, service, entry))
+func (c *consulConfigsAPI) SetTerminatingCE(ctx context.Context, namespace, service, cluster string, entry *structs.ConsulTerminatingConfigEntry) error {
+	return c.setCE(ctx, convertTerminatingCE(namespace, service, entry), cluster)
 }
 
 // setCE will set the Configuration Entry of any type Consul supports.
-func (c *consulConfigsAPI) setCE(ctx context.Context, entry api.ConfigEntry) error {
+func (c *consulConfigsAPI) setCE(ctx context.Context, entry api.ConfigEntry, cluster string) error {
 	defer metrics.MeasureSince([]string{"nomad", "consul", "create_config_entry"}, time.Now())
 
 	// make sure the background deletion goroutine has not been stopped
@@ -577,7 +577,8 @@ func (c *consulConfigsAPI) setCE(ctx context.Context, entry api.ConfigEntry) err
 		return err
 	}
 
-	_, _, err := c.configsClient.Set(entry, &api.WriteOptions{Namespace: entry.GetNamespace()})
+	client := c.configsClientFunc(cluster)
+	_, _, err := client.Set(entry, &api.WriteOptions{Namespace: entry.GetNamespace()})
 	return err
 }
 

--- a/nomad/consul_test.go
+++ b/nomad/consul_test.go
@@ -31,8 +31,9 @@ func TestConsulConfigsAPI_SetCE(t *testing.T) {
 		logger := testlog.HCLogger(t)
 		configsAPI := consul.NewMockConfigsAPI(logger)
 		configsAPI.SetError(expect)
+		configsAPIFunc := func(_ string) consul.ConfigAPI { return configsAPI }
 
-		c := NewConsulConfigsAPI(configsAPI, logger)
+		c := NewConsulConfigsAPI(configsAPIFunc, logger)
 		err := f(c) // set the config entry
 
 		switch expect {
@@ -51,26 +52,30 @@ func TestConsulConfigsAPI_SetCE(t *testing.T) {
 	ingressCE := new(structs.ConsulIngressConfigEntry)
 	t.Run("ingress ok", func(t *testing.T) {
 		try(t, nil, func(c ConsulConfigsAPI) error {
-			return c.SetIngressCE(ctx, consulNamespace, "ig", ingressCE)
+			return c.SetIngressCE(
+				ctx, consulNamespace, "ig", structs.ConsulDefaultCluster, ingressCE)
 		})
 	})
 
 	t.Run("ingress fail", func(t *testing.T) {
 		try(t, errors.New("consul broke"), func(c ConsulConfigsAPI) error {
-			return c.SetIngressCE(ctx, consulNamespace, "ig", ingressCE)
+			return c.SetIngressCE(
+				ctx, consulNamespace, "ig", structs.ConsulDefaultCluster, ingressCE)
 		})
 	})
 
 	terminatingCE := new(structs.ConsulTerminatingConfigEntry)
 	t.Run("terminating ok", func(t *testing.T) {
 		try(t, nil, func(c ConsulConfigsAPI) error {
-			return c.SetTerminatingCE(ctx, consulNamespace, "tg", terminatingCE)
+			return c.SetTerminatingCE(
+				ctx, consulNamespace, "tg", structs.ConsulDefaultCluster, terminatingCE)
 		})
 	})
 
 	t.Run("terminating fail", func(t *testing.T) {
 		try(t, errors.New("consul broke"), func(c ConsulConfigsAPI) error {
-			return c.SetTerminatingCE(ctx, consulNamespace, "tg", terminatingCE)
+			return c.SetTerminatingCE(
+				ctx, consulNamespace, "tg", structs.ConsulDefaultCluster, terminatingCE)
 		})
 	})
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -281,12 +281,12 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 
 	for ns, entries := range args.Job.ConfigEntries() {
 		for service, entry := range entries.Ingress {
-			if errCE := j.srv.consulConfigEntries.SetIngressCE(ctx, ns, service, entry); errCE != nil {
+			if errCE := j.srv.consulConfigEntries.SetIngressCE(ctx, ns, service, entries.Cluster, entry); errCE != nil {
 				return errCE
 			}
 		}
 		for service, entry := range entries.Terminating {
-			if errCE := j.srv.consulConfigEntries.SetTerminatingCE(ctx, ns, service, entry); errCE != nil {
+			if errCE := j.srv.consulConfigEntries.SetTerminatingCE(ctx, ns, service, entries.Cluster, entry); errCE != nil {
 				return errCE
 			}
 		}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -305,7 +305,7 @@ type Server struct {
 
 // NewServer is used to construct a new Nomad server from the
 // configuration, potentially returning an error
-func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigEntries consul.ConfigAPI, consulACLs consul.ACLsAPI) (*Server, error) {
+func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigFunc consul.ConfigAPIFunc, consulACLs consul.ACLsAPI) (*Server, error) {
 
 	// Create an eval broker
 	evalBroker, err := NewEvalBroker(
@@ -384,7 +384,7 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigEntr
 	s.statsFetcher = NewStatsFetcher(s.logger, s.connPool, s.config.Region)
 
 	// Setup Consul (more)
-	s.setupConsul(consulConfigEntries, consulACLs)
+	s.setupConsul(consulConfigFunc, consulACLs)
 
 	// Setup Vault
 	if err := s.setupVaultClient(); err != nil {
@@ -1143,8 +1143,8 @@ func (s *Server) setupNodeDrainer() {
 }
 
 // setupConsul is used to setup Server specific consul components.
-func (s *Server) setupConsul(consulConfigEntries consul.ConfigAPI, consulACLs consul.ACLsAPI) {
-	s.consulConfigEntries = NewConsulConfigsAPI(consulConfigEntries, s.logger)
+func (s *Server) setupConsul(consulConfigFunc consul.ConfigAPIFunc, consulACLs consul.ACLsAPI) {
+	s.consulConfigEntries = NewConsulConfigsAPI(consulConfigFunc, s.logger)
 	s.consulACLs = NewConsulACLsAPI(consulACLs, s.logger, s.purgeSITokenAccessors)
 }
 

--- a/nomad/structs/connect.go
+++ b/nomad/structs/connect.go
@@ -6,6 +6,7 @@ package structs
 // ConsulConfigEntries represents Consul ConfigEntry definitions from a job for
 // a single Consul namespace.
 type ConsulConfigEntries struct {
+	Cluster     string
 	Ingress     map[string]*ConsulIngressConfigEntry
 	Terminating map[string]*ConsulTerminatingConfigEntry
 }
@@ -31,8 +32,10 @@ func (j *Job) ConfigEntries() map[string]*ConsulConfigEntries {
 				gateway := service.Connect.Gateway
 				if ig := gateway.Ingress; ig != nil {
 					collection[ns].Ingress[service.Name] = ig
+					collection[ns].Cluster = service.Cluster
 				} else if term := gateway.Terminating; term != nil {
 					collection[ns].Terminating[service.Name] = term
+					collection[ns].Cluster = service.Cluster
 				}
 			}
 		}

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -130,6 +130,7 @@ func TestServerErr(t testing.T, cb func(*Config)) (*Server, func(), error) {
 
 	cCatalog := consul.NewMockCatalog(config.Logger)
 	cConfigs := consul.NewMockConfigsAPI(config.Logger)
+	cConfigFunc := func(_ string) consul.ConfigAPI { return cConfigs }
 	cACLs := consul.NewMockACLsAPI(config.Logger)
 
 	var server *Server
@@ -137,7 +138,7 @@ func TestServerErr(t testing.T, cb func(*Config)) (*Server, func(), error) {
 
 	for i := 10; i >= 0; i-- {
 		// Create server
-		server, err = NewServer(config, cCatalog, cConfigs, cACLs)
+		server, err = NewServer(config, cCatalog, cConfigFunc, cACLs)
 		if err == nil {
 			return server, func() {
 				ch := make(chan error)


### PR DESCRIPTION
When agents start, they create a shared Consul client that is then wrapped as various interfaces for testability, and used in constructing the Nomad client and server. The interfaces that support workload services (rather than the Nomad agent itself) need to support multiple Consul clusters for Nomad Enterprise. Update these interfaces to be factory functions that return the Consul client for a given cluster name. Update the `ServiceClient` to split workload updates between clusters by creating a wrapper around all the clients that delegates to the cluster-specific `ServiceClient`.