### PR TITLE
docs: fix documentation of client.reserved.cores

### DIFF
--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -368,7 +368,16 @@ see the [drivers documentation](/nomad/docs/drivers).
 
 - `cpu` `(int: 0)` - Specifies the amount of CPU to reserve, in MHz.
 
-- `cores` `(int: 0)` - Specifies the number of CPU cores to reserve.
+- `cores` `(int: 0)` - Specifies the cpuset of CPU cores to reserve. Only
+  supported on Linux.
+
+  ```hcl
+    client {
+      reserved {
+        cores = "0-4"
+      }
+    }
+  ```
 
 - `memory` `(int: 0)` - Specifies the amount of memory to reserve, in MB.
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/nomad/issues/17362

Leaving `reservable_cores` undocumented as it's a weird feature that probably shouldn't have been added to begin with and nobody has asked for it.