### PR TITLE
Nomad Actions

### DIFF
--- a/.changelog/18794.txt
+++ b/.changelog/18794.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+actions: introduces the action concept to jobspecs, the web UI, CLI and API
+```

--- a/api/allocations_exec.go
+++ b/api/allocations_exec.go
@@ -28,6 +28,7 @@ type execSession struct {
 	task    string
 	tty     bool
 	command []string
+	action  string
 
 	stdin  io.Reader
 	stdout io.Writer
@@ -94,8 +95,14 @@ func (s *execSession) startConnection() (*websocket.Conn, error) {
 	q.Params["tty"] = strconv.FormatBool(s.tty)
 	q.Params["task"] = s.task
 	q.Params["command"] = string(commandBytes)
-
 	reqPath := fmt.Sprintf("/v1/client/allocation/%s/exec", s.alloc.ID)
+
+	if s.action != "" {
+		q.Params["action"] = s.action
+		q.Params["allocID"] = s.alloc.ID
+		q.Params["group"] = s.alloc.TaskGroup
+		reqPath = fmt.Sprintf("/v1/job/%s/action", s.alloc.JobID)
+	}
 
 	var conn *websocket.Conn
 

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -4,8 +4,10 @@
 package api
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
 	"sort"
 	"strconv"
@@ -1513,4 +1515,31 @@ type JobEvaluateRequest struct {
 // EvalOptions is used to encapsulate options when forcing a job evaluation
 type EvalOptions struct {
 	ForceReschedule bool
+}
+
+// ActionExec is used to run a pre-defined command inside a running task.
+// The call blocks until command terminates (or an error occurs), and returns the exit code.
+func (j *Jobs) ActionExec(ctx context.Context,
+	alloc *Allocation, task string, tty bool, command []string,
+	action string,
+	stdin io.Reader, stdout, stderr io.Writer,
+	terminalSizeCh <-chan TerminalSize, q *QueryOptions) (exitCode int, err error) {
+
+	s := &execSession{
+		client:  j.client,
+		alloc:   alloc,
+		task:    task,
+		tty:     tty,
+		command: command,
+		action:  action,
+
+		stdin:  stdin,
+		stdout: stdout,
+		stderr: stderr,
+
+		terminalSizeCh: terminalSizeCh,
+		q:              q,
+	}
+
+	return s.run(ctx)
 }

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -731,6 +731,8 @@ type Task struct {
 
 	// Workload Identities
 	Identities []*WorkloadIdentity `hcl:"identity,block"`
+
+	Actions []*Action `hcl:"action,block"`
 }
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
@@ -1166,4 +1168,10 @@ type WorkloadIdentity struct {
 	File        bool          `hcl:"file,optional"`
 	ServiceName string        `hcl:"service_name,optional"`
 	TTL         time.Duration `mapstructure:"ttl" hcl:"ttl,optional"`
+}
+
+type Action struct {
+	Name    string   `hcl:"name,label"`
+	Command string   `mapstructure:"command" hcl:"command"`
+	Args    []string `mapstructure:"args" hcl:"args,optional"`
 }

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -182,6 +182,9 @@ type AllocExecRequest struct {
 	// Cmd is the command to be executed
 	Cmd []string
 
+	// The name of a predefined command to be executed (optional)
+	Action string
+
 	structs.QueryOptions
 }
 

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -504,19 +504,7 @@ func (s *HTTPServer) allocExec(allocID string, resp http.ResponseWriter, req *ht
 	}
 	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
 
-	// conn, err := s.wsUpgrader.Upgrade(resp, req, nil)
-	// FIXME: this is an open checkOrigin here that allows :4200 to make requests to :4646,
-	// freeing local ember up from not having to proxy.
-	// This is like three workarounds in a trenchcoat and I dno't feel good about it but it unblocks me
-
-	var upgrader = websocket.Upgrader{
-		// Allow all origins
-		CheckOrigin: func(r *http.Request) bool { return true },
-	}
-
-	// Then when you upgrade the connection:
-	conn, err := upgrader.Upgrade(resp, req, nil)
-
+	conn, err := s.wsUpgrader.Upgrade(resp, req, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to upgrade connection: %v", err)
 	}

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -504,7 +504,19 @@ func (s *HTTPServer) allocExec(allocID string, resp http.ResponseWriter, req *ht
 	}
 	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
 
-	conn, err := s.wsUpgrader.Upgrade(resp, req, nil)
+	// conn, err := s.wsUpgrader.Upgrade(resp, req, nil)
+	// FIXME: this is an open checkOrigin here that allows :4200 to make requests to :4646,
+	// freeing local ember up from not having to proxy.
+	// This is like three workarounds in a trenchcoat and I dno't feel good about it but it unblocks me
+
+	var upgrader = websocket.Upgrader{
+		// Allow all origins
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+
+	// Then when you upgrade the connection:
+	conn, err := upgrader.Upgrade(resp, req, nil)
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to upgrade connection: %v", err)
 	}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1341,6 +1341,11 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 			Sidecar: apiTask.Lifecycle.Sidecar,
 		}
 	}
+
+	for _, action := range apiTask.Actions {
+		act := ApiActionToStructsAction(job, action)
+		structsTask.Actions = append(structsTask.Actions, act)
+	}
 }
 
 // apiWaitConfigToStructsWaitConfig is a copy and type conversion between the API
@@ -1381,6 +1386,14 @@ func ApiCSIPluginConfigToStructsCSIPluginConfig(apiConfig *api.TaskCSIPluginConf
 	sc.StagePublishBaseDir = apiConfig.StagePublishBaseDir
 	sc.HealthTimeout = apiConfig.HealthTimeout
 	return sc
+}
+
+func ApiActionToStructsAction(job *structs.Job, action *api.Action) *structs.Action {
+	return &structs.Action{
+		Name:    action.Name,
+		Args:    slices.Clone(action.Args),
+		Command: action.Command,
+	}
 }
 
 func ApiResourcesToStructs(in *api.Resources) *structs.Resources {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -110,6 +110,9 @@ func (s *HTTPServer) JobSpecificRequest(resp http.ResponseWriter, req *http.Requ
 	case strings.HasSuffix(path, "/submission"):
 		jobID := strings.TrimSuffix(path, "/submission")
 		return s.jobSubmissionCRUD(resp, req, jobID)
+	case strings.HasSuffix(path, "/actions"):
+		jobID := strings.TrimSuffix(path, "/actions")
+		return s.jobActions(resp, req, jobID)
 	default:
 		return s.jobCRUD(resp, req, path)
 	}
@@ -331,6 +334,28 @@ func (s *HTTPServer) jobLatestDeployment(resp http.ResponseWriter, req *http.Req
 
 	setMeta(resp, &out.QueryMeta)
 	return out.Deployment, nil
+}
+
+func (s *HTTPServer) jobActions(resp http.ResponseWriter, req *http.Request, jobID string) (any, error) {
+	if req.Method != http.MethodGet {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	args := structs.JobSpecificRequest{
+		JobID: jobID,
+	}
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	var out structs.ActionListResponse
+	if err := s.agent.RPC("Job.GetActions", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &structs.QueryMeta{})
+
+	return out.Actions, nil
 }
 
 func (s *HTTPServer) jobSubmissionCRUD(resp http.ResponseWriter, req *http.Request, jobID string) (*structs.JobSubmission, error) {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 
 	"github.com/golang/snappy"
+	"github.com/gorilla/websocket"
 	"github.com/hashicorp/nomad/acl"
 	api "github.com/hashicorp/nomad/api"
+	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/jobspec"
 	"github.com/hashicorp/nomad/jobspec2"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -113,6 +115,8 @@ func (s *HTTPServer) JobSpecificRequest(resp http.ResponseWriter, req *http.Requ
 	case strings.HasSuffix(path, "/actions"):
 		jobID := strings.TrimSuffix(path, "/actions")
 		return s.jobActions(resp, req, jobID)
+	case strings.HasSuffix(path, "/action"):
+		return s.jobRunAction(resp, req)
 	default:
 		return s.jobCRUD(resp, req, path)
 	}
@@ -356,6 +360,47 @@ func (s *HTTPServer) jobActions(resp http.ResponseWriter, req *http.Request, job
 	setMeta(resp, &structs.QueryMeta{})
 
 	return out.Actions, nil
+}
+
+func (s *HTTPServer) jobRunAction(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+
+	s.logger.Info("jobRunAction called")
+
+	// Build the request and parse the ACL token
+	task := req.URL.Query().Get("task")
+	action := req.URL.Query().Get("action")
+	allocID := req.URL.Query().Get("allocID")
+	isTTY := false
+	err := error(nil)
+	if tty := req.URL.Query().Get("tty"); tty != "" {
+		isTTY, err = strconv.ParseBool(tty)
+		if err != nil {
+			return nil, fmt.Errorf("tty value is not a boolean: %v", err)
+		}
+	}
+
+	args := cstructs.AllocExecRequest{
+		Task:    task,
+		Action:  action,
+		AllocID: allocID,
+		Tty:     isTTY,
+	}
+
+	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
+
+	conn, err := s.wsUpgrader.Upgrade(resp, req, nil)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to upgrade connection: %v", err)
+	}
+
+	if err := readWsHandshake(conn.ReadJSON, req, &args.QueryOptions); err != nil {
+		conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(toWsCode(400), err.Error()))
+		return nil, err
+	}
+
+	return s.execStreamImpl(conn, &args)
 }
 
 func (s *HTTPServer) jobSubmissionCRUD(resp http.ResponseWriter, req *http.Request, jobID string) (*structs.JobSubmission, error) {

--- a/command/agent/testingutils_test.go
+++ b/command/agent/testingutils_test.go
@@ -78,6 +78,19 @@ func MockJob() *api.Job {
 								PortLabel: "admin",
 							},
 						},
+						// actions
+						Actions: []*api.Action{
+							{
+								Name:    "date test",
+								Command: "/bin/date",
+								Args:    []string{"-u"},
+							},
+							{
+								Name:    "echo test",
+								Command: "/bin/echo",
+								Args:    []string{"hello world"},
+							},
+						},
 						LogConfig: api.DefaultLogConfig(),
 						Resources: &api.Resources{
 							CPU:      pointer.Of(500),

--- a/command/alloc_fs.go
+++ b/command/alloc_fs.go
@@ -173,7 +173,7 @@ func (f *AllocFSCommand) Run(args []string) int {
 			return 1
 		}
 
-		allocID, err = getRandomJobAllocID(client, jobID, ns)
+		allocID, err = getRandomJobAllocID(client, jobID, "", ns)
 		if err != nil {
 			f.Ui.Error(fmt.Sprintf("Error fetching allocations: %v", err))
 			return 1
@@ -387,7 +387,7 @@ func (f *AllocFSCommand) followFile(client *api.Client, alloc *api.Allocation,
 
 // Get Random Allocation from a known jobID. Prefer to use a running allocation,
 // but use a dead allocation if no running allocations are found
-func getRandomJobAlloc(client *api.Client, jobID, namespace string) (*api.AllocationListStub, error) {
+func getRandomJobAlloc(client *api.Client, jobID, taskGroupName, namespace string) (*api.AllocationListStub, error) {
 	var runningAllocs []*api.AllocationListStub
 	q := &api.QueryOptions{
 		Namespace: namespace,
@@ -401,6 +401,19 @@ func getRandomJobAlloc(client *api.Client, jobID, namespace string) (*api.Alloca
 	// Check that the job actually has allocations
 	if len(allocs) == 0 {
 		return nil, fmt.Errorf("job %q doesn't exist or it has no allocations", jobID)
+	}
+
+	if taskGroupName != "" {
+		var filteredAllocs []*api.AllocationListStub
+		for _, alloc := range allocs {
+			if alloc.TaskGroup == taskGroupName {
+				filteredAllocs = append(filteredAllocs, alloc)
+			}
+		}
+		allocs = filteredAllocs
+		if len(allocs) == 0 {
+			return nil, fmt.Errorf("task group %q doesn't exist or it has no allocations", taskGroupName)
+		}
 	}
 
 	for _, v := range allocs {
@@ -419,8 +432,8 @@ func getRandomJobAlloc(client *api.Client, jobID, namespace string) (*api.Alloca
 	return alloc, err
 }
 
-func getRandomJobAllocID(client *api.Client, jobID, namespace string) (string, error) {
-	alloc, err := getRandomJobAlloc(client, jobID, namespace)
+func getRandomJobAllocID(client *api.Client, jobID, group, namespace string) (string, error) {
+	alloc, err := getRandomJobAlloc(client, jobID, group, namespace)
 	if err != nil {
 		return "", err
 	}

--- a/command/alloc_logs.go
+++ b/command/alloc_logs.go
@@ -173,7 +173,7 @@ func (l *AllocLogsCommand) Run(args []string) int {
 			return 1
 		}
 
-		allocID, err = getRandomJobAllocID(client, jobID, ns)
+		allocID, err = getRandomJobAllocID(client, jobID, "", ns)
 		if err != nil {
 			l.Ui.Error(fmt.Sprintf("Error fetching allocations: %v", err))
 			return 1

--- a/command/commands.go
+++ b/command/commands.go
@@ -235,6 +235,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"action": func() (cli.Command, error) {
+			return &ActionCommand{
+				Meta: meta,
+			}, nil
+		},
 		"alloc": func() (cli.Command, error) {
 			return &AllocCommand{
 				Meta: meta,

--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -46,6 +46,7 @@ var (
 		"kind",
 		"volume_mount",
 		"csi_plugin",
+		"actions",
 	)
 
 	sidecarTaskKeys = append(commonTaskKeys,

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1734,7 +1734,7 @@ func (j *Job) GetActions(args *structs.JobSpecificRequest, reply *structs.Action
 	// Check for read-job permissions
 	if aclObj, err := j.srv.ResolveACL(args); err != nil {
 		return err
-	} else if aclObj != nil && !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
+	} else if !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -705,3 +705,38 @@ func BigBenchmarkJob() *structs.Job {
 
 	return job
 }
+
+// A multi-group, multi-task job with actions testing.
+func ActionsJob() *structs.Job {
+	job := MinJob()
+
+	for i := 0; i < 2; i++ {
+		tg := job.TaskGroups[0].Copy()
+		tg.Name = fmt.Sprintf("g%d", i+1)
+		job.TaskGroups = append(job.TaskGroups, tg)
+	}
+
+	for i := 0; i < 2; i++ {
+		task := job.TaskGroups[0].Tasks[0].Copy()
+		task.Name = fmt.Sprintf("t%d", i+1)
+		job.TaskGroups[0].Tasks = append(job.TaskGroups[0].Tasks, task)
+	}
+
+	for _, tg := range job.TaskGroups {
+		for _, task := range tg.Tasks {
+			task.Actions = []*structs.Action{
+				{
+					Name:    "date test",
+					Command: "/bin/date",
+					Args:    []string{"-u"},
+				},
+				{
+					Name:    "echo test",
+					Command: "/bin/echo",
+					Args:    []string{"hello world"},
+				},
+			}
+		}
+	}
+	return job
+}

--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -76,6 +76,18 @@ func Job() *structs.Job {
 						Env: map[string]string{
 							"FOO": "bar",
 						},
+						Actions: []*structs.Action{
+							{
+								Name:    "date test",
+								Command: "/bin/date",
+								Args:    []string{"-u"},
+							},
+							{
+								Name:    "echo test",
+								Command: "/bin/echo",
+								Args:    []string{"hello world"},
+							},
+						},
 						Services: []*structs.Service{
 							{
 								Name:      "${TASK}-frontend",

--- a/nomad/structs/actions.go
+++ b/nomad/structs/actions.go
@@ -1,0 +1,38 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Actions are executable commands that can be run on an allocation within
+// the context of a task. They are left open-ended enough to be applied to
+// other Nomad concepts like Nodes in the future.
+
+package structs
+
+import "slices"
+
+type Action struct {
+	Name    string
+	Command string
+	Args    []string
+}
+
+func (a *Action) Copy() *Action {
+	if a == nil {
+		return nil
+	}
+	na := new(Action)
+	*na = *a
+	na.Args = slices.Clone(a.Args)
+	return na
+}
+
+func (a *Action) Equal(o *Action) bool {
+	if a == o {
+		return true
+	}
+	if a == nil || o == nil {
+		return false
+	}
+	return a.Name == o.Name &&
+		a.Command == o.Command &&
+		slices.Equal(a.Args, o.Args)
+}

--- a/nomad/structs/actions.go
+++ b/nomad/structs/actions.go
@@ -15,6 +15,17 @@ type Action struct {
 	Args    []string
 }
 
+type JobAction struct {
+	Action
+	TaskName      string
+	TaskGroupName string
+}
+
+type ActionListResponse struct {
+	Actions []*JobAction
+	QueryMeta
+}
+
 func (a *Action) Copy() *Action {
 	if a == nil {
 		return nil

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -8673,6 +8673,195 @@ func TestTaskDiff(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "Actions added",
+			Old:  &Task{},
+			New: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "echo",
+						Args:    []string{"bar"},
+					},
+				},
+			},
+			Expected: &TaskDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "Action",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "Command",
+								Old:  "",
+								New:  "echo",
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "Name",
+								Old:  "",
+								New:  "foo",
+							},
+						},
+						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeAdded,
+								Name: "Args",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "Args",
+										Old:  "",
+										New:  "bar",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Actions removed",
+			Old: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "echo",
+						Args:    []string{"bar"},
+					},
+				},
+			},
+			New: &Task{},
+			Expected: &TaskDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeDeleted,
+						Name: "Action",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "Command",
+								Old:  "echo",
+								New:  "",
+							},
+							{
+								Type: DiffTypeDeleted,
+								Name: "Name",
+								Old:  "foo",
+								New:  "",
+							},
+						},
+						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "Args",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeDeleted,
+										Name: "Args",
+										Old:  "bar",
+										New:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Actions edited",
+			Old: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "bar",
+						Args:    []string{"hello world"},
+					},
+				},
+			},
+			New: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "baz",
+						Args:    []string{"hello world"},
+					},
+				},
+			},
+			Expected: &TaskDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "Action",
+						Fields: []*FieldDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "Command",
+								Old:  "bar",
+								New:  "baz",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Action Args edited",
+			Old: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "echo",
+						// Multiple strings of "foo" and "bar"
+						Args: []string{"bar"},
+					},
+				},
+			},
+			New: &Task{
+				Actions: []*Action{
+					{
+						Name:    "foo",
+						Command: "echo",
+						Args:    []string{"baz"},
+					},
+				},
+			},
+			Expected: &TaskDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "Action",
+						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeEdited,
+								Name: "Args",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "Args",
+										Old:  "",
+										New:  "baz",
+									},
+									{
+										Type: DiffTypeDeleted,
+										Name: "Args",
+										Old:  "bar",
+										New:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -339,6 +339,19 @@ func CopySliceNodeScoreMeta(s []*NodeScoreMeta) []*NodeScoreMeta {
 	return c
 }
 
+func CopySliceActions(s []*Action) []*Action {
+	l := len(s)
+	if l == 0 {
+		return nil
+	}
+
+	c := make([]*Action, l)
+	for i, v := range s {
+		c[i] = v.Copy()
+	}
+	return c
+}
+
 // VaultPoliciesSet takes the structure returned by VaultPolicies and returns
 // the set of required policies
 func VaultPoliciesSet(policies map[string]map[string]*Vault) []string {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7629,6 +7629,9 @@ type Task struct {
 	// Identities are the alternate workload identities for use with 3rd party
 	// endpoints.
 	Identities []*WorkloadIdentity
+
+	// Alloc-exec-like runnable commands
+	Actions []*Action
 }
 
 func (t *Task) UsesCores() bool {
@@ -7715,6 +7718,7 @@ func (t *Task) Copy() *Task {
 	nt.Lifecycle = nt.Lifecycle.Copy()
 	nt.Identity = nt.Identity.Copy()
 	nt.Identities = helper.CopySlice(nt.Identities)
+	nt.Actions = CopySliceActions(nt.Actions)
 
 	if t.Artifacts != nil {
 		artifacts := make([]*TaskArtifact, 0, len(t.Artifacts))

--- a/ui/app/models/action.js
+++ b/ui/app/models/action.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { attr } from '@ember-data/model';
+import { fragmentOwner } from 'ember-data-model-fragments/attributes';
+import Fragment from 'ember-data-model-fragments/fragment';
+
+export default class ActionModel extends Fragment {
+  @attr('string') name;
+  @attr('string') command;
+  @attr() args;
+  @fragmentOwner() task;
+}

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -155,6 +155,18 @@ export default class Job extends Model {
 
   @hasMany('recommendation-summary') recommendationSummaries;
 
+  get actions() {
+    return this.taskGroups.reduce((acc, taskGroup) => {
+      return acc.concat(
+        taskGroup.tasks
+          .map((task) => {
+            return task.get('actions').toArray();
+          })
+          .reduce((taskAcc, taskActions) => taskAcc.concat(taskActions), [])
+      );
+    }, []);
+  }
+
   @computed('taskGroups.@each.drivers')
   get drivers() {
     return this.taskGroups

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -19,6 +19,8 @@ export default class Task extends Fragment {
   @attr('string') driver;
   @attr('string') kind;
 
+  @fragmentArray('action') actions;
+
   @attr() meta;
 
   @computed('taskGroup.mergedMeta', 'meta')

--- a/ui/app/services/sockets.js
+++ b/ui/app/services/sockets.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+// @ts-check
 import Service from '@ember/service';
 import config from 'nomad-ui/config/environment';
 import { getOwner } from '@ember/application';
@@ -35,12 +36,21 @@ export default class SocketsService extends Service {
         },
       });
     } else {
+      const shouldForward = config.APP.deproxyWebsockets;
+
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-      const applicationAdapter = getOwner(this).lookup('adapter:application');
-      const prefix = `${
-        applicationAdapter.host || window.location.host
-      }/${applicationAdapter.urlPrefix()}`;
+
+      // FIXME: Temporary, local ember implementation to get around websocket proxy issues duiring development.
+      let prefix;
       const region = this.system.activeRegion;
+      if (!shouldForward) {
+        const applicationAdapter = getOwner(this).lookup('adapter:application');
+        prefix = `${
+          applicationAdapter.host || window.location.host
+        }/${applicationAdapter.urlPrefix()}`;
+      } else {
+        prefix = 'localhost:4646/v1';
+      }
 
       return new WebSocket(
         `${protocol}//${prefix}/client/allocation/${taskState.allocation.id}` +

