### PR TITLE
identity: version check multiple and implicit identities

### DIFF
--- a/nomad/job_endpoint_hook_implicit_identities.go
+++ b/nomad/job_endpoint_hook_implicit_identities.go
@@ -18,6 +18,7 @@ func (jobImplicitIdentitiesHook) Name() string {
 }
 
 func (h jobImplicitIdentitiesHook) Mutate(job *structs.Job) (*structs.Job, []error, error) {
+
 	for _, tg := range job.TaskGroups {
 		for _, s := range tg.Services {
 			h.handleConsulService(s)

--- a/nomad/job_endpoint_hook_implicit_identities.go
+++ b/nomad/job_endpoint_hook_implicit_identities.go
@@ -18,7 +18,6 @@ func (jobImplicitIdentitiesHook) Name() string {
 }
 
 func (h jobImplicitIdentitiesHook) Mutate(job *structs.Job) (*structs.Job, []error, error) {
-
 	for _, tg := range job.TaskGroups {
 		for _, s := range tg.Services {
 			h.handleConsulService(s)

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -392,7 +392,7 @@ func (v *jobValidate) Validate(job *structs.Job) (warnings []error, err error) {
 
 		for _, t := range tg.Tasks {
 			if len(t.Identities) > 1 && !okForIdentity {
-				multierror.Append(validationErrors, fmt.Errorf("tasks can only have 1 identity block until all servers are upgraded to %s", minVersionMultiIdentities))
+				multierror.Append(validationErrors, fmt.Errorf("tasks can only have 1 identity block until all servers are upgraded to %s or later", minVersionMultiIdentities))
 			}
 			for _, s := range t.Services {
 				serviceErrs := v.validateServiceIdentity(
@@ -419,7 +419,7 @@ func (v *jobValidate) isEligibleForMultiIdentity() bool {
 
 func (v *jobValidate) validateServiceIdentity(s *structs.Service, parent string, okForIdentity bool) error {
 	if s.Identity != nil && !okForIdentity {
-		return fmt.Errorf("Service %s in %s cannot have an identity until all servers are upgraded to %s",
+		return fmt.Errorf("Service %s in %s cannot have an identity until all servers are upgraded to %s or later",
 			s.Name, parent, minVersionMultiIdentities)
 	}
 	if s.Identity != nil && s.Identity.Name == "" {
@@ -451,7 +451,7 @@ func (v *jobValidate) validateVaultIdentity(t *structs.Task, okForIdentity bool)
 	vaultWID := t.GetIdentity(vaultWIDName)
 
 	if vaultWID != nil && !okForIdentity {
-		return warnings, fmt.Errorf("Task %s cannot have an identity for Vault until all servers are upgraded to %s", t.Name, minVersionMultiIdentities)
+		return warnings, fmt.Errorf("Task %s cannot have an identity for Vault until all servers are upgraded to %s or later", t.Name, minVersionMultiIdentities)
 	}
 
 	if vaultWID == nil {

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -79,6 +79,11 @@ var minNomadServiceRegistrationVersion = version.Must(version.NewVersion("1.3.0"
 // prevent older versions of the server from crashing.
 var minNodePoolsVersion = version.Must(version.NewVersion("1.6.0"))
 
+// minVersionMultiIdentities is the Nomad version at which users can add
+// multiple identity blocks to tasks and workload identities can be
+// automatically added to jobs that need access to Consul or Vault
+var minVersionMultiIdentities = version.Must(version.NewVersion("1.7.0"))
+
 // monitorLeadership is used to monitor if we acquire or lose our role
 // as the leader in the Raft cluster. There is some work the leader is
 // expected to do, so we must react to changes

--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ var (
 	GitDescribe string
 
 	// The main version number that is being run at the moment.
-	Version = "1.6.4"
+	Version = "1.7.0"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
Job submitters cannot set multiple identities prior to Nomad 1.7, and cluster administrators should not set the identity configurations for their `consul` and `vault` configuration blocks until all servers have been upgraded. Validate these cases during job submission so as to prevent state store corruption when jobs are submitting in the middle of a cluster upgrade.