### PR TITLE
scaling: set Index on nil-job scale status reply

### DIFF
--- a/.changelog/18637.txt
+++ b/.changelog/18637.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scaling: Unblock blocking queries to /v1/job/{job-id}/scale if the job goes away
+```

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -2216,8 +2216,13 @@ func (j *Job) ScaleStatus(args *structs.JobScaleStatusRequest,
 				return err
 			}
 			if job == nil {
+				// HTTPServer.jobScaleStatus() will 404 if this is nil
 				reply.JobScaleStatus = nil
-				return nil
+
+				// reply with latest index, since if the job does get created,
+				// it must necessarily be later than current latest.
+				reply.Index, err = state.LatestIndex()
+				return err
 			}
 
 			events, eventsIndex, err := state.ScalingEventsByJob(ws, args.RequestNamespace(), args.JobID)


### PR DESCRIPTION
I noticed this while working on hashicorp/nomad-autoscaler#604 -- When a job went away, the blocking query on `/v1/job/{job-id}/scale` kept blocking for the full 5 minute timeout, instead of returning "not found" as soon as the job was purged/gc'd.

returning a nil error in a `blockingOptions.run()`
without increasing the reply `Index` can cause the
query to block indefinitely (until timeout).

this fixes that happening in `Job.ScaleStatus`
when the job is deleted -- the job going away
should now return as not-found and provide a new
index for the caller to try if they so please.