### PR TITLE
docs: deprecate rsadecrypt

### DIFF
--- a/website/content/docs/job-specification/hcl2/functions/crypto/rsadecrypt.mdx
+++ b/website/content/docs/job-specification/hcl2/functions/crypto/rsadecrypt.mdx
@@ -6,11 +6,17 @@ description: The rsadecrypt function decrypts an RSA-encrypted message.
 
 # `rsadecrypt` Function
 
--> **Deprecated:** This function is deprecated and may be removed in the
-future. While it is possible to use safely, it encourages use of cryptographic
-primitives with [known weaknesses][attacks]. [Nomad Variables][nvars] and
-[HashiCorp Vault][vault] are the recommended ways to provide secrets to
-workloads.
+<Note title="Deprecated">
+This function is deprecated and may be removed in the future.
+</Note>
+
+<Warning>
+While it is possible to use safely, it encourages use of cryptographic
+primitives with <a href="https://en.wikipedia.org/wiki/PKCS_1#Attacks">known
+weaknesses</a>. <a href="/nomad/docs/concepts/variables">Nomad Variables</a>
+and <a href="/nomad/docs/integrations/vault-integration">HashiCorp Vault</a> are
+the recommended ways to provide secrets to workloads.
+</Warning>
 
 `rsadecrypt` decrypts an RSA-encrypted ciphertext, returning the corresponding
 cleartext.
@@ -36,7 +42,3 @@ negotiated out-of-band.
 > rsadecrypt(base64(file("${path.folder}/ciphertext")), file("privatekey.pem"))
 Hello, world!
 ```
-
-[attacks]: https://en.wikipedia.org/wiki/PKCS_1#Attacks
-[nvars]: /nomad/docs/concepts/variables
-[vault]: /nomad/docs/integrations/vault-integration

--- a/website/content/docs/job-specification/hcl2/functions/crypto/rsadecrypt.mdx
+++ b/website/content/docs/job-specification/hcl2/functions/crypto/rsadecrypt.mdx
@@ -6,6 +6,12 @@ description: The rsadecrypt function decrypts an RSA-encrypted message.
 
 # `rsadecrypt` Function
 
+-> **Deprecated:** This function is deprecated and may be removed in the
+future. While it is possible to use safely, it encourages use of cryptographic
+primitives with [known weaknesses][attacks]. [Nomad Variables][nvars] and
+[HashiCorp Vault][vault] are the recommended ways to provide secrets to
+workloads.
+
 `rsadecrypt` decrypts an RSA-encrypted ciphertext, returning the corresponding
 cleartext.
 
@@ -30,3 +36,7 @@ negotiated out-of-band.
 > rsadecrypt(base64(file("${path.folder}/ciphertext")), file("privatekey.pem"))
 Hello, world!
 ```
+
+[attacks]: https://en.wikipedia.org/wiki/PKCS_1#Attacks
+[nvars]: /nomad/docs/concepts/variables
+[vault]: /nomad/docs/integrations/vault-integration

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1316,7 +1316,12 @@
                   },
                   {
                     "title": "rsadecrypt",
-                    "path": "job-specification/hcl2/functions/crypto/rsadecrypt"
+                    "path": "job-specification/hcl2/functions/crypto/rsadecrypt",
+                    "badge": {
+                      "text": "Deprecated",
+                      "type": "outlined",
+                      "color": "neutral"
+                    }
                   },
                   {
                     "title": "sha1",


### PR DESCRIPTION
`rsadecrypt` uses `PKCS #1 v1.5` padding which has multiple known weaknesses. While it is possible to use safely in Nomad, we should not encourage our users to use bad cryptographic primitives.

If users want to decrypt secrets in jobspecs we should choose a cryptographic primitive designed for that purpose. `rsadecrypt` was inherited from Terraform which only implemented it to support decrypting Window's passwords on AWS EC2 instances:

https://github.com/hashicorp/terraform/pull/16647

This is not something that should ever be done in a jobspec, therefore there's no reason for Nomad to support this HCL2 function.

Preview to save you a few clicks: 
![image](https://github.com/hashicorp/nomad/assets/113362/3a250bf4-0d5c-4857-8071-e42008dd3c12)
