### PR TITLE
identity: Implement `change_mode`

### DIFF
--- a/.changelog/18943.txt
+++ b/.changelog/18943.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-identity: Implement `change_mode`
+identity: Implement `change_mode` and `change_signal` for workload identities
 ```

--- a/.changelog/18943.txt
+++ b/.changelog/18943.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity: Implement `change_mode`
+```

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1162,12 +1162,14 @@ func (t *TaskCSIPluginConfig) Canonicalize() {
 // WorkloadIdentity is the jobspec block which determines if and how a workload
 // identity is exposed to tasks.
 type WorkloadIdentity struct {
-	Name        string        `hcl:"name,optional"`
-	Audience    []string      `mapstructure:"aud" hcl:"aud,optional"`
-	Env         bool          `hcl:"env,optional"`
-	File        bool          `hcl:"file,optional"`
-	ServiceName string        `hcl:"service_name,optional"`
-	TTL         time.Duration `mapstructure:"ttl" hcl:"ttl,optional"`
+	Name         string        `hcl:"name,optional"`
+	Audience     []string      `mapstructure:"aud" hcl:"aud,optional"`
+	ChangeMode   string        `mapstructure:"change_mode" hcl:"change_mode,optional"`
+	ChangeSignal string        `mapstructure:"change_signal" hcl:"change_signal,optional"`
+	Env          bool          `hcl:"env,optional"`
+	File         bool          `hcl:"file,optional"`
+	ServiceName  string        `hcl:"service_name,optional"`
+	TTL          time.Duration `mapstructure:"ttl" hcl:"ttl,optional"`
 }
 
 type Action struct {

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -328,9 +328,9 @@ OUTER:
 				const noFailure = false
 				h.lifecycle.Restart(h.ctx,
 					structs.NewTaskEvent(structs.TaskRestartSignal).
-						SetDisplayMessage("Vault: new Vault token acquired"), false)
+						SetDisplayMessage("Vault: new Vault token acquired"), noFailure)
 			case structs.VaultChangeModeNoop:
-				fallthrough
+				// True to its name, this is a noop!
 			default:
 				h.logger.Error("invalid Vault change mode", "mode", h.vaultBlock.ChangeMode)
 			}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1277,11 +1277,13 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 	// the Task.Identity field, so if it is non-nil use it.
 	if id := apiTask.Identity; id != nil {
 		structsTask.Identity = &structs.WorkloadIdentity{
-			Name:     id.Name,
-			Audience: slices.Clone(id.Audience),
-			Env:      id.Env,
-			File:     id.File,
-			TTL:      id.TTL,
+			Name:         id.Name,
+			Audience:     slices.Clone(id.Audience),
+			ChangeMode:   id.ChangeMode,
+			ChangeSignal: id.ChangeSignal,
+			Env:          id.Env,
+			File:         id.File,
+			TTL:          id.TTL,
 		}
 	}
 
@@ -1293,11 +1295,13 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 			}
 
 			structsTask.Identities[i] = &structs.WorkloadIdentity{
-				Name:     id.Name,
-				Audience: slices.Clone(id.Audience),
-				Env:      id.Env,
-				File:     id.File,
-				TTL:      id.TTL,
+				Name:         id.Name,
+				Audience:     slices.Clone(id.Audience),
+				ChangeMode:   id.ChangeMode,
+				ChangeSignal: id.ChangeSignal,
+				Env:          id.Env,
+				File:         id.File,
+				TTL:          id.TTL,
 			}
 
 		}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1276,34 +1276,17 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 	// Nomad 1.5 CLIs and JSON jobs may set the default identity parameters in
 	// the Task.Identity field, so if it is non-nil use it.
 	if id := apiTask.Identity; id != nil {
-		structsTask.Identity = &structs.WorkloadIdentity{
-			Name:         id.Name,
-			Audience:     slices.Clone(id.Audience),
-			ChangeMode:   id.ChangeMode,
-			ChangeSignal: id.ChangeSignal,
-			Env:          id.Env,
-			File:         id.File,
-			TTL:          id.TTL,
-		}
+		structsTask.Identity = apiWorkloadIdentityToStructs(id)
 	}
 
 	if ids := apiTask.Identities; len(ids) > 0 {
-		structsTask.Identities = make([]*structs.WorkloadIdentity, len(ids))
-		for i, id := range ids {
+		structsTask.Identities = make([]*structs.WorkloadIdentity, 0, len(ids))
+		for _, id := range ids {
 			if id == nil {
 				continue
 			}
 
-			structsTask.Identities[i] = &structs.WorkloadIdentity{
-				Name:         id.Name,
-				Audience:     slices.Clone(id.Audience),
-				ChangeMode:   id.ChangeMode,
-				ChangeSignal: id.ChangeSignal,
-				Env:          id.Env,
-				File:         id.File,
-				TTL:          id.TTL,
-			}
-
+			structsTask.Identities = append(structsTask.Identities, apiWorkloadIdentityToStructs(id))
 		}
 	}
 
@@ -1657,11 +1640,13 @@ func apiWorkloadIdentityToStructs(in *api.WorkloadIdentity) *structs.WorkloadIde
 		return nil
 	}
 	return &structs.WorkloadIdentity{
-		Name:        in.Name,
-		Audience:    in.Audience,
-		Env:         in.Env,
-		File:        in.File,
-		ServiceName: in.ServiceName,
+		Name:         in.Name,
+		Audience:     in.Audience,
+		ChangeMode:   in.ChangeMode,
+		ChangeSignal: in.ChangeSignal,
+		Env:          in.Env,
+		File:         in.File,
+		ServiceName:  in.ServiceName,
 	}
 }
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1641,7 +1641,7 @@ func apiWorkloadIdentityToStructs(in *api.WorkloadIdentity) *structs.WorkloadIde
 	}
 	return &structs.WorkloadIdentity{
 		Name:         in.Name,
-		Audience:     in.Audience,
+		Audience:     slices.Clone(in.Audience),
 		ChangeMode:   in.ChangeMode,
 		ChangeSignal: in.ChangeSignal,
 		Env:          in.Env,

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -2779,6 +2779,16 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								Weight:  pointer.Of(int8(50)),
 							},
 						},
