### PR TITLE
Move deprecation warning to server

### DIFF
--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -227,9 +227,6 @@ func (c *JobPlanCommand) Run(args []string) int {
 	}
 
 	if vaultToken != "" {
-		c.Ui.Warn(strings.TrimSpace(`
-Warning: setting a Vault token when submitting a job is deprecated and will be
-removed in Nomad 1.9. Migrate your Vault configuration to use workload identity.`))
 		job.VaultToken = pointer.Of(vaultToken)
 	}
 

--- a/command/job_revert.go
+++ b/command/job_revert.go
@@ -132,17 +132,6 @@ func (c *JobRevertCommand) Run(args []string) int {
 		vaultToken = os.Getenv("VAULT_TOKEN")
 	}
 
-	if consulToken != "" {
-		c.Ui.Warn(strings.TrimSpace(`
-Warning: setting a Consul token when submitting a job is deprecated and will be
-removed in Nomad 1.9. Migrate your Consul configuration to use workload identity.`))
-	}
-	if vaultToken != "" {
-		c.Ui.Warn(strings.TrimSpace(`
-Warning: setting a Vault token when submitting a job is deprecated and will be
-removed in Nomad 1.9. Migrate your Vault configuration to use workload identity.`))
-	}
-
 	// Parse the job version
 	revertVersion, ok, err := parseVersion(args[1])
 	if !ok {

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -280,9 +280,6 @@ func (c *JobRunCommand) Run(args []string) int {
 	}
 
 	if consulToken != "" {
-		c.Ui.Warn(strings.TrimSpace(`
-Warning: setting a Consul token when submitting a job is deprecated and will be
-removed in Nomad 1.9. Migrate your Consul configuration to use workload identity.`))
 		job.ConsulToken = pointer.Of(consulToken)
 	}
 
@@ -297,9 +294,6 @@ removed in Nomad 1.9. Migrate your Consul configuration to use workload identity
 	}
 
 	if vaultToken != "" {
-		c.Ui.Warn(strings.TrimSpace(`
-Warning: setting a Vault token when submitting a job is deprecated and will be
-removed in Nomad 1.9. Migrate your Vault configuration to use workload identity.`))
 		job.VaultToken = pointer.Of(vaultToken)
 	}
 


### PR DESCRIPTION
Submitting a Consul or Vault token with a job is deprecated in Nomad 1.7 and
intended for removal in Nomad 1.9. We added a deprecation warning to the CLI
when the user passes in the appropriate flag or environment variable in
does not use Vault or Consul but happen to have the appropriate environment
variable in your environment. While this is generally a bad practice (because
the token is leaked to Nomad), it's also the existing practice for some users.

Move the warning to the job admission hook. This will allow us to warn only when
appropriate, and that will also help the migration process by producing warnings
only for the relevant jobs.