### PR TITLE
actions: use specific RPC request object and tighten naming.

### DIFF
--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -346,15 +346,15 @@ func (s *HTTPServer) jobActions(resp http.ResponseWriter, req *http.Request, job
 		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
 	}
 
-	args := structs.JobSpecificRequest{
+	args := structs.JobActionListRequest{
 		JobID: jobID,
 	}
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
 		return nil, nil
 	}
 
-	var out structs.ActionListResponse
-	if err := s.agent.RPC("Job.GetActions", &args, &out); err != nil {
+	var out structs.JobActionListResponse
+	if err := s.agent.RPC(structs.JobGetActionsRPCMethod, &args, &out); err != nil {
 		return nil, err
 	}
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1720,11 +1720,12 @@ func (j *Job) LatestDeployment(args *structs.JobSpecificRequest,
 	return j.srv.blockingRPC(&opts)
 }
 
-// jobActions is used to parse through a job's taskgroups' tasks and aggregate their actions, flattened
-func (j *Job) GetActions(args *structs.JobSpecificRequest, reply *structs.ActionListResponse) error {
+// GetActions is used to iterate through a job's taskgroups' tasks and
+// aggregate their actions, flattened.
+func (j *Job) GetActions(args *structs.JobActionListRequest, reply *structs.JobActionListResponse) error {
 	// authenticate, measure, and forward
 	authErr := j.srv.Authenticate(j.ctx, args)
-	if done, err := j.srv.forward("Job.GetActions", args, args, reply); done {
+	if done, err := j.srv.forward(structs.JobGetActionsRPCMethod, args, args, reply); done {
 		return err
 	}
 	j.srv.MeasureRPCRate("job", structs.RateMetricRead, args)

--- a/nomad/structs/actions.go
+++ b/nomad/structs/actions.go
@@ -31,7 +31,25 @@ type JobAction struct {
 	TaskGroupName string
 }
 
-type ActionListResponse struct {
+const (
+	// JobGetActionsRPCMethod is the RPC method for listing all configured
+	// actions within a job.
+	//
+	// Args: JobActionListRequest
+	// Reply: JobActionListResponse
+	JobGetActionsRPCMethod = "Job.GetActions"
+)
+
+// JobActionListRequest is the request object when listing the actions
+// configured within a job.
+type JobActionListRequest struct {
+	JobID string
+	QueryOptions
+}
+
+// JobActionListResponse is the response object when performing a listing of
+// actions configured within a job.
+type JobActionListResponse struct {
 	Actions []*JobAction
 	QueryMeta
 }

--- a/nomad/structs/actions_test.go
+++ b/nomad/structs/actions_test.go
@@ -12,6 +12,13 @@ import (
 	"github.com/shoenig/test/must"
 )
 
+func TestJobActionListRequest(t *testing.T) {
+	ci.Parallel(t)
+
+	req := JobActionListRequest{}
+	must.True(t, req.IsRead())
+}
+
 func TestAction_Copy(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
Custom RPC objects allows us to make future changes without impacting or bloating other RPC endpoints that use the same object. I also made some minor naming update to the response object and made use of a const for the handler name.

I noticed there were not any tests covering the RPC endpoint, so I will raise a followup PR to add some.