### PR TITLE
test: add consul namespace rules to consulcompat

### DIFF
--- a/e2e/consulcompat/run_ce_test.go
+++ b/e2e/consulcompat/run_ce_test.go
@@ -105,7 +105,7 @@ func testConsulBuild(t *testing.T, b build, baseDir string) {
 		nc := startNomad(t, consulCfg)
 
 		// configure authentication for WI to Consul
-		setupConsulJWTAuth(t, consulAPI, nc.Address())
+		setupConsulJWTAuth(t, consulAPI, nc.Address(), nil)
 
 		verifyConsulFingerprint(t, nc, b.Version, "default")
 		runConnectJob(t, nc, "default", "./input/connect.nomad.hcl")

--- a/e2e/consulcompat/shared_run_test.go
+++ b/e2e/consulcompat/shared_run_test.go
@@ -111,7 +111,7 @@ func setupConsulACLsForTasks(t *testing.T, consulAPI *consulapi.Client, roleName
 	must.NoError(t, err, must.Sprint("could not create token in Consul"))
 }
 
-func setupConsulJWTAuth(t *testing.T, consulAPI *consulapi.Client, address string) {
+func setupConsulJWTAuth(t *testing.T, consulAPI *consulapi.Client, address string, namespaceRules []*consulapi.ACLAuthMethodNamespaceRule) {
 
 	authConfig := map[string]any{
 		"JWKSURL":          fmt.Sprintf("%s/.well-known/jwks.json", address),
@@ -126,13 +126,14 @@ func setupConsulJWTAuth(t *testing.T, consulAPI *consulapi.Client, address strin
 	}
 
 	_, _, err := consulAPI.ACL().AuthMethodCreate(&consulapi.ACLAuthMethod{
-		Name:          "nomad-workloads",
-		Type:          "jwt",
-		DisplayName:   "nomad-workloads",
-		Description:   "login method for Nomad tasks with workload identity (WI)",
-		MaxTokenTTL:   time.Hour,
-		TokenLocality: "local",
-		Config:        authConfig,
+		Name:           "nomad-workloads",
+		Type:           "jwt",
+		DisplayName:    "nomad-workloads",
+		Description:    "login method for Nomad tasks with workload identity (WI)",
+		MaxTokenTTL:    time.Hour,
+		TokenLocality:  "local",
+		Config:         authConfig,
+		NamespaceRules: namespaceRules,
 	}, nil)
 	must.NoError(t, err, must.Sprint("could not create Consul auth method for Nomad workloads"))
 


### PR DESCRIPTION
When configuring Consul for multi-namespace support, the JWT auth method needs to specify namespace rules. This attribute is set to `nil` in CE but is used in Nomad ENT.