### PR TITLE
identity: default to RS256 for new workload ids

### DIFF
--- a/api/internal/testutil/server.go
+++ b/api/internal/testutil/server.go
@@ -297,19 +297,27 @@ func (s *TestServer) waitForAPI() {
 }
 
 // waitForLeader waits for the Nomad server's HTTP API to become
-// available, and then waits for a known leader and an index of
-// 1 or more to be observed to confirm leader election is done.
+// available, and then waits for the keyring to be intialized. This implies a
+// leader has been elected and Raft writes have occurred.
 func (s *TestServer) waitForLeader() {
 	f := func() error {
-		// Query the API and check the status code
-		// Using this endpoint as it is does not have restricted access
-		resp, err := s.HTTPClient.Get(s.url("/v1/status/leader"))
+		resp, err := s.HTTPClient.Get(s.url("/.well-known/jwks.json"))
 		if err != nil {
-			return fmt.Errorf("failed to get leader: %w", err)
+			return fmt.Errorf("failed to contact leader: %w", err)
 		}
 		defer func() { _ = resp.Body.Close() }()
 		if err = s.requireOK(resp); err != nil {
 			return fmt.Errorf("leader response is not ok: %w", err)
+		}
+
+		jwks := struct {
+			Keys []interface{} `json:"keys"`
+		}{}
+		if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+			return fmt.Errorf("error decoding jwks response: %w", err)
+		}
+		if len(jwks.Keys) == 0 {
+			return fmt.Errorf("no keys found")
 		}
 		return nil
 	}

--- a/api/internal/testutil/server.go
+++ b/api/internal/testutil/server.go
@@ -296,9 +296,9 @@ func (s *TestServer) waitForAPI() {
 	)
 }
 
