### PR TITLE
ignore KEK wrapper struct for codegen

### DIFF
--- a/nomad/structs/generate.sh
+++ b/nomad/structs/generate.sh
@@ -11,5 +11,5 @@ codecgen \
     -d 100 \
     -t codegen_generated \
     -o structs.generated.go \
-    -nr="(^ACLCache$)|(^IdentityClaims$)|(^OIDCDiscoveryConfig$)" \
+    -nr="(^ACLCache$)|(^IdentityClaims$)|(^OIDCDiscoveryConfig$)|(^KeyEncryptionKeyWrapper$)" \
     ${FILES}


### PR DESCRIPTION
Our codec code generation doesn't honor `json:"..."` tags which, if we were to ever implement `json.Marshaller` for the `KeyEncryptionKeyWrapper` struct, would break the on-disk format of all the existing KEKs.

As a precaution, add this struct to the code generator's ignore list (just like we have done with `IdentityClaims`).