### PR TITLE
metrics: prevent negative counter from iowait decrease

### DIFF
--- a/.changelog/18835.txt
+++ b/.changelog/18835.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+metrics: Fixed a bug where CPU counters could report errors for negative values
+```

--- a/client/hoststats/host.go
+++ b/client/hoststats/host.go
@@ -273,7 +273,7 @@ func (h *HostCpuStatsCalculator) Calculate(times cpu.TimesStat) (idle float64, u
 	currentIdle := times.Idle
 	currentUser := times.User
 	currentSystem := times.System
-	currentTotal := times.Total()
+	currentTotal := times.Total() // this is Idle + currentBusy
 	currentBusy := times.User + times.System + times.Nice + times.Iowait + times.Irq +
 		times.Softirq + times.Steal + times.Guest + times.GuestNice
 
@@ -284,16 +284,16 @@ func (h *HostCpuStatsCalculator) Calculate(times cpu.TimesStat) (idle float64, u
 	total = ((currentBusy - h.prevBusy) / deltaTotal) * 100
 
 	// Protect against any invalid values
-	if math.IsNaN(idle) || math.IsInf(idle, 0) {
+	if math.IsNaN(idle) || math.IsInf(idle, 0) || idle < 0.0 {
 		idle = 100.0
 	}
-	if math.IsNaN(user) || math.IsInf(user, 0) {
+	if math.IsNaN(user) || math.IsInf(user, 0) || user < 0.0 {
 		user = 0.0
 	}
-	if math.IsNaN(system) || math.IsInf(system, 0) {
+	if math.IsNaN(system) || math.IsInf(system, 0) || system < 0.0 {
 		system = 0.0
 	}
-	if math.IsNaN(total) || math.IsInf(total, 0) {
+	if math.IsNaN(total) || math.IsInf(total, 0) || total < 0.0 {
 		total = 0.0
 	}
 


### PR DESCRIPTION
The iowait metric obtained from `/proc/stat` can under some circumstances decrease. The relevant condition is when an interrupt arrives on a different core than the one that gets woken up for the IO, and a particular counter in the kernel for that core gets decremented. This is documented in the man page for the `proc(5)` pseudo-filesystem, and considered an unfortunate behavior that can't be changed for the sake of ABI compatibility.

In Nomad, we get the current "busy" time (everything except for idle) and compare it to the previous busy time to get the counter increment. If the iowait counter decreases and the idle counter increases more than the increase in the total busy time, we can get a negative total. This previously caused a panic in our metrics collection (see #15861) but that is being prevented by reporting an error message.

Fix the bug by putting a zero floor on the values we return from the host CPU stats calculator.

Fixes: #15861
Fixes: #18804

Note for reviewers: this code has been moved around quite a bit in `main` since 1.6.x, so I'll need to do a separate PR for the backports.