### PR TITLE
license: note that BUSL applies to 1.7 "or later"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             HashiCorp, Inc.
-Licensed Work:        Nomad 1.7.0. The Licensed Work is (c) 2023 HashiCorp, Inc.
+Licensed Work:        Nomad 1.7.0 or later. The Licensed Work is (c) 2023 HashiCorp, Inc.
 Additional Use Grant: You may make production use of the Licensed Work, provided
                       Your use does not include offering the Licensed Work to third
                       parties on a hosted or embedded basis in order to compete with 


### PR DESCRIPTION
The BUSL license applies to a specific version of the software. In order to avoid having to change the version with each version we ship (and ambiguity around prerelease versions), our legal folks have determined we can say "or later" for the version and be covered.

After the new year, we'll need to make an equivalent change for the license in the 1.5.x and 1.6.x branches, which will start shipping under BUSL as well.

Ref: https://github.com/hashicorp/nomad/issues/19053