### PR TITLE
[ui] job/$job/services page: consider tags when looking up services

### DIFF
--- a/.changelog/19245.txt
+++ b/.changelog/19245.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-ui: disambiguate same-named services with distinct tag arrays
+ui: disambiguate services with the same name but different tags
 ```

--- a/.changelog/19245.txt
+++ b/.changelog/19245.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: disambiguate same-named services with distinct tag arrays
+```

--- a/ui/app/components/job-service-row.js
+++ b/ui/app/components/job-service-row.js
@@ -15,7 +15,7 @@ export default class JobServiceRowComponent extends Component {
   gotoService(service) {
     if (service.provider === 'nomad') {
       this.router.transitionTo('jobs.job.services.service', service.name, {
-        queryParams: { level: service.level },
+        queryParams: { level: service.level, tags: service.tags },
         instances: service.instances,
       });
     }

--- a/ui/app/controllers/jobs/job/services/index.js
+++ b/ui/app/controllers/jobs/job/services/index.js
@@ -75,8 +75,8 @@ export default class JobsJobServicesIndexController extends Controller.extend(
         (s) =>
           s.name === fragment.name &&
           s.derivedLevel === fragment.level &&
-          s.tags.length === fragment.tags.length &&
-          s.tags.every((tag) => fragment.tags.includes(tag))
+          s.tags?.length === fragment.tags?.length &&
+          s.tags?.every((tag) => fragment.tags?.includes(tag))
       );
       return fragment;
     });

