### PR TITLE
client: change Consul client interface

### DIFF
--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -203,7 +203,7 @@ func (h *consulHook) getConsulTokens(cluster, identityName string, tokens map[st
 	}
 
 	// get consul acl tokens
-	t, err := client.DeriveSITokenWithJWT(req)
+	t, err := client.DeriveTokenWithJWT(req)
 	if err != nil {
 		return err
 	}

--- a/client/consul/consul.go
+++ b/client/consul/consul.go
@@ -51,9 +51,9 @@ type JWTLoginRequest struct {
 // Client is the interface that the nomad client uses to interact with
 // Consul.
 type Client interface {
-	// DeriveSITokenWithJWT logs into Consul using JWT and retrieves a Consul
-	// SI ACL token.
-	DeriveSITokenWithJWT(map[string]JWTLoginRequest) (map[string]*consulapi.ACLToken, error)
+	// DeriveTokenWithJWT logs into Consul using JWT and retrieves a Consul ACL
+	// token.
+	DeriveTokenWithJWT(map[string]JWTLoginRequest) (map[string]*consulapi.ACLToken, error)
 
 	RevokeTokens([]*consulapi.ACLToken) error
 }
@@ -101,9 +101,9 @@ func NewConsulClient(config *config.ConsulConfig, logger hclog.Logger) (Client, 
 	return c, nil
 }
 
-// DeriveSITokenWithJWT takes a JWT from request and returns a consul token for
+// DeriveTokenWithJWT takes a JWT from request and returns a consul token for
 // each identity in the request
-func (c *consulClient) DeriveSITokenWithJWT(reqs map[string]JWTLoginRequest) (map[string]*consulapi.ACLToken, error) {
+func (c *consulClient) DeriveTokenWithJWT(reqs map[string]JWTLoginRequest) (map[string]*consulapi.ACLToken, error) {
 	tokens := make(map[string]*consulapi.ACLToken, len(reqs))
 	var mErr *multierror.Error
 

--- a/client/consul/consul_testing.go
+++ b/client/consul/consul_testing.go
@@ -20,10 +20,10 @@ func NewMockConsulClient(config *config.ConsulConfig, logger hclog.Logger) (Clie
 	return &MockConsulClient{}, nil
 }
 
-// DeriveSITokenWithJWT returns ACLTokens with deterministic values for testing:
+// DeriveTokenWithJWT returns ACLTokens with deterministic values for testing:
 // the request ID for the AccessorID and the md5 checksum of the request ID for
 // the SecretID
-func (mc *MockConsulClient) DeriveSITokenWithJWT(reqs map[string]JWTLoginRequest) (map[string]*consulapi.ACLToken, error) {
+func (mc *MockConsulClient) DeriveTokenWithJWT(reqs map[string]JWTLoginRequest) (map[string]*consulapi.ACLToken, error) {
 	if mc.tokens != nil && len(mc.tokens) > 0 {
 		return mc.tokens, nil
 	}


### PR DESCRIPTION
`DeriveSITokenWithJWT` is a misleading method name, because it's used to derive Consul ACL tokens for other purposes too.