### PR TITLE
e2e disable windows

### DIFF
--- a/e2e/artifact/artifact_test.go
+++ b/e2e/artifact/artifact_test.go
@@ -46,6 +46,8 @@ func artifactCheckLogContents(t *testing.T, nomad *api.Client, group, task strin
 }
 
 func testWindows(t *testing.T) {
+	t.Skip("SKIP WINDOWS TEST") // TODO restore when windows client is fixed
+
 	nomad := e2eutil.NomadClient(t)
 	jobID := "artifact-windows-" + uuid.Short()
 	jobIDs := []string{jobID}

--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -5,7 +5,7 @@ region                          = "us-east-1"
 instance_type                   = "t3a.medium"
 server_count                    = "3"
 client_count_ubuntu_jammy_amd64 = "4"
-client_count_windows_2016_amd64 = "1"
+client_count_windows_2016_amd64 = "0"
 volumes                         = true
 
 nomad_local_binary                           = "../../pkg/linux_amd64/nomad"

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -33,7 +33,7 @@ variable "client_count_ubuntu_jammy_amd64" {
 
 variable "client_count_windows_2016_amd64" {
   description = "The number of windows 2016 clients to provision."
-  default     = "1"
+  default     = "0"
 }
 
 variable "restrict_ingress_cidrblock" {


### PR DESCRIPTION
- e2e: disable windows client
- e2e: disable windows artifact test

Note: the metrics suite also has Windows tests but it's also broken for other reasons; I'll follow up with fixing up my refactoring of that suite in https://github.com/hashicorp/nomad/compare/main...e2e-refactor-metrics and disable windows in that too for now.