### PR TITLE
docs: Add section for disable restart

### DIFF
--- a/website/content/docs/job-specification/restart.mdx
+++ b/website/content/docs/job-specification/restart.mdx
@@ -124,7 +124,7 @@ defaults by job type:
 
 ### Disabling restart
 
-To disable restarting, set the `attempts` parameter to zero and `mode` to "fail".
+To disable restarting, set the `attempts` parameter to zero and `mode` to `"fail"`.
 
 ```hcl
 job "docs" {
@@ -136,8 +136,6 @@ job "docs" {
   }
 }
 ```
-
-
 
 ### `mode` Values
 

--- a/website/content/docs/job-specification/restart.mdx
+++ b/website/content/docs/job-specification/restart.mdx
@@ -122,6 +122,23 @@ defaults by job type:
   }
   ```
 
+### Disabling restart
+
+To disable restarting, set the `attempts` parameter to zero and `mode` to "fail".
+
+```hcl
+job "docs" {
+  group "example" {
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+  }
+}
+```
+
+
+
 ### `mode` Values
 
 This section details the specific values for the "mode" parameter in the Nomad


### PR DESCRIPTION
This PR introduces a new section to the restart block on the job specs that explicitly defines how to disable the restart of a task group on the job specs.