### PR TITLE
e2e: bump packer build instances because faster

### DIFF
--- a/e2e/terraform/packer/ubuntu-jammy-amd64.pkr.hcl
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64.pkr.hcl
@@ -15,7 +15,7 @@ locals {
 source "amazon-ebs" "latest_ubuntu_jammy" {
   ami_name             = "nomad-e2e-${local.version}-ubuntu-jammy-amd64-${local.timestamp}"
   iam_instance_profile = "packer_build" // defined in nomad-e2e repo
-  instance_type        = "t3a.medium"
+  instance_type        = "m7a.large"
   region               = "us-east-1"
   ssh_username         = "ubuntu"
   ssh_interface        = "public_ip"

--- a/e2e/terraform/packer/windows-2016-amd64.pkr.hcl
+++ b/e2e/terraform/packer/windows-2016-amd64.pkr.hcl
@@ -14,7 +14,7 @@ locals {
 source "amazon-ebs" "latest_windows_2016" {
   ami_name       = "nomad-e2e-${local.version}-windows-2016-amd64-${local.timestamp}"
   communicator   = "ssh"
-  instance_type  = "t2.medium"
+  instance_type  = "m7a.large"
   region         = "us-east-1"
   user_data_file = "windows-2016-amd64/userdata.ps1" # enables ssh
   ssh_timeout    = "10m"


### PR DESCRIPTION
`t2` is ancient hardware; bump to the latest and greatest general compute type. builds are about twice as fast or so, though "Waiting for AMI to become ready..." unfortunately isn't any faster.