### PR TITLE
vault: fix legacy token workflow for poststop tasks

### DIFF
--- a/.changelog/19268.txt
+++ b/.changelog/19268.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault: Fixed a bug where poststop tasks would not get a Vault token
+```

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1860,7 +1860,7 @@ func (n *Node) DeriveVaultToken(args *structs.DeriveVaultTokenRequest, reply *st
 		setError(fmt.Errorf("Allocation %q not running on Node %q", args.AllocID, args.NodeID), false)
 		return nil
 	}
-	if alloc.TerminalStatus() {
+	if alloc.ClientTerminalStatus() {
 		setError(fmt.Errorf("Can't request Vault token for terminal allocation"), false)
 		return nil
 	}

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -3936,8 +3936,8 @@ func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 		t.Fatalf("Expected no policies error: %v", resp.Error)
 	}
 
-	// Update to be terminal
-	alloc.DesiredStatus = structs.AllocDesiredStatusStop
+	// Update to be client-terminal
+	alloc.ClientStatus = structs.AllocClientStatusFailed
 	if err := state.UpsertAllocs(structs.MsgTypeTestSetup, 5, []*structs.Allocation{alloc}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3949,6 +3949,7 @@ func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 	if resp.Error == nil || !strings.Contains(resp.Error.Error(), "terminal") {
 		t.Fatalf("Expected terminal allocation error: %v", resp.Error)
 	}
+
 }
 
 func TestClientEndpoint_DeriveVaultToken(t *testing.T) {


### PR DESCRIPTION
The new Workload Identity workflow for Vault tokens correctly handles post-stop tasks, however the legacy workflow does not. Attempts to get a Vault token are rejected if the allocation is server-terminal or client-terminal, but we should be waiting until the allocation is client-terminal (only) so that poststop tasks get a chance to get Vault tokens too.

Fixes: https://github.com/hashicorp/nomad/issues/16886
See https://github.com/hashicorp/nomad/issues/16886#issuecomment-1836456414 for testing details.