--- a/ui/app/services/sockets.js
+++ b/ui/app/services/sockets.js
@@ -36,21 +36,12 @@ export default class SocketsService extends Service {
         },
       });
     } else {
-      const shouldForward = config.APP.deproxyWebsockets;
-
       const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-
-      // FIXME: Temporary, local ember implementation to get around websocket proxy issues duiring development.
-      let prefix;
+      const applicationAdapter = getOwner(this).lookup('adapter:application');
+      const prefix = `${
+        applicationAdapter.host || window.location.host
+      }/${applicationAdapter.urlPrefix()}`;
       const region = this.system.activeRegion;
-      if (!shouldForward) {
-        const applicationAdapter = getOwner(this).lookup('adapter:application');
-        prefix = `${
-          applicationAdapter.host || window.location.host
-        }/${applicationAdapter.urlPrefix()}`;
-      } else {
-        prefix = 'localhost:4646/v1';
-      }
 
       return new WebSocket(
         `${protocol}//${prefix}/client/allocation/${taskState.allocation.id}` +

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -55,10 +55,6 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
 
-    // FIXME: Temporary, local ember implementation
-    // to get around websocket proxy issues duiring development.
-    ENV.APP.deproxyWebsockets = true;
-
     ENV['ember-cli-mirage'] = {
       enabled: USE_MIRAGE,
       excludeFilesFromBuild: !USE_MIRAGE,

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -55,6 +55,10 @@ module.exports = function (environment) {
     // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
     // ENV.APP.LOG_VIEW_LOOKUPS = true;
 
+    // FIXME: Temporary, local ember implementation
+    // to get around websocket proxy issues duiring development.
+    ENV.APP.deproxyWebsockets = true;
+
     ENV['ember-cli-mirage'] = {
       enabled: USE_MIRAGE,
       excludeFilesFromBuild: !USE_MIRAGE,


### PR DESCRIPTION
Introduces the concept of Actions to Nomad: operator-defined commands and workflows that Nomad users can run on an allocation without having to sweat the details.

These take a similar form to task config blocks and live at task level in the jobspec. To demonstrate:

```
job "actions-demo" {
  type = "system"

  group "group" {
    task "task" {
      driver = "raw_exec"
      config {
        command = "node"
        args    = ["-e",
        <<EOT
console.log('Howdy!');
// sleep every 3 seconds
setInterval((a) => {
  console.log('Howdy after 3 seconds');
}, 3000);
EOT
        ]
      }

      action "weather" {
        command = "/usr/bin/curl"
        args = ["-s", "wttr.in/Toronto?format=3"]
      }
      action "hello" {
        command = "say"
        args = ["howdy"]
      }
      action "get job info" {
        command = "/bin/sh"
        args    = ["-c",
          <<EOT
          nomad job status ${NOMAD_JOB_NAME}
          EOT
        ]
      }
      action "get alloc info" {
        command = "/bin/sh"
        args    = ["-c",
          <<EOT
          nomad alloc status ${NOMAD_ALLOC_ID}
          EOT
        ]
      }

      action "echo time" {
        command = "/bin/sh"
        args    = ["-c", "counter=0; while true; do echo \"Running for ${counter} seconds\"; counter=$((counter + 1)); sleep 1; done"]
      }

    }
  }
}
```

These actions can be run from the CLI with `nomad action` by passing in either the allocation ID, or if none is provided, the task and group names and an allocation will be randomly selected:

```
nomad action \
  -allocation=cafee3ae \
  -job=actions-demo \
weather
```

```
nomad action \
  -group=group \
  -task=task \
  -job=actions-demo \
"weather"
```

An endpoint at `v1/job/:id/actions` will GET return a list of actions the job has access to, and a GET at `v1/job/:id/action?action=NAME&allocID=ID&group=GROUP&task=TASK&tty=true` will open a websocket with base64-encoded output (be sure to use `Upgrade: websocket` and related headers)

Future work:

When https://github.com/hashicorp/nomad/pull/18793 lands, the Nomad web UI will display interactive elements to run actions and view their output in various places:

![image](https://github.com/hashicorp/nomad/assets/713991/21506eea-3d93-4079-a1ac-b7df7bee813a)
![image](https://github.com/hashicorp/nomad/assets/713991/7ed3857d-638f-4c4c-b995-a5037c84d820)
![image](https://github.com/hashicorp/nomad/assets/713991/9fb8ad97-8a7b-4a69-b935-f67e365a1972)

Further, part of the intent behind actions is to give operators greater ability to specify which sorts of things a Nomad user can perform. With this in mind, ACL changes with actions in mind are planned in the near future.





Resolves https://github.com/hashicorp/nomad/issues/18627