### PR TITLE
LICENSE: fix version in license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,41 +4,41 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             HashiCorp, Inc.
-Licensed Work:        Nomdad Version 1.6.2 or later. The Licensed Work is (c) 2023
+Licensed Work:        Nomdad Version 1.7.0 or later. The Licensed Work is (c) 2023
                       HashiCorp, Inc.
 Additional Use Grant: You may make production use of the Licensed Work, provided
                       Your use does not include offering the Licensed Work to third
-                      parties on a hosted or embedded basis in order to compete with 
-                      HashiCorp's paid version(s) of the Licensed Work. For purposes 
+                      parties on a hosted or embedded basis in order to compete with
+                      HashiCorp's paid version(s) of the Licensed Work. For purposes
                       of this license:
 
                       A "competitive offering" is a Product that is offered to third
-                      parties on a paid basis, including through paid support 
-                      arrangements, that significantly overlaps with the capabilities 
-                      of HashiCorp's paid version(s) of the Licensed Work. If Your 
-                      Product is not a competitive offering when You first make it 
+                      parties on a paid basis, including through paid support
+                      arrangements, that significantly overlaps with the capabilities
+                      of HashiCorp's paid version(s) of the Licensed Work. If Your
+                      Product is not a competitive offering when You first make it
                       generally available, it will not become a competitive offering
-                      later due to HashiCorp releasing a new version of the Licensed 
-                      Work with additional capabilities. In addition, Products that 
+                      later due to HashiCorp releasing a new version of the Licensed
+                      Work with additional capabilities. In addition, Products that
                       are not provided on a paid basis are not competitive.
 
-                      "Product" means software that is offered to end users to manage 
-                      in their own environments or offered as a service on a hosted 
+                      "Product" means software that is offered to end users to manage
+                      in their own environments or offered as a service on a hosted
                       basis.
 
-                      "Embedded" means including the source code or executable code 
-                      from the Licensed Work in a competitive offering. "Embedded" 
-                      also means packaging the competitive offering in such a way 
-                      that the Licensed Work must be accessed or downloaded for the 
+                      "Embedded" means including the source code or executable code
+                      from the Licensed Work in a competitive offering. "Embedded"
+                      also means packaging the competitive offering in such a way
+                      that the Licensed Work must be accessed or downloaded for the
                       competitive offering to operate.
 
-                      Hosting or using the Licensed Work(s) for internal purposes 
-                      within an organization is not considered a competitive 
-                      offering. HashiCorp considers your organization to include all 
+                      Hosting or using the Licensed Work(s) for internal purposes
+                      within an organization is not considered a competitive
+                      offering. HashiCorp considers your organization to include all
                       of your affiliates under common control.
 
-                      For binding interpretive guidance on using HashiCorp products 
-                      under the Business Source License, please visit our FAQ. 
+                      For binding interpretive guidance on using HashiCorp products
+                      under the Business Source License, please visit our FAQ.
                       (https://www.hashicorp.com/license-faq)
 Change Date:          Four years from the date the Licensed Work is published.
 Change License:       MPL 2.0


### PR DESCRIPTION
In #19194 the license was incorrectly changed to say that Nomad 1.6.2 or later was under the BUSL, when in fact Nomad 1.6.2 and 1.6.3 are MPL2 licensed. Fix this so that the correct (next!) version is shown as covered only.