### PR TITLE
[ui] Fix: Purging jobs via the UI when namespaces are present

### DIFF
--- a/.changelog/19139.txt
+++ b/.changelog/19139.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed an issue where purging a job with a namespace did not process correctly
+```

--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -52,7 +52,12 @@ export default class JobAdapter extends WatchableNamespaceIDs {
   }
 
   purge(job) {
-    const url = this.urlForFindRecord(job.get('id'), 'job') + '?purge=true';
+    const url = addToPath(
+      this.urlForFindRecord(job.get('id'), 'job'),
+      '',
+      'purge=true'
+    );
+
     return this.ajax(url, 'DELETE');
   }
 


### PR DESCRIPTION
Previously, we'd just concat `?purge=true` without checking to see if other params were present. With this PR, we use our `addToPath` helper to append either via `?` or `&`, depending whether other params like namespace are present.

Resolves #18677 