### PR TITLE
docs: remove stale note about `generate_lease` from template docs

### DIFF
--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -632,12 +632,6 @@ When generating PKI certificates with Vault, the certificate, private key, and
 any intermediate certs are all returned as part of the same API call. Most
 software requires these files be placed in separate files on the system.
 
-~> **Note**: `generate_lease` must be set to `true` (non-default) on the Vault
-PKI role.<br /><br /> Failure to do so will cause the template to frequently
-render a new certificate, approximately every minute. This creates a significant
-number of certificates to be expired in Vault and could ultimately lead to Vault
-performance impacts and failures.
-
 #### As individual files
 
 For templates, all dependencies are mapped into a single list. This means that


### PR DESCRIPTION
Prior to `consul-template` v0.22.0, automatic PKI renewal wouldn't work properly based on the expiration of the cert. More recent versions of `consul-template` can use the expiry to refresh the cert, so it's no longer necessary (and in fact generates extra load on Vault) to set `generate_lease`. Remove this recommendation from the docs.

Fixes: #18893