### PR TITLE
New endpoint: job/:id/actions

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -326,6 +326,17 @@ func (j *Jobs) LatestDeployment(jobID string, q *QueryOptions) (*Deployment, *Qu
 	return resp, qm, nil
 }
 
+// What...?
+// // Actions
+// func (j *Jobs) Actions(jobID string, q *QueryOptions) ([]*Action, *QueryMeta, error) {
+// 	var resp []*Action
+// 	qm, err := j.client.query("/v1/job/"+url.PathEscape(jobID)+"/actions", &resp, q)
+// 	if err != nil {
+// 		return nil, nil, err
+// 	}
+// 	return resp, qm, nil
+// }
+
 // Evaluations is used to query the evaluations associated with the given job
 // ID.
 func (j *Jobs) Evaluations(jobID string, q *QueryOptions) ([]*Evaluation, *QueryMeta, error) {

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -326,17 +326,6 @@ func (j *Jobs) LatestDeployment(jobID string, q *QueryOptions) (*Deployment, *Qu
 	return resp, qm, nil
 }
 
-// What...?
-// // Actions
-// func (j *Jobs) Actions(jobID string, q *QueryOptions) ([]*Action, *QueryMeta, error) {
-// 	var resp []*Action
-// 	qm, err := j.client.query("/v1/job/"+url.PathEscape(jobID)+"/actions", &resp, q)
-// 	if err != nil {
-// 		return nil, nil, err
-// 	}
-// 	return resp, qm, nil
-// }
-
 // Evaluations is used to query the evaluations associated with the given job
 // ID.
 func (j *Jobs) Evaluations(jobID string, q *QueryOptions) ([]*Evaluation, *QueryMeta, error) {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -336,9 +336,7 @@ func (s *HTTPServer) jobLatestDeployment(resp http.ResponseWriter, req *http.Req
 	return out.Deployment, nil
 }
 
-// Job Actions
 func (s *HTTPServer) jobActions(resp http.ResponseWriter, req *http.Request, jobID string) (any, error) {
-	// Since this only accepts GET, enforce HTTP method
 	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -337,7 +337,12 @@ func (s *HTTPServer) jobLatestDeployment(resp http.ResponseWriter, req *http.Req
 }
 
 // Job Actions
-func (s *HTTPServer) jobActions(resp http.ResponseWriter, req *http.Request, jobID string) (interface{}, error) {
+func (s *HTTPServer) jobActions(resp http.ResponseWriter, req *http.Request, jobID string) (any, error) {
+	// Since this only accepts GET, enforce HTTP method
+	if req.Method != http.MethodGet {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
 	args := structs.JobSpecificRequest{
 		JobID: jobID,
 	}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -347,7 +347,7 @@ func (s *HTTPServer) jobActions(resp http.ResponseWriter, req *http.Request, job
 
 	var out structs.ActionListResponse
 	if err := s.agent.RPC("Job.GetActions", &args, &out); err != nil {
-		return nil, fmt.Errorf("Oh dang: %w", err)
+		return nil, err
 	}
 
 	setMeta(resp, &structs.QueryMeta{})

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1758,14 +1758,21 @@ func (j *Job) GetActions(args *structs.JobSpecificRequest, reply *structs.Action
 	}
 
 	// Get its task groups' tasks' actions
-	actions := make([]*structs.Action, 0)
+	jobActions := make([]*structs.JobAction, 0)
 	for _, tg := range job.TaskGroups {
 		for _, task := range tg.Tasks {
-			actions = append(actions, task.Actions...)
+			for _, action := range task.Actions {
+				jobAction := &structs.JobAction{
+					Action:        *action,
+					TaskName:      task.Name,
+					TaskGroupName: tg.Name,
+				}
+				jobActions = append(jobActions, jobAction)
+			}
 		}
 	}
-	// set it on reply
-	reply.Actions = actions
+
+	reply.Actions = jobActions
 
 	// set meta
 	j.srv.setQueryMeta(&reply.QueryMeta)

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1774,10 +1774,7 @@ func (j *Job) GetActions(args *structs.JobSpecificRequest, reply *structs.Action
 
 	reply.Actions = jobActions
 
-	// set meta
 	j.srv.setQueryMeta(&reply.QueryMeta)
-	// log out the reply here for debugging purposes
-	j.logger.Debug("job actions", "job", job.ID, "actions", reply)
 
 	return nil
 }

--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -711,15 +711,15 @@ func ActionsJob() *structs.Job {
 	job := MinJob()
 
 	for i := 0; i < 2; i++ {
-		tg := *job.TaskGroups[0]
+		tg := job.TaskGroups[0].Copy()
 		tg.Name = fmt.Sprintf("g%d", i+1)
-		job.TaskGroups = append(job.TaskGroups, &tg)
+		job.TaskGroups = append(job.TaskGroups, tg)
 	}
 
 	for i := 0; i < 2; i++ {
-		task := *job.TaskGroups[0].Tasks[0]
+		task := job.TaskGroups[0].Tasks[0].Copy()
 		task.Name = fmt.Sprintf("t%d", i+1)
-		job.TaskGroups[0].Tasks = append(job.TaskGroups[0].Tasks, &task)
+		job.TaskGroups[0].Tasks = append(job.TaskGroups[0].Tasks, task)
 	}
 
 	for _, tg := range job.TaskGroups {

--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -705,3 +705,38 @@ func BigBenchmarkJob() *structs.Job {
 
 	return job
 }
+
+// A multi-group, multi-task job with actions testing.
+func ActionsJob() *structs.Job {
+	job := MinJob()
+
+	for i := 0; i < 2; i++ {
+		tg := *job.TaskGroups[0]
+		tg.Name = fmt.Sprintf("g%d", i+1)
+		job.TaskGroups = append(job.TaskGroups, &tg)
+	}
+
+	for i := 0; i < 2; i++ {
+		task := *job.TaskGroups[0].Tasks[0]
+		task.Name = fmt.Sprintf("t%d", i+1)
+		job.TaskGroups[0].Tasks = append(job.TaskGroups[0].Tasks, &task)
+	}
+
+	for _, tg := range job.TaskGroups {
+		for _, task := range tg.Tasks {
+			task.Actions = []*structs.Action{
+				{
+					Name:    "date test",
+					Command: "/bin/date",
+					Args:    []string{"-u"},
+				},
+				{
+					Name:    "echo test",
+					Command: "/bin/echo",
+					Args:    []string{"hello world"},
+				},
+			}
+		}
+	}
+	return job
+}

--- a/nomad/structs/actions.go
+++ b/nomad/structs/actions.go
@@ -15,6 +15,18 @@ type Action struct {
 	Args    []string
 }
 
+type JobAction struct {
+	Action        Action
+	TaskName      string
+	TaskGroupName string
+}
+
+// DeploymentListResponse is used for a list request
+type ActionListResponse struct {
+	Actions []*Action
+	QueryMeta
+}
+
 func (a *Action) Copy() *Action {
 	if a == nil {
 		return nil

--- a/nomad/structs/actions.go
+++ b/nomad/structs/actions.go
@@ -16,14 +16,13 @@ type Action struct {
 }
 
 type JobAction struct {
-	Action        Action
+	Action
 	TaskName      string
 	TaskGroupName string
 }
 
-// DeploymentListResponse is used for a list request
 type ActionListResponse struct {
-	Actions []*Action
+	Actions []*JobAction
 	QueryMeta
 }
 


### PR DESCRIPTION
Adds a new endpoint: /job/:id/actions

It parses through a job's taskgroups' tasks, and extracts their actions up to a single flat array with the name of task and taskGroup included as fields.

```
$ nomad operator api '/v1/job/actions-demo/actions' | jq
[
  {
    "Args": [
      "parrot.live"
    ],
    "Command": "/usr/bin/curl",
    "Name": "party",
    "TaskGroupName": "group",
    "TaskName": "task"
  },
  {
    "Args": [
      "ipinfo.io"
    ],
    "Command": "/usr/bin/curl",
    "Name": "ipinfo",
    "TaskGroupName": "group",
    "TaskName": "task"
  },
  {
    "Args": [
      "parrot.live"
    ],
    "Command": "/usr/bin/curl",
    "Name": "party",
    "TaskGroupName": "group",
    "TaskName": "task2"
  },
...
]
```

Resolves #18680 