### PR TITLE
E2E: Fix UI tests

### DIFF
--- a/e2e/ui/global-setup.js
+++ b/e2e/ui/global-setup.js
@@ -22,8 +22,9 @@ module.exports = async config => {
   const page = await context.newPage();
   await page.goto(NOMAD_ADDR+'/ui/settings/tokens');
   await page.fill('input[id="token-input"]', NOMAD_TOKEN);
-  await page.click('button:has-text("Set Token")', {strict: true});
+  await page.click('button:has-text("Sign in")', {strict: true});
 
-  await page.context().storageState({ path: 'storageState.json' });
+  const { storageState } = config.projects[0].use;
+  await page.context().storageState({ path: storageState });
   await browser.close();
 };

--- a/e2e/ui/input/proxy.nomad
+++ b/e2e/ui/input/proxy.nomad
@@ -19,6 +19,17 @@ job "nomad-proxy" {
       }
     }
 
+    service {
+      name     = "nomad-proxy"
+      port     = "www"
+      provider = "nomad"
+      check {
+        type     = "tcp"
+        interval = "1s"
+        timeout  = "2s"
+      }
+    }
+
     task "nginx" {
 
       driver = "docker"

--- a/e2e/ui/playwright.config.js
+++ b/e2e/ui/playwright.config.js
@@ -7,6 +7,8 @@
 // @ts-check
 const { devices } = require('@playwright/test');
 
+export const STORAGE_STATE = 'storageState.json';
+
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
   forbidOnly: !!process.env.CI,
@@ -19,7 +21,10 @@ const config = {
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: STORAGE_STATE,
+      },
     },
     // disabling firefox temporarily because the container doesn't
     // include it and so it tries to automatically install it and
@@ -31,7 +36,10 @@ const config = {
     // },
     {
       name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      use: {
+        ...devices['Desktop Safari'],
+        storageState: STORAGE_STATE,
+      },
     },
   ],
 };

--- a/e2e/ui/tests/example.spec.js
+++ b/e2e/ui/tests/example.spec.js
@@ -19,6 +19,6 @@ test('authenticated users can see their policies', async ({ page }) => {
   await expect(logo).toBeVisible();
 
 
-  const policies = page.locator('text=Policies')
+  const policies = page.getByText('Policies');
   await expect(policies).toBeVisible();
 });


### PR DESCRIPTION
Fixes #19114 -- a follow-up in nomad-e2e (private) repo will make use of these changes.

