### PR TITLE
[ui] Helios two-step button and uniform title bar for Actions

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -37,6 +37,7 @@ module.exports = {
     'ember/no-classic-components': 'off',
     'ember/no-component-lifecycle-hooks': 'off',
     'ember/require-tagless-components': 'off',
+    'no-control-regex': 'off',
   },
   overrides: [
     // node files

--- a/ui/app/components/job-page/parts/title.js
+++ b/ui/app/components/job-page/parts/title.js
@@ -111,7 +111,7 @@ export default class Title extends Component {
    * @param {string} allocID - The allocation ID to run the action on
    * @param {Event} ev - The event that triggered the action
    */
-  @task(function* (action, allocID, ev) {
+  @task(function* (action, allocID) {
     if (!allocID) {
       allocID =
         action.allocations[

--- a/ui/app/styles/core/title.scss
+++ b/ui/app/styles/core/title.scss
@@ -22,10 +22,17 @@
     display: flex;
     justify-content: space-between;
   }
+}
 
+// Job page header, actions bar
+.job-page-header {
+  margin-bottom: 1rem;
+  position: relative;
+  z-index: $z-modal;
+  .hds-page-header__main {
+    flex-direction: unset;
+  }
   .actions-dropdown {
     z-index: 3;
-    display: inline-block;
-    vertical-align: middle;
   }
 }

--- a/ui/app/styles/core/title.scss
+++ b/ui/app/styles/core/title.scss
@@ -28,11 +28,20 @@
 .job-page-header {
   margin-bottom: 1rem;
   position: relative;
-  z-index: $z-modal;
+  z-index: $z-base - 1;
   .hds-page-header__main {
     flex-direction: unset;
+    .hds-page-header__actions {
+      align-items: stretch;
+    }
   }
   .actions-dropdown {
     z-index: 3;
+  }
+  .exec-open-button,
+  .two-step-button {
+    & > button {
+      height: 100%;
+    }
   }
 }

--- a/ui/app/styles/core/title.scss
+++ b/ui/app/styles/core/title.scss
@@ -26,6 +26,6 @@
   .actions-dropdown {
     z-index: 3;
     display: inline-block;
-    margin-right: 0.5rem;
+    vertical-align: middle;
   }
 }

--- a/ui/app/templates/components/exec/open-button.hbs
+++ b/ui/app/templates/components/exec/open-button.hbs
@@ -4,19 +4,22 @@
 ~}}
 
 {{#let (cannot "exec allocation" namespace=this.job.namespace) as |cannotExec|}}
-  <Hds::Button
-    data-test-exec-button
-    @size="small"
-    @text="Exec"
-    @color="secondary"
-    disabled={{cannotExec}}
-    {{on "click" this.open}}
-    {{keyboard-shortcut 
+  <div
+    {{keyboard-shortcut
       label="Exec"
       pattern=(array "e" "x" "e" "c")
       action=this.open
     }}
+  >
+  <Hds::Button
+    data-test-exec-button
+    @size="medium"
+    @text="Exec"
+    @color="secondary"
+    disabled={{cannotExec}}
+    {{on "click" this.open}}
     @icon="terminal-screen"
   />
+</div>
 {{/let}}
 

--- a/ui/app/templates/components/exec/open-button.hbs
+++ b/ui/app/templates/components/exec/open-button.hbs
@@ -5,6 +5,7 @@
 
 {{#let (cannot "exec allocation" namespace=this.job.namespace) as |cannotExec|}}
   <div
+    class="exec-open-button"
     {{keyboard-shortcut
       label="Exec"
       pattern=(array "e" "x" "e" "c")

--- a/ui/app/templates/components/exec/open-button.hbs
+++ b/ui/app/templates/components/exec/open-button.hbs
@@ -4,20 +4,19 @@
 ~}}
 
 {{#let (cannot "exec allocation" namespace=this.job.namespace) as |cannotExec|}}
-  <button
+  <Hds::Button
     data-test-exec-button
-    type="button"
-    class="button exec-button is-outline is-small {{if cannotExec "tooltip"}}"
-    disabled={{if cannotExec 'disabled'}}
-    aria-label={{if cannotExec "You don’t have permission to exec"}}
-    {{action "open"}}
+    @size="small"
+    @text="Exec"
+    @color="secondary"
+    disabled={{cannotExec}}
+    {{on "click" this.open}}
     {{keyboard-shortcut 
       label="Exec"
       pattern=(array "e" "x" "e" "c")
-      action=(action "open")
-    }}>
-    {{x-icon "console"}}
-    <span>Exec</span>
-  </button>
+      action=this.open
+    }}
+    @icon="terminal-screen"
+  />
 {{/let}}
 

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -18,7 +18,7 @@
     {{#if (not (eq this.job.status "dead"))}}
       {{#if this.job.actions.length}}
         <Hds::Dropdown class="actions-dropdown" as |dd|>
-          <dd.ToggleButton @color="secondary" @text="Actions" />
+          <dd.ToggleButton @color="secondary" @text="Actions" @size="small" />
           {{#each this.job.actions as |action|}}
             {{#if (gt action.allocations.length 1)}}
               <dd.Separator />

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -3,8 +3,8 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<h1 class="title with-flex">
-  <div data-test-job-name>
+<Hds::PageHeader class="job-page-header" as |PH|>
+  <PH.Title data-test-job-name>
     {{or this.title this.job.name}}
     {{#if @job.meta.structured.pack}}
       <span data-test-pack-tag class="tag is-hollow">
@@ -13,8 +13,8 @@
       </span>
     {{/if}}
     {{yield}}
-  </div>
-  <div>
+  </PH.Title>
+  <PH.Actions>
     {{#if (not (eq this.job.status "dead"))}}
       {{#if this.job.actions.length}}
         <Hds::Dropdown class="actions-dropdown" as |dd|>
@@ -81,5 +81,5 @@
         }}
         />
     {{/if}}
-  </div>
-</h1>
+  </PH.Actions>
+</Hds::PageHeader>

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -18,7 +18,7 @@
     {{#if (not (eq this.job.status "dead"))}}
       {{#if this.job.actions.length}}
         <Hds::Dropdown class="actions-dropdown" as |dd|>
-          <dd.ToggleButton @color="secondary" @text="Actions" @size="small" />
+          <dd.ToggleButton @color="secondary" @text="Actions" @size="medium" />
           {{#each this.job.actions as |action|}}
             {{#if (gt action.allocations.length 1)}}
               <dd.Separator />

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -32,9 +32,7 @@
         </Hds::Dropdown>
 
       {{/if}}
-      <div class="two-step-button">
-        <Exec::OpenButton @job={{this.job}} />
-      </div>
+      <Exec::OpenButton @job={{this.job}} />
       <TwoStepButton
         data-test-stop
         @alignRight={{true}}

--- a/ui/app/templates/components/two-step-button.hbs
+++ b/ui/app/templates/components/two-step-button.hbs
@@ -4,37 +4,42 @@
 ~}}
 
 {{#if this.isIdle}}
-  <button
+  <Hds::Button
     data-test-idle-button
-    type="button"
-    class="button {{if this.classes.idleButton this.classes.idleButton "is-danger is-outlined"}} is-important is-small"
-    disabled={{this.disabled}}
-    onclick={{action "promptForConfirmation"}}>
-    {{this.idleText}}
-  </button>
+    @size="small"
+    @text={{@idleText}}
+    @color="critical"
+    disabled={{@disabled}}
+    {{on "click" this.promptForConfirmation}}
+  />
 {{else if this.isPendingConfirmation}}
   <span
     data-test-confirmation-message
     class="confirmation-text {{this.classes.confirmationMessage}} {{if this.alignRight "is-right-aligned"}} {{if this.inlineText "has-text-inline"}}">
     {{this.confirmationMessage}}
   </span>
-  <button
+  <Hds::Button
     data-test-cancel-button
-    type="button"
-    class="button is-outlined is-small {{if this.classes.cancelButton this.classes.cancelButton "is-dark"}}"
+    @size="small"
+    @text={{@cancelText}}
+    @color="secondary"
+    class="is-inline"
     disabled={{this.awaitingConfirmation}}
-    onclick={{action (queue
-      (action "setToIdle")
+    {{on "click" (queue
+      (action this.setToIdle)
       (action this.onCancel)
-    )}}>
-    {{this.cancelText}}
-  </button>
-  <button
+    )}}
+  />
+  <Hds::Button
     data-test-confirm-button
-    class="button is-small {{if this.awaitingConfirmation "is-loading"}} {{if this.classes.confirmButton this.classes.confirmButton "is-danger"}}"
+    @size="small"
+    @text={{@confirmText}}
+    @color="critical"
+    class="is-inline"
     disabled={{this.awaitingConfirmation}}
-    onclick={{action "confirm"}}
-    type="button">
-    {{this.confirmText}}
-  </button>
+    {{on "click" (queue
+      (action this.setToIdle)
+      (action this.onConfirm)
+    )}}
+  />
 {{/if}}

--- a/ui/app/templates/components/two-step-button.hbs
+++ b/ui/app/templates/components/two-step-button.hbs
@@ -6,7 +6,7 @@
 {{#if this.isIdle}}
   <Hds::Button
     data-test-idle-button
-    @size="small"
+    @size="medium"
     @text={{@idleText}}
     @color="critical"
     disabled={{@disabled}}
@@ -20,7 +20,7 @@
   </span>
   <Hds::Button
     data-test-cancel-button
-    @size="small"
+    @size="medium"
     @text={{@cancelText}}
     @color="secondary"
     class="is-inline"
@@ -32,7 +32,7 @@
   />
   <Hds::Button
     data-test-confirm-button
-    @size="small"
+    @size="medium"
     @text={{@confirmText}}
     @color="critical"
     class="is-inline"

--- a/ui/app/templates/components/two-step-button.hbs
+++ b/ui/app/templates/components/two-step-button.hbs
@@ -33,7 +33,7 @@
   <Hds::Button
     data-test-confirm-button
     @size="medium"
-    @text={{@confirmText}}
+    @text={{if this.awaitingConfirmation "Loading..." @confirmText}}
     @color="critical"
     class="is-inline"
     disabled={{this.awaitingConfirmation}}

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -402,7 +402,7 @@ module('Acceptance | allocation detail', function (hooks) {
     await Allocation.stop.idle();
 
     run.later(() => {
-      assert.ok(Allocation.stop.isRunning, 'Stop is loading');
+      assert.ok(Allocation.stop.isDisabled, 'Stop is disabled');
       assert.ok(Allocation.restart.isDisabled, 'Restart is disabled');
       assert.ok(Allocation.restartAll.isDisabled, 'Restart All is disabled');
       server.pretender.resolve(server.pretender.requestReferences[0].request);

--- a/ui/tests/integration/components/two-step-button-test.js
+++ b/ui/tests/integration/components/two-step-button-test.js
@@ -138,8 +138,10 @@ module('Integration | Component | two step button', function (hooks) {
       TwoStepButton.confirmIsDisabled,
       'The confirm button is disabled'
     );
-    assert.ok(
-      TwoStepButton.isRunning,
+
+    assert.equal(
+      TwoStepButton.confirmText,
+      'Loading...',
       'The confirm button is in a loading state'
     );
 

--- a/ui/tests/pages/components/two-step-button.js
+++ b/ui/tests/pages/components/two-step-button.js
@@ -3,13 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import {
-  attribute,
-  clickable,
-  hasClass,
-  isPresent,
-  text,
-} from 'ember-cli-page-object';
+import { attribute, clickable, isPresent, text } from 'ember-cli-page-object';
 
 export default (scope) => ({
   scope,
@@ -20,7 +14,6 @@ export default (scope) => ({
   confirm: clickable('[data-test-confirm-button]'),
   cancel: clickable('[data-test-cancel-button]'),
 
-  isRunning: hasClass('is-loading', '[data-test-confirm-button]'),
   isDisabled: attribute('disabled', '[data-test-idle-button]'),
 
   cancelIsDisabled: attribute('disabled', '[data-test-cancel-button]'),


### PR DESCRIPTION
For purposes of changing the Exec and Stop buttons shown here:
<img width="1182" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/7b47bbdc-1778-4b4f-b653-fe11fcc6e350">

we now have all two-step buttons using Helios-style buttons instead of our previous style.