-// waitForLeader waits for the Nomad server's HTTP API to become
-// available, and then waits for the keyring to be intialized. This implies a
-// leader has been elected and Raft writes have occurred.
+// waitForLeader waits for the Nomad server's HTTP API to become available, and
+// then waits for the keyring to be intialized. This implies a leader has been
+// elected and Raft writes have occurred.
 func (s *TestServer) waitForLeader() {
 	f := func() error {
 		resp, err := s.HTTPClient.Get(s.url("/.well-known/jwks.json"))

--- a/api/internal/testutil/server.go
+++ b/api/internal/testutil/server.go
@@ -225,7 +225,7 @@ func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
 
 	// Wait for the server to be ready
 	if nomadConfig.Server.Enabled && nomadConfig.Server.BootstrapExpect != 0 {
-		server.waitForLeader()
+		server.waitForServers()
 	} else {
 		server.waitForAPI()
 	}
@@ -296,10 +296,10 @@ func (s *TestServer) waitForAPI() {
 	)
 }
 
-// waitForLeader waits for the Nomad server's HTTP API to become available, and
-// then waits for the keyring to be intialized. This implies a leader has been
-// elected and Raft writes have occurred.
-func (s *TestServer) waitForLeader() {
+// waitForServers waits for the Nomad server's HTTP API to become available,
+// and then waits for the keyring to be intialized. This implies a leader has
+// been elected and Raft writes have occurred.
+func (s *TestServer) waitForServers() {
 	f := func() error {
 		resp, err := s.HTTPClient.Get(s.url("/.well-known/jwks.json"))
 		if err != nil {

--- a/client/vaultclient/vaultclient_test.go
+++ b/client/vaultclient/vaultclient_test.go
@@ -32,7 +32,7 @@ const (
 	jwtAuthConfigTemplate = `
 {
   "jwks_url": "<<.JWKSURL>>",
-  "jwt_supported_algs": ["EdDSA"],
+  "jwt_supported_algs": ["RS256", "EdDSA"],
   "default_role": "nomad-workloads"
 }
 `

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -1560,7 +1560,7 @@ func benchmarkJsonEncoding(b *testing.B, handle *codec.JsonHandle) {
 func httpTest(t testing.TB, cb func(c *Config), f func(srv *TestAgent)) {
 	s := makeHTTPServer(t, cb)
 	defer s.Shutdown()
-	testutil.WaitForKeyring(t, s.Agent.RPC, "global")
+	testutil.WaitForKeyring(t, s.Agent.RPC, s.Config.Region)
 	f(s)
 }
 
@@ -1572,7 +1572,7 @@ func httpACLTest(t testing.TB, cb func(c *Config), f func(srv *TestAgent)) {
 		}
 	})
 	defer s.Shutdown()
-	testutil.WaitForKeyring(t, s.Agent.RPC, "global")
+	testutil.WaitForKeyring(t, s.Agent.RPC, s.Config.Region)
 	f(s)
 }
 

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -1560,7 +1560,7 @@ func benchmarkJsonEncoding(b *testing.B, handle *codec.JsonHandle) {
 func httpTest(t testing.TB, cb func(c *Config), f func(srv *TestAgent)) {
 	s := makeHTTPServer(t, cb)
 	defer s.Shutdown()
-	testutil.WaitForLeader(t, s.Agent.RPC)
+	testutil.WaitForKeyring(t, s.Agent.RPC, "global")
 	f(s)
 }
 
@@ -1572,7 +1572,7 @@ func httpACLTest(t testing.TB, cb func(c *Config), f func(srv *TestAgent)) {
 		}
 	})
 	defer s.Shutdown()
-	testutil.WaitForLeader(t, s.Agent.RPC)
+	testutil.WaitForKeyring(t, s.Agent.RPC, "global")
 	f(s)
 }
 

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -192,15 +192,7 @@ RETRY:
 
 	failed := false
 	if a.Config.NomadConfig.BootstrapExpect == 1 && a.Config.Server.Enabled {
-		testutil.WaitForResult(func() (bool, error) {
-			args := &structs.GenericRequest{}
-			var leader string
-			err := a.RPC("Status.Leader", args, &leader)
-			return leader != "", err
-		}, func(err error) {
-			a.T.Logf("failed to find leader: %v", err)
-			failed = true
-		})
+		testutil.WaitForKeyring(a.T, a.RPC, a.Config.Region)
 	} else {
 		testutil.WaitForResult(func() (bool, error) {
 			req, _ := http.NewRequest(http.MethodGet, "/v1/agent/self", nil)

--- a/command/recommendation_dismiss_test.go
+++ b/command/recommendation_dismiss_test.go
@@ -96,6 +96,7 @@ func TestRecommendationDismissCommand_Run(t *testing.T) {
 }
 
 func TestRecommendationDismissCommand_AutocompleteArgs(t *testing.T) {
+	ci.Parallel(t)
 	srv, client, url := testServer(t, false, nil)
 	defer srv.Shutdown()
 
@@ -113,7 +114,6 @@ func TestRecommendationDismissCommand_AutocompleteArgs(t *testing.T) {
 }
 
 func testRecommendationAutocompleteCommand(t *testing.T, client *api.Client, srv *agent.TestAgent, cmd *RecommendationAutocompleteCommand) {
-	ci.Parallel(t)
 	require := require.New(t)
 
 	// Register a test job to write a recommendation against.

--- a/command/var_list_test.go
+++ b/command/var_list_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/mitchellh/cli"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -130,7 +131,7 @@ func TestVarListCommand_Online(t *testing.T) {
 
 	nsList := []string{api.DefaultNamespace, "ns1"}
 	pathList := []string{"a/b/c", "a/b/c/d", "z/y", "z/y/x"}
-	variables := setupTestVariables(client, nsList, pathList)
+	variables := setupTestVariables(t, client, nsList, pathList)
 
 	testTmpl := `{{ range $i, $e := . }}{{if ne $i 0}}{{print "•"}}{{end}}{{printf "%v\t%v" .Namespace .Path}}{{end}}`
 
@@ -349,14 +350,14 @@ type testSVNamespacePath struct {
 	Path      string
 }
 
-func setupTestVariables(c *api.Client, nsList, pathList []string) SVMSlice {
+func setupTestVariables(t *testing.T, c *api.Client, nsList, pathList []string) SVMSlice {
 
 	out := make(SVMSlice, 0, len(nsList)*len(pathList))
 
 	for _, ns := range nsList {
 		c.Namespaces().Register(&api.Namespace{Name: ns}, nil)
 		for _, p := range pathList {
-			setupTestVariable(c, ns, p, &out)
+			must.NoError(t, setupTestVariable(c, ns, p, &out))
 		}
 	}
 
@@ -369,8 +370,12 @@ func setupTestVariable(c *api.Client, ns, p string, out *SVMSlice) error {
 		Path:      p,
 		Items:     map[string]string{"k": "v"}}
 	v, _, err := c.Variables().Create(testVar, &api.WriteOptions{Namespace: ns})
+	if err != nil {
+		return err
+	}
+
 	*out = append(*out, *v.Metadata())
-	return err
+	return nil
 }
 
 type NSPather interface {

--- a/e2e/vaultcompat/cluster_setup_test.go
+++ b/e2e/vaultcompat/cluster_setup_test.go
@@ -25,7 +25,7 @@ var roleLegacy = map[string]interface{}{
 func authConfigJWT(jwksURL string) map[string]any {
 	return map[string]any{
 		"jwks_url":           jwksURL,
-		"jwt_supported_algs": []string{"EdDSA"},
+		"jwt_supported_algs": []string{"RS256", "EdDSA"},
 		"default_role":       "nomad-workloads",
 	}
 }

--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -156,13 +156,20 @@ func TestMonitor_Monitor_RemoteServer(t *testing.T) {
 	servers := []*Server{s1, s2}
 	var nonLeader *Server
 	var leader *Server
-	for _, s := range servers {
-		if !s.IsLeader() {
-			nonLeader = s
-		} else {
-			leader = s
+	testutil.WaitForResult(func() (bool, error) {
+		for _, s := range servers {
+			if !s.IsLeader() {
+				nonLeader = s
+			} else {
+				leader = s
+			}
 		}
-	}
+
+		return nonLeader != nil && leader != nil && nonLeader != leader, fmt.Errorf(
+			"leader=%p follower=%p", nonLeader, leader)
+	}, func(err error) {
+		t.Fatalf("timed out trying to find a leader: %v", err)
+	})
 
 	cases := []struct {
 		desc        string

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2444,7 +2444,7 @@ func TestCoreScheduler_CSIBadState_ClaimGC(t *testing.T) {
 			}
 		}
 		return true
-	}, time.Second*5, 10*time.Millisecond, "invalid claims should be marked for GC")
+	}, 10*time.Second, 50*time.Millisecond, "invalid claims should be marked for GC")
 
 }
 

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2454,7 +2454,7 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 
 	srv, cleanup := TestServer(t, nil)
 	defer cleanup()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 
 	// reset the time table
 	srv.fsm.timetable.table = make([]TimeTableEntry, 1, 10)

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2559,7 +2559,7 @@ func TestCoreScheduler_VariablesRekey(t *testing.T) {
 
 	srv, cleanup := TestServer(t, nil)
 	defer cleanup()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 
 	store := srv.fsm.State()
 	key0, err := store.GetActiveRootKeyMeta(nil)

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -8,6 +8,8 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io/fs"
@@ -51,10 +53,16 @@ type Encrypter struct {
 	lock    sync.RWMutex
 }
 
+// keyset contains the key material for variable encryption and workload
+// identity signing. As keysets are rotated they are identified by the RootKey
+// KeyID although the public key IDs are published with a type prefix to
+// disambiguate which signing algorithm to use.
 type keyset struct {
-	rootKey    *structs.RootKey
-	cipher     cipher.AEAD
-	privateKey ed25519.PrivateKey
+	rootKey           *structs.RootKey
+	cipher            cipher.AEAD
+	eddsaPrivateKey   ed25519.PrivateKey
+	rsaPrivateKey     *rsa.PrivateKey
+	rsaPKCS1PublicKey []byte // PKCS #1 DER encoded public key for JWKS
 }
 
 // NewEncrypter loads or creates a new local keystore and returns an
@@ -102,7 +110,7 @@ func (e *Encrypter) loadKeystore() error {
 
 		key, err := e.loadKeyFromStore(path)
 		if err != nil {
-			return fmt.Errorf("could not load key file %s from keystore: %v", path, err)
+			return fmt.Errorf("could not load key file %s from keystore: %w", path, err)
 		}
 		if key.Meta.KeyID != id {
 			return fmt.Errorf("root key ID %s must match key file %s", key.Meta.KeyID, path)
@@ -110,7 +118,7 @@ func (e *Encrypter) loadKeystore() error {
 
 		err = e.AddKey(key)
 		if err != nil {
-			return fmt.Errorf("could not add key file %s to keystore: %v", path, err)
+			return fmt.Errorf("could not add key file %s to keystore: %w", path, err)
 		}
 		return nil
 	})
@@ -198,8 +206,10 @@ func (e *Encrypter) SignClaims(claims *structs.IdentityClaims) (string, string, 
 		claims.Issuer = e.issuer
 	}
 
+	// Default to using RS256 for signing as it is the only algorithm OIDC
+	// mandates is supported.
 	opts := (&jose.SignerOptions{}).WithHeader("kid", keyset.rootKey.Meta.KeyID).WithType("JWT")
-	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.EdDSA, Key: keyset.privateKey}, opts)
+	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: keyset.rsaPrivateKey}, opts)
 	if err != nil {
 		return "", "", err
 	}
@@ -292,15 +302,29 @@ func (e *Encrypter) addCipher(rootKey *structs.RootKey) error {
 		return fmt.Errorf("invalid algorithm %s", rootKey.Meta.Algorithm)
 	}
 
-	privateKey := ed25519.NewKeyFromSeed(rootKey.Key)
+	ed25519Key := ed25519.NewKeyFromSeed(rootKey.Key)
+
+	ks := keyset{
+		rootKey:         rootKey,
+		cipher:          aead,
+		eddsaPrivateKey: ed25519Key,
+	}
+
+	// Unmarshal RSAKey for Workload Identity JWT signing if one exists. Prior to
+	// 1.7 only the ed25519 key was used.
+	if len(rootKey.RSAKey) > 0 {
+		rsaKey, err := x509.ParsePKCS1PrivateKey(rootKey.RSAKey)
+		if err != nil {
+			return fmt.Errorf("error parsing rsa key: %w", err)
+		}
+
+		ks.rsaPrivateKey = rsaKey
+		ks.rsaPKCS1PublicKey = x509.MarshalPKCS1PublicKey(&rsaKey.PublicKey)
+	}
 
 	e.lock.Lock()
 	defer e.lock.Unlock()
-	e.keyring[rootKey.Meta.KeyID] = &keyset{
-		rootKey:    rootKey,
-		cipher:     aead,
-		privateKey: privateKey,
-	}
+	e.keyring[rootKey.Meta.KeyID] = &ks
 	return nil
 }
 
@@ -356,21 +380,30 @@ func (e *Encrypter) saveKeyToStore(rootKey *structs.RootKey) error {
 
 	kek, err := crypto.Bytes(32)
 	if err != nil {
-		return fmt.Errorf("failed to generate key wrapper key: %v", err)
+		return fmt.Errorf("failed to generate key wrapper key: %w", err)
 	}
 	wrapper, err := e.newKMSWrapper(rootKey.Meta.KeyID, kek)
 	if err != nil {
-		return fmt.Errorf("failed to create encryption wrapper: %v", err)
+		return fmt.Errorf("failed to create encryption wrapper: %w", err)
 	}
-	blob, err := wrapper.Encrypt(e.srv.shutdownCtx, rootKey.Key)
+	rootBlob, err := wrapper.Encrypt(e.srv.shutdownCtx, rootKey.Key)
 	if err != nil {
-		return fmt.Errorf("failed to encrypt root key: %v", err)
+		return fmt.Errorf("failed to encrypt root key: %w", err)
 	}
 
 	kekWrapper := &structs.KeyEncryptionKeyWrapper{
 		Meta:                       rootKey.Meta,
-		EncryptedDataEncryptionKey: blob.Ciphertext,
+		EncryptedDataEncryptionKey: rootBlob.Ciphertext,
 		KeyEncryptionKey:           kek,
+	}
+
+	// Only keysets created after 1.7.0 will contain an RSA key.
+	if len(rootKey.RSAKey) > 0 {
+		rsaBlob, err := wrapper.Encrypt(e.srv.shutdownCtx, rootKey.RSAKey)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt rsa key: %w", err)
+		}
+		kekWrapper.EncryptedRSAKey = rsaBlob.Ciphertext
 	}
 
 	buf, err := json.Marshal(kekWrapper)
@@ -408,18 +441,32 @@ func (e *Encrypter) loadKeyFromStore(path string) (*structs.RootKey, error) {
 	// sure we wrap them with as much context as possible
 	wrapper, err := e.newKMSWrapper(meta.KeyID, kekWrapper.KeyEncryptionKey)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create key wrapper cipher: %v", err)
+		return nil, fmt.Errorf("unable to create key wrapper cipher: %w", err)
 	}
 	key, err := wrapper.Decrypt(e.srv.shutdownCtx, &kms.BlobInfo{
 		Ciphertext: kekWrapper.EncryptedDataEncryptionKey,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("unable to decrypt wrapped root key: %v", err)
+		return nil, fmt.Errorf("unable to decrypt wrapped root key: %w", err)
+	}
+
+	// Decrypt RSAKey for Workload Identity JWT signing if one exists. Prior to
+	// 1.7 an ed25519 key derived from the root key was used instead of an RSA
+	// key.
+	var rsaKey []byte
+	if len(kekWrapper.EncryptedRSAKey) > 0 {
+		rsaKey, err = wrapper.Decrypt(e.srv.shutdownCtx, &kms.BlobInfo{
+			Ciphertext: kekWrapper.EncryptedRSAKey,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable to decrypt wrapped rsa key: %w", err)
+		}
 	}
 
 	return &structs.RootKey{
-		Meta: meta,
-		Key:  key,
+		Meta:   meta,
+		Key:    key,
+		RSAKey: rsaKey,
 	}, nil
 }
 
@@ -434,13 +481,21 @@ func (e *Encrypter) GetPublicKey(keyID string) (*structs.KeyringPublicKey, error
 		return nil, err
 	}
 
-	return &structs.KeyringPublicKey{
-		KeyID:      ks.rootKey.Meta.KeyID,
-		PublicKey:  ks.privateKey.Public().(ed25519.PublicKey),
-		Algorithm:  structs.PubKeyAlgEdDSA,
+	pubKey := &structs.KeyringPublicKey{
+		KeyID:      keyID,
 		Use:        structs.PubKeyUseSig,
 		CreateTime: ks.rootKey.Meta.CreateTime,
-	}, nil
+	}
+
+	if ks.rsaPrivateKey != nil {
+		pubKey.PublicKey = ks.rsaPKCS1PublicKey
+		pubKey.Algorithm = structs.PubKeyAlgRS256
+	} else {
+		pubKey.PublicKey = ks.eddsaPrivateKey.Public().(ed25519.PublicKey)
+		pubKey.Algorithm = structs.PubKeyAlgEdDSA
+	}
+
+	return pubKey, nil
 }
 
 // newKMSWrapper returns a go-kms-wrapping interface the caller can use to

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -135,7 +135,7 @@ func TestEncrypter_Restore(t *testing.T) {
 		c.DataDir = tmpDir
 	})
 	defer shutdown2()
-	testutil.WaitForKeyring(t, srv.RPC, "global")
+	testutil.WaitForKeyring(t, srv2.RPC, "global")
 	codec = rpcClient(t, srv2)
 
 	// Verify we've restored all the keys from the old keystore

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -92,7 +92,7 @@ func TestEncrypter_Restore(t *testing.T) {
 		c.DataDir = tmpDir
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 	nodeID := srv.GetConfig().NodeID
 
@@ -135,7 +135,7 @@ func TestEncrypter_Restore(t *testing.T) {
 		c.DataDir = tmpDir
 	})
 	defer shutdown2()
-	testutil.WaitForLeader(t, srv2.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec = rpcClient(t, srv2)
 
 	// Verify we've restored all the keys from the old keystore
@@ -191,9 +191,9 @@ func TestEncrypter_KeyringReplication(t *testing.T) {
 	TestJoin(t, srv1, srv2)
 	TestJoin(t, srv1, srv3)
 
-	testutil.WaitForLeader(t, srv1.RPC)
-	testutil.WaitForLeader(t, srv2.RPC)
-	testutil.WaitForLeader(t, srv3.RPC)
+	testutil.WaitForKeyring(t, srv1.RPC, "global")
+	testutil.WaitForKeyring(t, srv2.RPC, "global")
+	testutil.WaitForKeyring(t, srv3.RPC, "global")
 
 	servers := []*Server{srv1, srv2, srv3}
 	var leader *Server
@@ -371,7 +371,7 @@ func TestEncrypter_EncryptDecrypt(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 
 	e := srv.encrypter
 
@@ -391,7 +391,7 @@ func TestEncrypter_SignVerify(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 
 	alloc := mock.Alloc()
 	claims := structs.NewIdentityClaims(alloc.Job, alloc, wiHandle, alloc.LookupTask("web").Identity, time.Now())
@@ -424,7 +424,7 @@ func TestEncrypter_SignVerify_Issuer(t *testing.T) {
 		c.OIDCIssuer = testIssuer
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 
 	alloc := mock.Alloc()
 	claims := structs.NewIdentityClaims(alloc.Job, alloc, wiHandle, alloc.LookupTask("web").Identity, time.Now())
@@ -449,7 +449,7 @@ func TestEncrypter_SignVerify_AlgNone(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 
 	alloc := mock.Alloc()
 	claims := structs.NewIdentityClaims(alloc.Job, alloc, wiHandle, alloc.LookupTask("web").Identity, time.Now())
@@ -502,7 +502,7 @@ func TestEncrypter_Upgrade17(t *testing.T) {
 		c.NumSchedulers = 0
 	})
 	t.Cleanup(shutdown)
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 
 	// Fake life as a 1.6 server by writing only ed25519 keys

--- a/nomad/keyring_endpoint_test.go
+++ b/nomad/keyring_endpoint_test.go
@@ -4,7 +4,6 @@
 package nomad
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -65,12 +64,11 @@ func TestKeyringEndpoint_CRUD(t *testing.T) {
 	// that Get queries don't need ACL tokens in the test server
 	// because they always pass the mTLS check
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	errCh := make(chan error, 1)
 	var listResp structs.KeyringListRootKeyMetaResponse
 
 	go func() {
-		defer wg.Done()
+		defer close(errCh)
 		codec := rpcClient(t, srv) // not safe to share across goroutines
 		listReq := &structs.KeyringListRootKeyMetaRequest{
 			QueryOptions: structs.QueryOptions{
@@ -79,8 +77,7 @@ func TestKeyringEndpoint_CRUD(t *testing.T) {
 				AuthToken:     rootToken.SecretID,
 			},
 		}
-		err = msgpackrpc.CallWithCodec(codec, "Keyring.List", listReq, &listResp)
-		require.NoError(t, err)
+		errCh <- msgpackrpc.CallWithCodec(codec, "Keyring.List", listReq, &listResp)
 	}()
 
 	updateReq.RootKey.Meta.CreateTime = time.Now().UTC().UnixNano()
@@ -89,7 +86,7 @@ func TestKeyringEndpoint_CRUD(t *testing.T) {
 	require.NotEqual(t, uint64(0), updateResp.Index)
 
 	// wait for the blocking query to complete and check the response
-	wg.Wait()
+	require.NoError(t, <-errCh)
 	require.Equal(t, listResp.Index, updateResp.Index)
 	require.Len(t, listResp.Keys, 2) // bootstrap + new one
 
@@ -138,7 +135,7 @@ func TestKeyringEndpoint_InvalidUpdates(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 
 	// Setup an existing key
@@ -228,7 +225,7 @@ func TestKeyringEndpoint_Rotate(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 
 	// Setup an existing key
@@ -312,7 +309,7 @@ func TestKeyringEndpoint_ListPublic(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 
 	// Assert 1 key exists and normal fields are set

--- a/nomad/keyring_endpoint_test.go
+++ b/nomad/keyring_endpoint_test.go
@@ -24,7 +24,7 @@ func TestKeyringEndpoint_CRUD(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 
 	// Upsert a new key

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -2763,7 +2763,7 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) {
 
 	err = s.encrypter.AddKey(rootKey)
 	if err != nil {
-		logger.Error("could not add initial key to keyring: %v", err)
+		logger.Error("could not add initial key to keyring", "error", err)
 		return
 	}
 
@@ -2771,7 +2771,7 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) {
 		structs.KeyringUpdateRootKeyMetaRequest{
 			RootKeyMeta: rootKey.Meta,
 		}); err != nil {
-		logger.Error("could not initialize keyring: %v", err)
+		logger.Error("could not initialize keyring", "error", err)
 		return
 	}
 

--- a/nomad/locks_test.go
+++ b/nomad/locks_test.go
@@ -54,7 +54,7 @@ func TestServer_invalidateVariableLock(t *testing.T) {
 
 	testServer, testServerCleanup := TestServer(t, nil)
 	defer testServerCleanup()
-	testutil.WaitForLeader(t, testServer.RPC)
+	testutil.WaitForKeyring(t, testServer.RPC, "global")
 
 	// Generate a variable that includes a lock entry and upsert this into our
 	// state.
@@ -87,7 +87,7 @@ func TestServer_createVariableLockTimer(t *testing.T) {
 
 	testServer, testServerCleanup := TestServer(t, nil)
 	defer testServerCleanup()
-	testutil.WaitForLeader(t, testServer.RPC)
+	testutil.WaitForKeyring(t, testServer.RPC, "global")
 
 	// Generate a variable that includes a lock entry and upsert this into our
 	// state.
@@ -135,7 +135,7 @@ func TestServer_createAndRenewVariableLockTimer(t *testing.T) {
 
 	testServer, testServerCleanup := TestServer(t, nil)
 	defer testServerCleanup()
-	testutil.WaitForLeader(t, testServer.RPC)
+	testutil.WaitForKeyring(t, testServer.RPC, "global")
 
 	// Generate a variable that includes a lock entry and upsert this into our
 	// state.

--- a/nomad/node_pool_endpoint_test.go
+++ b/nomad/node_pool_endpoint_test.go
@@ -1170,8 +1170,8 @@ func TestNodePoolEndpoint_DeleteNodePools_NonLocal(t *testing.T) {
 	})
 	defer cleanupS2()
 	TestJoin(t, s1, s2)
-	testutil.WaitForLeader(t, s1.RPC)
-	testutil.WaitForLeader(t, s2.RPC)
+	testutil.WaitForKeyring(t, s1.RPC, s1.config.Region)
+	testutil.WaitForKeyring(t, s2.RPC, s2.config.Region)
 
 	// Write a node pool to the authoritative region
 	np1 := mock.NodePool()

--- a/nomad/operator_endpoint_test.go
+++ b/nomad/operator_endpoint_test.go
@@ -533,12 +533,14 @@ func TestOperator_TransferLeadershipToServerID_ACL(t *testing.T) {
 
 	var tgtID raft.ServerID
 	// Find the first non-leader server in the list.
+	s1.peerLock.Lock()
 	for _, sp := range s1.localPeers {
 		tgtID = raft.ServerID(sp.ID)
 		if tgtID != ldrID {
 			break
 		}
 	}
+	s1.peerLock.Unlock()
 
 	// Create ACL token
 	invalidToken := mock.CreatePolicyAndToken(t, state, 1001, "test-invalid", mock.NodePolicy(acl.PolicyWrite))

--- a/nomad/service_registration_endpoint_test.go
+++ b/nomad/service_registration_endpoint_test.go
@@ -34,7 +34,7 @@ func TestServiceRegistration_Upsert(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations and ensure
 				// they are in the same namespace.
@@ -78,7 +78,7 @@ func TestServiceRegistration_Upsert(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations and ensure
 				// they are in the same namespace.
@@ -116,7 +116,7 @@ func TestServiceRegistration_Upsert(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations and ensure
 				// they are in the same namespace.
@@ -159,7 +159,7 @@ func TestServiceRegistration_Upsert(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations and ensure
 				// they are in the same namespace.
@@ -217,7 +217,7 @@ func TestServiceRegistration_DeleteByID(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Attempt to delete a service registration that does not
 				// exist.
@@ -244,7 +244,7 @@ func TestServiceRegistration_DeleteByID(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations.
 				services := mock.ServiceRegistrations()
@@ -272,7 +272,7 @@ func TestServiceRegistration_DeleteByID(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations.
 				services := mock.ServiceRegistrations()
@@ -301,7 +301,7 @@ func TestServiceRegistration_DeleteByID(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations.
 				services := mock.ServiceRegistrations()
@@ -331,7 +331,7 @@ func TestServiceRegistration_DeleteByID(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations.
 				services := mock.ServiceRegistrations()
@@ -365,7 +365,7 @@ func TestServiceRegistration_DeleteByID(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations.
 				services := mock.ServiceRegistrations()
@@ -420,7 +420,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations.
 				services := mock.ServiceRegistrations()
@@ -465,7 +465,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations.
 				services := mock.ServiceRegistrations()
@@ -503,7 +503,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Test a request without setting an ACL token.
 				serviceRegReq := &structs.ServiceRegistrationListRequest{
@@ -526,7 +526,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations.
 				services := mock.ServiceRegistrations()
@@ -553,7 +553,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations.
 				services := mock.ServiceRegistrations()
@@ -580,7 +580,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations.
 				services := mock.ServiceRegistrations()
@@ -625,7 +625,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate and upsert some service registrations.
 				services := mock.ServiceRegistrations()
@@ -662,7 +662,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Create a policy and grab the token which has the read-job
 				// capability on the platform namespace.
@@ -704,7 +704,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Create a namespace as this is needed when using an ACL like
 				// we do in this test.
@@ -757,7 +757,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Create a namespace as this is needed when using an ACL like
 				// we do in this test.
@@ -810,7 +810,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Create a namespace as this is needed when using an ACL like
 				// we do in this test.
@@ -868,7 +868,7 @@ func TestServiceRegistration_List(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Create a namespace as this is needed when using an ACL like
 				// we do in this test.
@@ -963,7 +963,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, _ *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate mock services then upsert them individually using different indexes.
 				services := mock.ServiceRegistrations()
@@ -1026,7 +1026,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate mock services then upsert them individually using different indexes.
 				services := mock.ServiceRegistrations()
@@ -1107,7 +1107,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate mock services then upsert them individually using different indexes.
 				services := mock.ServiceRegistrations()
@@ -1159,7 +1159,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, token *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate mock services then upsert them individually using different indexes.
 				services := mock.ServiceRegistrations()
@@ -1204,7 +1204,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, _ *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// Generate mock services then upsert them individually using different indexes.
 				services := mock.ServiceRegistrations()
@@ -1305,7 +1305,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, _ *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// insert 3 instances of service s1
 				nodeID, jobID, allocID := "node_id", "job_id", "alloc_id"
@@ -1383,7 +1383,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 			},
 			testFn: func(t *testing.T, s *Server, _ *structs.ACLToken) {
 				codec := rpcClient(t, s)
-				testutil.WaitForLeader(t, s.RPC)
+				testutil.WaitForKeyring(t, s.RPC, "global")
 
 				// insert 2 instances of service s1
 				nodeID, jobID, allocID := "node_id", "job_id", "alloc_id"

--- a/nomad/stats_fetcher_test.go
+++ b/nomad/stats_fetcher_test.go
@@ -17,6 +17,7 @@ func TestStatsFetcher(t *testing.T) {
 	ci.Parallel(t)
 
 	conf := func(c *Config) {
+		c.Region = "region-a"
 		c.BootstrapExpect = 3
 	}
 

--- a/nomad/stats_fetcher_test.go
+++ b/nomad/stats_fetcher_test.go
@@ -17,7 +17,6 @@ func TestStatsFetcher(t *testing.T) {
 	ci.Parallel(t)
 
 	conf := func(c *Config) {
-		c.Region = "region-a"
 		c.BootstrapExpect = 3
 	}
 

--- a/nomad/variables_endpoint_test.go
+++ b/nomad/variables_endpoint_test.go
@@ -31,7 +31,7 @@ func TestVariablesEndpoint_GetVariable_Blocking(t *testing.T) {
 
 	state := s1.fsm.State()
 	codec := rpcClient(t, s1)
-	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForKeyring(t, s1.RPC, "global")
 
 	// First create an unrelated variable.
 	delay := 100 * time.Millisecond
@@ -175,7 +175,7 @@ func TestVariablesEndpoint_Apply_ACL(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 	state := srv.fsm.State()
 
@@ -455,7 +455,7 @@ func TestVariablesEndpoint_auth(t *testing.T) {
 	})
 
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 
 	const ns = "nondefault-namespace"
 
@@ -838,7 +838,7 @@ func TestVariablesEndpoint_ListFiltering(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 
 	ns := "nondefault-namespace"
@@ -942,7 +942,7 @@ func TestVariablesEndpoint_ComplexACLPolicies(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 
 	idx := uint64(1000)
@@ -1062,7 +1062,7 @@ func TestVariablesEndpoint_Apply_LockAcquireUpsertAndRelease(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 
 	mockVar := mock.Variable()
@@ -1473,7 +1473,7 @@ func TestVariablesEndpoint_Read_Lock_ACL(t *testing.T) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 	})
 	defer shutdown()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 	state := srv.fsm.State()
 
@@ -1532,6 +1532,7 @@ func TestVariablesEndpoint_Read_Lock_ACL(t *testing.T) {
 
 		readResp := new(structs.VariablesReadResponse)
 		must.NoError(t, msgpackrpc.CallWithCodec(codec, "Variables.Read", req, &readResp))
+		must.NotNil(t, readResp.Data)
 		must.NotNil(t, readResp.Data.VariableMetadata.Lock)
 		must.Eq(t, latest.LockID(), readResp.Data.LockID())
 	})

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -338,20 +338,30 @@ func (s *TestServer) waitForAPI() {
 	})
 }
 
-// waitForLeader waits for the Nomad server's HTTP API to become
-// available, and then waits for a known leader and an index of
-// 1 or more to be observed to confirm leader election is done.
+// waitForLeader waits for the Nomad server's HTTP API to become available, and
+// then waits for the keyring to be intialized. This implies a leader has been
+// elected and Raft writes have occurred.
 func (s *TestServer) waitForLeader() {
 	WaitForResult(func() (bool, error) {
 		// Query the API and check the status code
 		// Using this endpoint as it is does not have restricted access
-		resp, err := s.HTTPClient.Get(s.url("/v1/status/leader"))
+		resp, err := s.HTTPClient.Get(s.url("/.well-known/jwks.json"))
 		if err != nil {
 			return false, err
 		}
 		defer resp.Body.Close()
 		if err := s.requireOK(resp); err != nil {
 			return false, err
+		}
+
+		jwks := struct {
+			Keys []interface{} `json:"keys"`
+		}{}
+		if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+			return false, fmt.Errorf("error decoding jwks response: %w", err)
+		}
+		if len(jwks.Keys) == 0 {
+			return false, fmt.Errorf("no keys found")
 		}
 
 		return true, nil

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -242,7 +242,7 @@ func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
 
 	// Wait for the server to be ready
 	if nomadConfig.Server.Enabled && nomadConfig.Server.BootstrapExpect != 0 {
-		server.waitForLeader()
+		server.waitForServers()
 	} else {
 		server.waitForAPI()
 	}
@@ -338,10 +338,10 @@ func (s *TestServer) waitForAPI() {
 	})
 }
 
-// waitForLeader waits for the Nomad server's HTTP API to become available, and
-// then waits for the keyring to be intialized. This implies a leader has been
-// elected and Raft writes have occurred.
-func (s *TestServer) waitForLeader() {
+// waitForServers waits for the Nomad server's HTTP API to become available,
+// and then waits for the keyring to be intialized. This implies a leader has
+// been elected and Raft writes have occurred.
+func (s *TestServer) waitForServers() {
 	WaitForResult(func() (bool, error) {
 		// Query the API and check the status code
 		// Using this endpoint as it is does not have restricted access

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -169,6 +169,24 @@ func WaitForLeaders(t testing.TB, rpcs ...rpcFn) string {
 	return leader
 }
 
+// WaitForKeyring blocks until the keyring is initialized.
+func WaitForKeyring(t testing.TB, rpc rpcFn, region string) {
+	t.Helper()
+	args := structs.GenericRequest{
+		QueryOptions: structs.QueryOptions{
+			Namespace: "default",
+			Region:    region,
+		},
+	}
+	reply := structs.KeyringListPublicResponse{}
+	WaitForResult(func() (bool, error) {
+		err := rpc("Keyring.ListPublic", &args, &reply)
+		return len(reply.PublicKeys) > 0, err
+	}, func(err error) {
+		t.Fatalf("timed out waiting for keyring to initialize: %v", err)
+	})
+}
+
 // WaitForClient blocks until the client can be found
 func WaitForClient(t testing.TB, rpc rpcFn, nodeID string, region string) {
 	t.Helper()

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -138,10 +138,27 @@ type rpcFn func(string, interface{}, interface{}) error
 func WaitForLeader(t testing.TB, rpc rpcFn) {
 	t.Helper()
 	WaitForResult(func() (bool, error) {
-		args := &structs.GenericRequest{}
+		args := &structs.GenericRequest{
+			QueryOptions: structs.QueryOptions{
+				Namespace: "default",
+				Region:    "global",
+			},
+		}
 		var leader string
 		err := rpc("Status.Leader", args, &leader)
-		return leader != "", err
+		if err != nil {
+			return leader != "", err
+		}
+		if leader == "" {
+			return false, err
+		}
+
+		// As of 1.7 the RSA key generation slows down keyring initialization so
+		// much that tests relying on the keyring being initialized fail unless
+		// they wait until the key was generated
+		var resp structs.KeyringListPublicResponse
+		err = rpc("Keyring.ListPublic", args, &resp)
+		return err == nil, err
 	}, func(err error) {
 		t.Fatalf("failed to find leader: %v", err)
 	})
@@ -154,10 +171,27 @@ func WaitForLeaders(t testing.TB, rpcs ...rpcFn) string {
 	var leader string
 	for i := 0; i < len(rpcs); i++ {
 		ok := func() (bool, error) {
-			leader = ""
-			args := &structs.GenericRequest{}
+			args := &structs.GenericRequest{
+				QueryOptions: structs.QueryOptions{
+					Namespace: "default",
+					Region:    "global",
+				},
+			}
+			var leader string
 			err := rpcs[i]("Status.Leader", args, &leader)
-			return leader != "", err
+			if err != nil {
+				return leader != "", err
+			}
+			if leader == "" {
+				return false, err
+			}
+
+			// As of 1.7 the RSA key generation slows down keyring initialization so
+			// much that tests relying on the keyring being initialized fail unless
+			// they wait until the key was generated
+			var resp structs.KeyringListPublicResponse
+			err = rpcs[i]("Keyring.ListPublic", args, &resp)
+			return err == nil, err
 		}
 		must.Wait(t, wait.InitialSuccess(
 			wait.TestFunc(ok),


### PR DESCRIPTION
OIDC mandates the support of the RS256 signing algorithm so in order to maximize workload identity's usefulness this change switches from using the EdDSA signing algorithm to RS256.

Old keys will continue to use EdDSA but new keys will use RS256. The EdDSA generation code was left in place because it's fast and cheap and I'm not going to lie I hope we get to use it again.

**Test Updates**

Most of our Variables and Keyring tests had a subtle assumption in them that the keyring would be initialized by the time the test server had elected a leader. ed25519 key generation is so fast that the fact that it was happening asynchronously with server startup didn't seem to cause problems. Sadly rsa key generation is so slow that basically all of these tests failed.

I added a new `testutil.WaitForKeyring` helper to replace `testutil.WaitForLeader` in cases where the keyring must be initialized before the test may continue. However this is mostly used in the `nomad/` package.

In the `api` and `command/agent` packages I decided to switch their helpers to wait for keyring initialization by default. This will slow down tests a bit, but allow those packages to not be as concerned with subtle server readiness details. On my machine rsa key generation takes 63ms, so hopefully the difference isn't significant on CI runners.

**TODO**

- Docs and changelog entries.
- Upgrades - right now upgrades won't get RS256 keys until their root key rotates either manually or after ~30 days.
- Observability - I'm not sure there's a way for operators to see if they're using EdDSA or RS256 unless they inspect a key. The JWKS endpoint can be inspected to see if EdDSA will be used for new identities, but it doesn't technically define which key is active. If upgrades can be fixed to automatically rotate keys, we probably don't need to worry about this.

**Requiem for ed25519**

When workload identities were first implemented we did not immediately consider OIDC compliance. Consul, Vault, and many other third parties support JWT auth methods without full OIDC compliance. For the machine<-->machine use cases workload identity is intended to fulfill, OIDC seemed like a bigger risk than asset.

EdDSA/ed25519 is the signing algorithm we chose for workload identity JWTs because of all these lovely properties:

1. Deterministic keys that can be derived from our preexisting root keys. This was perhaps the biggest factor since we already had a root encryption key around from which we could derive a signing key.
2. Wonderfully compact: 64 byte private key, 32 byte public key, 64 byte signatures. Just glorious.
3. No parameters. No choices of encodings. It's all well-defined by [RFC 8032](https://datatracker.ietf.org/doc/html/rfc8032).
4. Fastest performing signing algorithm! We don't even care that much about the performance of our chosen algorithm, but what a free bonus!
5. Arguably one of the most secure signing algorithms widely available. Not just from a cryptanalysis perspective, but from an API and usage perspective too.

Life was good with ed25519, but sadly it could not last.

[IDPs](https://en.wikipedia.org/wiki/Identity_provider), such as AWS's IAM OIDC Provider, love OIDC. They have OIDC implemented for humans, so why not reuse that OIDC support for machines as well? Since OIDC mandates RS256, many implementations don't bother implementing other signing algorithms (or at least not advertising their support). A quick survey of OIDC Discovery endpoints revealed only 2 out of 10 OIDC providers advertised support for anything other than RS256:

- [PayPal](https://www.paypalobjects.com/.well-known/openid-configuration) supports HS256
- [Yahoo](https://api.login.yahoo.com/.well-known/openid-configuration) supports ES256

RS256 only:

- [GitHub](https://token.actions.githubusercontent.com/.well-known/openid-configuration)
- [GitLab](https://gitlab.com/.well-known/openid-configuration)
- [Google](https://accounts.google.com/.well-known/openid-configuration)
- [Intuit](https://developer.api.intuit.com/.well-known/openid_configuration)
- [Microsoft](https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration)
- [SalesForce](https://login.salesforce.com/.well-known/openid-configuration)
- [SimpleLogin (acquired by ProtonMail)](https://app.simplelogin.io/.well-known/openid-configuration/)
- [TFC](https://app.terraform.io/.well-known/openid-configuration)