### PR TITLE
Fix the "Starting" allocations link

### DIFF
--- a/ui/app/components/allocation-status-bar.js
+++ b/ui/app/components/allocation-status-bar.js
@@ -59,7 +59,7 @@ export default class AllocationStatusBar extends DistributionBar {
         value: allocs.startingAllocs,
         className: 'starting',
         layers: 2,
-        legendLink: this.generateLegendLink(this.job, 'starting'),
+        legendLink: this.generateLegendLink(this.job, 'pending'),
       },
       {
         label: 'Running',


### PR DESCRIPTION
Before this commit, it would bring you to the list of allocations
filtered by status=starting. This status does not exist in the Status
drop-down on the Allocations section of a job in the UI.