### PR TITLE
Only generate default workload identity once per alloc task - 1.5.x

### DIFF
--- a/client/allocrunner/taskrunner/identity_hook.go
+++ b/client/allocrunner/taskrunner/identity_hook.go
@@ -52,13 +52,6 @@ func (h *identityHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 	return h.setToken()
 }
 
-func (h *identityHook) Update(_ context.Context, req *interfaces.TaskUpdateRequest, _ *interfaces.TaskUpdateResponse) error {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
-	return h.setToken()
-}
-
 // setToken adds the Nomad token to the task's environment and writes it to a
 // file if requested by the jobsepc.
 func (h *identityHook) setToken() error {

--- a/client/allocrunner/taskrunner/identity_hook_test.go
+++ b/client/allocrunner/taskrunner/identity_hook_test.go
@@ -3,6 +3,5 @@ package taskrunner
 import "github.com/hashicorp/nomad/client/allocrunner/interfaces"
 
 var _ interfaces.TaskPrestartHook = (*identityHook)(nil)
-var _ interfaces.TaskUpdateHook = (*identityHook)(nil)
 
 // See task_runner_test.go:TestTaskRunner_IdentityHook

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -27,6 +27,12 @@ import (
 
 const nomadKeystoreExtension = ".nks.json"
 
+type claimSigner interface {
+	SignClaims(*structs.IdentityClaims) (string, string, error)
+}
+
+var _ claimSigner = &Encrypter{}
+
 // Encrypter is the keyring for encrypting variables and signing workload
 // identities.
 type Encrypter struct {

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -18,6 +18,18 @@ import (
 	"github.com/hashicorp/nomad/testutil"
 )
 
+type mockSigner struct {
+	calls []*structs.IdentityClaims
+
+	nextToken, nextKeyID string
+	nextErr              error
+}
+
+func (s *mockSigner) SignClaims(c *structs.IdentityClaims) (token, keyID string, err error) {
+	s.calls = append(s.calls, c)
+	return s.nextToken, s.nextKeyID, s.nextErr
+}
+
 // TestEncrypter_LoadSave exercises round-tripping keys to disk
 func TestEncrypter_LoadSave(t *testing.T) {
 	ci.Parallel(t)

--- a/nomad/service_registration_endpoint_test.go
+++ b/nomad/service_registration_endpoint_test.go
@@ -885,7 +885,7 @@ func TestServiceRegistration_List(t *testing.T) {
 				job.Namespace = "platform"
 				allocs[0].Namespace = "platform"
 				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, job))
-				s.signAllocIdentities(job, allocs)
+				signAllocIdentities(s.encrypter, job, allocs)
 				require.NoError(t, s.State().UpsertAllocs(structs.MsgTypeTestSetup, 15, allocs))
 
 				signedToken := allocs[0].SignedIdentities["web"]
@@ -1172,7 +1172,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc()}
 				job := allocs[0].Job
 				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, job))
-				s.signAllocIdentities(job, allocs)
+				signAllocIdentities(s.encrypter, job, allocs)
 				require.NoError(t, s.State().UpsertAllocs(structs.MsgTypeTestSetup, 15, allocs))
 
 				signedToken := allocs[0].SignedIdentities["web"]


### PR DESCRIPTION
Fixes #16846 -- This is the `1.5.x` edition of #18776