### PR TITLE
Scaffolding actions

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1172,6 +1172,6 @@ type WorkloadIdentity struct {
 
 type Action struct {
 	Name    string   `hcl:"name,label"`
-	Command string  `mapstructure:"command" hcl:"command"`
+	Command string   `mapstructure:"command" hcl:"command"`
 	Args    []string `mapstructure:"args" hcl:"args,optional"`
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1172,6 +1172,6 @@ type WorkloadIdentity struct {
 
 type Action struct {
 	Name    string   `hcl:"name,label"`
-	Command *string  `mapstructure:"command" hcl:"command"`
+	Command string  `mapstructure:"command" hcl:"command"`
 	Args    []string `mapstructure:"args" hcl:"args,optional"`
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1174,5 +1174,4 @@ type Action struct {
 	Name    string   `hcl:"name,label"`
 	Command *string  `mapstructure:"command" hcl:"command"`
 	Args    []string `mapstructure:"args" hcl:"args,optional"`
-	// Type    *string  `mapstructure:"type" hcl:"type,optional"`
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -731,6 +731,8 @@ type Task struct {
 
 	// Workload Identities
 	Identities []*WorkloadIdentity `hcl:"identity,block"`
+
+	Actions []*Action `hcl:"action,block"`
 }
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
@@ -1166,4 +1168,11 @@ type WorkloadIdentity struct {
 	File        bool          `hcl:"file,optional"`
 	ServiceName string        `hcl:"service_name,optional"`
 	TTL         time.Duration `mapstructure:"ttl" hcl:"ttl,optional"`
+}
+
+type Action struct {
+	Name    string   `hcl:"name,label"`
+	Command *string  `mapstructure:"command" hcl:"command"`
+	Args    []string `mapstructure:"args" hcl:"args,optional"`
+	// Type    *string  `mapstructure:"type" hcl:"type,optional"`
 }

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -504,7 +504,19 @@ func (s *HTTPServer) allocExec(allocID string, resp http.ResponseWriter, req *ht
 	}
 	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
 
-	conn, err := s.wsUpgrader.Upgrade(resp, req, nil)
+	// conn, err := s.wsUpgrader.Upgrade(resp, req, nil)
+	// FIXME: this is an open checkOrigin here that allows :4200 to make requests to :4646,
+	// freeing local ember up from not having to proxy.
+	// This is like three workarounds in a trenchcoat and I dno't feel good about it but it unblocks me
+
+	var upgrader = websocket.Upgrader{
+		// Allow all origins
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+
+	// Then when you upgrade the connection:
+	conn, err := upgrader.Upgrade(resp, req, nil)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to upgrade connection: %v", err)
 	}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1398,7 +1398,6 @@ func ApiActionToStructsAction(job *structs.Job, action *api.Action, act *structs
 	act.Name = action.Name
 	act.Args = action.Args
 	act.Command = action.Command
-	// act.Type = action.Type
 }
 
 func ApiResourcesToStructs(in *api.Resources) *structs.Resources {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1344,13 +1344,9 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 		}
 	}
 
-	if apiTask.Actions != nil {
-		structsTask.Actions = []*structs.Action{}
-		for _, action := range apiTask.Actions {
-			act := &structs.Action{}
-			ApiActionToStructsAction(job, action, act)
-			structsTask.Actions = append(structsTask.Actions, act)
-		}
+	for _, action := range apiTask.Actions {
+		act := ApiActionToStructsAction(job, action, &structs.Action{})
+		structsTask.Actions = append(structsTask.Actions, act)
 	}
 }
 
@@ -1394,10 +1390,12 @@ func ApiCSIPluginConfigToStructsCSIPluginConfig(apiConfig *api.TaskCSIPluginConf
 	return sc
 }
 
-func ApiActionToStructsAction(job *structs.Job, action *api.Action, act *structs.Action) {
-	act.Name = action.Name
-	act.Args = slices.Clone(action.Args)
-	act.Command = action.Command
+func ApiActionToStructsAction(job *structs.Job, action *api.Action, act *structs.Action) *structs.Action {
+	return &structs.Action{
+		Name:    action.Name,
+		Args:    slices.Clone(action.Args),
+		Command: action.Command,
+	}
 }
 
 func ApiResourcesToStructs(in *api.Resources) *structs.Resources {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1343,6 +1343,15 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 			Sidecar: apiTask.Lifecycle.Sidecar,
 		}
 	}
+
+	if apiTask.Actions != nil {
+		structsTask.Actions = []*structs.Action{}
+		for _, action := range apiTask.Actions {
+			act := &structs.Action{}
+			ApiActionToStructsAction(job, action, act)
+			structsTask.Actions = append(structsTask.Actions, act)
+		}
+	}
 }
 
 // apiWaitConfigToStructsWaitConfig is a copy and type conversion between the API
@@ -1383,6 +1392,13 @@ func ApiCSIPluginConfigToStructsCSIPluginConfig(apiConfig *api.TaskCSIPluginConf
 	sc.StagePublishBaseDir = apiConfig.StagePublishBaseDir
 	sc.HealthTimeout = apiConfig.HealthTimeout
 	return sc
+}
+
+func ApiActionToStructsAction(job *structs.Job, action *api.Action, act *structs.Action) {
+	act.Name = action.Name
+	act.Args = action.Args
+	act.Command = action.Command
+	// act.Type = action.Type
 }
 
 func ApiResourcesToStructs(in *api.Resources) *structs.Resources {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1345,7 +1345,7 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 	}
 
 	for _, action := range apiTask.Actions {
-		act := ApiActionToStructsAction(job, action, &structs.Action{})
+		act := ApiActionToStructsAction(job, action)
 		structsTask.Actions = append(structsTask.Actions, act)
 	}
 }
@@ -1390,7 +1390,7 @@ func ApiCSIPluginConfigToStructsCSIPluginConfig(apiConfig *api.TaskCSIPluginConf
 	return sc
 }
 
-func ApiActionToStructsAction(job *structs.Job, action *api.Action, act *structs.Action) *structs.Action {
+func ApiActionToStructsAction(job *structs.Job, action *api.Action) *structs.Action {
 	return &structs.Action{
 		Name:    action.Name,
 		Args:    slices.Clone(action.Args),

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1396,7 +1396,7 @@ func ApiCSIPluginConfigToStructsCSIPluginConfig(apiConfig *api.TaskCSIPluginConf
 
 func ApiActionToStructsAction(job *structs.Job, action *api.Action, act *structs.Action) {
 	act.Name = action.Name
-	act.Args = action.Args
+	act.Args = slices.Clone(action.Args)
 	act.Command = action.Command
 }
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -1565,12 +1565,6 @@ func TestHTTP_JobVersions(t *testing.T) {
 		job2.ID = job.ID
 		job2.Priority = 100
 
-		job2.TaskGroups[0].Tasks[0].Actions[0] = &structs.Action{
-			Name:    "updated date test",
-			Command: "/bin/date",
-			Args:    []string{"--utc"},
-		}
-
 		args2 := structs.JobRegisterRequest{
 			Job: job2,
 			WriteRequest: structs.WriteRequest{
@@ -1605,43 +1599,6 @@ func TestHTTP_JobVersions(t *testing.T) {
 
 		if v := versions[0]; v.Version != 1 || v.Priority != 100 {
 			t.Fatalf("bad %v", v)
-		}
-
-		if len(vResp.Diffs) != 1 {
-			t.Fatalf("bad %v", vResp)
-		} else {
-			for _, jobDiff := range vResp.Diffs {
-				for _, taskGroupDiff := range jobDiff.TaskGroups {
-					for _, taskDiff := range taskGroupDiff.Tasks {
-						if len(taskDiff.Objects) == 0 {
-							continue
-						}
-						firstObject := taskDiff.Objects[0]
-						if firstObject.Type != "Added" {
-							t.Errorf("Expected first object type to be 'Added', got '%s'", firstObject.Type)
-							return
-						}
-						for _, field := range firstObject.Fields {
-							if field.Name == "Name" {
-								if field.New != "updated date test" {
-									t.Errorf("Expected new 'Name' to be 'updated date test', got '%s'", field.New)
-								}
-							}
-						}
-						for _, argObject := range firstObject.Objects {
-							if argObject.Name == "Args" {
-								for _, argField := range argObject.Fields {
-									if argField.Name == "Args" {
-										if argField.New != "--utc" {
-											t.Errorf("Expected new 'Args' to be '--utc', got '%s'", argField.New)
-										}
-									}
-								}
-							}
-						}
-					}
-				}
-			}
 		}
 
 		if v := versions[1]; v.Version != 0 {

--- a/command/agent/testingutils_test.go
+++ b/command/agent/testingutils_test.go
@@ -78,6 +78,19 @@ func MockJob() *api.Job {
 								PortLabel: "admin",
 							},
 						},
+						// actions
+						Actions: []*api.Action{
+							{
+								Name:    "date test",
+								Command: "/bin/date",
+								Args:    []string{"-u"},
+							},
+							{
+								Name:    "echo test",
+								Command: "/bin/echo",
+								Args:    []string{"hello world"},
+							},
+						},
 						LogConfig: api.DefaultLogConfig(),
 						Resources: &api.Resources{
 							CPU:      pointer.Of(500),

--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -46,6 +46,7 @@ var (
 		"kind",
 		"volume_mount",
 		"csi_plugin",
+		"actions",
 	)
 
 	sidecarTaskKeys = append(commonTaskKeys,

--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -76,6 +76,18 @@ func Job() *structs.Job {
 						Env: map[string]string{
 							"FOO": "bar",
 						},
+						Actions: []*structs.Action{
+							{
+								Name:    "date test",
+								Command: "/bin/date",
+								Args:    []string{"-u"},
+							},
+							{
+								Name:    "echo test",
+								Command: "/bin/echo",
+								Args:    []string{"hello world"},
+							},
+						},
 						Services: []*structs.Service{
 							{
 								Name:      "${TASK}-frontend",

--- a/nomad/structs/actions.go
+++ b/nomad/structs/actions.go
@@ -1,6 +1,10 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
+// Actions are executable commands that can be run on an allocation within
+// the context of a task. They are left open-ended enough to be applied to
+// other Nomad concepts like Nodes in the future.
+
 package structs
 
 import "slices"

--- a/nomad/structs/actions.go
+++ b/nomad/structs/actions.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package structs
+
+import "slices"
+
+type Action struct {
+	Name    string
+	Command string
+	Args    []string
+}
+
+func (a *Action) Copy() *Action {
+	if a == nil {
+		return nil
+	}
+	na := new(Action)
+	*na = *a
+	na.Args = slices.Clone(a.Args)
+	return na
+}
+
+func (a *Action) Equal(o *Action) bool {
+	if a == o {
+		return true
+	}
+	if a == nil || o == nil {
+		return false
+	}
+	return a.Name == o.Name &&
+		a.Command == o.Command &&
+		slices.Equal(a.Args, o.Args)
+}

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -579,23 +579,6 @@ func (t *Task) Diff(other *Task, contextual bool) (*TaskDiff, error) {
 	return diff, nil
 }
 
-func findActionMatch(action *Action, newActions []*Action, newActionMatches []int) int {
-	indexMatch := -1
-
-	for i, newAction := range newActions {
-		if newActionMatches[i] >= 0 {
-			continue
-		}
-
-		if action.Name == newAction.Name {
-			indexMatch = i
-			break
-		}
-	}
-
-	return indexMatch
-}
-
 func actionDiff(old, new *Action, contextual bool) *ObjectDiff {
 	diff := &ObjectDiff{Type: DiffTypeNone, Name: "Action"}
 	var oldPrimitiveFlat, newPrimitiveFlat map[string]string
@@ -630,10 +613,8 @@ func actionDiff(old, new *Action, contextual bool) *ObjectDiff {
 // actionDiffs diffs a set of actions. If contextual diff is enabled, unchanged
 // fields within objects nested in the actions will be returned.
 func actionDiffs(old, new []*Action, contextual bool) []*ObjectDiff {
-	// Initialize diffs array
 	var diffs []*ObjectDiff
 
-	// Start by matching actions by their index
 	for i := 0; i < len(old) && i < len(new); i++ {
 		oldAction := old[i]
 		newAction := new[i]
@@ -643,21 +624,18 @@ func actionDiffs(old, new []*Action, contextual bool) []*ObjectDiff {
 		}
 	}
 
-	// Handle remaining old actions (which have been deleted)
 	for i := len(new); i < len(old); i++ {
 		if diff := actionDiff(old[i], nil, contextual); diff != nil {
 			diffs = append(diffs, diff)
 		}
 	}
 
-	// Handle remaining new actions (which have been added)
 	for i := len(old); i < len(new); i++ {
 		if diff := actionDiff(nil, new[i], contextual); diff != nil {
 			diffs = append(diffs, diff)
 		}
 	}
 
-	// Optionally, sort the diffs for more predictable output
 	sort.Sort(ObjectDiffs(diffs))
 
 	return diffs

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -8673,6 +8673,195 @@ func TestTaskDiff(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Actions added",
+			Old:  &Task{},
+			New: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "echo",
+						Args:    []string{"bar"},
+					},
+				},
+			},
+			Expected: &TaskDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "Action",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "Command",
+								Old:  "",
+								New:  "echo",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "Name",
+								Old:  "",
+								New:  "foo",
+							},
+						},
+						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "Args",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "Args",
+										Old:  "",
+										New:  "bar",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Actions removed",
+			Old: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "echo",
+						Args:    []string{"bar"},
+					},
+				},
+			},
+			New: &Task{},
+			Expected: &TaskDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeDeleted,
+						Name: "Action",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "Command",
+								Old:  "echo",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "Name",
+								Old:  "foo",
+								New:  "",
+							},
+						},
+						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "Args",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeDeleted,
+										Name: "Args",
+										Old:  "bar",
+										New:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Actions edited",
+			Old: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "bar",
+						Args:    []string{"hello world"},
+					},
+				},
+			},
+			New: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "baz",
+						Args:    []string{"hello world"},
+					},
+				},
+			},
+			Expected: &TaskDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "Action",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "Command",
+								Old:  "bar",
+								New:  "baz",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Action Args edited",
+			Old: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "echo",
+						// Multiple strings of "foo" and "bar"
+						Args: []string{"bar"},
+					},
+				},
+			},
+			New: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "echo",
+						Args:    []string{"baz"},
+					},
+				},
+			},
+			Expected: &TaskDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "Action",
+						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "Args",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "Args",
+										Old:  "",
+										New:  "baz",
+									},
+									{
+										Type: DiffTypeDeleted,
+										Name: "Args",
+										Old:  "bar",
+										New:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -339,6 +339,19 @@ func CopySliceNodeScoreMeta(s []*NodeScoreMeta) []*NodeScoreMeta {
 	return c
 }
 
+func CopySliceActions(s []*Action) []*Action {
+	l := len(s)
+	if l == 0 {
+		return nil
+	}
+
+	c := make([]*Action, l)
+	for i, v := range s {
+		c[i] = v.Copy()
+	}
+	return c
+}
+
 // VaultPoliciesSet takes the structure returned by VaultPolicies and returns
 // the set of required policies
 func VaultPoliciesSet(policies map[string]map[string]*Vault) []string {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7699,6 +7699,7 @@ func (t *Task) Copy() *Task {
 	nt.Lifecycle = nt.Lifecycle.Copy()
 	nt.Identity = nt.Identity.Copy()
 	nt.Identities = helper.CopySlice(nt.Identities)
+	nt.Actions = CopySliceActions(nt.Actions)
 
 	if t.Artifacts != nil {
 		artifacts := make([]*TaskArtifact, 0, len(t.Artifacts))
@@ -13288,6 +13289,27 @@ func (r *RpcError) Error() string {
 
 type Action struct {
 	Name    string
-	Command *string
+	Command string
 	Args    []string
+}
+
+func (a *Action) Copy() *Action {
+	if a == nil {
+		return nil
+	}
+	na := new(Action)
+	*na = *a
+	return na
+}
+
+func (a *Action) Equal(o *Action) bool {
+	if a == o {
+		return true
+	}
+	if a == nil || o == nil {
+		return false
+	}
+	return a.Name == o.Name &&
+		a.Command == o.Command &&
+		strings.Join(a.Args, ",") == strings.Join(o.Args, ",")
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -13290,5 +13290,4 @@ type Action struct {
 	Name    string
 	Command *string
 	Args    []string
-	// Type    *string
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -13286,30 +13286,3 @@ func NewRpcError(err error, code *int64) *RpcError {
 func (r *RpcError) Error() string {
 	return r.Message
 }
-
-type Action struct {
-	Name    string
-	Command string
-	Args    []string
-}
-
-func (a *Action) Copy() *Action {
-	if a == nil {
-		return nil
-	}
-	na := new(Action)
-	*na = *a
-	return na
-}
-
-func (a *Action) Equal(o *Action) bool {
-	if a == o {
-		return true
-	}
-	if a == nil || o == nil {
-		return false
-	}
-	return a.Name == o.Name &&
-		a.Command == o.Command &&
-		strings.Join(a.Args, ",") == strings.Join(o.Args, ",")
-}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7620,6 +7620,9 @@ type Task struct {
 	// Identities are the alternate workload identities for use with 3rd party
 	// endpoints.
 	Identities []*WorkloadIdentity
+
+	// Alloc-exec-like runnable commands
+	Actions []*Action
 }
 
 func (t *Task) UsesCores() bool {
@@ -13281,4 +13284,11 @@ func NewRpcError(err error, code *int64) *RpcError {
 
 func (r *RpcError) Error() string {
 	return r.Message
+}
+
+type Action struct {
+	Name    string
+	Command *string
+	Args    []string
+	// Type    *string
 }

--- a/ui/app/services/sockets.js
+++ b/ui/app/services/sockets.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+// @ts-check
 import Service from '@ember/service';
 import config from 'nomad-ui/config/environment';
 import { getOwner } from '@ember/application';
@@ -35,12 +36,21 @@ export default class SocketsService extends Service {
         },
       });
     } else {
+      const shouldForward = config.APP.deproxyWebsockets;
+
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const applicationAdapter = getOwner(this).lookup('adapter:application');
-      const prefix = `${
-        applicationAdapter.host || window.location.host
-      }/${applicationAdapter.urlPrefix()}`;
+
+      // FIXME: Temporary, local ember implementation to get around websocket proxy issues duiring development.
+      let prefix;
       const region = this.system.activeRegion;
+      if (!shouldForward) {
+        const applicationAdapter = getOwner(this).lookup('adapter:application');
+        prefix = `${
+          applicationAdapter.host || window.location.host
+        }/${applicationAdapter.urlPrefix()}`;
+      } else {
+        prefix = 'localhost:4646/v1';
+      }
 
       return new WebSocket(
         `${protocol}//${prefix}/client/allocation/${taskState.allocation.id}` +

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -55,6 +55,10 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
 
+    // FIXME: Temporary, local ember implementation
+    // to get around websocket proxy issues duiring development.
+    ENV.APP.deproxyWebsockets = true;
+
     ENV['ember-cli-mirage'] = {
       enabled: USE_MIRAGE,
       excludeFilesFromBuild: !USE_MIRAGE,


### PR DESCRIPTION
First steps in setting up Nomad Actions (#18627)
- Establishes the Action struct at task level and allows them to be included in a jobspec
- Returns them under tasks on the GET job endpoint

Also includes a (temporary) workaround to get exec working on our local Ember development environment: direct forwarding to :4646. This is marked with FIXMEs and will be removed prior to merge with main.