### PR TITLE
consul: fix lookups of default cluster across upgrades

### DIFF
--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -180,7 +180,12 @@ func (h *consulHook) prepareConsulTokensForServices(services []*structs.Service,
 			continue
 		}
 
-		if err := h.getConsulTokens(service.Cluster, service.Identity.Name, tokens, req); err != nil {
+		cluster := service.Cluster
+		if cluster == "" {
+			cluster = structs.ConsulDefaultCluster
+		}
+
+		if err := h.getConsulTokens(cluster, service.Identity.Name, tokens, req); err != nil {
 			mErr.Errors = append(mErr.Errors, err)
 			continue
 		}

--- a/client/allocrunner/group_service_hook.go
+++ b/client/allocrunner/group_service_hook.go
@@ -267,7 +267,11 @@ func (h *groupServiceHook) getWorkloadServicesLocked() *serviceregistration.Work
 
 	tokens := map[string]string{}
 	for _, service := range h.services {
-		if token, ok := allocTokens[service.Cluster][service.MakeUniqueIdentityName()]; ok {
+		cluster := service.Cluster
+		if cluster == "" {
+			cluster = structs.ConsulDefaultCluster
+		}
+		if token, ok := allocTokens[cluster][service.MakeUniqueIdentityName()]; ok {
 			tokens[service.Name] = token
 		}
 	}

--- a/client/allocrunner/taskrunner/service_hook.go
+++ b/client/allocrunner/taskrunner/service_hook.go
@@ -234,7 +234,11 @@ func (h *serviceHook) getWorkloadServices() *serviceregistration.WorkloadService
 
 	tokens := map[string]string{}
 	for _, service := range h.services {
-		if token, ok := allocTokens[service.Cluster][service.MakeUniqueIdentityName()]; ok {
+		cluster := service.Cluster
+		if cluster == "" {
+			cluster = structs.ConsulDefaultCluster
+		}
+		if token, ok := allocTokens[cluster][service.MakeUniqueIdentityName()]; ok {
 			tokens[service.Name] = token
 		}
 	}


### PR DESCRIPTION
Allocations that were created before Nomad 1.7 will not have the cluster field set for their Consul blocks. While this can be corrected server-side, that doesn't help allocations already on clients.