### PR TITLE
cli: deprecate -vault-token flag

### DIFF
--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -226,6 +226,13 @@ func (c *JobPlanCommand) Run(args []string) int {
 		vaultToken = os.Getenv("VAULT_TOKEN")
 	}
 
+	if vaultToken != "" {
+		c.Ui.Warn(strings.TrimSpace(`
+Warning: setting a Vault token when submitting a job is deprecated and will be
+removed in Nomad 1.9. Migrate your Vault configuration to use workload identity.`))
+		job.VaultToken = pointer.Of(vaultToken)
+	}
+
 	// Set the vault token.
 	if vaultToken != "" {
 		job.VaultToken = pointer.Of(vaultToken)


### PR DESCRIPTION
Apply the same deprecation notice from #18863 to the `nomad job plan` command.