### PR TITLE
docs: update link to tc-redirect-tap

### DIFF
--- a/website/content/plugins/drivers/community/firecracker-task-driver.mdx
+++ b/website/content/plugins/drivers/community/firecracker-task-driver.mdx
@@ -124,7 +124,7 @@ match the name of the network, and use the .conflist extension.
 - [tc-redirect-tap][tc-redirect-tap]
 
 [plugin_dir]: /nomad/docs/configuration#plugin_dir
-[tc-redirect-tap]: https://github.com/firecracker-microvm/firecracker-go-sdk/tree/master/cni
+[tc-redirect-tap]: https://github.com/awslabs/tc-redirect-tap
 [container network plugins]: https://github.com/containernetworking/plugins
 [firecracker binary]: https://github.com/firecracker-microvm/firecracker/releases
 [firecracker-task-guide]: https://github.com/cneira/firecracker-task-driver


### PR DESCRIPTION
The location of tc-redirect-tap has been changed and the docs are now out of date.
This PR points the link in the Firecracker task driver to the correct repository.

The new location is [here](https://github.com/awslabs/tc-redirect-tap) (https://github.com/awslabs/tc-redirect-tap)