+						Identities: []*api.WorkloadIdentity{
+							{
+								Name:         "aws",
+								Audience:     []string{"s3"},
+								Env:          true,
+								File:         true,
+								ChangeMode:   "signal",
+								ChangeSignal: "SIGHUP",
+							},
+						},
 						VolumeMounts: []*api.VolumeMount{
 							{
 								Volume:          pointer.Of("vol"),
@@ -3194,6 +3204,16 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								RTarget: "b",
 								Operand: "c",
 								Weight:  50,
+							},
+						},
+						Identities: []*structs.WorkloadIdentity{
+							{
+								Name:         "aws",
+								Audience:     []string{"s3"},
+								Env:          true,
+								File:         true,
+								ChangeMode:   "signal",
+								ChangeSignal: "SIGHUP",
 							},
 						},
 						Env: map[string]string{
@@ -4243,5 +4263,20 @@ func Test_apiWorkloadIdentityToStructs(t *testing.T) {
 		Env:         false,
 		File:        false,
 		ServiceName: "web",
+	}))
+	must.Eq(t, &structs.WorkloadIdentity{
+		Name:         "aws",
+		Audience:     []string{"s3"},
+		Env:          true,
+		File:         true,
+		ChangeMode:   "signal",
+		ChangeSignal: "SIGHUP",
+	}, apiWorkloadIdentityToStructs(&api.WorkloadIdentity{
+		Name:         "aws",
+		Audience:     []string{"s3"},
+		Env:          true,
+		File:         true,
+		ChangeMode:   "signal",
+		ChangeSignal: "SIGHUP",
 	}))
 }

--- a/contributing/checklist-jobspec.md
+++ b/contributing/checklist-jobspec.md
@@ -2,12 +2,12 @@
 
 ## Code
 
-* [x] Consider similar features in Consul, Kubernetes, and other tools. Is there prior art we should match? Terminology, structure, etc?
-* [t] Add structs/fields to `api/` package
+* [ ] Consider similar features in Consul, Kubernetes, and other tools. Is there prior art we should match? Terminology, structure, etc?
+* [ ] Add structs/fields to `api/` package
   * `api/` structs usually have Canonicalize and Copy methods
   * New fields should be added to existing Canonicalize, Copy methods
   * Test the structs/fields via methods mentioned above
-* [t] Add structs/fields to `nomad/structs` package
+* [ ] Add structs/fields to `nomad/structs` package
   * `structs/` structs usually have Copy, Equal, and Validate methods
     * `Validate` methods in this package _must_ be implemented
     * `Equal` methods are used when comparing one job to another (e.g. did this thing get updated?)
@@ -16,14 +16,14 @@
   * Note that analogous struct field names should match with `api/` package
   * Test the structs/fields via methods mentioned above
   * Implement and test other logical methods
-* [t] Add conversion between `api/` and `nomad/structs/` in `command/agent/job_endpoint.go`
+* [ ] Add conversion between `api/` and `nomad/structs/` in `command/agent/job_endpoint.go`
   * Add test for conversion
