### PR TITLE
website: fix spellcheck path and cleanup some misspellings

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -165,7 +165,7 @@ check: ## Lint the source code
 	@hclogvet .
 
 	@echo "==> Spell checking website..."
-	@misspell -error -source=text website/pages/
+	@misspell -error -source=text website/content/
 
 	@echo "==> Checking for breaking changes in protos..."
 	@buf breaking --config tools/buf/buf.yaml --against-config tools/buf/buf.yaml --against .git#tag=$(PROTO_COMPARE_TAG)

--- a/website/content/api-docs/client.mdx
+++ b/website/content/api-docs/client.mdx
@@ -61,7 +61,7 @@ The table below shows this endpoint's support for
 
 - `:node_id` `(string: <optional>)` - Specifies the node to query.
   This is required when the endpoint is being accessed via a server. Defaults
-  to the node recieving the request otherwise. This is specified as part of
+  to the node receiving the request otherwise. This is specified as part of
   the URL.  Note, this must be the _full_ node ID, not the short 8-character
   one. This must be specified as part of the path (`?node_id=...`).
 
@@ -127,7 +127,7 @@ The table below shows this endpoint's support for
 
 - `NodeID` or `:node_id` `(string: <optional>)` - Specifies the node to query.
   This is required when the endpoint is being accessed via a server. Defaults
-  to the node recieving the request otherwise. This is specified as part of
+  to the node receiving the request otherwise. This is specified as part of
   the URL.  Note, this must be the _full_ node ID, not the short 8-character
   one. This may be specified as part of the path (`?node_id=...`) or request
   (`NodeID: "..."`).

--- a/website/content/docs/commands/acl/bootstrap.mdx
+++ b/website/content/docs/commands/acl/bootstrap.mdx
@@ -19,7 +19,7 @@ The `acl bootstrap` command can be used in two ways:
 - If you provide no arguments it will return a system generated bootstrap token.
 - If you would like to provide an operator generated token it is possible to provide the token
 using a file `acl bootstrap [path]`. The Token can be read from stdin by setting the path to "-". 
-Please make sure you secure this token in an apropriate manner as it could be written to your terminal history.
+Please make sure you secure this token in an appropriate manner as it could be written to your terminal history.
 
 ## General Options
 

--- a/website/content/docs/commands/eval/delete.mdx
+++ b/website/content/docs/commands/eval/delete.mdx
@@ -49,7 +49,7 @@ Delete an evaluation using its ID:
 
 ```shell-session
 $ nomad eval delete 9ecffbba-73be-d909-5d7e-ac2694c10e0c
-Successfuly deleted 1 evaluation
+Successfully deleted 1 evaluation
 ```
 
 Delete all evaluations with status `pending` for the `example` job:
@@ -58,7 +58,7 @@ Delete all evaluations with status `pending` for the `example` job:
 $ nomad eval delete -filter='Status == "pending" and JobID == "example"'
 Are you sure you want to delete 3 evals? [y/N] y
 
-Successfuly deleted 3 evaluations
+Successfully deleted 3 evaluations
 ```
 
 Delete all evaluations for the `system` and `service` whilst skipping all
@@ -66,7 +66,7 @@ prompts:
 
 ```shell-session
 $ nomad eval delete -filter='Scheduler == "system" or Scheduler == "service"' -yes
-Successfuly deleted 23 evaluations
+Successfully deleted 23 evaluations
 ```
 
 [scheduler_get_config]: /nomad/docs/commands/operator/scheduler/get-config

--- a/website/content/docs/job-specification/artifact.mdx
+++ b/website/content/docs/job-specification/artifact.mdx
@@ -247,7 +247,7 @@ artifact {
 ## Environment
 
 The `artifact` downloader by default does not have access to the environment variables
-set for the Nomad client. Inheritence of environment variables can be managed through the [`artifact.set_environment_variables`][client_artifact]
+set for the Nomad client. Inheritance of environment variables can be managed through the [`artifact.set_environment_variables`][client_artifact]
 client configuration.
 
 [client_artifact]: /nomad/docs/configuration/client#artifact-parameters

--- a/website/content/docs/job-specification/network.mdx
+++ b/website/content/docs/job-specification/network.mdx
@@ -232,7 +232,7 @@ $ sudo firewall-cmd --zone=trusted --add-interface=nomad
 $ sudo firewall-cmd --zone=trusted --add-interface=nomad --permanent
 ```
 
