### PR TITLE
deps: upgrade to go-set/v2 and fixup a few broken things

### DIFF
--- a/client/acl.go
+++ b/client/acl.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/nomad/structs"
 )

--- a/client/lib/cgroupslib/editor.go
+++ b/client/lib/cgroupslib/editor.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"golang.org/x/sys/unix"
 )
 

--- a/client/lib/cgroupslib/mount.go
+++ b/client/lib/cgroupslib/mount.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 )
 
 func detect() Mode {

--- a/client/lib/idset/idset.go
+++ b/client/lib/idset/idset.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 )
 
 // An ID is representative of a non-negative identifier of something like

--- a/client/serviceregistration/watcher.go
+++ b/client/serviceregistration/watcher.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )

--- a/command/acl_token_create.go
+++ b/command/acl_token_create.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/posener/complete"
@@ -182,10 +182,10 @@ func (c *ACLTokenCreateCommand) Run(args []string) int {
 func generateACLTokenRoleLinks(roleNames, roleIDs []string) []*api.ACLTokenRoleLink {
 	var tokenLinks []*api.ACLTokenRoleLink
 
-	roleNameSet := set.From[string](roleNames).List()
+	roleNameSet := set.From[string](roleNames).Slice()
 	roleNameFn := func(name string) *api.ACLTokenRoleLink { return &api.ACLTokenRoleLink{Name: name} }
 
-	roleIDsSet := set.From[string](roleIDs).List()
+	roleIDsSet := set.From[string](roleIDs).Slice()
 	roleIDFn := func(id string) *api.ACLTokenRoleLink { return &api.ACLTokenRoleLink{ID: id} }
 
 	tokenLinks = append(tokenLinks, helper.ConvertSlice(roleNameSet, roleNameFn)...)

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -21,7 +21,7 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/client/serviceregistration"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/envoy"

--- a/command/job_restart.go
+++ b/command/job_restart.go
@@ -18,7 +18,7 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/dustin/go-humanize/english"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"

--- a/command/job_restart_test.go
+++ b/command/job_restart_test.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"

--- a/command/node_pool.go
+++ b/command/node_pool.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/mitchellh/cli"

--- a/command/node_pool_delete.go
+++ b/command/node_pool_delete.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/api"
 	"github.com/posener/complete"
 )

--- a/command/node_pool_test.go
+++ b/command/node_pool_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/mitchellh/cli"

--- a/command/var_put.go
+++ b/command/var_put.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/nomad/api"
@@ -581,10 +581,12 @@ func formatInvalidVarKeyChars(invalid []string) string {
 
 	// Sort the characters for output
 	charList := make([]string, 0, chars.Size())
-	for _, k := range chars.List() {
+	chars.ForEach(func(k string) bool {
 		// Use %s instead of %q to avoid escaping characters.
 		charList = append(charList, fmt.Sprintf(`"%s"`, k))
-	}
+		return true
+	})
+
 	slices.Sort(charList)
 
 	// Build string

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -23,7 +23,7 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
 	plugin "github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/cpustats"
 	"github.com/hashicorp/nomad/client/taskenv"
@@ -102,7 +102,7 @@ func (s *pauseContainerStore) remove(id string) {
 	s.containerIDs.Remove(id)
 }
 
-func (s *pauseContainerStore) union(other *set.Set[string]) *set.Set[string] {
+func (s *pauseContainerStore) union(other *set.Set[string]) set.Collection[string] {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return other.Union(s.containerIDs)

--- a/drivers/docker/reconcile_dangling.go
+++ b/drivers/docker/reconcile_dangling.go
@@ -12,7 +12,7 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 )
 
 // containerReconciler detects and kills unexpectedly running containers.
@@ -28,7 +28,7 @@ type containerReconciler struct {
 	getClient func() (*docker.Client, error)
 
 	isDriverHealthy   func() bool
-	trackedContainers func() *set.Set[string]
+	trackedContainers func() set.Collection[string]
 	isNomadContainer  func(c docker.APIContainers) bool
 
 	once sync.Once
@@ -134,7 +134,7 @@ func (r *containerReconciler) removeDanglingContainersIteration() error {
 
 // untrackedContainers returns the ids of containers that suspected
 // to have been started by Nomad but aren't tracked by this driver
-func (r *containerReconciler) untrackedContainers(tracked *set.Set[string], cutoffTime time.Time) (*set.Set[string], error) {
+func (r *containerReconciler) untrackedContainers(tracked set.Collection[string], cutoffTime time.Time) (*set.Set[string], error) {
 	result := set.New[string](10)
 
 	ctx, cancel := r.dockerAPIQueryContext()
@@ -230,7 +230,7 @@ func hasNomadName(c docker.APIContainers) bool {
 // trackedContainers returns the set of container IDs of containers that were
 // started by Driver and are expected to be running. This includes both normal
 // Task containers, as well as infra pause containers.
-func (d *Driver) trackedContainers() *set.Set[string] {
+func (d *Driver) trackedContainers() set.Collection[string] {
 	// collect the task containers
 	ids := d.tasks.IDs()
 	// now also accumulate pause containers

--- a/drivers/docker/reconcile_dangling_test.go
+++ b/drivers/docker/reconcile_dangling_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
 

--- a/drivers/docker/state.go
+++ b/drivers/docker/state.go
@@ -6,7 +6,7 @@ package docker
 import (
 	"sync"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 )
 
 type taskStore struct {

--- a/drivers/shared/executor/executor_basic.go
+++ b/drivers/shared/executor/executor_basic.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/client/lib/cpustats"
 	"github.com/hashicorp/nomad/drivers/shared/executor/procstats"
 	"github.com/hashicorp/nomad/plugins/drivers"

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -21,7 +21,7 @@ import (
 	"github.com/armon/circbuf"
 	"github.com/hashicorp/consul-template/signals"
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/cpustats"

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -10,7 +10,7 @@ import (
 	"syscall"
 
 	"github.com/containernetworking/plugins/pkg/ns"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/drivers/shared/executor/procstats"
 	"github.com/hashicorp/nomad/helper/users"

--- a/drivers/shared/executor/procstats/list_default.go
+++ b/drivers/shared/executor/procstats/list_default.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/lib/lang"
 	"github.com/shirou/gopsutil/v3/process"
 )

--- a/drivers/shared/executor/procstats/list_linux.go
+++ b/drivers/shared/executor/procstats/list_linux.go
@@ -6,7 +6,7 @@
 package procstats
 
 import (
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 )
 

--- a/drivers/shared/executor/procstats/procstats.go
+++ b/drivers/shared/executor/procstats/procstats.go
@@ -6,7 +6,7 @@ package procstats
 import (
 	"time"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/client/lib/cpustats"
 	"github.com/hashicorp/nomad/plugins/drivers"
 )

--- a/e2e/acl/helpers.go
+++ b/e2e/acl/helpers.go
@@ -6,7 +6,7 @@ package acl
 import (
 	"testing"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/api"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"

--- a/e2e/artifact/artifact_test.go
+++ b/e2e/artifact/artifact_test.go
@@ -41,7 +41,7 @@ func artifactCheckLogContents(t *testing.T, nomad *api.Client, group, task strin
 	t.Run(task, func(t *testing.T) {
 		logs, err := e2eutil.AllocTaskLogs(allocID, task, e2eutil.LogsStdOut)
 		must.NoError(t, err)
-		must.StrContains(t, logs, "module github.com/hashicorp/go-set")
+		must.StrContains(t, logs, "module github.com/hashicorp/go-set/v2")
 	})
 }
 

--- a/e2e/nodedrain/node_drain_test.go
+++ b/e2e/nodedrain/node_drain_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"

--- a/e2e/v3/jobs3/jobs3.go
+++ b/e2e/v3/jobs3/jobs3.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/e2e/v3/util3"
 	"github.com/hashicorp/nomad/helper/pointer"

--- a/e2e/v3/namespaces3/namespaces3.go
+++ b/e2e/v3/namespaces3/namespaces3.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/e2e/v3/util3"
 	"github.com/hashicorp/nomad/helper"

--- a/e2e/vaultcompat/vaultcompat_test.go
+++ b/e2e/vaultcompat/vaultcompat_test.go
@@ -15,7 +15,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/go-version"
 	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -218,7 +218,7 @@ func keep(b build) bool {
 // A tracker keeps track of the set of patch versions for each minor version.
 // The patch versions are stored in a treeset so we can grab the highest  patch
 // version of each minor version at the end.
-type tracker map[int]*set.TreeSet[build, set.Compare[build]]
+type tracker map[int]*set.TreeSet[build]
 
 func (t tracker) add(v *version.Version, b build) {
 	y := v.Segments()[1] // minor version
@@ -226,7 +226,7 @@ func (t tracker) add(v *version.Version, b build) {
 	// create the treeset for this minor version if needed
 	if _, exists := t[y]; !exists {
 		cmp := func(g, h build) int { return g.compare(h) }
-		t[y] = set.NewTreeSet[build, set.Compare[build]](cmp)
+		t[y] = set.NewTreeSet[build](cmp)
 	}
 
 	// insert the patch version into the set of patch versions for this minor version

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/hashicorp/go-plugin v1.4.10
 	github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.4
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
-	github.com/hashicorp/go-set v0.1.14
+	github.com/hashicorp/go-set/v2 v2.0.0-alpha.2
 	github.com/hashicorp/go-sockaddr v1.0.2
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.3
@@ -213,6 +213,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7 // indirect
 	github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1 // indirect
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.2 // indirect
+	github.com/hashicorp/go-set v0.1.8 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/mdns v1.0.4 // indirect
 	github.com/hashicorp/vault/api/auth/kubernetes v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -888,8 +888,10 @@ github.com/hashicorp/go-secure-stdlib/strutil v0.1.2/go.mod h1:Gou2R9+il93BqX25L
 github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.1/go.mod h1:l8slYwnJA26yBz+ErHpp2IRCLr0vuOMGBORIz4rRiAs=
 github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.2 h1:phcbL8urUzF/kxA/Oj6awENaRwfWsjP59GW7u2qlDyY=
 github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.2/go.mod h1:l8slYwnJA26yBz+ErHpp2IRCLr0vuOMGBORIz4rRiAs=
-github.com/hashicorp/go-set v0.1.14 h1:ZU7JyS6QGueDuXYldjcuyKLR0XV14eOKcsQlGddXGgA=
-github.com/hashicorp/go-set v0.1.14/go.mod h1:FH9zJxnQYHPlZ7j9JaoQjZOFPBStOrelKOE11Wjwirc=
+github.com/hashicorp/go-set v0.1.8 h1:q2r58lFkJrikmC4I+vS3A+bn6QgR7EYeFD8kRiAIAnk=
+github.com/hashicorp/go-set v0.1.8/go.mod h1:wedp+UE6HoxBywExd7mrdGdcXOo3awtiELmnRnpzsKI=
+github.com/hashicorp/go-set/v2 v2.0.0-alpha.2 h1:lSoXIz3jTo0nNQ17H7tgB2iletJTaUF73mbEZ5Z91tM=
+github.com/hashicorp/go-set/v2 v2.0.0-alpha.2/go.mod h1:6q4nh8UCVZODn2tJ5RbJi8+ki7pjZBsAEYGt6yaGeTo=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/hcl/hcl/ast"
 )
 
@@ -85,9 +85,9 @@ func HashUUID(input string) (output string, hashed bool) {
 func UniqueMapSliceValues[K, V comparable](m map[K][]V) []V {
 	s := set.New[V](0)
 	for _, slice := range m {
-		s.InsertAll(slice)
+		s.InsertSlice(slice)
 	}
-	return s.List()
+	return s.Slice()
 }
 
 // IsSubset returns whether the smaller set of items is a subset of
@@ -95,11 +95,11 @@ func UniqueMapSliceValues[K, V comparable](m map[K][]V) []V {
 // returned.
 func IsSubset[T comparable](larger, smaller []T) (bool, []T) {
 	l := set.From(larger)
-	if l.ContainsAll(smaller) {
+	if l.ContainsSlice(smaller) {
 		return true, nil
 	}
 	s := set.From(smaller)
-	return false, s.Difference(l).List()
+	return false, s.Difference(l).Slice()
 }
 
 // StringHasPrefixInSlice returns true if s starts with any prefix in list.
@@ -118,7 +118,7 @@ func IsDisjoint[T comparable](first, second []T) (bool, []T) {
 	f, s := set.From(first), set.From(second)
 	intersection := f.Intersect(s)
 	if intersection.Size() > 0 {
-		return false, intersection.List()
+		return false, intersection.Slice()
 	}
 	return true, nil
 }

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -17,7 +17,7 @@ import (
 	capOIDC "github.com/hashicorp/cap/oidc"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 
 	policy "github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
@@ -208,7 +208,7 @@ func (a *ACL) ListPolicies(args *structs.ACLPolicyListRequest, reply *structs.AC
 		}
 
 		// Add the token policies which are directly referenced into the set.
-		tokenPolicyNames.InsertAll(token.Policies)
+		tokenPolicyNames.InsertSlice(token.Policies)
 	}
 
 	// Setup the blocking query
@@ -302,7 +302,7 @@ func (a *ACL) GetPolicy(args *structs.ACLPolicySpecificRequest, reply *structs.S
 		}
 
 		// Add the token policies which are directly referenced into the set.
-		tokenPolicyNames.InsertAll(token.Policies)
+		tokenPolicyNames.InsertSlice(token.Policies)
 
 		if !tokenPolicyNames.Contains(args.Name) {
 			return structs.ErrPermissionDenied
@@ -387,10 +387,10 @@ func (a *ACL) GetPolicies(args *structs.ACLPolicySetRequest, reply *structs.ACLP
 	}
 
 	// Add the token policies which are directly referenced into the set.
-	tokenPolicyNames.InsertAll(token.Policies)
+	tokenPolicyNames.InsertSlice(token.Policies)
 
 	// Ensure the token has enough permissions to query the named policies.
-	if token.Type != structs.ACLManagementToken && !tokenPolicyNames.ContainsAll(args.Names) {
+	if token.Type != structs.ACLManagementToken && !tokenPolicyNames.ContainsSlice(args.Names) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	memdb "github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/ci"

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"

--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/helper/envoy"
 	"github.com/hashicorp/nomad/helper/pointer"

--- a/nomad/node_pool_endpoint_test.go
+++ b/nomad/node_pool_endpoint_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper"

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -14,7 +14,7 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/nomad/state"
@@ -180,7 +180,7 @@ func (s serviceTagSet) add(service string, tags []string) {
 	if _, exists := s[service]; !exists {
 		s[service] = set.From[string](tags)
 	} else {
-		s[service].InsertAll(tags)
+		s[service].InsertSlice(tags)
 	}
 }
 
@@ -250,7 +250,7 @@ func (s *ServiceRegistration) List(
 			for service, tags := range tagSet {
 				serviceList = append(serviceList, &structs.ServiceRegistrationStub{
 					ServiceName: service,
-					Tags:        tags.List(),
+					Tags:        tags.Slice(),
 				})
 			}
 
@@ -346,7 +346,7 @@ func (s *ServiceRegistration) listAllServiceRegistrations(
 				for service, tags := range tagSet {
 					stubs = append(stubs, &structs.ServiceRegistrationStub{
 						ServiceName: service,
-						Tags:        tags.List(),
+						Tags:        tags.Slice(),
 					})
 				}
 				registrations = append(registrations, &structs.ServiceRegistrationListStub{

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/lib/lang"
@@ -3772,7 +3772,7 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 	}
 
 	// Update the index of when nodes last updated their allocs.
-	for _, nodeID := range nodeIDs.List() {
+	for _, nodeID := range nodeIDs.Slice() {
 		if err := s.updateClientAllocUpdateIndex(txn, index, nodeID); err != nil {
 			return fmt.Errorf("node update failed: %v", err)
 		}

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"

--- a/nomad/structs/config/workload_id.go
+++ b/nomad/structs/config/workload_id.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"time"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/helper/pointer"
 )
 

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/acl"
 	"golang.org/x/crypto/blake2b"
 )
@@ -346,11 +346,11 @@ func VaultPoliciesSet(policies map[string]map[string]*Vault) []string {
 	for _, tgp := range policies {
 		for _, tp := range tgp {
 			if tp != nil {
-				s.InsertAll(tp.Policies)
+				s.InsertSlice(tp.Policies)
 			}
 		}
 	}
-	return s.List()
+	return s.Slice()
 }
 
 // VaultNamespaceSet takes the structure returned by VaultPolicies and
@@ -364,7 +364,7 @@ func VaultNamespaceSet(policies map[string]map[string]*Vault) []string {
 			}
 		}
 	}
-	return s.List()
+	return s.Slice()
 }
 
 // DenormalizeAllocationJobs is used to attach a job to all allocations that are

--- a/nomad/structs/job.go
+++ b/nomad/structs/job.go
@@ -4,7 +4,7 @@
 package structs
 
 import (
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 )
 
 const (

--- a/nomad/structs/job_test.go
+++ b/nomad/structs/job_test.go
@@ -6,7 +6,7 @@ package structs
 import (
 	"testing"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/args"
 	"github.com/hashicorp/nomad/helper/pointer"

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -33,7 +33,7 @@ import (
 	"github.com/hashicorp/cronexpr"
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/client/lib/idset"

--- a/scheduler/propertyset.go
+++ b/scheduler/propertyset.go
@@ -9,7 +9,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/testlog"

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,10 +1,12 @@
 module github.com/hashicorp/nomad/tools
 
-go 1.20
+go 1.21
+
+toolchain go1.21.0
 
 require (
-	github.com/hashicorp/go-set v0.1.11
-	github.com/shoenig/test v0.6.4
+	github.com/hashicorp/go-set/v2 v2.0.0-alpha.1
+	github.com/shoenig/test v0.6.7
 )
 
 require github.com/google/go-cmp v0.5.9 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,6 +1,6 @@
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/hashicorp/go-set v0.1.11 h1:EZU3AzhNfCcMHtU0hCo2j4FAp7OHFDe/KTfmsbu1QIM=
-github.com/hashicorp/go-set v0.1.11/go.mod h1:BaYYjrI6m7H3D0j+N5Z0rZkCbBXOgNtuoDHrMJfORsk=
-github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
-github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/hashicorp/go-set/v2 v2.0.0-alpha.1 h1:vnuI6A2kou5+tcj5sF+cROU3mTeWPx2BGmsbBhBp/+E=
+github.com/hashicorp/go-set/v2 v2.0.0-alpha.1/go.mod h1:6q4nh8UCVZODn2tJ5RbJi8+ki7pjZBsAEYGt6yaGeTo=
+github.com/shoenig/test v0.6.7 h1:k92ohN9VyRfZn0ezNfwamtIBT/5byyfLVktRmL/Jmek=
+github.com/shoenig/test v0.6.7/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=

--- a/tools/missing/main.go
+++ b/tools/missing/main.go
@@ -14,7 +14,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 )
 
 func main() {
@@ -177,7 +177,7 @@ func skip(p string) bool {
 }
 
 func inCode(root string) ([]string, error) {
-	pkgs := set.NewTreeSet[string, set.Compare[string]](set.Cmp[string])
+	pkgs := set.NewTreeSet[string](set.Compare[string])
 
 	err := filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
 		if info.IsDir() {


### PR DESCRIPTION
https://github.com/hashicorp/go-set/issues/73

Using Nomad as a large project test case of the `v2.0.0-alpha.2` to make sure everything is fine before actually tagging the `v2.0.0` final release.
No functional changes, just cleaning up deprecated usages that are removed in v2, and replace one call of `.Slice` with `.ForEach` to avoid making the intermediate copy. 

Much smaller PR than it looks - it's almost all import name fixes.