### PR TITLE
Add reverse query param while fetching job allocations

### DIFF
--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -248,10 +248,14 @@ func (s *HTTPServer) jobAllocations(resp http.ResponseWriter, req *http.Request,
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 	allAllocs, _ := strconv.ParseBool(req.URL.Query().Get("all"))
+	reverse, _ := strconv.ParseBool(req.URL.Query().Get("reverse"))
 
 	args := structs.JobSpecificRequest{
 		JobID: jobID,
 		All:   allAllocs,
+		QueryOptions: structs.QueryOptions {
+			Reverse: reverse,
+		},
 	}
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
 		return nil, nil

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1551,6 +1551,13 @@ func (j *Job) Allocations(args *structs.JobSpecificRequest,
 				return err
 			}
 
+			sort.Slice(allocs,  func(i,j int) bool {
+				if (args.QueryOptions.Reverse) {
+					return allocs[i].ID > allocs[j].ID
+				}
+				return allocs[i].ID < allocs[j].ID
+			})
+
 			// Convert to stubs
 			if len(allocs) > 0 {
 				reply.Allocations = make([]*structs.AllocListStub, 0, len(allocs))

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -1246,7 +1246,7 @@ The table below shows this endpoint's support for
 enabled, this value must match a namespace that the token is allowed to
 access. This is specified as a query string parameter.
 
-- `reverse` `(bool: false)` - Specifies the list of returned allocations to be sorted in the reverse lexicographical order. By default, they are sorted by lexicographical order.
+- `reverse` `(bool: false)` - Specifies the list of returned allocations to be sorted in the reverse lexicographical order. By default, they are lexicographically sorted.
 
 ### Sample Request
 

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -1246,6 +1246,8 @@ The table below shows this endpoint's support for
 enabled, this value must match a namespace that the token is allowed to
 access. This is specified as a query string parameter.
 
+- `reverse` `(bool: false)` - Specifies the list of returned allocations to be sorted in the reverse lexicographical order. By default, they are sorted by lexicographical order.
+
 ### Sample Request
 
 ```shell-session


### PR DESCRIPTION
#17742

Job allocations can now be reverse sorted. I have also updated the docs for it.