### PR TITLE
bump Consul constraint to 1.8.0

### DIFF
--- a/.changelog/19104.txt
+++ b/.changelog/19104.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+consul: constraint for minimum version of Consul increased to 1.8.0
+```

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -34,10 +34,10 @@ var (
 	// consulServiceDiscoveryConstraint is the implicit constraint added to
 	// task groups which include services utilising the Consul provider. The
 	// Consul version is pinned to a minimum of that which introduced the
-	// namespace feature.
+	// JWT auth feature.
 	consulServiceDiscoveryConstraint = &structs.Constraint{
 		LTarget: attrConsulVersion,
-		RTarget: ">= 1.7.0",
+		RTarget: ">= 1.8.0",
 		Operand: structs.ConstraintSemver,
 	}
 
@@ -285,7 +285,7 @@ func consulConstraintFn(service *structs.Service) *structs.Constraint {
 	if service.Cluster != structs.ConsulDefaultCluster && service.Cluster != "" {
 		return &structs.Constraint{
 			LTarget: fmt.Sprintf("${attr.consul.%s.version}", service.Cluster),
-			RTarget: ">= 1.7.0",
+			RTarget: ">= 1.8.0",
 			Operand: structs.ConstraintSemver,
 		}
 	}

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -1026,7 +1026,7 @@ func Test_jobImpliedConstraints_Mutate(t *testing.T) {
 							consulServiceDiscoveryConstraint,
 							&structs.Constraint{
 								LTarget: "${attr.consul.infra.version}",
-								RTarget: ">= 1.7.0",
+								RTarget: ">= 1.8.0",
 								Operand: structs.ConstraintSemver,
 							},
 						},

--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -36,7 +36,7 @@ func Job() *structs.Job {
 				Constraints: []*structs.Constraint{
 					{
 						LTarget: "${attr.consul.version}",
-						RTarget: ">= 1.7.0",
+						RTarget: ">= 1.8.0",
 						Operand: structs.ConstraintSemver,
 					},
 				},


### PR DESCRIPTION
The JWT authentication feature was added to Consul in 1.8.0. Bump the version constraint in the job endpoint hooks to match. This version is long out of support so it shouldn't have any impact on existing jobs.