### PR TITLE
variables: fix access to variables for poststop tasks

### DIFF
--- a/.changelog/19270.txt
+++ b/.changelog/19270.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+variables: Fixed a bug where poststop tasks were not allowed access to Variables
+```

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -247,7 +247,7 @@ func (s *Server) VerifyClaim(token string) (*structs.IdentityClaims, error) {
 	}
 
 	// the claims for terminal allocs are always treated as expired
-	if alloc.TerminalStatus() {
+	if alloc.ClientTerminalStatus() {
 		return nil, fmt.Errorf("allocation is terminal")
 	}
 


### PR DESCRIPTION
In the recent auth refactor, we accidentally fixed a bug where poststop tasks would not get access to Variables. Fix this same bug for backports by ensuring that we use client-terminal status and not server-terminal status to enforce access.

Note this is a backport-only PR.

Ref: https://github.com/hashicorp/nomad/issues/16886