### PR TITLE
identity: don't generate codec for oidc config

### DIFF
--- a/nomad/structs/generate.sh
+++ b/nomad/structs/generate.sh
@@ -11,5 +11,5 @@ codecgen \
     -d 100 \
     -t codegen_generated \
     -o structs.generated.go \
-    -nr="(^ACLCache$)|(^IdentityClaims$)" \
+    -nr="(^ACLCache$)|(^IdentityClaims$)|(^OIDCDiscoveryConfig$)" \
     ${FILES}


### PR DESCRIPTION
Our codec code generation doesn't honor `json:"..."` tags which breaks the OIDC Discovery endpoint.

This adds the relevant struct to the code generators ignore list (just like we have done with IdentityClaims).