### PR TITLE
deps: remove Vault SDK

### DIFF
--- a/client/vaultclient_test.go
+++ b/client/vaultclient_test.go
@@ -16,10 +16,11 @@ import (
 	"github.com/hashicorp/nomad/helper/useragent"
 	"github.com/hashicorp/nomad/testutil"
 	vaultapi "github.com/hashicorp/vault/api"
-	vaultconsts "github.com/hashicorp/vault/sdk/helper/consts"
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
+
+const vaultNamespaceHeaderName = "X-Vault-Namespace"
 
 func TestVaultClient_TokenRenewals(t *testing.T) {
 	ci.Parallel(t)
@@ -123,7 +124,7 @@ func TestVaultClient_NamespaceSupport(t *testing.T) {
 	conf.VaultConfig.Namespace = testNs
 	c, err := vaultclient.NewVaultClient(conf.VaultConfig, logger, nil)
 	must.NoError(t, err)
-	must.Eq(t, testNs, c.Vault.Headers().Get(vaultconsts.NamespaceHeaderName))
+	must.Eq(t, testNs, c.Vault.Headers().Get(vaultNamespaceHeaderName))
 }
 
 func TestVaultClient_Heap(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -85,7 +85,6 @@ require (
 	github.com/hashicorp/raft-boltdb/v2 v2.2.2
 	github.com/hashicorp/serf v0.10.1
 	github.com/hashicorp/vault/api v1.9.1
-	github.com/hashicorp/vault/sdk v0.9.0
 	github.com/hashicorp/yamux v0.1.1
 	github.com/hpcloud/tail v1.0.1-0.20170814160653-37f427138745
 	github.com/klauspost/cpuid/v2 v2.2.5

--- a/go.sum
+++ b/go.sum
@@ -947,8 +947,6 @@ github.com/hashicorp/vault/api v1.9.1/go.mod h1:78kktNcQYbBGSrOjQfHjXN32OhhxXnbY
 github.com/hashicorp/vault/api/auth/kubernetes v0.3.0 h1:HkaCmTKzcgLa2tjdiAid1rbmyQNmQGHfnmvIIM2WorY=
 github.com/hashicorp/vault/api/auth/kubernetes v0.3.0/go.mod h1:l1B4MGtLc+P37MabBQiIhP3qd9agj0vqhETmaQjjC/Y=
 github.com/hashicorp/vault/sdk v0.6.0/go.mod h1:+DRpzoXIdMvKc88R4qxr+edwy/RvH5QK8itmxLiDHLc=
-github.com/hashicorp/vault/sdk v0.9.0 h1:Cbu9ezaZafZTXnen98QKVmufEPquhZ+r1ORZ7csNLFU=
-github.com/hashicorp/vault/sdk v0.9.0/go.mod h1:VX9d+xF62YBNtiEc4l3Z2aea9HVtAS49EoniuXzHtC4=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443 h1:O/pT5C1Q3mVXMyuqg7yuAWUg/jMZR1/0QTzTRdNR6Uw=
 github.com/hashicorp/vic v1.5.1-0.20190403131502-bbfe86ec9443/go.mod h1:bEpDU35nTu0ey1EXjwNwPjI9xErAsoOCmcMb9GKvyxo=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/nomad/ci"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"golang.org/x/time/rate"
 
 	"github.com/hashicorp/nomad/helper/pointer"
@@ -29,7 +28,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/testutil"
 	vapi "github.com/hashicorp/vault/api"
-	vaultconsts "github.com/hashicorp/vault/sdk/helper/consts"
 )
 
 const (
@@ -73,6 +71,8 @@ path "secret/*" {
 	capabilities = ["create", "read", "update", "delete", "list"]
 }
 `
+
+	vaultNamespaceHeaderName = "X-Vault-Namespace"
 )
 
 // defaultTestVaultAllowlistRoleAndToken creates a test Vault role and returns a token
@@ -202,8 +202,8 @@ func TestVaultClient_WithNamespaceSupport(t *testing.T) {
 		t.Fatalf("failed to build vault client: %v", err)
 	}
 
-	require.Equal(testNs, c.client.Headers().Get(vaultconsts.NamespaceHeaderName))
-	require.Equal("", c.clientSys.Headers().Get(vaultconsts.NamespaceHeaderName))
+	require.Equal(testNs, c.client.Headers().Get(vaultNamespaceHeaderName))
+	require.Equal("", c.clientSys.Headers().Get(vaultNamespaceHeaderName))
 	require.NotEqual(c.clientSys, c.client)
 }
 
@@ -227,8 +227,8 @@ func TestVaultClient_WithoutNamespaceSupport(t *testing.T) {
 		t.Fatalf("failed to build vault client: %v", err)
 	}
 
-	require.Equal("", c.client.Headers().Get(vaultconsts.NamespaceHeaderName))
-	require.Equal("", c.clientSys.Headers().Get(vaultconsts.NamespaceHeaderName))
+	require.Equal("", c.client.Headers().Get(vaultNamespaceHeaderName))
+	require.Equal("", c.clientSys.Headers().Get(vaultNamespaceHeaderName))
 	require.Equal(c.clientSys, c.client)
 }
 


### PR DESCRIPTION
Nomad imports the Vault SDK to get testing helpers, but it turns out the only thing actually in use was a single string constant for the Vault namespace header. Remove this dependency and hardcode the constant to reduce dependency churn.