### PR TITLE
cli: remove default for ACL token type on update

### DIFF
--- a/.changelog/18689.txt
+++ b/.changelog/18689.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed an unexpected behavior of the `nomad acl token update` command that could cause a management token to be downgraded to client on update
+```

--- a/command/acl_token_update.go
+++ b/command/acl_token_update.go
@@ -30,7 +30,7 @@ Update Options:
     Sets the human readable name for the ACL token.
 
   -type="client"
-    Sets the type of token. Must be one of "client" (default), or "management".
+    Sets the type of token. Must be one of "client" or "management".
 
   -global=false
     Toggles the global mode of the token. Global tokens are replicated to all regions.
@@ -70,7 +70,7 @@ func (c *ACLTokenUpdateCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.StringVar(&name, "name", "", "")
-	flags.StringVar(&tokenType, "type", "client", "")
+	flags.StringVar(&tokenType, "type", "", "")
 	flags.BoolVar(&global, "global", false, "")
 	flags.Var((funcVar)(func(s string) error {
 		policies = append(policies, s)

--- a/website/content/docs/commands/acl/token/update.mdx
+++ b/website/content/docs/commands/acl/token/update.mdx
@@ -25,8 +25,7 @@ The `acl token update` command requires an existing token's accessor ID.
 
 - `-name`: Sets the human readable name for the ACL token.
 
-- `-type`: Sets the type of token. Must be one of "client" (default), or
-  "management".
+- `-type`: Sets the type of token. Must be one of "client" or "management".
 
 - `-global`: Toggles the global mode of the token. Global tokens are replicated
   to all regions. Defaults false.


### PR DESCRIPTION
With a default value set to `client`, the `nomad acl token update` command can silently downgrade a management token to client on update if the command does not specify `-type=management` on every update.