### PR TITLE
ui: fix websocket connections on dev proxy

### DIFF
--- a/ui/server/proxies/api.js
+++ b/ui/server/proxies/api.js
@@ -46,12 +46,9 @@ module.exports = function (app, options) {
   });
 
   server.on('upgrade', function (req, socket, head) {
-    if (
-      req.url.startsWith('/v1/client/allocation') &&
-      req.url.includes('exec?')
-    ) {
-      req.headers.origin = proxyAddress;
-      proxy.ws(req, socket, head, { target: proxyAddress });
-    }
+    // Set Origin header so Nomad accepts the proxied request.
+    // WebSocket proxing is handled by ember-cli.
+    // https://github.com/ember-cli/ember-cli/blob/v3.28.5/lib/tasks/server/middleware/proxy-server/index.js#L51
+    req.headers.origin = proxyAddress;
   });
 };

--- a/ui/server/proxies/api.js
+++ b/ui/server/proxies/api.js
@@ -45,7 +45,7 @@ module.exports = function (app, options) {
     proxy.web(req, res, { target: proxyAddress });
   });
 
-  server.on('upgrade', function (req, socket, head) {
+  server.on('upgrade', function (req) {
     // Set Origin header so Nomad accepts the proxied request.
     // WebSocket proxing is handled by ember-cli.
     // https://github.com/ember-cli/ember-cli/blob/v3.28.5/lib/tasks/server/middleware/proxy-server/index.js#L51


### PR DESCRIPTION
`ember-cli` includes a handler for websocket upgrade requests to start proxying requests. Handling the same upgrade event by also proxying in `api.js` causes some kind of conflict where the connection is closed unexpectedly.

The only change necessary on upgrade is to overwrite the Origin header so Nomad accepts the connection.