### PR TITLE
cli: setup consul proper ns handling

### DIFF
--- a/command/asset/consul-wi-default-auth-method-config.json
+++ b/command/asset/consul-wi-default-auth-method-config.json
@@ -3,6 +3,7 @@
   "JWTSupportedAlgs": ["ES256"],
   "BoundAudiences": ["consul.io"],
   "ClaimMappings": {
+	"consul_namespace": "consul_namespace",
     "nomad_namespace": "nomad_namespace",
     "nomad_job_id": "nomad_job_id",
     "nomad_task": "nomad_task",

--- a/command/asset/consul-wi-default-auth-method-config.json
+++ b/command/asset/consul-wi-default-auth-method-config.json
@@ -1,9 +1,13 @@
 {
   "JWKSURL": "http://localhost:4646/.well-known/jwks.json",
-  "JWTSupportedAlgs": ["ES256"],
-  "BoundAudiences": ["consul.io"],
+  "JWTSupportedAlgs": [
+    "ES256"
+  ],
+  "BoundAudiences": [
+    "consul.io"
+  ],
   "ClaimMappings": {
-	"consul_namespace": "consul_namespace",
+    "consul_namespace": "consul_namespace",
     "nomad_namespace": "nomad_namespace",
     "nomad_job_id": "nomad_job_id",
     "nomad_task": "nomad_task",

--- a/command/setup_consul.go
+++ b/command/setup_consul.go
@@ -623,7 +623,11 @@ func (s *SetupConsulCommand) removeConfiguredComponents() int {
 		componentsToRemove["Auth method"] = []string{consulAuthMethodName}
 	}
 
-	authMethodRules, _, err := s.client.ACL().BindingRuleList(consulAuthMethodName, nil)
+	qo := &api.QueryOptions{}
+	if s.consulEnt {
+		qo.Namespace = "default"
+	}
+	authMethodRules, _, err := s.client.ACL().BindingRuleList(consulAuthMethodName, qo)
 	if err != nil {
 		s.Ui.Error(fmt.Sprintf("[✘] Failed to fetch binding rules for method: %q", consulAuthMethodName))
 		exitCode = 1
@@ -704,7 +708,11 @@ func (s *SetupConsulCommand) removeConfiguredComponents() int {
 		}
 
 		for _, b := range authMethodRules {
-			_, err := s.client.ACL().BindingRuleDelete(b.ID, nil)
+			wo := &api.WriteOptions{}
+			if s.consulEnt {
+				wo.Namespace = "default"
+			}
+			_, err := s.client.ACL().BindingRuleDelete(b.ID, wo)
 			if err != nil {
 				s.Ui.Error(fmt.Sprintf("[✘] Failed to delete binding rule %q: %v", b.ID, err.Error()))
 				exitCode = 1
@@ -714,7 +722,11 @@ func (s *SetupConsulCommand) removeConfiguredComponents() int {
 		}
 
 		for _, authMethod := range componentsToRemove["Auth method"] {
-			_, err := s.client.ACL().AuthMethodDelete(authMethod, nil)
+			wo := &api.WriteOptions{}
+			if s.consulEnt {
+				wo.Namespace = "default"
+			}
+			_, err := s.client.ACL().AuthMethodDelete(authMethod, wo)
 			if err != nil {
 				s.Ui.Error(fmt.Sprintf("[✘] Failed to delete auth method %q: %v", authMethod, err.Error()))
 				exitCode = 1

--- a/command/setup_consul.go
+++ b/command/setup_consul.go
@@ -441,7 +441,7 @@ func (s *SetupConsulCommand) renderAuthMethod(name string, desc string) (*api.AC
 	if s.consulEnt {
 		method.NamespaceRules = []*api.ACLAuthMethodNamespaceRule{{
 			Selector:      "",
-			BindNamespace: "${value.nomad_namespace}",
+			BindNamespace: s.clientCfg.Namespace,
 		}}
 	}
 

--- a/command/setup_consul.go
+++ b/command/setup_consul.go
@@ -441,7 +441,7 @@ func (s *SetupConsulCommand) renderAuthMethod(name string, desc string) (*api.AC
 	if s.consulEnt {
 		method.NamespaceRules = []*api.ACLAuthMethodNamespaceRule{{
 			Selector:      "",
-			BindNamespace: s.clientCfg.Namespace,
+			BindNamespace: "${value.consul_namespace}",
 		}}
 	}
 


### PR DESCRIPTION
In order to correctly handle Consul namespaces, auth methods and binding rules must always be created in the `default` namespace only. 