### PR TITLE
-json option on jobs status command

### DIFF
--- a/.changelog/18925.txt
+++ b/.changelog/18925.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+build: Added json option on job status command
+```

--- a/.changelog/18925.txt
+++ b/.changelog/18925.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-build: Added json option on job status command
+cli: Added -json option on job status command
 ```

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"sort"
 	"strings"
 	"time"
@@ -35,11 +36,6 @@ type JobJson struct {
 	Allocations      []*api.AllocationListStub
 	LatestDeployment *api.Deployment
 	Evaluations      []*api.Evaluation
-}
-
-type jobIDNamespacePair struct {
-	ID        string
-	Namespace string
 }
 
 func (c *JobStatusCommand) Help() string {
@@ -160,10 +156,10 @@ func (c *JobStatusCommand) Run(args []string) int {
 			c.Ui.Output("No running jobs")
 		} else {
 			if c.json || len(c.tmpl) > 0 {
-				pairs := make([]jobIDNamespacePair, len(jobs))
+				pairs := make([]structs.NamespacedID, len(jobs))
 
 				for i, j := range jobs {
-					pairs[i] = jobIDNamespacePair{ID: j.ID, Namespace: j.Namespace}
+					pairs[i] = structs.NamespacedID{ID: j.ID, Namespace: j.Namespace}
 				}
 
 				jsonJobs, err := createJsonJobsOutput(client, c.allAllocs, pairs...)
@@ -212,7 +208,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 
 	if c.json || len(c.tmpl) > 0 {
 		jsonJobs, err := createJsonJobsOutput(client, c.allAllocs,
-			jobIDNamespacePair{ID: *job.ID, Namespace: *job.Namespace})
+			structs.NamespacedID{ID: *job.ID, Namespace: *job.Namespace})
 
 		if err != nil {
 			c.Ui.Error(err.Error())
@@ -724,7 +720,7 @@ func (c *JobStatusCommand) outputFailedPlacements(failedEval *api.Evaluation) {
 	}
 }
 
-func createJsonJobsOutput(client *api.Client, allAllocs bool, jobs ...jobIDNamespacePair) ([]JobJson, error) {
+func createJsonJobsOutput(client *api.Client, allAllocs bool, jobs ...structs.NamespacedID) ([]JobJson, error) {
 	jsonJobs := make([]JobJson, len(jobs))
 
 	for i, pair := range jobs {

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
-	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/posener/complete"
 )
 
@@ -29,6 +28,12 @@ type JobStatusCommand struct {
 	verbose   bool
 	json      bool
 	tmpl      string
+}
+
+// NamespacedID is a tuple of an ID and a namespace
+type NamespacedID struct {
+	ID        string
+	Namespace string
 }
 
 type JobJson struct {
@@ -156,10 +161,10 @@ func (c *JobStatusCommand) Run(args []string) int {
 			c.Ui.Output("No running jobs")
 		} else {
 			if c.json || len(c.tmpl) > 0 {
-				pairs := make([]structs.NamespacedID, len(jobs))
+				pairs := make([]NamespacedID, len(jobs))
 
 				for i, j := range jobs {
-					pairs[i] = structs.NamespacedID{ID: j.ID, Namespace: j.Namespace}
+					pairs[i] = NamespacedID{ID: j.ID, Namespace: j.Namespace}
 				}
 
 				jsonJobs, err := createJsonJobsOutput(client, c.allAllocs, pairs...)
@@ -208,7 +213,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 
 	if c.json || len(c.tmpl) > 0 {
 		jsonJobs, err := createJsonJobsOutput(client, c.allAllocs,
-			structs.NamespacedID{ID: *job.ID, Namespace: *job.Namespace})
+			NamespacedID{ID: *job.ID, Namespace: *job.Namespace})
 
 		if err != nil {
 			c.Ui.Error(err.Error())
@@ -720,7 +725,7 @@ func (c *JobStatusCommand) outputFailedPlacements(failedEval *api.Evaluation) {
 	}
 }
 
-func createJsonJobsOutput(client *api.Client, allAllocs bool, jobs ...structs.NamespacedID) ([]JobJson, error) {
+func createJsonJobsOutput(client *api.Client, allAllocs bool, jobs ...NamespacedID) ([]JobJson, error) {
 	jsonJobs := make([]JobJson, len(jobs))
 
 	for i, pair := range jobs {

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -5,13 +5,13 @@ package command
 
 import (
 	"fmt"
-	"github.com/hashicorp/nomad/nomad/structs"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/posener/complete"
 )
 

--- a/website/content/docs/commands/job/status.mdx
+++ b/website/content/docs/commands/job/status.mdx
@@ -44,6 +44,10 @@ run the command with a job prefix instead of the exact job ID.
 - `-short`: Display short output. Used only when a single node is being queried.
   Drops verbose node allocation data from the output.
 
+- `-json`: Output the job status in JSON format.
+
+- `-t`: Format and display the job status using a Go template.
+
 - `-verbose`: Show full information. Allocation create and modify times are
   shown in `yyyy/mm/dd hh:mm:ss` format.
 


### PR DESCRIPTION
https://github.com/hashicorp/nomad/issues/16566

This modification dumps the entire `job` struct in JSON format. I don't know if just dumps the entire struct is the better approach, if not, i can expose specific fields.