-* [x] Determine JSON encoding strategy for responses from RPC (see "JSON Encoding" below)
-  * [x] Write `nomad/structs/` to `api/` conversions if necessary and write tests
-* [t] Implement diff logic for new structs/fields in `nomad/structs/diff.go`
+* [ ] Determine JSON encoding strategy for responses from RPC (see "JSON Encoding" below)
+  * [ ] Write `nomad/structs/` to `api/` conversions if necessary and write tests
+* [ ] Implement diff logic for new structs/fields in `nomad/structs/diff.go`
   * Note that fields must be listed in alphabetical order in `FieldDiff` slices in `nomad/structs/diff_test.go`
   * Add test for diff of new structs/fields
-* [x] Add change detection for new structs/fields in `scheduler/util.go/tasksUpdated`
+* [ ] Add change detection for new structs/fields in `scheduler/util.go/tasksUpdated`
   * Might be covered by `.Equals` but might not be, check.
   * Should return true if the task must be replaced as a result of the change.
 
@@ -40,8 +40,8 @@ required in the original `jobspec` package.
 ## Docs
 
 * [ ] Changelog
-* [x] Jobspec entry https://developer.hashicorp.com/nomad/docs/job-specification/index.html
-* [x] Jobspec sidebar entry https://github.com/hashicorp/nomad/blob/main/website/data/docs-navigation.js
+* [ ] Jobspec entry https://developer.hashicorp.com/nomad/docs/job-specification/index.html
+* [ ] Jobspec sidebar entry https://github.com/hashicorp/nomad/blob/main/website/data/docs-navigation.js
 * [ ] Job JSON API entry https://developer.hashicorp.com/nomad/api/json-jobs.html
 * [ ] Sample Response output in API https://developer.hashicorp.com/nomad/api/jobs.html
 * [ ] Consider if it needs a guide https://developer.hashicorp.com/nomad/guides/index.html

--- a/contributing/checklist-jobspec.md
+++ b/contributing/checklist-jobspec.md
@@ -2,12 +2,12 @@
 
 ## Code
 
-* [ ] Consider similar features in Consul, Kubernetes, and other tools. Is there prior art we should match? Terminology, structure, etc?
-* [ ] Add structs/fields to `api/` package
+* [x] Consider similar features in Consul, Kubernetes, and other tools. Is there prior art we should match? Terminology, structure, etc?
+* [t] Add structs/fields to `api/` package
   * `api/` structs usually have Canonicalize and Copy methods
   * New fields should be added to existing Canonicalize, Copy methods
   * Test the structs/fields via methods mentioned above
-* [ ] Add structs/fields to `nomad/structs` package
+* [t] Add structs/fields to `nomad/structs` package
   * `structs/` structs usually have Copy, Equal, and Validate methods
     * `Validate` methods in this package _must_ be implemented
     * `Equal` methods are used when comparing one job to another (e.g. did this thing get updated?)
@@ -16,14 +16,14 @@
   * Note that analogous struct field names should match with `api/` package
   * Test the structs/fields via methods mentioned above
   * Implement and test other logical methods
-* [ ] Add conversion between `api/` and `nomad/structs/` in `command/agent/job_endpoint.go`
+* [t] Add conversion between `api/` and `nomad/structs/` in `command/agent/job_endpoint.go`
   * Add test for conversion
-* [ ] Determine JSON encoding strategy for responses from RPC (see "JSON Encoding" below)
-  * [ ] Write `nomad/structs/` to `api/` conversions if necessary and write tests
-* [ ] Implement diff logic for new structs/fields in `nomad/structs/diff.go`
+* [x] Determine JSON encoding strategy for responses from RPC (see "JSON Encoding" below)
+  * [x] Write `nomad/structs/` to `api/` conversions if necessary and write tests
+* [t] Implement diff logic for new structs/fields in `nomad/structs/diff.go`
   * Note that fields must be listed in alphabetical order in `FieldDiff` slices in `nomad/structs/diff_test.go`
   * Add test for diff of new structs/fields
-* [ ] Add change detection for new structs/fields in `scheduler/util.go/tasksUpdated`
+* [x] Add change detection for new structs/fields in `scheduler/util.go/tasksUpdated`
   * Might be covered by `.Equals` but might not be, check.
   * Should return true if the task must be replaced as a result of the change.
 
@@ -40,8 +40,8 @@ required in the original `jobspec` package.
 ## Docs
 
 * [ ] Changelog
