### PR TITLE
Vault small fixes

### DIFF
--- a/e2e/vaultcompat/cluster_setup_test.go
+++ b/e2e/vaultcompat/cluster_setup_test.go
@@ -42,9 +42,8 @@ func roleWID(policies []string) map[string]any {
 			"nomad_namespace": "nomad_namespace",
 			"nomad_job_id":    "nomad_job_id",
 		},
-		"token_ttl":      "30m",
 		"token_type":     "service",
-		"token_period":   "72h",
+		"token_period":   "30m",
 		"token_policies": policies,
 	}
 }

--- a/e2e/vaultcompat/vaultcompat_test.go
+++ b/e2e/vaultcompat/vaultcompat_test.go
@@ -347,7 +347,7 @@ func downloadVaultBuild(t *testing.T, b build) {
 }
 
 func getMinimumVersion(t *testing.T) *version.Version {
-	v, err := version.NewVersion("1.1.0")
+	v, err := version.NewVersion("1.11.0")
 	must.NoError(t, err)
 	return v
 }

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -265,9 +265,11 @@ func (jobImpliedConstraints) Mutate(j *structs.Job) (*structs.Job, []error, erro
 // need to split out the behavior to ENT-specific code.
 func vaultConstraintFn(vault *structs.Vault) *structs.Constraint {
 	if vault.Cluster != structs.VaultDefaultCluster && vault.Cluster != "" {
+		// Non-default clusters use workload identities to derive tokens, which
+		// require Vault 1.11.0+.
 		return &structs.Constraint{
 			LTarget: fmt.Sprintf("${attr.vault.%s.version}", vault.Cluster),
-			RTarget: ">= 0.6.1",
+			RTarget: ">= 1.11.0",
 			Operand: structs.ConstraintSemver,
 		}
 	}

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -468,9 +468,9 @@ func Test_jobImpliedConstraints_Mutate(t *testing.T) {
 							},
 						},
 						Constraints: []*structs.Constraint{
-							&structs.Constraint{
+							{
 								LTarget: "${attr.vault.infra.version}",
-								RTarget: ">= 0.6.1",
+								RTarget: ">= 1.11.0",
 								Operand: structs.ConstraintSemver,
 							},
 							vaultConstraint,


### PR DESCRIPTION
Small fixes on Vault JWT auth:

* Remove `token_ttl` from `vaultcompat` since Nomad uses periodic tokens.
* Set minimum version required for JWT auth to 1.11.0+ because that's when `user_claim_json_pointer` was added.