Test setup:
 * The Nomad service{} allows the `run.sh` script to fallback to a service IP addr, as when running against a local agent instead of AWS
 * I think the `nomad exec ... curl aws metadata` here is significantly tidier that what was done over in the (failing) CI step
   * it was: `IP=$(nomad node status -json -verbose "$(nomad operator api '/v1/allocations?namespace=proxy' | jq -r '.[] | select(.JobID == "nomad-proxy") | .NodeID')" | jq -r '.Attributes."unique.platform.aws.public-ipv4"')`
 * Detect whether running in a TTY (docker errors if you try to run with `-it` when it can't actually do that)
 * Add `ci` subcommand, which runs the whole setup, test, teardown process, instead of needing all that written in CI.

The actual tests:
 * "Set token" button in UI was renamed at some point to "Sign in" (presumably when other login methods were added)
 * The UI login "storageState" was not persisted from global setup into the test.  Idk if something changed with "Playwright", but this seems to be [the way](https://playwright.dev/docs/test-global-setup-teardown#setup-example) to pass the state nowadays.
 * I don't think the getByText() change is necessary, but I kinda like it anyway.

<details>
<summary>Example output from a CI run over in nomad-e2e repo:</summary>

```
Run ./run.sh ci
++ run_proxy
++ nomad namespace apply proxy
Successfully applied namespace "proxy"!
++ nomad job run ./input/proxy.nomad
==> 2023-11-20T20:49:08Z: Monitoring evaluation "cfe69d89"
    2023-11-20T20:49:08Z: Evaluation triggered by job "nomad-proxy"
    2023-11-20T20:49:08Z: Allocation "ac5725c6" created: node "7b626be7", group "proxy"
    2023-11-20T20:49:09Z: Evaluation within deployment: "c74f600c"
    2023-11-20T20:49:09Z: Evaluation status changed: "pending" -> "complete"
==> 2023-11-20T20:49:09Z: Evaluation "cfe69d89" finished with status "complete"
==> 2023-11-20T20:49:09Z: Monitoring deployment "c74f600c"
    
2023-11-20T20:49:09Z
ID          = c74f600c
Job ID      = nomad-proxy
Job Version = 0
Status      = running
Description = Deployment is running

Deployed
Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
proxy       1        1       0        0          2023-11-20T20:59:08Z
    
2023-11-20T20:49:34Z
ID          = c74f600c
Job ID      = nomad-proxy
Job Version = 0
Status      = running
Description = Deployment is running

Deployed
Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
proxy       1        1       1        0          2023-11-20T20:59:33Z
    
2023-11-20T20:49:35Z
ID          = c74f600c
Job ID      = nomad-proxy
Job Version = 0
Status      = successful
Description = Deployment completed successfully

Deployed
Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
proxy       1        1       1        0          2023-11-20T20:59:33Z
+++ _get_aws_ip
+++ aws_metadata_url=http://169.254.169.254/latest/meta-data
+++ nomad exec -namespace=proxy -job nomad-proxy curl -s http://169.254.169.254/latest/meta-data/public-ipv4
++ IP=34.239.114.238
++ '[' -n 34.239.114.238 ']'
++ '[' -n 34.239.114.238 ']'
++ echo 'export NOMAD_ADDR=https://34.239.114.238:6464/'
+ eval 'export NOMAD_ADDR=https://34.239.114.238:6464/'
++ export NOMAD_ADDR=https://34.239.114.238:6464/
++ NOMAD_ADDR=https://34.239.114.238:6464/
+ run_tests
+ run bash script.sh
+ local tty_args
+ '[' -t 1 ']'
++ pwd
+ docker run --rm -v /home/runner/actions-runner/_work/nomad-e2e/nomad-e2e/nomad/e2e/ui:/src -w /src -e NOMAD_ADDR=https://34.239.114.238:6464/ -e NOMAD_TOKEN=*** --ipc=host --net=host mcr.microsoft.com/playwright:focal bash script.sh
Unable to find image 'mcr.microsoft.com/playwright:focal' locally
focal: Pulling from playwright
7a2c55901189: Pulling fs layer
3859e6c7cdc0: Pulling fs layer
348de1fc56d1: Pulling fs layer
5fa3d9bee9b3: Pulling fs layer
5fa3d9bee9b3: Waiting
348de1fc56d1: Download complete
7a2c55901189: Download complete
7a2c55901189: Pull complete
3859e6c7cdc0: Verifying Checksum
3859e6c7cdc0: Download complete
5fa3d9bee9b3: Verifying Checksum
5fa3d9bee9b3: Download complete
3859e6c7cdc0: Pull complete
348de1fc56d1: Pull complete
5fa3d9bee9b3: Pull complete
Digest: sha256:e05d5c146063de4b7303135a1970e6612afc3143178ecc6feafe6882ef147a6e
Status: Downloaded newer image for mcr.microsoft.com/playwright:focal

added 3 packages, and audited 4 packages in 1s

found 0 vulnerabilities
npm notice 
npm notice New minor version of npm available! 10.1.0 -> 10.2.4
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.2.4>
npm notice Run `npm install -g npm@10.2.4` to update!
npm notice 

Running 2 tests using 2 workers

  ✓  1 [chromium] › tests/example.spec.js:8:1 › authenticated users can see their policies (2.2s)
  ✓  2 [webkit] › tests/example.spec.js:8:1 › authenticated users can see their policies (2.7s)

  2 passed (7.0s)
+ rc=0
+ stop_proxy
+ export NOMAD_ADDR=https://34.239.114.238:4646/
+ NOMAD_ADDR=https://34.239.114.238:4646/
+ nomad job stop -namespace=proxy nomad-proxy
==> 2023-11-20T20:50:13Z: Monitoring evaluation "127102f3"
    2023-11-20T20:50:13Z: Evaluation triggered by job "nomad-proxy"
    2023-11-20T20:50:14Z: Evaluation within deployment: "c74f600c"
    2023-11-20T20:50:14Z: Evaluation status changed: "pending" -> "complete"
==> 2023-11-20T20:50:14Z: Evaluation "127102f3" finished with status "complete"
==> 2023-11-20T20:50:14Z: Monitoring deployment "c74f600c"
    
2023-11-20T20:50:14Z
ID          = c74f600c
Job ID      = nomad-proxy
Job Version = 0
Status      = successful
Description = Deployment completed successfully

Deployed
Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
proxy       1        1       1        0          2023-11-20T20:59:33Z
+ nomad namespace delete proxy
Successfully deleted namespace "proxy"!
+ exit 0
```
</details>