### PR TITLE
scheduler: appropriately unblock evals with quotas

### DIFF
--- a/.changelog/18838.txt
+++ b/.changelog/18838.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler (Enterprise): auto-unblock evals with associated quotas when node resources are freed up
+```

--- a/nomad/blocked_evals.go
+++ b/nomad/blocked_evals.go
@@ -567,10 +567,13 @@ func (b *BlockedEvals) unblock(computedClass, quota string, index uint64) {
 	// never saw a node with the given computed class and thus needs to be
 	// unblocked for correctness.
 	for id, wrapped := range b.captured {
-		if quota != "" && wrapped.eval.QuotaLimitReached != quota {
+		if quota != "" &&
+			wrapped.eval.QuotaLimitReached != "" &&
+			wrapped.eval.QuotaLimitReached != quota {
 			// We are unblocking based on quota and this eval doesn't match
 			continue
-		} else if elig, ok := wrapped.eval.ClassEligibility[computedClass]; ok && !elig {
+		}
+		if elig, ok := wrapped.eval.ClassEligibility[computedClass]; ok && !elig {
 			// Can skip because the eval has explicitly marked the node class
 			// as ineligible.
 			continue


### PR DESCRIPTION
Fixes #17278

When an eval is blocked due to e.g. cpu exhausted on nodes, but there happens to also be a quota on the job's namespace, the eval would not get auto-unblocked when the node cpu got freed up.

This change ensures, when considering quota during BlockedEvals.unblock(), that the block was due to quota in the first place, so unblocking does not get skipped due to the mere existence of a quota on the namespace.