### PR TITLE
vault: add multi-cluster support on templates

### DIFF
--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -146,7 +146,7 @@ func (h *testHarness) startWithErr() error {
 		Templates:            h.templates,
 		ClientConfig:         h.config,
 		VaultToken:           h.vaultToken,
-		VaultCluster:         structs.VaultDefaultCluster,
+		VaultConfig:          h.config.VaultConfigs[structs.VaultDefaultCluster],
 		TaskDir:              h.taskDir,
 		EnvBuilder:           h.envBuilder,
 		MaxTemplateEventRate: h.emitRate,
@@ -1721,7 +1721,7 @@ func TestTaskTemplateManager_Config_ServerName(t *testing.T) {
 	config := &TaskTemplateManagerConfig{
 		ClientConfig: c,
 		VaultToken:   "token",
-		VaultCluster: structs.VaultDefaultCluster,
+		VaultConfig:  c.VaultConfigs[structs.VaultDefaultCluster],
 	}
 	ctconf, err := newRunnerConfig(config, nil)
 	if err != nil {
@@ -1756,7 +1756,7 @@ func TestTaskTemplateManager_Config_VaultNamespace(t *testing.T) {
 	config := &TaskTemplateManagerConfig{
 		ClientConfig: c,
 		VaultToken:   "token",
-		VaultCluster: structs.VaultDefaultCluster,
+		VaultConfig:  c.VaultConfigs[structs.VaultDefaultCluster],
 		EnvBuilder:   taskenv.NewBuilder(c.Node, alloc, alloc.Job.TaskGroups[0].Tasks[0], c.Region),
 	}
 
@@ -1794,7 +1794,7 @@ func TestTaskTemplateManager_Config_VaultNamespace_TaskOverride(t *testing.T) {
 	config := &TaskTemplateManagerConfig{
 		ClientConfig:   c,
 		VaultToken:     "token",
-		VaultCluster:   structs.VaultDefaultCluster,
+		VaultConfig:    c.VaultConfigs[structs.VaultDefaultCluster],
 		VaultNamespace: overriddenNS,
 		EnvBuilder:     taskenv.NewBuilder(c.Node, alloc, alloc.Job.TaskGroups[0].Tasks[0], c.Region),
 	}
@@ -2229,7 +2229,7 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 			&TaskTemplateManagerConfig{
 				ClientConfig: clientConfig,
 				VaultToken:   "token",
-				VaultCluster: structs.VaultDefaultCluster,
+				VaultConfig:  clientConfig.VaultConfigs[structs.VaultDefaultCluster],
 				EnvBuilder:   taskenv.NewBuilder(clientConfig.Node, alloc, alloc.Job.TaskGroups[0].Tasks[0], clientConfig.Region),
 			},
 			&config.Config{
@@ -2263,7 +2263,7 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 			&TaskTemplateManagerConfig{
 				ClientConfig: clientConfig,
 				VaultToken:   "token",
-				VaultCluster: structs.VaultDefaultCluster,
+				VaultConfig:  clientConfig.VaultConfigs[structs.VaultDefaultCluster],
 				EnvBuilder:   taskenv.NewBuilder(clientConfig.Node, allocWithOverride, allocWithOverride.Job.TaskGroups[0].Tasks[0], clientConfig.Region),
 			},
 			&config.Config{
@@ -2301,7 +2301,7 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 			&TaskTemplateManagerConfig{
 				ClientConfig: clientConfig,
 				VaultToken:   "token",
-				VaultCluster: structs.VaultDefaultCluster,
+				VaultConfig:  clientConfig.VaultConfigs[structs.VaultDefaultCluster],
 				EnvBuilder:   taskenv.NewBuilder(clientConfig.Node, allocWithOverride, allocWithOverride.Job.TaskGroups[0].Tasks[0], clientConfig.Region),
 				Templates: []*structs.Template{
 					{

--- a/client/config/config_ce.go
+++ b/client/config/config_ce.go
@@ -19,7 +19,7 @@ func (c *Config) GetVaultConfigs(logger hclog.Logger) map[string]*structsc.Vault
 		return nil
 	}
 
-	if len(c.VaultConfigs) > 1 && logger != nil {
+	if len(c.VaultConfigs) > 1 {
 		logger.Warn("multiple Vault configurations are only supported in Nomad Enterprise")
 	}
 

--- a/client/config/config_ce.go
+++ b/client/config/config_ce.go
@@ -19,7 +19,7 @@ func (c *Config) GetVaultConfigs(logger hclog.Logger) map[string]*structsc.Vault
 		return nil
 	}
 
-	if len(c.VaultConfigs) > 1 {
+	if len(c.VaultConfigs) > 1 && logger != nil {
 		logger.Warn("multiple Vault configurations are only supported in Nomad Enterprise")
 	}
 

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -485,14 +485,15 @@ func (c *Config) ConsulTaskIdentity() *structs.WorkloadIdentity {
 	return workloadIdentityFromConfig(c.ConsulConfig.TaskIdentity)
 }
 
-// VaultDefaultIdentity returns the workload identity to be used for accessing
-// the Vault API.
-func (c *Config) VaultDefaultIdentity() *structs.WorkloadIdentity {
-	if c.VaultConfig == nil {
+// VaultIdentityConfig returns the workload identity to be used for accessing
+// the API of a given Vault cluster.
+func (c *Config) VaultIdentityConfig(cluster string) *structs.WorkloadIdentity {
+	conf := c.VaultConfigs[cluster]
+	if conf == nil {
 		return nil
 	}
 
-	return workloadIdentityFromConfig(c.VaultConfig.DefaultIdentity)
+	return workloadIdentityFromConfig(conf.DefaultIdentity)
 }
 
 // UseConsulIdentity returns true when Consul workload identity is enabled.

--- a/nomad/job_endpoint_hook_implicit_identities.go
+++ b/nomad/job_endpoint_hook_implicit_identities.go
@@ -120,7 +120,7 @@ func (h jobImplicitIdentitiesHook) handleVault(t *structs.Task) {
 
 	// If the task doesn't specify an identity for Vault, fallback to the
 	// default identity defined in the server configuration.
-	vaultWID = h.srv.config.VaultDefaultIdentity()
+	vaultWID = h.srv.config.VaultIdentityConfig(t.Vault.Cluster)
 	if vaultWID == nil {
 		// If no identity is found skip inject the implicit identity and
 		// fallback to the legacy flow.

--- a/nomad/job_endpoint_hook_implicit_identities_test.go
+++ b/nomad/job_endpoint_hook_implicit_identities_test.go
@@ -360,9 +360,11 @@ func Test_jobImplicitIndentitiesHook_Mutate_vault(t *testing.T) {
 				}},
 			},
 			inputConfig: &Config{
-				VaultConfig: &config.VaultConfig{
-					DefaultIdentity: &config.WorkloadIdentityConfig{
-						Audience: []string{"vault.io"},
+				VaultConfigs: map[string]*config.VaultConfig{
+					structs.VaultDefaultCluster: {
+						DefaultIdentity: &config.WorkloadIdentityConfig{
+							Audience: []string{"vault.io"},
+						},
 					},
 				},
 			},
@@ -382,7 +384,9 @@ func Test_jobImplicitIndentitiesHook_Mutate_vault(t *testing.T) {
 				}},
 			},
 			inputConfig: &Config{
-				VaultConfig: &config.VaultConfig{},
+				VaultConfigs: map[string]*config.VaultConfig{
+					structs.VaultDefaultCluster: {},
+				},
 			},
 			expectedOutputJob: &structs.Job{
 				TaskGroups: []*structs.TaskGroup{{
@@ -408,9 +412,11 @@ func Test_jobImplicitIndentitiesHook_Mutate_vault(t *testing.T) {
 				}},
 			},
 			inputConfig: &Config{
-				VaultConfig: &config.VaultConfig{
-					DefaultIdentity: &config.WorkloadIdentityConfig{
-						Audience: []string{"vault-from-config.io"},
+				VaultConfigs: map[string]*config.VaultConfig{
+					structs.VaultDefaultCluster: {
+						DefaultIdentity: &config.WorkloadIdentityConfig{
+							Audience: []string{"vault-from-config.io"},
+						},
 					},
 				},
 			},
@@ -440,9 +446,11 @@ func Test_jobImplicitIndentitiesHook_Mutate_vault(t *testing.T) {
 				}},
 			},
 			inputConfig: &Config{
-				VaultConfig: &config.VaultConfig{
-					DefaultIdentity: &config.WorkloadIdentityConfig{
-						Audience: []string{"vault.io"},
+				VaultConfigs: map[string]*config.VaultConfig{
+					structs.VaultDefaultCluster: {
+						DefaultIdentity: &config.WorkloadIdentityConfig{
+							Audience: []string{"vault.io"},
+						},
 					},
 				},
 			},

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -404,14 +404,12 @@ func (v *jobValidate) validateVaultIdentity(t *structs.Task) ([]error, error) {
 	var mErr *multierror.Error
 	var warnings []error
 
-	vaultWIDs := []string{}
+	vaultWIDs := make([]string, 0, len(t.Identities))
 	for _, wid := range t.Identities {
 		if strings.HasPrefix(wid.Name, structs.WorkloadIdentityVaultPrefix) {
 			vaultWIDs = append(vaultWIDs, wid.Name)
 		}
 	}
-	hasTaskWID := len(vaultWIDs) > 0
-	hasDefaultWID := v.srv.config.VaultDefaultIdentity() != nil
 
 	if t.Vault == nil {
 		for _, wid := range vaultWIDs {
@@ -419,6 +417,9 @@ func (v *jobValidate) validateVaultIdentity(t *structs.Task) ([]error, error) {
 		}
 		return warnings, nil
 	}
+
+	hasTaskWID := len(vaultWIDs) > 0
+	hasDefaultWID := v.srv.config.VaultIdentityConfig(t.Vault.Cluster) != nil
 
 	if hasTaskWID || hasDefaultWID {
 		if len(t.Vault.Policies) > 0 {

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -174,18 +174,22 @@ func Test_jobValidate_Validate_vault(t *testing.T) {
 		name                string
 		inputTaskVault      *structs.Vault
 		inputTaskIdentities []*structs.WorkloadIdentity
-		inputConfig         *config.VaultConfig
+		inputConfig         map[string]*config.VaultConfig
 		expectedWarns       []string
 		expectedErr         string
 	}{
 		{
-			name:                "no error when vault identity is provided via config",
-			inputTaskVault:      &structs.Vault{},
+			name: "no error when vault identity is provided via config",
+			inputTaskVault: &structs.Vault{
+				Cluster: structs.VaultDefaultCluster,
+			},
 			inputTaskIdentities: nil,
-			inputConfig: &config.VaultConfig{
-				DefaultIdentity: &config.WorkloadIdentityConfig{
-					Audience: []string{"vault.io"},
-					TTL:      pointer.Of(time.Hour),
+			inputConfig: map[string]*config.VaultConfig{
+				structs.VaultDefaultCluster: {
+					DefaultIdentity: &config.WorkloadIdentityConfig{
+						Audience: []string{"vault.io"},
+						TTL:      pointer.Of(time.Hour),
+					},
 				},
 			},
 		},
@@ -197,25 +201,26 @@ func Test_jobValidate_Validate_vault(t *testing.T) {
 				Audience: []string{"vault.io"},
 				TTL:      time.Hour,
 			}},
-			inputConfig: &config.VaultConfig{},
 		},
 		{
 			name:                "error when not using vault identity and vault block is missing policies",
 			inputTaskVault:      &structs.Vault{},
 			inputTaskIdentities: nil,
-			inputConfig:         &config.VaultConfig{},
 			expectedErr:         "Vault block with an empty list of policies",
 		},
 		{
 			name: "warn when using default vault identity but task has vault policies",
 			inputTaskVault: &structs.Vault{
+				Cluster:  structs.VaultDefaultCluster,
 				Policies: []string{"nomad-workload"},
 			},
 			inputTaskIdentities: nil,
-			inputConfig: &config.VaultConfig{
-				DefaultIdentity: &config.WorkloadIdentityConfig{
-					Audience: []string{"vault.io"},
-					TTL:      pointer.Of(time.Hour),
+			inputConfig: map[string]*config.VaultConfig{
+				structs.VaultDefaultCluster: {
+					DefaultIdentity: &config.WorkloadIdentityConfig{
+						Audience: []string{"vault.io"},
+						TTL:      pointer.Of(time.Hour),
+					},
 				},
 			},
 			expectedWarns: []string{"policies will be ignored"},
@@ -230,7 +235,6 @@ func Test_jobValidate_Validate_vault(t *testing.T) {
 				Audience: []string{"vault.io"},
 				TTL:      time.Hour,
 			}},
-			inputConfig:   &config.VaultConfig{},
 			expectedWarns: []string{"policies will be ignored"},
 		},
 		{
@@ -241,7 +245,6 @@ func Test_jobValidate_Validate_vault(t *testing.T) {
 				Audience: []string{"vault.io"},
 				TTL:      time.Hour,
 			}},
-			inputConfig: &config.VaultConfig{},
 			expectedWarns: []string{
 				"has an identity called vault_default but no vault block",
 			},
@@ -253,7 +256,7 @@ func Test_jobValidate_Validate_vault(t *testing.T) {
 			impl := jobValidate{srv: &Server{
 				config: &Config{
 					JobMaxPriority: 100,
-					VaultConfig:    tc.inputConfig,
+					VaultConfigs:   tc.inputConfig,
 				},
 			}}
 


### PR DESCRIPTION
In Nomad Enterprise, a task may connect to a non-default Vault cluster, requiring `consul-template` to be configured with a specific client `vault` block.

Tests require an ENT feature, so they will be done in a separate PR on the ENT repo.