### PR TITLE
client: pass alloc hook resources to template hook

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -121,6 +121,7 @@ func (tr *TaskRunner) initHooks() {
 			templates:           task.Templates,
 			clientConfig:        tr.clientConfig,
 			envBuilder:          tr.envBuilder,
+			hookResources:       tr.allocHookResources,
 			consulNamespace:     consulNamespace,
 			nomadNamespace:      tr.alloc.Job.Namespace,
 			renderOnTaskRestart: task.RestartPolicy.RenderTemplates,


### PR DESCRIPTION
The task template hook uses the alloc resource to retrieve Consul tokens, so it must be passed from the allocation.