### PR TITLE
docs: add note about `consul.service_identity` ignoring fields

### DIFF
--- a/website/content/docs/configuration/consul.mdx
+++ b/website/content/docs/configuration/consul.mdx
@@ -200,9 +200,10 @@ consul {
 ### Workload Identity
 
 The `service_identity` and `task_identity` blocks accept all the same values as
-the job specification's [`identity`][identity_block]. By ensuring these blocks
-are set on the Nomad servers, you can automatically migrate your existing jobs
-to use Workload Identity without modifying the job specification and
+the job specification's [`identity`][identity_block] (except that the
+`service_identity` ignores the `env` and `file` fields). By ensuring these
+blocks are set on the Nomad servers, you can automatically migrate your existing
+jobs to use Workload Identity without modifying the job specification and
 resubmitting them.
 
 The recommended configuration for `service_identity` and `task_identity` is as


### PR DESCRIPTION
The WI we get for Consul services is saved to the client state DB like all other WIs, but the resulting JWT is never exposed to the task secrets directory because (a) it's only intended for use with Consul service configuration, and (b) for group services it could be ambiguous which task to expose it to.

Add a note to the `consul.service_identity` docs that these fields are ignored.