### PR TITLE
e2e: fix bind name to allow Connect reachability

### DIFF
--- a/e2e/consulcompat/input/connect.nomad.hcl
+++ b/e2e/consulcompat/input/connect.nomad.hcl
@@ -32,8 +32,7 @@ job "countdash" {
       mode = "bridge"
 
       port "http" {
-        static = 9002
-        to     = 9002
+        to = 9002
       }
     }
 

--- a/e2e/consulcompat/run_ce_test.go
+++ b/e2e/consulcompat/run_ce_test.go
@@ -204,7 +204,7 @@ func setupConsulJWTAuthForServices(t *testing.T, consulAPI *consulapi.Client, ad
 		AuthMethod:  "nomad-services",
 		Selector:    "",
 		BindType:    "service",
-		BindName:    "${value.nomad_namespace}-${value.nomad_service}",
+		BindName:    "${value.nomad_service}",
 	}
 	_, _, err = consulAPI.ACL().BindingRuleCreate(rule, nil)
 	must.NoError(t, err, must.Sprint("could not create Consul binding rule"))

--- a/e2e/consulcompat/run_ce_test.go
+++ b/e2e/consulcompat/run_ce_test.go
@@ -34,7 +34,7 @@ func testConsulBuildLegacy(t *testing.T, b build, baseDir string) {
 		// need it up to serve the JWKS endpoint
 
 		consulCfg := &testutil.Consul{
-			//Name:    "default", // TODO: restore once we're using the new one
+			Name:    "default",
 			Address: consulHTTPAddr,
 			Auth:    "",
 			Token:   consulToken,

--- a/e2e/consulcompat/run_ce_test.go
+++ b/e2e/consulcompat/run_ce_test.go
@@ -34,7 +34,7 @@ func testConsulBuildLegacy(t *testing.T, b build, baseDir string) {
 		// need it up to serve the JWKS endpoint
 
 		consulCfg := &testutil.Consul{
-			Name:    "default",
+			//Name:    "default", // TODO: restore once we're using the new one
 			Address: consulHTTPAddr,
 			Auth:    "",
 			Token:   consulToken,

--- a/e2e/consulcompat/shared_run_test.go
+++ b/e2e/consulcompat/shared_run_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -78,7 +79,29 @@ func runConnectJob(t *testing.T, nc *nomadapi.Client) {
 	t.Cleanup(func() {
 		_, _, err = jobs.Deregister(*job.Name, true, nil)
 		must.NoError(t, err, must.Sprint("failed to deregister job"))
+
+		must.Wait(t, wait.InitialSuccess(
+			wait.ErrorFunc(func() error {
+				allocs, _, err := jobs.Allocations(*job.ID, false, nil)
+				if err != nil {
+					return err
+				}
+				for _, alloc := range allocs {
+					if alloc.ClientStatus == "running" {
+						return fmt.Errorf("expected alloc %s to be stopped", alloc.ID)
+					}
+				}
+				return nil
+			}),
+			wait.Timeout(30*time.Second),
+			wait.Gap(1*time.Second),
+		))
+
+		// give Nomad time to sync Consul before shutdown
+		time.Sleep(3 * time.Second)
 	})
+
+	var dashboardAllocID string
 
 	must.Wait(t, wait.InitialSuccess(
 		wait.ErrorFunc(func() error {
@@ -90,6 +113,9 @@ func runConnectJob(t *testing.T, nc *nomadapi.Client) {
 				return fmt.Errorf("expected 2 alloc, got %d", n)
 			}
 			for _, alloc := range allocs {
+				if alloc.TaskGroup == "dashboard" {
+					dashboardAllocID = alloc.ID // save for later
+				}
 				if alloc.ClientStatus != "running" {
 					return fmt.Errorf(
 						"expected alloc status running, got %s for %s",
@@ -103,16 +129,30 @@ func runConnectJob(t *testing.T, nc *nomadapi.Client) {
 	))
 
 	// Ensure that the dashboard is reachable and can connect to the API
-	allocs, _, err := jobs.Allocations(*job.ID, false, nil)
+	alloc, _, err := nc.Allocations().Info(dashboardAllocID, nil)
 	must.NoError(t, err)
-	for _, alloc := range allocs {
-		if alloc.TaskGroup == "dashboard" {
-			resp, err := http.Get("http://127.0.0.1:9002")
-			must.NoError(t, err)
-			defer resp.Body.Close()
-			body, _ := io.ReadAll(resp.Body)
-			t.Logf(string(body))
-		}
-	}
 
+	network := alloc.AllocatedResources.Shared.Networks[0]
+	dynPort := network.DynamicPorts[0]
+	addr := fmt.Sprintf("http://%s:%d", network.IP, dynPort.Value)
+
+	// the alloc may be running but not yet listening, so give it a few seconds
+	// to start up
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(func() error {
+			info, err := http.Get(addr)
+			if err != nil {
+				return err
+			}
+			defer info.Body.Close()
+			body, _ := io.ReadAll(info.Body)
+
+			if !strings.Contains(string(body), "Dashboard") {
+				return fmt.Errorf("expected body to contain \"Dashboard\"")
+			}
+			return nil
+		}),
+		wait.Timeout(10*time.Second),
+		wait.Gap(1*time.Second),
+	))
 }

--- a/e2e/consulcompat/shared_setup_test.go
+++ b/e2e/consulcompat/shared_setup_test.go
@@ -49,7 +49,7 @@ func startConsul(t *testing.T, b build, baseDir, ns string) (string, *consulapi.
 			}
 			c.Datacenter = consulDC1
 			c.DataDir = filepath.Join(baseDir, binDir, b.Version, consulDataDir)
-			c.LogLevel = "info"
+			c.LogLevel = "debug"
 			c.Connect = map[string]any{"enabled": true}
 			c.Server = true
 

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -46,6 +46,7 @@ type TestServerConfig struct {
 	Vault             *VaultConfig  `json:"vault,omitempty"`
 	ACL               *ACLConfig    `json:"acl,omitempty"`
 	DevMode           bool          `json:"-"`
+	DevConnectMode    bool          `json:"-"`
 	Stdout, Stderr    io.Writer     `json:"-"`
 }
 
@@ -174,6 +175,8 @@ func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
 	if err := vcmd.Run(); err != nil {
 		t.Skipf("nomad version failed: %v", err)
 	}
+	out, _ := vcmd.Output()
+	t.Logf("nomad version: %s", out)
 
 	dataDir, err := os.MkdirTemp("", "nomad")
 	if err != nil {
@@ -218,6 +221,9 @@ func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
 	args := []string{"agent", "-config", configFile.Name()}
 	if nomadConfig.DevMode {
 		args = append(args, "-dev")
+	}
+	if nomadConfig.DevConnectMode {
+		args = append(args, "-dev-connect")
 	}
 
 	// Start the server


### PR DESCRIPTION
The `BindName` for JWT authentication should always bind to the `nomad_service` field in the JWT and not include the namespace, as the `nomad_service` is what's actually registered in Consul. 

* Fix the binding rule for the `consulcompat` test 
* Add a reachability assertion so that we don't miss regressions.
* Ensure we have a clean shutdown so that we don't leak state (containers and iptables) between tests.

---

A note on debugging the original configuration problem. The allocations start up just fine and are healthy, so Nomad wasn't able to give much help here. To debug, I compared the results of `consul catalog services` with the results of `consul acl token list`, and looked for the tokens that resulted from the login. The `Service Identities` block in the token listing was the clue needed.