### PR TITLE
vault: avoid continual renewal of invalid token

### DIFF
--- a/.changelog/18985.txt
+++ b/.changelog/18985.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault: Fixed an issue that could cause Nomad to attempt to renew a Vault token that is already expired
+```

--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -453,6 +453,7 @@ func (c *vaultClient) renew(req *vaultClientRenewalRequest) error {
 	fatal := false
 	if renewalErr != nil &&
 		(strings.Contains(renewalErr.Error(), "lease not found or lease is not renewable") ||
+			strings.Contains(renewalErr.Error(), "invalid lease ID") ||
 			strings.Contains(renewalErr.Error(), "lease is not renewable") ||
 			strings.Contains(renewalErr.Error(), "token not found") ||
 			strings.Contains(renewalErr.Error(), "permission denied")) {


### PR DESCRIPTION
A series of errors may happen when a token is invalidated while the Vault client is waiting to renew it. The token may have been invalidated for several reasons, such as the alloc finished running and it's now terminal or the token may have been change directly on Vault out-of-band.

Most of the errors are caused by retries that will never succeed until Vault fully removes the token from its state.

This commit prevents the retries by making the error `invalid lease ID` a fatal error.

In earlier versions of Vault, this case was covered by the error `lease not found or lease is not renewable`, which is already considered to be a fatal error by Nomad:

https://github.com/hashicorp/vault/blob/2d0cde4ccc0323591d9414342cb15f5cb70271d7/vault/expiration.go#L636-L639

But https://github.com/hashicorp/vault/pull/5346 introduced an earlier `nil` check that generates a different error message:

https://github.com/hashicorp/vault/blob/750ab337eaa0b049d9cf1535c00e860129e5e9a0/vault/expiration.go#L1362-L1364

Both errors happen for the same reason (`le == nil`) and so should be considered fatal on renewal.

Closes https://github.com/hashicorp/nomad/issues/12465