### PR TITLE
[ui] Allow nomad agent to configure stats polling

### DIFF
--- a/nomad/structs/config/ui.go
+++ b/nomad/structs/config/ui.go
@@ -28,6 +28,9 @@ type UIConfig struct {
 
 	// Label configures UI label styles
 	Label *LabelUIConfig `hcl:"label"`
+
+	// PollStats configures the polling of stats from the server
+	PollStats *PollStatsConfig `hcl:"poll_stats"`
 }
 
 // only covers the elements of
@@ -133,6 +136,14 @@ type LabelUIConfig struct {
 	TextColor       string `hcl:"text_color"`
 }
 
+// PollStatsConfig configures the polling of stats from the server
+type PollStatsConfig struct {
+	// Enabled is used to enable polling of stats from the server
+	Enabled bool `hcl:"enabled"`
+	// Interval is the interval, in seconds, at which to poll stats from the server
+	Interval int `hcl:"interval"`
+}
+
 // DefaultUIConfig returns the canonical defaults for the Nomad
 // `ui` configuration.
 func DefaultUIConfig() *UIConfig {
@@ -142,6 +153,7 @@ func DefaultUIConfig() *UIConfig {
 		Vault:                 &VaultUIConfig{},
 		Label:                 &LabelUIConfig{},
 		ContentSecurityPolicy: DefaultCSPConfig(),
+		PollStats:             &PollStatsConfig{},
 	}
 }
 
@@ -175,6 +187,7 @@ func (old *UIConfig) Merge(other *UIConfig) *UIConfig {
 	result.Consul = result.Consul.Merge(other.Consul)
 	result.Vault = result.Vault.Merge(other.Vault)
 	result.Label = result.Label.Merge(other.Label)
+	result.PollStats = result.PollStats.Merge(other.PollStats)
 	result.ContentSecurityPolicy = result.ContentSecurityPolicy.Merge(other.ContentSecurityPolicy)
 
 	return result
@@ -267,5 +280,32 @@ func (old *LabelUIConfig) Merge(other *LabelUIConfig) *LabelUIConfig {
 	if other.TextColor != "" {
 		result.TextColor = other.TextColor
 	}
+	return result
+}
+
+// Copy returns a copy of this PollStats config.
+func (old *PollStatsConfig) Copy() *PollStatsConfig {
+	if old == nil {
+		return nil
+	}
+
+	nc := new(PollStatsConfig)
+	*nc = *old
+	return nc
+}
+
+// Merge returns a new PollStats configuration by merging another PollStats
+// configuration into this one
+func (old *PollStatsConfig) Merge(other *PollStatsConfig) *PollStatsConfig {
+	result := old.Copy()
+	if result == nil {
+		result = &PollStatsConfig{}
+	}
+	if other == nil {
+		return result
+	}
+
+	result.Enabled = other.Enabled
+	result.Interval = other.Interval
 	return result
 }

--- a/ui/app/components/allocation-row.js
+++ b/ui/app/components/allocation-row.js
@@ -48,7 +48,7 @@ export default class AllocationRow extends Component {
       this.system.agent.get('config')?.UI?.PollStats
     );
     return (
-      !Ember.testing && this.system.agent.get('config')?.UI?.PollStats.Enabled
+      !Ember.testing && this.system.agent.get('config')?.UI?.PollStats?.Enabled
     );
   }
 
@@ -59,6 +59,7 @@ export default class AllocationRow extends Component {
     return new AllocationStatsTracker({
       fetch: (url) => this.token.authorizedRequest(url),
       allocation: this.allocation,
+      interval: this.system.agent.get('config')?.UI?.PollStats?.Interval,
     });
   }
 
