### PR TITLE
WI: set the right identity name for Consul tasks

### DIFF
--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/nomad/client/consul"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/widmgr"
-	"github.com/hashicorp/nomad/nomad"
 	"github.com/hashicorp/nomad/nomad/structs"
 	structsc "github.com/hashicorp/nomad/nomad/structs/config"
 )
@@ -108,7 +107,7 @@ func (h *consulHook) prepareConsulTokensForTask(job *structs.Job, task *structs.
 	// get tokens for alt identities for Consul
 	mErr := multierror.Error{}
 	for _, i := range task.Identities {
-		if i.Name != fmt.Sprintf("%s/%s", nomad.ConsulTaskIdentityNamePrefix, task.GetConsulTaskName()) {
+		if i.Name != fmt.Sprintf("%s/%s", structs.ConsulTaskIdentityNamePrefix, task.GetConsulTaskName()) {
 			continue
 		}
 

--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -116,7 +116,7 @@ func (h *consulHook) prepareConsulTokensForTask(job *structs.Job, task *structs.
 	// get tokens for alt identities for Consul
 	mErr := multierror.Error{}
 	for _, i := range task.Identities {
-		if i.Name != fmt.Sprintf("%s/%s", structs.ConsulTaskIdentityNamePrefix, task.GetConsulTaskName()) {
+		if i.Name != fmt.Sprintf("%s_%s", structs.ConsulTaskIdentityNamePrefix, task.GetConsulTaskName()) {
 			continue
 		}
 

--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -116,7 +116,7 @@ func (h *consulHook) prepareConsulTokensForTask(job *structs.Job, task *structs.
 	// get tokens for alt identities for Consul
 	mErr := multierror.Error{}
 	for _, i := range task.Identities {
-		if i.Name != fmt.Sprintf("%s_%s", structs.ConsulTaskIdentityNamePrefix, task.GetConsulTaskName()) {
+		if i.Name != fmt.Sprintf("%s_%s", structs.ConsulTaskIdentityNamePrefix, consulClusterName) {
 			continue
 		}
 

--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -98,8 +98,17 @@ func (h *consulHook) Prerun() error {
 }
 
 func (h *consulHook) prepareConsulTokensForTask(job *structs.Job, task *structs.Task, tgName string, tokens map[string]map[string]string) error {
+	var consulClusterName string
+	if task.Consul != nil && task.Consul.Cluster != "" {
+		consulClusterName = task.Consul.Cluster
+	} else {
+		consulClusterName = structs.ConsulDefaultCluster
+	}
+
+	// get consul config
+	consulConfig := h.consulConfigs[consulClusterName]
+
 	// if UseIdentity is unset of set to false, quit
-	consulConfig := h.consulConfigs[task.Consul.Cluster]
 	if consulConfig.UseIdentity == nil || !*consulConfig.UseIdentity {
 		return nil
 	}
@@ -131,7 +140,7 @@ func (h *consulHook) prepareConsulTokensForTask(job *structs.Job, task *structs.
 			AuthMethodName: consulTasksAuthMethodName,
 		}
 
-		if err := h.getConsulTokens(task.Consul.Cluster, ti.IdentityName, tokens, req); err != nil {
+		if err := h.getConsulTokens(consulClusterName, ti.IdentityName, tokens, req); err != nil {
 			return err
 		}
 	}

--- a/nomad/job_endpoint_hook_implicit_identities.go
+++ b/nomad/job_endpoint_hook_implicit_identities.go
@@ -81,14 +81,7 @@ func (h jobImplicitIdentitiesHook) handleConsulTasks(t *structs.Task) {
 		return
 	}
 
-	var clusterName string
-	if t.Consul != nil && t.Consul.Cluster != "" {
-		clusterName = t.Consul.Cluster
-	} else {
-		clusterName = structs.ConsulDefaultCluster
-	}
-
-	widName := fmt.Sprintf("%s_%s", structs.ConsulTaskIdentityNamePrefix, clusterName)
+	widName := t.Consul.IdentityName()
 
 	// Use the Consul identity specified in the task if present
 	for _, wid := range t.Identities {

--- a/nomad/job_endpoint_hook_implicit_identities.go
+++ b/nomad/job_endpoint_hook_implicit_identities.go
@@ -81,7 +81,14 @@ func (h jobImplicitIdentitiesHook) handleConsulTasks(t *structs.Task) {
 		return
 	}
 
-	widName := fmt.Sprintf("%s_%s", structs.ConsulTaskIdentityNamePrefix, t.GetConsulTaskName())
+	var clusterName string
+	if t.Consul != nil && t.Consul.Cluster != "" {
+		clusterName = t.Consul.Cluster
+	} else {
+		clusterName = structs.ConsulDefaultCluster
+	}
+
+	widName := fmt.Sprintf("%s_%s", structs.ConsulTaskIdentityNamePrefix, clusterName)
 
 	// Use the Consul identity specified in the task if present
 	for _, wid := range t.Identities {

--- a/nomad/job_endpoint_hook_implicit_identities.go
+++ b/nomad/job_endpoint_hook_implicit_identities.go
@@ -70,7 +70,7 @@ func (h jobImplicitIdentitiesHook) handleConsulService(s *structs.Service) {
 
 	// Set the expected identity name and service name.
 	name := s.MakeUniqueIdentityName()
-	serviceWID.Name = fmt.Sprintf("%s/%s", structs.ConsulServiceIdentityNamePrefix, name)
+	serviceWID.Name = fmt.Sprintf("%s_%s", structs.ConsulServiceIdentityNamePrefix, name)
 	serviceWID.ServiceName = s.Name
 
 	s.Identity = serviceWID
@@ -81,7 +81,7 @@ func (h jobImplicitIdentitiesHook) handleConsulTasks(t *structs.Task) {
 		return
 	}
 
-	widName := fmt.Sprintf("%s/%s", structs.ConsulTaskIdentityNamePrefix, t.GetConsulTaskName())
+	widName := fmt.Sprintf("%s_%s", structs.ConsulTaskIdentityNamePrefix, t.GetConsulTaskName())
 
 	// Use the Consul identity specified in the task if present
 	for _, wid := range t.Identities {

--- a/nomad/job_endpoint_hook_implicit_identities.go
+++ b/nomad/job_endpoint_hook_implicit_identities.go
@@ -9,11 +9,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-const (
-	ConsulServiceIdentityNamePrefix = "consul-service"
-	ConsulTaskIdentityNamePrefix    = "consul"
-)
-
 // jobImplicitIdentitiesHook adds implicit `identity` blocks for external
 // services, like Consul and Vault.
 type jobImplicitIdentitiesHook struct {
@@ -75,7 +70,7 @@ func (h jobImplicitIdentitiesHook) handleConsulService(s *structs.Service) {
 
 	// Set the expected identity name and service name.
 	name := s.MakeUniqueIdentityName()
-	serviceWID.Name = fmt.Sprintf("%s/%s", ConsulServiceIdentityNamePrefix, name)
+	serviceWID.Name = fmt.Sprintf("%s/%s", structs.ConsulServiceIdentityNamePrefix, name)
 	serviceWID.ServiceName = s.Name
 
 	s.Identity = serviceWID
@@ -86,7 +81,7 @@ func (h jobImplicitIdentitiesHook) handleConsulTasks(t *structs.Task) {
 		return
 	}
 
-	widName := fmt.Sprintf("%s/%s", ConsulTaskIdentityNamePrefix, t.GetConsulTaskName())
+	widName := fmt.Sprintf("%s/%s", structs.ConsulTaskIdentityNamePrefix, t.GetConsulTaskName())
 
 	// Use the Consul identity specified in the task if present
 	for _, wid := range t.Identities {

--- a/nomad/job_endpoint_hook_implicit_identities.go
+++ b/nomad/job_endpoint_hook_implicit_identities.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	consulServiceIdentityNamePrefix = "consul-service"
-	consulTaskIdentityNamePrefix    = "consul"
+	ConsulServiceIdentityNamePrefix = "consul-service"
+	ConsulTaskIdentityNamePrefix    = "consul"
 )
 
 // jobImplicitIdentitiesHook adds implicit `identity` blocks for external
@@ -75,7 +75,7 @@ func (h jobImplicitIdentitiesHook) handleConsulService(s *structs.Service) {
 
 	// Set the expected identity name and service name.
 	name := s.MakeUniqueIdentityName()
-	serviceWID.Name = fmt.Sprintf("%s/%s", consulServiceIdentityNamePrefix, name)
+	serviceWID.Name = fmt.Sprintf("%s/%s", ConsulServiceIdentityNamePrefix, name)
 	serviceWID.ServiceName = s.Name
 
 	s.Identity = serviceWID
@@ -87,7 +87,7 @@ func (h jobImplicitIdentitiesHook) handleConsulTasks(t *structs.Task, taskGroup 
 	}
 
 	name := t.MakeUniqueIdentityName(taskGroup)
-	widName := fmt.Sprintf("%s/%s", consulTaskIdentityNamePrefix, name)
+	widName := fmt.Sprintf("%s/%s", ConsulTaskIdentityNamePrefix, name)
 
 	// Use the Consul identity specified in the task if present
 	for _, wid := range t.Identities {

--- a/nomad/job_endpoint_hook_implicit_identities.go
+++ b/nomad/job_endpoint_hook_implicit_identities.go
@@ -35,7 +35,7 @@ func (h jobImplicitIdentitiesHook) Mutate(job *structs.Job) (*structs.Job, []err
 				h.handleConsulService(s)
 			}
 			if len(t.Templates) > 0 {
-				h.handleConsulTasks(t, tg.Name)
+				h.handleConsulTasks(t)
 			}
 			h.handleVault(t)
 		}
@@ -81,13 +81,12 @@ func (h jobImplicitIdentitiesHook) handleConsulService(s *structs.Service) {
 	s.Identity = serviceWID
 }
 
-func (h jobImplicitIdentitiesHook) handleConsulTasks(t *structs.Task, taskGroup string) {
+func (h jobImplicitIdentitiesHook) handleConsulTasks(t *structs.Task) {
 	if !h.srv.config.UseConsulIdentity() {
 		return
 	}
 
-	name := t.MakeUniqueIdentityName(taskGroup)
-	widName := fmt.Sprintf("%s/%s", ConsulTaskIdentityNamePrefix, name)
+	widName := fmt.Sprintf("%s/%s", ConsulTaskIdentityNamePrefix, t.GetConsulTaskName())
 
 	// Use the Consul identity specified in the task if present
 	for _, wid := range t.Identities {

--- a/nomad/job_endpoint_hook_implicit_identities_test.go
+++ b/nomad/job_endpoint_hook_implicit_identities_test.go
@@ -150,7 +150,7 @@ func Test_jobImplicitIndentitiesHook_Mutate_consul_service(t *testing.T) {
 							TaskName:  "task",
 							PortLabel: "80",
 							Identity: &structs.WorkloadIdentity{
-								Name:        "consul-service/task-web-80",
+								Name:        "consul-service_task-web-80",
 								Audience:    []string{"consul.io", "nomad.dev"},
 								File:        true,
 								Env:         false,
@@ -162,7 +162,7 @@ func Test_jobImplicitIndentitiesHook_Mutate_consul_service(t *testing.T) {
 							TaskName:  "task",
 							PortLabel: "80",
 							Identity: &structs.WorkloadIdentity{
-								Name:        "consul-service/task-web-80",
+								Name:        "consul-service_task-web-80",
 								Audience:    []string{"consul.io", "nomad.dev"},
 								File:        true,
 								Env:         false,
@@ -177,7 +177,7 @@ func Test_jobImplicitIndentitiesHook_Mutate_consul_service(t *testing.T) {
 							TaskName:  "task",
 							PortLabel: "80",
 							Identity: &structs.WorkloadIdentity{
-								Name:        "consul-service/task-web-task-80",
+								Name:        "consul-service_task-web-task-80",
 								Audience:    []string{"consul.io", "nomad.dev"},
 								File:        true,
 								Env:         false,
@@ -224,7 +224,7 @@ func Test_jobImplicitIndentitiesHook_Mutate_consul_service(t *testing.T) {
 						Name:      "web",
 						TaskName:  "task",
 						Identity: &structs.WorkloadIdentity{
-							Name:        "consul-service/task-web-80",
+							Name:        "consul-service_task-web-80",
 							Audience:    []string{"consul.io"},
 							ServiceName: "web",
 						},
@@ -236,7 +236,7 @@ func Test_jobImplicitIndentitiesHook_Mutate_consul_service(t *testing.T) {
 							Name:      "web-task",
 							TaskName:  "task",
 							Identity: &structs.WorkloadIdentity{
-								Name:        "consul-service/task-web-task-80",
+								Name:        "consul-service_task-web-task-80",
 								Audience:    []string{"consul.io"},
 								ServiceName: "web-task",
 							},
@@ -271,7 +271,7 @@ func Test_jobImplicitIndentitiesHook_Mutate_consul_service(t *testing.T) {
 						Name:      "web-task",
 						Templates: []*structs.Template{{}},
 						Identities: []*structs.WorkloadIdentity{{
-							Name:     "consul/group-web-task",
+							Name:     "consul_group-web-task",
 							Audience: []string{"consul.io"},
 						}},
 					}},

--- a/nomad/job_endpoint_hook_implicit_identities_test.go
+++ b/nomad/job_endpoint_hook_implicit_identities_test.go
@@ -271,7 +271,7 @@ func Test_jobImplicitIndentitiesHook_Mutate_consul_service(t *testing.T) {
 						Name:      "web-task",
 						Templates: []*structs.Template{{}},
 						Identities: []*structs.WorkloadIdentity{{
-							Name:     "consul_group-web-task",
+							Name:     "consul_default",
 							Audience: []string{"consul.io"},
 						}},
 					}},

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -61,7 +61,7 @@ func Test_jobValidate_Validate_consul_service(t *testing.T) {
 				Provider: "consul",
 				Name:     "web",
 				Identity: &structs.WorkloadIdentity{
-					Name:        "consul-service/web",
+					Name:        "consul-service_web",
 					Audience:    []string{"consul.io"},
 					File:        true,
 					Env:         false,
@@ -81,7 +81,7 @@ func Test_jobValidate_Validate_consul_service(t *testing.T) {
 				Provider: "consul",
 				Name:     "web",
 				Identity: &structs.WorkloadIdentity{
-					Name:        "consul-service/web",
+					Name:        "consul-service_web",
 					Audience:    []string{"consul.io"},
 					File:        true,
 					Env:         false,
@@ -103,7 +103,7 @@ func Test_jobValidate_Validate_consul_service(t *testing.T) {
 				Provider: "consul",
 				Name:     "web",
 				Identity: &structs.WorkloadIdentity{
-					Name:     fmt.Sprintf("%s/web", structs.ConsulServiceIdentityNamePrefix),
+					Name:     fmt.Sprintf("%s_web", structs.ConsulServiceIdentityNamePrefix),
 					Audience: []string{"consul.io"},
 					File:     true,
 					Env:      false,

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -103,7 +103,7 @@ func Test_jobValidate_Validate_consul_service(t *testing.T) {
 				Provider: "consul",
 				Name:     "web",
 				Identity: &structs.WorkloadIdentity{
-					Name:     fmt.Sprintf("%s/web", consulServiceIdentityNamePrefix),
+					Name:     fmt.Sprintf("%s/web", structs.ConsulServiceIdentityNamePrefix),
 					Audience: []string{"consul.io"},
 					File:     true,
 					Env:      false,

--- a/nomad/structs/consul.go
+++ b/nomad/structs/consul.go
@@ -12,6 +12,13 @@ const (
 	// ConsulDefaultCluster is the name used for the Consul cluster that doesn't
 	// have a name.
 	ConsulDefaultCluster = "default"
+
+	// ConsulServiceIdentityNamePrefix is used in naming identities of consul
+	// services
+	ConsulServiceIdentityNamePrefix = "consul-service"
+
+	// ConsulTaskIdentityNamePrefix is used in naming identities of consul tasks
+	ConsulTaskIdentityNamePrefix = "consul"
 )
 
 // Consul represents optional per-group consul configuration.
@@ -53,6 +60,19 @@ func (c *Consul) Equal(o *Consul) bool {
 func (c *Consul) Validate() error {
 	// nothing to do here
 	return nil
+}
+
+// IdentityName returns the name of the workload identity to be used to access
+// this Consul cluster.
+func (c *Consul) IdentityName() string {
+	var clusterName string
+	if c != nil && c.Cluster != "" {
+		clusterName = c.Cluster
+	} else {
+		clusterName = ConsulDefaultCluster
+	}
+
+	return fmt.Sprintf("%s_%s", ConsulTaskIdentityNamePrefix, clusterName)
 }
 
 var (

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -208,13 +208,6 @@ const (
 	RateMetricRead  = "read"
 	RateMetricList  = "list"
 	RateMetricWrite = "write"
-
-	// ConsulServiceIdentityNamePrefix is used in naming identities of consul
-	// services
-	ConsulServiceIdentityNamePrefix = "consul-service"
-
-	// ConsulTaskIdentityNamePrefix is used in naming identities of consul tasks
-	ConsulTaskIdentityNamePrefix = "consul"
 )
 
 var (

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7672,6 +7672,11 @@ func (t *Task) MakeUniqueIdentityName(taskGroup string) string {
 	return fmt.Sprintf("%v-%v", taskGroup, t.Name)
 }
 
+// GetConsulTaskName returns the consulClusterName_TaskName string.
+func (t *Task) GetConsulTaskName() string {
+	return fmt.Sprintf("%s_%s", t.Consul.Cluster, t.Name)
+}
+
 // IdentityHandle returns a WorkloadIdentityHandle which is a pair of unique WI
 // name and task name.
 func (t *Task) IdentityHandle(identity *WorkloadIdentity) *WIHandle {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7673,14 +7673,6 @@ func (t *Task) GetIdentity(name string) *WorkloadIdentity {
 	return nil
 }
 
-// GetConsulTaskName returns the consulClusterName_TaskName string.
-func (t *Task) GetConsulTaskName() string {
-	if t.Consul != nil && t.Consul.Cluster != "" {
-		return fmt.Sprintf("%s_%s", t.Consul.Cluster, t.Name)
-	}
-	return fmt.Sprintf("%s_%s", ConsulDefaultCluster, t.Name)
-}
-
 // IdentityHandle returns a WorkloadIdentityHandle which is a pair of unique WI
 // name and task name.
 func (t *Task) IdentityHandle(identity *WorkloadIdentity) *WIHandle {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7675,7 +7675,10 @@ func (t *Task) GetIdentity(name string) *WorkloadIdentity {
 
 // GetConsulTaskName returns the consulClusterName_TaskName string.
 func (t *Task) GetConsulTaskName() string {
-	return fmt.Sprintf("%s_%s", t.Consul.Cluster, t.Name)
+	if t.Consul != nil && t.Consul.Cluster != "" {
+		return fmt.Sprintf("%s_%s", t.Consul.Cluster, t.Name)
+	}
+	return fmt.Sprintf("%s_%s", ConsulDefaultCluster, t.Name)
 }
 
 // IdentityHandle returns a WorkloadIdentityHandle which is a pair of unique WI

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7666,12 +7666,6 @@ func (t *Task) GetIdentity(name string) *WorkloadIdentity {
 	return nil
 }
 
-// MakeUniqueIdentityName returns a task identity name consisting of: task
-// group name and task name.
-func (t *Task) MakeUniqueIdentityName(taskGroup string) string {
-	return fmt.Sprintf("%v-%v", taskGroup, t.Name)
-}
-
 // GetConsulTaskName returns the consulClusterName_TaskName string.
 func (t *Task) GetConsulTaskName() string {
 	return fmt.Sprintf("%s_%s", t.Consul.Cluster, t.Name)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -208,6 +208,13 @@ const (
 	RateMetricRead  = "read"
 	RateMetricList  = "list"
 	RateMetricWrite = "write"
+
+	// ConsulServiceIdentityNamePrefix is used in naming identities of consul
+	// services
+	ConsulServiceIdentityNamePrefix = "consul-service"
+
+	// ConsulTaskIdentityNamePrefix is used in naming identities of consul tasks
+	ConsulTaskIdentityNamePrefix = "consul"
 )
 
 var (


### PR DESCRIPTION
Consul tasks should only have 1 identity of the form `consul/{consul_cluster_name}`. 