### PR TITLE
scheduler: fix host volume feasibility check

### DIFF
--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -1237,7 +1237,8 @@ OUTER:
 }
 
 // available checks transient feasibility checkers which depend on changing conditions,
-// e.g. the health status of a plugin or driver
+// e.g. the health status of a plugin or driver, or that are not considered in node
+// computed class, e.g. host volumes.
 func (w *FeasibilityWrapper) available(option *structs.Node) bool {
 	// If we don't have any availability checks, we're available
 	if len(w.tgAvailable) == 0 {

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -259,11 +259,13 @@ func NewSystemStack(sysbatch bool, ctx Context) *SystemStack {
 	tgs := []FeasibilityChecker{
 		s.taskGroupDrivers,
 		s.taskGroupConstraint,
-		s.taskGroupHostVolumes,
 		s.taskGroupDevices,
 		s.taskGroupNetwork,
 	}
-	avail := []FeasibilityChecker{s.taskGroupCSIVolumes}
+	avail := []FeasibilityChecker{
+		s.taskGroupHostVolumes,
+		s.taskGroupCSIVolumes,
+	}
 	s.wrappedChecks = NewFeasibilityWrapper(ctx, s.source, jobs, tgs, avail)
 
 	// Filter on distinct property constraints.
@@ -406,11 +408,13 @@ func NewGenericStack(batch bool, ctx Context) *GenericStack {
 	tgs := []FeasibilityChecker{
 		s.taskGroupDrivers,
 		s.taskGroupConstraint,
-		s.taskGroupHostVolumes,
 		s.taskGroupDevices,
 		s.taskGroupNetwork,
 	}
-	avail := []FeasibilityChecker{s.taskGroupCSIVolumes}
+	avail := []FeasibilityChecker{
+		s.taskGroupHostVolumes,
+		s.taskGroupCSIVolumes,
+	}
 	s.wrappedChecks = NewFeasibilityWrapper(ctx, s.source, jobs, tgs, avail)
 
 	// Filter on distinct host constraints.

--- a/scheduler/stack_test.go
+++ b/scheduler/stack_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -245,6 +246,86 @@ func TestServiceStack_Select_DriverFilter(t *testing.T) {
 	if node.Node != zero {
 		t.Fatalf("bad")
 	}
+}
+
+func TestServiceStack_Select_HostVolume(t *testing.T) {
+	ci.Parallel(t)
+
+	_, ctx := testContext(t)
+
+	// Create nodes with host volumes.
+	node1 := mock.Node()
+	node1.HostVolumes = map[string]*structs.ClientHostVolumeConfig{
+		"unique": {
+			Name: "unique",
+			Path: "/tmp/unique",
+		},
+		"per_alloc[0]": {
+			Name: "per_alloc[0]",
+			Path: "/tmp/per_alloc_0",
+		},
+	}
+	node1.ComputeClass()
+
+	node2 := mock.Node()
+	node2.HostVolumes = map[string]*structs.ClientHostVolumeConfig{
+		"per_alloc[1]": {
+			Name: "per_alloc[1]",
+			Path: "/tmp/per_alloc_1",
+		},
+	}
+	node2.ComputeClass()
+
+	// Create stack with nodes.
+	stack := NewGenericStack(false, ctx)
+	stack.SetNodes([]*structs.Node{node1, node2})
+
+	job := mock.Job()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Volumes = map[string]*structs.VolumeRequest{"unique": {
+		Name:     "unique",
+		Type:     structs.VolumeTypeHost,
+		Source:   "unique",
+		PerAlloc: false,
+	}}
+	stack.SetJob(job)
+
+	selectOptions := &SelectOptions{
+		AllocName: structs.AllocName(job.Name, job.TaskGroups[0].Name, 0),
+	}
+
+	option := stack.Select(job.TaskGroups[0], selectOptions)
+	must.NotNil(t, option)
+	must.Eq(t, option.Node.ID, node1.ID)
+
+	// Recreate the stack and select volumes per alloc.
+	stack = NewGenericStack(false, ctx)
+	stack.SetNodes([]*structs.Node{node1, node2})
+
+	job.TaskGroups[0].Count = 2
+	job.TaskGroups[0].Volumes = map[string]*structs.VolumeRequest{"per_alloc": {
+		Name:     "per_alloc",
+		Type:     structs.VolumeTypeHost,
+		Source:   "per_alloc",
+		PerAlloc: true,
+	}}
+	stack.SetJob(job)
+
+	// First alloc selects node with volume per_alloc[0].
+	selectOptions = &SelectOptions{
+		AllocName: structs.AllocName(job.Name, job.TaskGroups[0].Name, 0),
+	}
+	option = stack.Select(job.TaskGroups[0], selectOptions)
+	must.NotNil(t, option)
+	must.Eq(t, option.Node.ID, node1.ID)
+
+	// Second alloc selects node with volume per_alloc[1].
+	selectOptions = &SelectOptions{
+		AllocName: structs.AllocName(job.Name, job.TaskGroups[0].Name, 1),
+	}
+	option = stack.Select(job.TaskGroups[0], selectOptions)
+	must.NotNil(t, option)
+	must.Eq(t, option.Node.ID, node2.ID)
 }
 
 func TestServiceStack_Select_CSI(t *testing.T) {


### PR DESCRIPTION
Host volumes were considered regular feasibility checks. This had two unintended consequences.

The first happened when scheduling an allocation with a host volume on a set of nodes with the same computed class but where only some of them had the desired host volume.

If the first node evaluated did not have the host volume, the entire node class was considered ineligible for the task group.

```go
// Run the job feasibility checks.
for _, check := range w.jobCheckers {
	feasible := check.Feasible(option)
	if !feasible {
		// If the job hasn't escaped, set it to be ineligible since it
		// failed a job check.
		if !jobEscaped {
			evalElig.SetJobEligibility(false, option.ComputedClass)
		}
		continue OUTER
	}
}
```

This results in all nodes with the same computed class to be skipped, even if they do have the desired host volume.

```go
switch evalElig.JobStatus(option.ComputedClass) {
case EvalComputedClassIneligible:
	// Fast path the ineligible case
	metrics.FilterNode(option, "computed class ineligible")
	continue
```

The second consequence is somewhat the opposite. When an allocation has a host volume with `per_alloc = true` the node must have a host volume that matches the allocation index, so each allocation is likely to be placed in different nodes.

But when the first allocation found a node match, it registered the node class as eligible for the task group.

```go
// Set the task group eligibility if the constraints weren't escaped and
// it hasn't been set before.
if !tgEscaped && tgUnknown {
	evalElig.SetTaskGroupEligibility(true, w.tg, option.ComputedClass)
}
```

This could cause other allocations to be placed on nodes without the expected host volume because of the computed node class fast path. The node feasibility for the volume was never checked.

```go
case EvalComputedClassEligible:
	// Fast path the eligible case
	if w.available(option) {
		return option
	}
	// We match the class but are temporarily unavailable
	continue OUTER
```

These problems did not happen with CSI volumes kind of accidentally. Since the `CSIVolumeChecker` was not placed in the `tgCheckers` list it did not cause the node class to be considered ineligible on failure (avoiding the first problem).

And, as illustrated in the code snippet above, the eligible node class fast path checks `tgAvailable` (where `CSIVolumeChecker` is placed) before returning the option (avoiding the second problem).

By also placing `HostVolumeChecker` in the `tgAvailable` list instead of `tgCheckers` we also avoid these problems on host volume feasibility.

Closes #18567

----

Note to reviewers: since both volume feasibility checks completely by-pass the computed class aspect of `FeasibilityWrapper` (which is kind of the whole point of this iterator 😅) we could refactor this code to extract the volume checkers to a separate iterator and keep `FeasibilityWrapper` just about computed class, but I kept the changeset minimum for now.