### PR TITLE
agent: ignore websocket statuses 1000, 1001 and 1005 correctly

### DIFF
--- a/.changelog/19172.txt
+++ b/.changelog/19172.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Correct websocket status code handling
+```

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -669,6 +670,15 @@ func toWsCode(httpCode int) int {
 func isClosedError(err error) bool {
 	if err == nil {
 		return false
+	}
+
+	// check if the websocket "error" is one of the benign "close" status codes
+	if codedErr, ok := err.(HTTPCodedError); ok {
+		return slices.ContainsFunc([]string{
+			"close 1000", // CLOSE_NORMAL
+			"close 1001", // CLOSE_GOING_AWAY
+			"close 1005", // CLOSED_NO_STATUS
+		}, func(s string) bool { return strings.Contains(codedErr.Error(), s) })
 	}
 
 	return err == io.EOF ||


### PR DESCRIPTION
These are "close" messages and not actual errors. 

Fixes https://github.com/hashicorp/nomad/issues/19164.