### PR TITLE
WID manager: save and restore signed WIs from client state DB

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -273,7 +273,7 @@ func NewAllocRunner(config *config.AllocRunnerConfig) (interfaces.AllocRunner, e
 	ar.shutdownDelayCancelFn = shutdownDelayCancel
 
 	// initialize the workload identity manager
-	widmgr := widmgr.NewWIDMgr(ar.widsigner, alloc, ar.logger)
+	widmgr := widmgr.NewWIDMgr(ar.widsigner, alloc, ar.stateDB, ar.logger)
 	ar.widmgr = widmgr
 
 	// Initialize the runners hooks.

--- a/client/allocrunner/identity_hook_test.go
+++ b/client/allocrunner/identity_hook_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	cstate "github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/widmgr"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -44,10 +45,11 @@ func TestIdentityHook_Prerun(t *testing.T) {
 	defer stopAR()
 
 	logger := testlog.HCLogger(t)
+	db := cstate.NewMemDB(logger)
 
 	// setup mock signer and WIDMgr
 	mockSigner := widmgr.NewMockWIDSigner(task.Identities)
-	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, logger)
+	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, db, logger)
 	allocrunner.widmgr = mockWIDMgr
 	allocrunner.widsigner = mockSigner
 

--- a/client/allocrunner/taskrunner/identity_hook_test.go
+++ b/client/allocrunner/taskrunner/identity_hook_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	cstate "github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/client/widmgr"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -73,8 +74,10 @@ func TestIdentityHook_RenewAll(t *testing.T) {
 	t.Cleanup(stop)
 
 	// setup mock signer and WIDMgr
+	logger := testlog.HCLogger(t)
+	db := cstate.NewMemDB(logger)
 	mockSigner := widmgr.NewMockWIDSigner(task.Identities)
-	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, testlog.HCLogger(t))
+	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, db, logger)
 	mockWIDMgr.SetMinWait(time.Second) // fast renewals, because the default is 10s
 
 	// do the initial signing
