### PR TITLE
build: load time/tzdata on Windows

### DIFF
--- a/.changelog/18676.txt
+++ b/.changelog/18676.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+build: Add `timetzdata` Go build tag on Windows binaries to embed time zone data so periodic jobs are able to specify a time zone value on Windows environments
+```

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -109,6 +109,7 @@ pkg/linux_%/nomad: CGO_ENABLED = 0
 endif
 
 pkg/windows_%/nomad: GO_OUT = $@.exe
+pkg/windows_%/nomad: GO_TAGS += timetzdata
 
 # Define package targets for each of the build targets we actually have on this system
 define makePackageTarget


### PR DESCRIPTION
Nomad uses `time.LoadLocation()` to translate a periodic job time zone string value to a `time.Location`. From godocs:

    LoadLocation looks for the IANA Time Zone database in the following locations in order:

    * the directory or uncompressed zip file named by the ZONEINFO environment variable
    * on a Unix system, the system standard installation location
    * $GOROOT/lib/time/zoneinfo.zip
    * the time/tzdata package, if it was imported

So non-Unix systems require Go to be installed or `time/tzdata` to be imported, otherwise running periodic jobs with a specific `time_zone` value results in an error:

    Invalid time zone "America/Toronto": unknown time zone America/Toronto

This commit adds the `timetzdata` build tag on Windows to embed the time zone data into the final binary. This results in a slightly bigger binary, but from `time/tzdata` godocs:

    Importing this package will increase the size of a program by about 450 KB.
    [..]
    This package will be automatically imported if you build with -tags timetzdata.

Closes https://github.com/hashicorp/nomad/issues/18578