### PR TITLE
service hook: get correct NS for task-level `consul`

### DIFF
--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -53,7 +53,7 @@ func (a *Allocation) ServiceProviderNamespace() string {
 			case ServiceProviderNomad:
 				return a.Job.Namespace
 			default:
-				return tg.Consul.GetNamespace()
+				return a.ConsulNamespaceForTask(task.Name)
 			}
 		}
 	}


### PR DESCRIPTION
Ensure that the `ServiceProviderNamespace` correctly picks the task-level `consul.namespace` and falls back to the group if set.

---

I've also verified that the ENT test that covers the consumer of this are working:

```
$ go test -v -count=1 ./client/allocrunner/taskrunner -run Test_serviceHook_Namespaces
=== RUN   Test_serviceHook_Namespaces
--- PASS: Test_serviceHook_Namespaces (0.00s)
PASS
ok      github.com/hashicorp/nomad/client/allocrunner/taskrunner        0.027s
```