@@ -177,8 +180,10 @@ func TestIdentityHook_RenewOne(t *testing.T) {
 	t.Cleanup(stop)
 
 	// setup mock signer and WIDMgr
+	logger := testlog.HCLogger(t)
+	db := cstate.NewMemDB(logger)
 	mockSigner := widmgr.NewMockWIDSigner(task.Identities)
-	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, testlog.HCLogger(t))
+	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, db, logger)
 	mockWIDMgr.SetMinWait(time.Second) // fast renewals, because the default is 10s
 
 	// do the initial signing

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -120,6 +120,7 @@ func testTaskRunnerConfig(t *testing.T, alloc *structs.Allocation, taskName stri
 
 	task := alloc.LookupTask(taskName)
 	widsigner := widmgr.NewMockWIDSigner(task.Identities)
+	db := cstate.NewMemDB(logger)
 
 	var vaultFunc vaultclient.VaultClientFunc
 	if vault != nil {
@@ -146,7 +147,7 @@ func testTaskRunnerConfig(t *testing.T, alloc *structs.Allocation, taskName stri
 		ServiceRegWrapper:     wrapperMock,
 		Getter:                getter.TestSandbox(t),
 		Wranglers:             proclib.MockWranglers(t),
-		WIDMgr:                widmgr.NewWIDMgr(widsigner, alloc, logger),
+		WIDMgr:                widmgr.NewWIDMgr(widsigner, alloc, db, logger),
 		AllocHookResources:    cstructs.NewAllocHookResources(),
 	}
 

--- a/client/state/db_error.go
+++ b/client/state/db_error.go
@@ -70,6 +70,14 @@ func (m *ErrDB) GetAllocVolumes(allocID string) (*arstate.AllocVolumes, error) {
 	return nil, fmt.Errorf("Error!")
 }
 
+func (m *ErrDB) PutAllocIdentities(_ string, _ []*structs.SignedWorkloadIdentity, _ ...WriteOption) error {
+	return fmt.Errorf("Error!")
+}
+
+func (m *ErrDB) GetAllocIdentities(_ string) ([]*structs.SignedWorkloadIdentity, error) {
+	return nil, fmt.Errorf("Error!")
+}
+
 func (m *ErrDB) GetTaskRunnerState(allocID string, taskName string) (*state.LocalState, *structs.TaskState, error) {
 	return nil, nil, fmt.Errorf("Error!")
 }

--- a/client/state/db_noop.go
+++ b/client/state/db_noop.go
@@ -61,6 +61,14 @@ func (n NoopDB) PutAllocVolumes(allocID string, state *arstate.AllocVolumes, opt
 
 func (n NoopDB) GetAllocVolumes(allocID string) (*arstate.AllocVolumes, error) { return nil, nil }
 
+func (n NoopDB) PutAllocIdentities(_ string, _ []*structs.SignedWorkloadIdentity, _ ...WriteOption) error {
+	return nil
+}
+
+func (n NoopDB) GetAllocIdentities(_ string) ([]*structs.SignedWorkloadIdentity, error) {
+	return nil, nil
+}
+
 func (n NoopDB) GetTaskRunnerState(allocID string, taskName string) (*state.LocalState, *structs.TaskState, error) {
 	return nil, nil, nil
 }

--- a/client/state/interface.go
+++ b/client/state/interface.go
@@ -62,6 +62,13 @@ type StateDB interface {
 	// so they can be restored.
 	GetAllocVolumes(allocID string) (*arstate.AllocVolumes, error)
 
+	// PutAllocIdentities stores signed workload identities for an allocation.
+	PutAllocIdentities(allocID string, identities []*structs.SignedWorkloadIdentity, opts ...WriteOption) error
+
+	// GetAllocIdentities returns the previously-signed workload identities for
+	// an allocation.
+	GetAllocIdentities(allocID string) ([]*structs.SignedWorkloadIdentity, error)
+
 	// GetTaskRunnerState returns the LocalState and TaskState for a
 	// TaskRunner. Either state may be nil if it is not found, but if an
 	// error is encountered only the error will be non-nil.

--- a/client/widmgr/widmgr.go
+++ b/client/widmgr/widmgr.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
+	cstate "github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -30,6 +31,7 @@ type WIDMgr struct {
 	minIndex                uint64
 	widSpecs                map[string][]*structs.WorkloadIdentity // task -> WI
 	signer                  IdentitySigner
+	db                      cstate.StateDB
 
 	// lastToken are the last retrieved signed workload identifiers keyed by
 	// TaskIdentity
@@ -51,7 +53,7 @@ type WIDMgr struct {
 	logger hclog.Logger
 }
 
-func NewWIDMgr(signer IdentitySigner, a *structs.Allocation, logger hclog.Logger) *WIDMgr {
+func NewWIDMgr(signer IdentitySigner, a *structs.Allocation, db cstate.StateDB, logger hclog.Logger) *WIDMgr {
 	widspecs := map[string][]*structs.WorkloadIdentity{}
 	tg := a.Job.LookupTaskGroup(a.TaskGroup)
 	for _, task := range tg.Tasks {
@@ -71,6 +73,7 @@ func NewWIDMgr(signer IdentitySigner, a *structs.Allocation, logger hclog.Logger
 		minIndex:                a.CreateIndex,
 		widSpecs:                widspecs,
 		signer:                  signer,
+		db:                      db,
 		minWait:                 10 * time.Second,
 		lastToken:               map[structs.WIHandle]*structs.SignedWorkloadIdentity{},
 		watchers:                map[structs.WIHandle][]chan *structs.SignedWorkloadIdentity{},
@@ -98,8 +101,14 @@ func (m *WIDMgr) Run() error {
 
 	m.logger.Debug("retrieving and renewing workload identities", "num_identities", len(m.widSpecs))
 
-	if err := m.getIdentities(); err != nil {
-		return fmt.Errorf("failed to fetch signed identities: %w", err)
+	hasExpired, err := m.restoreStoredIdentities()
+	if err != nil {
+		m.logger.Warn("failed to get signed identities from state DB, refreshing from server: %w", err)
+	}
+	if hasExpired {
+		if err := m.getInitialIdentities(); err != nil {
+			return fmt.Errorf("failed to fetch signed identities: %w", err)
+		}
 	}
 
 	go m.renew()
@@ -186,8 +195,37 @@ func (m *WIDMgr) Shutdown() {
 	}
 }
 
-// getIdentities fetches all signed identities or returns an error.
-func (m *WIDMgr) getIdentities() error {
+// restoreStoredIdentities recreates the state of the WIDMgr from a previously
+// saved state, so that we can avoid asking for all identities again after a
+// client agent restart. It returns true if the caller should immediately call
+// getIdentities because one or more of the identities is expired.
+func (m *WIDMgr) restoreStoredIdentities() (bool, error) {
+	storedIdentities, err := m.db.GetAllocIdentities(m.allocID)
+	if err != nil {
+		return true, err
+	}
+	if len(storedIdentities) == 0 {
+		return true, nil
+	}
+
+	m.lastTokenLock.Lock()
+	defer m.lastTokenLock.Unlock()
+
+	var hasExpired bool
+
+	for _, identity := range storedIdentities {
+		if !identity.Expiration.IsZero() && identity.Expiration.Before(time.Now()) {
+			hasExpired = true
+		}
+		m.lastToken[identity.WIHandle] = identity
+	}
+
+	return hasExpired, nil
+}
+
+// getInitialIdentities fetches all signed identities or returns an error. It
+// should be run once when the WIDMgr first runs.
+func (m *WIDMgr) getInitialIdentities() error {
 	// get the default identity signed by the plan applier
 	defaultTokens := map[structs.WIHandle]*structs.SignedWorkloadIdentity{}
 	for taskName, signature := range m.defaultSignedIdentities {
@@ -249,8 +287,7 @@ func (m *WIDMgr) getIdentities() error {
 		m.lastToken[swid.WIHandle] = swid
 	}
 
-	// TODO: Persist signed identity token to client state
-	return nil
+	return m.db.PutAllocIdentities(m.allocID, signedWIDs)
 }
 
 // renew fetches new signed workload identity tokens before the existing tokens

--- a/client/widmgr/widmgr_int_test.go
+++ b/client/widmgr/widmgr_int_test.go
@@ -1,0 +1,119 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package widmgr_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/client/widmgr"
+	"github.com/hashicorp/nomad/command/agent"
+	"github.com/hashicorp/nomad/helper/pointer"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
+)
+
+func TestWIDMgr(t *testing.T) {
+	ci.Parallel(t)
+
+	// Create a mixed ta
+	ta := agent.NewTestAgent(t, "widtest", func(c *agent.Config) {
+		c.Server.Enabled = true
+		c.Server.NumSchedulers = pointer.Of(1)
+		c.Client.Enabled = true
+	})
+	t.Cleanup(ta.Shutdown)
+
+	mgr := widmgr.NewSigner(widmgr.SignerConfig{
+		NodeSecret: uuid.Generate(), // not checked when ACLs disabled
+		Region:     "global",
+		RPC:        ta,
+	})
+
+	_, err := mgr.SignIdentities(1, nil)
+	must.ErrorContains(t, err, "no identities to sign")
+
+	_, err = mgr.SignIdentities(1, []*structs.WorkloadIdentityRequest{
+		{
+			AllocID: uuid.Generate(),
+			WIHandle: structs.WIHandle{
+				WorkloadIdentifier: "web",
+				IdentityName:       "foo",
+			},
+		},
+	})
+	must.ErrorContains(t, err, "rejected")
+
+	// Register a job with 3 identities (but only 2 that need signing)
+	job := mock.MinJob()
+	job.TaskGroups[0].Tasks[0].Identity = &structs.WorkloadIdentity{
+		Env: true,
+	}
+	job.TaskGroups[0].Tasks[0].Identities = []*structs.WorkloadIdentity{
+		{
+			Name:     "consul",
+			Audience: []string{"a", "b"},
+			Env:      true,
+		},
+		{
+			Name: "vault",
+			File: true,
+		},
+	}
+	job.Canonicalize()
+
+	testutil.RegisterJob(t, ta.RPC, job)
+
+	var allocs []*structs.AllocListStub
+	testutil.WaitForResult(func() (bool, error) {
+		args := &structs.JobSpecificRequest{}
+		args.JobID = job.ID
+		args.QueryOptions.Region = job.Region
+		args.Namespace = job.Namespace
+		var resp structs.JobAllocationsResponse
+		err := ta.RPC("Job.Allocations", args, &resp)
+		if err != nil {
+			return false, fmt.Errorf("Job.Allocations error: %v", err)
+		}
+
+		if len(resp.Allocations) == 0 {
+			return false, fmt.Errorf("no allocs")
+		}
+		allocs = resp.Allocations
+		return len(allocs) == 1, fmt.Errorf("unexpected number of allocs: %d", len(allocs))
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+	must.Len(t, 1, allocs)
+
+	// Get signed identites for alloc
+	widreqs := []*structs.WorkloadIdentityRequest{
+		{
+			AllocID: allocs[0].ID,
+			WIHandle: structs.WIHandle{
+				WorkloadIdentifier: job.TaskGroups[0].Tasks[0].Name,
+				IdentityName:       "consul",
+			},
+		},
+		{
+			AllocID: allocs[0].ID,
+			WIHandle: structs.WIHandle{
+				WorkloadIdentifier: job.TaskGroups[0].Tasks[0].Name,
+				IdentityName:       "vault",
+			},
+		},
+	}
+
+	swids, err := mgr.SignIdentities(allocs[0].CreateIndex, widreqs)
+	must.NoError(t, err)
+	must.Len(t, 2, swids)
+	must.Eq(t, *widreqs[0], swids[0].WorkloadIdentityRequest)
+	must.StrContains(t, swids[0].JWT, ".")
+	must.Eq(t, *widreqs[1], swids[1].WorkloadIdentityRequest)
+	must.StrContains(t, swids[1].JWT, ".")
+}


### PR DESCRIPTION
When clients are restarted and the identity hook runs when we restore allocations, the running allocations are likely to have already-signed Workload Identities that are unexpired. Save these to the client's local state DB so that we can avoid a thundering herd of RPCs during client restart. When we restore, we'll check if there's at least one expired signed WI before making any initial signing request.

Included:
* Renames `getIdentities` to `getInitialIdentities` to make the workflow more clear.
* Renames the existing `widmgr_test.go` file of integration tests, which is in its own package to avoid circular imports to `widmgr_int_test.go`

Currently WIP because we'll need https://github.com/hashicorp/nomad/pull/18650 for it to make any sense for service identities, which @pkazmierczak is currently working on.