-* [ ] Jobspec entry https://developer.hashicorp.com/nomad/docs/job-specification/index.html
-* [ ] Jobspec sidebar entry https://github.com/hashicorp/nomad/blob/main/website/data/docs-navigation.js
+* [x] Jobspec entry https://developer.hashicorp.com/nomad/docs/job-specification/index.html
+* [x] Jobspec sidebar entry https://github.com/hashicorp/nomad/blob/main/website/data/docs-navigation.js
 * [ ] Job JSON API entry https://developer.hashicorp.com/nomad/api/json-jobs.html
 * [ ] Sample Response output in API https://developer.hashicorp.com/nomad/api/jobs.html
 * [ ] Consider if it needs a guide https://developer.hashicorp.com/nomad/guides/index.html

--- a/website/content/docs/job-specification/identity.mdx
+++ b/website/content/docs/job-specification/identity.mdx
@@ -30,16 +30,22 @@ job "docs" {
     task "api" {
 
       identity {
-        env  = true
-        file = true
+        env         = true
+        file        = true
+
+        # Restart on token renewal to get the new env var
+        change_mode = "restart"
       }
 
       identity {
-        name = "example"
-        aud  = ["oidc.example.com"]
-        env  = true
-        file = true
-        ttl  = "1h"
+        name        = "example"
+        aud         = ["oidc.example.com"]
+        file        = true
+        ttl         = "1h"
+
+        # Send a HUP signal when the token file is updated
+        change_mode   = "signal"
+        change_signal = "SIGHUP"
       }
 
       # ...
@@ -55,6 +61,16 @@ job "docs" {
   field.
 - `aud` `([]string: nil)` - The audience field for the workload identity. This
   should always be set for non-default identities.
+- `change_mode` `(string: "noop")` - Specifies the behavior Nomad should take when the token changes.
+
+  - `"noop"` - take no action. The default since tasks may choose to reload
+    tokens when their current token gets rejected.
+  - `"restart"` - restart the task
+  - `"signal"` - send a configurable signal to the task. Must set `change_signal`.
+
+- `change_signal` `(string: "")` - Specifies the signal to send to the task as a
+  string like `"SIGHUP"` or `"SIGUSR1"`. This option is required if the
+  `change_mode` is `signal`.
 - `env` `(bool: false)` - If true the workload identity will be available in the
   task's `NOMAD_TOKEN` environment variable.
 - `file` `(bool: false)` - If true the workload identity will be available in

--- a/website/content/docs/job-specification/identity.mdx
+++ b/website/content/docs/job-specification/identity.mdx
@@ -64,8 +64,9 @@ job "docs" {
 - `change_mode` `(string: "noop")` - Specifies the behavior Nomad should take when the token changes.
 
   - `"noop"` - take no action. The default since tasks may choose to reload
-    tokens when their current token gets rejected.
-  - `"restart"` - restart the task
+      tokens only when their current token gets rejected or implement their own
+      change detection.
+  - `"restart"` - restart the task.
   - `"signal"` - send a configurable signal to the task. Must set `change_signal`.
 
 - `change_signal` `(string: "")` - Specifies the signal to send to the task as a


### PR DESCRIPTION
This implements the jobspec and client internals for `identity.change_mode`: allowing users to signal or restart tasks when their identity tokens get rotated.

## Identity Watcher Firstrun

As part of this I also blocked `taskrunner/identityHook.Prestart(...)` from completing until tokens are initially written (_or_ a timeout/context-cancellation is hit). I think before we technically had a race between `taskrunner/identityHook.Prestart(...)` writing initial tokens and the things that rely on those initial tokens starting up. Not sure if it would be realistically hit, but it seemed like a good idea to copy our `template` implementation of waiting for a first run.

Let me know if you think the 1 minute timeout should be changed or removed. `template` blocks indefinitely, but it has a lot more concerns than `identity`. I really couldn't think of a good reason to have the timer or not and was just guided by my desire to avoid dead/live-locking tasks without a good reason. If a task starts and immediately (well... after the timeout) fails due to a missing `identity` ... that seems preferable to blocking forever? At least the alloc could eventually be rescheduled elsewhere that might have a better chance to succeed?

## Empty String Default

I treat `""` and `"noop"` the same without actually Canonicalizing `"" -> "noop"` like other `change_mode`s do. I did this for 2 not weak reasons:

1. Why waste the bytes on the word "noop" when just omitting the entire field communicates the same thing?
2. We need to default to a coordinated `change_mode`. If folks end up with >1 TTL'd renewing identities per task, it's going to be hard to manage `change_mode` well. If you have 2 identities with the same TTL they will cause 2 restarts! Even worse: if you noop one, there's no telling if the other one will signal/restart right before or right after this one due to the jitter added. Add in `change_mode`s from other blocks and this could be a big headache.

Due to `#2` I'd almost rather folks just use `file = true; env = false`, and reload the token file when they get a 403 from their upstream service. :shrug: Us barraging their task with signals is probably more error prone than that.