### PR TITLE
refactor: rename allocrunner's Consul service reg handler

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -70,9 +70,9 @@ type allocRunner struct {
 	// update.
 	allocUpdatedCh chan *structs.Allocation
 
-	// consulClient is the client used by the consul service hook for
-	// registering services and checks
-	consulClient serviceregistration.Handler
+	// consulServicesHandler is used by the consul service hook for registering
+	// services and checks
+	consulServicesHandler serviceregistration.Handler
 
 	// consulProxiesClientFunc gets a client used by the envoy version hook for
 	// looking up supported envoy versions of the consul agent.
@@ -225,7 +225,7 @@ func NewAllocRunner(config *config.AllocRunnerConfig) (interfaces.AllocRunner, e
 		id:                       alloc.ID,
 		alloc:                    alloc,
 		clientConfig:             config.ClientConfig,
-		consulClient:             config.Consul,
+		consulServicesHandler:    config.ConsulServices,
 		consulProxiesClientFunc:  config.ConsulProxiesFunc,
 		sidsClient:               config.ConsulSI,
 		vaultClientFunc:          config.VaultFunc,
@@ -301,7 +301,7 @@ func (ar *allocRunner) initTaskRunners(tasks []*structs.Task) error {
 			StateDB:             ar.stateDB,
 			StateUpdater:        ar,
 			DynamicRegistry:     ar.dynamicRegistry,
-			Consul:              ar.consulClient,
+			ConsulServices:      ar.consulServicesHandler,
 			ConsulProxiesFunc:   ar.consulProxiesClientFunc,
 			ConsulSI:            ar.sidsClient,
 			VaultFunc:           ar.vaultClientFunc,

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -133,7 +133,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 		newUpstreamAllocsHook(hookLogger, ar.prevAllocWatcher),
 		newDiskMigrationHook(hookLogger, ar.prevAllocMigrator, ar.allocDir),
 		newCPUPartsHook(hookLogger, ar.partitions, alloc),
-		newAllocHealthWatcherHook(hookLogger, alloc, newEnvBuilder, hs, ar.Listener(), ar.consulClient, ar.checkStore),
+		newAllocHealthWatcherHook(hookLogger, alloc, newEnvBuilder, hs, ar.Listener(), ar.consulServicesHandler, ar.checkStore),
 		newNetworkHook(hookLogger, ns, alloc, nm, nc, ar, builtTaskEnv),
 		newGroupServiceHook(groupServiceHookConfig{
 			alloc:             alloc,

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -1051,9 +1051,9 @@ func TestAllocRunner_TaskGroup_ShutdownDelay(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	})
 
-	// Get consul client operations
-	consulClient := conf.Consul.(*regMock.ServiceRegistrationHandler)
-	consulOpts := consulClient.GetOps()
+	// Get consul operations
+	consulServices := conf.ConsulServices.(*regMock.ServiceRegistrationHandler)
+	consulOpts := consulServices.GetOps()
 	var groupRemoveOp regMock.Operation
 	for _, op := range consulOpts {
 		// Grab the first deregistration request
@@ -1535,8 +1535,8 @@ func TestAllocRunner_DeploymentHealth_Unhealthy_Checks(t *testing.T) {
 	defer cleanup()
 
 	// Only return the check as healthy after a duration
-	consulClient := conf.Consul.(*regMock.ServiceRegistrationHandler)
-	consulClient.AllocRegistrationsFn = func(allocID string) (*serviceregistration.AllocRegistration, error) {
+	consulServices := conf.ConsulServices.(*regMock.ServiceRegistrationHandler)
+	consulServices.AllocRegistrationsFn = func(allocID string) (*serviceregistration.AllocRegistration, error) {
 		return &serviceregistration.AllocRegistration{
 			Tasks: map[string]*serviceregistration.ServiceRegistrations{
 				task.Name: {
@@ -1862,8 +1862,8 @@ func TestAllocRunner_TaskFailed_KillTG(t *testing.T) {
 	conf, cleanup := testAllocRunnerConfig(t, alloc)
 	defer cleanup()
 
-	consulClient := conf.Consul.(*regMock.ServiceRegistrationHandler)
-	consulClient.AllocRegistrationsFn = func(allocID string) (*serviceregistration.AllocRegistration, error) {
+	consulServices := conf.ConsulServices.(*regMock.ServiceRegistrationHandler)
+	consulServices.AllocRegistrationsFn = func(allocID string) (*serviceregistration.AllocRegistration, error) {
 		return &serviceregistration.AllocRegistration{
 			Tasks: map[string]*serviceregistration.ServiceRegistrations{
 				task.Name: {

--- a/client/allocrunner/alloc_runner_unix_test.go
+++ b/client/allocrunner/alloc_runner_unix_test.go
@@ -131,7 +131,7 @@ func TestAllocRunner_Restore_RunningTerminal(t *testing.T) {
 	//    - removal during exited is de-duped due to prekill
 	//    - removal during stop is de-duped due to prekill
 	//   1 removal group during stop
-	consulOps := conf2.Consul.(*regMock.ServiceRegistrationHandler).GetOps()
+	consulOps := conf2.ConsulServices.(*regMock.ServiceRegistrationHandler).GetOps()
 	require.Len(t, consulOps, 2)
 	for _, op := range consulOps {
 		require.Equal(t, "remove", op.Op)

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -279,8 +279,8 @@ type Config struct {
 	TaskDir      *allocdir.TaskDir
 	Logger       log.Logger
 
-	// Consul is the client to use for managing Consul service registrations
-	Consul serviceregistration.Handler
+	// ConsulServices is used for managing Consul service registrations
+	ConsulServices serviceregistration.Handler
 
 	// ConsulProxiesFunc gets a client to use for looking up supported envoy versions
 	// from Consul.
@@ -378,7 +378,7 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 		taskLeader:              config.Task.Leader,
 		envBuilder:              envBuilder,
 		dynamicRegistry:         config.DynamicRegistry,
-		consulServiceClient:     config.Consul,
+		consulServiceClient:     config.ConsulServices,
 		consulProxiesClientFunc: config.ConsulProxiesFunc,
 		siClient:                config.ConsulSI,
 		vaultClientFunc:         config.VaultFunc,

--- a/client/allocrunner/testing.go
+++ b/client/allocrunner/testing.go
@@ -84,7 +84,7 @@ func testAllocRunnerConfig(t *testing.T, alloc *structs.Allocation) (*config.All
 		Logger:             clientConf.Logger,
 		ClientConfig:       clientConf,
 		StateDB:            stateDB,
-		Consul:             consulRegMock,
+		ConsulServices:     consulRegMock,
 		ConsulSI:           consul.NewMockServiceIdentitiesClient(),
 		VaultFunc:          vaultclient.NewMockVaultClient,
 		StateUpdater:       &MockStateUpdater{},

--- a/client/client.go
+++ b/client/client.go
@@ -2754,7 +2754,7 @@ func (c *Client) newAllocRunnerConfig(
 		CSIManager:          c.csimanager,
 		CheckStore:          c.checkStore,
 		ClientConfig:        c.GetConfig(),
-		Consul:              c.consulServices,
+		ConsulServices:      c.consulServices,
 		ConsulProxiesFunc:   c.consulProxiesFunc,
 		ConsulSI:            c.tokensClient,
 		DeviceManager:       c.devicemanager,

--- a/client/config/arconfig.go
+++ b/client/config/arconfig.go
@@ -49,8 +49,8 @@ type AllocRunnerConfig struct {
 	// StateDB is used to store and restore state.
 	StateDB cstate.StateDB
 
-	// Consul is the Consul client used to register task services and checks
-	Consul serviceregistration.Handler
+	// ConsulServices is used to register task services and checks
+	ConsulServices serviceregistration.Handler
 
 	// ConsulProxiesFunc gets a Consul client used to lookup supported envoy
 	// versions of the Consul agent.

--- a/client/state/upgrade_int_test.go
+++ b/client/state/upgrade_int_test.go
@@ -208,7 +208,7 @@ func checkUpgradedAlloc(t *testing.T, path string, db StateDB, alloc *structs.Al
 		Logger:            clientConf.Logger,
 		ClientConfig:      clientConf,
 		StateDB:           db,
-		Consul:            regMock.NewServiceRegistrationHandler(clientConf.Logger),
+		ConsulServices:    regMock.NewServiceRegistrationHandler(clientConf.Logger),
 		VaultFunc:         vaultclient.NewMockVaultClient,
 		StateUpdater:      &allocrunner.MockStateUpdater{},
 		PrevAllocWatcher:  allocwatcher.NoopPrevAlloc{},

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -162,7 +162,7 @@ func TestConsul_Integration(t *testing.T) {
 	config := &taskrunner.Config{
 		Alloc:               alloc,
 		ClientConfig:        conf,
-		Consul:              serviceClient,
+		ConsulServices:      serviceClient,
 		Task:                task,
 		TaskDir:             taskDir,
 		Logger:              logger,


### PR DESCRIPTION
The allocrunner has a service registration handler that proxies various API calls to Consul. With multi-cluster support (for ENT), the service registration handler is what selects the correct Consul client. The name of this field in the allocrunner and taskrunner code base looks like it's referring to the actual Consul API client. This was actually the case before Nomad native service discovery was implemented, but now the name is misleading.

I ran into this while working on #19000.