### PR TITLE
add deprecation warning for Vault/Consul token usage

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -612,6 +612,12 @@ func (c *Command) setupAgent(config *Config, logger hclog.InterceptLogger, logOu
 	}
 	c.httpServers = httpServers
 
+	for _, vault := range config.Vaults {
+		if vault.Token != "" {
+			logger.Warn("Setting a Vault token in the agent configuration is deprecated and will be removed in Nomad 1.9. Migrate your Vault configuration to use workload identity.", "cluster", vault.Name)
+		}
+	}
+
 	// If DisableUpdateCheck is not enabled, set up update checking
 	// (DisableUpdateCheck is false by default)
 	if config.DisableUpdateCheck != nil && !*config.DisableUpdateCheck {

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -132,6 +132,17 @@ func (c *JobRevertCommand) Run(args []string) int {
 		vaultToken = os.Getenv("VAULT_TOKEN")
 	}
 
+	if consulToken != "" {
+		c.Ui.Warn(strings.TrimSpace(`
+Warning: setting a Consul token when submitting a job is deprecated and will be
+removed in Nomad 1.9. Migrate your Consul configuration to use workload identity.`))
+	}
+	if vaultToken != "" {
+		c.Ui.Warn(strings.TrimSpace(`
+Warning: setting a Vault token when submitting a job is deprecated and will be
+removed in Nomad 1.9. Migrate your Vault configuration to use workload identity.`))
+	}
+
 	// Parse the job version
 	revertVersion, ok, err := parseVersion(args[1])
 	if !ok {

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -280,6 +280,9 @@ func (c *JobRunCommand) Run(args []string) int {
 	}
 
 	if consulToken != "" {
+		c.Ui.Warn(strings.TrimSpace(`
+Warning: setting a Consul token when submitting a job is deprecated and will be
+removed in Nomad 1.9. Migrate your Consul configuration to use workload identity.`))
 		job.ConsulToken = pointer.Of(consulToken)
 	}
 
@@ -294,6 +297,9 @@ func (c *JobRunCommand) Run(args []string) int {
 	}
 
 	if vaultToken != "" {
+		c.Ui.Warn(strings.TrimSpace(`
+Warning: setting a Vault token when submitting a job is deprecated and will be
+removed in Nomad 1.9. Migrate your Vault configuration to use workload identity.`))
 		job.VaultToken = pointer.Of(vaultToken)
 	}
 


### PR DESCRIPTION
Submitting a Consul or Vault token with a job is deprecated in Nomad 1.7 and intended for removal in Nomad 1.9. Add a deprecation warning to the CLI when the user passes in the appropriate flag or environment variable.

Nomad agents will no longer need a Vault token when configured with workload identity, and we'll ignore Vault tokens in the agent config after Nomad 1.9. Log a warning at agent startup.

Ref: https://github.com/hashicorp/nomad/issues/15617
Ref: https://github.com/hashicorp/nomad/issues/15618

---

Resulting log line in the agent:

> 2023-10-25T10:15:27.664-0400 [WARN]  agent: Setting a Vault token in the agent configuration is deprecated and will be removed in Nomad 1.9. Migrate your Vault configuration to use workload identity.: cluster=default

Resulting output from `nomad job run`:

```
$ nomad job run -vault-token hvs.RYwFOzaEc8aKyNIMzNiHfi4w ~/ws/nomad/etc/jobs/httpd.nomad
Warning: setting a Vault token when submitting a job is deprecated and will be
removed in Nomad 1.9. Migrate your Vault configuration to use workload identity.
==> 2023-10-25T10:16:19-04:00: Monitoring evaluation "a884a82e"
    2023-10-25T10:16:19-04:00: Evaluation triggered by job "httpd"
    2023-10-25T10:16:20-04:00: Evaluation within deployment: "25cc4819"
    2023-10-25T10:16:20-04:00: Allocation "a4ca7d9b" created: node "7a1e78e3", group "web"
    2023-10-25T10:16:20-04:00: Evaluation status changed: "pending" -> "complete"
==> 2023-10-25T10:16:20-04:00: Evaluation "a884a82e" finished with status "complete"
==> 2023-10-25T10:16:20-04:00: Monitoring deployment "25cc4819"
  ⠇ Deployment "25cc4819" in progress...
  ...
```
