### PR TITLE
client: add metadata to tokens requested by Consul client

### DIFF
--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -140,6 +140,9 @@ func (h *consulHook) prepareConsulTokensForTask(task *structs.Task, tg *structs.
 		req[ti.IdentityName] = consul.JWTLoginRequest{
 			JWT:            jwt.JWT,
 			AuthMethodName: consulConfig.TaskIdentityAuthMethod,
+			Meta: map[string]string{
+				"requested_by": fmt.Sprintf("nomad_task_%s", ti.WorkloadIdentifier),
+			},
 		}
 
 		if err := h.getConsulTokens(consulConfig.Name, ti.IdentityName, tokens, req); err != nil {
@@ -185,6 +188,9 @@ func (h *consulHook) prepareConsulTokensForServices(services []*structs.Service,
 		req[identity.IdentityName] = consul.JWTLoginRequest{
 			JWT:            jwt.JWT,
 			AuthMethodName: consulConfig.ServiceIdentityAuthMethod,
+			Meta: map[string]string{
+				"requested_by": fmt.Sprintf("nomad_service_%s", identity.WorkloadIdentifier),
+			},
 		}
 		if err != nil {
 			mErr.Errors = append(mErr.Errors, err)

--- a/client/consul/consul.go
+++ b/client/consul/consul.go
@@ -46,6 +46,7 @@ type SupportedProxiesAPIFunc func(string) SupportedProxiesAPI
 type JWTLoginRequest struct {
 	JWT            string
 	AuthMethodName string
+	Meta           map[string]string
 }
 
 // Client is the interface that the nomad client uses to interact with
@@ -112,6 +113,7 @@ func (c *consulClient) DeriveTokenWithJWT(reqs map[string]JWTLoginRequest) (map[
 		t, _, err := c.client.ACL().Login(&consulapi.ACLLoginParams{
 			AuthMethod:  req.AuthMethodName,
 			BearerToken: req.JWT,
+			Meta:        req.Meta,
 		}, &consulapi.WriteOptions{})
 		if err != nil {
 			mErr = multierror.Append(mErr, fmt.Errorf(


### PR DESCRIPTION
This way tokens created by Nomad workloads are easier to keep track of. 