### PR TITLE
E2E: add template block to `consulcompat` test

### DIFF
--- a/e2e/consulcompat/input/connect.nomad.hcl
+++ b/e2e/consulcompat/input/connect.nomad.hcl
@@ -63,6 +63,20 @@ job "countdash" {
         image          = "hashicorpdev/counter-dashboard:v3"
         auth_soft_fail = true
       }
+
+
+      # this template can't be used for the COUNTING_SERVICE_URL because it
+      # needs the Nomad-assigned upstream address here and not the Consul
+      # service address, but this is handy for testing.
+      template {
+        data = <<EOT
+{{- range service "count-api" }}
+API_ADDR=http://{{ .Address }}:{{ .Port }}{{- end }}
+EOT
+
+        destination = "local/count-api.txt"
+      }
+
     }
   }
 }

--- a/e2e/consulcompat/input/consul-policy-for-nomad.hcl
+++ b/e2e/consulcompat/input/consul-policy-for-nomad.hcl
@@ -14,15 +14,11 @@ agent_prefix "" {
   policy = "read"
 }
 
-key_prefix "" {
-  policy = "read"
-}
-
 node_prefix "" {
   policy = "read"
 }
 
-service_prefix "" {
+service_prefix "nomad" {
   policy = "write"
 }
 
@@ -36,7 +32,7 @@ namespace_prefix "" {
     policy = "read"
   }
 
-  service_prefix "" {
+  service_prefix "nomad" {
     policy = "write"
   }
 }

--- a/e2e/consulcompat/input/consul-policy-for-nomad.hcl
+++ b/e2e/consulcompat/input/consul-policy-for-nomad.hcl
@@ -22,6 +22,10 @@ service_prefix "nomad" {
   policy = "write"
 }
 
+service_prefix "" {
+  policy = "read"
+}
+
 # for use with Consul ENT
 namespace_prefix "" {
   key_prefix "" {

--- a/e2e/consulcompat/shared_run_test.go
+++ b/e2e/consulcompat/shared_run_test.go
@@ -155,4 +155,8 @@ func runConnectJob(t *testing.T, nc *nomadapi.Client) {
 		wait.Timeout(10*time.Second),
 		wait.Gap(1*time.Second),
 	))
+
+	// Ensure that the template rendered
+	_, _, err = nc.AllocFS().Stat(alloc, "dashboard/local/count-api.txt", nil)
+	must.NoError(t, err)
 }


### PR DESCRIPTION
The Consul compatibility test focuses on Connect, but it'd be a good idea to ensure we can successfully get template data out of Consul as well.

(`client` package test is failing because of https://github.com/hashicorp/nomad/pull/19056, will rebase once that's been merged)