### PR TITLE
consul WI: rename default auth method for services

### DIFF
--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -235,7 +235,7 @@ var basicConfig = &Config{
 		ChecksUseAdvertise:        &trueValue,
 		Timeout:                   5 * time.Second,
 		TimeoutHCL:                "5s",
-		ServiceIdentityAuthMethod: "nomad-workloads",
+		ServiceIdentityAuthMethod: "nomad-services",
 		ServiceIdentity: &config.WorkloadIdentityConfig{
 			Audience: []string{"consul.io", "nomad.dev"},
 			Env:      pointer.Of(false),
@@ -276,7 +276,7 @@ var basicConfig = &Config{
 			ChecksUseAdvertise:        &trueValue,
 			Timeout:                   5 * time.Second,
 			TimeoutHCL:                "5s",
-			ServiceIdentityAuthMethod: "nomad-workloads",
+			ServiceIdentityAuthMethod: "nomad-services",
 			ServiceIdentity: &config.WorkloadIdentityConfig{
 				Audience: []string{"consul.io", "nomad.dev"},
 				Env:      pointer.Of(false),

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -245,7 +245,7 @@ consul {
   auto_advertise         = true
   checks_use_advertise   = true
   timeout                = "5s"
-  service_auth_method    = "nomad-workloads"
+  service_auth_method    = "nomad-services"
   task_auth_method       = "nomad-tasks"
 
   service_identity {

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -167,7 +167,7 @@
       "server_rpc_check_name": "nomad-server-rpc-health-check",
       "server_serf_check_name": "nomad-server-serf-health-check",
       "server_service_name": "nomad",
-      "service_auth_method": "nomad-workloads",
+      "service_auth_method": "nomad-services",
       "task_auth_method": "nomad-tasks",
 
       "service_identity": {

--- a/e2e/consulcompat/run_ce_test.go
+++ b/e2e/consulcompat/run_ce_test.go
@@ -73,7 +73,7 @@ func testConsulBuild(t *testing.T, b build, baseDir string) {
 			Address:                   consulHTTPAddr,
 			Auth:                      "",
 			Token:                     consulToken,
-			ServiceIdentityAuthMethod: "nomad-workloads",
+			ServiceIdentityAuthMethod: "nomad-services",
 			ServiceIdentity: &testutil.WorkloadIdentityConfig{
 				Audience: []string{"consul.io"},
 				TTL:      "1h",
@@ -185,9 +185,9 @@ func setupConsulJWTAuthForServices(t *testing.T, consulAPI *consulapi.Client, ad
 	// note: we can't include NamespaceRules here because Consul CE doesn't
 	// support namespaces
 	_, _, err := consulAPI.ACL().AuthMethodCreate(&consulapi.ACLAuthMethod{
-		Name:          "nomad-workloads",
+		Name:          "nomad-services",
 		Type:          "jwt",
-		DisplayName:   "nomad-workloads",
+		DisplayName:   "nomad-services",
 		Description:   "login method for Nomad workload identities (WI)",
 		MaxTokenTTL:   time.Hour,
 		TokenLocality: "local",
@@ -201,7 +201,7 @@ func setupConsulJWTAuthForServices(t *testing.T, consulAPI *consulapi.Client, ad
 	rule := &consulapi.ACLBindingRule{
 		ID:          "",
 		Description: "binding rule for Nomad workload identities (WI) for services",
-		AuthMethod:  "nomad-workloads",
+		AuthMethod:  "nomad-services",
 		Selector:    "",
 		BindType:    "service",
 		BindName:    "${value.nomad_namespace}-${value.nomad_service}",

--- a/e2e/vaultcompat/cluster_setup_test.go
+++ b/e2e/vaultcompat/cluster_setup_test.go
@@ -26,7 +26,7 @@ func authConfigJWT(jwksURL string) map[string]any {
 	return map[string]any{
 		"jwks_url":           jwksURL,
 		"jwt_supported_algs": []string{"EdDSA"},
-		"default_role":       "nomad-workloads",
+		"default_role":       "nomad-services",
 	}
 }
 

--- a/e2e/vaultcompat/cluster_setup_test.go
+++ b/e2e/vaultcompat/cluster_setup_test.go
@@ -26,7 +26,7 @@ func authConfigJWT(jwksURL string) map[string]any {
 	return map[string]any{
 		"jwks_url":           jwksURL,
 		"jwt_supported_algs": []string{"EdDSA"},
-		"default_role":       "nomad-services",
+		"default_role":       "nomad-workloads",
 	}
 }
 

--- a/nomad/structs/consul.go
+++ b/nomad/structs/consul.go
@@ -23,7 +23,7 @@ const (
 	// ConsulServicesDefaultAuthMethodName is the default JWT auth method name
 	// that has to be configured in Consul in order to authenticate Nomad
 	// services.
-	ConsulServicesDefaultAuthMethodName = "nomad-workloads"
+	ConsulServicesDefaultAuthMethodName = "nomad-services"
 
 	// ConsulTasksDefaultAuthMethodName the default JWT auth method name that
 	// has to be configured in Consul in order to authenticate Nomad tasks (used

--- a/website/content/docs/configuration/consul.mdx
+++ b/website/content/docs/configuration/consul.mdx
@@ -131,7 +131,7 @@ value for the [`name`](#name) field.
   Consul service name defined in the `server_service_name` option. This search
   only happens if the server does not have a leader.
 
-- `service_auth_method` `(string: "nomad-workloads")` - Specifies the name of the
+- `service_auth_method` `(string: "nomad-services")` - Specifies the name of the
   Consul [authentication method][auth-method] that will be used to login with a
   Nomad JWT for services.
 

--- a/website/content/docs/integrations/consul-integration.mdx
+++ b/website/content/docs/integrations/consul-integration.mdx
@@ -79,7 +79,7 @@ match those shown here.
 
 Using that configuration file, you'll create two different Consul Auth Methods:
 
-* The first, named `nomad-workloads`, controls authentication for Service
+* The first, named `nomad-services`, controls authentication for Service
   Identity tokens used to register services and configure Consul Connect. You'll
   create a binding rule for this method that maps Nomad `service` blocks to
   Consul services.
@@ -101,7 +101,7 @@ In Consul Community Edition, you'll always bind to the default Consul namespace.
 
 ```shell-session
 $ consul acl auth-method create \
-         -name 'nomad-workloads' \
+         -name 'nomad-services' \
          -type jwt \
          -description 'login method for Nomad services' \
          -format json \
@@ -117,7 +117,7 @@ In Consul Enterprise, you'll map a Nomad namespace to a Consul namespace.
 
 ```shell-session
 $ consul acl auth-method create \
-         -name 'nomad-workloads' \
+         -name 'nomad-services' \
          -type jwt \
          -description 'login method for Nomad services' \
          -format json \
@@ -134,7 +134,7 @@ Consul Service Identity.
 
 ```shell-session
 $ consul acl binding-rule create \
-         -method 'nomad-workloads' \
+         -method 'nomad-services' \
          -description 'binding rule for Nomad workload identities (WI)' \
          -bind-type service \
          -bind-name '${value.nomad_namespace}-${value.nomad_service}'


### PR DESCRIPTION
It should be called `nomad-services` instead of `nomad-workloads`. 