### PR TITLE
cli: non-service jobs on `job restart -reschedule`

### DIFF
--- a/.changelog/19147.txt
+++ b/.changelog/19147.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed the `nomad job restart` command to create replacements for system jobs and prevent batch and sysbatch jobs from being rescheduled
+```

--- a/.changelog/19147.txt
+++ b/.changelog/19147.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-cli: Fixed the `nomad job restart` command to create replacements for system jobs and prevent batch and sysbatch jobs from being rescheduled
+cli: Fixed the `nomad job restart` command to create replacements for batch and system jobs and to prevent sysbatch jobs from being rescheduled since they never create replacements
 ```

--- a/command/job_restart.go
+++ b/command/job_restart.go
@@ -187,7 +187,8 @@ Restart Options:
     in-place. Since the group is not modified the restart does not create a new
     deployment, and so values defined in 'update' blocks, such as
     'max_parallel', are not taken into account. This option cannot be used with
-    '-task'. Only jobs of type 'service' and 'system' can be rescheduled.
+    '-task'. Only jobs of type 'batch', 'service', and 'system' can be
+    rescheduled.
 
   -task=<task-name>
     Specify the task to restart. Can be specified multiple times. If groups are
@@ -289,7 +290,7 @@ func (c *JobRestartCommand) Run(args []string) int {
 	// Verify job type can be rescheduled.
 	if c.reschedule {
 		switch *job.Type {
-		case api.JobTypeService, api.JobTypeSystem:
+		case api.JobTypeBatch, api.JobTypeService, api.JobTypeSystem:
 		default:
 			c.Ui.Error(fmt.Sprintf("Jobs of type %q are not allowed to be rescheduled.", *job.Type))
 			return 1

--- a/website/content/docs/commands/job/restart.mdx
+++ b/website/content/docs/commands/job/restart.mdx
@@ -86,7 +86,8 @@ of the exact job ID.
   restarted in-place. Since the group is not modified the restart does not
   create a new deployment, and so values defined in [`update`][] blocks, such
   as [`max_parallel`][], are not taken into account. This option cannot be used
-  with `-task`. Only jobs of type `service` and `system` can be rescheduled.
+  with `-task`. Only jobs of type `batch`, `service`, and `system` can be
+  rescheduled.
 
 - `-on-error=<ask|fail>`: Determines what action to take when an error happens
   during a restart batch. If `ask` the command stops and waits for user

--- a/website/content/docs/commands/job/restart.mdx
+++ b/website/content/docs/commands/job/restart.mdx
@@ -86,7 +86,7 @@ of the exact job ID.
   restarted in-place. Since the group is not modified the restart does not
   create a new deployment, and so values defined in [`update`][] blocks, such
   as [`max_parallel`][], are not taken into account. This option cannot be used
-  with `-task`.
+  with `-task`. Only jobs of type `service` and `system` can be rescheduled.
 
 - `-on-error=<ask|fail>`: Determines what action to take when an error happens
   during a restart batch. If `ask` the command stops and waits for user


### PR DESCRIPTION
The `-reschedule` flag stops allocations and assumes the Nomad scheduler will create new allocations to replace them. But this is only true for service jobs.

Restarting non-service jobs with the `-reschedule` flag causes the command to loop forever waiting for the allocations to be replaced, which never happens.

Allocations for system jobs may be replaced by triggering an evaluation after each stop to cause the reconciler to run again.

Batch and sysbatch jobs should not be allowed to be rescheduled as they are expected to run to completion unless stopped.

Closes #19043