### PR TITLE
E2E: refactor `vaultcompat` to allow for ENT tests

### DIFF
--- a/e2e/vaultcompat/run_ce_test.go
+++ b/e2e/vaultcompat/run_ce_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+
+package vaultcompat
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/shoenig/test/must"
+)
+
+// usable is used by the downloader to verify that we're getting the right
+// versions of Vault CE
+func usable(v, minimum *version.Version) bool {
+	switch {
+	case v.Prerelease() != "":
+		return false
+	case v.Metadata() != "":
+		return false
+	case v.LessThan(minimum):
+		return false
+	default:
+		return true
+	}
+}
+
+func testVaultLegacy(t *testing.T, b build) {
+	vStop, vc := startVault(t, b)
+	defer vStop()
+	setupVaultLegacy(t, vc)
+
+	nStop, nc := startNomad(t, configureNomadVaultLegacy(vc))
+	defer nStop()
+	runJob(t, nc, "input/cat.hcl", "default", validateLegacyAllocs)
+}
+
+func testVaultJWT(t *testing.T, b build) {
+	vStop, vc := startVault(t, b)
+	defer vStop()
+
+	// Start Nomad without access to the Vault token.
+	vaultToken := vc.Token()
+	vc.SetToken("")
+	nStop, nc := startNomad(t, configureNomadVaultJWT(vc))
+	defer nStop()
+
+	// Restore token and configure Vault for JWT login.
+	vc.SetToken(vaultToken)
+	setupVaultJWT(t, vc, nc.Address()+"/.well-known/jwks.json")
+
+	// Write secrets for test job.
+	_, err := vc.KVv2("secret").Put(context.Background(), "default/cat_jwt", map[string]any{
+		"secret": "workload",
+	})
+	must.NoError(t, err)
+
+	_, err = vc.KVv2("secret").Put(context.Background(), "restricted", map[string]any{
+		"secret": "restricted",
+	})
+	must.NoError(t, err)
+
+	// Run test job.
+	runJob(t, nc, "input/cat_jwt.hcl", "default", validateJWTAllocs)
+}


### PR DESCRIPTION
We want to run the Vault compatibility E2E test with Vault Enterprise binaries and use Vault namespaces. Refactor the `vaultcompat` test so as to parameterize most of the test setup logic with the namespace, and add the appropriate build tag for the CE version of the test.

Ref: https://github.com/hashicorp/nomad-enterprise/pull/1311