### PR TITLE
[ui] Only run test-ui, and percy, in the event that a push/pr touches the ui directory

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -1,39 +1,15 @@
 name: test-ui
 on:
   pull_request:
-    paths-ignore:
-      - 'README.md'
-      - 'CHANGELOG.md'
-      - '.changelog/**'
-      - '.tours/**'
-      - 'contributing/**'
-      - 'demo/**'
-      - 'dev/**'
-      - 'e2e/**'
-      - 'integrations/**'
-      - 'pkg/**'
-      - 'scripts/**'
-      - 'terraform/**'
-      - 'website/**'
+    paths:
+      - 'ui'
   push:
     branches:
       - main
       - release/**
       - test-ui
-    paths-ignore:
-      - 'README.md'
-      - 'CHANGELOG.md'
-      - '.changelog/**'
-      - '.tours/**'
-      - 'contributing/**'
-      - 'demo/**'
-      - 'dev/**'
-      - 'e2e/**'
-      - 'integrations/**'
-      - 'pkg/**'
-      - 'scripts/**'
-      - 'terraform/**'
-      - 'website/**'
+    paths:
+      - 'ui'
 
 jobs:
   pre-test:


### PR DESCRIPTION
Our percy and test-ui runs shouldn't need to be run on any non-ui-dir changes, since we fully mock our needed API endpoints etc. with mirage for our test runs.

This should save us some time and money on checks in the future.