### PR TITLE
e2e: use tf variable defaults

### DIFF
--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -1,12 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-region                          = "us-east-1"
-instance_type                   = "t3a.medium"
-server_count                    = "3"
-client_count_ubuntu_jammy_amd64 = "4"
-client_count_windows_2016_amd64 = "0"
-volumes                         = true
+# this default tfvars file expects that you have built nomad
+# with `make dev` or similar (../../ = this repository root)
+# before running `terraform apply`
 
 nomad_local_binary                           = "../../pkg/linux_amd64/nomad"
 nomad_local_binary_client_windows_2016_amd64 = ["../../pkg/windows_amd64/nomad.exe"]

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -18,7 +18,7 @@ variable "availability_zone" {
 
 variable "instance_type" {
   description = "The AWS instance type to use for both clients and servers."
-  default     = "t2.medium"
+  default     = "t3a.medium"
 }
 
 variable "server_count" {


### PR DESCRIPTION
I noticed that despite #19012, a Windows instance was still being provisioned during E2E runs.

Turns out that's because our E2E repo has its own tfvars file(s), which means that these values are set in at least 3 different places:

* `variables.tf` defaults
* `terraform.tfvars` in this repo
* `github.tfvars` in e2e repo

To reduce the likelihood of this causing more confusion in the future, this removes most variables from tfvars, leaving only those that are actually different depending on context.