### PR TITLE
vault: fix lookups of default cluster across upgrades

### DIFF
--- a/client/allocrunner/taskrunner/template_hook.go
+++ b/client/allocrunner/taskrunner/template_hook.go
@@ -193,6 +193,9 @@ func (h *templateHook) newManager() (unblock chan struct{}, err error) {
 	var vaultConfig *structsc.VaultConfig
 	if h.task.Vault != nil {
 		vaultCluster := h.task.Vault.Cluster
+		if vaultCluster == "" {
+			vaultCluster = structs.VaultDefaultCluster
+		}
 		vaultConfig = h.config.clientConfig.GetVaultConfigs(h.logger)[vaultCluster]
 
 		if vaultConfig == nil {

--- a/client/allocrunner/taskrunner/template_hook.go
+++ b/client/allocrunner/taskrunner/template_hook.go
@@ -131,18 +131,22 @@ func (h *templateHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 		consulTokens := h.config.hookResources.GetConsulTokens()
 
 		var found bool
-		if _, found = consulTokens[req.Task.Consul.Cluster]; !found {
+		cluster := req.Task.Consul.Cluster
+		if cluster == "" {
+			cluster = structs.ConsulDefaultCluster
+		}
+		if _, found = consulTokens[cluster]; !found {
 			return fmt.Errorf(
 				"consul tokens for cluster %s requested by task %s not found",
-				req.Task.Consul.Cluster, req.Task.Name,
+				cluster, req.Task.Name,
 			)
 		}
 
-		h.consulToken, found = consulTokens[req.Task.Consul.Cluster][req.Task.Consul.IdentityName()]
+		h.consulToken, found = consulTokens[cluster][req.Task.Consul.IdentityName()]
 		if !found {
 			return fmt.Errorf(
 				"consul tokens for cluster %s and identity %s requested by task %s not found",
-				req.Task.Consul.Cluster, req.Task.Consul.IdentityName(), req.Task.Name,
+				cluster, req.Task.Consul.IdentityName(), req.Task.Name,
 			)
 		}
 	}

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -172,6 +172,9 @@ func (h *vaultHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRe
 	}
 
 	cluster := h.vaultBlock.Cluster
+	if cluster == "" {
+		cluster = structs.VaultDefaultCluster
+	}
 	vclient, err := h.clientFunc(cluster)
 	if err != nil {
 		return err


### PR DESCRIPTION
Allocations that were created before Nomad 1.7 will not have the `cluster` field set for their Vault blocks. While this can be corrected server-side, that doesn't help allocations already on clients.