### PR TITLE
vault: validate tasks using non-default clusters

### DIFF
--- a/nomad/job_endpoint_hook_implicit_identities_test.go
+++ b/nomad/job_endpoint_hook_implicit_identities_test.go
@@ -410,6 +410,45 @@ func Test_jobImplicitIndentitiesHook_Mutate_vault(t *testing.T) {
 				}},
 			},
 		},
+		{
+			name: "mutate when task does not have a vault identity for non-default cluster",
+			inputJob: &structs.Job{
+				TaskGroups: []*structs.TaskGroup{{
+					Tasks: []*structs.Task{{
+						Vault: &structs.Vault{
+							Cluster: "other",
+						},
+					}},
+				}},
+			},
+			inputConfig: &Config{
+				VaultConfigs: map[string]*config.VaultConfig{
+					structs.VaultDefaultCluster: {
+						DefaultIdentity: &config.WorkloadIdentityConfig{
+							Audience: []string{"vault.io"},
+						},
+					},
+					"other": {
+						DefaultIdentity: &config.WorkloadIdentityConfig{
+							Audience: []string{"vault-other.io"},
+						},
+					},
+				},
+			},
+			expectedOutputJob: &structs.Job{
+				TaskGroups: []*structs.TaskGroup{{
+					Tasks: []*structs.Task{{
+						Identities: []*structs.WorkloadIdentity{{
+							Name:     "vault_other",
+							Audience: []string{"vault-other.io"},
+						}},
+						Vault: &structs.Vault{
+							Cluster: "other",
+						},
+					}},
+				}},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -384,61 +384,53 @@ func (v *jobValidate) validateServiceIdentity(s *structs.Service, parent string)
 	return nil
 }
 
+// validateVaultIdentity validates that a task is properly configured to access
+// a Vault cluster.
+//
+// It assumes the jobImplicitIdentitiesHook mutator hook has been called to
+// inject task identities if necessary.
 func (v *jobValidate) validateVaultIdentity(t *structs.Task) ([]error, error) {
-	var mErr *multierror.Error
 	var warnings []error
 
-	var vaultWID *structs.WorkloadIdentity
-	vaultWIDs := make([]string, 0, len(t.Identities))
-
-	for _, wid := range t.Identities {
-		if strings.HasPrefix(wid.Name, structs.WorkloadIdentityVaultPrefix) {
-			vaultWIDs = append(vaultWIDs, wid.Name)
-
-			if t.Vault != nil && wid.Name == t.Vault.IdentityName() {
-				vaultWID = wid
+	if t.Vault == nil {
+		// Warn if task doesn't use Vault but has Vault identities.
+		for _, wid := range t.Identities {
+			if strings.HasPrefix(wid.Name, structs.WorkloadIdentityVaultPrefix) {
+				warnings = append(warnings, fmt.Errorf("Task %s has an identity called %s but no vault block", t.Name, wid.Name))
 			}
 		}
-	}
-
-	if t.Vault == nil {
-		for _, wid := range vaultWIDs {
-			warnings = append(warnings, fmt.Errorf("Task %s has an identity called %s but no vault block", t.Name, wid))
-		}
 		return warnings, nil
 	}
 
-	hasTaskWID := vaultWID != nil
-	hasDefaultWID := v.srv.config.VaultIdentityConfig(t.Vault.Cluster) != nil
-
-	if hasTaskWID || hasDefaultWID {
-		if len(t.Vault.Policies) > 0 {
-			warnings = append(warnings, fmt.Errorf(
-				"Task %s has a Vault block with policies but uses workload identity to authenticate with Vault, policies will be ignored",
-				t.Name,
-			))
+	vaultWIDName := t.Vault.IdentityName()
+	vaultWID := t.GetIdentity(vaultWIDName)
+	if vaultWID == nil {
+		// Tasks using non-default clusters are required to have an identity.
+		if t.Vault.Cluster != structs.VaultDefaultCluster {
+			return warnings, fmt.Errorf(
+				"Task %s uses Vault cluster %s but does not have an identity named %s and no default identity is provided in agent configuration",
+				t.Name, t.Vault.Cluster, vaultWIDName,
+			)
 		}
+
+		// Tasks using the default cluster but without a Vault identity will
+		// use the legacy flow.
+		if len(t.Vault.Policies) == 0 {
+			return warnings, fmt.Errorf("Task %s has a Vault block with an empty list of policies", t.Name)
+		}
+
 		return warnings, nil
 	}
 
-	// Only the default cluster is allowed to use the legacy flow. Using a
-	// non-default cluster requires an identity to be provided either in the
-	// task or as a default in the agent config.
-	if t.Vault.Cluster != structs.VaultDefaultCluster {
-		mErr = multierror.Append(mErr, fmt.Errorf(
-			"Task %s uses Vault cluster %s but does not have an identity named %s and no default identity is provided in agent configuration",
-			t.Name, t.Vault.Cluster, t.Vault.IdentityName(),
+	// Warn if tasks is using identity-based flow with the deprecated policies
+	// field.
+	if len(t.Vault.Policies) > 0 {
+		warnings = append(warnings, fmt.Errorf(
+			"Task %s has a Vault block with policies but uses workload identity to authenticate with Vault, policies will be ignored",
+			t.Name,
 		))
-		return warnings, mErr.ErrorOrNil()
 	}
-
-	// At this point Nomad will use the legacy token-based flow, so keep the
-	// existing validations.
-	if len(t.Vault.Policies) == 0 {
-		mErr = multierror.Append(mErr, fmt.Errorf("Task %s has a Vault block with an empty list of policies", t.Name))
-	}
-
-	return warnings, mErr.ErrorOrNil()
+	return warnings, nil
 }
 
 type memoryOversubscriptionValidate struct {


### PR DESCRIPTION
Since Nomad servers only start a Vault client for the default cluster, tasks using non-default clusters must provide an identity to be used for token derivation, either in the task itself or in the agent configuration.