### PR TITLE
qemu: fix panic from missing resources block

### DIFF
--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -176,6 +176,12 @@ func (e *UniversalExecutor) enterCG1(statsCgroup, cpusetCgroup string) func() {
 }
 
 func (e *UniversalExecutor) configureCG1(cgroup string, command *ExecCommand) {
+
+	// some drivers like qemu entirely own resource management
+	if command.Resources == nil || command.Resources.LinuxResources == nil {
+		return
+	}
+
 	// write memory limits
 	memHard, memSoft := e.computeMemory(command)
 	ed := cgroupslib.OpenFromFreezerCG1(cgroup, "memory")
@@ -205,6 +211,12 @@ func (e *UniversalExecutor) configureCG1(cgroup string, command *ExecCommand) {
 }
 
 func (e *UniversalExecutor) configureCG2(cgroup string, command *ExecCommand) {
+
+	// some drivers like qemu entirely own resource management
+	if command.Resources == nil || command.Resources.LinuxResources == nil {
+		return
+	}
+
 	// write memory cgroup files
 	memHard, memSoft := e.computeMemory(command)
 	ed := cgroupslib.OpenPath(cgroup)


### PR DESCRIPTION
The `qemu` driver uses our universal executor to run the QEMU command line tool. Because QEMU owns the resource isolation, we don't pass in the resource block that the universal executor uses to configure cgroups and core pinning. This resulted in a panic.

Fix the panic by returning early in the cgroup configuration in the universal executor. This fixes `qemu` but also any third-party drivers that might exist and are using our executor code without passing in the resource block.

In future work, we should ensure that the `resources` block is being translated into QEMU equivalents, so that we have support for things like NUMA-aware scheduling for that driver.

Fixes: https://github.com/hashicorp/nomad/issues/19078
Ref: https://github.com/hashicorp/nomad/issues/19090