### PR TITLE
consul: prevent unnecessary periodic service sync

### DIFF
--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -341,11 +341,13 @@ func proxyUpstreamsDifferent(wanted *api.AgentServiceConnect, sidecar *api.Agent
 				return true
 			case A.LocalBindPort != B.LocalBindPort:
 				return true
-			case A.MeshGateway.Mode != B.MeshGateway.Mode:
+			case A.MeshGateway.Mode != "" &&
+				A.MeshGateway.Mode != B.MeshGateway.Mode:
 				return true
 			case A.DestinationPeer != B.DestinationPeer:
 				return true
-			case A.DestinationType != B.DestinationType:
+			case A.DestinationType != "" &&
+				A.DestinationType != B.DestinationType:
 				return true
 			case A.LocalBindSocketPath != B.LocalBindSocketPath:
 				return true

--- a/command/agent/consul/service_client_test.go
+++ b/command/agent/consul/service_client_test.go
@@ -578,6 +578,7 @@ func TestSyncLogic_proxyUpstreamsDifferent(t *testing.T) {
 		return api.Upstream{
 			Datacenter:       "sfo",
 			DestinationName:  "billing",
+			DestinationType:  "service",
 			LocalBindAddress: "127.0.0.1",
 			LocalBindPort:    5050,
 			MeshGateway: api.MeshGatewayConfig{
@@ -716,7 +717,7 @@ func TestSyncLogic_proxyUpstreamsDifferent(t *testing.T) {
 
 	try(t, "different destination type", func(p proxy) {
 		diff := upstream1()
-		diff.DestinationType = "service"
+		diff.DestinationType = "prepared_query"
 		p.Upstreams = []api.Upstream{
 			diff,
 			upstream2(),


### PR DESCRIPTION
The periodic Consul service sync routine computes a diff between the service registration from Nomad's point-of-view against Consul's.

This diff logic is done over strict equality of some string values that have defaults in Consul that Nomad may not be aware of. This commit fixes two of such cases.

* `DestinationType` is an optional field that defaults (and is written to Consul state) as `service`.
* `MeshGateway.Mode` may be an empty string, in which case the final value is defined by a hierarchy of possibilities, including service defaults and overrides that are not available to Nomad.

In both cases, Nomad's view is that these fields are empty strings, but in Consul an actual final value is written.

This difference results in constant unnecessary service sync from Nomad to Consul.

Other fields may also be affected in a similar way, but these are the two I found while investigating #18538