### PR TITLE
config: remove old Vault/Consul config blocks from server

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -517,15 +517,8 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	}
 
 	// Add the Consul and Vault configs
-	conf.ConsulConfig = agentConfig.Consul
-	for _, consulConfig := range agentConfig.Consuls {
-		conf.ConsulConfigs[consulConfig.Name] = consulConfig
-	}
-
-	conf.VaultConfig = agentConfig.Vault
-	for _, vaultConfig := range agentConfig.Vaults {
-		conf.VaultConfigs[vaultConfig.Name] = vaultConfig
-	}
+	conf.ConsulConfigs = agentConfig.Consuls
+	conf.VaultConfigs = agentConfig.Vaults
 
 	// Set the TLS config
 	conf.TLSConfig = agentConfig.TLSConfig

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -246,7 +246,7 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 	//   - reading kv store of each group
 	//   - establishing consul connect services
 	checkConsulToken := func(usages map[string]*structs.ConsulUsage) error {
-		if j.srv.config.ConsulConfig.AllowsUnauthenticated() {
+		if j.srv.config.GetDefaultConsul().AllowsUnauthenticated() {
 			// if consul.allow_unauthenticated is enabled (which is the default)
 			// just let the job through without checking anything
 			return nil

--- a/nomad/job_endpoint_ce_test.go
+++ b/nomad/job_endpoint_ce_test.go
@@ -30,7 +30,7 @@ func TestJobEndpoint_Register_Connect_AllowUnauthenticatedFalse_oss(t *testing.T
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
-		c.ConsulConfig.AllowUnauthenticated = pointer.Of(false)
+		c.GetDefaultConsul().AllowUnauthenticated = pointer.Of(false)
 	})
 	defer cleanupS1()
 	codec := rpcClient(t, s1)

--- a/nomad/job_endpoint_hook_implicit_identities_test.go
+++ b/nomad/job_endpoint_hook_implicit_identities_test.go
@@ -31,7 +31,7 @@ func Test_jobImplicitIdentitiesHook_Mutate_consul_service(t *testing.T) {
 				}},
 			},
 			inputConfig: &Config{
-				ConsulConfig: &config.ConsulConfig{},
+				ConsulConfigs: map[string]*config.ConsulConfig{},
 			},
 			expectedOutputJob: &structs.Job{
 				TaskGroups: []*structs.TaskGroup{{
@@ -51,11 +51,12 @@ func Test_jobImplicitIdentitiesHook_Mutate_consul_service(t *testing.T) {
 				}},
 			},
 			inputConfig: &Config{
-				ConsulConfig: &config.ConsulConfig{
-					ServiceIdentity: &config.WorkloadIdentityConfig{
-						Audience: []string{"consul.io"},
-					},
-				},
+				ConsulConfigs: map[string]*config.ConsulConfig{
+					structs.ConsulDefaultCluster: {
+						ServiceIdentity: &config.WorkloadIdentityConfig{
+							Audience: []string{"consul.io"},
+						},
+					}},
 			},
 			expectedOutputJob: &structs.Job{
 				TaskGroups: []*structs.TaskGroup{{
@@ -108,9 +109,11 @@ func Test_jobImplicitIdentitiesHook_Mutate_consul_service(t *testing.T) {
 				}},
 			},
 			inputConfig: &Config{
-				ConsulConfig: &config.ConsulConfig{
-					ServiceIdentity: &config.WorkloadIdentityConfig{
-						Audience: []string{"consul.io"},
+				ConsulConfigs: map[string]*config.ConsulConfig{
+					structs.ConsulDefaultCluster: {
+						ServiceIdentity: &config.WorkloadIdentityConfig{
+							Audience: []string{"consul.io"},
+						},
 					},
 				},
 			},
@@ -182,9 +185,11 @@ func Test_jobImplicitIdentitiesHook_Mutate_consul_service(t *testing.T) {
 				}},
 			},
 			inputConfig: &Config{
-				ConsulConfig: &config.ConsulConfig{
-					ServiceIdentity: &config.WorkloadIdentityConfig{
-						Audience: []string{"consul.io"},
+				ConsulConfigs: map[string]*config.ConsulConfig{
+					structs.ConsulDefaultCluster: {
+						ServiceIdentity: &config.WorkloadIdentityConfig{
+							Audience: []string{"consul.io"},
+						},
 					},
 				},
 			},
@@ -229,9 +234,11 @@ func Test_jobImplicitIdentitiesHook_Mutate_consul_service(t *testing.T) {
 				}},
 			},
 			inputConfig: &Config{
-				ConsulConfig: &config.ConsulConfig{
-					TaskIdentity: &config.WorkloadIdentityConfig{
-						Audience: []string{"consul.io"},
+				ConsulConfigs: map[string]*config.ConsulConfig{
+					structs.ConsulDefaultCluster: {
+						TaskIdentity: &config.WorkloadIdentityConfig{
+							Audience: []string{"consul.io"},
+						},
 					},
 				},
 			},
@@ -260,7 +267,7 @@ func Test_jobImplicitIdentitiesHook_Mutate_consul_service(t *testing.T) {
 				}},
 			},
 			inputConfig: &Config{
-				ConsulConfig: &config.ConsulConfig{},
+				ConsulConfigs: map[string]*config.ConsulConfig{},
 			},
 			expectedOutputJob: &structs.Job{
 				TaskGroups: []*structs.TaskGroup{{

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -33,7 +33,7 @@ func Test_jobValidate_Validate_consul_service(t *testing.T) {
 				Name:     "web",
 			},
 			inputConfig: &Config{
-				ConsulConfig: &config.ConsulConfig{},
+				ConsulConfigs: map[string]*config.ConsulConfig{},
 			},
 		},
 		{
@@ -43,10 +43,12 @@ func Test_jobValidate_Validate_consul_service(t *testing.T) {
 				Name:     "web",
 			},
 			inputConfig: &Config{
-				ConsulConfig: &config.ConsulConfig{
-					ServiceIdentity: &config.WorkloadIdentityConfig{
-						Audience: []string{"consul.io"},
-						TTL:      pointer.Of(time.Hour),
+				ConsulConfigs: map[string]*config.ConsulConfig{
+					structs.ConsulDefaultCluster: {
+						ServiceIdentity: &config.WorkloadIdentityConfig{
+							Audience: []string{"consul.io"},
+							TTL:      pointer.Of(time.Hour),
+						},
 					},
 				},
 			},
@@ -66,7 +68,7 @@ func Test_jobValidate_Validate_consul_service(t *testing.T) {
 				},
 			},
 			inputConfig: &Config{
-				ConsulConfig: &config.ConsulConfig{},
+				ConsulConfigs: map[string]*config.ConsulConfig{},
 			},
 		},
 		{
@@ -83,7 +85,7 @@ func Test_jobValidate_Validate_consul_service(t *testing.T) {
 				},
 			},
 			inputConfig: &Config{
-				ConsulConfig: &config.ConsulConfig{},
+				ConsulConfigs: map[string]*config.ConsulConfig{},
 			},
 			expectedWarns: []string{
 				"identities without an expiration are insecure",

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1550,7 +1550,7 @@ func TestJobEndpoint_Register_Vault_Disabled(t *testing.T) {
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
 		c.NumSchedulers = 0 // Prevent automatic dequeue
 		f := false
-		c.VaultConfig.Enabled = &f
+		c.GetDefaultVault().Enabled = &f
 	})
 	defer cleanupS1()
 	codec := rpcClient(t, s1)
@@ -1573,7 +1573,7 @@ func TestJobEndpoint_Register_Vault_Disabled(t *testing.T) {
 	// Fetch the response
 	var resp structs.JobRegisterResponse
 	err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
-	if err == nil || !strings.Contains(err.Error(), "Vault not enabled") {
+	if err == nil || !strings.Contains(err.Error(), "Vault \"default\" not enabled") {
 		t.Fatalf("expected Vault not enabled error: %v", err)
 	}
 }
@@ -1593,8 +1593,8 @@ func TestJobEndpoint_Register_Vault_AllowUnauthenticated(t *testing.T) {
 
 	// Enable vault and allow authenticated
 	tr := true
-	s1.config.VaultConfig.Enabled = &tr
-	s1.config.VaultConfig.AllowUnauthenticated = &tr
+	s1.config.GetDefaultVault().Enabled = &tr
+	s1.config.GetDefaultVault().AllowUnauthenticated = &tr
 
 	// Replace the Vault Client on the server
 	s1.vault = &TestVaultClient{}
@@ -1650,8 +1650,8 @@ func TestJobEndpoint_Register_Vault_OverrideConstraint(t *testing.T) {
 
 	// Enable vault and allow authenticated
 	tr := true
-	s1.config.VaultConfig.Enabled = &tr
-	s1.config.VaultConfig.AllowUnauthenticated = &tr
+	s1.config.GetDefaultVault().Enabled = &tr
+	s1.config.GetDefaultVault().AllowUnauthenticated = &tr
 
 	// Replace the Vault Client on the server
 	s1.vault = &TestVaultClient{}
@@ -1707,8 +1707,8 @@ func TestJobEndpoint_Register_Vault_NoToken(t *testing.T) {
 
 	// Enable vault
 	tr, f := true, false
-	s1.config.VaultConfig.Enabled = &tr
-	s1.config.VaultConfig.AllowUnauthenticated = &f
+	s1.config.GetDefaultVault().Enabled = &tr
+	s1.config.GetDefaultVault().AllowUnauthenticated = &f
 
 	// Replace the Vault Client on the server
 	s1.vault = &TestVaultClient{}
@@ -1748,8 +1748,8 @@ func TestJobEndpoint_Register_Vault_Policies(t *testing.T) {
 
 	// Enable vault
 	tr, f := true, false
-	s1.config.VaultConfig.Enabled = &tr
-	s1.config.VaultConfig.AllowUnauthenticated = &f
+	s1.config.GetDefaultVault().Enabled = &tr
+	s1.config.GetDefaultVault().AllowUnauthenticated = &f
 
 	// Replace the Vault Client on the server
 	tvc := &TestVaultClient{}
@@ -1888,8 +1888,8 @@ func TestJobEndpoint_Register_Vault_MultiNamespaces(t *testing.T) {
 
 	// Enable vault
 	tr, f := true, false
-	s1.config.VaultConfig.Enabled = &tr
-	s1.config.VaultConfig.AllowUnauthenticated = &f
+	s1.config.GetDefaultVault().Enabled = &tr
+	s1.config.GetDefaultVault().AllowUnauthenticated = &f
 
 	// Replace the Vault Client on the server
 	tvc := &TestVaultClient{}
@@ -2671,8 +2671,8 @@ func TestJobEndpoint_Revert_Vault_NoToken(t *testing.T) {
 
 	// Enable vault
 	tr, f := true, false
-	s1.config.VaultConfig.Enabled = &tr
-	s1.config.VaultConfig.AllowUnauthenticated = &f
+	s1.config.GetDefaultVault().Enabled = &tr
+	s1.config.GetDefaultVault().AllowUnauthenticated = &f
 
 	// Replace the Vault Client on the server
 	tvc := &TestVaultClient{}
@@ -2771,8 +2771,8 @@ func TestJobEndpoint_Revert_Vault_Policies(t *testing.T) {
 
 	// Enable vault
 	tr, f := true, false
-	s1.config.VaultConfig.Enabled = &tr
-	s1.config.VaultConfig.AllowUnauthenticated = &f
+	s1.config.GetDefaultVault().Enabled = &tr
+	s1.config.GetDefaultVault().AllowUnauthenticated = &f
 
 	// Replace the Vault Client on the server
 	tvc := &TestVaultClient{}
@@ -6403,8 +6403,8 @@ func TestJobEndpoint_ImplicitConstraints_Vault(t *testing.T) {
 
 	// Enable vault
 	tr, f := true, false
-	s1.config.VaultConfig.Enabled = &tr
-	s1.config.VaultConfig.AllowUnauthenticated = &f
+	s1.config.GetDefaultVault().Enabled = &tr
+	s1.config.GetDefaultVault().AllowUnauthenticated = &f
 
 	// Replace the Vault Client on the server
 	tvc := &TestVaultClient{}

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -1573,7 +1573,7 @@ func TestJobEndpoint_Register_Vault_Disabled(t *testing.T) {
 	// Fetch the response
 	var resp structs.JobRegisterResponse
 	err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
-	if err == nil || !strings.Contains(err.Error(), "Vault \"default\" not enabled") {
+	if err == nil || !strings.Contains(err.Error(), `Vault "default" not enabled`) {
 		t.Fatalf("expected Vault not enabled error: %v", err)
 	}
 }

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -3962,8 +3962,8 @@ func TestClientEndpoint_DeriveVaultToken(t *testing.T) {
 
 	// Enable vault and allow authenticated
 	tr := true
-	s1.config.VaultConfig.Enabled = &tr
-	s1.config.VaultConfig.AllowUnauthenticated = &tr
+	s1.config.GetDefaultVault().Enabled = &tr
+	s1.config.GetDefaultVault().AllowUnauthenticated = &tr
 
 	// Replace the Vault Client on the server
 	tvc := &TestVaultClient{}
@@ -4055,8 +4055,8 @@ func TestClientEndpoint_DeriveVaultToken_VaultError(t *testing.T) {
 
 	// Enable vault and allow authenticated
 	tr := true
-	s1.config.VaultConfig.Enabled = &tr
-	s1.config.VaultConfig.AllowUnauthenticated = &tr
+	s1.config.GetDefaultVault().Enabled = &tr
+	s1.config.GetDefaultVault().AllowUnauthenticated = &tr
 
 	// Replace the Vault Client on the server
 	tvc := &TestVaultClient{}
@@ -4194,7 +4194,7 @@ func TestClientEndpoint_DeriveSIToken(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Set allow unauthenticated (no operator token required)
-	s1.config.ConsulConfig.AllowUnauthenticated = pointer.Of(true)
+	s1.config.GetDefaultConsul().AllowUnauthenticated = pointer.Of(true)
 
 	// Create the node
 	node := mock.Node()
@@ -4246,7 +4246,7 @@ func TestClientEndpoint_DeriveSIToken_ConsulError(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC)
 
 	// Set allow unauthenticated (no operator token required)
-	s1.config.ConsulConfig.AllowUnauthenticated = pointer.Of(true)
+	s1.config.GetDefaultConsul().AllowUnauthenticated = pointer.Of(true)
 
 	// Create the node
 	node := mock.Node()

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1106,7 +1106,7 @@ func (s *Server) setupBootstrapHandler() error {
 // setupConsulSyncer creates Server-mode consul.Syncer which periodically
 // executes callbacks on a fixed interval.
 func (s *Server) setupConsulSyncer() error {
-	conf := s.config.ConsulConfigs[structs.ConsulDefaultCluster]
+	conf := s.config.GetDefaultConsul()
 	if conf.ServerAutoJoin != nil && *conf.ServerAutoJoin {
 		if err := s.setupBootstrapHandler(); err != nil {
 			return err

--- a/nomad/server_test.go
+++ b/nomad/server_test.go
@@ -216,9 +216,9 @@ func TestServer_Reload_Vault(t *testing.T) {
 
 	tr := true
 	config := DefaultConfig()
-	config.VaultConfig.Enabled = &tr
-	config.VaultConfig.Token = uuid.Generate()
-	config.VaultConfig.Namespace = "nondefault"
+	config.GetDefaultVault().Enabled = &tr
+	config.GetDefaultVault().Token = uuid.Generate()
+	config.GetDefaultVault().Namespace = "nondefault"
 
 	if err := s1.Reload(config); err != nil {
 		t.Fatalf("Reload failed: %v", err)

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -84,7 +84,7 @@ func TestConfigForServer(t testing.T) *Config {
 
 	// Disable Vault
 	f := false
-	config.VaultConfig.Enabled = &f
+	config.GetDefaultVault().Enabled = &f
 
 	// Tighten the autopilot timing
 	config.AutopilotConfig.ServerStabilizationTime = 100 * time.Millisecond
@@ -92,7 +92,7 @@ func TestConfigForServer(t testing.T) *Config {
 	config.AutopilotInterval = 100 * time.Millisecond
 
 	// Disable consul autojoining: tests typically join servers directly
-	config.ConsulConfig.ServerAutoJoin = &f
+	config.GetDefaultConsul().ServerAutoJoin = &f
 
 	// Enable fuzzy search API
 	config.SearchConfig = &structs.SearchConfig{


### PR DESCRIPTION
Remove the now-unused original configuration blocks for Consul and Vault from the server. When the server needs to refer to a Consul or Vault block it will always be for a specific cluster for the task/service. Add a helper for accessing the default clusters (for the servers' own use).

This is one of three changesets for this work. The remainder will implement the same changes in the `client` package and on the `command/agent` package.

As part of this work I discovered two bugs:
* The job submission hook for Vault only checks the enabled flag on the default cluster, rather than the clusters that are used by the job being submitted. This will return an error on job registration saying that Vault is disabled. Fix that to check only the cluster(s) used by the job.
* The `consul.service_identity` and `consul.task_identity` are only ever taken from default Consul block. This will prevent the cluster admin from setting different identity configs across multiple Consul clusters. (It works fine for Vault though.)

Ref: https://github.com/hashicorp/nomad/issues/18947
Ref: https://github.com/hashicorp/nomad/pull/18994
Fixes: https://github.com/hashicorp/nomad/issues/18990
Fixes: https://github.com/hashicorp/nomad/issues/18978