### PR TITLE
Move systemd unit file rate limits from [Service] to [Unit] block

### DIFF
--- a/.release/linux/package/usr/lib/systemd/system/nomad.service
+++ b/.release/linux/package/usr/lib/systemd/system/nomad.service
@@ -10,17 +10,6 @@ After=network-online.target
 #Wants=consul.service
 #After=consul.service
 
-[Service]
-EnvironmentFile=-/etc/nomad.d/nomad.env
-ExecReload=/bin/kill -HUP $MAINPID
-ExecStart=/usr/bin/nomad agent -config /etc/nomad.d
-KillMode=process
-KillSignal=SIGINT
-LimitNOFILE=65536
-LimitNPROC=infinity
-Restart=on-failure
-RestartSec=2
-
 ## Configure unit start rate limiting. Units which are started more than
 ## *burst* times within an *interval* time span are not permitted to start any
 ## more. Use `StartLimitIntervalSec` or `StartLimitInterval` (depending on
@@ -35,6 +24,17 @@ RestartSec=2
 
 ## StartLimitInterval is used for systemd versions < 230
 # StartLimitInterval = 10s
+
+[Service]
+EnvironmentFile=-/etc/nomad.d/nomad.env
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/bin/nomad agent -config /etc/nomad.d
+KillMode=process
+KillSignal=SIGINT
+LimitNOFILE=65536
+LimitNPROC=infinity
+Restart=on-failure
+RestartSec=2
 
 TasksMax=infinity
 OOMScoreAdjust=-1000


### PR DESCRIPTION
Same issue as #10065:

```
Nov 16 06:45:52 nuc-01 systemd[1]: /lib/systemd/system/nomad.service:30: Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring.
Nov 16 09:24:11 nuc-01 systemd[1]: /lib/systemd/system/nomad.service:30: Unknown key name 'StartLimitIntervalSec' in section 'Service', ignoring.
```

 which was fixed by @shoenig in #10068, but seems to have disappeared with the [reorganisation](https://github.com/hashicorp/nomad/commits/5a0a8f606ffe87fe8b8a09aa7e827498d1ed8a1a/.release/linux/package/etc/usr/lib/systemd/system/nomad.service?browsing_rename_history=true&new_path=.release/linux/package/usr/lib/systemd/system/nomad.service&original_branch=f95697abaf1a07b7445f2d2a10ff45c519c3866c) of releases.

All the params being moved belong in [Unit] instead of [Service]: https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html