### PR TITLE
fix: handling non reschedule disconnecting and reconnecting allocs

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10897,7 +10897,8 @@ func (a *Allocation) NextRescheduleTime() (time.Time, bool) {
 	failTime := a.LastEventTime()
 	reschedulePolicy := a.ReschedulePolicy()
 
-	if reschedulePolicy.Attempts == 0 && reschedulePolicy.Unlimited {
+	//If reschedule is disabled, return early
+	if reschedulePolicy.Attempts == 0 && !reschedulePolicy.Unlimited {
 		return time.Time{}, false
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10914,16 +10914,16 @@ func (a *Allocation) nextRescheduleTime(failTime time.Time, reschedulePolicy *Re
 	return nextRescheduleTime, rescheduleEligible
 }
 
-// NextRescheduleTimeByFailTime works like NextRescheduleTime but allows callers
+// NextRescheduleTimeByTime works like NextRescheduleTime but allows callers
 // specify a failure time. Useful for things like determining whether to reschedule
 // an alloc on a disconnected node.
-func (a *Allocation) NextRescheduleTimeByFailTime(failTime time.Time) (time.Time, bool) {
+func (a *Allocation) NextRescheduleTimeByTime(t time.Time) (time.Time, bool) {
 	reschedulePolicy := a.ReschedulePolicy()
 	if reschedulePolicy == nil {
 		return time.Time{}, false
 	}
 
-	return a.nextRescheduleTime(failTime, reschedulePolicy)
+	return a.nextRescheduleTime(t, reschedulePolicy)
 }
 
 // ShouldClientStop tests an alloc for StopAfterClientDisconnect configuration

--- a/nomad/worker.go
+++ b/nomad/worker.go
@@ -786,7 +786,7 @@ SUBMIT:
 		}
 		return err
 	} else {
-		w.logger.Debug("created evaluation", "eval", log.Fmt("%#v", eval))
+		w.logger.Debug("created evaluation", "eval", log.Fmt("%#v", eval), "waitUntil", log.Fmt("%#v", eval.WaitUntil.String()))
 		w.backoffReset()
 	}
 	return nil

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -6939,6 +6939,7 @@ func TestServiceSched_Client_Disconnect_Creates_Updates_and_Evals(t *testing.T) 
 		NodeID:      disconnectedNode.ID,
 		Status:      structs.EvalStatusPending,
 	}}
+
 	nodeStatusUpdateEval := evals[0]
 	require.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), evals))
 
@@ -6948,16 +6949,21 @@ func TestServiceSched_Client_Disconnect_Creates_Updates_and_Evals(t *testing.T) 
 	require.Equal(t, structs.EvalStatusComplete, h.Evals[0].Status)
 	require.Len(t, h.Plans, 1, "plan")
 
-	// One followup delayed eval created
-	require.Len(t, h.CreateEvals, 1)
-	followUpEval := h.CreateEvals[0]
-	require.Equal(t, nodeStatusUpdateEval.ID, followUpEval.PreviousEval)
-	require.Equal(t, "pending", followUpEval.Status)
-	require.NotEmpty(t, followUpEval.WaitUntil)
+	// Two followup delayed eval created
+	require.Len(t, h.CreateEvals, 2)
+	followUpEval1 := h.CreateEvals[0]
+	require.Equal(t, nodeStatusUpdateEval.ID, followUpEval1.PreviousEval)
+	require.Equal(t, "pending", followUpEval1.Status)
+	require.NotEmpty(t, followUpEval1.WaitUntil)
 
-	// Insert eval in the state store
+	followUpEval2 := h.CreateEvals[1]
+	require.Equal(t, nodeStatusUpdateEval.ID, followUpEval2.PreviousEval)
+	require.Equal(t, "pending", followUpEval2.Status)
+	require.NotEmpty(t, followUpEval2.WaitUntil)
+
+	// Insert eval1 in the state store
 	testutil.WaitForResult(func() (bool, error) {
-		found, err := h.State.EvalByID(nil, followUpEval.ID)
+		found, err := h.State.EvalByID(nil, followUpEval1.ID)
 		if err != nil {
 			return false, err
 		}
@@ -6971,12 +6977,34 @@ func TestServiceSched_Client_Disconnect_Creates_Updates_and_Evals(t *testing.T) 
 
 		return true, nil
 	}, func(err error) {
+
+		require.NoError(t, err)
+	})
+
+	// Insert eval2 in the state store
+	testutil.WaitForResult(func() (bool, error) {
+		found, err := h.State.EvalByID(nil, followUpEval2.ID)
+		if err != nil {
+			return false, err
+		}
+		if found == nil {
+			return false, nil
+		}
+
+		require.Equal(t, nodeStatusUpdateEval.ID, found.PreviousEval)
+		require.Equal(t, "pending", found.Status)
+		require.NotEmpty(t, found.WaitUntil)
+
+		return true, nil
+	}, func(err error) {
+
 		require.NoError(t, err)
 	})
 
 	// Validate that the ClientStatus updates are part of the plan.
 	require.Len(t, h.Plans[0].NodeAllocation[disconnectedNode.ID], count)
 	// Pending update should have unknown status.
+
 	for _, nodeAlloc := range h.Plans[0].NodeAllocation[disconnectedNode.ID] {
 		require.Equal(t, nodeAlloc.ClientStatus, structs.AllocClientStatusUnknown)
 	}
@@ -6986,6 +7014,7 @@ func TestServiceSched_Client_Disconnect_Creates_Updates_and_Evals(t *testing.T) 
 	require.NoError(t, err, "plan.NodeUpdate")
 
 	// Validate that the StateStore Upsert applied the ClientStatus we specified.
