### PR TITLE
cli: use single dep func for opening URLs.

### DIFF
--- a/command/ui.go
+++ b/command/ui.go
@@ -8,9 +8,9 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/hashicorp/cap/util"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
-	"github.com/skratchdot/open-golang/open"
 )
 
 var (
@@ -212,7 +212,7 @@ func (c *UiCommand) Run(args []string) int {
 	}
 
 	c.Ui.Output(output)
-	if err := open.Start(url.String()); err != nil {
+	if err := util.OpenURL(url.String()); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error opening URL: %s", err))
 		return 1
 	}

--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,6 @@ require (
 	github.com/shoenig/go-landlock v0.1.5
 	github.com/shoenig/go-m1cpu v0.1.6
 	github.com/shoenig/test v0.6.7
-	github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c
 	github.com/stretchr/testify v1.8.4
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	github.com/zclconf/go-cty v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -1325,8 +1325,6 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
-github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c h1:fyKiXKO1/I/B6Y2U8T7WdQGWzwehOuGIrljPtt7YTTI=
-github.com/skratchdot/open-golang v0.0.0-20160302144031-75fb7ed4208c/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/softlayer/softlayer-go v0.0.0-20180806151055-260589d94c7d h1:bVQRCxQvfjNUeRqaY/uT0tFuvuFY0ulgnczuR684Xic=


### PR DESCRIPTION
The cap library is used by the login command and the functionality that it provides to the CLI looks the same. Therefore swapping the login command out means we can reduce our dependency imports and use a single library.