### PR TITLE
client: ensure task only runs with prestart hooks

### DIFF
--- a/.changelog/18662.txt
+++ b/.changelog/18662.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: prevent tasks from starting without the prestart hooks running
+```

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -599,6 +599,12 @@ MAIN:
 			goto RESTART
 		}
 
+		// Check for a terminal allocation once more before proceeding as the
+		// prestart hooks may have been skipped.
+		if tr.shouldShutdown() {
+			break MAIN
+		}
+
 		select {
 		case <-tr.killCtx.Done():
 			break MAIN


### PR DESCRIPTION
Since the allocation in the task runner is updated in a separate goroutine, a race condition may happen where the task is started but the prestart hooks are skipped because the allocation became terminal.

Checking for a terminal allocation before proceeding with the task start ensures the task only runs if the prestart hooks are also executed.

Since `shouldShutdown()` only uses terminal allocation status, it remains `true` after the first transition, so it's safe to check it again after the prestart hooks as it will never revert to `false`.

Some other implementations ideas I considered:
1. Move the check for `shouldShutdown()` from within `prestart()` to before it is called. I think this would be more or less equivalent to this approach.
2. Create a read lock on the task runner alloc so that `shouldShutdown()` is guaranteed not to change while `prestart()` runs and the task starts. This is probably the most "correct"  approach, but since `shouldShutdown()` can only transition from `false` to `true`, checking it again after `prestart()` seems enough.

Closes #18659