### PR TITLE
consul/vault: use accessor method to get cluster name in client

### DIFF
--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -180,12 +180,7 @@ func (h *consulHook) prepareConsulTokensForServices(services []*structs.Service,
 			continue
 		}
 
-		cluster := service.Cluster
-		if cluster == "" {
-			cluster = structs.ConsulDefaultCluster
-		}
-
-		if err := h.getConsulTokens(cluster, service.Identity.Name, tokens, req); err != nil {
+		if err := h.getConsulTokens(clusterName, service.Identity.Name, tokens, req); err != nil {
 			mErr.Errors = append(mErr.Errors, err)
 			continue
 		}

--- a/client/allocrunner/group_service_hook.go
+++ b/client/allocrunner/group_service_hook.go
@@ -28,6 +28,7 @@ type groupServiceHook struct {
 	allocID          string
 	jobID            string
 	group            string
+	tg               *structs.TaskGroup
 	namespace        string
 	restarter        serviceregistration.WorkloadRestarter
 	prerun           bool
@@ -100,6 +101,7 @@ func newGroupServiceHook(cfg groupServiceHookConfig) *groupServiceHook {
 		logger:            cfg.logger.Named(groupServiceHookName),
 		serviceRegWrapper: cfg.serviceRegWrapper,
 		services:          tg.Services,
+		tg:                tg,
 		hookResources:     cfg.hookResources,
 		shutdownDelayCtx:  cfg.shutdownDelayCtx,
 	}
@@ -267,10 +269,7 @@ func (h *groupServiceHook) getWorkloadServicesLocked() *serviceregistration.Work
 
 	tokens := map[string]string{}
 	for _, service := range h.services {
-		cluster := service.Cluster
-		if cluster == "" {
-			cluster = structs.ConsulDefaultCluster
-		}
+		cluster := service.GetConsulClusterName(h.tg)
 		if token, ok := allocTokens[cluster][service.MakeUniqueIdentityName()]; ok {
 			tokens[service.Name] = token
 		}

--- a/client/allocrunner/taskrunner/sids_hook.go
+++ b/client/allocrunner/taskrunner/sids_hook.go
@@ -137,7 +137,7 @@ func (h *sidsHook) Prestart(
 	for _, service := range tg.Services {
 		if service.Name == serviceName {
 			serviceIdentityName = service.MakeUniqueIdentityName()
-			cluster = service.Cluster
+			cluster = service.GetConsulClusterName(tg)
 			break
 		}
 	}

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -114,6 +114,7 @@ func (tr *TaskRunner) initHooks() {
 	// If there are templates is enabled, add the hook
 	if len(task.Templates) != 0 {
 		tr.runnerHooks = append(tr.runnerHooks, newTemplateHook(&templateHookConfig{
+			alloc:               tr.Alloc(),
 			logger:              hookLogger,
 			lifecycle:           tr,
 			events:              tr,

--- a/client/allocrunner/taskrunner/template_hook_test.go
+++ b/client/allocrunner/taskrunner/template_hook_test.go
@@ -46,6 +46,7 @@ func Test_templateHook_Prestart_ConsulWI(t *testing.T) {
 	taskHooks := trtesting.NewMockTaskHooks()
 
 	conf := &templateHookConfig{
+		alloc:         a,
 		logger:        logger,
 		lifecycle:     taskHooks,
 		events:        &trtesting.MockEmitter{},
@@ -81,7 +82,7 @@ func Test_templateHook_Prestart_ConsulWI(t *testing.T) {
 				TaskDir: &allocdir.TaskDir{Dir: "foo"},
 			},
 			true,
-			"consul tokens for cluster bar requested by task foo not found",
+			"consul tokens for cluster default and identity consul_bar requested by task foo not found",
 			"",
 		},
 		{

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -171,10 +171,7 @@ func (h *vaultHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRe
 		return nil
 	}
 
-	cluster := h.vaultBlock.Cluster
-	if cluster == "" {
-		cluster = structs.VaultDefaultCluster
-	}
+	cluster := h.task.GetVaultClusterName()
 	vclient, err := h.clientFunc(cluster)
 	if err != nil {
 		return err

--- a/nomad/structs/vault.go
+++ b/nomad/structs/vault.go
@@ -84,3 +84,14 @@ func ValidateVaultClusterName(cluster string) error {
 
 	return nil
 }
+
+// GetVaultClusterName gets the Vault cluster for this task. Only a single
+// default cluster is supported in Nomad CE, but this function can be safely
+// used for ENT as well because the appropriate Cluster value will be set at the
+// time of job submission.
+func (t *Task) GetVaultClusterName() string {
+	if t.Vault != nil && t.Vault.Cluster != "" {
+		return t.Vault.Cluster
+	}
+	return VaultDefaultCluster
+}


### PR DESCRIPTION
When looking up the Consul or Vault cluster from a client hook, we should always use an accessor function rather than trying to lookup the `Cluster` field, which may be empty for jobs registered before Nomad 1.7.

Follow-up to https://github.com/hashicorp/nomad/pull/18945 and https://github.com/hashicorp/nomad/pull/18940