### PR TITLE
consul: respect task-level namespace when checking permissions

### DIFF
--- a/nomad/structs/consul.go
+++ b/nomad/structs/consul.go
@@ -138,13 +138,24 @@ func (j *Job) ConsulUsages() map[string]*ConsulUsage {
 
 		// Gather task services and KV usage
 		for _, task := range tg.Tasks {
+			taskNamespace := namespace
+			if task.Consul != nil && task.Consul.Namespace != "" {
+				taskNamespace = task.Consul.Namespace
+			}
+
 			for _, service := range task.Services {
 				if service.IsConsul() {
-					m[namespace].Services = append(m[namespace].Services, service.Name)
+					if _, exists := m[taskNamespace]; !exists {
+						m[taskNamespace] = new(ConsulUsage)
+					}
+					m[taskNamespace].Services = append(m[taskNamespace].Services, service.Name)
 				}
 			}
 			if len(task.Templates) > 0 {
-				m[namespace].KV = true
+				if _, exists := m[taskNamespace]; !exists {
+					m[taskNamespace] = new(ConsulUsage)
+				}
+				m[taskNamespace].KV = true
 			}
 		}
 	}


### PR DESCRIPTION
In the legacy Consul token workflow, we check the user's token's permissions in Consul at the time of job submit. The new task-level `consul` block was not being respected when checking the list of namespaces.

---

This can only really be test in ENT. The following test (ref https://github.com/hashicorp/nomad-enterprise/pull/1329) passes:

```go

func TestConsul_Usages(t *testing.T) {
	ci.Parallel(t)

	job := &Job{
		ConsulNamespace: "default",
		TaskGroups: []*TaskGroup{
			{
				Consul: &Consul{Namespace: "nondefault1"},
				Services: []*Service{
					{Name: "service1"},
					{Name: "nomad1", Provider: "nomad"},
				},
				Tasks: []*Task{
					{
						Consul: &Consul{Namespace: "nondefault2"},
						Services: []*Service{
							{Name: "service2"},
							{Name: "nomad2", Provider: "nomad"},
						},
					},
					{
						Services: []*Service{
							{Name: "service3"},
							{Name: "nomad3", Provider: "nomad"},
						},
					},
				},
			},
			{
				Services: []*Service{
					{Name: "service4"},
					{Name: "nomad4", Provider: "nomad"},
				},
				Tasks: []*Task{
					{
						Services: []*Service{
							{Name: "service5"},
							{Name: "nomad5", Provider: "nomad"},
						},
						Templates: []*Template{{}},
					},
				},
			},
		},
	}

	usages := job.ConsulUsages()
	must.Eq(t,
		map[string]*ConsulUsage{
			"default": {
				Services: []string{"service4", "service5"},
				KV:       true,
			},
			"nondefault1": {
				Services: []string{"service1", "service3"},
				KV:       false,
			},
			"nondefault2": {
				Services: []string{"service2"},
				KV:       false,
			},
		},
		usages)

}
```