### PR TITLE
e2e: push nomad token to test servers

### DIFF
--- a/e2e/terraform/nomad-acls.tf
+++ b/e2e/terraform/nomad-acls.tf
@@ -30,7 +30,39 @@ data "template_file" "bootstrap_nomad_script" {
   template = "${local.nomad_env} ./scripts/bootstrap-nomad.sh"
 }
 
-data "local_file" "nomad_token" {
+data "local_sensitive_file" "nomad_token" {
   depends_on = [null_resource.bootstrap_nomad_acls]
   filename   = "${path.root}/keys/nomad_root_token"
+}
+
+# push the token out to the servers for humans to use.
+# cert/key files are placed by ./provision-nomad module.
+# this is here instead of there, because the servers
+# must be provisioned before the token can be made,
+# so this avoids a dependency cycle.
+locals {
+  root_nomad_env = <<EXEC
+cat <<ENV | sudo tee -a /root/.bashrc
+export NOMAD_ADDR=https://localhost:4646
+export NOMAD_SKIP_VERIFY=true
+export NOMAD_CLIENT_CERT=/etc/nomad.d/tls/agent.crt
+export NOMAD_CLIENT_KEY=/etc/nomad.d/tls/agent.key
+export NOMAD_TOKEN=${data.local_sensitive_file.nomad_token.content}
+ENV
+EXEC
+}
+
+resource "null_resource" "root_nomad_env_servers" {
+  count = var.server_count
+  connection {
+    type        = "ssh"
+    user        = "ubuntu"
+    host        = aws_instance.server[count.index].public_ip
+    port        = 22
+    private_key = file("${path.root}/keys/${local.random_name}.pem")
+    timeout     = "5m"
+  }
+  provisioner "remote-exec" {
+    inline = [local.root_nomad_env]
+  }
 }

--- a/e2e/terraform/outputs.tf
+++ b/e2e/terraform/outputs.tf
@@ -52,7 +52,7 @@ export NOMAD_ADDR=https://${aws_instance.server[0].public_ip}:4646
 export NOMAD_CACERT=${abspath(path.root)}/keys/tls_ca.crt
 export NOMAD_CLIENT_CERT=${abspath(path.root)}/keys/tls_api_client.crt
 export NOMAD_CLIENT_KEY=${abspath(path.root)}/keys/tls_api_client.key
-export NOMAD_TOKEN=${data.local_file.nomad_token.content}
+export NOMAD_TOKEN=${data.local_sensitive_file.nomad_token.content}
 export NOMAD_E2E=1
 
 EOM


### PR DESCRIPTION
so humans with root shell access can use it to debug

this is not ideal security, but this is a short-lived test cluster.