### PR TITLE
log: add Consul and Vault cluster name to output

### DIFF
--- a/client/consul/consul.go
+++ b/client/consul/consul.go
@@ -72,7 +72,7 @@ func NewConsulClient(config *config.ConsulConfig, logger hclog.Logger) (Client, 
 		return nil, fmt.Errorf("nil consul config")
 	}
 
-	logger = logger.Named("consul")
+	logger = logger.Named("consul").With("name", config.Name)
 
 	c := &consulClient{
 		config: config,

--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -147,7 +147,7 @@ func NewVaultClient(config *config.VaultConfig, logger hclog.Logger, tokenDerive
 		return nil, fmt.Errorf("nil vault Config")
 	}
 
-	logger = logger.Named("vault")
+	logger = logger.Named("vault").With("name", config.Name)
 
 	c := &Client{
 		Config: config,


### PR DESCRIPTION
Ensure Consul and Vault loggers have the cluster name as an attribute to help differentiate log source.