### PR TITLE
docs: changelog entry for bugfix introduced in #18754

### DIFF
--- a/.changelog/18754.txt
+++ b/.changelog/18754.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+variables: Fixed a bug where poststop tasks were not allowed access to Variables
+```


### PR DESCRIPTION
In #18754 we accidentally fixed a bug that prevented poststop tasks from getting access to Variables. This was fixed in the 1.6.x branch in #19270, at which point we discovered the fix had been done in main already as part of the auth refactor. Add a changelog entry for it.