### PR TITLE
[ui] Shows the client/node name alongside alloc short ID if the job is system/sysbatch

### DIFF
--- a/.changelog/19051.txt
+++ b/.changelog/19051.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: for system and sysbatch jobs, now show client name on hover in job panel
+```

--- a/ui/app/components/job-status/individual-allocation.hbs
+++ b/ui/app/components/job-status/individual-allocation.hbs
@@ -2,8 +2,9 @@
   Copyright (c) HashiCorp, Inc.
   SPDX-License-Identifier: BUSL-1.1
 ~}}
-
-<Hds::TooltipButton @text="{{get @allocation "shortId"}}" aria-label="Allocation" @extraTippyOptions={{hash trigger=(if (eq @status "unplaced") "manual")}}>
+<Hds::TooltipButton
+  @text="{{if this.showClient (concat this.nodeName " - " (get @allocation "shortId")) (get @allocation "shortId")}}"
+aria-label="Allocation" @extraTippyOptions={{hash trigger=(if (eq @status "unplaced") "manual")}}>
   <ConditionalLinkTo
     @condition={{not (eq @status "unplaced")}}
     @route="allocations.allocation"

--- a/ui/app/components/job-status/individual-allocation.js
+++ b/ui/app/components/job-status/individual-allocation.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+// @ts-check
+import Component from '@glimmer/component';
+import { alias } from '@ember/object/computed';
+
+export default class JobStatusIndividualAllocationComponent extends Component {
+  @alias('args.allocation.job.type') jobType;
+  @alias('args.allocation.node.name') nodeName;
+
+  get showClient() {
+    return this.jobType === 'system' || this.jobType === 'sysbatch';
+  }
+}


### PR DESCRIPTION
On hover, shows client info on the job status panel's allocs:
<img width="777" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/d4b3594f-c1f0-4502-8b5d-9d785fa245d8">

Resolves #19050 