### PR TITLE
client: deprecate loading plugins without config

### DIFF
--- a/.changelog/19189.txt
+++ b/.changelog/19189.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+config: Loading plugins from `plugin_dir` without a `plugin` configuration block is deprecated
+```

--- a/helper/pluginutils/loader/init.go
+++ b/helper/pluginutils/loader/init.go
@@ -266,6 +266,7 @@ func (l *PluginLoader) fingerprintPlugins(plugins []os.FileInfo, configs map[str
 		name := cleanPluginExecutable(p.Name())
 		c, ok := configs[name]
 		if !ok {
+			// COMPAT(1.7): Skip executing unconfigured plugins in 1.8 or later.
 			l.logger.Warn("plugin not referenced in the agent configuration file, future versions of Nomad will not load this plugin until the agent configuration is updated", "plugin", name)
 		}
 		info, err := l.fingerprintPlugin(p, c)

--- a/helper/pluginutils/loader/init.go
+++ b/helper/pluginutils/loader/init.go
@@ -264,7 +264,10 @@ func (l *PluginLoader) fingerprintPlugins(plugins []os.FileInfo, configs map[str
 	fingerprinted := make(map[PluginID]*pluginInfo, len(plugins))
 	for _, p := range plugins {
 		name := cleanPluginExecutable(p.Name())
-		c := configs[name]
+		c, ok := configs[name]
+		if !ok {
+			l.logger.Warn("plugin not referenced in the agent configuration file, future versions of Nomad will not load this plugin until the agent configuration is updated", "plugin", name)
+		}
 		info, err := l.fingerprintPlugin(p, c)
 		if err != nil {
 			l.logger.Error("failed to fingerprint plugin", "plugin", name, "error", err)

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -110,6 +110,13 @@ onto the same client when they are in different namespaces. To prevent this,
 consider using [node pools] and constrain the jobs with a [`distinct_property`][]
 constraint over [`${node.pool}`][node_attributes].
 
+#### Loading Binaries from `plugin_dir` Without Configuration
+
+Starting with Nomad 1.7.0, loading plugins that are not referenced in the agent
+configuration file is deprecated. Future versions of Nomad will only load
+plugins that have a corresponding [`plugin`](/nomad/docs/configuration/plugin)
+block in the agent configuration file.
+
 ## Nomad 1.6.0
 
 #### Enterprise License Validation with BuildDate


### PR DESCRIPTION
Nomad load all plugins from `plugin_dir` regardless if it is listed in the agent configuration file. This can cause unexpected binaries to be executed.

This commit begins the deprecation process of this behaviour. The Nomad agent will emit a warning log for every plugin binary found without a corresponding agent configuration block.

Ref: #18529