### PR TITLE
deps: bump go-set/v2 to alpha.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.4
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/go-set v0.1.8
-	github.com/hashicorp/go-set/v2 v2.0.0-alpha.2
+	github.com/hashicorp/go-set/v2 v2.0.0-alpha.3
 	github.com/hashicorp/go-sockaddr v1.0.2
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -892,8 +892,8 @@ github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.2 h1:phcbL8urUzF/kxA/Oj6awENa
 github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.2/go.mod h1:l8slYwnJA26yBz+ErHpp2IRCLr0vuOMGBORIz4rRiAs=
 github.com/hashicorp/go-set v0.1.8 h1:q2r58lFkJrikmC4I+vS3A+bn6QgR7EYeFD8kRiAIAnk=
 github.com/hashicorp/go-set v0.1.8/go.mod h1:wedp+UE6HoxBywExd7mrdGdcXOo3awtiELmnRnpzsKI=
-github.com/hashicorp/go-set/v2 v2.0.0-alpha.2 h1:lSoXIz3jTo0nNQ17H7tgB2iletJTaUF73mbEZ5Z91tM=
-github.com/hashicorp/go-set/v2 v2.0.0-alpha.2/go.mod h1:6q4nh8UCVZODn2tJ5RbJi8+ki7pjZBsAEYGt6yaGeTo=
+github.com/hashicorp/go-set/v2 v2.0.0-alpha.3 h1:ZpDBhigUACKvj4pVS973badI8ult/5U5TiPoPkdPgVc=
+github.com/hashicorp/go-set/v2 v2.0.0-alpha.3/go.mod h1:6q4nh8UCVZODn2tJ5RbJi8+ki7pjZBsAEYGt6yaGeTo=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.0
 
 require (
-	github.com/hashicorp/go-set/v2 v2.0.0-alpha.1
+	github.com/hashicorp/go-set/v2 v2.0.0-alpha.3
 	github.com/shoenig/test v0.6.7
 )
 

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,6 +1,6 @@
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/hashicorp/go-set/v2 v2.0.0-alpha.1 h1:vnuI6A2kou5+tcj5sF+cROU3mTeWPx2BGmsbBhBp/+E=
-github.com/hashicorp/go-set/v2 v2.0.0-alpha.1/go.mod h1:6q4nh8UCVZODn2tJ5RbJi8+ki7pjZBsAEYGt6yaGeTo=
+github.com/hashicorp/go-set/v2 v2.0.0-alpha.3 h1:ZpDBhigUACKvj4pVS973badI8ult/5U5TiPoPkdPgVc=
+github.com/hashicorp/go-set/v2 v2.0.0-alpha.3/go.mod h1:6q4nh8UCVZODn2tJ5RbJi8+ki7pjZBsAEYGt6yaGeTo=
 github.com/shoenig/test v0.6.7 h1:k92ohN9VyRfZn0ezNfwamtIBT/5byyfLVktRmL/Jmek=
 github.com/shoenig/test v0.6.7/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=


### PR DESCRIPTION
fixes a rather critical bug in .Equals implementation
