### PR TITLE
vault: derive token using `create_from_role`

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -91,15 +91,16 @@ func (tr *TaskRunner) initHooks() {
 	// If Vault is enabled, add the hook
 	if task.Vault != nil && tr.vaultClientFunc != nil {
 		tr.runnerHooks = append(tr.runnerHooks, newVaultHook(&vaultHookConfig{
-			vaultBlock: task.Vault,
-			clientFunc: tr.vaultClientFunc,
-			events:     tr,
-			lifecycle:  tr,
-			updater:    tr,
-			logger:     hookLogger,
-			alloc:      tr.Alloc(),
-			task:       tr.Task(),
-			widmgr:     tr.widmgr,
+			vaultBlock:       task.Vault,
+			vaultConfigsFunc: tr.clientConfig.GetVaultConfigs,
+			clientFunc:       tr.vaultClientFunc,
+			events:           tr,
+			lifecycle:        tr,
+			updater:          tr,
+			logger:           hookLogger,
+			alloc:            tr.Alloc(),
+			task:             tr.Task(),
+			widmgr:           tr.widmgr,
 		}))
 	}
 

--- a/client/allocrunner/taskrunner/task_runner_linux_test.go
+++ b/client/allocrunner/taskrunner/task_runner_linux_test.go
@@ -29,6 +29,7 @@ func TestTaskRunner_DisableFileForVaultToken_UpgradePath(t *testing.T) {
 		"run_for": "0s",
 	}
 	task.Vault = &structs.Vault{
+		Cluster:  structs.VaultDefaultCluster,
 		Policies: []string{"default"},
 	}
 

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -1602,7 +1602,10 @@ func TestTaskRunner_BlockForVaultToken(t *testing.T) {
 	task.Config = map[string]interface{}{
 		"run_for": "0s",
 	}
-	task.Vault = &structs.Vault{Policies: []string{"default"}}
+	task.Vault = &structs.Vault{
+		Cluster:  structs.VaultDefaultCluster,
+		Policies: []string{"default"},
+	}
 
 	// Control when we get a Vault token
 	token := "1234"
@@ -1692,6 +1695,7 @@ func TestTaskRunner_DisableFileForVaultToken(t *testing.T) {
 		"run_for": "0s",
 	}
 	task.Vault = &structs.Vault{
+		Cluster:     structs.VaultDefaultCluster,
 		Policies:    []string{"default"},
 		DisableFile: true,
 	}
@@ -1741,7 +1745,10 @@ func TestTaskRunner_DeriveToken_Retry(t *testing.T) {
 	ci.Parallel(t)
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
-	task.Vault = &structs.Vault{Policies: []string{"default"}}
+	task.Vault = &structs.Vault{
+		Cluster:  structs.VaultDefaultCluster,
+		Policies: []string{"default"},
+	}
 
 	// Fail on the first attempt to derive a vault token
 	token := "1234"
@@ -1821,7 +1828,10 @@ func TestTaskRunner_DeriveToken_Unrecoverable(t *testing.T) {
 	task.Config = map[string]interface{}{
 		"run_for": "0s",
 	}
-	task.Vault = &structs.Vault{Policies: []string{"default"}}
+	task.Vault = &structs.Vault{
+		Cluster:  structs.VaultDefaultCluster,
+		Policies: []string{"default"},
+	}
 
 	// Error the token derivation
 	vc, err := vaultclient.NewMockVaultClient(structs.VaultDefaultCluster)
@@ -2135,7 +2145,10 @@ func TestTaskRunner_RestartSignalTask_NotRunning(t *testing.T) {
 	}
 
 	// Use vault to block the start
-	task.Vault = &structs.Vault{Policies: []string{"default"}}
+	task.Vault = &structs.Vault{
+		Cluster:  structs.VaultDefaultCluster,
+		Policies: []string{"default"},
+	}
 
 	// Control when we get a Vault token
 	waitCh := make(chan struct{}, 1)
@@ -2361,7 +2374,10 @@ func TestTaskRunner_Template_NewVaultToken(t *testing.T) {
 			ChangeMode:   structs.TemplateChangeModeNoop,
 		},
 	}
-	task.Vault = &structs.Vault{Policies: []string{"default"}}
+	task.Vault = &structs.Vault{
+		Cluster:  structs.VaultDefaultCluster,
+		Policies: []string{"default"},
+	}
 
 	vc, err := vaultclient.NewMockVaultClient(structs.VaultDefaultCluster)
 	must.NoError(t, err)
@@ -2440,6 +2456,7 @@ func TestTaskRunner_VaultManager_Restart(t *testing.T) {
 		"run_for": "10s",
 	}
 	task.Vault = &structs.Vault{
+		Cluster:    structs.VaultDefaultCluster,
 		Policies:   []string{"default"},
 		ChangeMode: structs.VaultChangeModeRestart,
 	}
@@ -2516,6 +2533,7 @@ func TestTaskRunner_VaultManager_Signal(t *testing.T) {
 		"run_for": "10s",
 	}
 	task.Vault = &structs.Vault{
+		Cluster:      structs.VaultDefaultCluster,
 		Policies:     []string{"default"},
 		ChangeMode:   structs.VaultChangeModeSignal,
 		ChangeSignal: "SIGUSR1",

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -179,6 +179,8 @@ type Config struct {
 	ConsulConfigs map[string]*structsc.ConsulConfig
 
 	// VaultConfig is this Agent's default Vault configuration
+	//
+	// Deprecated: use GetVaultConfigs() instead.
 	VaultConfig *structsc.VaultConfig
 
 	// VaultConfigs is a map of Vault configurations, here to support features

--- a/client/vaultclient/vaultclient_testing.go
+++ b/client/vaultclient/vaultclient_testing.go
@@ -5,6 +5,7 @@ package vaultclient
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -64,6 +65,9 @@ func (vc *MockVaultClient) DeriveTokenWithJWT(ctx context.Context, req JWTLoginR
 	}
 
 	token := uuid.Generate()
+	if req.Role != "" {
+		token = fmt.Sprintf("%s-%s", token, req.Role)
+	}
 	vc.jwtTokens[req.JWT] = token
 	return token, nil
 }


### PR DESCRIPTION
Fallback to the ACL role defined in the client's `create_from_role` configuration when using the JWT flow and the task does not specify a role to use.