### PR TITLE
E2E: Fix vault secrets test

### DIFF
--- a/e2e/e2eutil/allocs.go
+++ b/e2e/e2eutil/allocs.go
@@ -140,7 +140,11 @@ func AllocTaskEventsForJob(jobID, ns string) (map[string][]map[string]string, er
 	for _, alloc := range allocs {
 		results[alloc["ID"]] = make([]map[string]string, 0)
 
-		cmd := []string{"nomad", "alloc", "status", alloc["ID"]}
+		cmd := []string{"nomad", "alloc", "status"}
+		if ns != "" {
+			cmd = append(cmd, "-namespace="+ns)
+		}
+		cmd = append(cmd, alloc["ID"])
 		out, err := Command(cmd[0], cmd[1:]...)
 		if err != nil {
 			return nil, fmt.Errorf("querying alloc status: %w", err)

--- a/e2e/e2eutil/cli.go
+++ b/e2e/e2eutil/cli.go
@@ -55,7 +55,7 @@ func CleanupCommand(t *testing.T, format string, args ...any) {
 	t.Helper()
 	t.Cleanup(func() {
 		t.Helper() // yes, another Helper() because this is another nested func
-		util3.Log3(t, false, "cleanup command: "+format, args)
+		util3.Log3(t, false, "cleanup command: "+format, args...)
 		_, err := Commandf(format, args...)
 		test.NoError(t, err)
 	})

--- a/e2e/e2eutil/cli.go
+++ b/e2e/e2eutil/cli.go
@@ -6,10 +6,15 @@ package e2eutil
 import (
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
+	"testing"
 	"time"
+
+	"github.com/shoenig/test"
+	"github.com/shoenig/test/must"
 )
 
 // Command sends a command line argument to Nomad and returns the unbuffered
@@ -23,6 +28,32 @@ func Command(cmd string, args ...string) (string, error) {
 		return out, fmt.Errorf("command %v %v failed: %v\nOutput: %v", cmd, args, err, out)
 	}
 	return out, err
+}
+
+// Commandf runs a Command but with a Sprintf-style string and args
+func Commandf(format string, args ...any) (string, error) {
+	cmd := fmt.Sprintf(format, args...)
+	parts := strings.Split(cmd, " ")
+	return Command(parts[0], parts[1:]...)
+}
+
+// MustCommand runs a Commandf and must run without error
+func MustCommand(t *testing.T, format string, args ...any) {
+	t.Helper()
+	_, err := Commandf(format, args...)
+	must.NoError(t, err)
+}
+
+// CleanupCommand adds a Commandf to t.Cleanup
+func CleanupCommand(t *testing.T, format string, args ...any) {
+	t.Helper()
+	if os.Getenv("NOMAD_TEST_SKIPCLEANUP") == "1" {
+		return
+	}
+	t.Cleanup(func() {
+		_, err := Commandf(format, args...)
+		test.NoError(t, err)
+	})
 }
 
 // GetField returns the value of an output field (ex. the "Submit Date" field

--- a/e2e/e2eutil/cli.go
+++ b/e2e/e2eutil/cli.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/nomad/e2e/v3/util3"
+
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 )
@@ -40,17 +42,20 @@ func Commandf(format string, args ...any) (string, error) {
 // MustCommand runs a Commandf and must run without error
 func MustCommand(t *testing.T, format string, args ...any) {
 	t.Helper()
+	util3.Log3(t, false, "must command: "+format, args...)
 	_, err := Commandf(format, args...)
 	must.NoError(t, err)
 }
 
 // CleanupCommand adds a Commandf to t.Cleanup
 func CleanupCommand(t *testing.T, format string, args ...any) {
-	t.Helper()
 	if os.Getenv("NOMAD_TEST_SKIPCLEANUP") == "1" {
 		return
 	}
+	t.Helper()
 	t.Cleanup(func() {
+		t.Helper() // yes, another Helper() because this is another nested func
+		util3.Log3(t, false, "cleanup command: "+format, args)
 		_, err := Commandf(format, args...)
 		test.NoError(t, err)
 	})

--- a/e2e/e2eutil/job.go
+++ b/e2e/e2eutil/job.go
@@ -128,49 +128,6 @@ func Dispatch(jobID string, meta map[string]string, payload string) error {
 	return nil
 }
 
-// JobInspectTemplate runs nomad job inspect and formats the output
-// using the specified go template
-func JobInspectTemplate(jobID, template string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "nomad", "job", "inspect", "-t", template, jobID)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("could not inspect job: %w\n%v", err, string(out))
-	}
-	outStr := string(out)
-	outStr = strings.TrimSuffix(outStr, "\n")
-	return outStr, nil
-}
-
-// RegisterFromJobspec registers a jobspec from a string, also with a unique
-// ID. The caller is responsible for recording that ID for later cleanup.
-func RegisterFromJobspec(jobID, jobspec string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "nomad", "job", "run", "-detach", "-")
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return fmt.Errorf("could not open stdin?: %w", err)
-	}
-
-	// replace job label with our unique ID
-	var re = regexp.MustCompile(`job "\w+" \{`)
-	jobspec = re.ReplaceAllString(jobspec,
-		fmt.Sprintf("job \"%s\" {", jobID))
-
-	go func() {
-		defer stdin.Close()
-		io.WriteString(stdin, jobspec)
-	}()
-
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("could not register job: %w\n%v", err, string(out))
-	}
-	return nil
-}
-
 func ChildrenJobSummary(jobID string) ([]map[string]string, error) {
 	out, err := Command("nomad", "job", "status", jobID)
 	if err != nil {

--- a/e2e/e2eutil/job.go
+++ b/e2e/e2eutil/job.go
@@ -154,8 +154,8 @@ func RegisterFromJobspec(jobID, jobspec string) error {
 		return fmt.Errorf("could not open stdin?: %w", err)
 	}
 
-	// hack off the first line to replace with our unique ID
-	var re = regexp.MustCompile(`^job "\w+" \{`)
+	// replace job label with our unique ID
+	var re = regexp.MustCompile(`job "\w+" \{`)
 	jobspec = re.ReplaceAllString(jobspec,
 		fmt.Sprintf("job \"%s\" {", jobID))
 

--- a/e2e/v3/jobs3/allocexec3.go
+++ b/e2e/v3/jobs3/allocexec3.go
@@ -60,11 +60,16 @@ func (sub *Submission) Exec(group, task string, cmd []string) Logs {
 	)
 	sub.logf("alloc exec exit code: %d in: %s", exitCode, allocID)
 
+	sout, serr := stdout.String(), stderr.String()
+
 	must.NoError(sub.t, err, must.Sprintf("failed to exec cmd %q in %s/%s (%s)", cmd, group, task, allocID))
-	must.Zero(sub.t, exitCode, must.Sprintf("expected success exit code executing %s in %s/%s %s", cmd, group, task, allocID))
+	must.Zero(sub.t, exitCode, must.Sprintf(
+		"expected success exit code executing %s in %s/%s %s\nstdout: %s\nstderr: %s\n",
+		cmd, group, task, allocID, sout, serr),
+	)
 
 	return Logs{
-		Stdout: stdout.String(),
-		Stderr: stderr.String(),
+		Stdout: sout,
+		Stderr: serr,
 	}
 }

--- a/e2e/v3/util3/util3.go
+++ b/e2e/v3/util3/util3.go
@@ -19,6 +19,7 @@ func ShortID(prefix string) string {
 //
 // Do not call this directly from tests.
 func Log3(t *testing.T, verbose bool, msg string, args ...any) {
+	t.Helper()
 	env := os.Getenv("NOMAD_E2E_VERBOSE")
 	on := verbose || env == "1" || env == "true"
 	if on {

--- a/e2e/vaultsecrets/doc.go
+++ b/e2e/vaultsecrets/doc.go
@@ -1,0 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package vaultsecrets contains test cases for Vault integration
+package vaultsecrets


### PR DESCRIPTION
Fixes #19113

Only the first commit is strictly necessary, and tiny.  I can drop as much of the other stuff as we'd like, but I went ahead and refactored to the v3 e2e structure, and took advantage of having a `testing.T` in there.

The file rename is a separate commit, so the refactor commit(s) can be reviewed by line change instead of the whole file getting recreated (as will happen when I squash all this).

Added some test helper stuff, and removed a couple of unused funcs.