### PR TITLE
Fix panic in Allocation.Stub() when Job is nil

### DIFF
--- a/.changelog/19115.txt
+++ b/.changelog/19115.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fix panic in `Allocation.Stub` method when `Job` is unset
+```

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -311,7 +311,7 @@ type NodeScoreMeta struct {
 
 // Stub returns a list stub for the allocation
 func (a *Allocation) Stub() *AllocationListStub {
-	return &AllocationListStub{
+	stub := &AllocationListStub{
 		ID:                    a.ID,
 		EvalID:                a.EvalID,
 		Name:                  a.Name,
@@ -319,8 +319,6 @@ func (a *Allocation) Stub() *AllocationListStub {
 		NodeID:                a.NodeID,
 		NodeName:              a.NodeName,
 		JobID:                 a.JobID,
-		JobType:               *a.Job.Type,
-		JobVersion:            *a.Job.Version,
 		TaskGroup:             a.TaskGroup,
 		DesiredStatus:         a.DesiredStatus,
 		DesiredDescription:    a.DesiredDescription,
@@ -338,6 +336,13 @@ func (a *Allocation) Stub() *AllocationListStub {
 		CreateTime:            a.CreateTime,
 		ModifyTime:            a.ModifyTime,
 	}
+
+	if a.Job != nil {
+		stub.JobType = *a.Job.Type
+		stub.JobVersion = *a.Job.Version
+	}
+
+	return stub
 }
 
 // ServerTerminalStatus returns true if the desired state of the allocation is


### PR DESCRIPTION
Fixes: #18134 