### PR TITLE
Only generate default workload identity once per alloc task - 1.4.x

### DIFF
--- a/client/allocrunner/taskrunner/identity_hook.go
+++ b/client/allocrunner/taskrunner/identity_hook.go
@@ -41,14 +41,3 @@ func (h *identityHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 	}
 	return nil
 }
-
-func (h *identityHook) Update(_ context.Context, req *interfaces.TaskUpdateRequest, _ *interfaces.TaskUpdateResponse) error {
-	h.lock.Lock()
-	defer h.lock.Unlock()
-
-	token := h.tr.alloc.SignedIdentities[h.taskName]
-	if token != "" {
-		h.tr.setNomadToken(token)
-	}
-	return nil
-}

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -27,6 +27,12 @@ import (
 
 const nomadKeystoreExtension = ".nks.json"
 
+type claimSigner interface {
+	SignClaims(*structs.IdentityClaims) (string, string, error)
+}
+
+var _ claimSigner = &Encrypter{}
+
 // Encrypter is the keyring for encrypting variables and signing workload
 // identities.
 type Encrypter struct {

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -18,6 +18,18 @@ import (
 	"github.com/hashicorp/nomad/testutil"
 )
 
+type mockSigner struct {
+	calls []*structs.IdentityClaims
+
+	nextToken, nextKeyID string
+	nextErr              error
+}
+
+func (s *mockSigner) SignClaims(c *structs.IdentityClaims) (token, keyID string, err error) {
+	s.calls = append(s.calls, c)
+	return s.nextToken, s.nextKeyID, s.nextErr
+}
+
 // TestEncrypter_LoadSave exercises round-tripping keys to disk
 func TestEncrypter_LoadSave(t *testing.T) {
 	ci.Parallel(t)

--- a/nomad/service_registration_endpoint_test.go
+++ b/nomad/service_registration_endpoint_test.go
@@ -883,7 +883,7 @@ func TestServiceRegistration_List(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc()}
 				job := allocs[0].Job
 				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, job))
-				s.signAllocIdentities(job, allocs)
+				signAllocIdentities(s.encrypter, job, allocs)
 				require.NoError(t, s.State().UpsertAllocs(structs.MsgTypeTestSetup, 15, allocs))
 
 				signedToken := allocs[0].SignedIdentities["web"]
@@ -1156,7 +1156,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 				allocs := []*structs.Allocation{mock.Alloc()}
 				job := allocs[0].Job
 				require.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, 10, job))
-				s.signAllocIdentities(job, allocs)
+				signAllocIdentities(s.encrypter, job, allocs)
 				require.NoError(t, s.State().UpsertAllocs(structs.MsgTypeTestSetup, 15, allocs))
 
 				signedToken := allocs[0].SignedIdentities["web"]


### PR DESCRIPTION
Fixes #16846 -- This is the `1.4.x` edition of #18776