### PR TITLE
identity: add Consul and Vault namespace claims

### DIFF
--- a/nomad/structs/workload_id.go
+++ b/nomad/structs/workload_id.go
@@ -91,6 +91,19 @@ type WorkloadIdentity struct {
 	TTL time.Duration
 }
 
+// IsConsul returns true if the identity name starts with the standard prefix
+// for Consul tasks and services.
+func (wi *WorkloadIdentity) IsConsul() bool {
+	return strings.HasPrefix(wi.Name, ConsulTaskIdentityNamePrefix) ||
+		strings.HasPrefix(wi.Name, ConsulServiceIdentityNamePrefix)
+}
+
+// IsVault returns true if the identity name starts with the standard prefix
+// for Vault tasks.
+func (wi *WorkloadIdentity) IsVault() bool {
+	return strings.HasPrefix(wi.Name, WorkloadIdentityVaultPrefix)
+}
+
 func (wi *WorkloadIdentity) Copy() *WorkloadIdentity {
 	if wi == nil {
 		return nil


### PR DESCRIPTION
Token claims are used in several dynamic configuration in Consul and Vault, such as Consul ACL bind and namespace rules, and Vault templated policies.

Adding a claim for the Consul and Vault namespace defined for the service or task allows cluster operators to create more flexible and precise rules.

The `consul_namespace` claim is added to workload identities for Consul services and to task workload identities that have the `consul_` name prefix and are affected by a task or group `consul` block.

The `vault_namespace` claim is added to task workload identities that have the `vault_` name prefix and are affected by a `vault` block.