### PR TITLE
docs: fix `token_period` in example Vault role for WI

### DIFF
--- a/website/content/docs/integrations/vault-integration.mdx
+++ b/website/content/docs/integrations/vault-integration.mdx
@@ -57,8 +57,8 @@ $ vault auth enable jwt
 ```
 
 Create a configuration file for the default Vault [Role][]. This configuration
-maps each Nomad job to its own Vault user claim. You can set the `token_ttl` and
-`token_policies` to whatever value is suitable for your environment. A
+maps each Nomad job to its own Vault user claim. You can set the `token_period`
+and `token_policies` to whatever value is suitable for your environment. A
 recommended policy is shown later.
 
 ```json
@@ -71,7 +71,7 @@ recommended policy is shown later.
     "nomad_namespace": "nomad_namespace",
     "nomad_job_id": "nomad_job_id"
   },
-  "token_ttl": "30m",
+  "token_period": "30m",
   "token_type": "service",
   "token_policies": ["nomad-workloads"]
 }


### PR DESCRIPTION
Vault tokens requested for WI are "periodic" Vault tokens (ones that get periodically renewed). The field we should be setting for the renewal window is `token_period`.

Ref: https://developer.hashicorp.com/vault/docs/concepts/tokens#periodic-tokens