### PR TITLE
docs: clarify difference between /client and /node

### DIFF
--- a/website/content/api-docs/client.mdx
+++ b/website/content/api-docs/client.mdx
@@ -2,25 +2,29 @@
 layout: api
 page_title: Client - HTTP API
 description: |-
-  The /client endpoints are used to access client information and inspect
-  allocations running on a particular client.
+  The /client endpoints are used to access client information, read and write
+  dynamic node metadata, and inspect allocations running on a particular
+  client.
 ---
 
 # Client HTTP API
 
-The `/v1/client` endpoints are used to interact with the Nomad clients.
+The `/client` endpoints are used to interact with the Nomad clients.
 
-Since Nomad 0.8.0, both a client and server can handle client endpoints. This is
-particularly useful for when a direct connection to a client is not possible due
-to the network configuration. For high volume access to the client endpoints,
-particularly endpoints streaming file contents, direct access to the node should
-be preferred as it avoids adding additional load to the servers.
+Both clients and servers can handle client endpoints. This is particularly
+useful for when a direct connection to a client is not possible due to the
+network configuration. For high volume access to the client endpoints,
+particularly endpoints streaming file contents, direct access to the node
+should be preferred as it avoids adding additional load to the servers.
 
 When accessing the endpoints via the server, if the desired node is ambiguous
 based on the URL, an additional `?node_id` query parameter must be provided to
 disambiguate.
 
-## Read Node Metadata
+The [`/node`](/nomad/api-docs/nodes) endpoints provide node information that
+are retried from Nomad servers.
+
+## Read Dynamic Node Metadata
 
 This endpoint queries Node metadata on a specific Client agent and responds
 with the following fields:
@@ -97,7 +101,7 @@ Formatted by appending `?pretty` above.
 
 ### Sample Request
 
-## Update Node Metadata
+## Update Dynamic Node Metadata
 
 This endpoint updates dynamic Node metadata on a specific Client agent. Since
 dynamic Node metadata is only periodically synchronized to Nomad Servers, the

--- a/website/content/api-docs/nodes.mdx
+++ b/website/content/api-docs/nodes.mdx
@@ -8,6 +8,10 @@ description: The /node endpoints are used to query for and interact with client 
 
 The `/node` endpoints are used to query for and interact with client nodes.
 
+Requests to these endpoints are always forwarded to and answered by Nomad
+servers. The [`/client`](/nomad/api-docs/client) endpoints provide node
+information that are answered directly by the Nomad client.
+
 ## List Nodes
 
 This endpoint lists all nodes registered with Nomad.


### PR DESCRIPTION
@sofixa reported that was quite hard to find the API endpoints for dynamic node metadata. I think the reason is two-fold:

1. since the feature is called dynamic **node** metadata, and the command is placed under `nomad node meta`, users expect to find the endpoints under `/node`, but it's actually under `/client`.
2. search engines have a really hard time matching the `/client` page with a query such as "nomad dynamic node metadata". From my quick experiment, Google never found the page, Bing had it at the bottom of first page, and DDG had it mid-page.

This PR applies the following changes to try to fix these problems.

Clarify the difference between the `/client` and `/node` endpoints and link from one to the other to help users discover the endpoint they are looking for.

Also update the  `/client` page description and dynamic nod metadata section headers to help the page be more discoverable by search engines.