### PR TITLE
Mark CGroups as off when missing essential controllers

### DIFF
--- a/.changelog/19176.txt
+++ b/.changelog/19176.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cgroupslib: Log an error message when failing to enable CGroup controllers
+```

--- a/.changelog/19176.txt
+++ b/.changelog/19176.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cgroupslib: Log an error message when failing to enable CGroup controllers
+cgroupslib: Consider CGroups OFF when essential controllers are missing
 ```

--- a/client/lib/cgroupslib/init.go
+++ b/client/lib/cgroupslib/init.go
@@ -152,7 +152,7 @@ func Init(log hclog.Logger, cores string) {
 		controllersRootPath := filepath.Join(root, controllersFile)
 		content, err := os.ReadFile(controllersRootPath)
 		if err != nil {
-			log.Info("failed to read cgroups controller file", "path", controllersRootPath, "error", err)
+			log.Error("failed to read cgroups controller file", "path", controllersRootPath, "error", err)
 		} else {
 			rootSubtreeControllers := strings.Split(strings.TrimSpace(string(content)), " ")
 

--- a/client/lib/cgroupslib/init.go
+++ b/client/lib/cgroupslib/init.go
@@ -142,24 +142,17 @@ func Init(log hclog.Logger, cores string) {
 		// the name of the cgroup subtree interface file
 		const subtreeFile = "cgroup.subtree_control"
 
-		// the name of the cgroup controllers interface file
-		const controllersFile = "cgroup.controllers"
-
 		//
 		// configuring root cgroup (/sys/fs/cgroup)
 		//
 
-		controllersRootPath := filepath.Join(root, controllersFile)
-		content, err := os.ReadFile(controllersRootPath)
-		if err != nil {
-			log.Error("failed to read cgroups controller file", "path", controllersRootPath, "error", err)
-		} else {
-			rootSubtreeControllers := strings.Split(strings.TrimSpace(string(content)), " ")
+		subtreeRootPath := filepath.Join(root, subtreeFile)
+		content, _ := os.ReadFile(subtreeRootPath)
+		rootSubtreeControllers := strings.Split(strings.TrimSpace(string(content)), " ")
 
-			for _, controller := range controllers {
-				if !slices.Contains(rootSubtreeControllers, controller) {
-					log.Error("controller not enabled in your system, check kernel build configuration and commandline (/proc/cmdline)", "controller", controller)
-				}
+		for _, controller := range controllers {
+			if !slices.Contains(rootSubtreeControllers, controller) {
+				log.Error("controller not enabled in your system, check kernel build configuration and commandline (/proc/cmdline)", "controller", controller)
 			}
 		}
 

--- a/client/lib/cgroupslib/mount.go
+++ b/client/lib/cgroupslib/mount.go
@@ -9,13 +9,12 @@ import (
 	"bufio"
 	"io"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
-	"path/filepath"
 
 	"github.com/hashicorp/go-set/v2"
 )
-
 
 func detect() Mode {
 	if os.Geteuid() > 0 {

--- a/client/lib/cgroupslib/mount.go
+++ b/client/lib/cgroupslib/mount.go
@@ -10,7 +10,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 
 	"github.com/hashicorp/go-set/v2"
@@ -45,14 +44,9 @@ func functionalCgroups2() bool {
 	if err != nil {
 		return false
 	}
-	rootSubtreeControllers := strings.Split(strings.TrimSpace(string(content)), " ")
 
-	for _, controller := range requiredCgroup2Controllers {
-		if !slices.Contains(rootSubtreeControllers, controller) {
-			return false
-		}
-	}
-	return true
+	rootSubtreeControllers := set.From[string](strings.Fields(string(content)))
+	return rootSubtreeControllers.ContainsSlice(requiredCgroup2Controllers)
 }
 
 func scan(in io.Reader) Mode {


### PR DESCRIPTION
On Linux systems that have been built without all necessary CGroup controllers enabled, you may get a non-descriptive error when initializing `cgroupslib`:

```
[ERROR] client.proclib.cg2: failed to create nomad cgroup: error="write /sys/fs/cgroup/cgroup.subtree_control: invalid argument"
```

A similarly-opaque error is logged on every run of `cpuparts_hook`, but I could not find a simple way of clarifying the error logs.

This PR checks whether all expected controllers are available, and will log an error if they are not.
On top of that, the controllers will be enabled one at a time, giving a more clear error when one of them is not supported.

You can validate this PR by appending `cgroup_disable=cpuset` to your kernel's command line arguments (`/etc/default/grub` or similar)

