### PR TITLE
E2E: fix expected error message from token expiration test

### DIFF
--- a/e2e/acl/acl_token_test.go
+++ b/e2e/acl/acl_token_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/e2e/e2eutil"
 	"github.com/hashicorp/nomad/helper/uuid"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 var (
@@ -46,7 +46,7 @@ func testACLTokenExpiration(t *testing.T) {
 		Rules:       `namespace "default" {policy = "read"}`,
 	}
 	_, err := nomadClient.ACLPolicies().Upsert(&customNamespacePolicy, nil)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	cleanUpProcess.Add(customNamespacePolicy.Name, ACLPolicyTestResourceType)
 
@@ -63,9 +63,9 @@ func testACLTokenExpiration(t *testing.T) {
 		ExpirationTTL: minTokenExpiryDur / 2,
 	}
 	aclTokenCreateResp, _, err := nomadClient.ACLTokens().Create(&tokenTTLLow, nil)
-	require.ErrorContains(t, err, fmt.Sprintf(
+	must.ErrorContains(t, err, fmt.Sprintf(
 		"expiration time cannot be less than %s in the future", minTokenExpiryDur))
-	require.Nil(t, aclTokenCreateResp)
+	must.Nil(t, aclTokenCreateResp)
 
 	// Attempt to create a token with a higher than acceptable TTL and ensure
 	// we get an error.
@@ -76,9 +76,9 @@ func testACLTokenExpiration(t *testing.T) {
 		ExpirationTTL: 8766 * time.Hour,
 	}
 	aclTokenCreateResp, _, err = nomadClient.ACLTokens().Create(&tokenTTLHigh, nil)
-	require.ErrorContains(t, err, fmt.Sprintf(
+	must.ErrorContains(t, err, fmt.Sprintf(
 		"expiration time cannot be more than %s in the future", maxTokenExpiryDur))
-	require.Nil(t, aclTokenCreateResp)
+	must.Nil(t, aclTokenCreateResp)
 
 	// Create an ACL token that has a fairly standard TTL that will allow us to
 	// make successful calls without it expiring.
@@ -89,9 +89,9 @@ func testACLTokenExpiration(t *testing.T) {
 		ExpirationTTL: 10 * time.Minute,
 	}
 	tokenNormalExpiryCreateResp, _, err := nomadClient.ACLTokens().Create(&tokenNormalExpiry, nil)
-	require.NoError(t, err)
-	require.NotNil(t, tokenNormalExpiryCreateResp)
-	require.Equal(t,
+	must.NoError(t, err)
+	must.NotNil(t, tokenNormalExpiryCreateResp)
+	must.Eq(t,
 		*tokenNormalExpiryCreateResp.ExpirationTime,
 		tokenNormalExpiryCreateResp.CreateTime.Add(tokenNormalExpiryCreateResp.ExpirationTTL))
 
@@ -102,7 +102,7 @@ func testACLTokenExpiration(t *testing.T) {
 	defaultNSQueryMeta.AuthToken = tokenNormalExpiryCreateResp.SecretID
 
 	jobListResp, _, err := nomadClient.Jobs().List(&defaultNSQueryMeta)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	// Create an ACL token with the lowest expiry TTL possible, so it will
 	// expire almost immediately.
@@ -113,9 +113,9 @@ func testACLTokenExpiration(t *testing.T) {
 		ExpirationTTL: minTokenExpiryDur,
 	}
 	tokenQuickExpiryCreateResp, _, err := nomadClient.ACLTokens().Create(&tokenQuickExpiry, nil)
-	require.NoError(t, err)
-	require.NotNil(t, tokenQuickExpiryCreateResp)
-	require.Equal(t,
+	must.NoError(t, err)
+	must.NotNil(t, tokenQuickExpiryCreateResp)
+	must.Eq(t,
 		*tokenQuickExpiryCreateResp.ExpirationTime,
 		tokenQuickExpiryCreateResp.CreateTime.Add(tokenQuickExpiryCreateResp.ExpirationTTL))
 
@@ -129,8 +129,8 @@ func testACLTokenExpiration(t *testing.T) {
 	defaultNSQueryMeta.AuthToken = tokenQuickExpiryCreateResp.SecretID
 
 	jobListResp, _, err = nomadClient.Jobs().List(&defaultNSQueryMeta)
-	require.ErrorContains(t, err, "ACL token expired")
-	require.Nil(t, jobListResp)
+	must.ErrorContains(t, err, "Permission denied")
+	must.Nil(t, jobListResp)
 
 	cleanUpProcess.Remove(tokenQuickExpiryCreateResp.AccessorID, ACLTokenTestResourceType)
 
@@ -138,7 +138,7 @@ func testACLTokenExpiration(t *testing.T) {
 	// expiration. Other tests may have left tokens in state, so do not perform
 	// a length check.
 	tokenListResp, _, err := nomadClient.ACLTokens().List(nil)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	var quickExpiryFound, normalExpiryFound bool
 
@@ -146,26 +146,26 @@ func testACLTokenExpiration(t *testing.T) {
 		switch token.AccessorID {
 		case tokenQuickExpiryCreateResp.AccessorID:
 			quickExpiryFound = true
-			require.NotNil(t, token.ExpirationTime)
+			must.NotNil(t, token.ExpirationTime)
 		case tokenNormalExpiryCreateResp.AccessorID:
 			normalExpiryFound = true
-			require.NotNil(t, token.ExpirationTime)
+			must.NotNil(t, token.ExpirationTime)
 		default:
 			continue
 		}
 	}
 
-	require.True(t, quickExpiryFound)
-	require.True(t, normalExpiryFound)
+	must.True(t, quickExpiryFound)
+	must.True(t, normalExpiryFound)
 
 	// Ensure we can manually delete unexpired tokens and that they are
 	// immediately removed from state.
 	_, err = nomadClient.ACLTokens().Delete(tokenNormalExpiryCreateResp.AccessorID, nil)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	tokenNormalExpiryReadResp, _, err := nomadClient.ACLTokens().Info(tokenNormalExpiryCreateResp.AccessorID, nil)
-	require.ErrorContains(t, err, "ACL token not found")
-	require.Nil(t, tokenNormalExpiryReadResp)
+	must.ErrorContains(t, err, "ACL token not found")
+	must.Nil(t, tokenNormalExpiryReadResp)
 
 	cleanUpProcess.Remove(tokenNormalExpiryCreateResp.AccessorID, ACLTokenTestResourceType)
 }
@@ -192,7 +192,7 @@ func testACLTokenRolePolicyAssignment(t *testing.T) {
 		Rules:       `namespace "default" {policy = "read"}`,
 	}
 	_, err := nomadClient.ACLPolicies().Upsert(&defaultNamespacePolicy, nil)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	cleanUpProcess.Add(defaultNamespacePolicy.Name, ACLPolicyTestResourceType)
 
@@ -202,7 +202,7 @@ func testACLTokenRolePolicyAssignment(t *testing.T) {
 		Rules:       `node { policy = "read" }`,
 	}
 	_, err = nomadClient.ACLPolicies().Upsert(&nodePolicy, nil)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	cleanUpProcess.Add(nodePolicy.Name, ACLPolicyTestResourceType)
 
@@ -213,9 +213,9 @@ func testACLTokenRolePolicyAssignment(t *testing.T) {
 		Policies:    []*api.ACLRolePolicyLink{{Name: nodePolicy.Name}},
 	}
 	aclRoleCreateResp, _, err := nomadClient.ACLRoles().Create(&aclRole, nil)
-	require.NoError(t, err)
-	require.NotNil(t, aclRoleCreateResp)
-	require.NotEmpty(t, aclRoleCreateResp.ID)
+	must.NoError(t, err)
+	must.NotNil(t, aclRoleCreateResp)
+	must.NotEq(t, "", aclRoleCreateResp.ID)
 
 	cleanUpProcess.Add(aclRoleCreateResp.ID, ACLRoleTestResourceType)
 
@@ -227,9 +227,9 @@ func testACLTokenRolePolicyAssignment(t *testing.T) {
 		Policies: []string{defaultNamespacePolicy.Name},
 	}
 	aclTokenCreateResp, _, err := nomadClient.ACLTokens().Create(&token, nil)
-	require.NoError(t, err)
-	require.NotNil(t, aclTokenCreateResp)
-	require.NotEmpty(t, aclTokenCreateResp.SecretID)
+	must.NoError(t, err)
+	must.NotNil(t, aclTokenCreateResp)
+	must.NotEq(t, "", aclTokenCreateResp.SecretID)
 
 	cleanUpProcess.Add(aclTokenCreateResp.AccessorID, ACLTokenTestResourceType)
 
@@ -237,50 +237,50 @@ func testACLTokenRolePolicyAssignment(t *testing.T) {
 	// read node objects.
 	defaultNSQueryMeta := api.QueryOptions{Namespace: "default", AuthToken: aclTokenCreateResp.SecretID}
 	jobListResp, _, err := nomadClient.Jobs().List(&defaultNSQueryMeta)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	nodeStubList, _, err := nomadClient.Nodes().List(&defaultNSQueryMeta)
-	require.ErrorContains(t, err, "Permission denied")
-	require.Nil(t, nodeStubList)
+	must.ErrorContains(t, err, "Permission denied")
+	must.Nil(t, nodeStubList)
 
 	// Update the token to also include the ACL role which will allow reading
 	// node objects.
 	newToken := aclTokenCreateResp
 	newToken.Roles = []*api.ACLTokenRoleLink{{ID: aclRoleCreateResp.ID}}
 	aclTokenUpdateResp, _, err := nomadClient.ACLTokens().Update(newToken, nil)
-	require.NoError(t, err)
-	require.Equal(t, aclTokenUpdateResp.SecretID, aclTokenCreateResp.SecretID)
+	must.NoError(t, err)
+	must.Eq(t, aclTokenUpdateResp.SecretID, aclTokenCreateResp.SecretID)
 
 	// Test that the token can now read the default namespace and node objects.
 	jobListResp, _, err = nomadClient.Jobs().List(&defaultNSQueryMeta)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	nodeStubList, _, err = nomadClient.Nodes().List(&defaultNSQueryMeta)
-	require.NoError(t, err)
-	require.Greater(t, len(nodeStubList), 0)
+	must.NoError(t, err)
+	must.Greater(t, 0, len(nodeStubList))
 
 	// Remove the policy assignment from the token.
 	newToken.Policies = []string{}
 	aclTokenUpdateResp, _, err = nomadClient.ACLTokens().Update(newToken, nil)
-	require.NoError(t, err)
-	require.Equal(t, aclTokenUpdateResp.SecretID, aclTokenCreateResp.SecretID)
+	must.NoError(t, err)
+	must.Eq(t, aclTokenUpdateResp.SecretID, aclTokenCreateResp.SecretID)
 
 	// Test that the token can now only read node objects and not the default
 	// namespace.
 	jobListResp, _, err = nomadClient.Jobs().List(&defaultNSQueryMeta)
-	require.ErrorContains(t, err, "Permission denied")
-	require.Nil(t, jobListResp)
+	must.ErrorContains(t, err, "Permission denied")
+	must.Nil(t, jobListResp)
 
 	nodeStubList, _, err = nomadClient.Nodes().List(&defaultNSQueryMeta)
-	require.NoError(t, err)
-	require.Greater(t, len(nodeStubList), 0)
+	must.NoError(t, err)
+	must.Greater(t, 0, len(nodeStubList))
 
 	// Try and remove the role assignment which should result in a validation
 	// error as it needs to include either a policy or role linking.
 	newToken.Roles = nil
 	aclTokenUpdateResp, _, err = nomadClient.ACLTokens().Update(newToken, nil)
-	require.ErrorContains(t, err, "client token missing policies or roles")
-	require.Nil(t, aclTokenUpdateResp)
+	must.ErrorContains(t, err, "client token missing policies or roles")
+	must.Nil(t, aclTokenUpdateResp)
 
 	// Create a new token that has both the role and policy linking in place.
 	token = api.ACLToken{
@@ -290,9 +290,9 @@ func testACLTokenRolePolicyAssignment(t *testing.T) {
 		Roles:    []*api.ACLTokenRoleLink{{ID: aclRoleCreateResp.ID}},
 	}
 	aclTokenCreateResp, _, err = nomadClient.ACLTokens().Create(&token, nil)
-	require.NoError(t, err)
-	require.NotNil(t, aclTokenCreateResp)
-	require.NotEmpty(t, aclTokenCreateResp.SecretID)
+	must.NoError(t, err)
+	must.NotNil(t, aclTokenCreateResp)
+	must.NotEq(t, "", aclTokenCreateResp.SecretID)
 
 	cleanUpProcess.Add(aclTokenCreateResp.AccessorID, ACLTokenTestResourceType)
 
@@ -300,30 +300,30 @@ func testACLTokenRolePolicyAssignment(t *testing.T) {
 	defaultNSQueryMeta.AuthToken = aclTokenCreateResp.SecretID
 
 	jobListResp, _, err = nomadClient.Jobs().List(&defaultNSQueryMeta)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	nodeStubList, _, err = nomadClient.Nodes().List(&defaultNSQueryMeta)
-	require.NoError(t, err)
-	require.Greater(t, len(nodeStubList), 0)
+	must.NoError(t, err)
+	must.Greater(t, 0, len(nodeStubList))
 
 	// Now delete both the policy and the role from underneath the token. This
 	// differs to the graceful approaches above where the token was modified to
 	// remove the assignment.
 	_, err = nomadClient.ACLPolicies().Delete(defaultNamespacePolicy.Name, nil)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	cleanUpProcess.Remove(defaultNamespacePolicy.Name, ACLPolicyTestResourceType)
 
 	_, err = nomadClient.ACLRoles().Delete(aclRoleCreateResp.ID, nil)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	cleanUpProcess.Remove(aclRoleCreateResp.ID, ACLRoleTestResourceType)
 
 	// The token now should not have any power here; quite different to
 	// Gandalf's power over the spell on King Theoden.
 	jobListResp, _, err = nomadClient.Jobs().List(&defaultNSQueryMeta)
-	require.ErrorContains(t, err, "Permission denied")
-	require.Nil(t, jobListResp)
+	must.ErrorContains(t, err, "Permission denied")
+	must.Nil(t, jobListResp)
 
 	nodeStubList, _, err = nomadClient.Nodes().List(&defaultNSQueryMeta)
-	require.ErrorContains(t, err, "Permission denied")
-	require.Nil(t, nodeStubList)
+	must.ErrorContains(t, err, "Permission denied")
+	must.Nil(t, nodeStubList)
 }


### PR DESCRIPTION
In Nomad 1.5 we started masking the specific error returned from the authentication method and returned the "permission denied" error instead. Update the E2E test that covers token expiration to ensure we're asserting the correct error here.

(Also updates all the uses of `testify` to `shoenig/test`)

Fixes: https://github.com/hashicorp/nomad/issues/16803

---

Run against a real E2E cluster:

```
$ go test -v -count=1 ./e2e/acl -run TestACL/TestACL_TokenExpiration
=== RUN   TestACL
=== RUN   TestACL/TestACL_TokenExpiration
--- PASS: TestACL (1.39s)
    --- PASS: TestACL/TestACL_TokenExpiration (1.22s)
PASS
ok      github.com/hashicorp/nomad/e2e/acl      1.399s
```