-It is neccessary to restart the affected jobs afterwards for them to be able to access
+It is necessary to restart the affected jobs afterwards for them to be able to access
 the network. Further details can be found in Docker's documentation under [Docker and iptables](https://docs.docker.com/network/iptables/#integration-with-firewalld).
 
 ### DNS

--- a/website/content/docs/operations/nomad-agent.mdx
+++ b/website/content/docs/operations/nomad-agent.mdx
@@ -84,7 +84,7 @@ There are several important messages that `nomad agent` outputs:
 
 By default, any stop signal to an agent (interrupt or terminate) will cause the
 agent to exit after ensuring its internal state is committed to disk as
-needed. You can configuration additonal behaviors by setting shutdown
+needed. You can configuration additional behaviors by setting shutdown
 [`leave_on_interrupt`][] or [`leave_on_terminate`][] to respond to the
 respective signals.
 

--- a/website/content/plugins/drivers/community/lightrun.mdx
+++ b/website/content/plugins/drivers/community/lightrun.mdx
@@ -56,7 +56,7 @@ task "run-with-lightrun" {
 The `lightrun-java` driver accepts all configuration options of the Nomad
 [`java`] driver.
 
-Additionaly, the `lightrun-java` driver requires the following configuration in
+Additionally, the `lightrun-java` driver requires the following configuration in
 the job spec. To find these configurations, log into the
 [Lightrun Management Portal][lightrun_portal] and refer to the **Download the
 Agent** section:

--- a/website/content/plugins/drivers/remote/ecs.mdx
+++ b/website/content/plugins/drivers/remote/ecs.mdx
@@ -81,7 +81,7 @@ job "nomad-ecs-demo" {
 
     task "http-server" {
       driver       = "ecs"
-      kill_timeout = "1m" // increased from default to accomodate ECS.
+      kill_timeout = "1m" // increased from default to accommodate ECS.
 
       config {
         task {

--- a/website/content/tools/autoscaling/agent/dynamic_application_sizing.mdx
+++ b/website/content/tools/autoscaling/agent/dynamic_application_sizing.mdx
@@ -15,7 +15,7 @@ description: >-
   present in the open source version of Nomad Autoscaler.
 </EnterpriseAlert>
 
-~> Note that currently Prometheus is the only APM availible for Dynamic Application Sizing
+~> Note that currently Prometheus is the only APM available for Dynamic Application Sizing
 
 The `dynamic_application_sizing` blocks configures the Nomad Autoscaler agent
 options for Dynamic Application Sizing. Learn more about the Dynamic

--- a/website/content/tools/autoscaling/plugins/target/app-sizing-nomad.mdx
+++ b/website/content/tools/autoscaling/plugins/target/app-sizing-nomad.mdx
@@ -11,7 +11,7 @@ description: The "app-sizing-nomad" target plugin scales a task resource.
   present in the open source version of Nomad Autoscaler.
 </EnterpriseAlert>
 
-~> Note that currently Prometheus is the only APM availible for Dynamic Application Sizing
+~> Note that currently Prometheus is the only APM available for Dynamic Application Sizing
 
 The `app-sizing-nomad` target plugin reports on the current task resource value
 as well as submits recommendations to Nomad via the [recommendations API endpoint][nomad_recommendations_api]


### PR DESCRIPTION
We moved the website content directory a while back and never updated the spell checking thing used by `make check`; fix the path and fixup old spelling mistakes.