### PR TITLE
OpenID Configuration Discovery Endpoint (just the endpoint)

### DIFF
--- a/.semgrep/rpc_endpoint.yml
+++ b/.semgrep/rpc_endpoint.yml
@@ -98,6 +98,7 @@ rules:
             - pattern-not: '"Status.Peers"'
             - pattern-not: '"Status.Version"'
             - pattern-not: '"Keyring.ListPublic"'
+            - pattern-not: '"Keyring.GetConfig"'
     message: "RPC method $METHOD appears to be unauthenticated"
     languages:
       - "go"

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -358,6 +358,8 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		conf.JobTrackedVersions = *agentConfig.Server.JobTrackedVersions
 	}
 
+	conf.OIDCIssuer = agentConfig.Server.OIDCIssuer
+
 	// Set up the bind addresses
 	rpcAddr, err := net.ResolveTCPAddr("tcp", agentConfig.normalizedAddrs.RPC)
 	if err != nil {

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -482,6 +483,19 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 		}
 		if config.Server.Enabled && config.Server.BootstrapExpect%2 == 0 {
 			c.Ui.Error("WARNING: Number of bootstrap servers should ideally be set to an odd number.")
+		}
+
+		// Check OIDC Issuer if set
+		if config.Server.Enabled && config.Server.OIDCIssuer != "" {
+			issuerURL, err := url.Parse(config.Server.OIDCIssuer)
+			if err != nil {
+				c.Ui.Error(fmt.Sprintf(`Error using server.oidc_issuer = "%s" as a base URL: %s`, config.Server.OIDCIssuer, err))
+				return false
+			}
+
+			if issuerURL.Scheme != "https" {
+				c.Ui.Warn(fmt.Sprintf(`server.oidc_issuer = "%s" is not using https. Many OIDC implementations require https.`, config.Server.OIDCIssuer))
+			}
 		}
 	}
 

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -472,6 +472,17 @@ func TestIsValidConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "BadOIDCIssuer",
+			conf: Config{
+				DataDir: "/tmp",
+				Server: &ServerConfig{
+					Enabled:    true,
+					OIDCIssuer: ":/example.com",
+				},
+			},
+			err: "missing protocol scheme",
+		},
 	}
 
 	for _, tc := range cases {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -701,6 +701,11 @@ type ServerConfig struct {
 
 	// JobTrackedVersions is the number of historic job versions that are kept.
 	JobTrackedVersions *int `hcl:"job_tracked_versions"`
+
+	// OIDCIssuer if set enables OIDC Discovery and uses this value as the
+	// issuer. Third parties such as AWS IAM OIDC Provider expect the issuer to
+	// be a publically accessible HTTPS URL signed by a trusted well-known CA.
+	OIDCIssuer string `hcl:"oidc_issuer"`
 }
 
 func (s *ServerConfig) Copy() *ServerConfig {
@@ -2119,6 +2124,10 @@ func (s *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 
 	if b.JobTrackedVersions != nil {
 		result.JobTrackedVersions = b.JobTrackedVersions
+	}
+
+	if b.OIDCIssuer != "" {
+		result.OIDCIssuer = b.OIDCIssuer
 	}
 
 	// Add the schedulers

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -160,6 +160,7 @@ func TestConfig_Merge(t *testing.T) {
 				NodeThreshold: 100,
 				NodeWindow:    11 * time.Minute,
 			},
+			OIDCIssuer: "https://example.com",
 		},
 		ACL: &ACLConfig{
 			Enabled:               true,
@@ -408,6 +409,7 @@ func TestConfig_Merge(t *testing.T) {
 			},
 			JobMaxPriority:     pointer.Of(200),
 			JobDefaultPriority: pointer.Of(100),
+			OIDCIssuer:         "https://example.com",
 		},
 		ACL: &ACLConfig{
 			Enabled:               true,

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -160,7 +160,7 @@ func TestConfig_Merge(t *testing.T) {
 				NodeThreshold: 100,
 				NodeWindow:    11 * time.Minute,
 			},
-			OIDCIssuer: "https://example.com",
+			OIDCIssuer: "https://oidc.test.nomadproject.io",
 		},
 		ACL: &ACLConfig{
 			Enabled:               true,
@@ -409,7 +409,7 @@ func TestConfig_Merge(t *testing.T) {
 			},
 			JobMaxPriority:     pointer.Of(200),
 			JobDefaultPriority: pointer.Of(100),
-			OIDCIssuer:         "https://example.com",
+			OIDCIssuer:         "https://oidc.test.nomadproject.io",
 		},
 		ACL: &ACLConfig{
 			Enabled:               true,

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -502,8 +502,9 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.Handle("/v1/vars", wrapCORS(s.wrap(s.VariablesListRequest)))
 	s.mux.Handle("/v1/var/", wrapCORSWithAllowedMethods(s.wrap(s.VariableSpecificRequest), "HEAD", "GET", "PUT", "DELETE"))
 
-	// JWKS Handler
-	s.mux.HandleFunc("/.well-known/jwks.json", s.wrap(s.JWKSRequest))
+	// OIDC Handlers
+	s.mux.HandleFunc(structs.JWKSPath, s.wrap(s.JWKSRequest))
+	s.mux.HandleFunc("/.well-known/openid-configuration", s.wrap(s.OIDCDiscoveryRequest))
 
 	agentConfig := s.agent.GetConfig()
 	uiConfigEnabled := agentConfig.UI != nil && agentConfig.UI.Enabled

--- a/command/agent/keyring_endpoint.go
+++ b/command/agent/keyring_endpoint.go
@@ -83,7 +83,7 @@ func (s *HTTPServer) JWKSRequest(resp http.ResponseWriter, req *http.Request) (a
 // See https://openid.net/specs/openid-connect-discovery-1_0.html for details.
 func (s *HTTPServer) OIDCDiscoveryRequest(resp http.ResponseWriter, req *http.Request) (any, error) {
 	if req.Method != http.MethodGet {
-		return nil, CodedError(405, ErrInvalidMethod)
+		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
 	}
 
 	args := structs.GenericRequest{}

--- a/command/agent/keyring_endpoint.go
+++ b/command/agent/keyring_endpoint.go
@@ -77,6 +77,31 @@ func (s *HTTPServer) JWKSRequest(resp http.ResponseWriter, req *http.Request) (a
 	return out, nil
 }
 
+// OIDCDiscoveryRequest implements the OIDC Discovery protocol for using
+// workload identity JWTs with external services.
+//
+// See https://openid.net/specs/openid-connect-discovery-1_0.html for details.
+func (s *HTTPServer) OIDCDiscoveryRequest(resp http.ResponseWriter, req *http.Request) (any, error) {
+	if req.Method != http.MethodGet {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	args := structs.GenericRequest{}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+	var rpcReply structs.KeyringGetConfigResponse
+	if err := s.agent.RPC("Keyring.GetConfig", &args, &rpcReply); err != nil {
+		return nil, err
+	}
+
+	if rpcReply.OIDCDiscovery == nil {
+		return nil, CodedError(http.StatusNotFound, "OIDC Discovery endpoint disabled")
+	}
+
+	return rpcReply.OIDCDiscovery, nil
+}
+
 // KeyringRequest is used route operator/raft API requests to the implementing
 // functions.
 func (s *HTTPServer) KeyringRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/command/agent/keyring_endpoint_test.go
+++ b/command/agent/keyring_endpoint_test.go
@@ -134,7 +134,7 @@ func TestHTTP_Keyring_OIDCDisco_Disabled(t *testing.T) {
 	})
 }
 
-// TestHTTP_Keyring_OIDCDisco_Disabled asserts that the OIDC Discovery endpoint
+// TestHTTP_Keyring_OIDCDisco_Enabled asserts that the OIDC Discovery endpoint
 // is enabled when OIDCIssuer is set.
 func TestHTTP_Keyring_OIDCDisco_Enabled(t *testing.T) {
 	ci.Parallel(t)

--- a/command/agent/keyring_endpoint_test.go
+++ b/command/agent/keyring_endpoint_test.go
@@ -140,7 +140,7 @@ func TestHTTP_Keyring_OIDCDisco_Enabled(t *testing.T) {
 	ci.Parallel(t)
 
 	// Set OIDCIssuer to a valid looking (but fake) issuer
-	const testIssuer = "https://oidc.test.nomadproject.io/"
+	const testIssuer = "https://oidc.test.nomadproject.io"
 
 	cb := func(c *Config) {
 		c.Server.OIDCIssuer = testIssuer

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -431,6 +431,11 @@ type Config struct {
 	JobTrackedVersions int
 
 	Reporting *config.ReportingConfig
+
+	// OIDCIssuer is the URL for the OIDC Issuer field in Workload Identity JWTs.
+	// If this is not configured the /.well-known/openid-configuration endpoint
+	// will not be available.
+	OIDCIssuer string
 }
 
 func (c *Config) Copy() *Config {

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -47,8 +47,13 @@ func (s *mockSigner) SignClaims(c *structs.IdentityClaims) (token, keyID string,
 func TestEncrypter_LoadSave(t *testing.T) {
 	ci.Parallel(t)
 
+	srv, cleanupSrv := TestServer(t, func(c *Config) {
+		c.NumSchedulers = 0
+	})
+	t.Cleanup(cleanupSrv)
+
 	tmpDir := t.TempDir()
-	encrypter, err := NewEncrypter(&Server{shutdownCtx: context.Background()}, tmpDir)
+	encrypter, err := NewEncrypter(srv, tmpDir)
 	require.NoError(t, err)
 
 	algos := []structs.EncryptionAlgorithm{

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -413,7 +413,7 @@ func TestEncrypter_SignVerify(t *testing.T) {
 // is configured.
 func TestEncrypter_SignVerify_Issuer(t *testing.T) {
 	// Set OIDCIssuer to a valid looking (but fake) issuer
-	const testIssuer = "https://oidc.test.nomadproject.io/"
+	const testIssuer = "https://oidc.test.nomadproject.io"
 
 	ci.Parallel(t)
 	srv, shutdown := TestServer(t, func(c *Config) {

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -394,11 +394,45 @@ func TestEncrypter_SignVerify(t *testing.T) {
 	require.NoError(t, err)
 
 	got, err := e.VerifyClaim(out)
+	must.NoError(t, err)
+	must.NotNil(t, got)
+	must.Eq(t, alloc.ID, got.AllocationID)
+	must.Eq(t, alloc.JobID, got.JobID)
+	must.Eq(t, "web", got.TaskName)
+
+	// By default an issuer should not be set. See _Issuer test.
+	must.Eq(t, "", got.Issuer)
+}
+
+// TestEncrypter_SignVerify_Issuer asserts that the signer adds an issuer if it
+// is configured.
+func TestEncrypter_SignVerify_Issuer(t *testing.T) {
+	// Set OIDCIssuer to a valid looking (but fake) issuer
+	const testIssuer = "https://oidc.test.nomadproject.io/"
+
+	ci.Parallel(t)
+	srv, shutdown := TestServer(t, func(c *Config) {
+		c.NumSchedulers = 0 // Prevent automatic dequeue
+
+		c.OIDCIssuer = testIssuer
+	})
+	defer shutdown()
+	testutil.WaitForLeader(t, srv.RPC)
+
+	alloc := mock.Alloc()
+	claims := structs.NewIdentityClaims(alloc.Job, alloc, wiHandle, alloc.LookupTask("web").Identity, time.Now())
+	e := srv.encrypter
+
+	out, _, err := e.SignClaims(claims)
 	require.NoError(t, err)
-	require.NotNil(t, got)
-	require.Equal(t, alloc.ID, got.AllocationID)
-	require.Equal(t, alloc.JobID, got.JobID)
-	require.Equal(t, "web", got.TaskName)
+
+	got, err := e.VerifyClaim(out)
+	must.NoError(t, err)
+	must.NotNil(t, got)
+	must.Eq(t, alloc.ID, got.AllocationID)
+	must.Eq(t, alloc.JobID, got.JobID)
+	must.Eq(t, "web", got.TaskName)
+	must.Eq(t, testIssuer, got.Issuer)
 }
 
 func TestEncrypter_SignVerify_AlgNone(t *testing.T) {

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -291,6 +291,15 @@ type Server struct {
 	// dependencies.
 	reportingManager *reporting.Manager
 
+	// oidcDisco is the OIDC Discovery configuration to be returned by the
+	// Keyring.GetConfig RPC and /.well-known/openid-configuration HTTP API.
+	//
+	// The issuer and jwks url are user configurable and therefore the struct is
+	// initialized when NewServer is setup.
+	//
+	// MAY BE nil! Issuer must be explicitly configured by the end user.
+	oidcDisco *structs.OIDCDiscoveryConfig
+
 	// EnterpriseState is used to fill in state for Pro/Ent builds
 	EnterpriseState
 
@@ -407,9 +416,22 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigFunc
 	}
 	s.encrypter = encrypter
 
-	// Set up the OIDC provider cache. This is needed by the setupRPC, but must
-	// be done separately so that the server can stop all background processes
-	// when it shuts down itself.
+	// Set up the OIDC discovery configuration required by third parties, such as
+	// AWS's IAM OIDC Provider, to authenticate workload identity JWTs.
+	if iss := config.OIDCIssuer; iss != "" {
+		oidcDisco, err := structs.NewOIDCDiscoveryConfig(iss)
+		if err != nil {
+			return nil, err
+		}
+		s.oidcDisco = oidcDisco
+		s.logger.Info("issuer set; OIDC Discovery endpoint for workload identities enabled", "issuer", iss)
+	} else {
+		s.logger.Debug("issuer not set; OIDC Discovery endpoint for workload identities disabled")
+	}
+
+	// Set up the SSO OIDC provider cache. This is needed by the setupRPC, but
+	// must be done separately so that the server can stop all background
+	// processes when it shuts down itself.
 	s.oidcProviderCache = oidc.NewProviderCache()
 
 	// Initialize the RPC layer

--- a/nomad/structs/keyring.go
+++ b/nomad/structs/keyring.go
@@ -6,6 +6,7 @@ package structs
 import (
 	"crypto/ed25519"
 	"fmt"
+	"net/url"
 	"time"
 
 	"github.com/hashicorp/nomad/helper"
@@ -21,6 +22,9 @@ const (
 	// PubKeyUseSig is the JWK (JSON Web Key) "use" parameter value for
 	// signatures.
 	PubKeyUseSig = "sig"
+
+	// JWKSPath is the path component of the URL to Nomad's JWKS endpoint.
+	JWKSPath = "/.well-known/jwks.json"
 )
 
 // RootKey is used to encrypt and decrypt variables. It is never stored in raft.
@@ -305,4 +309,41 @@ func (pubKey *KeyringPublicKey) GetPublicKey() (any, error) {
 	default:
 		return nil, fmt.Errorf("unknown algorithm: %q", alg)
 	}
+}
+
+// KeyringGetConfigResponse is the response for Keyring.GetConfig RPCs.
+type KeyringGetConfigResponse struct {
+	OIDCDiscovery *OIDCDiscoveryConfig
+}
+
+// OIDCDiscoveryConfig represents the response to OIDC Discovery requests
+// usually at: /.well-known/openid-configuration
+//
+// Only the fields Nomad uses are implemented since many fields in the
+// specification are not relevant to Nomad's use case:
+// https://openid.net/specs/openid-connect-discovery-1_0.html
+type OIDCDiscoveryConfig struct {
+	Issuer        string   `json:"issuer"`
+	JWKS          string   `json:"jwks_uri"`
+	IDTokenAlgs   []string `json:"id_token_signing_alg_values_supported"`
+	ResponseTypes []string `json:"response_types_supported"`
+	Subjects      []string `json:"subject_types_supported"`
+}
+
+// NewOIDCDiscoveryConfig returns a populated OIDCDiscoveryConfig or an error.
+func NewOIDCDiscoveryConfig(issuer string) (*OIDCDiscoveryConfig, error) {
+	jwksURL, err := url.JoinPath(issuer, JWKSPath)
+	if err != nil {
+		return nil, fmt.Errorf("error determining jwks path: %w", err)
+	}
+
+	disc := &OIDCDiscoveryConfig{
+		Issuer:        issuer,
+		JWKS:          jwksURL,
+		IDTokenAlgs:   []string{PubKeyAlgEdDSA},
+		ResponseTypes: []string{"code"},
+		Subjects:      []string{"public"},
+	}
+
+	return disc, nil
 }

--- a/nomad/structs/keyring.go
+++ b/nomad/structs/keyring.go
@@ -332,6 +332,13 @@ type OIDCDiscoveryConfig struct {
 
 // NewOIDCDiscoveryConfig returns a populated OIDCDiscoveryConfig or an error.
 func NewOIDCDiscoveryConfig(issuer string) (*OIDCDiscoveryConfig, error) {
+	if issuer == "" {
+		// url.JoinPath doesn't mind empty strings, so check for it specifically.
+		// Likely a programming error as we shouldn't even be trying to create OIDC
+		// Discovery configurations without an issuer explicitly set.
+		return nil, fmt.Errorf("issuer must not be empty")
+	}
+
 	jwksURL, err := url.JoinPath(issuer, JWKSPath)
 	if err != nil {
 		return nil, fmt.Errorf("error determining jwks path: %w", err)

--- a/nomad/structs/keyring_test.go
+++ b/nomad/structs/keyring_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package structs
 
 import (

--- a/nomad/structs/keyring_test.go
+++ b/nomad/structs/keyring_test.go
@@ -1,0 +1,30 @@
+package structs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
+)
+
+func TestKeyring_OIDCDiscoveryConfig(t *testing.T) {
+	ci.Parallel(t)
+
+	c, err := NewOIDCDiscoveryConfig("")
+	must.Error(t, err)
+	must.Nil(t, c)
+
+	c, err = NewOIDCDiscoveryConfig(":/invalid")
+	must.Error(t, err)
+	must.Nil(t, c)
+
+	const testIssuer = "https://oidc.test.nomadproject.io/"
+	c, err = NewOIDCDiscoveryConfig(testIssuer)
+	must.NoError(t, err)
+	must.NotNil(t, c)
+	must.Eq(t, testIssuer, c.Issuer)
+	must.StrHasPrefix(t, testIssuer, c.JWKS)
+	must.SliceNotEmpty(t, c.IDTokenAlgs)
+	must.SliceNotEmpty(t, c.ResponseTypes)
+	must.SliceNotEmpty(t, c.Subjects)
+}

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -267,6 +267,10 @@ server {
 - `job_tracked_versions` `(int: 6)` - Specifies the number of historic job versions that
   are kept.
 
+- `oidc_issuer` `(string: "")` - Specifies the Issuer URL for [Workload
+  Identity][wi] JWTs. If set the `/.well-known/openid-configuration` HTTP
+  endpoint is enabled for third parties to discover Nomad's OIDC configuration.
+
 ### Deprecated Parameters
 
 - `retry_join` `(array<string>: [])` - Specifies a list of server addresses to
@@ -502,3 +506,4 @@ work.
 [encryption key]: /nomad/docs/operations/key-management
 [max_client_disconnect]: /nomad/docs/job-specification/group#max-client-disconnect
 [herd]: https://en.wikipedia.org/wiki/Thundering_herd_problem
+[wi]: /nomad/docs/concepts/workload-identity

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -268,12 +268,13 @@ server {
   are kept.
 
 - `oidc_issuer` `(string: "")` - Specifies the Issuer URL for [Workload
-  Identity][wi] JWTs. If set the `/.well-known/openid-configuration` HTTP
-  endpoint is enabled for third parties to discover Nomad's OIDC configuration.
-  Once set `oidc_issuer` *cannot be changed* without invalidating Workload
-  Identities that have the old issuer claim. For this reason it is suggested to
-  set `oidc_issuer` to a proxy in front of Nomad's HTTP API to ensure a stable
-  DNS name can be used instead of a potentially ephemeral Nomad server IP.
+    Identity][wi] JWTs. For example, `"https://nomad.example.com"`. If set the
+    `/.well-known/openid-configuration` HTTP endpoint is enabled for third
+    parties to discover Nomad's OIDC configuration.  Once set `oidc_issuer`
+    *cannot be changed* without invalidating Workload Identities that have the
+    old issuer claim. For this reason it is suggested to set `oidc_issuer` to a
+    proxy in front of Nomad's HTTP API to ensure a stable DNS name can be used
+    instead of a potentially ephemeral Nomad server IP.
 
 ### Deprecated Parameters
 

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -270,6 +270,10 @@ server {
 - `oidc_issuer` `(string: "")` - Specifies the Issuer URL for [Workload
   Identity][wi] JWTs. If set the `/.well-known/openid-configuration` HTTP
   endpoint is enabled for third parties to discover Nomad's OIDC configuration.
+  Once set `oidc_issuer` *cannot be changed* without invalidating Workload
+  Identities that have the old issuer claim. For this reason it is suggested to
+  set `oidc_issuer` to a proxy in front of Nomad's HTTP API to ensure a stable
+  DNS name can be used instead of a potentially ephemeral Nomad server IP.
 
 ### Deprecated Parameters
 


### PR DESCRIPTION
Added the [OIDC Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html) `/.well-known/openid-configuration` endpoint to Nomad, but it is only enabled if the `server.oidc_issuer` parameter is set. Documented the parameter, but without a tutorial trying to actually _use_ this will be very hard.

I intentionally did *not* use https://github.com/hashicorp/cap for the OIDC configuration struct because it's built to be a *compliant* OIDC provider. Nomad is *not* trying to be compliant initially because compliance to the spec does not guarantee it will actually satisfy the requirements of third parties. I want to avoid the problem where in an attempt to be standards compliant we ship configuration parameters that lock us in to a certain behavior that we end up regretting. I want to add parameters and behaviors as there's a demonstrable need.

Users always have the escape hatch of providing their own OIDC configuration endpoint. Nomad just needs to know the Issuer so that the JWTs match the OIDC configuration. There's no reason the actual OIDC configuration JSON couldn't live in S3 and get served directly from there. Unlike JWKS the OIDC configuration should be static, or at least change very rarely.

This PR is just the endpoint extracted from #18535. The `RS256` algorithm still needs to be added in hopes of supporting third parties such as [AWS IAM OIDC Provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html).