### PR TITLE
docs: upgrade guide for integrations deprecation warnings

### DIFF
--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -13,6 +13,48 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 1.7.0
+
+#### Vault Integration Changes
+
+Starting in Nomad 1.7, Nomad clients will use a task's [Workload Identity][] to
+authenticate to Vault and obtain a Vault token specific to the task.
+
+The existing workflow using a Vault token provided in either the agent
+configuration or at the time of job submission is deprecated and will be removed
+in Nomad 1.9. The [`vault.policies`][] field is also deprecated and will work
+only with the existing workflow. Instead, you should configure a suitable Vault
+role and use that.
+
+The following agent configuration fields are deprecated:
+- [`vault.allow_unauthenticated`][] will be removed in Nomad 1.9. Tasks will use
+  the workload identity without the user supplying a Vault token.
+- [`vault.task_token_ttl`][] will be removed in Nomad 1.9. With workload
+  identity, tasks will receive their TTL configuration from the Vault role.
+- [`vault.token`][] will be removed in Nomad 1.9. Nomad agents will no longer
+  make requests to authenticated endpoints except with a task's workload
+  identity.
+
+Before upgrading to Nomad 1.9 you will need to have configured authentication
+with Vault to work with workload identity. See [Migrating to Using Workload
+Identity with Vault][] for more details.
+
+#### Consul Integration Changes
+
+Starting in Nomad 1.7, Nomad clients will use a service's or task's [Workload
+Identity][] to authenticate to Consul and obtain a Consul token specific to the
+workload.
+
+The existing workflow using a Consul token provided in either the agent
+configuration or at the time of job submission is deprecated and will be removed
+in Nomad 1.9. The [`consul.allow_unauthenticated`][] agent configuration field
+will be removed in Nomad 1.9. Tasks will use the workload identity without the
+user supplying a Consul token.
+
+Before upgrading to Nomad 1.9 you will need to have configured authentication
+with Consul to work with workload identity. See [Migrating to Using Workload
+Identity with Consul][] for more details.
+
 ## Nomad 1.6.0
 
 #### Enterprise License Validation with BuildDate
@@ -1870,3 +1912,11 @@ deleted and then Nomad 0.3.0 can be launched.
 [artifact_env]: /nomad/docs/configuration/client#set_environment_variables
 [dangling_container_reconciliation]: /nomad/docs/drivers/docker#enabled
 [hard_guide]: /nomad/docs/install/production/requirements#hardening-nomad
+[Workload Identity]: /nomad/docs/concepts/workload-identity
+[Migrating to Using Workload Identity with Consul]: /nomad/docs/integrations/consul-integration#migrating-to-using-workload-identity-with-consul
+[Migrating to Using Workload Identity with Vault]: /nomad/docs/integrations/vault-integration#migrating-to-using-workload-identity-with-vault
+[`vault.policies`]: /nomad/docs/job-specification/vault#policies
+[`vault.allow_unauthenticated`]: /nomad/docs/configuration/vault#allow_unauthenticated
+[`vault.token`]: /nomad/docs/configuration/vault#token
+[`vault.task_token_ttl`]: /nomad/docs/configuration/vault#task_token_ttl
+[`consul.allow_unauthenticated`]: /nomad/docs/configuration/consul#allow_unauthenticated


### PR DESCRIPTION
The Consul and Vault integrations work shipping in Nomad 1.7 will deprecated the existing token-based workflows. These will be removed in Nomad 1.9, so add a note describing this to the upgrade guide.

Preview link: https://nomad-f2mh6uwj4-hashicorp.vercel.app/nomad/docs/upgrade/upgrade-specific#nomad-1-7-0