### PR TITLE
cli: add `-dev-consul` and `-dev-vault` agent mode

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -61,7 +61,6 @@ type Command struct {
 }
 
 func (c *Command) readConfig() *Config {
-	var dev *devModeConfig
 	var configPath []string
 	var servers string
 	var meta []string
@@ -86,8 +85,12 @@ func (c *Command) readConfig() *Config {
 	// Role options
 	var devMode bool
 	var devConnectMode bool
+	var devConsulMode bool
+	var devVaultMode bool
 	flags.BoolVar(&devMode, "dev", false, "")
 	flags.BoolVar(&devConnectMode, "dev-connect", false, "")
+	flags.BoolVar(&devConsulMode, "dev-consul", false, "")
+	flags.BoolVar(&devVaultMode, "dev-vault", false, "")
 	flags.BoolVar(&cmdConfig.Server.Enabled, "server", false, "")
 	flags.BoolVar(&cmdConfig.Client.Enabled, "client", false, "")
 
@@ -221,14 +224,26 @@ func (c *Command) readConfig() *Config {
 	}
 
 	// Load the configuration
-	dev, err := newDevModeConfig(devMode, devConnectMode)
-	if err != nil {
-		c.Ui.Error(err.Error())
-		return nil
-	}
 	var config *Config
-	if dev != nil {
-		config = DevConfig(dev)
+
+	devConfig := &devModeConfig{
+		defaultMode: devMode,
+		connectMode: devConnectMode,
+		consulMode:  devConsulMode,
+		vaultMode:   devVaultMode,
+	}
+	if devConfig.enabled() {
+		err := devConfig.validate()
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return nil
+		}
+		err = devConfig.networkConfig()
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return nil
+		}
+		config = DevConfig(devConfig)
 	} else {
 		config = DefaultConfig()
 	}
@@ -1404,6 +1419,14 @@ General Options (clients and servers):
     Start the agent in development mode, but bind to a public network
     interface rather than localhost for using Consul Connect. This
     mode is supported only on Linux as root.
+
+  -dev-consul
+    Starts the agent in development mode with a default Consul configuration
+    for Nomad workload identity.
+
+  -dev-vault
+    Starts the agent in development mode with a default Vault configuration
+    for Nomad workload identity.
 
 Server Options:
 

--- a/website/content/docs/commands/agent.mdx
+++ b/website/content/docs/commands/agent.mdx
@@ -101,6 +101,12 @@ via CLI arguments. The `agent` command accepts the following arguments:
   network interface rather than localhost for using Consul Connect. This mode
   is supported only on Linux as root.
 
+- `-dev-consul`: Starts the agent in development mode with a default Consul
+  configuration for Nomad workload identity.
+
+- `-dev-vault`: Starts the agent in development mode with a default Vault
+  configuration for Nomad workload identity.
+
 - `-encrypt`: Set the Serf encryption key. See the [Encryption Overview] for
   more details.
 


### PR DESCRIPTION
The `-dev-consul` and `-dev-vault` flags add default identities and configuration to the Nomad agent to connect and use the workload indetity integration with Consul and Vault.