### PR TITLE
e2e: give isolation test jobs more time to start

### DIFF
--- a/e2e/isolation/pids_test.go
+++ b/e2e/isolation/pids_test.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/nomad/e2e/v3/cluster3"
 	"github.com/hashicorp/nomad/e2e/v3/jobs3"
@@ -62,7 +63,10 @@ func testExecHostPID(t *testing.T) {
 }
 
 func testExecNamespaceAllocExec(t *testing.T) {
-	job, cleanup := jobs3.Submit(t, "./input/alloc_exec.hcl")
+	job, cleanup := jobs3.Submit(t,
+		"./input/alloc_exec.hcl",
+		jobs3.Timeout(time.Second*30), // exec can be a bit slow
+	)
 	t.Cleanup(cleanup)
 
 	logs := job.Exec("group", "sleep", []string{"ps", "ax"})
@@ -76,6 +80,7 @@ func testJavaNamespacePID(t *testing.T) {
 	job, cleanup := jobs3.Submit(t,
 		"./input/java.hcl",
 		jobs3.WaitComplete("group"),
+		jobs3.Timeout(time.Second*30), // exec prestart can be slow
 	)
 	t.Cleanup(cleanup)
 
@@ -87,6 +92,7 @@ func testJavaHostPID(t *testing.T) {
 	job, cleanup := jobs3.Submit(t,
 		"./input/java_host.hcl",
 		jobs3.WaitComplete("group"),
+		jobs3.Timeout(time.Second*30), // exec prestart can be slow
 	)
 	t.Cleanup(cleanup)
 
@@ -97,7 +103,10 @@ func testJavaHostPID(t *testing.T) {
 }
 
 func testJavaNamespaceAllocExec(t *testing.T) {
-	job, cleanup := jobs3.Submit(t, "./input/alloc_exec_java.hcl")
+	job, cleanup := jobs3.Submit(t,
+		"./input/alloc_exec_java.hcl",
+		jobs3.Timeout(time.Second*30), // exec prestart can be slow
+	)
 	t.Cleanup(cleanup)
 
 	logs := job.Exec("group", "sleep", []string{"ps", "ax"})


### PR DESCRIPTION
I think these are slower than [the current default 20s for `jobs3.Submit()`](https://github.com/hashicorp/nomad/blob/639c3f5/e2e/v3/jobs3/jobs3.go#L445) due to `exec` driver, either as a prestart task (for `java` tests) or the main task (for the alloc exec test).

Fixes #16607