### PR TITLE
wi: introduce workload identity handler

### DIFF
--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -110,9 +110,9 @@ func (h *consulHook) prepareConsulTokensForTask(job *structs.Job, task *structs.
 		if i.Name != expectedIdentity {
 			continue
 		}
-		ti := widmgr.TaskIdentity{
-			TaskName:     task.Name,
-			IdentityName: i.Name,
+		ti := structs.WIHandle{
+			WorkloadIdentifier: task.Name,
+			IdentityName:       i.Name,
 		}
 
 		req, err := h.prepareConsulClientReq(ti, consulTasksAuthMethodName)
@@ -157,9 +157,9 @@ func (h *consulHook) prepareConsulTokensForServices(services []*structs.Service,
 			continue
 		}
 
-		ti := widmgr.TaskIdentity{
-			TaskName:     service.TaskName,
-			IdentityName: service.Identity.Name,
+		ti := structs.WIHandle{
+			WorkloadIdentifier: service.TaskName,
+			IdentityName:       service.Identity.Name,
 		}
 
 		req, err := h.prepareConsulClientReq(ti, consulServicesAuthMethodName)
@@ -207,7 +207,7 @@ func (h *consulHook) getConsulTokens(cluster, identityName string, tokens map[st
 	return nil
 }
 
-func (h *consulHook) prepareConsulClientReq(identity widmgr.TaskIdentity, authMethodName string) (map[string]consul.JWTLoginRequest, error) {
+func (h *consulHook) prepareConsulClientReq(identity structs.WIHandle, authMethodName string) (map[string]consul.JWTLoginRequest, error) {
 	req := map[string]consul.JWTLoginRequest{}
 
 	jwt, err := h.widmgr.Get(identity)

--- a/client/allocrunner/identity_hook_test.go
+++ b/client/allocrunner/identity_hook_test.go
@@ -67,9 +67,9 @@ func TestIdentityHook_Prerun(t *testing.T) {
 	must.NoError(t, hook.Prerun())
 
 	time.Sleep(time.Second) // give goroutines a moment to run
-	sid, err := hook.widmgr.Get(widmgr.TaskIdentity{
-		TaskName:     task.Name,
-		IdentityName: task.Identities[0].Name},
+	sid, err := hook.widmgr.Get(structs.WIHandle{
+		WorkloadIdentifier: task.Name,
+		IdentityName:       task.Identities[0].Name},
 	)
 	must.Nil(t, err)
 	must.Eq(t, sid.IdentityName, task.Identity.Name)

--- a/client/allocrunner/identity_hook_test.go
+++ b/client/allocrunner/identity_hook_test.go
@@ -54,9 +54,11 @@ func TestIdentityHook_Prerun(t *testing.T) {
 	// do the initial signing
 	_, err := mockSigner.SignIdentities(1, []*structs.WorkloadIdentityRequest{
 		{
-			AllocID:      alloc.ID,
-			TaskName:     task.Name,
-			IdentityName: task.Identities[0].Name,
+			AllocID: alloc.ID,
+			WIHandle: structs.WIHandle{
+				WorkloadIdentifier: task.Name,
+				IdentityName:       task.Identities[0].Name,
+			},
 		},
 	})
 	must.NoError(t, err)

--- a/client/allocrunner/taskrunner/identity_hook.go
+++ b/client/allocrunner/taskrunner/identity_hook.go
@@ -82,7 +82,7 @@ func (h *identityHook) Prestart(context.Context, *interfaces.TaskPrestartRequest
 }
 
 func (h *identityHook) watchIdentity(wid *structs.WorkloadIdentity) {
-	id := widmgr.TaskIdentity{TaskName: h.task.Name, IdentityName: wid.Name}
+	id := structs.WIHandle{WorkloadIdentifier: h.task.Name, IdentityName: wid.Name}
 	signedIdentitiesChan, stopWatching := h.widmgr.Watch(id)
 	defer stopWatching()
 

--- a/client/allocrunner/taskrunner/identity_hook_test.go
+++ b/client/allocrunner/taskrunner/identity_hook_test.go
@@ -81,9 +81,11 @@ func TestIdentityHook_RenewAll(t *testing.T) {
 	for _, i := range task.Identities {
 		_, err := mockSigner.SignIdentities(1, []*structs.WorkloadIdentityRequest{
 			{
-				AllocID:      alloc.ID,
-				TaskName:     task.Name,
-				IdentityName: i.Name,
+				AllocID: alloc.ID,
+				WIHandle: structs.WIHandle{
+					WorkloadIdentifier: task.Name,
+					IdentityName:       i.Name,
+				},
 			},
 		})
 		must.NoError(t, err)
@@ -183,9 +185,11 @@ func TestIdentityHook_RenewOne(t *testing.T) {
 	for _, i := range task.Identities {
 		_, err := mockSigner.SignIdentities(1, []*structs.WorkloadIdentityRequest{
 			{
-				AllocID:      alloc.ID,
-				TaskName:     task.Name,
-				IdentityName: i.Name,
+				AllocID: alloc.ID,
+				WIHandle: structs.WIHandle{
+					WorkloadIdentifier: task.Name,
+					IdentityName:       i.Name,
+				},
 			},
 		})
 		must.NoError(t, err)

--- a/client/widmgr/mock.go
+++ b/client/widmgr/mock.go
@@ -57,7 +57,7 @@ func (m *MockWIDSigner) SignIdentities(minIndex uint64, req []*structs.WorkloadI
 			Namespace:    "default",
 			JobID:        "test",
 			AllocationID: idReq.AllocID,
-			TaskName:     idReq.TaskName,
+			TaskName:     idReq.WorkloadIdentifier,
 		}
 		claims.ID = uuid.Generate()
 		// If test has set workload identities. Lookup claims or reject unknown

--- a/client/widmgr/mock.go
+++ b/client/widmgr/mock.go
@@ -94,17 +94,17 @@ func (m *MockWIDSigner) SignIdentities(minIndex uint64, req []*structs.WorkloadI
 // MockWIDMgr mocks IdentityManager interface allowing to only get identities
 // signed by the mock signer.
 type MockWIDMgr struct {
-	swids map[TaskIdentity]*structs.SignedWorkloadIdentity
+	swids map[structs.WIHandle]*structs.SignedWorkloadIdentity
 }
 
-func NewMockWIDMgr(swids map[TaskIdentity]*structs.SignedWorkloadIdentity) *MockWIDMgr {
+func NewMockWIDMgr(swids map[structs.WIHandle]*structs.SignedWorkloadIdentity) *MockWIDMgr {
 	return &MockWIDMgr{swids: swids}
 }
 
 // Run does not run a renewal loop in this mock
 func (m MockWIDMgr) Run() error { return nil }
 
-func (m MockWIDMgr) Get(identity TaskIdentity) (*structs.SignedWorkloadIdentity, error) {
+func (m MockWIDMgr) Get(identity structs.WIHandle) (*structs.SignedWorkloadIdentity, error) {
 	sid, ok := m.swids[identity]
 	if !ok {
 		return nil, fmt.Errorf("identity not found")
@@ -113,7 +113,7 @@ func (m MockWIDMgr) Get(identity TaskIdentity) (*structs.SignedWorkloadIdentity,
 }
 
 // Watch does not do anything, this mock doesn't support watching.
-func (m MockWIDMgr) Watch(identity TaskIdentity) (<-chan *structs.SignedWorkloadIdentity, func()) {
+func (m MockWIDMgr) Watch(identity structs.WIHandle) (<-chan *structs.SignedWorkloadIdentity, func()) {
 	return nil, nil
 }
 

--- a/client/widmgr/widmgr.go
+++ b/client/widmgr/widmgr.go
@@ -192,8 +192,6 @@ func (m *WIDMgr) getIdentities() error {
 	defaultTokens := map[structs.WIHandle]*structs.SignedWorkloadIdentity{}
 	for taskName, signature := range m.defaultSignedIdentities {
 		id := structs.WIHandle{
-			// no need to call MakeUniqueTaskName, because the plan applier
-			// does this for us
 			WorkloadIdentifier: taskName,
 			IdentityName:       "default",
 		}

--- a/client/widmgr/widmgr_test.go
+++ b/client/widmgr/widmgr_test.go
@@ -40,9 +40,11 @@ func TestWIDMgr(t *testing.T) {
 
 	_, err = mgr.SignIdentities(1, []*structs.WorkloadIdentityRequest{
 		{
-			AllocID:      uuid.Generate(),
-			TaskName:     "web",
-			IdentityName: "foo",
+			AllocID: uuid.Generate(),
+			WIHandle: structs.WIHandle{
+				WorkloadIdentifier: "web",
+				IdentityName:       "foo",
+			},
 		},
 	})
 	must.ErrorContains(t, err, "rejected")
@@ -92,14 +94,18 @@ func TestWIDMgr(t *testing.T) {
 	// Get signed identites for alloc
 	widreqs := []*structs.WorkloadIdentityRequest{
 		{
-			AllocID:      allocs[0].ID,
-			TaskName:     job.TaskGroups[0].Tasks[0].Name,
-			IdentityName: "consul",
+			AllocID: allocs[0].ID,
+			WIHandle: structs.WIHandle{
+				WorkloadIdentifier: job.TaskGroups[0].Tasks[0].Name,
+				IdentityName:       "consul",
+			},
 		},
 		{
 			AllocID:      allocs[0].ID,
-			TaskName:     job.TaskGroups[0].Tasks[0].Name,
+			WIHandle: structs.WIHandle{
+			WorkloadIdentifier:     job.TaskGroups[0].Tasks[0].Name,
 			IdentityName: "vault",
+			},
 		},
 	}
 

--- a/client/widmgr/widmgr_test.go
+++ b/client/widmgr/widmgr_test.go
@@ -101,10 +101,10 @@ func TestWIDMgr(t *testing.T) {
 			},
 		},
 		{
-			AllocID:      allocs[0].ID,
+			AllocID: allocs[0].ID,
 			WIHandle: structs.WIHandle{
-			WorkloadIdentifier:     job.TaskGroups[0].Tasks[0].Name,
-			IdentityName: "vault",
+				WorkloadIdentifier: job.TaskGroups[0].Tasks[0].Name,
+				IdentityName:       "vault",
 			},
 		},
 	}

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -565,7 +565,7 @@ func (a *Alloc) SignIdentities(args *structs.AllocIdentitiesRequest, reply *stru
 			continue
 		}
 
-		task := out.LookupTask(idReq.TaskName)
+		task := out.LookupTask(idReq.WorkloadIdentifier)
 		if task == nil {
 			// Job has likely been updated to remove this task
 			reply.Rejections = append(reply.Rejections, &structs.WorkloadIdentityRejection{
@@ -582,7 +582,7 @@ func (a *Alloc) SignIdentities(args *structs.AllocIdentitiesRequest, reply *stru
 			}
 
 			widFound = true
-			claims := structs.NewIdentityClaims(out.Job, out, idReq.TaskName, wid, now)
+			claims := structs.NewIdentityClaims(out.Job, out, idReq.WorkloadIdentifier, wid, now)
 			token, _, err := a.srv.encrypter.SignClaims(claims)
 			if err != nil {
 				return err

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -423,7 +423,8 @@ func (p *planner) signAllocIdentities(job *structs.Job, allocations []*structs.A
 			if err != nil {
 				return err
 			}
-			alloc.SignedIdentities[task.Name] = token
+			// keys for signed identities must be unique
+			alloc.SignedIdentities[task.MakeUniqueIdentityName(tg.Name)] = token
 			alloc.SigningKeyID = keyID
 		}
 	}

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -423,8 +423,7 @@ func (p *planner) signAllocIdentities(job *structs.Job, allocations []*structs.A
 			if err != nil {
 				return err
 			}
-			// keys for signed identities must be unique
-			alloc.SignedIdentities[task.MakeUniqueIdentityName(tg.Name)] = token
+			alloc.SignedIdentities[task.Name] = token
 			alloc.SigningKeyID = keyID
 		}
 	}

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -782,12 +782,12 @@ func (s *Service) MakeUniqueIdentityName() string {
 }
 
 // IdentityHandle returns a WorkloadIdentityHandle which is a pair of service
-// identity name and service name.
+// identity name and unique service name.
 func (s *Service) IdentityHandle() *WIHandle {
 	if s.Identity != nil {
 		return &WIHandle{
 			IdentityName:       s.Identity.Name,
-			WorkloadIdentifier: s.Name,
+			WorkloadIdentifier: s.MakeUniqueIdentityName(),
 		}
 	}
 	return nil

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -781,6 +781,18 @@ func (s *Service) MakeUniqueIdentityName() string {
 	return fmt.Sprintf("%v-%v", s.Name, s.PortLabel)
 }
 
+// IdentityHandle returns a WorkloadIdentityHandle which is a pair of service
+// identity name and service name.
+func (s *Service) IdentityHandle() *WIHandle {
+	if s.Identity != nil {
+		return &WIHandle{
+			IdentityName:       s.Identity.Name,
+			WorkloadIdentifier: s.Name,
+		}
+	}
+	return nil
+}
+
 func (s *Service) validateCheckPort(c *ServiceCheck) error {
 	if s.PortLabel == "" && c.PortLabel == "" && c.RequiresPort() {
 		return fmt.Errorf("Check %s invalid: check requires a port but neither check nor service %+q have a port", c.Name, s.Name)

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -782,12 +782,12 @@ func (s *Service) MakeUniqueIdentityName() string {
 }
 
 // IdentityHandle returns a WorkloadIdentityHandle which is a pair of service
-// identity name and unique service name.
+// identity name and service name.
 func (s *Service) IdentityHandle() *WIHandle {
 	if s.Identity != nil {
 		return &WIHandle{
 			IdentityName:       s.Identity.Name,
-			WorkloadIdentifier: s.MakeUniqueIdentityName(),
+			WorkloadIdentifier: s.Name,
 		}
 	}
 	return nil

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7674,10 +7674,10 @@ func (t *Task) MakeUniqueIdentityName(taskGroup string) string {
 
 // IdentityHandle returns a WorkloadIdentityHandle which is a pair of unique WI
 // name and task name.
-func (t *Task) IdentityHandle(identity *WorkloadIdentity, taskGroup string) *WIHandle {
+func (t *Task) IdentityHandle(identity *WorkloadIdentity) *WIHandle {
 	return &WIHandle{
 		IdentityName:       identity.Name,
-		WorkloadIdentifier: t.MakeUniqueIdentityName(taskGroup),
+		WorkloadIdentifier: t.Name,
 	}
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7672,6 +7672,15 @@ func (t *Task) MakeUniqueIdentityName(taskGroup string) string {
 	return fmt.Sprintf("%v-%v", taskGroup, t.Name)
 }
 
+// IdentityHandle returns a WorkloadIdentityHandle which is a pair of WI name
+// and task name.
+func (t *Task) IdentityHandle(identity *WorkloadIdentity) *WIHandle {
+	return &WIHandle{
+		IdentityName:       identity.Name,
+		WorkloadIdentifier: t.Name,
+	}
+}
+
 func (t *Task) Copy() *Task {
 	if t == nil {
 		return nil

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7672,12 +7672,12 @@ func (t *Task) MakeUniqueIdentityName(taskGroup string) string {
 	return fmt.Sprintf("%v-%v", taskGroup, t.Name)
 }
 
-// IdentityHandle returns a WorkloadIdentityHandle which is a pair of WI name
-// and task name.
-func (t *Task) IdentityHandle(identity *WorkloadIdentity) *WIHandle {
+// IdentityHandle returns a WorkloadIdentityHandle which is a pair of unique WI
+// name and task name.
+func (t *Task) IdentityHandle(identity *WorkloadIdentity, taskGroup string) *WIHandle {
 	return &WIHandle{
 		IdentityName:       identity.Name,
-		WorkloadIdentifier: t.Name,
+		WorkloadIdentifier: t.MakeUniqueIdentityName(taskGroup),
 	}
 }
 

--- a/nomad/structs/workload_id.go
+++ b/nomad/structs/workload_id.go
@@ -222,3 +222,11 @@ type AllocIdentitiesResponse struct {
 	Rejections       []*WorkloadIdentityRejection
 	QueryMeta
 }
+
+// WIHandle is used by code that needs to uniquely match a workload identity
+// with the task or service it belongs to.
+type WIHandle struct {
+	IdentityName string
+	// WorkloadIdentifier is either a ServiceName or a TaskName
+	WorkloadIdentifier string
+}

--- a/nomad/structs/workload_id.go
+++ b/nomad/structs/workload_id.go
@@ -188,9 +188,8 @@ func (wi *WorkloadIdentity) Warnings() error {
 // WorkloadIdentityRequest encapsulates the 3 parameters used to generated a
 // signed workload identity: the alloc, task, and specific identity's name.
 type WorkloadIdentityRequest struct {
-	AllocID      string
-	TaskName     string
-	IdentityName string
+	AllocID string
+	WIHandle
 }
 
 // SignedWorkloadIdentity is the response to a WorkloadIdentityRequest and


### PR DESCRIPTION
Any code that tracks workloads and their identities should not rely on string comparisons, especially since we support 2 types of workload identities: those that identify tasks and those that identify services. This means we cannot rely on `task.Name` for workload-identity pairs. 

The new type `structs.WIHandle` solves this problem by providing a uniform way of identifying workloads and their identities. 

(https://github.com/hashicorp/nomad/pull/18650 depends on this PR)