### PR TITLE
E2E: fix assertion in dynamic node metadata test

### DIFF
--- a/e2e/workload_id/nodemeta_test.go
+++ b/e2e/workload_id/nodemeta_test.go
@@ -157,6 +157,6 @@ func testDynamicNodeMetadata(t *testing.T) {
 	must.Eq(t, "bar", resp.Meta[keyFoo])
 	must.Eq(t, "set", resp.Meta[keyUnset])
 	must.MapNotContainsKey(t, resp.Meta, keyEmpty)
-	must.MapContainsKey(t, resp.Dynamic, keyEmpty)
+	must.MapNotContainsKey(t, resp.Dynamic, keyEmpty)
 	must.Nil(t, resp.Dynamic[keyEmpty])
 }


### PR DESCRIPTION
In #18664 we change how null values worked with dynamic node metadata so that they were no longer returned if there wasn't also a static value for that key. The test assertion in E2E was not updated to match the new behavior.

Fixes: #19112