### PR TITLE
[ui] Bugfix: expecting job.name and job.namespace passed as separate params, rather than job.id

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -179,7 +179,9 @@ export default class JobAdapter extends WatchableNamespaceIDs {
     }/${applicationAdapter.urlPrefix()}`;
 
     const wsUrl =
-      `${protocol}//${prefix}/job/${encodeURIComponent(job.get('id'))}/action` +
+      `${protocol}//${prefix}/job/${encodeURIComponent(
+        job.get('name')
+      )}/action` +
       `?namespace=${job.get('namespace.id')}&action=${
         action.name
       }&allocID=${allocID}&task=${action.task.name}&group=${


### PR DESCRIPTION
Small fix to let UI actions passing use job.name instead of job.id, since namespace is passed as an explicit param afterward