### PR TITLE
core: port common code changes from ENT for numa scheduling

### DIFF
--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -1058,6 +1058,49 @@ func Test_jobImpliedConstraints_Mutate(t *testing.T) {
 			expectedOutputWarnings: nil,
 			expectedOutputError:    nil,
 		},
+		{
+			name: "task group with numa block",
+			inputJob: &structs.Job{
+				Name: "numa",
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "group1",
+						Tasks: []*structs.Task{
+							{
+								Resources: &structs.Resources{
+									NUMA: &structs.NUMA{
+										Affinity: "require",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedOutputJob: &structs.Job{
+				Name: "numa",
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "group1",
+						Constraints: []*structs.Constraint{
+							numaVersionConstraint,
+							numaKernelConstraint,
+						},
+						Tasks: []*structs.Task{
+							{
+								Resources: &structs.Resources{
+									NUMA: &structs.NUMA{
+										Affinity: "require",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedOutputWarnings: nil,
+			expectedOutputError:    nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/nomad/structs/job.go
+++ b/nomad/structs/job.go
@@ -117,3 +117,18 @@ func requiresConsulServiceDiscovery(services []*Service) bool {
 	}
 	return false
 }
+
+// RequiredNUMA identifies which task groups, if any, within the job contain
+// tasks requesting NUMA resources.
+func (j *Job) RequiredNUMA() set.Collection[string] {
+	result := set.New[string](10)
+	for _, tg := range j.TaskGroups {
+		for _, task := range tg.Tasks {
+			if task.Resources != nil && task.Resources.NUMA.Requested() {
+				result.Insert(tg.Name)
+				break
+			}
+		}
+	}
+	return result
+}

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -500,6 +500,7 @@ OUTER:
 				cores, bandwidth := (&coreSelector{
 					topology:       option.Node.NodeResources.Processors.Topology,
 					availableCores: availableCores,
+					shuffle:        randomizeCores,
 				}).Select(task.Resources)
 
 				// mark the node as exhausted if not enough cores available given

--- a/scheduler/rank_test.go
+++ b/scheduler/rank_test.go
@@ -1385,6 +1385,9 @@ func TestBinPackIterator_ReservedCores(t *testing.T) {
 				Resources: &structs.Resources{
 					Cores:    1,
 					MemoryMB: 1024,
+					NUMA: &structs.NUMA{
+						Affinity: "none",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
Some additional changes were made in the [ENT PR](https://github.com/hashicorp/nomad-enterprise/pull/1292) to the common code in
support of numa scheduling; this PR copies those changes back to CE.
