### PR TITLE
e2e: more cpu and memory for java tasks and some scripts

### DIFF
--- a/e2e/isolation/input/chroot_docker.nomad
+++ b/e2e/isolation/input/chroot_docker.nomad
@@ -21,8 +21,8 @@ job "chroot_docker" {
         ]
       }
       resources {
-        cpu    = 50
-        memory = 50
+        cpu    = 200
+        memory = 128
       }
     }
   }

--- a/e2e/isolation/input/java.hcl
+++ b/e2e/isolation/input/java.hcl
@@ -46,8 +46,8 @@ EOH
       }
 
       resources {
-        cpu    = 50
-        memory = 64
+        cpu    = 500
+        memory = 256
       }
     }
 
@@ -60,8 +60,8 @@ EOH
       }
 
       resources {
-        cpu    = 50
-        memory = 64
+        cpu    = 500
+        memory = 256
       }
     }
   }

--- a/e2e/isolation/input/java_host.hcl
+++ b/e2e/isolation/input/java_host.hcl
@@ -47,8 +47,8 @@ EOH
       }
 
       resources {
-        cpu    = 50
-        memory = 64
+        cpu    = 500
+        memory = 256
       }
     }
 
@@ -62,8 +62,8 @@ EOH
       }
 
       resources {
-        cpu    = 50
-        memory = 64
+        cpu    = 500
+        memory = 256
       }
     }
   }

--- a/e2e/isolation/input/raw_exec.hcl
+++ b/e2e/isolation/input/raw_exec.hcl
@@ -44,7 +44,7 @@ EOF
       }
 
       resources {
-        cpu    = 10
+        cpu    = 100
         memory = 64
       }
     }


### PR DESCRIPTION
The memory limits on the java tasks in particular were probably too low; bump these to be more sensible.