### PR TITLE
[f-gh-1106-reporting] Use full cluster metadata for reporting 

### DIFF
--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -368,7 +368,7 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 	schedulerConfig := s.getOrCreateSchedulerConfig()
 
 	// Initialize the Cluster metadata
-	clusterMetadata, err := s.ClusterMetadata()
+	clusterMetadata, err := s.ClusterMetaData()
 	if err != nil {
 		return err
 	}

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -368,7 +368,7 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 	schedulerConfig := s.getOrCreateSchedulerConfig()
 
 	// Initialize the Cluster metadata
-	clusterMetadata, err := s.generateClusterMetadata()
+	clusterMetadata, err := s.ClusterMetadata()
 	if err != nil {
 		return err
 	}

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -367,8 +367,11 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 	// Initialize scheduler configuration.
 	schedulerConfig := s.getOrCreateSchedulerConfig()
 
-	// Initialize the ClusterID
-	_, _ = s.ClusterID()
+	// Initialize the Cluster metadata
+	clusterMetadata, err := s.generateClusterMetadata()
+	if err != nil {
+		return err
+	}
 	// todo: use cluster ID for stuff, later!
 
 	// Enable the plan queue, since we are now the leader
@@ -489,7 +492,7 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 	}
 
 	// Setup any enterprise systems required.
-	if err := s.establishEnterpriseLeadership(stopCh); err != nil {
+	if err := s.establishEnterpriseLeadership(stopCh, clusterMetadata); err != nil {
 		return err
 	}
 
@@ -2776,20 +2779,20 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) {
 	logger.Info("initialized keyring", "id", rootKey.Meta.KeyID)
 }
 
-func (s *Server) generateClusterID() (string, error) {
+func (s *Server) generateClusterMetadata() (structs.ClusterMetadata, error) {
 	if !ServersMeetMinimumVersion(s.Members(), AllRegions, minClusterIDVersion, false) {
 		s.logger.Named("core").Warn("cannot initialize cluster ID until all servers are above minimum version", "min_version", minClusterIDVersion)
-		return "", fmt.Errorf("cluster ID cannot be created until all servers are above minimum version %s", minClusterIDVersion)
+		return structs.ClusterMetadata{}, fmt.Errorf("cluster ID cannot be created until all servers are above minimum version %s", minClusterIDVersion)
 	}
 
 	newMeta := structs.ClusterMetadata{ClusterID: uuid.Generate(), CreateTime: time.Now().UnixNano()}
 	if _, _, err := s.raftApply(structs.ClusterMetadataRequestType, newMeta); err != nil {
 		s.logger.Named("core").Error("failed to create cluster ID", "error", err)
-		return "", fmt.Errorf("failed to create cluster ID: %w", err)
+		return structs.ClusterMetadata{}, fmt.Errorf("failed to create cluster ID: %w", err)
 	}
 
 	s.logger.Named("core").Info("established cluster id", "cluster_id", newMeta.ClusterID, "create_time", newMeta.CreateTime)
-	return newMeta.ClusterID, nil
+	return newMeta, nil
 }
 
 // handleEvalBrokerStateChange handles changing the evalBroker and blockedEvals

--- a/nomad/leader_ce.go
+++ b/nomad/leader_ce.go
@@ -6,8 +6,10 @@
 
 package nomad
 
+import "github.com/hashicorp/nomad/nomad/structs"
+
 // establishEnterpriseLeadership is a no-op on OSS.
-func (s *Server) establishEnterpriseLeadership(stopCh chan struct{}) error {
+func (s *Server) establishEnterpriseLeadership(stopCh chan struct{}, clusterMD structs.ClusterMetadata) error {
 	return nil
 }
 

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -2042,11 +2042,13 @@ func (n *Node) DeriveSIToken(args *structs.DeriveSITokenRequest, reply *structs.
 	}
 
 	// Get the ClusterID
-	clusterID, err := n.srv.ClusterID()
+	clusterMD, err := n.srv.ClusterMetaData()
 	if err != nil {
 		setError(err, false)
 		return nil
 	}
+
+	clusterID := clusterMD.ClusterID
 
 	// Verify the following:
 	// * The Node exists and has the correct SecretID.

--- a/nomad/operator_endpoint_test.go
+++ b/nomad/operator_endpoint_test.go
@@ -584,7 +584,7 @@ func TestOperator_SchedulerGetConfiguration(t *testing.T) {
 	ci.Parallel(t)
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
-		c.Build = "0.9.0+unittest"
+		c.Build = "1.3.0+unittest"
 	})
 	defer cleanupS1()
 	codec := rpcClient(t, s1)
@@ -608,7 +608,7 @@ func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 	ci.Parallel(t)
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
-		c.Build = "0.9.0+unittest"
+		c.Build = "1.3.0+unittest"
 	})
 	defer cleanupS1()
 	rpcCodec := rpcClient(t, s1)
@@ -654,7 +654,7 @@ func TestOperator_SchedulerGetConfiguration_ACL(t *testing.T) {
 
 	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 3
-		c.Build = "0.9.0+unittest"
+		c.Build = "1.3.0+unittest"
 	})
 	defer cleanupS1()
 	codec := rpcClient(t, s1)
@@ -701,7 +701,7 @@ func TestOperator_SchedulerSetConfiguration_ACL(t *testing.T) {
 
 	s1, root, cleanupS1 := TestACLServer(t, func(c *Config) {
 		c.RaftConfig.ProtocolVersion = 3
-		c.Build = "0.9.0+unittest"
+		c.Build = "1.3.0+unittest"
 	})
 	defer cleanupS1()
 	codec := rpcClient(t, s1)

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -47,7 +47,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/nomad/volumewatcher"
-	"github.com/hashicorp/nomad/reporting"
 	"github.com/hashicorp/nomad/scheduler"
 )
 

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -47,6 +47,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/nomad/volumewatcher"
+	"github.com/hashicorp/nomad/reporting"
 	"github.com/hashicorp/nomad/scheduler"
 )
 

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	structsconfig "github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/version"
 	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/shoenig/test/must"
@@ -114,6 +115,8 @@ func TestConfigForServer(t testing.T) *Config {
 
 	// Default to having concurrent schedulers
 	config.NumSchedulers = 2
+
+	config.Reporting = structsconfig.DefaultReporting()
 
 	return config
 }


### PR DESCRIPTION
This PR changes the usage of Cluster ID to Cluster metadata and uses it to start the reporting agent.

Refer to [1257](https://github.com/hashicorp/nomad-enterprise/pull/1257)