### PR TITLE
vault: use an importable const for Vault header string.

### DIFF
--- a/client/vaultclient_test.go
+++ b/client/vaultclient_test.go
@@ -14,13 +14,12 @@ import (
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/useragent"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
-
-const vaultNamespaceHeaderName = "X-Vault-Namespace"
 
 func TestVaultClient_TokenRenewals(t *testing.T) {
 	ci.Parallel(t)
@@ -124,7 +123,7 @@ func TestVaultClient_NamespaceSupport(t *testing.T) {
 	conf.VaultConfig.Namespace = testNs
 	c, err := vaultclient.NewVaultClient(conf.VaultConfig, logger, nil)
 	must.NoError(t, err)
-	must.Eq(t, testNs, c.Vault.Headers().Get(vaultNamespaceHeaderName))
+	must.Eq(t, testNs, c.Vault.Headers().Get(structs.VaultNamespaceHeaderName))
 }
 
 func TestVaultClient_Heap(t *testing.T) {

--- a/nomad/structs/vault.go
+++ b/nomad/structs/vault.go
@@ -15,6 +15,11 @@ const (
 	// VaultDefaultCluster is the name used for the Vault cluster that doesn't
 	// have a name.
 	VaultDefaultCluster = "default"
+
+	// VaultNamespaceHeaderName is the header set to specify which namespace
+	// the request is indented for. This is defined within Nomad, so we do not
+	// need to import the entire Vault SDK package.
+	VaultNamespaceHeaderName = "X-Vault-Namespace"
 )
 
 // VaultTokenData represents some of the fields returned in the Data map of the

--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -71,8 +71,6 @@ path "secret/*" {
 	capabilities = ["create", "read", "update", "delete", "list"]
 }
 `
-
-	vaultNamespaceHeaderName = "X-Vault-Namespace"
 )
 
 // defaultTestVaultAllowlistRoleAndToken creates a test Vault role and returns a token
@@ -202,8 +200,8 @@ func TestVaultClient_WithNamespaceSupport(t *testing.T) {
 		t.Fatalf("failed to build vault client: %v", err)
 	}
 
-	require.Equal(testNs, c.client.Headers().Get(vaultNamespaceHeaderName))
-	require.Equal("", c.clientSys.Headers().Get(vaultNamespaceHeaderName))
+	require.Equal(testNs, c.client.Headers().Get(structs.VaultNamespaceHeaderName))
+	require.Equal("", c.clientSys.Headers().Get(structs.VaultNamespaceHeaderName))
 	require.NotEqual(c.clientSys, c.client)
 }
 
@@ -227,8 +225,8 @@ func TestVaultClient_WithoutNamespaceSupport(t *testing.T) {
 		t.Fatalf("failed to build vault client: %v", err)
 	}
 
-	require.Equal("", c.client.Headers().Get(vaultNamespaceHeaderName))
-	require.Equal("", c.clientSys.Headers().Get(vaultNamespaceHeaderName))
+	require.Equal("", c.client.Headers().Get(structs.VaultNamespaceHeaderName))
+	require.Equal("", c.clientSys.Headers().Get(structs.VaultNamespaceHeaderName))
 	require.Equal(c.clientSys, c.client)
 }
 


### PR DESCRIPTION
Enterprise also requires this, therefore setting up a const that can be used within both codebases. Once merged, I will raise a PR for the enterprise side, and balance the merge processes.