--- a/ui/app/controllers/jobs/job/services/index.js
+++ b/ui/app/controllers/jobs/job/services/index.js
@@ -72,7 +72,11 @@ export default class JobsJobServicesIndexController extends Controller.extend(
   get services() {
     return this.serviceFragments.map((fragment) => {
       fragment.instances = this.job.services.filter(
-        (s) => s.name === fragment.name && s.derivedLevel === fragment.level
+        (s) =>
+          s.name === fragment.name &&
+          s.derivedLevel === fragment.level &&
+          s.tags.length === fragment.tags.length &&
+          s.tags.every((tag) => fragment.tags.includes(tag))
       );
       return fragment;
     });

--- a/ui/app/controllers/jobs/job/services/service.js
+++ b/ui/app/controllers/jobs/job/services/service.js
@@ -9,7 +9,7 @@ import { inject as service } from '@ember/service';
 
 export default class JobsJobServicesServiceController extends Controller {
   @service router;
-  queryParams = ['level'];
+  queryParams = ['level', 'tags'];
 
   @action
   gotoAllocation(allocation) {

--- a/ui/app/routes/jobs/job/services/service.js
+++ b/ui/app/routes/jobs/job/services/service.js
@@ -16,7 +16,7 @@ export default class JobsJobServicesServiceRoute extends Route {
           service.derivedLevel === level &&
           // Tags are an array, but queryparam is a string of values separated by commas.
           (tags
-            ? tags.split(',').every((tag) => service.tags.includes(tag))
+            ? tags.split(',').every((tag) => service.tags?.includes(tag))
             : true)
       );
     return { name, instances: services || [] };

--- a/ui/app/routes/jobs/job/services/service.js
+++ b/ui/app/routes/jobs/job/services/service.js
@@ -6,11 +6,18 @@
 import Route from '@ember/routing/route';
 
 export default class JobsJobServicesServiceRoute extends Route {
-  model({ name = '', level = '' }) {
+  model(params) {
+    let { name = '', level = '', tags = '' } = params;
     const services = this.modelFor('jobs.job')
       .get('services')
       .filter(
-        (service) => service.name === name && service.derivedLevel === level
+        (service) =>
+          service.name === name &&
+          service.derivedLevel === level &&
+          // Tags are an array, but queryparam is a string of values separated by commas.
+          (tags
+            ? tags.split(',').every((tag) => service.tags.includes(tag))
+            : true)
       );
     return { name, instances: services || [] };
   }

--- a/ui/app/templates/components/job-service-row.hbs
+++ b/ui/app/templates/components/job-service-row.hbs
@@ -20,7 +20,7 @@
   >
     {{#if (eq @service.provider "nomad")}}
       <FlightIcon @name="nomad-color" />
-      <LinkTo class="is-primary" @route="jobs.job.services.service" @model={{@service}} @query={{hash level=@service.level}}>{{@service.name}}</LinkTo>
+      <LinkTo class="is-primary" @route="jobs.job.services.service" @model={{@service}} @query={{hash level=@service.level tags=@service.tags canary_tags=@service.canary_tags}}>{{@service.name}}</LinkTo>
     {{else}}
       <FlightIcon @name="consul-color" />
       {{#if (and (eq @service.provider "consul") this.consulRedirectLink)}}

--- a/ui/app/templates/jobs/job/services/service.hbs
+++ b/ui/app/templates/jobs/job/services/service.hbs
@@ -16,6 +16,7 @@
       <th>Allocation</th>
       <th>Client</th>
       <th>IP Address &amp; Port</th>
+      <th>Tags</th>
     </t.head>
     <t.body as |row|>
       <tr data-test-service-row>
@@ -32,7 +33,7 @@
             >{{allocation.shortId}}</LinkTo>
           </td>
         {{/let}}
-		{{#let (async-escape-hatch row.model "node") as |node|}}
+        {{#let (async-escape-hatch row.model "node") as |node|}}
           <td>
             <Tooltip @text={{node.name}}>
               <LinkTo
@@ -44,6 +45,14 @@
         {{/let}}
         <td>
           {{row.model.address}}:{{row.model.port}}
+        </td>
+        <td>
+          {{#each row.model.tags as |tag|}}
+            <span class="tag is-service">{{tag}}</span>
+          {{/each}}
+          {{#each row.model.canary_tags as |tag|}}
+            <span class="tag canary is-service">{{tag}}</span>
+          {{/each}}
         </td>
       </tr>
     </t.body>

--- a/ui/mirage/factories/task-group.js
+++ b/ui/mirage/factories/task-group.js
@@ -219,14 +219,17 @@ export default Factory.extend({
         server.create('service', {
           serviceName: fragment.name,
           id: `${faker.internet.domainWord()}-group-${fragment.name}`,
+          tags: fragment.tags || [],
         });
         server.create('service', {
           serviceName: fragment.name,
           id: `${faker.internet.domainWord()}-group-${fragment.name}`,
+          tags: fragment.tags || [],
         });
         server.create('service', {
           serviceName: fragment.name,
           id: `${faker.internet.domainWord()}-group-${fragment.name}`,
+          tags: fragment.tags || [],
         });
       });
 

--- a/ui/mirage/factories/task.js
+++ b/ui/mirage/factories/task.js
@@ -114,7 +114,8 @@ export default Factory.extend({
           ],
         },
       ];
-      task?.update({ actions: actionsData });
+      console.log('about to update task', task.id, task.update.toString());
+      task.update({ actions: actionsData });
     }
   },
 });

--- a/ui/mirage/factories/task.js
+++ b/ui/mirage/factories/task.js
@@ -114,7 +114,7 @@ export default Factory.extend({
           ],
         },
       ];
-      task.update({ actions: actionsData });
+      task?.update({ actions: actionsData });
     }
   },
 });

--- a/ui/mirage/factories/task.js
+++ b/ui/mirage/factories/task.js
@@ -114,7 +114,6 @@ export default Factory.extend({
           ],
         },
       ];
-      console.log('about to update task', task.id, task.update.toString());
       task.update({ actions: actionsData });
     }
   },

--- a/ui/mirage/factories/task.js
+++ b/ui/mirage/factories/task.js
@@ -96,6 +96,7 @@ export default Factory.extend({
       services.forEach((fragment) => {
         server.createList('service', 5, {
           serviceName: fragment.name,
+          tags: fragment.tags || [],
         });
       });
       task.update({ services });

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -134,7 +134,7 @@ function smallCluster(server) {
   server.schema.allocations
     .all()
     .filter((x) => x.taskGroup === actionsGroup.name)
-    .models[0].taskStates.models[0].update({
+    .models[0].taskStates.models[0]?.update({
       state: 'running',
     });
 

--- a/ui/tests/acceptance/actions-test.js
+++ b/ui/tests/acceptance/actions-test.js
@@ -324,9 +324,20 @@ module('Acceptance | actions', function (hooks) {
     await Actions.flyout.close();
 
     // head back into the job, and into a task
+    console.log(
+      'dealing w this particular allocation and',
+      server.schema.allocations
+        .all()
+        .models.filter((a) => a.jobId === 'actionable-job')
+    );
     await Actions.visitIndex({ id: 'actionable-job' });
+    await percySnapshot('Actions flyout on task page 0');
     await click('[data-test-task-group="actionable-group"] a');
-    await click('.task-name');
+    await percySnapshot('Actions flyout on task page 1');
+    await click('.allocation-row [data-test-short-id] a');
+    await percySnapshot('Actions flyout on task page 2');
+    await click('.task-row [data-test-name] a');
+
     // Click global button
     await Actions.globalButton.click();
     // Dropdown present


### PR DESCRIPTION
Resolves #17109 

Before, a job could have multiple services with the same name but differing tags, and their allocation count would double up (their filter criteria would be satisfied more times than intended in the UI)

Now, in addition to name and level (group or task) equality, we also look up `service.tags` equality.

Example jobspec for testing:

```
job "whoami" {
  group "whoami" {
    count = 1

    network {
      port "http" {}
      port "http2" {}
    }

    task "whoami" {
      driver = "docker"

      config {
        image = "traefik/whoami:latest"
        ports = ["http", "http2", "http3"]

        args = [
          "--port", "${NOMAD_PORT_http}"
        ]
      }

      service {
        name     = "whoami"
        provider = "nomad"
        port     = "http"
        tags = ["foo"]
      }
      service {
        name     = "whoami"
        provider = "nomad"
        port     = "http2"
        tags = ["bar"]
      }
      service {
        name     = "no-tags"
        provider = "nomad"
        port     = "http2"
        tags = []
      }
      service {
        name     = "many-tags"
        provider = "nomad"
        port     = "http2"
        tags = ["foo", "bar", "baz", 3]
      }
    }
  }
}
```

NOTE: There is still potential for confusion here if the two services are identical, except for their `port` / `portLabel` This is because we do not expose the service's port in the same way when it's a serviceFragment (read from the `jobspec.groups[].services[]`, which gives us back a port label) or when it's a service proper (from the `job/$id/services endpoint, where it gives us back a port identifying number). I consider this edge-casey enough that my suggestion to jobspec authors who may run into this problem in the future is to not name your services the same if they differ in port. Or really to not name any two services on the same task/group the same name, generally.