### PR TITLE
e2e: fix ConsulNamespaces tests

### DIFF
--- a/e2e/consul/namespaces.go
+++ b/e2e/consul/namespaces.go
@@ -11,7 +11,7 @@ import (
 	capi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/nomad/e2e/e2eutil"
 	"github.com/hashicorp/nomad/e2e/framework"
-	"github.com/hashicorp/nomad/helper"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,7 +94,8 @@ func (tc *ConsulNamespacesE2ETest) AfterAll(f *framework.F) {
 func (tc *ConsulNamespacesE2ETest) TestNamespacesExist(f *framework.F) {
 	// make sure our namespaces exist + default
 	namespaces := e2eutil.ListConsulNamespaces(f.T(), tc.Consul())
-	require.True(f.T(), helper.SliceSetEq(namespaces, append(consulNamespaces, "default")))
+	must.SliceContainsSubset(f.T(), namespaces, allConsulNamespaces, must.Sprintf(
+		"expected %+v to be a subset of: %+v", allConsulNamespaces, namespaces))
 }
 
 func (tc *ConsulNamespacesE2ETest) testConsulRegisterGroupServices(f *framework.F, token, nsA, nsB, nsC, nsZ string) {

--- a/e2e/e2eutil/consul.go
+++ b/e2e/e2eutil/consul.go
@@ -203,7 +203,7 @@ func DeleteConsulPolicies(t *testing.T, client *capi.Client, policies map[string
 // the given policyID in the specified namespace.
 //
 // Requires Consul Enterprise.
-func CreateConsulToken(t *testing.T, client *capi.Client, namespace, policyID string) string {
+func CreateConsulToken(t *testing.T, client *capi.Client, namespace, policyID string) (secret, accessor string) {
 	aclClient := client.ACL()
 	opts := &capi.WriteOptions{Namespace: namespace}
 
@@ -212,7 +212,7 @@ func CreateConsulToken(t *testing.T, client *capi.Client, namespace, policyID st
 		Description: "An e2e test token",
 	}, opts)
 	require.NoError(t, err, "failed to create consul acl token")
-	return token.SecretID
+	return token.SecretID, token.AccessorID
 }
 
 // DeleteConsulTokens is used to delete a set of tokens from Consul.


### PR DESCRIPTION
CE side of hashicorp/nomad-enterprise#1337 (look out h4x0rz, 2 1337 4 u) which fixes #19300

* We need only expect a subset of the namespaces to exist, not an exact match (our test cluster may have extra)
* Need to delete a Consul token using its accessor ID, rather than the secret value.