### PR TITLE
Only generate default workload identity once per alloc task

### DIFF
--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -32,6 +32,12 @@ import (
 
 const nomadKeystoreExtension = ".nks.json"
 
+type claimSigner interface {
+	SignClaims(*structs.IdentityClaims) (string, string, error)
+}
+
+var _ claimSigner = &Encrypter{}
+
 // Encrypter is the keyring for encrypting variables and signing workload
 // identities.
 type Encrypter struct {

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -31,6 +31,18 @@ var (
 	}
 )
 
+type mockSigner struct {
+	calls []*structs.IdentityClaims
+
+	nextToken, nextKeyID string
+	nextErr              error
+}
+
+func (s *mockSigner) SignClaims(c *structs.IdentityClaims) (token, keyID string, err error) {
+	s.calls = append(s.calls, c)
+	return s.nextToken, s.nextKeyID, s.nextErr
+}
+
 // TestEncrypter_LoadSave exercises round-tripping keys to disk
 func TestEncrypter_LoadSave(t *testing.T) {
 	ci.Parallel(t)

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -280,7 +280,7 @@ func (p *planner) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap
 		// to approximate the scheduling time.
 		updateAllocTimestamps(req.AllocsUpdated, unixNow)
 
-		err := p.signAllocIdentities(plan.Job, req.AllocsUpdated, now)
+		err := signAllocIdentities(p.Server.encrypter, plan.Job, req.AllocsUpdated, now)
 		if err != nil {
 			return nil, err
 		}
@@ -410,17 +410,20 @@ func updateAllocTimestamps(allocations []*structs.Allocation, timestamp int64) {
 	}
 }
 
-func (p *planner) signAllocIdentities(job *structs.Job, allocations []*structs.Allocation, now time.Time) error {
-
-	encrypter := p.Server.encrypter
-
+func signAllocIdentities(signer claimSigner, job *structs.Job, allocations []*structs.Allocation, now time.Time) error {
 	for _, alloc := range allocations {
-		alloc.SignedIdentities = map[string]string{}
+		if alloc.SignedIdentities == nil {
+			alloc.SignedIdentities = map[string]string{}
+		}
 		tg := job.LookupTaskGroup(alloc.TaskGroup)
 		for _, task := range tg.Tasks {
+			// skip tasks that already have an identity
+			if _, ok := alloc.SignedIdentities[task.Name]; ok {
+				continue
+			}
 			defaultWI := &structs.WorkloadIdentity{Name: "default"}
 			claims := structs.NewIdentityClaims(job, alloc, task.IdentityHandle(defaultWI), task.Identity, now)
-			token, keyID, err := encrypter.SignClaims(claims)
+			token, keyID, err := signer.SignClaims(claims)
 			if err != nil {
 				return err
 			}

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -4,6 +4,7 @@
 package nomad
 
 import (
+	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/hashicorp/raft"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -391,6 +393,78 @@ func TestPlanApply_applyPlanWithNormalizedAllocs(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(evalOut)
 	assert.Equal(index, evalOut.ModifyIndex)
+}
+
+func TestPlanApply_signAllocIdentities(t *testing.T) {
+	// note: this is mutated by the method under test
+	alloc := mockAlloc()
+	job := alloc.Job
+	taskName := job.TaskGroups[0].Tasks[0].Name // "web"
+	allocs := []*structs.Allocation{alloc}
+
+	signErr := errors.New("could not sign the thing")
+
+	cases := []struct {
+		name      string
+		signer    *mockSigner
+		expectErr error
+		callNum   int
+	}{
+		{
+			name: "signer error",
+			signer: &mockSigner{
+				nextErr: signErr,
+			},
+			expectErr: signErr,
+			callNum:   1,
+		},
+		{
+			name: "first signing",
+			signer: &mockSigner{
+				nextToken: "first-token",
+				nextKeyID: "first-key",
+			},
+			callNum: 1,
+		},
+		{
+			name: "second signing",
+			signer: &mockSigner{
+				nextToken: "dont-sign-token",
+				nextKeyID: "dont-sign-key",
+			},
+			callNum: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			err := signAllocIdentities(tc.signer, job, allocs, time.Now())
+
+			if tc.expectErr != nil {
+				must.Error(t, err)
+				must.ErrorIs(t, err, tc.expectErr)
+			} else {
+				must.NoError(t, err)
+				// assert mutations happened
+				must.MapLen(t, 1, allocs[0].SignedIdentities)
+				// we should always keep the first signing
+				must.Eq(t, "first-token", allocs[0].SignedIdentities[taskName])
+				must.Eq(t, "first-key", allocs[0].SigningKeyID)
+			}
+
+			must.Len(t, tc.callNum, tc.signer.calls, must.Sprint("unexpected call count"))
+			if tc.callNum > 0 {
+				call := tc.signer.calls[tc.callNum-1]
+				must.NotNil(t, call)
+				must.Eq(t, call.AllocationID, alloc.ID)
+				must.Eq(t, call.Namespace, alloc.Namespace)
+				must.Eq(t, call.JobID, job.ID)
+				must.Eq(t, call.TaskName, taskName)
+			}
+
+		})
+	}
 }
 
 func TestPlanApply_EvalPlan_Simple(t *testing.T) {

--- a/nomad/service_registration_endpoint_test.go
+++ b/nomad/service_registration_endpoint_test.go
@@ -887,7 +887,7 @@ func TestServiceRegistration_List(t *testing.T) {
 				job.Namespace = "platform"
 				allocs[0].Namespace = "platform"
 				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, nil, job))
-				s.signAllocIdentities(job, allocs, time.Now())
+				signAllocIdentities(s.encrypter, job, allocs, time.Now())
 				require.NoError(t, s.State().UpsertAllocs(structs.MsgTypeTestSetup, 15, allocs))
 
 				signedToken := allocs[0].SignedIdentities["web"]
@@ -1174,7 +1174,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc()}
 				job := allocs[0].Job
 				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, nil, job))
-				s.signAllocIdentities(job, allocs, time.Now())
+				signAllocIdentities(s.encrypter, job, allocs, time.Now())
 				require.NoError(t, s.State().UpsertAllocs(structs.MsgTypeTestSetup, 15, allocs))
 
 				signedToken := allocs[0].SignedIdentities["web"]


### PR DESCRIPTION
This theoretically has no practical effect here, since 0e22fc1a0b removed `identityHook.Update()` from `main`, but this will line up with a separate PR targeting `1.6.x` with backports back to `1.4.x` to fix #16846.

Here this just keeps the `*Allocation` on the server aligned with what's used in the actual running task.