### PR TITLE
e2e: give node drain KillTimeout test more time

### DIFF
--- a/e2e/nodedrain/node_drain_test.go
+++ b/e2e/nodedrain/node_drain_test.go
@@ -231,12 +231,18 @@ func testKillTimeout(t *testing.T) {
 	must.Len(t, 1, newAllocs, must.Sprint("expected 1 new alloc"))
 
 	must.Wait(t, wait.InitialSuccess(
-		wait.BoolFunc(func() bool {
+		wait.ErrorFunc(func() error {
 			node, _, err := nomadClient.Nodes().Info(oldNodeID, nil)
-			must.NoError(t, err)
-			return node.DrainStrategy == nil
+			if err != nil {
+				return err
+			}
+			if node.DrainStrategy != nil {
+				return fmt.Errorf("node '%s' DrainStrategy should be nil, got: %+v",
+					oldNodeID, node.DrainStrategy)
+			}
+			return nil
 		}),
-		wait.Timeout(time.Second*5),
+		wait.Timeout(time.Second*10),
 		wait.Gap(500*time.Millisecond),
 	))
 }

--- a/e2e/v3/jobs3/jobs3.go
+++ b/e2e/v3/jobs3/jobs3.go
@@ -300,9 +300,10 @@ EVAL:
 			deploymentID = eval.DeploymentID
 			break EVAL
 		case nomadapi.EvalStatusFailed:
-			must.Unreachable(sub.t, must.Sprint("eval failed"))
+			must.Unreachable(sub.t, must.Sprintf("eval failed: %s, triggered by: %s, failed allocs: %d",
+				eval.StatusDescription, eval.TriggeredBy, len(eval.FailedTGAllocs)))
 		case nomadapi.EvalStatusCancelled:
-			must.Unreachable(sub.t, must.Sprint("eval cancelled"))
+			must.Unreachable(sub.t, must.Sprintf("eval canceled: %s", eval.StatusDescription))
 		default:
 			time.Sleep(1 * time.Second)
 		}


### PR DESCRIPTION
and error more verbosely if it fails

attempting to either resolve or illuminate #19111 (it's flaky, and I'm not able to reproduce)