### PR TITLE
cli: add Consul namespace selector

### DIFF
--- a/command/setup_consul.go
+++ b/command/setup_consul.go
@@ -440,7 +440,7 @@ func (s *SetupConsulCommand) renderAuthMethod(name string, desc string) (*api.AC
 	}
 	if s.consulEnt {
 		method.NamespaceRules = []*api.ACLAuthMethodNamespaceRule{{
-			Selector:      "",
+			Selector:      `"consul_namespace" in value`,
 			BindNamespace: "${value.consul_namespace}",
 		}}
 	}


### PR DESCRIPTION
Update the `nomad setup consul` command to include a `Selector` for the `NamespaceRule` so the logic is only applied when the token has a claim for `consul_namespace`.

Jobs without an explicit `consul.namespace` value receive a JWT without the `consul_namespace` claim because Nomad is unable to determine which Consul namespace should be used.

By using `NamespaceRules`, cluster operators are able to set a default value for these jobs.