### PR TITLE
cl: note breaking change of numcores attribute on apple systems

### DIFF
--- a/.changelog/18843.txt
+++ b/.changelog/18843.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+client/fingerprint: The `cpu.numcores.power` node attribute has been renamed to `cpu.numcores.performance` on Apple Silicon nodes
+```


### PR DESCRIPTION
I goofed the name the first time around, "power" should have been
"performance" which is consistent with both Apple and Intel branding.