@@ -88,7 +89,6 @@ export default class AllocationRow extends Component {
 
   @(task(function* () {
     do {
-      console.log('fetchStats');
       console.timeEnd('fetchStats');
       console.time('fetchStats');
       if (this.stats) {
@@ -126,8 +126,6 @@ async function qualifyAllocation() {
     const job = allocation.get('job.content');
     if (job.isPartial) await job.reload();
   }
-
-  console.log('qualAlloc');
 
   this.fetchStats.perform();
 }

--- a/ui/app/components/primary-metric/task.js
+++ b/ui/app/components/primary-metric/task.js
@@ -58,6 +58,7 @@ export default class TaskPrimaryMetric extends Component {
   @action
   start() {
     this.taskState = this.args.taskState;
+    console.log('about to start');
     this.tracker = this.statsTrackersRegistry.getTracker(
       this.args.taskState.allocation
     );

--- a/ui/app/components/task-row.js
+++ b/ui/app/components/task-row.js
@@ -25,6 +25,7 @@ import classic from 'ember-classic-decorator';
 export default class TaskRow extends Component {
   @service store;
   @service token;
+  @service system;
   @service('stats-trackers-registry') statsTrackersRegistry;
 
   task = null;
@@ -34,7 +35,10 @@ export default class TaskRow extends Component {
 
   @computed
   get enablePolling() {
-    return !Ember.testing;
+    return (
+      !Ember.testing &&
+      !(this.system.agent.get('config')?.UI?.PollStats.Enabled === false)
+    );
   }
 
   // Since all tasks for an allocation share the same tracker, use the registry

--- a/ui/app/components/task-row.js
+++ b/ui/app/components/task-row.js
@@ -10,6 +10,7 @@ import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import { task, timeout } from 'ember-concurrency';
 import { lazyClick } from '../helpers/lazy-click';
+import AllocationStatsTracker from 'nomad-ui/utils/classes/allocation-stats-tracker';
 
 import {
   classNames,
@@ -37,7 +38,7 @@ export default class TaskRow extends Component {
   get enablePolling() {
     return (
       !Ember.testing &&
-      !(this.system.agent.get('config')?.UI?.PollStats.Enabled === false)
+      !(this.system.agent.get('config')?.UI?.PollStats?.Enabled === false)
     );
   }
 
@@ -46,7 +47,12 @@ export default class TaskRow extends Component {
   get stats() {
     if (!this.get('task.isRunning')) return undefined;
 
-    return this.statsTrackersRegistry.getTracker(this.get('task.allocation'));
+    // return this.statsTrackersRegistry.getTracker(this.get('task.allocation'));
+    return new AllocationStatsTracker({
+      fetch: (url) => this.token.authorizedRequest(url),
+      allocation: this.allocation,
+      interval: 9,
+    });
   }
 
   @computed('task.name', 'stats.tasks.[]')

--- a/ui/app/components/task-sub-row.js
+++ b/ui/app/components/task-sub-row.js
@@ -51,7 +51,7 @@ export default class TaskSubRowComponent extends Component {
   get enablePolling() {
     return (
       !Ember.testing &&
-      !(this.system.agent.get('config')?.UI?.PollStats.Enabled === false)
+      !(this.system.agent.get('config')?.UI?.PollStats?.Enabled === false)
     );
   }
 

--- a/ui/app/components/task-sub-row.js
+++ b/ui/app/components/task-sub-row.js
@@ -15,6 +15,7 @@ import { tracked } from '@glimmer/tracking';
 export default class TaskSubRowComponent extends Component {
   @service store;
   @service router;
+  @service system;
   @service('stats-trackers-registry') statsTrackersRegistry;
 
   constructor() {
@@ -48,7 +49,10 @@ export default class TaskSubRowComponent extends Component {
 
   @computed
   get enablePolling() {
-    return !Ember.testing;
+    return (
+      !Ember.testing &&
+      !(this.system.agent.get('config')?.UI?.PollStats.Enabled === false)
+    );
   }
 
   @computed('task.name', 'stats.tasks.[]')
@@ -72,7 +76,9 @@ export default class TaskSubRowComponent extends Component {
         }
       }
 
-      yield timeout(500);
+      yield timeout(
+        this.system.agent.get('config')?.UI?.PollStats.Interval * 1000 || 500
+      );
     } while (this.enablePolling);
   }).drop())
   fetchStats;

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -52,6 +52,9 @@ export default class SystemService extends Service {
             if (VersionMetadata)
               agent.version = `${agent.version}+${VersionMetadata}`;
           }
+
+          // Pseudo UI block if not present
+          console.log('agent UI?', agent, agent.config.UI);
           return agent;
         }),
     });

--- a/ui/app/utils/classes/abstract-stats-tracker.js
+++ b/ui/app/utils/classes/abstract-stats-tracker.js
@@ -3,44 +3,44 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import Ember from 'ember';
-import Mixin from '@ember/object/mixin';
-import { assert } from '@ember/debug';
+import EmberObject from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
 import jsonWithDefault from 'nomad-ui/utils/json-with-default';
+import { assert } from '@ember/debug';
+import classic from 'ember-classic-decorator';
 
-// eslint-disable-next-line ember/no-new-mixins
-export default Mixin.create({
-  url: '',
+@classic
+export default class AbstractStatsTracker {
+  url = '';
 
   // The max number of data points tracked. Once the max is reached,
   // data points at the head of the list are removed in favor of new
   // data appended at the tail
-  bufferSize: 500,
+  bufferSize = 500;
 
   // The number of consecutive request failures that can occur before an
   // empty frame is appended
-  maxFrameMisses: 5,
+  maxFrameMisses = 5;
+
+  frameMisses = 0;
 
   fetch() {
     assert(
       'StatsTrackers need a fetch method, which should have an interface like window.fetch'
     );
-  },
+  }
 
   append(/* frame */) {
     assert(
       'StatsTrackers need an append method, which takes the JSON response from a request to url as an argument'
     );
-  },
+  }
 
   pause() {
     assert(
       'StatsTrackers need a pause method, which takes no arguments but adds a frame of data at the current timestamp with null as the value'
     );
-  },
-
-  frameMisses: 0,
+  }
 
   handleResponse(frame) {
     if (frame.error) {
@@ -48,26 +48,31 @@ export default Mixin.create({
       if (this.frameMisses >= this.maxFrameMisses) {
         // Missing enough data consecutively is effectively a pause
         this.pause();
-        this.set('frameMisses', 0);
+        this.frameMisses = 0;
       }
       return;
     } else {
-      this.set('frameMisses', 0);
+      this.frameMisses = 0;
 
       // Only append non-error frames
       this.append(frame);
     }
-  },
+  }
 
   // Uses EC as a form of debounce to prevent multiple
   // references to the same tracker from flooding the tracker,
   // but also avoiding the issue where different places where the
   // same tracker is used needs to coordinate.
-  poll: task(function* () {
+  @task *poll() {
     // Interrupt any pause attempt
     this.signalPause.cancelAll();
 
     try {
+      console.log('tryin', this);
+      console.log('abstract poll called');
+      console.log('constructor', this.constructor.name);
+      console.log('prototype chain check', Object.getPrototypeOf(this));
+
       const url = this.url;
       assert('Url must be defined', url);
 
@@ -75,16 +80,18 @@ export default Mixin.create({
         .then(jsonWithDefault({ error: true }))
         .then((frame) => this.handleResponse(frame));
     } catch (error) {
+      console.log('caught', error);
       throw new Error(error);
     }
+    console.log('about to timeout');
 
     yield timeout(Ember.testing ? 0 : 2000);
-  }).drop(),
+  }
 
-  signalPause: task(function* () {
+  @task *signalPause() {
     // wait 2 seconds
     yield timeout(Ember.testing ? 0 : 2000);
     // if no poll called in 2 seconds, pause
     this.pause();
-  }).drop(),
-});
+  }
+}

--- a/ui/app/utils/classes/allocation-stats-tracker.js
+++ b/ui/app/utils/classes/allocation-stats-tracker.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import EmberObject, { get, computed } from '@ember/object';
+import { get, computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import RollingArray from 'nomad-ui/utils/classes/rolling-array';
 import AbstractStatsTracker from 'nomad-ui/utils/classes/abstract-stats-tracker';
@@ -43,11 +43,11 @@ const memoryUsed = (frame) =>
 
 @classic
 class AllocationStatsTracker extends AbstractStatsTracker {
-  constructor({ fetch, allocation }) {
+  constructor({ fetch, allocation, interval }) {
     super();
     this.fetch = fetch;
     this.allocation = allocation;
-    // this.url = `/v1/client/allocation/${this.allocation.id}/stats`;
+    this.interval = interval;
   }
 
   // Set via the stats computed property macro
@@ -55,7 +55,6 @@ class AllocationStatsTracker extends AbstractStatsTracker {
 
   @computed('allocation.id')
   get url() {
-    console.log('earl', this.allocation);
     return `/v1/client/allocation/${this.allocation.id}/stats`;
   }
 

--- a/ui/app/utils/classes/allocation-stats-tracker.js
+++ b/ui/app/utils/classes/allocation-stats-tracker.js
@@ -42,13 +42,21 @@ const memoryUsed = (frame) =>
   0;
 
 @classic
-class AllocationStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
+class AllocationStatsTracker extends AbstractStatsTracker {
+  constructor({ fetch, allocation }) {
+    super();
+    this.fetch = fetch;
+    this.allocation = allocation;
+    // this.url = `/v1/client/allocation/${this.allocation.id}/stats`;
+  }
+
   // Set via the stats computed property macro
   allocation = null;
 
   @computed('allocation.id')
   get url() {
-    return `/v1/client/allocation/${this.get('allocation.id')}/stats`;
+    console.log('earl', this.allocation);
+    return `/v1/client/allocation/${this.allocation.id}/stats`;
   }
 
   append(frame) {
@@ -139,7 +147,7 @@ class AllocationStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
   @computed('allocation.taskGroup.tasks', 'bufferSize')
   get tasks() {
     const bufferSize = this.bufferSize;
-    const tasks = this.get('allocation.taskGroup.tasks') || [];
+    const tasks = this.allocation.taskGroup.tasks || [];
     return tasks
       .slice()
       .sort(taskPrioritySort)
@@ -161,8 +169,14 @@ class AllocationStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
 export default AllocationStatsTracker;
 
 export function stats(allocationProp, fetch) {
+  // return computed(allocationProp, function () {
+  //   return AllocationStatsTracker.create({
+  //     fetch: fetch.call(this),
+  //     allocation: this.get(allocationProp),
+  //   });
+  // });
   return computed(allocationProp, function () {
-    return AllocationStatsTracker.create({
+    return new AllocationStatsTracker({
       fetch: fetch.call(this),
       allocation: this.get(allocationProp),
     });

--- a/ui/app/utils/classes/node-stats-tracker.js
+++ b/ui/app/utils/classes/node-stats-tracker.js
@@ -20,12 +20,19 @@ const empty = (ts) => ({ timestamp: ts, used: null, percent: null });
 
 @classic
 class NodeStatsTracker extends AbstractStatsTracker {
+  constructor({ fetch, allocation, interval }) {
+    super();
+    this.fetch = fetch;
+    this.allocation = allocation;
+    this.interval = 2;
+  }
+
   // Set via the stats computed property macro
   node = null;
 
   @computed('node.id')
   get url() {
-    return `/v1/client/stats?node_id=${this.get('node.id')}`;
+    return `/v1/client/stats?node_id=${this.node.id}`;
   }
 
   append(frame) {
@@ -75,7 +82,7 @@ export function stats(nodeProp, fetch) {
   return computed(nodeProp, function () {
     return new NodeStatsTracker({
       fetch: fetch.call(this),
-      node: this.get(nodeProp),
+      node: this[nodeProp],
     });
   });
 }

--- a/ui/app/utils/classes/node-stats-tracker.js
+++ b/ui/app/utils/classes/node-stats-tracker.js
@@ -19,7 +19,7 @@ const percent = (numerator, denominator) => {
 const empty = (ts) => ({ timestamp: ts, used: null, percent: null });
 
 @classic
-class NodeStatsTracker extends EmberObject.extend(AbstractStatsTracker) {
+class NodeStatsTracker extends AbstractStatsTracker {
   // Set via the stats computed property macro
   node = null;
 
@@ -73,7 +73,7 @@ export default NodeStatsTracker;
 
 export function stats(nodeProp, fetch) {
   return computed(nodeProp, function () {
-    return NodeStatsTracker.create({
+    return new NodeStatsTracker({
       fetch: fetch.call(this),
       node: this.get(nodeProp),
     });

--- a/ui/mirage/factories/agent.js
+++ b/ui/mirage/factories/agent.js
@@ -30,6 +30,10 @@ export default Factory.extend({
         BackgroundColor: 'hotpink',
         Text: `Mirage - ${scenario}`,
       },
+      PollStats: {
+        Enabled: true,
+        Interval: 10,
+      },
     },
     ACL: {
       Enabled: true,


### PR DESCRIPTION
Draft state, yak shaving:
- AbstractStatsTracker can't get the interval data from the agent service because that mixin cannot read injected services.
So, refactor it to a class. But then, 
- AbstractStatsTracker's `poll` method doesn't appear to see the `url` getter from `AllocationStatsTracker`, unless it's explicitly set in the `AllocationStatsTracker`'s constructor method, which I'd like to avoid for reactivity purposes.