### PR TITLE
[ui] Nicer comment styles in example jobs

### DIFF
--- a/.changelog/19037.txt
+++ b/.changelog/19037.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: nicer comment styles in UI example jobs
+```

--- a/ui/app/utils/default_jobs/hello-world.js
+++ b/ui/app/utils/default_jobs/hello-world.js
@@ -4,24 +4,24 @@
  */
 
 export default `job "hello-world" {
-  // Specifies the datacenter where this job should be run
-  // This can be omitted and it will default to ["*"]
+  # Specifies the datacenter where this job should be run
+  # This can be omitted and it will default to ["*"]
   datacenters = ["*"]
 
   meta {
-    // User-defined key/value pairs that can be used in your jobs.
-    // You can also use this meta block within Group and Task levels.
+    # User-defined key/value pairs that can be used in your jobs.
+    # You can also use this meta block within Group and Task levels.
     foo = "bar"
   }
 
-  // A group defines a series of tasks that should be co-located
-  // on the same client (host). All tasks within a group will be
-  // placed on the same host.
+  # A group defines a series of tasks that should be co-located
+  # on the same client (host). All tasks within a group will be
+  # placed on the same host.
   group "servers" {
 
-    // Specifies the number of instances of this group that should be running.
-    // Use this to scale or parallelize your job.
-    // This can be omitted and it will default to 1.
+    # Specifies the number of instances of this group that should be running.
+    # Use this to scale or parallelize your job.
+    # This can be omitted and it will default to 1.
     count = 1
 
     network {
@@ -35,9 +35,9 @@ export default `job "hello-world" {
       port     = "www"
     }
 
-    // Tasks are individual units of work that are run by Nomad.
+    # Tasks are individual units of work that are run by Nomad.
     task "web" {
-      // This particular task starts a simple web server within a Docker container
+      # This particular task starts a simple web server within a Docker container
       driver = "docker"
 
       config {
@@ -48,20 +48,20 @@ export default `job "hello-world" {
       }
 
       template {
-        data        = <<EOF
-                        <h1>Hello, Nomad!</h1>
-                        <ul>
-                          <li>Task: {{env "NOMAD_TASK_NAME"}}</li>
-                          <li>Group: {{env "NOMAD_GROUP_NAME"}}</li>
-                          <li>Job: {{env "NOMAD_JOB_NAME"}}</li>
-                          <li>Metadata value for foo: {{env "NOMAD_META_foo"}}</li>
-                          <li>Currently running on port: {{env "NOMAD_PORT_www"}}</li>
-                        </ul>
+        data        = <<-EOF
+                      <h1>Hello, Nomad!</h1>
+                      <ul>
+                        <li>Task: {{env "NOMAD_TASK_NAME"}}</li>
+                        <li>Group: {{env "NOMAD_GROUP_NAME"}}</li>
+                        <li>Job: {{env "NOMAD_JOB_NAME"}}</li>
+                        <li>Metadata value for foo: {{env "NOMAD_META_foo"}}</li>
+                        <li>Currently running on port: {{env "NOMAD_PORT_www"}}</li>
+                      </ul>
                       EOF
         destination = "local/index.html"
       }
 
-      // Specify the maximum resources required to run the task
+      # Specify the maximum resources required to run the task
       resources {
         cpu    = 50
         memory = 64

--- a/ui/app/utils/default_jobs/parameterized.js
+++ b/ui/app/utils/default_jobs/parameterized.js
@@ -4,22 +4,22 @@
  */
 
 export default `job "parameterized-job" {
-  // Specifies the datacenter where this job should be run
-  // This can be omitted and it will default to ["*"]
+  # Specifies the datacenter where this job should be run
+  # This can be omitted and it will default to ["*"]
   datacenters = ["*"]
 
-  // Unlike service jobs, Batch jobs are intended to run until they exit successfully.
+  # Unlike service jobs, Batch jobs are intended to run until they exit successfully.
   type = "batch"
 
-  // Run the job only on Linux or MacOS.
+  # Run the job only on Linux or MacOS.
   constraint {
     attribute = "\${attr.kernel.name}"
     operator  = "set_contains_any"
     value     = "darwin,linux"
   }
 
-  // Allow the job to be parameterized, and allow any meta key with
-  // a name starting with "i" to be specified.
+  # Allow the job to be parameterized, and allow any meta key with
+  # a name starting with "i" to be specified.
   parameterized {
     meta_optional = ["MY_META_KEY"]
   }

--- a/ui/app/utils/default_jobs/service-discovery.js
+++ b/ui/app/utils/default_jobs/service-discovery.js
@@ -4,8 +4,8 @@
  */
 
 export default `job "service-discovery-example" {
-  // Specifies the datacenter where this job should be run
-  // This can be omitted and it will default to ["*"]
+  # Specifies the datacenter where this job should be run
+  # This can be omitted and it will default to ["*"]
   datacenters = ["*"]
 
   group "client" {
@@ -53,8 +53,8 @@ EOF
         name     = "nomad-service-discovery-example-server"
         provider = "nomad"
         port     = "www"
-        // If you're running Nomad in dev mode, uncomment the following address_mode line to allow this service to be discovered
-        // address_mode = "driver"
+        # If you're running Nomad in dev mode, uncomment the following address_mode line to allow this service to be discovered
+        # address_mode = "driver"
 
         check {
           type     = "http"

--- a/ui/app/utils/default_jobs/variables.js
+++ b/ui/app/utils/default_jobs/variables.js
@@ -4,19 +4,19 @@
  */
 
 /* eslint-disable */
-export default `// Use Nomad Variables to modify this job's output:
-// run "nomad var put nomad/jobs/variables-example name=YOUR_NAME" to get started
+export default `# Use Nomad Variables to modify this job's output:
+# run "nomad var put nomad/jobs/variables-example name=YOUR_NAME" to get started
 
 job "variables-example" {
-  // Specifies the datacenter where this job should be run
-  // This can be omitted and it will default to ["*"]
+  # Specifies the datacenter where this job should be run
+  # This can be omitted and it will default to ["*"]
   datacenters = ["*"]
 
   group "web" {
 
     network {
-      // Task group will have an isolated network namespace with
-      // an interface that is bridged with the host
+      # Task group will have an isolated network namespace with
+      # an interface that is bridged with the host
       port "www" {
         to = 8001
       }
@@ -38,8 +38,8 @@ job "variables-example" {
         ports   = ["www"]
       }
 
-      // Create a template resource that will be used to render the html file
-      // using the Nomad variable at "nomad/jobs/variables-example"
+      # Create a template resource that will be used to render the html file
+      # using the Nomad variable at "nomad/jobs/variables-example"
       template {
         data        = "<html>hello, {{ with nomadVar \\" nomad/jobs/variables-example \\" }}{{ .name }}{{ end }}</html>"
         destination = "local/index.html"


### PR DESCRIPTION
Swaps out the `//` for `#` comment prefixes in our job template strings (which eventually are expressed as HCL) for highlighting reasons, among others.

Old:
![image](https://github.com/hashicorp/nomad/assets/713991/d20984e3-58db-4af4-82ef-0ad98d8b0e91)
New:
![image](https://github.com/hashicorp/nomad/assets/713991/0770c45c-d314-4054-87be-dfef27f69285)
