### PR TITLE
cli: add zero nodes message to `node status`

### DIFF
--- a/command/node_status.go
+++ b/command/node_status.go
@@ -229,6 +229,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 
 		// Return nothing if no nodes found
 		if len(nodes) == 0 {
+			c.Ui.Output("No nodes registered")
 			return 0
 		}
 


### PR DESCRIPTION
Display a message to indicate that there are no nodes registered when `node status` returns zero values.