### PR TITLE
vault: update default JWT auth method path

### DIFF
--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -846,7 +846,7 @@ var sample1 = &Config{
 		Enabled:              pointer.Of(true),
 		Role:                 "nomad-cluster",
 		Addr:                 "http://host.example.com:8200",
-		JWTAuthBackendPath:   "jwt",
+		JWTAuthBackendPath:   "jwt-nomad",
 		ConnectionRetryIntv:  30 * time.Second,
 		AllowUnauthenticated: pointer.Of(true),
 	}},
@@ -978,7 +978,7 @@ func TestConfig_MultipleVault(t *testing.T) {
 			must.Nil(t, defaultVault.Enabled) // unset
 			must.Eq(t, "https://vault.service.consul:8200", defaultVault.Addr)
 			must.Eq(t, "", defaultVault.Token)
-			must.Eq(t, "jwt", defaultVault.JWTAuthBackendPath)
+			must.Eq(t, "jwt-nomad", defaultVault.JWTAuthBackendPath)
 
 			// merge in the user's configuration
 			fc, err := LoadConfig("testdata/basic." + suffix)
@@ -1019,7 +1019,7 @@ func TestConfig_MultipleVault(t *testing.T) {
 
 			// check that extra Vault clusters have the defaults applied when not
 			// overridden
-			must.Eq(t, "jwt", cfg.Vaults[2].JWTAuthBackendPath)
+			must.Eq(t, "jwt-nomad", cfg.Vaults[2].JWTAuthBackendPath)
 		})
 	}
 }

--- a/nomad/structs/config/vault.go
+++ b/nomad/structs/config/vault.go
@@ -129,7 +129,7 @@ func DefaultVaultConfig() *VaultConfig {
 	return &VaultConfig{
 		Name:                 "default",
 		Addr:                 "https://vault.service.consul:8200",
-		JWTAuthBackendPath:   "jwt",
+		JWTAuthBackendPath:   "jwt-nomad",
 		ConnectionRetryIntv:  DefaultVaultConnectRetryIntv,
 		AllowUnauthenticated: pointer.Of(true),
 	}

--- a/website/content/docs/configuration/vault.mdx
+++ b/website/content/docs/configuration/vault.mdx
@@ -97,7 +97,7 @@ agents with [`client.enabled`] set to `true`.
   given in the format `protocol://host:port`. If your Vault installation is
   behind a load balancer, this should be the address of the load balancer.
 
-- `jwt_auth_backend_path` - `(string: "jwt")` - Specifies the mount
+- `jwt_auth_backend_path` - `(string: "jwt-nomad")` - Specifies the mount
   [path][vault_auth_enable_path] of the JWT authentication method to be used to
   login with workload identity JWTs.
 


### PR DESCRIPTION
Update default auth method path to be `jwt-nomad` to avoid potential conflicts when Vault's `jwt` default is already being used for something else.