### PR TITLE
config: remove old Vault/Consul config blocks from parser

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -518,15 +518,15 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		return nil, fmt.Errorf("server_service_name must be set when auto_advertise is enabled")
 	}
 
-	// handle system scheduler preemption default
-	if agentConfig.Server.DefaultSchedulerConfig != nil {
-		conf.DefaultSchedulerConfig = *agentConfig.Server.DefaultSchedulerConfig
-	}
-
 	conf.VaultConfigs = helper.SliceToMap[map[string]*config.VaultConfig](
 		agentConfig.Vaults,
 		func(cfg *config.VaultConfig) string { return cfg.Name },
 	)
+
+	// handle system scheduler preemption default
+	if agentConfig.Server.DefaultSchedulerConfig != nil {
+		conf.DefaultSchedulerConfig = *agentConfig.Server.DefaultSchedulerConfig
+	}
 
 	// Set the TLS config
 	conf.TLSConfig = agentConfig.TLSConfig
@@ -1164,13 +1164,7 @@ func (a *Agent) agentHTTPCheck(server bool) *structs.ServiceCheck {
 	// Resolve the http check address
 	httpCheckAddr := a.config.normalizedAddrs.HTTP[0]
 
-	var defaultConsul *config.ConsulConfig
-	for _, consulCfg := range a.config.Consuls {
-		if consulCfg.Name == structs.ConsulDefaultCluster {
-			defaultConsul = consulCfg
-			break
-		}
-	}
+	defaultConsul := a.config.defaultConsul()
 	if defaultConsul == nil {
 		return nil
 	}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -507,7 +507,14 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		conf.FailoverHeartbeatTTL = failoverTTL
 	}
 
-	if *agentConfig.Consul.AutoAdvertise && agentConfig.Consul.ServerServiceName == "" {
+	// Add the Consul and Vault configs
+	conf.ConsulConfigs = helper.SliceToMap[map[string]*config.ConsulConfig](
+		agentConfig.Consuls,
+		func(cfg *config.ConsulConfig) string { return cfg.Name },
+	)
+
+	consul := conf.ConsulConfigs[structs.ConsulDefaultCluster]
+	if *consul.AutoAdvertise && consul.ServerServiceName == "" {
 		return nil, fmt.Errorf("server_service_name must be set when auto_advertise is enabled")
 	}
 
@@ -516,9 +523,10 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		conf.DefaultSchedulerConfig = *agentConfig.Server.DefaultSchedulerConfig
 	}
 
-	// Add the Consul and Vault configs
-	conf.ConsulConfigs = agentConfig.Consuls
-	conf.VaultConfigs = agentConfig.Vaults
+	conf.VaultConfigs = helper.SliceToMap[map[string]*config.VaultConfig](
+		agentConfig.Vaults,
+		func(cfg *config.VaultConfig) string { return cfg.Name },
+	)
 
 	// Set the TLS config
 	conf.TLSConfig = agentConfig.TLSConfig
@@ -821,13 +829,22 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 
 	conf.Version = agentConfig.Version
 
