### PR TITLE
chore: remove comment about WI change mode

### DIFF
--- a/client/widmgr/widmgr.go
+++ b/client/widmgr/widmgr.go
@@ -377,7 +377,6 @@ func (m *WIDMgr) renew() {
 		}
 
 		// Renew all tokens together since its cheap
-		// FIXME this will have to be revisited once we support identity change modes
 		tokens, err := m.signer.SignIdentities(m.minIndex, reqs)
 		if err != nil {
 			retry++


### PR DESCRIPTION
Identity change mode was implemented in #18943 and handles the update at the task level, so workload identity manager receives the update as expected.