### PR TITLE
e2ev3: wait for logs to become ready

### DIFF
--- a/e2e/oversubscription/oversubscription_test.go
+++ b/e2e/oversubscription/oversubscription_test.go
@@ -41,10 +41,6 @@ func testDocker(t *testing.T) {
 	job, jobCleanup := jobs3.Submit(t, "./input/docker.hcl")
 	t.Cleanup(jobCleanup)
 
-	// wait for logs
-	// TODO(shoenig) a better way to do this?
-	time.Sleep(10 * time.Second)
-
 	// job will cat /sys/fs/cgroup/memory.max which should be
 	// set to the 30 megabyte memory_max value
 	logs := job.TaskLogs("group", "task")

--- a/e2e/v3/jobs3/jobs3.go
+++ b/e2e/v3/jobs3/jobs3.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/nomad/jobspec2"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
+	"github.com/shoenig/test/wait"
 )
 
 type Submission struct {
@@ -94,12 +95,26 @@ func (sub *Submission) getTaskLogs(allocID, task string) Logs {
 
 	fsAPI := sub.nomadClient.AllocFS()
 	read := func(path string) string {
-		rc, err := fsAPI.ReadAt(alloc, path, 0, 0, queryOpts)
-		must.NoError(sub.t, err, must.Sprintf("failed to read alloc logs for %s", allocID))
-		b, err := io.ReadAll(rc)
-		must.NoError(sub.t, err, must.Sprintf("failed to read alloc logs for %s", allocID))
-		must.NoError(sub.t, rc.Close(), must.Sprint("failed to close log stream"))
-		return string(b)
+		var content string
+		f := func() error {
+			rc, err := fsAPI.ReadAt(alloc, path, 0, 0, queryOpts)
+			if err != nil {
+				return fmt.Errorf("failed to read alloc %s logs: %w", allocID, err)
+			}
+			b, err := io.ReadAll(rc)
+			if err != nil {
+				return fmt.Errorf("failed to read alloc %s logs: %w", allocID, err)
+			}
+			content = string(b)
+			return rc.Close()
+		}
+		must.Wait(sub.t, wait.InitialSuccess(
+			wait.ErrorFunc(f),
+			wait.Timeout(15*time.Second),
+			wait.Gap(1*time.Second),
+		))
+
+		return content
 	}
 
 	stdout := fmt.Sprintf("alloc/logs/%s.stdout.0", task)


### PR DESCRIPTION
Just because an alloc is running does not mean nomad is ready to serve
task logs. In a test case where you immediatly read logs after starting
a task, it could be that nomad responds with "no logs found" when you
try to read logs, in which case you just need to wait longer. Do so in
the v3 TaskLogs helper function.
