### PR TITLE
[ui] Actions aggregated at job model level

### DIFF
--- a/ui/app/models/action.js
+++ b/ui/app/models/action.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { attr } from '@ember-data/model';
+import { fragmentOwner } from 'ember-data-model-fragments/attributes';
+import Fragment from 'ember-data-model-fragments/fragment';
+
+export default class ActionModel extends Fragment {
+  @attr('string') name;
+  @attr('string') command;
+  @attr() args;
+  @fragmentOwner() task;
+}

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -155,6 +155,18 @@ export default class Job extends Model {
 
   @hasMany('recommendation-summary') recommendationSummaries;
 
+  get actions() {
+    return this.taskGroups.reduce((acc, taskGroup) => {
+      return acc.concat(
+        taskGroup.tasks
+          .map((task) => {
+            return task.get('actions').toArray();
+          })
+          .reduce((taskAcc, taskActions) => taskAcc.concat(taskActions), [])
+      );
+    }, []);
+  }
+
   @computed('taskGroups.@each.drivers')
   get drivers() {
     return this.taskGroups

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -19,6 +19,8 @@ export default class Task extends Fragment {
   @attr('string') driver;
   @attr('string') kind;
 
+  @fragmentArray('action') actions;
+
   @attr() meta;
 
   @computed('taskGroup.mergedMeta', 'meta')


### PR DESCRIPTION
Introduces Actions as a fragment (non-independently fetched, but still modelled) on Tasks, and provides a computed property at Job level to get them and aggregate them.

This is a behind-the-scenes step to be able to list actions in the UI at Job and Task level.

![image](https://github.com/hashicorp/nomad/assets/713991/ad641c8e-d7ee-4213-89d7-9db7030c2c58)


Resolves #18726 