### PR TITLE
cli: prevent panic on CTRL+C during a question

### DIFF
--- a/.changelog/19154.txt
+++ b/.changelog/19154.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a panic when the `nomad job restart` command received an interrupt signal while waiting for an answer
+```

--- a/command/job_restart.go
+++ b/command/job_restart.go
@@ -275,6 +275,17 @@ func (c *JobRestartCommand) Run(args []string) int {
 		c.client.SetNamespace(*job.Namespace)
 	}
 
+	// Handle SIGINT to prevent accidental cancellations of the long-lived
+	// restart loop. activeCh is blocked while a signal is being handled to
+	// prevent new work from starting while the user is deciding if they want
+	// to cancel the command or not.
+	activeCh := make(chan any)
+	c.sigsCh = make(chan os.Signal, 1)
+	signal.Notify(c.sigsCh, os.Interrupt)
+	defer signal.Stop(c.sigsCh)
+
+	go c.handleSignal(c.sigsCh, activeCh)
+
 	// Confirm that we should restart a multi-region job in a single region.
 	if job.IsMultiregion() && !c.autoYes && !c.shouldRestartMultiregion() {
 		c.Ui.Output("\nJob restart canceled.")
@@ -328,17 +339,6 @@ func (c *JobRestartCommand) Run(args []string) int {
 		formatTime(time.Now()),
 		english.Plural(len(restartAllocs), "allocation", "allocations"),
 	)))
-
-	// Handle SIGINT to prevent accidental cancellations of the long-lived
-	// restart loop. activeCh is blocked while a signal is being handled to
-	// prevent new work from starting while the user is deciding if they want
-	// to cancel the command or not.
-	activeCh := make(chan any)
-	c.sigsCh = make(chan os.Signal, 1)
-	signal.Notify(c.sigsCh, os.Interrupt)
-	defer signal.Stop(c.sigsCh)
-
-	go c.handleSignal(c.sigsCh, activeCh)
 
 	// restartErr accumulates the errors that happen in each batch.
 	var restartErr *multierror.Error


### PR DESCRIPTION
Fix a panic when a question receives an interrupt signal before the signal handler is initialized.