### PR TITLE
docs: changelog & basic docs for 1.7 WI changes

### DIFF
--- a/.changelog/18035.txt
+++ b/.changelog/18035.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Add JWKS HTTP API endpoint
+```

--- a/.changelog/18123.txt
+++ b/.changelog/18123.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity: Add support for multiple workload identities
+```

--- a/.changelog/18262.txt
+++ b/.changelog/18262.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity: Support jwt expiration and rotation
+```

--- a/.changelog/18691.txt
+++ b/.changelog/18691.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+**Workload Identity IDP:** Nomad's workload identities may now be used with third parties that support JWT or OIDC IDPs such as the AWS IAM OIDC Provider.
+```

--- a/.changelog/18882.txt
+++ b/.changelog/18882.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity: default to RS256 for new workload ids
+```

--- a/website/content/api-docs/operator/keyring.mdx
+++ b/website/content/api-docs/operator/keyring.mdx
@@ -16,6 +16,106 @@ are used. For instructions on how to use the CLI to perform these operations
 manually, please see the documentation for the [`nomad operator root keyring`]
 commands.
 
+## List Active Public Keys
+
+This endpoint retrieves a list of active public keys used to sign [workload
+identities][wi]. The response is in the [JWKS][rfc7517] format as is commonly
+used by JWT auth methods.
+
+| Method | Path                        | Produces           |
+|--------|-----------------------------|--------------------|
+| `GET`  | `/.well-known/jwks.json`    | `application/json` |
+
+The table below shows this endpoint's support for [blocking queries] and
+[required ACLs].
+
+| Blocking Queries | ACL Required |
+|------------------|--------------|
+| `YES`            | `none`       |
+
+### Sample Request
+
+```shell-session
+$ nomad operator api '/.well-known/jwks.json'
+```
+
+### Sample Response
+
+```json
+{
+  "keys": [
+    {
+      "use": "sig",
+      "kty": "RSA",
+      "kid": "15a95f48-001a-8be5-5da9-d94901d022c9",
+      "alg": "RS256",
+      "n": "6sImUQR6A...FB7bKn02dKw",
+      "e": "AQAB"
+    },
+    {
+      "use": "sig",
+      "kty": "RSA",
+      "kid": "b7f6a3a7-14f9-4ac5-f713-32c9bce1fa93",
+      "alg": "RS256",
+      "n": "zEdiUB3DFuM...ii3kQvOf_eDApBDWJhfQw",
+      "e": "AQAB"
+    }
+  ]
+}
+```
+
+## OIDC Discovery
+
+This endpoint retrieves [OIDC configuration metadata][oidc-disco] for using
+[workload identities][wi] with third party services. Nomad will act as an
+identity provider (IDP) to allow third parties to authenticate workload
+identity JWTs based on the OIDC configurationa and JWKS.
+
+Most third parties will require this endpoint be accessible through a
+publically resolvable domain name and HTTPS signed by a trusted certificate
+authority.
+
+You must set the [`oidc_issuer`][oidc_issuer] Server agent configuration
+parameter before this endpoint is enabled. In most situations you will also
+need to run a proxy or load balancer for in front of this endpoint to serve the
+contents with HTTPS using a trusted certificate.
+
+| Method | Path                                | Produces           |
+|--------|-------------------------------------|--------------------|
+| `GET`  | `/.well-known/openid-configuration` | `application/json` |
+
+The table below shows this endpoint's support for [blocking queries] and
+[required ACLs].
+
+| Blocking Queries | ACL Required |
+|------------------|--------------|
+| `NO`             | `none` |
+
+### Sample Request
+
+```shell-session
+$ nomad operator api '/.well-known/openid-configuration'
+```
+
+### Sample Response
+
+```json
+{
+  "id_token_signing_alg_values_supported": [
+    "RS256",
+    "EdDSA"
+  ],
+  "issuer": "http://example.com",
+  "jwks_uri": "http://example.com/.well-known/jwks.json",
+  "response_types_supported": [
+    "code"
+  ],
+  "subject_types_supported": [
+    "public"
+  ]
+}
+```
+
 ## List Keys
 
 This endpoint retrieves a list of root keys known to the cluster. Note that only
@@ -154,4 +254,8 @@ $ curl \
 [Key Management]: /nomad/docs/operations/key-management
 [`nomad operator root keyring`]: /nomad/docs/commands/operator/root/keyring-rotate
 [blocking queries]: /nomad/api-docs#blocking-queries
+[oidc-disco]: https://openid.net/specs/openid-connect-discovery-1_0.html
+[oidc_issuer]: /nomad/docs/configuration/server#oidc_issuer
 [required ACLs]: /nomad/api-docs#acls
+[rfc7517]: https://datatracker.ietf.org/doc/html/rfc7517
+[wi]: /nomad/docs/concepts/workload-identity


### PR DESCRIPTION
Changelog entries and bare minimum docs for workload identity changes in 1.7.

1.7.0 Changelog would look like:

---


FEATURES:

* **Multiple Vault and Consul Clusters:** Nomad Enterprise can now use multiple Vault or Consul clusters. Each task or service can be registered with a different Consul cluster and each task can obtain secrets from a different Vault cluster. [[GH-5311](https://github.com/hashicorp/nomad/issues/5311)]
* **NUMA aware scheduling**: Nomad Enterprise now supports optimized scheduling on NUMA hardware [[GH-18681](https://github.com/hashicorp/nomad/issues/18681)]
* **Workload Identity IDP:** Nomad's workload identities may now be used with third parties that support JWT or OIDC IDPs such as the AWS IAM OIDC Provider. [[GH-18691](https://github.com/hashicorp/nomad/issues/18691)]
* **Workload Identity for Consul:** Jobs can now use workload identity to authenticate to Consul. [[GH-15618](https://github.com/hashicorp/nomad/issues/15618)]
* **Workload Identity for Vault:** Jobs can now use workload identity to authenticate to Vault. [[GH-15617](https://github.com/hashicorp/nomad/issues/15617)]
* **actions**: Introduces the action concept to jobspecs, the web UI, CLI and API. Operators can now define actions that Nomad users can execute against running allocations. [[GH-18794](https://github.com/hashicorp/nomad/issues/18794)]

BREAKING CHANGES:

* client/fingerprint: The `cpu.numcores.power` node attribute has been renamed to `cpu.numcores.performance` on Apple Silicon nodes [[GH-18843](https://github.com/hashicorp/nomad/issues/18843)]
* client: the `unique.cgroup.mountpoint` node attribute has been removed [[GH-18371](https://github.com/hashicorp/nomad/issues/18371)]
* client: the `unique.cgroup.version` node attribute has been renamed to `os.cgroups.version` [[GH-18371](https://github.com/hashicorp/nomad/issues/18371)]

IMPROVEMENTS:

* api: Add JWKS HTTP API endpoint [[GH-18035](https://github.com/hashicorp/nomad/issues/18035)]
* api: Added support for Unix domain sockets [[GH-16872](https://github.com/hashicorp/nomad/issues/16872)]
* build (Enterprise): Support building s390x binaries. [[GH-18069](https://github.com/hashicorp/nomad/issues/18069)]
* cli: Add file prediction for operator raft/snapshot commands [[GH-18901](https://github.com/hashicorp/nomad/issues/18901)]
* cli: Added support for prefix ID matching and wildcard namespaces to `service info` command [[GH-18836](https://github.com/hashicorp/nomad/issues/18836)]
* client: add support for NetBSD clients [[GH-18562](https://github.com/hashicorp/nomad/issues/18562)]
* client: enable detection of numa topology [[GH-18146](https://github.com/hashicorp/nomad/issues/18146)]
* deps: bumped `shirou/gopsutil` to v3.23.9 [[GH-18562](https://github.com/hashicorp/nomad/issues/18562)]
* fingerprint: clients now backoff after successfully fingerprinting Consul [[GH-18426](https://github.com/hashicorp/nomad/issues/18426)]
* identity: Add support for multiple workload identities [[GH-18123](https://github.com/hashicorp/nomad/issues/18123)]
* identity: Support jwt expiration and rotation [[GH-18262](https://github.com/hashicorp/nomad/issues/18262)]
* identity: default to RS256 for new workload ids [[GH-18882](https://github.com/hashicorp/nomad/issues/18882)]
* sentinel (Enterprise): Add existing job information to Sentinel when available. [[GH-18553](https://github.com/hashicorp/nomad/issues/18553)]
* server: Added transfer-leadership API and CLI [[GH-17383](https://github.com/hashicorp/nomad/issues/17383)]
* ui: color-code node and server status cells [[GH-18318](https://github.com/hashicorp/nomad/issues/18318)]
* ui: simplify presentation of task event times (10m2.230948s bceomes 10m2s etc.) [[GH-18595](https://github.com/hashicorp/nomad/issues/18595)]
* vars: Added a locking feature for Nomad Variables [[GH-18520](https://github.com/hashicorp/nomad/issues/18520)]

BUG FIXES:

* ui: fix the job auto-linked variable path name when user lacks variable write permissions [[GH-18598](https://github.com/hashicorp/nomad/issues/18598)]

