### PR TITLE
deps: purge and prohibit use of go-set/v1

### DIFF
--- a/.semgrep/imports.yml
+++ b/.semgrep/imports.yml
@@ -9,6 +9,7 @@ rules:
       - pattern: '"github.com/hashicorp/consul"'
       - pattern: '"github.com/hashicorp/consul/command/flags"'
       - pattern: '"github.com/hashicorp/consul/sdk"'
+      - pattern: '"github.com/hashicorp/go-set"'
       - pattern: '"golang.org/x/exp/slices"'
       - pattern: '"golang.org/x/exp/maps"'
     message: "Import of this package has been disallowed"

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,6 @@ require (
 	github.com/hashicorp/go-plugin v1.4.10
 	github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.4
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
-	github.com/hashicorp/go-set v0.1.8
 	github.com/hashicorp/go-set/v2 v2.0.0-alpha.3
 	github.com/hashicorp/go-sockaddr v1.0.2
 	github.com/hashicorp/go-syslog v1.0.0
@@ -213,6 +212,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7 // indirect
 	github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1 // indirect
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.2 // indirect
+	github.com/hashicorp/go-set v0.1.8 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/mdns v1.0.4 // indirect
 	github.com/hashicorp/vault/api/auth/kubernetes v0.3.0 // indirect

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -33,7 +33,7 @@ import (
 	"github.com/hashicorp/cronexpr"
 	"github.com/hashicorp/go-msgpack/codec"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/client/lib/idset"


### PR DESCRIPTION
I think go-set/v1 got added back in the merging of a branch; add semgrep rules to keep it out.