### PR TITLE
server: Rename functions and use iterator function for clarity

### DIFF
--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -372,7 +372,6 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	// todo: use cluster ID for stuff, later!
 
 	// Enable the plan queue, since we are now the leader
 	s.planQueue.SetEnabled(true)

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -368,7 +368,7 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 	schedulerConfig := s.getOrCreateSchedulerConfig()
 
 	// Initialize the Cluster metadata
-	clusterMetadata, err := s.ClusterMetaData()
+	clusterMetadata, err := s.ClusterMetadata()
 	if err != nil {
 		return err
 	}

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -860,7 +860,7 @@ func TestLeader_ClusterID(t *testing.T) {
 	defer cleanupS1()
 	testutil.WaitForLeader(t, s1.RPC)
 
-	clusterMD, err := s1.ClusterMetaData()
+	clusterMD, err := s1.ClusterMetadata()
 
 	require.NoError(t, err)
 	require.True(t, helper.IsUUID(clusterMD.ClusterID))
@@ -915,15 +915,15 @@ func agreeClusterID(t *testing.T, servers []*Server) {
 	must.Len(t, 3, servers)
 
 	f := func() error {
-		id1, err1 := servers[0].ClusterMetaData()
+		id1, err1 := servers[0].ClusterMetadata()
 		if err1 != nil {
 			return err1
 		}
-		id2, err2 := servers[1].ClusterMetaData()
+		id2, err2 := servers[1].ClusterMetadata()
 		if err2 != nil {
 			return err2
 		}
-		id3, err3 := servers[2].ClusterMetaData()
+		id3, err3 := servers[2].ClusterMetadata()
 		if err3 != nil {
 			return err3
 		}

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -2042,7 +2042,7 @@ func (n *Node) DeriveSIToken(args *structs.DeriveSITokenRequest, reply *structs.
 	}
 
 	// Get the ClusterID
-	clusterMD, err := n.srv.ClusterMetaData()
+	clusterMD, err := n.srv.ClusterMetadata()
 	if err != nil {
 		setError(err, false)
 		return nil

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -2060,8 +2060,8 @@ func (s *Server) ReplicationToken() string {
 	return s.config.ReplicationToken
 }
 
-// ClusterMetadata returns the unique ID for this cluster composed of a
-// uuid and a timestamp.
+// ClusterMetadata returns the metadata for this cluster composed of a
+// UUID and a timestamp.
 //
 // Any Nomad server agent may call this method to get at the ID.
 // If we are the leader and the ID has not yet been created, it will

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/codec"
 	"github.com/hashicorp/nomad/helper/goruntime"
+	"github.com/hashicorp/nomad/helper/iterator"
 	"github.com/hashicorp/nomad/helper/pool"
 	"github.com/hashicorp/nomad/helper/tlsutil"
 	"github.com/hashicorp/nomad/lib/auth/oidc"
@@ -2059,7 +2060,7 @@ func (s *Server) ReplicationToken() string {
 	return s.config.ReplicationToken
 }
 
-// ClusterMetaData returns the unique ID for this cluster composed of a
+// ClusterMetadata returns the unique ID for this cluster composed of a
 // uuid and a timestamp.
 //
 // Any Nomad server agent may call this method to get at the ID.
@@ -2068,7 +2069,7 @@ func (s *Server) ReplicationToken() string {
 //
 // The ID will not be created until all participating servers have reached
 // a minimum version (0.10.4).
-func (s *Server) ClusterMetaData() (structs.ClusterMetadata, error) {
+func (s *Server) ClusterMetadata() (structs.ClusterMetadata, error) {
 	s.clusterIDLock.Lock()
 	defer s.clusterIDLock.Unlock()
 
@@ -2109,21 +2110,12 @@ func (s *Server) GetClientNodesCount() (int, error) {
 		return 0, err
 	}
 
-	var count int
 	iter, err := stateSnapshot.Nodes(nil)
 	if err != nil {
 		return 0, err
 	}
 
-	for {
-		raw := iter.Next()
-		if raw == nil {
-			break
-		}
-		count++
-	}
-
-	return count, nil
+	return iterator.Len(iter), nil
 }
 
 // peersInfoContent is used to help operators understand what happened to the


### PR DESCRIPTION
This PR backports some changes from the ent repo for consistency.