### PR TITLE
cli: skip allocs with replacements on job restart

### DIFF
--- a/.changelog/19155.txt
+++ b/.changelog/19155.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug that caused the `nomad job restart` command to miscount the allocations to restart
+```

--- a/command/job_restart.go
+++ b/command/job_restart.go
@@ -633,6 +633,19 @@ func (c *JobRestartCommand) filterAllocs(stubs []AllocationListStubWithJob) []Al
 			continue
 		}
 
+		// Skip allocations that have already been replaced.
+		if stub.NextAllocation != "" {
+			if c.verbose {
+				c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
+					"[dark_gray]    %s: Skipping allocation %q because it has already been replaced by %q[reset]",
+					formatTime(time.Now()),
+					shortAllocID,
+					limit(stub.NextAllocation, c.length),
+				)))
+			}
+			continue
+		}
+
 		// Skip allocations for groups that were not requested.
 		if c.groups.Size() > 0 {
 			if !c.groups.Contains(stub.TaskGroup) {

--- a/command/job_restart_test.go
+++ b/command/job_restart_test.go
@@ -1245,6 +1245,21 @@ func TestJobRestartCommand_filterAllocs(t *testing.T) {
 					}
 					allocs[key] = alloc
 					allAllocs = append(allAllocs, alloc)
+
+					// Allocations with a replacement must always be skipped.
+					replacedAlloc := AllocationListStubWithJob{
+						AllocationListStub: &api.AllocationListStub{
+							ID:             key,
+							JobVersion:     *job.Version,
+							TaskGroup:      *tg.Name,
+							DesiredStatus:  desired,
+							ClientStatus:   client,
+							NextAllocation: alloc.ID,
+						},
+						Job: job,
+					}
+					allocs[key+"_replaced"] = replacedAlloc
+					allAllocs = append(allAllocs, replacedAlloc)
 				}
 			}
 		}


### PR DESCRIPTION
The `nomad job restart` command should skip allocations that already have replacements. Restarting an allocation with a replacement is a no-op because the allocation status is terminal and the command's replacement monitor returns immediatelly.

But by not skipping them, the effective batch size is computed incorrectly.