+
 	for _, alloc := range unknownAllocs {
 		alloc, err = h.State.AllocByID(nil, alloc.ID)
 		require.NoError(t, err)

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -1359,7 +1359,7 @@ func (a *allocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName
 
 	timeoutDelays, err := disconnecting.delayByMaxClientDisconnect(a.now)
 	if err != nil {
-		a.logger.Error("error computing disconnecting timeouts for task_group",
+		a.logger.Error("error for task_group",
 			"task_group", tgName, "error", err)
 		return map[string]string{}
 	}

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -1355,7 +1355,7 @@ func (a *allocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName
 	}
 
 	timeoutDelays, err := disconnecting.delayByMaxClientDisconnect(a.now)
-	if err != nil || len(timeoutDelays) != len(disconnecting) {
+	if err != nil {
 		a.logger.Error("error computing disconnecting timeouts for task_group",
 			"task_group", tgName, "error", err)
 		return map[string]string{}

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -457,7 +457,8 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 	// Determine what set of terminal allocations need to be rescheduled
 	untainted, rescheduleNow, rescheduleLater := untainted.filterByRescheduleable(a.batch, false, a.now, a.evalID, a.deployment)
 
-	// Determine what set of disconnecting allocations need to be rescheduled
+	// Determine what set of disconnecting allocations need to be rescheduled now
+	// and which ones can't be rescheduled at all.
 	untaintedDisconnecting, rescheduleDisconnecting, _ := disconnecting.filterByRescheduleable(a.batch, true, a.now, a.evalID, a.deployment)
 	rescheduleNow = rescheduleNow.union(rescheduleDisconnecting)
 	untainted = untainted.union(untaintedDisconnecting)

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -1074,7 +1074,7 @@ func (a *allocReconciler) computeStop(group *structs.TaskGroup, nameIndex *alloc
 //   - If the reconnecting allocation is to be stopped, its replacements may
 //     not be present in any of the returned sets. The rest of the reconciler
 //     logic will handle them.
-func (a *allocReconciler) reconcileReconnecting(reconnecting allocSet, others allocSet) (allocSet, allocSet) {
+func (a *allocReconciler) reconcileReconnecting(reconnecting allocSet, allAllocs allocSet) (allocSet, allocSet) {
 	stop := make(allocSet)
 	reconnect := make(allocSet)
 
@@ -1113,7 +1113,7 @@ func (a *allocReconciler) reconcileReconnecting(reconnecting allocSet, others al
 
 		// Find replacement allocations and decide which one to stop. A
 		// reconnecting allocation may have multiple replacements.
-		for _, replacementAlloc := range others {
+		for _, replacementAlloc := range allAllocs {
 
 			// Skip allocations that are not a replacement of the one
 			// reconnecting. Replacement allocations have the same name but a

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -458,8 +458,9 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 	untainted, rescheduleNow, rescheduleLater := untainted.filterByRescheduleable(a.batch, false, a.now, a.evalID, a.deployment)
 
 	// Determine what set of disconnecting allocations need to be rescheduled
-	_, rescheduleDisconnecting, _ := disconnecting.filterByRescheduleable(a.batch, true, a.now, a.evalID, a.deployment)
+	untaintedDisconnecting, rescheduleDisconnecting, _ := disconnecting.filterByRescheduleable(a.batch, true, a.now, a.evalID, a.deployment)
 	rescheduleNow = rescheduleNow.union(rescheduleDisconnecting)
+	untainted = untainted.union(untaintedDisconnecting)
 
 	// Find delays for any lost allocs that have stop_after_client_disconnect
 	lostLater := lost.delayByStopAfterClientDisconnect()
@@ -486,6 +487,7 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 	// include stopped allocations.
 	isCanarying := dstate != nil && dstate.DesiredCanaries != 0 && !dstate.Promoted
 	stop := a.computeStop(tg, nameIndex, untainted, migrate, lost, canaries, isCanarying, lostLaterEvals)
+
 	desiredChanges.Stop += uint64(len(stop))
 	untainted = untainted.difference(stop)
 

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -975,7 +975,7 @@ func (a *allocReconciler) computeStop(group *structs.TaskGroup, nameIndex *alloc
 	}
 
 	// Remove disconnected allocations so they won't be stopped
-	knownUntainted := untainted.FilterByClientStatus(structs.AllocClientStatusUnknown)
+	knownUntainted := untainted.filterOutByClientStatus(structs.AllocClientStatusUnknown)
 
 	// Hot path the nothing to do case
 	remove := len(knownUntainted) + len(migrate) - group.Count

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -5320,38 +5320,35 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 	}}
 
 	type testCase struct {
-		name                            string
-		allocCount                      int
-		disconnectedAllocCount          int
-		jobVersionIncrement             uint64
-		nodeScoreIncrement              float64
-		disconnectedAllocStatus         string
-		disconnectedAllocStates         []*structs.AllocState
-		disconnectedServerDesiredStatus string
-		serverDesiredStatus             string
-		isBatch                         bool
-		nodeStatusDisconnected          bool
-		replace                         bool
-		failReplacement                 bool
-		taintReplacement                bool
-		disconnectReplacement           bool
-		replaceFailedReplacement        bool
-		shouldStopOnDisconnectedNode    bool
-		maxDisconnect                   *time.Duration
-		expected                        *resultExpectation
+		name                         string
+		allocCount                   int
+		disconnectedAllocCount       int
+		jobVersionIncrement          uint64
+		nodeScoreIncrement           float64
+		disconnectedAllocStatus      string
+		disconnectedAllocStates      []*structs.AllocState
+		isBatch                      bool
+		nodeStatusDisconnected       bool
+		replace                      bool
+		failReplacement              bool
+		taintReplacement             bool
+		disconnectReplacement        bool
+		replaceFailedReplacement     bool
+		shouldStopOnDisconnectedNode bool
+		maxDisconnect                *time.Duration
+		expected                     *resultExpectation
 	}
 
 	testCases := []testCase{
 		{
-			name:                            "reconnect-original-no-replacement",
-			allocCount:                      2,
-			replace:                         false,
-			disconnectedAllocCount:          2,
-			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode:    false,
+			name:                    "reconnect-original-no-replacement",
+			allocCount:              2,
+			replace:                 false,
+			disconnectedAllocCount:  2,
+			disconnectedAllocStatus: structs.AllocClientStatusRunning,
+
+			disconnectedAllocStates:      disconnectAllocState,
+			shouldStopOnDisconnectedNode: false,
 			expected: &resultExpectation{
 				reconnectUpdates: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5362,15 +5359,14 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "resume-original-and-stop-replacement",
-			allocCount:                      3,
-			replace:                         true,
-			disconnectedAllocCount:          1,
-			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode:    false,
+			name:                    "resume-original-and-stop-replacement",
+			allocCount:              3,
+			replace:                 true,
+			disconnectedAllocCount:  1,
+			disconnectedAllocStatus: structs.AllocClientStatusRunning,
+
+			disconnectedAllocStates:      disconnectAllocState,
+			shouldStopOnDisconnectedNode: false,
 			expected: &resultExpectation{
 				stop:             1,
 				reconnectUpdates: 1,
@@ -5383,16 +5379,15 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "stop-original-with-lower-node-score",
-			allocCount:                      4,
-			replace:                         true,
-			disconnectedAllocCount:          1,
-			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode:    true,
-			nodeScoreIncrement:              1,
+			name:                    "stop-original-with-lower-node-score",
+			allocCount:              4,
+			replace:                 true,
+			disconnectedAllocCount:  1,
+			disconnectedAllocStatus: structs.AllocClientStatusRunning,
+
+			disconnectedAllocStates:      disconnectAllocState,
+			shouldStopOnDisconnectedNode: true,
+			nodeScoreIncrement:           1,
 			expected: &resultExpectation{
 				stop: 1,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5404,15 +5399,14 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "stop-original-failed-on-reconnect",
-			allocCount:                      4,
-			replace:                         true,
-			disconnectedAllocCount:          2,
-			disconnectedAllocStatus:         structs.AllocClientStatusFailed,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode:    true,
+			name:                    "stop-original-failed-on-reconnect",
+			allocCount:              4,
+			replace:                 true,
+			disconnectedAllocCount:  2,
+			disconnectedAllocStatus: structs.AllocClientStatusFailed,
+
+			disconnectedAllocStates:      disconnectAllocState,
+			shouldStopOnDisconnectedNode: true,
 			expected: &resultExpectation{
 				stop: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5424,15 +5418,14 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "reschedule-original-failed-if-not-replaced",
-			allocCount:                      4,
-			replace:                         false,
-			disconnectedAllocCount:          2,
-			disconnectedAllocStatus:         structs.AllocClientStatusFailed,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode:    true,
+			name:                    "reschedule-original-failed-if-not-replaced",
+			allocCount:              4,
+			replace:                 false,
+			disconnectedAllocCount:  2,
+			disconnectedAllocStatus: structs.AllocClientStatusFailed,
+
+			disconnectedAllocStates:      disconnectAllocState,
+			shouldStopOnDisconnectedNode: true,
 			expected: &resultExpectation{
 				stop:  2,
 				place: 2,
@@ -5446,15 +5439,14 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "ignore-reconnect-completed",
-			allocCount:                      2,
-			replace:                         false,
-			disconnectedAllocCount:          2,
-			disconnectedAllocStatus:         structs.AllocClientStatusComplete,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
-			isBatch:                         true,
+			name:                    "ignore-reconnect-completed",
+			allocCount:              2,
+			replace:                 false,
+			disconnectedAllocCount:  2,
+			disconnectedAllocStatus: structs.AllocClientStatusComplete,
+
+			disconnectedAllocStates: disconnectAllocState,
+			isBatch:                 true,
 			expected: &resultExpectation{
 				place: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5466,15 +5458,14 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "keep-original-alloc-and-stop-failed-replacement",
-			allocCount:                      3,
-			replace:                         true,
-			failReplacement:                 true,
-			disconnectedAllocCount:          2,
-			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			name:                    "keep-original-alloc-and-stop-failed-replacement",
+			allocCount:              3,
+			replace:                 true,
+			failReplacement:         true,
+			disconnectedAllocCount:  2,
+			disconnectedAllocStatus: structs.AllocClientStatusRunning,
+
+			disconnectedAllocStates: disconnectAllocState,
 			expected: &resultExpectation{
 				reconnectUpdates: 2,
 				stop:             0,
@@ -5486,15 +5477,14 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "keep-original-and-stop-reconnecting-replacement",
-			allocCount:                      2,
-			replace:                         true,
-			disconnectReplacement:           true,
-			disconnectedAllocCount:          1,
-			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			name:                    "keep-original-and-stop-reconnecting-replacement",
+			allocCount:              2,
+			replace:                 true,
+			disconnectReplacement:   true,
+			disconnectedAllocCount:  1,
+			disconnectedAllocStatus: structs.AllocClientStatusRunning,
+
+			disconnectedAllocStates: disconnectAllocState,
 			expected: &resultExpectation{
 				reconnectUpdates: 1,
 				stop:             1,
@@ -5507,15 +5497,14 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "keep-original-and-stop-tainted-replacement",
-			allocCount:                      3,
-			replace:                         true,
-			taintReplacement:                true,
-			disconnectedAllocCount:          2,
-			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			name:                    "keep-original-and-stop-tainted-replacement",
+			allocCount:              3,
+			replace:                 true,
+			taintReplacement:        true,
+			disconnectedAllocCount:  2,
+			disconnectedAllocStatus: structs.AllocClientStatusRunning,
+
+			disconnectedAllocStates: disconnectAllocState,
 			expected: &resultExpectation{
 				reconnectUpdates: 2,
 				stop:             2,
@@ -5528,16 +5517,15 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "stop-original-alloc-with-old-job-version",
-			allocCount:                      5,
-			replace:                         true,
-			disconnectedAllocCount:          2,
-			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode:    true,
-			jobVersionIncrement:             1,
+			name:                    "stop-original-alloc-with-old-job-version",
+			allocCount:              5,
+			replace:                 true,
+			disconnectedAllocCount:  2,
+			disconnectedAllocStatus: structs.AllocClientStatusRunning,
+
+			disconnectedAllocStates:      disconnectAllocState,
+			shouldStopOnDisconnectedNode: true,
+			jobVersionIncrement:          1,
 			expected: &resultExpectation{
 				stop: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5549,16 +5537,15 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "stop-original-alloc-with-old-job-version-reconnect-eval",
-			allocCount:                      5,
-			replace:                         true,
-			disconnectedAllocCount:          2,
-			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode:    true,
-			jobVersionIncrement:             1,
+			name:                    "stop-original-alloc-with-old-job-version-reconnect-eval",
+			allocCount:              5,
+			replace:                 true,
+			disconnectedAllocCount:  2,
+			disconnectedAllocStatus: structs.AllocClientStatusRunning,
+
+			disconnectedAllocStates:      disconnectAllocState,
+			shouldStopOnDisconnectedNode: true,
+			jobVersionIncrement:          1,
 			expected: &resultExpectation{
 				stop: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5570,18 +5557,17 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "stop-original-alloc-with-old-job-version-and-failed-replacements-replaced",
-			allocCount:                      5,
-			replace:                         true,
-			failReplacement:                 true,
-			replaceFailedReplacement:        true,
-			disconnectedAllocCount:          2,
-			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode:    false,
-			jobVersionIncrement:             1,
+			name:                     "stop-original-alloc-with-old-job-version-and-failed-replacements-replaced",
+			allocCount:               5,
+			replace:                  true,
+			failReplacement:          true,
+			replaceFailedReplacement: true,
+			disconnectedAllocCount:   2,
+			disconnectedAllocStatus:  structs.AllocClientStatusRunning,
+
+			disconnectedAllocStates:      disconnectAllocState,
+			shouldStopOnDisconnectedNode: false,
+			jobVersionIncrement:          1,
 			expected: &resultExpectation{
 				stop:             2,
 				reconnectUpdates: 2,
@@ -5594,16 +5580,15 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "stop-original-pending-alloc-for-disconnected-node",
-			allocCount:                      2,
-			replace:                         true,
-			disconnectedAllocCount:          1,
-			disconnectedAllocStatus:         structs.AllocClientStatusPending,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode:    true,
-			nodeStatusDisconnected:          true,
+			name:                    "stop-original-pending-alloc-for-disconnected-node",
+			allocCount:              2,
+			replace:                 true,
+			disconnectedAllocCount:  1,
+			disconnectedAllocStatus: structs.AllocClientStatusPending,
+
+			disconnectedAllocStates:      disconnectAllocState,
+			shouldStopOnDisconnectedNode: true,
+			nodeStatusDisconnected:       true,
 			expected: &resultExpectation{
 				stop: 1,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5615,16 +5600,15 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                            "stop-failed-original-and-failed-replacements-and-place-new",
-			allocCount:                      5,
-			replace:                         true,
-			failReplacement:                 true,
-			disconnectedAllocCount:          2,
-			disconnectedAllocStatus:         structs.AllocClientStatusFailed,
-			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
-			disconnectedAllocStates:         disconnectAllocState,
-			serverDesiredStatus:             structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode:    true,
+			name:                    "stop-failed-original-and-failed-replacements-and-place-new",
+			allocCount:              5,
+			replace:                 true,
+			failReplacement:         true,
+			disconnectedAllocCount:  2,
+			disconnectedAllocStatus: structs.AllocClientStatusFailed,
+
+			disconnectedAllocStates:      disconnectAllocState,
+			shouldStopOnDisconnectedNode: true,
 			expected: &resultExpectation{
 				stop:  2,
 				place: 2,
@@ -5644,7 +5628,6 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			disconnectedAllocCount:       2,
 			disconnectedAllocStatus:      structs.AllocClientStatusUnknown,
 			disconnectedAllocStates:      disconnectAllocState,
-			serverDesiredStatus:          structs.AllocDesiredStatusRun,
 			shouldStopOnDisconnectedNode: true,
 			nodeStatusDisconnected:       true,
 			maxDisconnect:                pointer.Of(2 * time.Second),
@@ -5665,7 +5648,6 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			disconnectedAllocCount:  2,
 			disconnectedAllocStatus: structs.AllocClientStatusRunning,
 			disconnectedAllocStates: []*structs.AllocState{},
-			serverDesiredStatus:     structs.AllocDesiredStatusRun,
 			nodeStatusDisconnected:  true,
 			expected: &resultExpectation{
 				place:             2,
@@ -5704,7 +5686,7 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			// Set alloc state
 			disconnectedAllocCount := tc.disconnectedAllocCount
 			for _, alloc := range allocs {
-				alloc.DesiredStatus = tc.serverDesiredStatus
+				alloc.DesiredStatus = structs.AllocDesiredStatusRun
 
 				if tc.maxDisconnect != nil {
 					alloc.Job.TaskGroups[0].MaxClientDisconnect = tc.maxDisconnect
@@ -5716,7 +5698,6 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 					// Set the node id on all the disconnected allocs to the node under test.
 					alloc.NodeID = testNode.ID
 					alloc.NodeName = "disconnected"
-					alloc.DesiredStatus = tc.disconnectedServerDesiredStatus
 					disconnectedAllocCount--
 				}
 			}
@@ -5807,6 +5788,12 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 
 // Tests that a client disconnect while a canary is in progress generates the result.
 func TestReconciler_Client_Disconnect_Canaries(t *testing.T) {
+
+	disconnectAllocState := []*structs.AllocState{{
+		Field: structs.AllocStateFieldClientStatus,
+		Value: structs.AllocClientStatusUnknown,
+		Time:  time.Now(),
+	}}
 
 	type testCase struct {
 		name            string
@@ -5900,7 +5887,7 @@ func TestReconciler_Client_Disconnect_Canaries(t *testing.T) {
 					updatedJob.TaskGroups[0].Name: {
 						Place:  3,
 						Canary: 0,
-						Ignore: 3,
+						Ignore: 6,
 					},
 				},
 			},
@@ -5964,7 +5951,7 @@ func TestReconciler_Client_Disconnect_Canaries(t *testing.T) {
 					updatedJob.TaskGroups[0].Name: {
 						Place:  2,
 						Canary: 0,
-						Ignore: 4,
+						Ignore: 7,
 					},
 				},
 			},
@@ -6030,7 +6017,7 @@ func TestReconciler_Client_Disconnect_Canaries(t *testing.T) {
 					updatedJob.TaskGroups[0].Name: {
 						Place:  2,
 						Canary: 0,
-						Ignore: 3,
+						Ignore: 6,
 						// The 2 stops in this test are transient failures, but
 						// the deployment can still progress. We don't include
 						// them in the stop count since DesiredTGUpdates is used
@@ -6100,6 +6087,12 @@ func TestReconciler_Client_Disconnect_Canaries(t *testing.T) {
 					if alloc.ClientStatus == structs.AllocClientStatusRunning {
 						alloc.DeploymentStatus.Healthy = pointer.Of(true)
 					}
+
+					if alloc.ClientStatus == structs.AllocClientStatusUnknown {
+						alloc.AllocStates = disconnectAllocState
+						alloc.FollowupEvalID = "eval-where-it-was-set-to-unknow"
+					}
+
 					tc.deploymentState.PlacedCanaries = append(tc.deploymentState.PlacedCanaries, alloc.ID)
 					handled[alloc.ID] = allocUpdateFnIgnore
 					canariesConfigured++

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -5320,36 +5320,38 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 	}}
 
 	type testCase struct {
-		name                         string
-		allocCount                   int
-		disconnectedAllocCount       int
-		jobVersionIncrement          uint64
-		nodeScoreIncrement           float64
-		disconnectedAllocStatus      string
-		disconnectedAllocStates      []*structs.AllocState
-		serverDesiredStatus          string
-		isBatch                      bool
-		nodeStatusDisconnected       bool
-		replace                      bool
-		failReplacement              bool
-		taintReplacement             bool
-		disconnectReplacement        bool
-		replaceFailedReplacement     bool
-		shouldStopOnDisconnectedNode bool
-		maxDisconnect                *time.Duration
-		expected                     *resultExpectation
+		name                            string
+		allocCount                      int
+		disconnectedAllocCount          int
+		jobVersionIncrement             uint64
+		nodeScoreIncrement              float64
+		disconnectedAllocStatus         string
+		disconnectedAllocStates         []*structs.AllocState
+		disconnectedServerDesiredStatus string
+		serverDesiredStatus             string
+		isBatch                         bool
+		nodeStatusDisconnected          bool
+		replace                         bool
+		failReplacement                 bool
+		taintReplacement                bool
+		disconnectReplacement           bool
+		replaceFailedReplacement        bool
+		shouldStopOnDisconnectedNode    bool
+		maxDisconnect                   *time.Duration
+		expected                        *resultExpectation
 	}
 
 	testCases := []testCase{
 		{
-			name:                         "reconnect-original-no-replacement",
-			allocCount:                   2,
-			replace:                      false,
-			disconnectedAllocCount:       2,
-			disconnectedAllocStatus:      structs.AllocClientStatusRunning,
-			disconnectedAllocStates:      disconnectAllocState,
-			serverDesiredStatus:          structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode: false,
+			name:                            "reconnect-original-no-replacement",
+			allocCount:                      2,
+			replace:                         false,
+			disconnectedAllocCount:          2,
+			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			shouldStopOnDisconnectedNode:    false,
 			expected: &resultExpectation{
 				reconnectUpdates: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5360,14 +5362,15 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                         "resume-original-and-stop-replacement",
-			allocCount:                   3,
-			replace:                      true,
-			disconnectedAllocCount:       1,
-			disconnectedAllocStatus:      structs.AllocClientStatusRunning,
-			disconnectedAllocStates:      disconnectAllocState,
-			serverDesiredStatus:          structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode: false,
+			name:                            "resume-original-and-stop-replacement",
+			allocCount:                      3,
+			replace:                         true,
+			disconnectedAllocCount:          1,
+			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			shouldStopOnDisconnectedNode:    false,
 			expected: &resultExpectation{
 				stop:             1,
 				reconnectUpdates: 1,
@@ -5380,15 +5383,16 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                         "stop-original-with-lower-node-score",
-			allocCount:                   4,
-			replace:                      true,
-			disconnectedAllocCount:       1,
-			disconnectedAllocStatus:      structs.AllocClientStatusRunning,
-			disconnectedAllocStates:      disconnectAllocState,
-			serverDesiredStatus:          structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode: true,
-			nodeScoreIncrement:           1,
+			name:                            "stop-original-with-lower-node-score",
+			allocCount:                      4,
+			replace:                         true,
+			disconnectedAllocCount:          1,
+			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			shouldStopOnDisconnectedNode:    true,
+			nodeScoreIncrement:              1,
 			expected: &resultExpectation{
 				stop: 1,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5400,14 +5404,15 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                         "stop-original-failed-on-reconnect",
-			allocCount:                   4,
-			replace:                      true,
-			disconnectedAllocCount:       2,
-			disconnectedAllocStatus:      structs.AllocClientStatusFailed,
-			disconnectedAllocStates:      disconnectAllocState,
-			serverDesiredStatus:          structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode: true,
+			name:                            "stop-original-failed-on-reconnect",
+			allocCount:                      4,
+			replace:                         true,
+			disconnectedAllocCount:          2,
+			disconnectedAllocStatus:         structs.AllocClientStatusFailed,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			shouldStopOnDisconnectedNode:    true,
 			expected: &resultExpectation{
 				stop: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5419,14 +5424,15 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                         "reschedule-original-failed-if-not-replaced",
-			allocCount:                   4,
-			replace:                      false,
-			disconnectedAllocCount:       2,
-			disconnectedAllocStatus:      structs.AllocClientStatusFailed,
-			disconnectedAllocStates:      disconnectAllocState,
-			serverDesiredStatus:          structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode: true,
+			name:                            "reschedule-original-failed-if-not-replaced",
+			allocCount:                      4,
+			replace:                         false,
+			disconnectedAllocCount:          2,
+			disconnectedAllocStatus:         structs.AllocClientStatusFailed,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			shouldStopOnDisconnectedNode:    true,
 			expected: &resultExpectation{
 				stop:  2,
 				place: 2,
@@ -5440,51 +5446,55 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                    "ignore-reconnect-completed",
-			allocCount:              2,
-			replace:                 false,
-			disconnectedAllocCount:  2,
-			disconnectedAllocStatus: structs.AllocClientStatusComplete,
-			disconnectedAllocStates: disconnectAllocState,
-			serverDesiredStatus:     structs.AllocDesiredStatusRun,
-			isBatch:                 true,
+			name:                            "ignore-reconnect-completed",
+			allocCount:                      2,
+			replace:                         false,
+			disconnectedAllocCount:          2,
+			disconnectedAllocStatus:         structs.AllocClientStatusComplete,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			isBatch:                         true,
 			expected: &resultExpectation{
+				place: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
 					"web": {
 						Ignore: 2,
+						Place:  2,
 					},
 				},
 			},
 		},
 		{
-			name:                    "keep-original-alloc-and-stop-failed-replacement",
-			allocCount:              3,
-			replace:                 true,
-			failReplacement:         true,
-			disconnectedAllocCount:  2,
-			disconnectedAllocStatus: structs.AllocClientStatusRunning,
-			disconnectedAllocStates: disconnectAllocState,
-			serverDesiredStatus:     structs.AllocDesiredStatusRun,
+			name:                            "keep-original-alloc-and-stop-failed-replacement",
+			allocCount:                      3,
+			replace:                         true,
+			failReplacement:                 true,
+			disconnectedAllocCount:          2,
+			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
 			expected: &resultExpectation{
 				reconnectUpdates: 2,
-				stop:             2,
+				stop:             0,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
 					"web": {
-						Ignore: 3,
-						Stop:   2,
+						Ignore: 5,
 					},
 				},
 			},
 		},
 		{
-			name:                    "keep-original-and-stop-reconnecting-replacement",
-			allocCount:              2,
-			replace:                 true,
-			disconnectReplacement:   true,
-			disconnectedAllocCount:  1,
-			disconnectedAllocStatus: structs.AllocClientStatusRunning,
-			disconnectedAllocStates: disconnectAllocState,
-			serverDesiredStatus:     structs.AllocDesiredStatusRun,
+			name:                            "keep-original-and-stop-reconnecting-replacement",
+			allocCount:                      2,
+			replace:                         true,
+			disconnectReplacement:           true,
+			disconnectedAllocCount:          1,
+			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
 			expected: &resultExpectation{
 				reconnectUpdates: 1,
 				stop:             1,
@@ -5497,14 +5507,15 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                    "keep-original-and-stop-tainted-replacement",
-			allocCount:              3,
-			replace:                 true,
-			taintReplacement:        true,
-			disconnectedAllocCount:  2,
-			disconnectedAllocStatus: structs.AllocClientStatusRunning,
-			disconnectedAllocStates: disconnectAllocState,
-			serverDesiredStatus:     structs.AllocDesiredStatusRun,
+			name:                            "keep-original-and-stop-tainted-replacement",
+			allocCount:                      3,
+			replace:                         true,
+			taintReplacement:                true,
+			disconnectedAllocCount:          2,
+			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
 			expected: &resultExpectation{
 				reconnectUpdates: 2,
 				stop:             2,
@@ -5517,15 +5528,16 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                         "stop-original-alloc-with-old-job-version",
-			allocCount:                   5,
-			replace:                      true,
-			disconnectedAllocCount:       2,
-			disconnectedAllocStatus:      structs.AllocClientStatusRunning,
-			disconnectedAllocStates:      disconnectAllocState,
-			serverDesiredStatus:          structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode: true,
-			jobVersionIncrement:          1,
+			name:                            "stop-original-alloc-with-old-job-version",
+			allocCount:                      5,
+			replace:                         true,
+			disconnectedAllocCount:          2,
+			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			shouldStopOnDisconnectedNode:    true,
+			jobVersionIncrement:             1,
 			expected: &resultExpectation{
 				stop: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5537,15 +5549,16 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                         "stop-original-alloc-with-old-job-version-reconnect-eval",
-			allocCount:                   5,
-			replace:                      true,
-			disconnectedAllocCount:       2,
-			disconnectedAllocStatus:      structs.AllocClientStatusRunning,
-			disconnectedAllocStates:      disconnectAllocState,
-			serverDesiredStatus:          structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode: true,
-			jobVersionIncrement:          1,
+			name:                            "stop-original-alloc-with-old-job-version-reconnect-eval",
+			allocCount:                      5,
+			replace:                         true,
+			disconnectedAllocCount:          2,
+			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			shouldStopOnDisconnectedNode:    true,
+			jobVersionIncrement:             1,
 			expected: &resultExpectation{
 				stop: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5557,37 +5570,40 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                         "stop-original-alloc-with-old-job-version-and-failed-replacements-replaced",
-			allocCount:                   5,
-			replace:                      true,
-			failReplacement:              true,
-			replaceFailedReplacement:     true,
-			disconnectedAllocCount:       2,
-			disconnectedAllocStatus:      structs.AllocClientStatusRunning,
-			disconnectedAllocStates:      disconnectAllocState,
-			serverDesiredStatus:          structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode: true,
-			jobVersionIncrement:          1,
+			name:                            "stop-original-alloc-with-old-job-version-and-failed-replacements-replaced",
+			allocCount:                      5,
+			replace:                         true,
+			failReplacement:                 true,
+			replaceFailedReplacement:        true,
+			disconnectedAllocCount:          2,
+			disconnectedAllocStatus:         structs.AllocClientStatusRunning,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			shouldStopOnDisconnectedNode:    false,
+			jobVersionIncrement:             1,
 			expected: &resultExpectation{
-				stop: 2,
+				stop:             2,
+				reconnectUpdates: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
 					"web": {
 						Stop:   2,
-						Ignore: 5,
+						Ignore: 7,
 					},
 				},
 			},
 		},
 		{
-			name:                         "stop-original-pending-alloc-for-disconnected-node",
-			allocCount:                   2,
-			replace:                      true,
-			disconnectedAllocCount:       1,
-			disconnectedAllocStatus:      structs.AllocClientStatusPending,
-			disconnectedAllocStates:      disconnectAllocState,
-			serverDesiredStatus:          structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode: true,
-			nodeStatusDisconnected:       true,
+			name:                            "stop-original-pending-alloc-for-disconnected-node",
+			allocCount:                      2,
+			replace:                         true,
+			disconnectedAllocCount:          1,
+			disconnectedAllocStatus:         structs.AllocClientStatusPending,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			shouldStopOnDisconnectedNode:    true,
+			nodeStatusDisconnected:          true,
 			expected: &resultExpectation{
 				stop: 1,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
@@ -5599,23 +5615,24 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 			},
 		},
 		{
-			name:                         "stop-failed-original-and-failed-replacements-and-place-new",
-			allocCount:                   5,
-			replace:                      true,
-			failReplacement:              true,
-			disconnectedAllocCount:       2,
-			disconnectedAllocStatus:      structs.AllocClientStatusFailed,
-			disconnectedAllocStates:      disconnectAllocState,
-			serverDesiredStatus:          structs.AllocDesiredStatusRun,
-			shouldStopOnDisconnectedNode: true,
+			name:                            "stop-failed-original-and-failed-replacements-and-place-new",
+			allocCount:                      5,
+			replace:                         true,
+			failReplacement:                 true,
+			disconnectedAllocCount:          2,
+			disconnectedAllocStatus:         structs.AllocClientStatusFailed,
+			disconnectedServerDesiredStatus: structs.AllocDesiredStatusRun,
+			disconnectedAllocStates:         disconnectAllocState,
+			serverDesiredStatus:             structs.AllocDesiredStatusRun,
+			shouldStopOnDisconnectedNode:    true,
 			expected: &resultExpectation{
-				stop:  4,
+				stop:  2,
 				place: 2,
 				desiredTGUpdates: map[string]*structs.DesiredUpdates{
 					"web": {
-						Stop:   4,
+						Stop:   2,
 						Place:  2,
-						Ignore: 3,
+						Ignore: 5,
 					},
 				},
 			},
@@ -5699,7 +5716,7 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 					// Set the node id on all the disconnected allocs to the node under test.
 					alloc.NodeID = testNode.ID
 					alloc.NodeName = "disconnected"
-
+					alloc.DesiredStatus = tc.disconnectedServerDesiredStatus
 					disconnectedAllocCount--
 				}
 			}

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -291,6 +291,7 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, serverS
 						lost[alloc.ID] = alloc
 						continue
 					}
+
 					reconnecting[alloc.ID] = alloc
 					continue
 				}
@@ -482,8 +483,11 @@ func updateByReschedulable(alloc *structs.Allocation, now time.Time, evalID stri
 	}
 
 	// Reschedule if the eval ID matches the alloc's followup evalID or if its close to its reschedule time
-	var eligible bool
+	var eligible bool = false
 	if isDisconnecting {
+		if alloc.FollowupEvalID != "" && alloc.NeedsToReconnect() {
+			return
+		}
 		rescheduleTime, eligible = alloc.NextRescheduleTimeByTime(alloc.LastEventTime())
 	} else {
 		rescheduleTime, eligible = alloc.NextRescheduleTime()

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -392,7 +392,7 @@ func (a allocSet) filterByRescheduleable(isBatch, isDisconnecting bool, now time
 		}
 
 		isUntainted, ignore := shouldFilter(alloc, isBatch)
-		if isUntainted {
+		if isUntainted && !isDisconnecting {
 			untainted[alloc.ID] = alloc
 		}
 
@@ -400,10 +400,13 @@ func (a allocSet) filterByRescheduleable(isBatch, isDisconnecting bool, now time
 			continue
 		}
 
-		// Disconnecting delay evals are
+		// Only failed allocs with desired state run get to this point
+		// If the failed alloc is not eligible for rescheduling now we
+		// add it to the untainted set. Disconnecting delay evals are
 		// handled by allocReconciler.createTimeoutLaterEvals
 		eligibleNow, eligibleLater, rescheduleTime = updateByReschedulable(alloc, now, evalID, deployment, isDisconnecting)
 		if !eligibleNow {
+			untainted[alloc.ID] = alloc
 			if eligibleLater {
 				rescheduleLater = append(rescheduleLater, &delayedRescheduleInfo{alloc.ID, alloc, rescheduleTime})
 			}
@@ -484,14 +487,15 @@ func updateByReschedulable(alloc *structs.Allocation, now time.Time, evalID stri
 		rescheduleTime, eligible = alloc.NextRescheduleTime()
 	}
 
-	if eligible && (alloc.FollowupEvalID == evalID || rescheduleTime.Sub(now) <= rescheduleWindowSize) {
+	if eligible && (alloc.FollowupEvalID == evalID || rescheduleTime.Sub(now) <= rescheduleWindowSize || isDisconnecting) {
 		rescheduleNow = true
 		return
 	}
 
-	if eligible && alloc.FollowupEvalID == "" {
+	if eligible && (alloc.FollowupEvalID == "" && !isDisconnecting) {
 		rescheduleLater = true
 	}
+
 	return
 }
 
@@ -757,4 +761,39 @@ func (a *allocNameIndex) Next(n uint) []string {
 	}
 
 	return next
+}
+
+// filterByRescheduleableDisconnecting
+func (a allocSet) filterByDisconnectingRescheduleable(isBatch bool, now time.Time,
+	evalID string, deployment *structs.Deployment) (allocSet, allocSet) {
+	untainted := make(map[string]*structs.Allocation)
+	reschedule := make(map[string]*structs.Allocation)
+
+	for _, alloc := range a {
+		// Ignore disconnecting allocs that are already unknown. This can happen
+		// in the case of canaries that are interrupted by a disconnect.
+		if alloc.ClientStatus == structs.AllocClientStatusUnknown {
+			continue
+		}
+
+		// Ignore failing allocs that have already been rescheduled.
+		// Only failed or disconnecting allocs should be rescheduled.
+		// Protects against a bug allowing rescheduling running allocs.
+		if alloc.NextAllocation != "" && alloc.TerminalStatus() {
+			continue
+		}
+
+		_, ignore := shouldFilter(alloc, isBatch)
+		if ignore {
+			continue
+		}
+
+		eligible, _, _ := updateByReschedulable(alloc, now, evalID, deployment, true)
+		if eligible {
+			reschedule[alloc.ID] = alloc
+		} else {
+			untainted[alloc.ID] = alloc
+		}
+	}
+	return untainted, reschedule
 }

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -395,7 +395,7 @@ func (a allocSet) filterByRescheduleable(isBatch, isDisconnecting bool, now time
 			untainted[alloc.ID] = alloc
 		}
 
-		if isUntainted || ignore {
+		if ignore {
 			continue
 		}
 
@@ -404,7 +404,7 @@ func (a allocSet) filterByRescheduleable(isBatch, isDisconnecting bool, now time
 		// add it to the untainted set. Disconnecting delay evals are
 		// handled by allocReconciler.createTimeoutLaterEvals
 		eligibleNow, eligibleLater, rescheduleTime = updateByReschedulable(alloc, now, evalID, deployment, isDisconnecting)
-		if !isDisconnecting && !eligibleNow {
+		if !eligibleNow {
 			untainted[alloc.ID] = alloc
 			if eligibleLater {
 				rescheduleLater = append(rescheduleLater, &delayedRescheduleInfo{alloc.ID, alloc, rescheduleTime})
@@ -490,6 +490,7 @@ func updateByReschedulable(alloc *structs.Allocation, now time.Time, evalID stri
 		rescheduleNow = true
 		return
 	}
+
 	if eligible && alloc.FollowupEvalID == "" {
 		rescheduleLater = true
 	}

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -400,14 +400,13 @@ func (a allocSet) filterByRescheduleable(isBatch, isDisconnecting bool, now time
 			continue
 		}
 
-		// Only failed allocs with desired state run get to this point
 		// If the failed alloc is not eligible for rescheduling now we
 		// add it to the untainted set. Disconnecting delay evals are
 		// handled by allocReconciler.createTimeoutLaterEvals
 		eligibleNow, eligibleLater, rescheduleTime = updateByReschedulable(alloc, now, evalID, deployment, isDisconnecting)
 		if !eligibleNow {
 			untainted[alloc.ID] = alloc
-			if eligibleLater {
+			if eligibleLater && !isDisconnecting {
 				rescheduleLater = append(rescheduleLater, &delayedRescheduleInfo{alloc.ID, alloc, rescheduleTime})
 			}
 		} else {

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -484,12 +484,12 @@ func updateByReschedulable(alloc *structs.Allocation, now time.Time, evalID stri
 	// Reschedule if the eval ID matches the alloc's followup evalID or if its close to its reschedule time
 	var eligible bool
 	if isDisconnecting {
-		rescheduleTime, eligible = alloc.NextRescheduleTimeByFailTime(now)
+		rescheduleTime, eligible = alloc.NextRescheduleTimeByTime(alloc.LastEventTime())
 	} else {
 		rescheduleTime, eligible = alloc.NextRescheduleTime()
 	}
 
-	if eligible && (alloc.FollowupEvalID == evalID || rescheduleTime.Sub(now) <= rescheduleWindowSize || isDisconnecting) {
+	if eligible && (alloc.FollowupEvalID == evalID || rescheduleTime.Sub(now) <= rescheduleWindowSize) {
 		rescheduleNow = true
 		return
 	}

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -394,6 +394,7 @@ func (a allocSet) filterByRescheduleable(isBatch, isDisconnecting bool, now time
 		if isUntainted && !isDisconnecting {
 			untainted[alloc.ID] = alloc
 		}
+
 		if isUntainted || ignore {
 			continue
 		}
@@ -440,28 +441,25 @@ func shouldFilter(alloc *structs.Allocation, isBatch bool) (untainted, ignore bo
 			return false, true
 		case structs.AllocDesiredStatusEvict:
 			return false, true
-		default:
 		}
 
 		switch alloc.ClientStatus {
 		case structs.AllocClientStatusFailed:
-		default:
-			return true, false
+			return false, false
 		}
-		return false, false
+
+		return true, false
 	}
 
 	// Handle service jobs
 	switch alloc.DesiredStatus {
 	case structs.AllocDesiredStatusStop, structs.AllocDesiredStatusEvict:
 		return false, true
-	default:
 	}
 
 	switch alloc.ClientStatus {
 	case structs.AllocClientStatusComplete, structs.AllocClientStatusLost:
 		return false, true
-	default:
 	}
 	return false, false
 }

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -269,6 +269,7 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, serverS
 			switch taintedNode.Status {
 			case structs.NodeStatusDisconnected:
 				if supportsDisconnectedClients {
+
 					// Filter running allocs on a node that is disconnected to be marked as unknown.
 					if alloc.ClientStatus == structs.AllocClientStatusRunning {
 						disconnecting[alloc.ID] = alloc
@@ -316,11 +317,11 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, serverS
 			continue
 		}
 
-		// Ignore unknown allocs that we want to reconnect eventually.
+		// Acknowledge unknown allocs that we want to reconnect eventually.
 		if supportsDisconnectedClients &&
 			alloc.ClientStatus == structs.AllocClientStatusUnknown &&
 			alloc.DesiredStatus == structs.AllocDesiredStatusRun {
-			ignore[alloc.ID] = alloc
+			untainted[alloc.ID] = alloc
 			continue
 		}
 
@@ -491,7 +492,7 @@ func updateByReschedulable(alloc *structs.Allocation, now time.Time, evalID stri
 		return
 	}
 
-	if eligible && (alloc.FollowupEvalID == "" && !isDisconnecting) {
+	if eligible && (alloc.FollowupEvalID == "") {
 		rescheduleLater = true
 	}
 

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -9,6 +9,7 @@ package scheduler
 // all scheduler types before moving it into util.go
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -547,12 +548,13 @@ func (a allocSet) delayByStopAfterClientDisconnect() (later []*delayedReschedule
 
 // delayByMaxClientDisconnect returns a delay for any unknown allocation
 // that's got a max_client_reconnect configured
-func (a allocSet) delayByMaxClientDisconnect(now time.Time) (later []*delayedRescheduleInfo, err error) {
+func (a allocSet) delayByMaxClientDisconnect(now time.Time) ([]*delayedRescheduleInfo, error) {
+	var later []*delayedRescheduleInfo
+
 	for _, alloc := range a {
 		timeout := alloc.DisconnectTimeout(now)
-
 		if !timeout.After(now) {
-			continue
+			return nil, errors.New("unable to computing disconnecting timeouts")
 		}
 
 		later = append(later, &delayedRescheduleInfo{
@@ -562,7 +564,7 @@ func (a allocSet) delayByMaxClientDisconnect(now time.Time) (later []*delayedRes
 		})
 	}
 
-	return
+	return later, nil
 }
 
 // filterByClientStatus returns allocs from the set with the specified client status.

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -508,7 +508,7 @@ func updateByReschedulable(alloc *structs.Allocation, now time.Time, evalID stri
 		return
 	}
 
-	if eligible && (alloc.FollowupEvalID == "") {
+	if eligible && (alloc.FollowupEvalID == "" || isDisconnecting) {
 		rescheduleLater = true
 	}
 

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -299,11 +299,17 @@ func (a allocSet) filterByTainted(taintedNodes map[string]*structs.Node, serverS
 			}
 		}
 
-		// Terminal allocs, if not reconnect, are always untainted as they
-		// should never be migrated.
 		if alloc.TerminalStatus() && !reconnect {
-			//untainted[alloc.ID] = alloc
-			ignore[alloc.ID] = alloc
+			// Terminal allocs, if supportsDisconnectedClient and not reconnect,
+			// are probably stopped replacements and should be ignored
+			if supportsDisconnectedClients {
+				ignore[alloc.ID] = alloc
+				continue
+			}
+
+			// Terminal allocs, if not reconnect, are always untainted as they
+			// should never be migrated.
+			untainted[alloc.ID] = alloc
 			continue
 		}
 

--- a/scheduler/reconcile_util_test.go
+++ b/scheduler/reconcile_util_test.go
@@ -539,10 +539,10 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 					NodeID:        "disconnected",
 					TaskGroup:     "web",
 				},
-				// Unknown allocs on disconnected nodes are ignored
-				"ignore-unknown": {
-					ID:            "ignore-unknown",
-					Name:          "ignore-unknown",
+				// Unknown allocs on disconnected nodes are acknowledge, so they wont be rescheduled again
+				"untainted-unknown": {
+					ID:            "untainted-unknown",
+					Name:          "untainted-unknown",
 					ClientStatus:  structs.AllocClientStatusUnknown,
 					DesiredStatus: structs.AllocDesiredStatusRun,
 					Job:           testJob,
@@ -595,8 +595,20 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 					AllocStates:   unknownAllocState,
 				},
 			},
-			untainted: allocSet{},
-			migrate:   allocSet{},
+			untainted: allocSet{
+				// Unknown allocs on disconnected nodes are acknowledge, so they wont be rescheduled again
+				"untainted-unknown": {
+					ID:            "untainted-unknown",
+					Name:          "untainted-unknown",
+					ClientStatus:  structs.AllocClientStatusUnknown,
+					DesiredStatus: structs.AllocDesiredStatusRun,
+					Job:           testJob,
+					NodeID:        "disconnected",
+					TaskGroup:     "web",
+					AllocStates:   unknownAllocState,
+				},
+			},
+			migrate: allocSet{},
 			disconnecting: allocSet{
 				"disconnect-running": {
 					ID:            "disconnect-running",
@@ -610,17 +622,6 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 			},
 			reconnecting: allocSet{},
 			ignore: allocSet{
-				// Unknown allocs on disconnected nodes are ignored
-				"ignore-unknown": {
-					ID:            "ignore-unknown",
-					Name:          "ignore-unknown",
-					ClientStatus:  structs.AllocClientStatusUnknown,
-					DesiredStatus: structs.AllocDesiredStatusRun,
-					Job:           testJob,
-					NodeID:        "disconnected",
-					TaskGroup:     "web",
-					AllocStates:   unknownAllocState,
-				},
 				"ignore-reconnected-failed-stopped": {
 					ID:            "ignore-reconnected-failed-stopped",
 					Name:          "ignore-reconnected-failed-stopped",

--- a/scheduler/reconcile_util_test.go
+++ b/scheduler/reconcile_util_test.go
@@ -237,7 +237,6 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			name:                        "disco-client-disconnect-unset-max-disconnect",
 			supportsDisconnectedClients: true,
@@ -273,7 +272,6 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 			},
 		},
-
 		// Everything below this line tests the disconnected client mode.
 		{
 			name:                        "disco-client-untainted-reconnect-failed-and-replaced",
@@ -381,10 +379,10 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 			taintedNodes:                nodes,
 			skipNilNodeTest:             false,
 			all: allocSet{
-				// Allocs on reconnected nodes that are complete are untainted
-				"untainted-reconnect-complete": {
-					ID:            "untainted-reconnect-complete",
-					Name:          "untainted-reconnect-complete",
+				// Allocs on reconnected nodes that are complete are ignored
+				"ignored-reconnect-complete": {
+					ID:            "ignored-reconnect-complete",
+					Name:          "ignored-reconnect-complete",
 					ClientStatus:  structs.AllocClientStatusComplete,
 					DesiredStatus: structs.AllocDesiredStatusRun,
 					Job:           testJob,
@@ -405,9 +403,9 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 					AllocStates:   unknownAllocState,
 				},
 				// Lost allocs on reconnected nodes don't get restarted
-				"untainted-reconnect-lost": {
-					ID:            "untainted-reconnect-lost",
-					Name:          "untainted-reconnect-lost",
+				"ignored-reconnect-lost": {
+					ID:            "ignored-reconnect-lost",
+					Name:          "ignored-reconnect-lost",
 					ClientStatus:  structs.AllocClientStatusLost,
 					DesiredStatus: structs.AllocDesiredStatusStop,
 					Job:           testJob,
@@ -415,10 +413,10 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 					TaskGroup:     "web",
 					AllocStates:   unknownAllocState,
 				},
-				// Replacement allocs that are complete are untainted
-				"untainted-reconnect-complete-replacement": {
-					ID:                 "untainted-reconnect-complete-replacement",
-					Name:               "untainted-reconnect-complete",
+				// Replacement allocs that are complete are ignored
+				"ignored-reconnect-complete-replacement": {
+					ID:                 "ignored-reconnect-complete-replacement",
+					Name:               "ignored-reconnect-complete",
 					ClientStatus:       structs.AllocClientStatusComplete,
 					DesiredStatus:      structs.AllocDesiredStatusRun,
 					Job:                testJob,
@@ -427,10 +425,10 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 					AllocStates:        unknownAllocState,
 					PreviousAllocation: "untainted-reconnect-complete",
 				},
-				// Replacement allocs on reconnected nodes that are failed are untainted
-				"untainted-reconnect-failed-replacement": {
-					ID:                 "untainted-reconnect-failed-replacement",
-					Name:               "untainted-reconnect-failed",
+				// Replacement allocs on reconnected nodes that are failed are ignored
+				"ignored-reconnect-failed-replacement": {
+					ID:                 "ignored-reconnect-failed-replacement",
+					Name:               "ignored-reconnect-failed",
 					ClientStatus:       structs.AllocClientStatusFailed,
 					DesiredStatus:      structs.AllocDesiredStatusStop,
 					Job:                testJob,
@@ -439,9 +437,9 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 					PreviousAllocation: "reconnecting-failed",
 				},
 				// Lost replacement allocs on reconnected nodes don't get restarted
-				"untainted-reconnect-lost-replacement": {
-					ID:                 "untainted-reconnect-lost-replacement",
-					Name:               "untainted-reconnect-lost",
+				"ignored-reconnect-lost-replacement": {
+					ID:                 "ignored-reconnect-lost-replacement",
+					Name:               "ignored-reconnect-lost",
 					ClientStatus:       structs.AllocClientStatusLost,
 					DesiredStatus:      structs.AllocDesiredStatusStop,
 					Job:                testJob,
@@ -451,60 +449,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 					PreviousAllocation: "untainted-reconnect-lost",
 				},
 			},
-			untainted: allocSet{
-				"untainted-reconnect-complete": {
-					ID:            "untainted-reconnect-complete",
-					Name:          "untainted-reconnect-complete",
-					ClientStatus:  structs.AllocClientStatusComplete,
-					DesiredStatus: structs.AllocDesiredStatusRun,
-					Job:           testJob,
-					NodeID:        "normal",
-					TaskGroup:     "web",
-					AllocStates:   unknownAllocState,
-				},
-				"untainted-reconnect-lost": {
-					ID:            "untainted-reconnect-lost",
-					Name:          "untainted-reconnect-lost",
-					ClientStatus:  structs.AllocClientStatusLost,
-					DesiredStatus: structs.AllocDesiredStatusStop,
-					Job:           testJob,
-					NodeID:        "normal",
-					TaskGroup:     "web",
-					AllocStates:   unknownAllocState,
-				},
-				"untainted-reconnect-complete-replacement": {
-					ID:                 "untainted-reconnect-complete-replacement",
-					Name:               "untainted-reconnect-complete",
-					ClientStatus:       structs.AllocClientStatusComplete,
-					DesiredStatus:      structs.AllocDesiredStatusRun,
-					Job:                testJob,
-					NodeID:             "normal",
-					TaskGroup:          "web",
-					AllocStates:        unknownAllocState,
-					PreviousAllocation: "untainted-reconnect-complete",
-				},
-				"untainted-reconnect-failed-replacement": {
-					ID:                 "untainted-reconnect-failed-replacement",
-					Name:               "untainted-reconnect-failed",
-					ClientStatus:       structs.AllocClientStatusFailed,
-					DesiredStatus:      structs.AllocDesiredStatusStop,
-					Job:                testJob,
-					NodeID:             "normal",
-					TaskGroup:          "web",
-					PreviousAllocation: "reconnecting-failed",
-				},
-				"untainted-reconnect-lost-replacement": {
-					ID:                 "untainted-reconnect-lost-replacement",
-					Name:               "untainted-reconnect-lost",
-					ClientStatus:       structs.AllocClientStatusLost,
-					DesiredStatus:      structs.AllocDesiredStatusStop,
-					Job:                testJob,
-					NodeID:             "normal",
-					TaskGroup:          "web",
-					AllocStates:        unknownAllocState,
-					PreviousAllocation: "untainted-reconnect-lost",
-				},
-			},
+			untainted:     allocSet{},
 			migrate:       allocSet{},
 			disconnecting: allocSet{},
 			reconnecting: allocSet{
@@ -519,8 +464,62 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 					AllocStates:   unknownAllocState,
 				},
 			},
-			ignore: allocSet{},
-			lost:   allocSet{},
+			ignore: allocSet{
+
+				"ignored-reconnect-complete": {
+					ID:            "ignored-reconnect-complete",
+					Name:          "ignored-reconnect-complete",
+					ClientStatus:  structs.AllocClientStatusComplete,
+					DesiredStatus: structs.AllocDesiredStatusRun,
+					Job:           testJob,
+					NodeID:        "normal",
+					TaskGroup:     "web",
+					AllocStates:   unknownAllocState,
+				},
+				"ignored-reconnect-lost": {
+					ID:            "ignored-reconnect-lost",
+					Name:          "ignored-reconnect-lost",
+					ClientStatus:  structs.AllocClientStatusLost,
+					DesiredStatus: structs.AllocDesiredStatusStop,
+					Job:           testJob,
+					NodeID:        "normal",
+					TaskGroup:     "web",
+					AllocStates:   unknownAllocState,
+				},
+				"ignored-reconnect-complete-replacement": {
+					ID:                 "ignored-reconnect-complete-replacement",
+					Name:               "ignored-reconnect-complete",
+					ClientStatus:       structs.AllocClientStatusComplete,
+					DesiredStatus:      structs.AllocDesiredStatusRun,
+					Job:                testJob,
+					NodeID:             "normal",
+					TaskGroup:          "web",
+					AllocStates:        unknownAllocState,
+					PreviousAllocation: "untainted-reconnect-complete",
+				},
+				"ignored-reconnect-failed-replacement": {
+					ID:                 "ignored-reconnect-failed-replacement",
+					Name:               "ignored-reconnect-failed",
+					ClientStatus:       structs.AllocClientStatusFailed,
+					DesiredStatus:      structs.AllocDesiredStatusStop,
+					Job:                testJob,
+					NodeID:             "normal",
+					TaskGroup:          "web",
+					PreviousAllocation: "reconnecting-failed",
+				},
+				"ignored-reconnect-lost-replacement": {
+					ID:                 "ignored-reconnect-lost-replacement",
+					Name:               "ignored-reconnect-lost",
+					ClientStatus:       structs.AllocClientStatusLost,
+					DesiredStatus:      structs.AllocDesiredStatusStop,
+					Job:                testJob,
+					NodeID:             "normal",
+					TaskGroup:          "web",
+					AllocStates:        unknownAllocState,
+					PreviousAllocation: "untainted-reconnect-lost",
+				},
+			},
+			lost: allocSet{},
 		},
 		{
 			name:                        "disco-client-disconnect",


### PR DESCRIPTION
This PR fixes  [Max_client_disconnect ignores no-reschedule policy](https://github.com/hashicorp/nomad/issues/16515)

 The bug had 2 root causes:

- The code was written under the assumption that disconnecting allocs should always be rescheduled:
https://github.com/hashicorp/nomad/blob/cecd9b04729e63839428cfa67fdc983ed2182481/scheduler/reconcile.go#L461

Any disconnecting allocation that should not be rescheduled now, was ignored for the rest of the reconcile process and would always end up on a new placement, because it was not taken into consideration for the deployment final count.  

- The logic to define if an allocation should be reschedule didn't take into account disconnecting allocations, they were 
never set to be explicitly replaced, because according to the [`shouldFilter`](https://github.com/hashicorp/nomad/blob/cecd9b04729e63839428cfa67fdc983ed2182481/scheduler/reconcile_util.go#L428) logic, they are `untainted` and are ignored on line 396, and never make it to the `elegibleNow` selection.
 ```
           isUntainted, ignore := shouldFilter(alloc, isBatch)
		if isUntainted && !isDisconnecting {
			untainted[alloc.ID] = alloc
		}
		if isUntainted || ignore {
			continue
		}

		// Only failed allocs with desired state run get to this point
		// If the failed alloc is not eligible for rescheduling now we
		// add it to the untainted set. Disconnecting delay evals are
		// handled by allocReconciler.createTimeoutLaterEvals
		eligibleNow, eligibleLater, rescheduleTime = updateByReschedulable(alloc, now, evalID, deployment, isDisconnecting)
		if !isDisconnecting && !eligibleNow {
```
[L396](https://github.com/hashicorp/nomad/blob/cecd9b04729e63839428cfa67fdc983ed2182481/scheduler/reconcile_util.go#L396)
Also on the `updateByReschedulable`, disonnecting allocs where never set to reschedule now:
```
	if eligible && (alloc.FollowupEvalID == evalID || rescheduleTime.Sub(now) <= rescheduleWindowSize) {
		rescheduleNow = true
		return
	}
```


This allocations would once again end up being replaced because the deployment count would be one short, not because it should be replaced and most definitely not taking into account its reschedule policy. 

Once the previous problem was fixed and the correct reschedule policy was being taken into account, a new bug was visible: The `disconnecting` allocations don't have a fail time, so to calculate the next reschedule time, the alloc reconciler `now`  was used. The minimun delay for batch jobs is 5 sec and 30 sec for services, following the logic in the code, the next reschedule time ends up always being at least 5 sec from now, and the disconnecting allocations were always set  to `rescheduleLater`, but for disconnecting allocations, the `rescheduleLater` group was ignored, as shown previously on line 461 of the rescheduler.

The function `filterByRescheduleable` was modified to correctly process disconnecting allocation and the disconnecting untainted  and reconnect later allocations were added to the result to avoid unnecessary placement and correctly replace the `disconnecting` allocs using the reschedule policy.

Once the previous change was done, new evaluations were created with the new reschedule time to replace the `disconnecting` allocs, but by the time the evaluation was executed, the allocs don't qualify as disconnecting anymore  so a new restriction needed to be added in the `updateByReschedule` function for alloc that were not disconnecting and had not failed yet, the `unknown` allocs.
In order to avoid adding replacements for this allocs every time the reconciler run, a validation using the `followupEvalID` was added. 
When taking into account the reschedule policy, every `disconnecting` alloc generates 2 new evaluations: one for the next reschedule time, in order to place a replacement and a second one to set the alloc as lost once the `max_client_disconnect` times out. 
The way the code is written, the disconnecting alloc would get updated with the evaluation ID of the second generated evaluation, making the `nextEvalID` useless to verify if the `unknown` alloc being rescheduled was in fact a replacement for an old one. A change to overwrite the  `nextEvalID` with the ID of the evaluation corresponding to the replacement was set in place. This change also made finding if an alloc was a replacement of an older one or not on reconnecting a lot easier. 