### PR TITLE
docs: clarify when "all" is not permitted for `cap_add`

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -511,7 +511,9 @@ config {
   directly to [`--cap-add`][]. Effective capabilities (computed from `cap_add`
   and `cap_drop`) must be a subset of the allowed capabilities configured with
   the [`allow_caps`][allow_caps] plugin option key in the client node's
-  configuration. For example:
+  configuration. Note that `"all"` is not permitted here if the `allow_caps`
+  field in the driver configuration doesn't also allow all capabilities. For
+  example:
 
 ```hcl
 config {

--- a/website/content/docs/drivers/exec.mdx
+++ b/website/content/docs/drivers/exec.mdx
@@ -65,8 +65,10 @@ be able to access sensitive process information like environment variables.
 able to make use of IPC features, like sending unexpected POSIX signals.
 
 - `cap_add` - (Optional) A list of Linux capabilities to enable for the task.
-  Effective capabilities (computed from `cap_add` and `cap_drop`) must be a subset
-  of the allowed capabilities configured with [`allow_caps`][allow_caps].
+  Effective capabilities (computed from `cap_add` and `cap_drop`) must be a
+  subset of the allowed capabilities configured with [`allow_caps`][allow_caps].
+  Note that `"all"` is not permitted here if the `allow_caps` field in the
+  driver configuration doesn't also allow all capabilities.
 
 ```hcl
 config {

--- a/website/content/docs/drivers/java.mdx
+++ b/website/content/docs/drivers/java.mdx
@@ -62,8 +62,11 @@ be able to access sensitive process information like environment variables.
 able to make use of IPC features, like sending unexpected POSIX signals.
 
 - `cap_add` - (Optional) A list of Linux capabilities to enable for the task.
-  Effective capabilities (computed from `cap_add` and `cap_drop`) must be a subset
-  of the allowed capabilities configured with [`allow_caps`][allow_caps].
+  Effective capabilities (computed from `cap_add` and `cap_drop`) must be a
+  subset of the allowed capabilities configured with [`allow_caps`][allow_caps].
+  Note that `"all"` is not permitted here if the `allow_caps` field in the
+  driver configuration doesn't also allow all capabilities.
+
 
 ```hcl
 config {


### PR DESCRIPTION
Linux capabilities configurable by the task must be a subset of those configured in the plugin configuration. Clarify this implies that `"all"` is not permitted if the plugin is not also configured to allow all capabilities.

Fixes: https://github.com/hashicorp/nomad/issues/19059