### PR TITLE
[docs] Note reboot to update `bridge_network_hairpin_mode`

### DIFF
--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -163,7 +163,10 @@ client {
 - `bridge_network_hairpin_mode` `(bool: false)` - Specifies if hairpin mode
   is enabled on the network bridge created by Nomad for allocations running
   with bridge networking mode on this client. You may use the corresponding
-  node attribute `nomad.bridge.hairpin_mode` in constraints.
+  node attribute `nomad.bridge.hairpin_mode` in constraints. When hairpin mode
+  is enabled, allocations are able to reach their own IP and **all ports** bound
+  to it. Changing this value requires a reboot of the client host to take
+  effect.
 
 - `artifact` <code>([Artifact](#artifact-parameters): varied)</code> -
   Specifies controls on the behavior of task
@@ -234,7 +237,7 @@ client. To find the options supported by each individual Nomad driver, please
 see the [drivers documentation](/nomad/docs/drivers).
 
 - `"driver.allowlist"` `(string: "")` - Specifies a comma-separated list of
-  allowlisted drivers . If specified, drivers not in the allowlist will be
+  allowlisted drivers. If specified, drivers not in the allowlist will be
   disabled. If the allowlist is empty, all drivers are fingerprinted and enabled
   where applicable.
 
@@ -247,7 +250,7 @@ see the [drivers documentation](/nomad/docs/drivers).
   ```
 
 - `"driver.denylist"` `(string: "")` - Specifies a comma-separated list of
-  denylisted drivers . If specified, drivers in the denylist will be
+  denylisted drivers. If specified, drivers in the denylist will be
   disabled.
 
   ```hcl


### PR DESCRIPTION
Circling back on the comment in [#15961](https://github.com/hashicorp/nomad/pull/15961#discussion_r1092464814). This adds a note to the `bridge_network_hairpin_mode` setting indicating that if it is changed that you need to restart the node.  

I don't thing restarting is a strict requirement but it is by far easier (and more tooling friendly) than the corresponding manual steps.