### PR TITLE
Clarify docs around CSI volume context updates

### DIFF
--- a/website/content/docs/other-specifications/volume/index.mdx
+++ b/website/content/docs/other-specifications/volume/index.mdx
@@ -144,8 +144,9 @@ parameters {
   of strings passed directly to the CSI plugin to validate the volume. The
   details of these parameters are specific to each storage provider, so consult
   the specific plugin documentation for more information. Only allowed on
-  **volume registration**. Note that this block is declarative, and an update 
-  replaces it in its entirety, thefore all paramters need to be specified.
+  **volume registration**. Note that, like the rest of the volume specification, 
+  this block is declarative, and an update replaces it in its entirety, therefore 
+  all parameters need to be specified.
 
 ## Differences Between Create and Register
 

--- a/website/content/docs/other-specifications/volume/index.mdx
+++ b/website/content/docs/other-specifications/volume/index.mdx
@@ -144,7 +144,8 @@ parameters {
   of strings passed directly to the CSI plugin to validate the volume. The
   details of these parameters are specific to each storage provider, so consult
   the specific plugin documentation for more information. Only allowed on
-  **volume registration**.
+  **volume registration**. Note that this block is declarative, and an update 
+  replaces it in its entirety, thefore all paramters need to be specified.
 
 ## Differences Between Create and Register
 


### PR DESCRIPTION
Clarify that when updating a CSI volume's `context` via `nomad volume register`, all parameters need to be specified, not only those to be updated.