-	if *agentConfig.Consul.AutoAdvertise && agentConfig.Consul.ClientServiceName == "" {
+	// Set the Consul configurations
+	conf.ConsulConfigs = helper.SliceToMap[map[string]*config.ConsulConfig](
+		agentConfig.Consuls,
+		func(cfg *config.ConsulConfig) string { return cfg.Name },
+	)
+
+	consul := conf.ConsulConfigs[structs.ConsulDefaultCluster]
+	if *consul.AutoAdvertise && consul.ClientServiceName == "" {
 		return nil, fmt.Errorf("client_service_name must be set when auto_advertise is enabled")
 	}
 
-	// Set the Vault and Consul configurations
-	conf.ConsulConfigs = agentConfig.Consuls
-	conf.VaultConfigs = agentConfig.Vaults
+	// Set the Vault configurations
+	conf.VaultConfigs = helper.SliceToMap[map[string]*config.VaultConfig](
+		agentConfig.Vaults,
+		func(cfg *config.VaultConfig) string { return cfg.Name },
+	)
 
 	// Set up Telemetry configuration
 	conf.StatsCollectionInterval = agentConfig.Telemetry.collectionInterval
@@ -925,29 +942,32 @@ func (a *Agent) setupServer() error {
 	// Consul check addresses default to bind but can be toggled to use advertise
 	rpcCheckAddr := a.config.normalizedAddrs.RPC
 	serfCheckAddr := a.config.normalizedAddrs.Serf
-	if *a.config.Consul.ChecksUseAdvertise {
+
+	defaultConsul := conf.ConsulConfigs[structs.ConsulDefaultCluster]
+
+	if *defaultConsul.ChecksUseAdvertise {
 		rpcCheckAddr = a.config.AdvertiseAddrs.RPC
 		serfCheckAddr = a.config.AdvertiseAddrs.Serf
 	}
 
 	// Create the Nomad Server services for Consul
-	if *a.config.Consul.AutoAdvertise {
+	if *defaultConsul.AutoAdvertise {
 		httpServ := &structs.Service{
-			Name:      a.config.Consul.ServerServiceName,
+			Name:      defaultConsul.ServerServiceName,
 			PortLabel: a.config.AdvertiseAddrs.HTTP,
-			Tags:      append([]string{consul.ServiceTagHTTP}, a.config.Consul.Tags...),
+			Tags:      append([]string{consul.ServiceTagHTTP}, defaultConsul.Tags...),
 		}
 		const isServer = true
 		if check := a.agentHTTPCheck(isServer); check != nil {
 			httpServ.Checks = []*structs.ServiceCheck{check}
 		}
 		rpcServ := &structs.Service{
-			Name:      a.config.Consul.ServerServiceName,
+			Name:      defaultConsul.ServerServiceName,
 			PortLabel: a.config.AdvertiseAddrs.RPC,
-			Tags:      append([]string{consul.ServiceTagRPC}, a.config.Consul.Tags...),
+			Tags:      append([]string{consul.ServiceTagRPC}, defaultConsul.Tags...),
 			Checks: []*structs.ServiceCheck{
 				{
-					Name:      a.config.Consul.ServerRPCCheckName,
+					Name:      defaultConsul.ServerRPCCheckName,
 					Type:      "tcp",
 					Interval:  serverRpcCheckInterval,
 					Timeout:   serverRpcCheckTimeout,
@@ -956,12 +976,12 @@ func (a *Agent) setupServer() error {
 			},
 		}
 		serfServ := &structs.Service{
-			Name:      a.config.Consul.ServerServiceName,
+			Name:      defaultConsul.ServerServiceName,
 			PortLabel: a.config.AdvertiseAddrs.Serf,
-			Tags:      append([]string{consul.ServiceTagSerf}, a.config.Consul.Tags...),
+			Tags:      append([]string{consul.ServiceTagSerf}, defaultConsul.Tags...),
 			Checks: []*structs.ServiceCheck{
 				{
-					Name:      a.config.Consul.ServerSerfCheckName,
+					Name:      defaultConsul.ServerSerfCheckName,
 					Type:      "tcp",
 					Interval:  serverSerfCheckInterval,
 					Timeout:   serverSerfCheckTimeout,
@@ -1119,11 +1139,12 @@ func (a *Agent) setupClient() error {
 	a.client = nomadClient
 
 	// Create the Nomad Client  services for Consul
-	if *a.config.Consul.AutoAdvertise {
+	defaultConsul := conf.ConsulConfigs[structs.ConsulDefaultCluster]
+	if *defaultConsul.AutoAdvertise {
 		httpServ := &structs.Service{
-			Name:      a.config.Consul.ClientServiceName,
+			Name:      defaultConsul.ClientServiceName,
 			PortLabel: a.config.AdvertiseAddrs.HTTP,
-			Tags:      append([]string{consul.ServiceTagHTTP}, a.config.Consul.Tags...),
+			Tags:      append([]string{consul.ServiceTagHTTP}, defaultConsul.Tags...),
 		}
 		const isServer = false
 		if check := a.agentHTTPCheck(isServer); check != nil {
@@ -1142,11 +1163,22 @@ func (a *Agent) setupClient() error {
 func (a *Agent) agentHTTPCheck(server bool) *structs.ServiceCheck {
 	// Resolve the http check address
 	httpCheckAddr := a.config.normalizedAddrs.HTTP[0]
-	if *a.config.Consul.ChecksUseAdvertise {
+
+	var defaultConsul *config.ConsulConfig
+	for _, consulCfg := range a.config.Consuls {
+		if consulCfg.Name == structs.ConsulDefaultCluster {
+			defaultConsul = consulCfg
+			break
+		}
+	}
+	if defaultConsul == nil {
+		return nil
+	}
+	if *defaultConsul.ChecksUseAdvertise {
 		httpCheckAddr = a.config.AdvertiseAddrs.HTTP
 	}
 	check := structs.ServiceCheck{
-		Name:      a.config.Consul.ClientHTTPCheckName,
+		Name:      defaultConsul.ClientHTTPCheckName,
 		Type:      "http",
 		Path:      "/v1/agent/health?type=client",
 		Protocol:  "http",
@@ -1156,7 +1188,7 @@ func (a *Agent) agentHTTPCheck(server bool) *structs.ServiceCheck {
 	}
 	// Switch to endpoint that doesn't require a leader for servers
 	if server {
-		check.Name = a.config.Consul.ServerHTTPCheckName
+		check.Name = defaultConsul.ServerHTTPCheckName
 		check.Path = "/v1/agent/health?type=server"
 	}
 	if !a.config.TLSConfig.EnableHTTP {
@@ -1400,7 +1432,7 @@ func (a *Agent) GetMetricsSink() *metrics.InmemSink {
 	return a.inmemSink
 }
 
-func (a *Agent) setupConsuls(cfgs map[string]*config.ConsulConfig) error {
+func (a *Agent) setupConsuls(cfgs []*config.ConsulConfig) error {
 
 	isClient := false
 	if a.config.Client != nil && a.config.Client.Enabled {
@@ -1411,7 +1443,8 @@ func (a *Agent) setupConsuls(cfgs map[string]*config.ConsulConfig) error {
 	consulProxies := map[string]*consul.ConnectProxies{}
 	consulConfigEntries := map[string]consul.ConfigAPI{}
 
-	for cluster, consulConfig := range cfgs {
+	for _, consulConfig := range cfgs {
+		cluster := consulConfig.Name
 		apiConf, err := consulConfig.ApiConfig()
 		if err != nil {
 			return err

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -84,9 +84,6 @@ func (s *HTTPServer) AgentSelfRequest(resp http.ResponseWriter, req *http.Reques
 
 	self.Config = s.agent.GetConfig().Copy()
 
-	if self.Config != nil && self.Config.Vault != nil && self.Config.Vault.Token != "" {
-		self.Config.Vault.Token = "<redacted>"
-	}
 	for _, vaultConfig := range self.Config.Vaults {
 		if vaultConfig.Token != "" {
 			vaultConfig.Token = "<redacted>"
@@ -97,9 +94,6 @@ func (s *HTTPServer) AgentSelfRequest(resp http.ResponseWriter, req *http.Reques
 		self.Config.ACL.ReplicationToken = "<redacted>"
 	}
 
-	if self.Config != nil && self.Config.Consul != nil && self.Config.Consul.Token != "" {
-		self.Config.Consul.Token = "<redacted>"
-	}
 	for _, consulConfig := range self.Config.Consuls {
 		if consulConfig.Token != "" {
 			consulConfig.Token = "<redacted>"

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -57,15 +57,15 @@ func TestHTTP_AgentSelf(t *testing.T) {
 		require.NotEmpty(self.Stats)
 
 		// Check the Vault config
-		require.Empty(self.Config.Vault.Token)
+		require.Empty(self.Config.defaultVault().Token)
 
 		// Assign a Vault token and require it is redacted.
-		s.Config.Vault.Token = "badc0deb-adc0-deba-dc0d-ebadc0debadc"
+		s.Config.defaultVault().Token = "badc0deb-adc0-deba-dc0d-ebadc0debadc"
 		respW = httptest.NewRecorder()
 		obj, err = s.Server.AgentSelfRequest(respW, req)
 		require.NoError(err)
 		self = obj.(agentSelf)
-		require.Equal("<redacted>", self.Config.Vault.Token)
+		require.Equal("<redacted>", self.Config.defaultVault().Token)
 
 		// Assign a ReplicationToken token and require it is redacted.
 		s.Config.ACL.ReplicationToken = "badc0deb-adc0-deba-dc0d-ebadc0debadc"
@@ -76,15 +76,15 @@ func TestHTTP_AgentSelf(t *testing.T) {
 		require.Equal("<redacted>", self.Config.ACL.ReplicationToken)
 
 		// Check the Consul config
-		require.Empty(self.Config.Consul.Token)
+		require.Empty(self.Config.Consuls[0].Token)
 
 		// Assign a Consul token and require it is redacted.
-		s.Config.Consul.Token = "badc0deb-adc0-deba-dc0d-ebadc0debadc"
+		s.Config.Consuls[0].Token = "badc0deb-adc0-deba-dc0d-ebadc0debadc"
 		respW = httptest.NewRecorder()
 		obj, err = s.Server.AgentSelfRequest(respW, req)
 		require.NoError(err)
 		self = obj.(agentSelf)
-		require.Equal("<redacted>", self.Config.Consul.Token)
+		require.Equal("<redacted>", self.Config.Consuls[0].Token)
 
 		// Check the Circonus config
 		require.Empty(self.Config.Telemetry.CirconusAPIToken)

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -774,9 +774,10 @@ func TestAgent_HTTPCheck(t *testing.T) {
 			config: &Config{
 				AdvertiseAddrs:  &AdvertiseAddrs{HTTP: "advertise:4646"},
 				normalizedAddrs: &NormalizedAddrs{HTTP: []string{"normalized:4646"}},
-				Consul: &config.ConsulConfig{
+				Consuls: []*config.ConsulConfig{{
+					Name:               "default",
 					ChecksUseAdvertise: pointer.Of(false),
-				},
+				}},
 				TLSConfig: &config.TLSConfig{EnableHTTP: false},
 			},
 		}
@@ -804,7 +805,7 @@ func TestAgent_HTTPCheck(t *testing.T) {
 
 	t.Run("Plain HTTP + ChecksUseAdvertise", func(t *testing.T) {
 		a := agent()
-		a.config.Consul.ChecksUseAdvertise = pointer.Of(true)
+		a.config.Consuls[0].ChecksUseAdvertise = pointer.Of(true)
 		check := a.agentHTTPCheck(false)
 		if check == nil {
 			t.Fatalf("expected non-nil check")
@@ -1077,8 +1078,6 @@ func Test_GetConfig(t *testing.T) {
 		Ports:          &Ports{},
 		Addresses:      &Addresses{},
 		AdvertiseAddrs: &AdvertiseAddrs{},
-		Vault:          &config.VaultConfig{},
-		Consul:         &config.ConsulConfig{},
 		Sentinel:       &config.SentinelConfig{},
 	}
 
@@ -1193,7 +1192,8 @@ func TestServer_Reload_VaultConfig(t *testing.T) {
 
 	agent := NewTestAgent(t, t.Name(), func(c *Config) {
 		c.Server.NumSchedulers = pointer.Of(0)
-		c.Vault = &config.VaultConfig{
+		c.Vaults[0] = &config.VaultConfig{
+			Name:      "default",
 			Enabled:   pointer.Of(true),
 			Token:     "vault-token",
 			Namespace: "vault-namespace",
@@ -1203,7 +1203,8 @@ func TestServer_Reload_VaultConfig(t *testing.T) {
 	defer agent.Shutdown()
 
 	newConfig := agent.GetConfig().Copy()
-	newConfig.Vault = &config.VaultConfig{
+	newConfig.Vaults[0] = &config.VaultConfig{
+		Name:      "default",
 		Enabled:   pointer.Of(true),
 		Token:     "vault-token",
 		Namespace: "another-namespace",

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -68,19 +68,17 @@ func (c *Command) readConfig() *Config {
 
 	// Make a new, empty config.
 	cmdConfig := &Config{
-		Client: &ClientConfig{},
-		Consul: &config.ConsulConfig{},
-		Ports:  &Ports{},
+		Client:  &ClientConfig{},
+		Consuls: []*config.ConsulConfig{{Name: structs.ConsulDefaultCluster}},
+		Ports:   &Ports{},
 		Server: &ServerConfig{
 			ServerJoin: &ServerJoin{},
 		},
-		Vault:     &config.VaultConfig{},
+		Vaults:    []*config.VaultConfig{{Name: structs.VaultDefaultCluster}},
 		ACL:       &ACLConfig{},
 		Audit:     &config.AuditConfig{},
 		Reporting: &config.ReportingConfig{},
 	}
-	cmdConfig.Vaults = map[string]*config.VaultConfig{structs.VaultDefaultCluster: cmdConfig.Vault}
-	cmdConfig.Consuls = map[string]*config.ConsulConfig{structs.ConsulDefaultCluster: cmdConfig.Consul}
 
 	flags := flag.NewFlagSet("agent", flag.ContinueOnError)
 	flags.Usage = func() { c.Ui.Error(c.Help()) }
@@ -129,69 +127,71 @@ func (c *Command) readConfig() *Config {
 	flags.StringVar(&cmdConfig.NodeName, "node", "", "")
 
 	// Consul options
-	flags.StringVar(&cmdConfig.Consul.Auth, "consul-auth", "", "")
+	defaultConsul := cmdConfig.defaultConsul()
+	flags.StringVar(&defaultConsul.Auth, "consul-auth", "", "")
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
-		cmdConfig.Consul.AutoAdvertise = &b
+		defaultConsul.AutoAdvertise = &b
 		return nil
 	}), "consul-auto-advertise", "")
-	flags.StringVar(&cmdConfig.Consul.CAFile, "consul-ca-file", "", "")
-	flags.StringVar(&cmdConfig.Consul.CertFile, "consul-cert-file", "", "")
-	flags.StringVar(&cmdConfig.Consul.KeyFile, "consul-key-file", "", "")
+	flags.StringVar(&defaultConsul.CAFile, "consul-ca-file", "", "")
+	flags.StringVar(&defaultConsul.CertFile, "consul-cert-file", "", "")
+	flags.StringVar(&defaultConsul.KeyFile, "consul-key-file", "", "")
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
-		cmdConfig.Consul.ChecksUseAdvertise = &b
+		defaultConsul.ChecksUseAdvertise = &b
 		return nil
 	}), "consul-checks-use-advertise", "")
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
-		cmdConfig.Consul.ClientAutoJoin = &b
+		defaultConsul.ClientAutoJoin = &b
 		return nil
 	}), "consul-client-auto-join", "")
-	flags.StringVar(&cmdConfig.Consul.ClientServiceName, "consul-client-service-name", "", "")
-	flags.StringVar(&cmdConfig.Consul.ClientHTTPCheckName, "consul-client-http-check-name", "", "")
-	flags.StringVar(&cmdConfig.Consul.ServerServiceName, "consul-server-service-name", "", "")
-	flags.StringVar(&cmdConfig.Consul.ServerHTTPCheckName, "consul-server-http-check-name", "", "")
-	flags.StringVar(&cmdConfig.Consul.ServerSerfCheckName, "consul-server-serf-check-name", "", "")
-	flags.StringVar(&cmdConfig.Consul.ServerRPCCheckName, "consul-server-rpc-check-name", "", "")
+	flags.StringVar(&defaultConsul.ClientServiceName, "consul-client-service-name", "", "")
+	flags.StringVar(&defaultConsul.ClientHTTPCheckName, "consul-client-http-check-name", "", "")
+	flags.StringVar(&defaultConsul.ServerServiceName, "consul-server-service-name", "", "")
+	flags.StringVar(&defaultConsul.ServerHTTPCheckName, "consul-server-http-check-name", "", "")
+	flags.StringVar(&defaultConsul.ServerSerfCheckName, "consul-server-serf-check-name", "", "")
+	flags.StringVar(&defaultConsul.ServerRPCCheckName, "consul-server-rpc-check-name", "", "")
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
-		cmdConfig.Consul.ServerAutoJoin = &b
+		defaultConsul.ServerAutoJoin = &b
 		return nil
 	}), "consul-server-auto-join", "")
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
-		cmdConfig.Consul.EnableSSL = &b
+		defaultConsul.EnableSSL = &b
 		return nil
 	}), "consul-ssl", "")
-	flags.StringVar(&cmdConfig.Consul.Token, "consul-token", "", "")
+	flags.StringVar(&defaultConsul.Token, "consul-token", "", "")
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
-		cmdConfig.Consul.VerifySSL = &b
+		defaultConsul.VerifySSL = &b
 		return nil
 	}), "consul-verify-ssl", "")
-	flags.StringVar(&cmdConfig.Consul.Addr, "consul-address", "", "")
+	flags.StringVar(&defaultConsul.Addr, "consul-address", "", "")
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
-		cmdConfig.Consul.AllowUnauthenticated = &b
+		defaultConsul.AllowUnauthenticated = &b
 		return nil
 	}), "consul-allow-unauthenticated", "")
 
 	// Vault options
+	defaultVault := cmdConfig.defaultVault()
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
-		cmdConfig.Vault.Enabled = &b
+		defaultVault.Enabled = &b
 		return nil
 	}), "vault-enabled", "")
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
-		cmdConfig.Vault.AllowUnauthenticated = &b
+		defaultVault.AllowUnauthenticated = &b
 		return nil
 	}), "vault-allow-unauthenticated", "")
-	flags.StringVar(&cmdConfig.Vault.Token, "vault-token", "", "")
-	flags.StringVar(&cmdConfig.Vault.Addr, "vault-address", "", "")
-	flags.StringVar(&cmdConfig.Vault.Namespace, "vault-namespace", "", "")
-	flags.StringVar(&cmdConfig.Vault.Role, "vault-create-from-role", "", "")
-	flags.StringVar(&cmdConfig.Vault.TLSCaFile, "vault-ca-file", "", "")
-	flags.StringVar(&cmdConfig.Vault.TLSCaPath, "vault-ca-path", "", "")
-	flags.StringVar(&cmdConfig.Vault.TLSCertFile, "vault-cert-file", "", "")
-	flags.StringVar(&cmdConfig.Vault.TLSKeyFile, "vault-key-file", "", "")
+	flags.StringVar(&defaultVault.Token, "vault-token", "", "")
+	flags.StringVar(&defaultVault.Addr, "vault-address", "", "")
+	flags.StringVar(&defaultVault.Namespace, "vault-namespace", "", "")
+	flags.StringVar(&defaultVault.Role, "vault-create-from-role", "", "")
+	flags.StringVar(&defaultVault.TLSCaFile, "vault-ca-file", "", "")
+	flags.StringVar(&defaultVault.TLSCaPath, "vault-ca-path", "", "")
+	flags.StringVar(&defaultVault.TLSCertFile, "vault-cert-file", "", "")
+	flags.StringVar(&defaultVault.TLSKeyFile, "vault-key-file", "", "")
 	flags.Var((flaghelper.FuncBoolVar)(func(b bool) error {
-		cmdConfig.Vault.TLSSkipVerify = &b
+		defaultVault.TLSSkipVerify = &b
 		return nil
 	}), "vault-tls-skip-verify", "")
-	flags.StringVar(&cmdConfig.Vault.TLSServerName, "vault-tls-server-name", "", "")
+	flags.StringVar(&defaultVault.TLSServerName, "vault-tls-server-name", "", "")
 
 	// ACL options
 	flags.BoolVar(&cmdConfig.ACL.Enabled, "acl-enabled", false, "")
@@ -279,13 +279,13 @@ func (c *Command) readConfig() *Config {
 	}
 
 	// Check to see if we should read the Vault token from the environment
-	if config.Vault.Token == "" {
-		config.Vault.Token = os.Getenv("VAULT_TOKEN")
+	if defaultVault.Token == "" {
+		defaultVault.Token = os.Getenv("VAULT_TOKEN")
 	}
 
 	// Check to see if we should read the Vault namespace from the environment
-	if config.Vault.Namespace == "" {
-		config.Vault.Namespace = os.Getenv("VAULT_NAMESPACE")
+	if defaultVault.Namespace == "" {
+		defaultVault.Namespace = os.Getenv("VAULT_NAMESPACE")
 	}
 
 	// Default the plugin directory to be under that of the data directory if it

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -136,30 +136,15 @@ type Config struct {
 	// for security bulletins
 	DisableAnonymousSignature bool `hcl:"disable_anonymous_signature"`
 
-	// Consul contains the configuration for the default Consul Agent and
-	// parameters necessary to register services, their checks, and
-	// discover the current Nomad servers.
-	//
-	// TODO(tgross): we'll probably want to remove this field once we've added a
-	// selector so that we don't have to maintain it
-	Consul *config.ConsulConfig `hcl:"-"`
+	// Consuls is a slice derived from multiple `consul` blocks, here to support
+	// features in Nomad Enterprise. The default Consul config pointer above
+	// will be found in this map under the name "default"
+	Consuls []*config.ConsulConfig `hcl:"-"`
 
-	// Consuls is a map derived from multiple `consul` blocks, here to support
-	// features in Nomad Enterprise. The default Consul config pointer above will
-	// be found in this map under the name "default"
-	Consuls map[string]*config.ConsulConfig `hcl:"-"`
-
-	// Vault contains the configuration for the default Vault Agent and
-	// parameters necessary to derive tokens.
-	//
-	// TODO(tgross): we'll probably want to remove this field once we've added a
-	// selector so that we don't have to maintain it
-	Vault *config.VaultConfig `hcl:"-"`
-
-	// Vaults is a map derived from multiple `vault` blocks, here to support
+	// Vaults is a slice derived from multiple `vault` blocks, here to support
 	// features in Nomad Enterprise. The default Vault config pointer above will
 	// be found in this map under the name "default"
-	Vaults map[string]*config.VaultConfig `hcl:"-"`
+	Vaults []*config.VaultConfig `hcl:"-"`
 
 	// UI is used to configure the web UI
 	UI *config.UIConfig `hcl:"ui"`
@@ -209,6 +194,24 @@ type Config struct {
 
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
+}
+
+func (c *Config) defaultConsul() *config.ConsulConfig {
+	for _, cfg := range c.Consuls {
+		if cfg.Name == structs.ConsulDefaultCluster {
+			return cfg
+		}
+	}
+	return nil
+}
+
+func (c *Config) defaultVault() *config.VaultConfig {
+	for _, cfg := range c.Vaults {
+		if cfg.Name == structs.VaultDefaultCluster {
+			return cfg
+		}
+	}
+	return nil
 }
 
 // ClientConfig is configuration specific to the client mode
@@ -471,7 +474,7 @@ type ServerConfig struct {
 	// the source of truth for global tokens and ACL policies.
 	AuthoritativeRegion string `hcl:"authoritative_region"`
 
-	// BootstrapExpect tries to automatically bootstrap the Consul cluster,
+	// BootstrapExpect tries to automatically bootstrap the Nomad cluster,
 	// by withholding peers until enough servers join.
 	BootstrapExpect int `hcl:"bootstrap_expect"`
 
@@ -1267,7 +1270,7 @@ func DevConfig(mode *devModeConfig) *Config {
 	conf.Server.BootstrapExpect = 1
 	conf.EnableDebug = true
 	conf.DisableAnonymousSignature = true
-	conf.Consul.AutoAdvertise = pointer.Of(true)
+	conf.defaultConsul().AutoAdvertise = pointer.Of(true)
 	conf.Client.NetworkInterface = mode.iface
 	conf.Client.Options = map[string]string{
 		"driver.raw_exec.enable": "true",
@@ -1305,8 +1308,8 @@ func DefaultConfig() *Config {
 		},
 		Addresses:      &Addresses{},
 		AdvertiseAddrs: &AdvertiseAddrs{},
-		Consul:         config.DefaultConsulConfig(),
-		Vault:          config.DefaultVaultConfig(),
+		Consuls:        []*config.ConsulConfig{config.DefaultConsulConfig()},
+		Vaults:         []*config.VaultConfig{config.DefaultVaultConfig()},
 		UI:             config.DefaultUIConfig(),
 		Client: &ClientConfig{
 			Enabled:               false,
@@ -1386,8 +1389,6 @@ func DefaultConfig() *Config {
 		Reporting:          config.DefaultReporting(),
 	}
 
-	cfg.Consuls = map[string]*config.ConsulConfig{structs.ConsulDefaultCluster: cfg.Consul}
-	cfg.Vaults = map[string]*config.VaultConfig{structs.VaultDefaultCluster: cfg.Vault}
 	return cfg
 }
 
@@ -1559,13 +1560,11 @@ func (c *Config) Merge(b *Config) *Config {
 		result.AdvertiseAddrs = result.AdvertiseAddrs.Merge(b.AdvertiseAddrs)
 	}
 
-	// Apply the Consul Configurations and overwrite the default Consul config
+	// Apply the Consul Configurations
 	result.Consuls = mergeConsulConfigs(result.Consuls, b.Consuls)
-	result.Consul = result.Consuls[structs.ConsulDefaultCluster]
 
-	// Apply the Vault Configurations and overwrite the default Vault config
+	// Apply the Vault Configurations
 	result.Vaults = mergeVaultConfigs(result.Vaults, b.Vaults)
-	result.Vault = result.Vaults[structs.VaultDefaultCluster]
 
 	// Apply the UI Configuration
 	if result.UI == nil && b.UI != nil {
@@ -1616,36 +1615,72 @@ func (c *Config) Merge(b *Config) *Config {
 	return &result
 }
 
-func mergeVaultConfigs(left, right map[string]*config.VaultConfig) map[string]*config.VaultConfig {
-	merged := helper.DeepCopyMap(left)
-	if left == nil {
-		merged = map[string]*config.VaultConfig{}
-	}
-	for name, rConfig := range right {
-		if lConfig, ok := left[name]; ok {
-			merged[name] = lConfig.Merge(rConfig)
-		} else {
-			merged[name] = config.DefaultVaultConfig().Merge(rConfig)
-			merged[name].Name = name
+// mergeVaultConfigs takes two slices of VaultConfig and returns a slice
+// containing the superset of all configurations, and with every configuration
+// with the same name merged
+func mergeVaultConfigs(left, right []*config.VaultConfig) []*config.VaultConfig {
+	results := []*config.VaultConfig{}
+
+	doMerge := func(dstConfigs, srcConfigs []*config.VaultConfig) []*config.VaultConfig {
+		for _, src := range srcConfigs {
+			if src.Name == "" {
+				src.Name = "default"
+			}
+			var found bool
+			for i, dst := range dstConfigs {
+				if dst.Name == src.Name {
+					dstConfigs[i] = dst.Merge(src)
+					found = true
+					break
+				}
+			}
+			if !found {
+				dstConfigs = append(dstConfigs, config.DefaultVaultConfig().Merge(src))
+			}
 		}
+		return dstConfigs
 	}
-	return merged
+
+	results = doMerge(results, left)
+	results = doMerge(results, right)
+	return results
 }
 
-func mergeConsulConfigs(left, right map[string]*config.ConsulConfig) map[string]*config.ConsulConfig {
-	merged := helper.DeepCopyMap(left)
-	if left == nil {
-		merged = map[string]*config.ConsulConfig{}
+// mergeConsulConfigs takes two slices of ConsulConfig and returns a slice
+// containing the superset of all configurations, and with every configuration
+// with the same name merged
+func mergeConsulConfigs(left, right []*config.ConsulConfig) []*config.ConsulConfig {
+	if len(left) == 0 {
+		return right
 	}
-	for name, rConfig := range right {
-		if lConfig, ok := left[name]; ok {
-			merged[name] = lConfig.Merge(rConfig)
-		} else {
-			merged[name] = config.DefaultConsulConfig().Merge(rConfig)
-			merged[name].Name = name
+	if len(right) == 0 {
+		return left
+	}
+	results := []*config.ConsulConfig{}
+
+	doMerge := func(dstConfigs, srcConfigs []*config.ConsulConfig) []*config.ConsulConfig {
+		for _, src := range srcConfigs {
+			if src.Name == "" {
+				src.Name = "default"
+			}
+			var found bool
+			for i, dst := range dstConfigs {
+				if dst.Name == src.Name {
+					dstConfigs[i] = dst.Merge(src)
+					found = true
+					break
+				}
+			}
+			if !found {
+				dstConfigs = append(dstConfigs, config.DefaultConsulConfig().Merge(src))
+			}
 		}
+		return dstConfigs
 	}
-	return merged
+
+	results = doMerge(results, left)
+	results = doMerge(results, right)
+	return results
 }
 
 // Copy returns a deep copy safe for mutation.
@@ -1664,10 +1699,8 @@ func (c *Config) Copy() *Config {
 	nc.ACL = c.ACL.Copy()
 	nc.Telemetry = c.Telemetry.Copy()
 	nc.DisableUpdateCheck = pointer.Copy(c.DisableUpdateCheck)
-	nc.Consuls = helper.DeepCopyMap(c.Consuls)
-	nc.Consul = nc.Consuls[structs.ConsulDefaultCluster]
-	nc.Vaults = helper.DeepCopyMap(c.Vaults)
-	nc.Vault = nc.Vaults[structs.VaultDefaultCluster]
+	nc.Consuls = helper.CopySlice(c.Consuls)
+	nc.Vaults = helper.CopySlice(c.Vaults)
 	nc.UI = c.UI.Copy()
 
 	nc.NomadConfig = c.NomadConfig.Copy()

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -137,13 +137,11 @@ type Config struct {
 	DisableAnonymousSignature bool `hcl:"disable_anonymous_signature"`
 
 	// Consuls is a slice derived from multiple `consul` blocks, here to support
-	// features in Nomad Enterprise. The default Consul config pointer above
-	// will be found in this map under the name "default"
+	// features in Nomad Enterprise.
 	Consuls []*config.ConsulConfig `hcl:"-"`
 
 	// Vaults is a slice derived from multiple `vault` blocks, here to support
-	// features in Nomad Enterprise. The default Vault config pointer above will
-	// be found in this map under the name "default"
+	// features in Nomad Enterprise.
 	Vaults []*config.VaultConfig `hcl:"-"`
 
 	// UI is used to configure the web UI

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -172,9 +172,6 @@ func ParseConfigFile(path string) (*Config, error) {
 	}
 
 	// Parse durations for Consul and Vault config blocks if provided.
-	//
-	// Since the map of multiple cluster configuration contains a pointer to
-	// the default block we don't need to parse it directly.
 	for _, consulConfig := range c.Consuls {
 		// Capture consulConfig inside the loop so the parse duration function
 		// modifies the right configuration.

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -212,7 +212,7 @@ var basicConfig = &Config{
 	SyslogFacility:            "LOCAL1",
 	DisableUpdateCheck:        pointer.Of(true),
 	DisableAnonymousSignature: true,
-	Consul: &config.ConsulConfig{
+	Consuls: []*config.ConsulConfig{{
 		Name:                      structs.ConsulDefaultCluster,
 		ServerServiceName:         "nomad",
 		ServerHTTPCheckName:       "nomad-server-http-health-check",
@@ -251,55 +251,13 @@ var basicConfig = &Config{
 			TTL:      pointer.Of(2 * time.Hour),
 			TTLHCL:   "2h",
 		},
-	},
-	Consuls: map[string]*config.ConsulConfig{
-		structs.ConsulDefaultCluster: {
-			Name:                      structs.ConsulDefaultCluster,
-			ServerServiceName:         "nomad",
-			ServerHTTPCheckName:       "nomad-server-http-health-check",
-			ServerSerfCheckName:       "nomad-server-serf-health-check",
-			ServerRPCCheckName:        "nomad-server-rpc-health-check",
-			ClientServiceName:         "nomad-client",
-			ClientHTTPCheckName:       "nomad-client-http-health-check",
-			Addr:                      "127.0.0.1:9500",
-			AllowUnauthenticated:      &trueValue,
-			Token:                     "token1",
-			Auth:                      "username:pass",
-			EnableSSL:                 &trueValue,
-			VerifySSL:                 &trueValue,
-			CAFile:                    "/path/to/ca/file",
-			CertFile:                  "/path/to/cert/file",
-			KeyFile:                   "/path/to/key/file",
-			ServerAutoJoin:            &trueValue,
-			ClientAutoJoin:            &trueValue,
-			AutoAdvertise:             &trueValue,
-			ChecksUseAdvertise:        &trueValue,
-			Timeout:                   5 * time.Second,
-			TimeoutHCL:                "5s",
-			ServiceIdentityAuthMethod: "nomad-services",
-			ServiceIdentity: &config.WorkloadIdentityConfig{
-				Audience: []string{"consul.io", "nomad.dev"},
-				Env:      pointer.Of(false),
-				File:     pointer.Of(true),
-				TTL:      pointer.Of(1 * time.Hour),
-				TTLHCL:   "1h",
-			},
-			TaskIdentityAuthMethod: "nomad-tasks",
-			TaskIdentity: &config.WorkloadIdentityConfig{
-				Audience: []string{"consul.io"},
-				Env:      pointer.Of(true),
-				File:     pointer.Of(false),
-				TTL:      pointer.Of(2 * time.Hour),
-				TTLHCL:   "2h",
-			},
-		},
-	},
-	Vault: &config.VaultConfig{
+	}},
+	Vaults: []*config.VaultConfig{{
 		Name:                 structs.VaultDefaultCluster,
 		Addr:                 "127.0.0.1:9500",
 		JWTAuthBackendPath:   "nomad_jwt",
+		ConnectionRetryIntv:  30 * time.Second,
 		AllowUnauthenticated: &trueValue,
-		ConnectionRetryIntv:  config.DefaultVaultConnectRetryIntv,
 		Enabled:              &falseValue,
 		Role:                 "test_role",
 		TLSCaFile:            "/path/to/ca/file",
@@ -317,33 +275,7 @@ var basicConfig = &Config{
 			TTL:      pointer.Of(3 * time.Hour),
 			TTLHCL:   "3h",
 		},
-	},
-	Vaults: map[string]*config.VaultConfig{
-		structs.VaultDefaultCluster: {
-			Name:                 structs.VaultDefaultCluster,
-			Addr:                 "127.0.0.1:9500",
-			JWTAuthBackendPath:   "nomad_jwt",
-			AllowUnauthenticated: &trueValue,
-			ConnectionRetryIntv:  config.DefaultVaultConnectRetryIntv,
-			Enabled:              &falseValue,
-			Role:                 "test_role",
-			TLSCaFile:            "/path/to/ca/file",
-			TLSCaPath:            "/path/to/ca",
-			TLSCertFile:          "/path/to/cert/file",
-			TLSKeyFile:           "/path/to/key/file",
-			TLSServerName:        "foobar",
-			TLSSkipVerify:        &trueValue,
-			TaskTokenTTL:         "1s",
-			Token:                "12345",
-			DefaultIdentity: &config.WorkloadIdentityConfig{
-				Audience: []string{"vault.io", "nomad.io"},
-				Env:      pointer.Of(false),
-				File:     pointer.Of(true),
-				TTL:      pointer.Of(3 * time.Hour),
-				TTLHCL:   "3h",
-			},
-		},
-	},
+	}},
 	TLSConfig: &config.TLSConfig{
 		EnableHTTP:                  true,
 		EnableRPC:                   true,
@@ -458,10 +390,6 @@ var pluginConfig = &Config{
 	SyslogFacility:            "",
 	DisableUpdateCheck:        nil,
 	DisableAnonymousSignature: false,
-	Consul:                    nil,
-	Consuls:                   map[string]*config.ConsulConfig{},
-	Vault:                     nil,
-	Vaults:                    map[string]*config.VaultConfig{},
 	TLSConfig:                 nil,
 	HTTPAPIResponseHeaders:    map[string]string{},
 	Sentinel:                  nil,
@@ -482,6 +410,8 @@ var pluginConfig = &Config{
 	Reporting: &config.ReportingConfig{
 		&config.LicenseReportingConfig{},
 	},
+	Consuls: []*config.ConsulConfig{},
+	Vaults:  []*config.VaultConfig{},
 }
 
 var nonoptConfig = &Config{
@@ -529,14 +459,14 @@ var nonoptConfig = &Config{
 	SyslogFacility:            "",
 	DisableUpdateCheck:        nil,
 	DisableAnonymousSignature: false,
-	Consul:                    nil,
-	Vault:                     nil,
 	TLSConfig:                 nil,
 	HTTPAPIResponseHeaders:    map[string]string{},
 	Sentinel:                  nil,
 	Reporting: &config.ReportingConfig{
 		&config.LicenseReportingConfig{},
 	},
+	Consuls: []*config.ConsulConfig{},
+	Vaults:  []*config.VaultConfig{},
 }
 
 func TestConfig_ParseMerge(t *testing.T) {
@@ -546,16 +476,13 @@ func TestConfig_ParseMerge(t *testing.T) {
 	must.NoError(t, err)
 
 	actual, err := ParseConfigFile(path)
-	must.NoError(t, err)
 
 	// The Vault connection retry interval is an internal only configuration
 	// option, and therefore needs to be added here to ensure the test passes.
-	actual.Vault.ConnectionRetryIntv = config.DefaultVaultConnectRetryIntv
+	actual.Vaults[0].ConnectionRetryIntv = config.DefaultVaultConnectRetryIntv
 	must.Eq(t, basicConfig, actual)
 
 	oldDefault := &Config{
-		Consul:    config.DefaultConsulConfig(),
-		Vault:     config.DefaultVaultConfig(),
 		Autopilot: config.DefaultAutopilotConfig(),
 		Client:    &ClientConfig{},
 		Server:    &ServerConfig{},
@@ -607,15 +534,10 @@ func TestConfig_Parse(t *testing.T) {
 			actual, err := ParseConfigFile(path)
 			must.NoError(t, err)
 
-			// ParseConfig used to re-merge defaults for these three objects,
-			// despite them already being merged in LoadConfig. The test structs
-			// expect these defaults to be set, but not the DefaultConfig
-			// defaults, which include additional settings
+			// The test assertion structs expect these defaults to be set, but
+			// not the DefaultConfig defaults, which include a large number of
+			// additional settings.
 			oldDefault := &Config{
-				Consul:    config.DefaultConsulConfig(),
-				Consuls:   map[string]*config.ConsulConfig{structs.ConsulDefaultCluster: config.DefaultConsulConfig()},
-				Vault:     config.DefaultVaultConfig(),
-				Vaults:    map[string]*config.VaultConfig{structs.VaultDefaultCluster: config.DefaultVaultConfig()},
 				Autopilot: config.DefaultAutopilotConfig(),
 				Reporting: config.DefaultReporting(),
 			}
@@ -649,16 +571,14 @@ func (c *Config) addDefaults() {
 	if c.Audit == nil {
 		c.Audit = &config.AuditConfig{}
 	}
-	if c.Consul == nil {
-		c.Consul = config.DefaultConsulConfig()
-		c.Consuls = map[string]*config.ConsulConfig{structs.ConsulDefaultCluster: c.Consul}
+	if c.Consuls == nil {
+		c.Consuls = []*config.ConsulConfig{config.DefaultConsulConfig()}
 	}
 	if c.Autopilot == nil {
 		c.Autopilot = config.DefaultAutopilotConfig()
 	}
-	if c.Vault == nil {
-		c.Vault = config.DefaultVaultConfig()
-		c.Vaults = map[string]*config.VaultConfig{structs.VaultDefaultCluster: c.Vault}
+	if c.Vaults == nil {
+		c.Vaults = []*config.VaultConfig{config.DefaultVaultConfig()}
 	}
 	if c.Telemetry == nil {
 		c.Telemetry = &Telemetry{}
@@ -802,34 +722,18 @@ var sample0 = &Config{
 	LeaveOnTerm:    true,
 	EnableSyslog:   true,
 	SyslogFacility: "LOCAL0",
-	Consul: &config.ConsulConfig{
+	Consuls: []*config.ConsulConfig{{
 		Name:           structs.ConsulDefaultCluster,
 		Token:          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 		ServerAutoJoin: pointer.Of(false),
 		ClientAutoJoin: pointer.Of(false),
-	},
-	Consuls: map[string]*config.ConsulConfig{
-		structs.ConsulDefaultCluster: {
-			Name:           structs.ConsulDefaultCluster,
-			Token:          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-			ServerAutoJoin: pointer.Of(false),
-			ClientAutoJoin: pointer.Of(false),
-		},
-	},
-	Vault: &config.VaultConfig{
+	}},
+	Vaults: []*config.VaultConfig{{
 		Name:    structs.VaultDefaultCluster,
 		Enabled: pointer.Of(true),
 		Role:    "nomad-cluster",
 		Addr:    "http://host.example.com:8200",
-	},
-	Vaults: map[string]*config.VaultConfig{
-		structs.VaultDefaultCluster: {
-			Name:    structs.VaultDefaultCluster,
-			Enabled: pointer.Of(true),
-			Role:    "nomad-cluster",
-			Addr:    "http://host.example.com:8200",
-		},
-	},
+	}},
 	TLSConfig: &config.TLSConfig{
 		EnableHTTP:           true,
 		EnableRPC:            true,
@@ -916,36 +820,36 @@ var sample1 = &Config{
 	LeaveOnTerm:    true,
 	EnableSyslog:   true,
 	SyslogFacility: "LOCAL0",
-	Consul: &config.ConsulConfig{
-		Name:           structs.ConsulDefaultCluster,
-		EnableSSL:      pointer.Of(true),
-		Token:          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-		ServerAutoJoin: pointer.Of(false),
-		ClientAutoJoin: pointer.Of(false),
-	},
-	Consuls: map[string]*config.ConsulConfig{
-		structs.ConsulDefaultCluster: {
-			Name:           structs.ConsulDefaultCluster,
-			EnableSSL:      pointer.Of(true),
-			Token:          "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-			ServerAutoJoin: pointer.Of(false),
-			ClientAutoJoin: pointer.Of(false),
-		},
-	},
-	Vault: &config.VaultConfig{
-		Name:    structs.VaultDefaultCluster,
-		Enabled: pointer.Of(true),
-		Role:    "nomad-cluster",
-		Addr:    "http://host.example.com:8200",
-	},
-	Vaults: map[string]*config.VaultConfig{
-		structs.VaultDefaultCluster: {
-			Name:    structs.VaultDefaultCluster,
-			Enabled: pointer.Of(true),
-			Role:    "nomad-cluster",
-			Addr:    "http://host.example.com:8200",
-		},
-	},
+	Consuls: []*config.ConsulConfig{{
+		Name:                      structs.ConsulDefaultCluster,
+		EnableSSL:                 pointer.Of(true),
+		Token:                     "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		ServerAutoJoin:            pointer.Of(false),
+		ClientAutoJoin:            pointer.Of(false),
+		ServerServiceName:         "nomad",
+		ServerHTTPCheckName:       "Nomad Server HTTP Check",
+		ServerSerfCheckName:       "Nomad Server Serf Check",
+		ServerRPCCheckName:        "Nomad Server RPC Check",
+		ClientServiceName:         "nomad-client",
+		ClientHTTPCheckName:       "Nomad Client HTTP Check",
+		AutoAdvertise:             pointer.Of(true),
+		ChecksUseAdvertise:        pointer.Of(false),
+		AllowUnauthenticated:      pointer.Of(true),
+		Timeout:                   5 * time.Second,
+		ServiceIdentityAuthMethod: structs.ConsulServicesDefaultAuthMethodName,
+		TaskIdentityAuthMethod:    structs.ConsulTasksDefaultAuthMethodName,
+		Addr:                      "127.0.0.1:8500",
+		VerifySSL:                 pointer.Of(true),
+	}},
+	Vaults: []*config.VaultConfig{{
+		Name:                 structs.VaultDefaultCluster,
+		Enabled:              pointer.Of(true),
+		Role:                 "nomad-cluster",
+		Addr:                 "http://host.example.com:8200",
+		JWTAuthBackendPath:   "jwt",
+		ConnectionRetryIntv:  30 * time.Second,
+		AllowUnauthenticated: pointer.Of(true),
+	}},
 	TLSConfig: &config.TLSConfig{
 		EnableHTTP:           true,
 		EnableRPC:            true,
@@ -1062,114 +966,116 @@ func permutations(arr []string) [][]string {
 
 func TestConfig_MultipleVault(t *testing.T) {
 
-	// verify the default Vault config is set from the list
-	cfg := DefaultConfig()
-	must.Eq(t, structs.VaultDefaultCluster, cfg.Vault.Name)
-	must.Equal(t, config.DefaultVaultConfig(), cfg.Vault)
-	must.Nil(t, cfg.Vault.Enabled) // unset
-	must.Eq(t, "https://vault.service.consul:8200", cfg.Vault.Addr)
-	must.Eq(t, "", cfg.Vault.Token)
-	must.Eq(t, "jwt", cfg.Vault.JWTAuthBackendPath)
+	for _, suffix := range []string{"hcl", "json"} {
+		t.Run(suffix, func(t *testing.T) {
 
-	must.MapLen(t, 1, cfg.Vaults)
-	must.Equal(t, cfg.Vault, cfg.Vaults[structs.VaultDefaultCluster])
-	must.True(t, cfg.Vault == cfg.Vaults[structs.VaultDefaultCluster]) // must be same pointer
+			// verify the default Vault config is set from the list
+			cfg := DefaultConfig()
+			must.Len(t, 1, cfg.Vaults)
+			defaultVault := cfg.Vaults[0]
+			must.Eq(t, structs.VaultDefaultCluster, defaultVault.Name)
+			must.Equal(t, config.DefaultVaultConfig(), defaultVault)
+			must.Nil(t, defaultVault.Enabled) // unset
+			must.Eq(t, "https://vault.service.consul:8200", defaultVault.Addr)
+			must.Eq(t, "", defaultVault.Token)
+			must.Eq(t, "jwt", defaultVault.JWTAuthBackendPath)
 
-	// merge in the user's configuration
-	fc, err := LoadConfig("testdata/basic.hcl")
-	must.NoError(t, err)
-	cfg = cfg.Merge(fc)
+			// merge in the user's configuration
+			fc, err := LoadConfig("testdata/basic." + suffix)
+			must.NoError(t, err)
+			cfg = cfg.Merge(fc)
 
-	must.Eq(t, structs.VaultDefaultCluster, cfg.Vault.Name)
-	must.NotNil(t, cfg.Vault.Enabled, must.Sprint("override should set to non-nil"))
-	must.False(t, *cfg.Vault.Enabled)
-	must.Eq(t, "127.0.0.1:9500", cfg.Vault.Addr)
-	must.Eq(t, "nomad_jwt", cfg.Vault.JWTAuthBackendPath)
-	must.Eq(t, "12345", cfg.Vault.Token)
+			must.Len(t, 1, cfg.Vaults)
+			defaultVault = cfg.Vaults[0]
+			must.Eq(t, structs.VaultDefaultCluster, defaultVault.Name)
+			must.NotNil(t, defaultVault.Enabled, must.Sprint("override should set to non-nil"))
+			must.False(t, *defaultVault.Enabled)
+			must.Eq(t, "127.0.0.1:9500", defaultVault.Addr)
+			must.Eq(t, "nomad_jwt", defaultVault.JWTAuthBackendPath)
+			must.Eq(t, "12345", defaultVault.Token)
 
-	must.MapLen(t, 1, cfg.Vaults)
-	must.Equal(t, cfg.Vault, cfg.Vaults[structs.VaultDefaultCluster])
+			// add an extra Vault config and override fields in the default
+			fc, err = LoadConfig("testdata/extra-vault." + suffix)
+			must.NoError(t, err)
 
-	// add an extra Vault config and override fields in the default
-	fc, err = LoadConfig("testdata/extra-vault.hcl")
-	must.NoError(t, err)
+			cfg = cfg.Merge(fc)
 
-	cfg = cfg.Merge(fc)
+			must.Len(t, 3, cfg.Vaults)
+			defaultVault = cfg.Vaults[0]
+			must.Eq(t, structs.VaultDefaultCluster, defaultVault.Name)
+			must.True(t, *defaultVault.Enabled)
+			must.Eq(t, "127.0.0.1:9500", defaultVault.Addr)
+			must.Eq(t, "abracadabra", defaultVault.Token)
 
-	must.Eq(t, structs.VaultDefaultCluster, cfg.Vault.Name)
-	must.True(t, *cfg.Vault.Enabled)
-	must.Eq(t, "127.0.0.1:9500", cfg.Vault.Addr)
-	must.Eq(t, "abracadabra", cfg.Vault.Token)
+			must.Eq(t, "alternate", cfg.Vaults[1].Name)
+			must.True(t, *cfg.Vaults[1].Enabled)
+			must.Eq(t, "127.0.0.1:9501", cfg.Vaults[1].Addr)
+			must.Eq(t, "xyzzy", cfg.Vaults[1].Token)
 
-	must.MapLen(t, 3, cfg.Vaults)
-	must.Equal(t, cfg.Vault, cfg.Vaults[structs.VaultDefaultCluster])
+			must.Eq(t, "other", cfg.Vaults[2].Name)
+			must.Nil(t, cfg.Vaults[2].Enabled)
+			must.Eq(t, "127.0.0.1:9502", cfg.Vaults[2].Addr)
+			must.Eq(t, pointer.Of(4*time.Hour), cfg.Vaults[2].DefaultIdentity.TTL)
 
-	must.Eq(t, "alternate", cfg.Vaults["alternate"].Name)
-	must.True(t, *cfg.Vaults["alternate"].Enabled)
-	must.Eq(t, "127.0.0.1:9501", cfg.Vaults["alternate"].Addr)
-	must.Eq(t, "xyzzy", cfg.Vaults["alternate"].Token)
-
-	must.Eq(t, "other", cfg.Vaults["other"].Name)
-	must.Nil(t, cfg.Vaults["other"].Enabled)
-	must.Eq(t, "127.0.0.1:9502", cfg.Vaults["other"].Addr)
-	must.Eq(t, pointer.Of(4*time.Hour), cfg.Vaults["other"].DefaultIdentity.TTL)
-
-	// check that extra Vault clusters have the defaults applied when not
-	// overridden
-	must.Eq(t, "jwt", cfg.Vaults["other"].JWTAuthBackendPath)
+			// check that extra Vault clusters have the defaults applied when not
+			// overridden
+			must.Eq(t, "jwt", cfg.Vaults[2].JWTAuthBackendPath)
+		})
+	}
 }
 
 func TestConfig_MultipleConsul(t *testing.T) {
 
-	// verify the default Consul config is set from the list
-	cfg := DefaultConfig()
-	must.Eq(t, structs.ConsulDefaultCluster, cfg.Consul.Name)
-	must.Eq(t, config.DefaultConsulConfig(), cfg.Consul)
-	must.True(t, *cfg.Consul.AllowUnauthenticated)
-	must.Eq(t, "127.0.0.1:8500", cfg.Consul.Addr)
-	must.Eq(t, "", cfg.Consul.Token)
+	for _, suffix := range []string{"hcl", "json"} {
+		t.Run(suffix, func(t *testing.T) {
+			// verify the default Consul config is set from the list
+			cfg := DefaultConfig()
 
-	must.MapLen(t, 1, cfg.Consuls)
-	must.Eq(t, cfg.Consul, cfg.Consuls[structs.ConsulDefaultCluster])
-	must.True(t, cfg.Consul == cfg.Consuls[structs.ConsulDefaultCluster]) // must be same pointer
+			must.Len(t, 1, cfg.Consuls)
+			defaultConsul := cfg.Consuls[0]
+			must.Eq(t, structs.ConsulDefaultCluster, defaultConsul.Name)
+			must.Eq(t, config.DefaultConsulConfig(), defaultConsul)
+			must.True(t, *defaultConsul.AllowUnauthenticated)
+			must.Eq(t, "127.0.0.1:8500", defaultConsul.Addr)
+			must.Eq(t, "", defaultConsul.Token)
 
-	// merge in the user's configuration
-	fc, err := LoadConfig("testdata/basic.hcl")
-	must.NoError(t, err)
-	cfg = cfg.Merge(fc)
+			// merge in the user's configuration which overrides fields in the
+			// default config
+			fc, err := LoadConfig("testdata/basic." + suffix)
+			must.NoError(t, err)
+			cfg = cfg.Merge(fc)
 
-	must.Eq(t, structs.ConsulDefaultCluster, cfg.Consul.Name)
-	must.True(t, *cfg.Consul.AllowUnauthenticated)
-	must.Eq(t, "127.0.0.1:9500", cfg.Consul.Addr)
-	must.Eq(t, "token1", cfg.Consul.Token)
+			must.Len(t, 1, cfg.Consuls)
+			defaultConsul = cfg.Consuls[0]
+			must.Eq(t, structs.ConsulDefaultCluster, defaultConsul.Name)
+			must.True(t, *defaultConsul.AllowUnauthenticated)
+			must.Eq(t, "127.0.0.1:9500", defaultConsul.Addr)
+			must.Eq(t, "token1", defaultConsul.Token)
 
-	must.MapLen(t, 1, cfg.Consuls)
-	must.Eq(t, cfg.Consul, cfg.Consuls[structs.ConsulDefaultCluster])
+			// add an extra Consul config and override fields in the default
+			fc, err = LoadConfig("testdata/extra-consul." + suffix)
+			must.NoError(t, err)
+			cfg = cfg.Merge(fc)
 
-	// add an extra Consul config and override fields in the default
-	fc, err = LoadConfig("testdata/extra-consul.hcl")
-	must.NoError(t, err)
+			must.Len(t, 3, cfg.Consuls)
+			defaultConsul = cfg.Consuls[0]
+			must.Eq(t, structs.ConsulDefaultCluster, defaultConsul.Name)
+			must.False(t, *defaultConsul.AllowUnauthenticated)
+			must.Eq(t, "127.0.0.1:9501", defaultConsul.Addr)
+			must.Eq(t, "abracadabra", defaultConsul.Token)
 
-	cfg = cfg.Merge(fc)
+			must.Eq(t, "alternate", cfg.Consuls[1].Name)
+			must.True(t, *cfg.Consuls[1].AllowUnauthenticated)
+			must.Eq(t, "127.0.0.2:8501", cfg.Consuls[1].Addr)
+			must.Eq(t, "xyzzy", cfg.Consuls[1].Token)
 
-	must.Eq(t, structs.ConsulDefaultCluster, cfg.Consul.Name)
-	must.False(t, *cfg.Consul.AllowUnauthenticated)
-	must.Eq(t, "127.0.0.1:9501", cfg.Consul.Addr)
-	must.Eq(t, "abracadabra", cfg.Consul.Token)
+			must.Eq(t, "other", cfg.Consuls[2].Name)
+			must.Eq(t, pointer.Of(3*time.Hour), cfg.Consuls[2].ServiceIdentity.TTL)
+			must.Eq(t, pointer.Of(5*time.Hour), cfg.Consuls[2].TaskIdentity.TTL)
 
-	must.MapLen(t, 3, cfg.Consuls)
-	must.Eq(t, cfg.Consul, cfg.Consuls[structs.ConsulDefaultCluster])
-
-	must.Eq(t, "alternate", cfg.Consuls["alternate"].Name)
-	must.True(t, *cfg.Consuls["alternate"].AllowUnauthenticated)
-	must.Eq(t, "127.0.0.2:8501", cfg.Consuls["alternate"].Addr)
-	must.Eq(t, "xyzzy", cfg.Consuls["alternate"].Token)
-
-	must.Eq(t, "other", cfg.Consuls["other"].Name)
-	must.Eq(t, pointer.Of(3*time.Hour), cfg.Consuls["other"].ServiceIdentity.TTL)
-	must.Eq(t, pointer.Of(5*time.Hour), cfg.Consuls["other"].TaskIdentity.TTL)
-
-	// check that extra Consul clusters have the defaults applied when not
-	// overridden
-	must.Eq(t, "nomad-client", cfg.Consuls["other"].ClientServiceName)
+			// check that extra Consul clusters have the defaults applied when
+			// not overridden
+			must.Eq(t, "nomad-client", cfg.Consuls[2].ClientServiceName)
+		})
+	}
 }

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,8 +45,6 @@ func TestConfig_Merge(t *testing.T) {
 		Ports:          &Ports{},
 		Addresses:      &Addresses{},
 		AdvertiseAddrs: &AdvertiseAddrs{},
-		Vault:          &config.VaultConfig{},
-		Consul:         &config.ConsulConfig{},
 		Sentinel:       &config.SentinelConfig{},
 		Autopilot:      &config.AutopilotConfig{},
 	}
@@ -188,7 +187,7 @@ func TestConfig_Merge(t *testing.T) {
 		HTTPAPIResponseHeaders: map[string]string{
 			"Access-Control-Allow-Origin": "*",
 		},
-		Vault: &config.VaultConfig{
+		Vaults: []*config.VaultConfig{{
 			Name:                 structs.VaultDefaultCluster,
 			Token:                "1",
 			AllowUnauthenticated: &falseValue,
@@ -200,23 +199,8 @@ func TestConfig_Merge(t *testing.T) {
 			TLSKeyFile:           "1",
 			TLSSkipVerify:        &falseValue,
 			TLSServerName:        "1",
-		},
-		Vaults: map[string]*config.VaultConfig{
-			structs.VaultDefaultCluster: {
-				Name:                 structs.VaultDefaultCluster,
-				Token:                "1",
-				AllowUnauthenticated: &falseValue,
-				TaskTokenTTL:         "1",
-				Addr:                 "1",
-				TLSCaFile:            "1",
-				TLSCaPath:            "1",
-				TLSCertFile:          "1",
-				TLSKeyFile:           "1",
-				TLSSkipVerify:        &falseValue,
-				TLSServerName:        "1",
-			},
-		},
-		Consul: &config.ConsulConfig{
+		}},
+		Consuls: []*config.ConsulConfig{{
 			ServerServiceName:    "1",
 			ClientServiceName:    "1",
 			AutoAdvertise:        &falseValue,
@@ -233,27 +217,7 @@ func TestConfig_Merge(t *testing.T) {
 			ServerAutoJoin:       &falseValue,
 			ClientAutoJoin:       &falseValue,
 			ChecksUseAdvertise:   &falseValue,
-		},
-		Consuls: map[string]*config.ConsulConfig{
-			structs.ConsulDefaultCluster: {
-				ServerServiceName:    "1",
-				ClientServiceName:    "1",
-				AutoAdvertise:        &falseValue,
-				Addr:                 "1",
-				AllowUnauthenticated: &falseValue,
-				Timeout:              1 * time.Second,
-				Token:                "1",
-				Auth:                 "1",
-				EnableSSL:            &falseValue,
-				VerifySSL:            &falseValue,
-				CAFile:               "1",
-				CertFile:             "1",
-				KeyFile:              "1",
-				ServerAutoJoin:       &falseValue,
-				ClientAutoJoin:       &falseValue,
-				ChecksUseAdvertise:   &falseValue,
-			},
-		},
+		}},
 		Autopilot: &config.AutopilotConfig{
 			CleanupDeadServers:      &falseValue,
 			ServerStabilizationTime: 1 * time.Second,
@@ -438,7 +402,7 @@ func TestConfig_Merge(t *testing.T) {
 			"Access-Control-Allow-Origin":  "*",
 			"Access-Control-Allow-Methods": "GET, POST, OPTIONS",
 		},
-		Vault: &config.VaultConfig{
+		Vaults: []*config.VaultConfig{{
 			Name:                 structs.VaultDefaultCluster,
 			Token:                "2",
 			AllowUnauthenticated: &trueValue,
@@ -450,60 +414,34 @@ func TestConfig_Merge(t *testing.T) {
 			TLSKeyFile:           "2",
 			TLSSkipVerify:        &trueValue,
 			TLSServerName:        "2",
-		},
-		Vaults: map[string]*config.VaultConfig{
-			structs.VaultDefaultCluster: {
-				Name:                 structs.VaultDefaultCluster,
-				Token:                "2",
-				AllowUnauthenticated: &trueValue,
-				TaskTokenTTL:         "2",
-				Addr:                 "2",
-				TLSCaFile:            "2",
-				TLSCaPath:            "2",
-				TLSCertFile:          "2",
-				TLSKeyFile:           "2",
-				TLSSkipVerify:        &trueValue,
-				TLSServerName:        "2",
-			},
-		},
-		Consul: &config.ConsulConfig{
-			ServerServiceName:    "2",
-			ClientServiceName:    "2",
-			AutoAdvertise:        &trueValue,
-			Addr:                 "2",
-			AllowUnauthenticated: &trueValue,
-			Timeout:              2 * time.Second,
-			Token:                "2",
-			Auth:                 "2",
-			EnableSSL:            &trueValue,
-			VerifySSL:            &trueValue,
-			CAFile:               "2",
-			CertFile:             "2",
-			KeyFile:              "2",
-			ServerAutoJoin:       &trueValue,
-			ClientAutoJoin:       &trueValue,
-			ChecksUseAdvertise:   &trueValue,
-		},
-		Consuls: map[string]*config.ConsulConfig{
-			structs.ConsulDefaultCluster: {
-				ServerServiceName:    "2",
-				ClientServiceName:    "2",
-				AutoAdvertise:        &trueValue,
-				Addr:                 "2",
-				AllowUnauthenticated: &trueValue,
-				Timeout:              2 * time.Second,
-				Token:                "2",
-				Auth:                 "2",
-				EnableSSL:            &trueValue,
-				VerifySSL:            &trueValue,
-				CAFile:               "2",
-				CertFile:             "2",
-				KeyFile:              "2",
-				ServerAutoJoin:       &trueValue,
-				ClientAutoJoin:       &trueValue,
-				ChecksUseAdvertise:   &trueValue,
-			},
-		},
+			ConnectionRetryIntv:  time.Duration(30000000000),
+			JWTAuthBackendPath:   "jwt",
+		}},
+		Consuls: []*config.ConsulConfig{{
+			Name:                      "default",
+			ServerServiceName:         "2",
+			ClientServiceName:         "2",
+			AutoAdvertise:             &trueValue,
+			Addr:                      "2",
+			AllowUnauthenticated:      &trueValue,
+			Timeout:                   2 * time.Second,
+			Token:                     "2",
+			Auth:                      "2",
+			EnableSSL:                 &trueValue,
+			VerifySSL:                 &trueValue,
+			CAFile:                    "2",
+			CertFile:                  "2",
+			KeyFile:                   "2",
+			ServerAutoJoin:            &trueValue,
+			ClientAutoJoin:            &trueValue,
+			ChecksUseAdvertise:        &trueValue,
+			ServerHTTPCheckName:       "Nomad Server HTTP Check",
+			ServerSerfCheckName:       "Nomad Server Serf Check",
+			ServerRPCCheckName:        "Nomad Server RPC Check",
+			ClientHTTPCheckName:       "Nomad Client HTTP Check",
+			ServiceIdentityAuthMethod: structs.ConsulServicesDefaultAuthMethodName,
+			TaskIdentityAuthMethod:    structs.ConsulTasksDefaultAuthMethodName,
+		}},
 		Sentinel: &config.SentinelConfig{
 			Imports: []*config.SentinelImport{
 				{
@@ -549,19 +487,9 @@ func TestConfig_Merge(t *testing.T) {
 	result := c0.Merge(c1)
 	result = result.Merge(c2)
 	result = result.Merge(c3)
-
-	// Apply expected Consuls and Vaults defaults.
-	//
-	// Update pointers so the "default" key also updates expected.Consul and
-	// expected.Vault.
 	expected := c3.Copy()
-	for name, consul := range expected.Consuls {
-		*expected.Consuls[name] = *config.DefaultConsulConfig().Merge(consul)
-	}
-	for name, vault := range expected.Vaults {
-		*expected.Vaults[name] = *config.DefaultVaultConfig().Merge(vault)
-	}
-	require.Equal(t, expected, result)
+
+	must.Eq(t, expected, result)
 }
 
 func TestConfig_ParseConfigFile(t *testing.T) {

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -354,9 +354,8 @@ func (a *TestAgent) config() *Config {
 	// Bind and set ports
 	conf.BindAddr = "127.0.0.1"
 
-	conf.Consul = sconfig.DefaultConsulConfig()
-	conf.Consuls[structs.ConsulDefaultCluster] = conf.Consul
-	conf.Vault.Enabled = new(bool)
+	conf.Consuls = []*sconfig.ConsulConfig{sconfig.DefaultConsulConfig()}
+	conf.defaultVault().Enabled = new(bool)
 
 	// Tighten the Serf timing
 	config.SerfConfig.MemberlistConfig.SuspicionMult = 2

--- a/command/agent/testdata/extra-consul.json
+++ b/command/agent/testdata/extra-consul.json
@@ -1,0 +1,38 @@
+{
+  "consul": [
+    {
+      "address": "127.0.0.1:9501",
+      "allow_unauthenticated": false,
+      "token": "abracadabra",
+      "timeout": "20s"
+    },
+    {
+      "name": "alternate",
+      "server_service_name": "nomad",
+      "server_http_check_name": "nomad-server-http-health-check",
+      "server_serf_check_name": "nomad-server-serf-health-check",
+      "server_rpc_check_name": "nomad-server-rpc-health-check",
+      "client_service_name": "nomad-client",
+      "client_http_check_name": "nomad-client-http-health-check",
+      "address": "127.0.0.2:8501",
+      "allow_unauthenticated": true,
+      "token": "xyzzy",
+      "auth": "username:pass"
+    },
+    {
+      "name": "other",
+      "service_identity": {
+        "aud": [
+          "consul-other.io"
+        ],
+        "ttl": "3h"
+      },
+      "task_identity": {
+        "aud": [
+          "consul-other.io"
+        ],
+        "ttl": "5h"
+      }
+    }
+  ]
+}

--- a/command/agent/testdata/extra-vault.json
+++ b/command/agent/testdata/extra-vault.json
@@ -1,0 +1,33 @@
+{
+  "vault": [
+    {
+      "enabled": true,
+      "token": "abracadabra"
+    },
+    {
+      "name": "alternate",
+      "address": "127.0.0.1:9501",
+      "allow_unauthenticated": true,
+      "task_token_ttl": "5s",
+      "enabled": true,
+      "token": "xyzzy",
+      "ca_file": "/path/to/ca/file",
+      "ca_path": "/path/to/ca",
+      "cert_file": "/path/to/cert/file",
+      "key_file": "/path/to/key/file",
+      "tls_server_name": "barbaz",
+      "tls_skip_verify": true,
+      "create_from_role": "test_role2"
+    },
+    {
+      "name": "other",
+      "address": "127.0.0.1:9502",
+      "default_identity": {
+        "aud": [
+          "vault-other.io"
+        ],
+        "ttl": "4h"
+      }
+    }
+  ]
+}

--- a/command/job_plan_test.go
+++ b/command/job_plan_test.go
@@ -187,10 +187,10 @@ func TestPlanCommand_From_Files(t *testing.T) {
 
 	// Create a Nomad server
 	s := testutil.NewTestServer(t, func(c *testutil.TestServerConfig) {
-		c.Vault.Address = v.HTTPAddr
-		c.Vault.Enabled = true
-		c.Vault.AllowUnauthenticated = pointer.Of(false)
-		c.Vault.Token = v.RootToken
+		c.Vaults[0].Address = v.HTTPAddr
+		c.Vaults[0].Enabled = true
+		c.Vaults[0].AllowUnauthenticated = pointer.Of(false)
+		c.Vaults[0].Token = v.RootToken
 	})
 	defer s.Stop()
 

--- a/command/job_validate_test.go
+++ b/command/job_validate_test.go
@@ -28,10 +28,10 @@ func TestValidateCommand_Files(t *testing.T) {
 
 	// Create a Nomad server
 	s := testutil.NewTestServer(t, func(c *testutil.TestServerConfig) {
-		c.Vault.Address = v.HTTPAddr
-		c.Vault.Enabled = true
-		c.Vault.AllowUnauthenticated = pointer.Of(false)
-		c.Vault.Token = v.RootToken
+		c.Vaults[0].Address = v.HTTPAddr
+		c.Vaults[0].Enabled = true
+		c.Vaults[0].AllowUnauthenticated = pointer.Of(false)
+		c.Vaults[0].Token = v.RootToken
 	})
 	defer s.Stop()
 

--- a/e2e/consulcompat/shared_download_test.go
+++ b/e2e/consulcompat/shared_download_test.go
@@ -24,7 +24,7 @@ import (
 // changes
 const (
 	binDir           = "consul-bins"
-	minConsulVersion = "1.15.0"
+	minConsulVersion = "1.16.0"
 
 	// environment variable to pick only one Consul version for testing
 	exactConsulVersionEnv = "NOMAD_E2E_CONSULCOMPAT_CONSUL_VERSION"

--- a/e2e/consulcompat/shared_setup_test.go
+++ b/e2e/consulcompat/shared_setup_test.go
@@ -94,7 +94,7 @@ func startNomad(t *testing.T, consulConfig *testutil.Consul) *nomadapi.Client {
 		c.DevMode = true
 		c.DevConnectMode = true
 		c.LogLevel = testlog.HCLoggerTestLevel().String()
-		c.Consul = consulConfig
+		c.Consuls = []*testutil.Consul{consulConfig}
 		c.ACL = &testutil.ACLConfig{
 			Enabled:        true,
 			BootstrapToken: rootToken,

--- a/e2e/vaultcompat/vaultcompat_test.go
+++ b/e2e/vaultcompat/vaultcompat_test.go
@@ -297,19 +297,19 @@ func startNomad(t *testing.T, cb func(*testutil.TestServerConfig)) (func(), *nom
 
 func configureNomadVaultLegacy(vc *vaultapi.Client) func(*testutil.TestServerConfig) {
 	return func(c *testutil.TestServerConfig) {
-		c.Vault = &testutil.VaultConfig{
+		c.Vaults = []*testutil.VaultConfig{{
 			Enabled:              true,
 			Address:              vc.Address(),
 			Token:                vc.Token(),
 			Role:                 "nomad-cluster",
 			AllowUnauthenticated: pointer.Of(true),
-		}
+		}}
 	}
 }
 
 func configureNomadVaultJWT(vc *vaultapi.Client) func(*testutil.TestServerConfig) {
 	return func(c *testutil.TestServerConfig) {
-		c.Vault = &testutil.VaultConfig{
+		c.Vaults = []*testutil.VaultConfig{{
 			Enabled: true,
 			// Server configs.
 			DefaultIdentity: &testutil.WorkloadIdentityConfig{
@@ -320,7 +320,7 @@ func configureNomadVaultJWT(vc *vaultapi.Client) func(*testutil.TestServerConfig
 			// Client configs.
 			Address:            vc.Address(),
 			JWTAuthBackendPath: jwtPath,
-		}
+		}}
 	}
 }
 

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -189,6 +189,17 @@ func CopyMapOfSlice[K comparable, V any](m map[K][]V) map[K][]V {
 	return c
 }
 
+// SliceToMap creates a map from a slice, using keyFn to extract a key from each
+// value. Note this doesn't copy the elements of the slice, so you may need to
+// call slices.Clone on the result
+func SliceToMap[M ~map[K]V, K comparable, V any](slice []V, keyFn func(value V) K) M {
+	result := make(map[K]V, len(slice))
+	for _, item := range slice {
+		result[keyFn(item)] = item
+	}
+	return result
+}
+
 // CleanEnvVar replaces all occurrences of illegal characters in an environment
 // variable with the specified byte.
 func CleanEnvVar(s string, r byte) string {

--- a/nomad/structs/config/consul.go
+++ b/nomad/structs/config/consul.go
@@ -220,7 +220,7 @@ func (c *ConsulConfig) Merge(b *ConsulConfig) *ConsulConfig {
 	result := c.Copy()
 
 	if b.Name != "" {
-		c.Name = b.Name
+		result.Name = b.Name
 	}
 	if b.ServerServiceName != "" {
 		result.ServerServiceName = b.ServerServiceName

--- a/nomad/structs/config/vault.go
+++ b/nomad/structs/config/vault.go
@@ -151,7 +151,7 @@ func (c *VaultConfig) Merge(b *VaultConfig) *VaultConfig {
 	result := *c
 
 	if b.Name != "" {
-		c.Name = b.Name
+		result.Name = b.Name
 	}
 	if b.Enabled != nil {
 		result.Enabled = b.Enabled

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -33,21 +33,21 @@ import (
 
 // TestServerConfig is the main server configuration struct.
 type TestServerConfig struct {
-	NodeName          string        `json:"name,omitempty"`
-	DataDir           string        `json:"data_dir,omitempty"`
-	Region            string        `json:"region,omitempty"`
-	DisableCheckpoint bool          `json:"disable_update_check"`
-	LogLevel          string        `json:"log_level,omitempty"`
-	Consul            *Consul       `json:"consul,omitempty"`
-	AdvertiseAddrs    *Advertise    `json:"advertise,omitempty"`
-	Ports             *PortsConfig  `json:"ports,omitempty"`
-	Server            *ServerConfig `json:"server,omitempty"`
-	Client            *ClientConfig `json:"client,omitempty"`
-	Vault             *VaultConfig  `json:"vault,omitempty"`
-	ACL               *ACLConfig    `json:"acl,omitempty"`
-	DevMode           bool          `json:"-"`
-	DevConnectMode    bool          `json:"-"`
-	Stdout, Stderr    io.Writer     `json:"-"`
+	NodeName          string         `json:"name,omitempty"`
+	DataDir           string         `json:"data_dir,omitempty"`
+	Region            string         `json:"region,omitempty"`
+	DisableCheckpoint bool           `json:"disable_update_check"`
+	LogLevel          string         `json:"log_level,omitempty"`
+	Consuls           []*Consul      `json:"consul,omitempty"`
+	AdvertiseAddrs    *Advertise     `json:"advertise,omitempty"`
+	Ports             *PortsConfig   `json:"ports,omitempty"`
+	Server            *ServerConfig  `json:"server,omitempty"`
+	Client            *ClientConfig  `json:"client,omitempty"`
+	Vaults            []*VaultConfig `json:"vault,omitempty"`
+	ACL               *ACLConfig     `json:"acl,omitempty"`
+	DevMode           bool           `json:"-"`
+	DevConnectMode    bool           `json:"-"`
+	Stdout, Stderr    io.Writer      `json:"-"`
 }
 
 // Consul is used to configure the communication with Consul
@@ -139,10 +139,10 @@ func defaultServerConfig() *TestServerConfig {
 		Client: &ClientConfig{
 			Enabled: false,
 		},
-		Vault: &VaultConfig{
+		Vaults: []*VaultConfig{{
 			Enabled:              false,
 			AllowUnauthenticated: pointer.Of(true),
-		},
+		}},
 		ACL: &ACLConfig{
 			Enabled: false,
 		},


### PR DESCRIPTION
Remove the now-unused original configuration blocks for Consul and Vault from the agent configuration parsing. When the agent needs to refer to a Consul or Vault block it will always be for a specific cluster for the task/service (or the default cluster for the agent's own use).

This is third of three changesets for this work. It includes:
* A fix to the `Merge` methods where the `Name` field was not being correctly merged.
* Changing the map of Vault/Consul configs in the agent's `Config` to a slice. This doesn't change the resulting maps in the server/client `Config` because it's a lot easier to use them at the call site that way.
* Fixes to tests that were masking problems in parsing JSON format agent configuration.

Fixes: https://github.com/hashicorp/nomad/issues/18947
Ref: https://github.com/hashicorp/nomad/pull/18991
Ref: https://github.com/hashicorp/nomad/pull/18994

(Note this does not fix #19000 because this is already a huge PR and all of that fix will happen in the `client` package anyways.)