### PR TITLE
[ui] Job status panel: show breakdown by groups

### DIFF
--- a/ui/app/components/job-page/parts/task-groups.js
+++ b/ui/app/components/job-page/parts/task-groups.js
@@ -4,8 +4,7 @@
  */
 
 import Component from '@ember/component';
-import { action, computed } from '@ember/object';
-import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
 import Sortable from 'nomad-ui/mixins/sortable';
 import { classNames } from '@ember-decorators/component';
@@ -14,18 +13,11 @@ import classic from 'ember-classic-decorator';
 @classic
 @classNames('boxed-section')
 export default class TaskGroups extends Component.extend(Sortable) {
-  @service router;
-
   job = null;
 
   // Provide a value that is bound to a query param
   sortProperty = null;
   sortDescending = null;
-
-  @action
-  gotoTaskGroup(taskGroup) {
-    this.router.transitionTo('jobs.job.task-group', this.job, taskGroup.name);
-  }
 
   @computed('job.taskGroups.[]')
   get taskGroups() {

--- a/ui/app/components/job-status/allocation-status-block.hbs
+++ b/ui/app/components/job-status/allocation-status-block.hbs
@@ -3,6 +3,13 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
+{{!--
+  Exists as a "middleman" between AllocationStatusRow and IndividualAllocation
+  only when showSummaries in AllocationStatusRow is true (i.e. when the math of how
+  many allocations to show in each block is done x minWidth of each alloc exceeds
+  available space)
+--}}
+
 <div
   class="allocation-status-block {{unless this.countToShow "rest-only"}}"
   style={{html-safe (concat "width: " @width "px")}}
@@ -16,6 +23,7 @@
           @health={{@health}}
           @canary={{@canary}}
           @steady={{@steady}}
+          @focusedGroup={{@focusedGroup}}
         />
       {{/each}}
     </div>

--- a/ui/app/components/job-status/allocation-status-row.hbs
+++ b/ui/app/components/job-status/allocation-status-row.hbs
@@ -20,7 +20,9 @@
                 @steady={{@steady}}
                 @count={{allocsByCanary.length}}
                 @width={{compute (action this.calcPerc) allocsByCanary.length}}
-                @allocs={{allocsByCanary}} />
+                @allocs={{allocsByCanary}}
+                @focusedGroup={{@focusedGroup}}
+                />
             {{/if}}
           {{/each-in}}
         {{/each-in}}
@@ -42,6 +44,7 @@
                       @health={{health}}
                       @canary={{canary}}
                       @steady={{@steady}}
+                      @focusedGroup={{@focusedGroup}}
                     />
               {{/each}}
             {{/if}}

--- a/ui/app/components/job-status/individual-allocation.hbs
+++ b/ui/app/components/job-status/individual-allocation.hbs
@@ -10,7 +10,7 @@
     @condition={{not (eq @status "unplaced")}}
     @route="allocations.allocation"
     @model={{@allocation.id}}
-    @class="represented-allocation {{@status}} {{@health}} {{@canary}}"
+    @class="represented-allocation {{@status}} {{@health}} {{@canary}} {{if this.shouldFade "faded"}}"
     @label="View allocation"
   >
     {{#unless @steady}}

--- a/ui/app/components/job-status/individual-allocation.hbs
+++ b/ui/app/components/job-status/individual-allocation.hbs
@@ -3,8 +3,9 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 <Hds::TooltipButton
-  @text="{{if this.showClient (concat this.nodeName " - " (get @allocation "shortId")) (get @allocation "shortId")}}"
-aria-label="Allocation" @extraTippyOptions={{hash trigger=(if (eq @status "unplaced") "manual")}}>
+  @text={{this.tooltipText}}
+  aria-label="Allocation" @extraTippyOptions={{hash trigger=(if (eq @status "unplaced") "manual")}}
+>
   <ConditionalLinkTo
     @condition={{not (eq @status "unplaced")}}
     @route="allocations.allocation"

--- a/ui/app/components/job-status/individual-allocation.js
+++ b/ui/app/components/job-status/individual-allocation.js
@@ -21,10 +21,22 @@ export default class JobStatusIndividualAllocationComponent extends Component {
   get tooltipText() {
     if (this.showClient) {
       return `${this.nodeName} - ${this.shortId}`;
-    } else if (this.taskGroups.length > 1) {
+    } else if (this.groupName && this.taskGroups?.length > 1) {
       return `${this.groupName} - ${this.shortId}`;
-    } else {
+    } else if (this.shortId) {
       return this.shortId;
+    } else {
+      return 'oof';
     }
+  }
+
+  // If a user has hovered or otherwise focused a taskGroup,
+  // and it differs from this alloc's task group, then fade it.
+  get shouldFade() {
+    return (
+      this.groupName &&
+      this.args.focusedGroup &&
+      this.args.focusedGroup !== this.args.allocation.taskGroup
+    );
   }
 }

--- a/ui/app/components/job-status/individual-allocation.js
+++ b/ui/app/components/job-status/individual-allocation.js
@@ -10,8 +10,21 @@ import { alias } from '@ember/object/computed';
 export default class JobStatusIndividualAllocationComponent extends Component {
   @alias('args.allocation.job.type') jobType;
   @alias('args.allocation.node.name') nodeName;
+  @alias('args.allocation.taskGroup.name') groupName;
+  @alias('args.allocation.job.taskGroups') taskGroups;
+  @alias('args.allocation.shortId') shortId;
 
   get showClient() {
     return this.jobType === 'system' || this.jobType === 'sysbatch';
+  }
+
+  get tooltipText() {
+    if (this.showClient) {
+      return `${this.nodeName} - ${this.shortId}`;
+    } else if (this.taskGroups.length > 1) {
+      return `${this.groupName} - ${this.shortId}`;
+    } else {
+      return this.shortId;
+    }
   }
 }

--- a/ui/app/components/job-status/panel.hbs
+++ b/ui/app/components/job-status/panel.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 {{#if this.isActivelyDeploying}}
-  <JobStatus::Panel::Deploying @job={{@job}} @handleError={{@handleError}} />
+  <JobStatus::Panel::Deploying @job={{@job}} @handleError={{@handleError}} @focusedGroup={{@focusedGroup}} />
 {{else}}
-  <JobStatus::Panel::Steady @job={{@job}} @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} @nodes={{this.nodes}} />
+  <JobStatus::Panel::Steady @job={{@job}} @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} @nodes={{this.nodes}}  @focusedGroup={{@focusedGroup}} />
 {{/if}}

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -88,7 +88,7 @@
             </section>
           </h4>
           <div class="previous-allocations">
-            <JobStatus::AllocationStatusRow @allocBlocks={{this.oldVersionAllocBlocks}} @steady={{true}} />
+            <JobStatus::AllocationStatusRow @allocBlocks={{this.oldVersionAllocBlocks}} @steady={{true}}  @focusedGroup={{@focusedGroup}} />
           </div>
           <div class="legend-and-summary" data-test-previous-allocations-legend>
             <legend>
@@ -113,7 +113,7 @@
           </span>
         </h4>
         <div class="new-allocations">
-          <JobStatus::AllocationStatusRow @allocBlocks={{this.newVersionAllocBlocks}} />
+          <JobStatus::AllocationStatusRow @allocBlocks={{this.newVersionAllocBlocks}}  @focusedGroup={{@focusedGroup}} />
         </div>
       </div>
 

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -45,7 +45,7 @@
           {{pluralize "Allocation" @job.runningAllocs}} Running
         {{/if}}
       </h3>
-      <JobStatus::AllocationStatusRow @allocBlocks={{this.allocBlocks}} @steady={{true}} />
+      <JobStatus::AllocationStatusRow @allocBlocks={{this.allocBlocks}} @steady={{true}}  @focusedGroup={{@focusedGroup}} />
 
       <div class="legend-and-summary {{if @job.latestDeployment "has-latest-deployment"}}">
         <legend>

--- a/ui/app/components/task-group-row.js
+++ b/ui/app/components/task-group-row.js
@@ -3,34 +3,26 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import Component from '@ember/component';
+// import Component from '@ember/component';
+import Component from '@glimmer/component';
+
 import { inject as service } from '@ember/service';
 import { computed, action } from '@ember/object';
 import { alias, oneWay } from '@ember/object/computed';
 import { debounce } from '@ember/runloop';
-import {
-  classNames,
-  tagName,
-  attributeBindings,
-} from '@ember-decorators/component';
-import classic from 'ember-classic-decorator';
 import { lazyClick } from '../helpers/lazy-click';
 
-@classic
-@tagName('tr')
-@classNames('task-group-row', 'is-interactive')
-@attributeBindings('data-test-task-group')
 export default class TaskGroupRow extends Component {
   @service can;
 
-  taskGroup = null;
+  @alias('args.taskGroup') taskGroup;
   debounce = 500;
 
   @oneWay('taskGroup.count') count;
   @alias('taskGroup.job.runningDeployment') runningDeployment;
 
   get namespace() {
-    return this.get('taskGroup.job.namespace.name');
+    return this.taskGroup.job.namespace.get('name');
   }
 
   @computed('runningDeployment', 'namespace')
@@ -46,6 +38,11 @@ export default class TaskGroupRow extends Component {
 
   click(event) {
     lazyClick([this.onClick, event]);
+  }
+
+  // TODO: DONT DO THIS, JUST PASS ON HOVER TO ALL JOB TYPES
+  get onHover() {
+    return this.args.onHover || (() => {});
   }
 
   @computed('count', 'taskGroup.scaling.min')

--- a/ui/app/components/task-group-row.js
+++ b/ui/app/components/task-group-row.js
@@ -63,7 +63,7 @@ export default class TaskGroupRow extends Component {
   countUp() {
     const scaling = this.taskGroup.scaling;
     if (!scaling || scaling.max == null || this.count < scaling.max) {
-      this.incrementProperty('count');
+      this.count++;
       this.scale(this.count);
     }
   }
@@ -72,7 +72,7 @@ export default class TaskGroupRow extends Component {
   countDown() {
     const scaling = this.taskGroup.scaling;
     if (!scaling || scaling.min == null || this.count > scaling.min) {
-      this.decrementProperty('count');
+      this.count--;
       this.scale(this.count);
     }
   }

--- a/ui/app/components/task-group-row.js
+++ b/ui/app/components/task-group-row.js
@@ -48,7 +48,6 @@ export default class TaskGroupRow extends Component {
     lazyClick([() => this.gotoTaskGroup(this.taskGroup), event]);
   }
 
-  // TODO: DONT DO THIS, JUST PASS ON HOVER TO ALL JOB TYPES
   get onHover() {
     return this.args.onHover || (() => {});
   }

--- a/ui/app/components/task-group-row.js
+++ b/ui/app/components/task-group-row.js
@@ -44,10 +44,8 @@ export default class TaskGroupRow extends Component {
     return undefined;
   }
 
-  onClick() {}
-
   click(event) {
-    lazyClick([this.onClick, event]);
+    lazyClick([() => this.gotoTaskGroup(this.taskGroup), event]);
   }
 
   // TODO: DONT DO THIS, JUST PASS ON HOVER TO ALL JOB TYPES

--- a/ui/app/components/task-group-row.js
+++ b/ui/app/components/task-group-row.js
@@ -14,12 +14,22 @@ import { lazyClick } from '../helpers/lazy-click';
 
 export default class TaskGroupRow extends Component {
   @service can;
+  @service router;
 
   @alias('args.taskGroup') taskGroup;
   debounce = 500;
 
   @oneWay('taskGroup.count') count;
   @alias('taskGroup.job.runningDeployment') runningDeployment;
+
+  @action
+  gotoTaskGroup(taskGroup) {
+    this.router.transitionTo(
+      'jobs.job.task-group',
+      taskGroup.job,
+      taskGroup.name
+    );
+  }
 
   get namespace() {
     return this.taskGroup.job.namespace.get('name');

--- a/ui/app/components/task-group-row.js
+++ b/ui/app/components/task-group-row.js
@@ -8,7 +8,7 @@ import Component from '@glimmer/component';
 
 import { inject as service } from '@ember/service';
 import { computed, action } from '@ember/object';
-import { alias, oneWay } from '@ember/object/computed';
+import { alias } from '@ember/object/computed';
 import { debounce } from '@ember/runloop';
 import { lazyClick } from '../helpers/lazy-click';
 
@@ -19,7 +19,7 @@ export default class TaskGroupRow extends Component {
   @alias('args.taskGroup') taskGroup;
   debounce = 500;
 
-  @oneWay('taskGroup.count') count;
+  @alias('taskGroup.count') count;
   @alias('taskGroup.job.runningDeployment') runningDeployment;
 
   @action

--- a/ui/app/controllers/jobs/job/index.js
+++ b/ui/app/controllers/jobs/job/index.js
@@ -62,4 +62,10 @@ export default class IndexController extends Controller.extend(
   setStatusMode(mode) {
     this.statusMode = mode;
   }
+
+  @tracked focusedGroup = null;
+
+  @action focusGroup(group) {
+    this.focusedGroup = group;
+  }
 }

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -278,6 +278,7 @@
     $complete: $nomad-green-pale;
     $failed: $danger;
     $lost: $dark;
+    transition: 0.2s;
 
     // Client Statuses
     &.running {
@@ -347,6 +348,7 @@
 
     &.faded {
       opacity: 0.3;
+      transform: scale(0.5);
     }
 
     &.legend-example {

--- a/ui/app/styles/components/job-status-panel.scss
+++ b/ui/app/styles/components/job-status-panel.scss
@@ -345,6 +345,10 @@
       }
     }
 
+    &.faded {
+      opacity: 0.3;
+    }
+
     &.legend-example {
       background: #eee;
     }

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -496,12 +496,16 @@
             <th>
               Memory
             </th>
+            <th>
+              Actions
+            </th>
           </t.head>
           <t.body as |row|>
             <AllocationRow
               @allocation={{row.model}}
               @context="job"
               @data-test-allocation={{row.model.id}}
+              @jobHasActions={{true}}
             />
           </t.body>
         </ListTable>

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -576,6 +576,7 @@
                 @context="node"
                 @onClick={{action "gotoAllocation" row.model}}
                 @data-test-allocation={{row.model.id}}
+                @jobHasActions={{true}}
               />
               {{#if this.showSubTasks}}
                 {{#each row.model.states as |task|}}

--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -137,4 +137,6 @@
     @error={{this.statsError}}
   />
 </td>
-<td class="job-actions-cell" />
+{{#if @jobHasActions}}
+  <td class="job-actions-cell" />
+{{/if}}

--- a/ui/app/templates/components/job-page/batch.hbs
+++ b/ui/app/templates/components/job-page/batch.hbs
@@ -9,8 +9,8 @@
     <jobPage.ui.Title />
     <jobPage.ui.StatsBox />
     <jobPage.ui.PlacementFailures />
-    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} />
-    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} />
+    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} @focusedGroup={{@focusedGroup}} />
+    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}}  @focusGroup={{@focusGroup}} />
     <jobPage.ui.RecentAllocations @activeTask={{@activeTask}} @setActiveTaskQueryParam={{@setActiveTaskQueryParam}} />
     <jobPage.ui.Meta />
   </jobPage.ui.Body>

--- a/ui/app/templates/components/job-page/parameterized-child.hbs
+++ b/ui/app/templates/components/job-page/parameterized-child.hbs
@@ -23,8 +23,8 @@
       </:before-namespace>
     </jobPage.ui.StatsBox>
     <jobPage.ui.PlacementFailures />
-    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} />
-    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} />
+    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} @focusedGroup={{@focusedGroup}} />
+    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} @focusGroup={{@focusGroup}} />
     <jobPage.ui.RecentAllocations @activeTask={{@activeTask}} @setActiveTaskQueryParam={{@setActiveTaskQueryParam}} />
     <div class="boxed-section">
       {{#if @job.meta}}

--- a/ui/app/templates/components/job-page/parts/recent-allocations.hbs
+++ b/ui/app/templates/components/job-page/parts/recent-allocations.hbs
@@ -68,6 +68,7 @@
             @context="job"
             @onClick={{action "gotoAllocation" row.model}}
             @showSubTasks={{this.showSubTasks}}
+            @jobHasActions={{this.job.actions.length}}
             {{keyboard-shortcut
               enumerated=true
               action=(action "gotoAllocation" row.model)

--- a/ui/app/templates/components/job-page/parts/task-groups.hbs
+++ b/ui/app/templates/components/job-page/parts/task-groups.hbs
@@ -38,14 +38,8 @@
       </t.head>
       <t.body as |row|>
         <TaskGroupRow
-          @data-test-task-group={{row.model.name}}
           @taskGroup={{row.model}}
-          @onClick={{fn this.gotoTaskGroup row.model}}
           @onHover={{@focusGroup}}
-          {{keyboard-shortcut 
-            enumerated=true
-            action=(fn this.gotoTaskGroup row.model)
-          }}
         />
       </t.body>
     </ListTable>

--- a/ui/app/templates/components/job-page/parts/task-groups.hbs
+++ b/ui/app/templates/components/job-page/parts/task-groups.hbs
@@ -41,6 +41,7 @@
           @data-test-task-group={{row.model.name}}
           @taskGroup={{row.model}}
           @onClick={{fn this.gotoTaskGroup row.model}}
+          @onHover={{@focusGroup}}
           {{keyboard-shortcut 
             enumerated=true
             action=(fn this.gotoTaskGroup row.model)

--- a/ui/app/templates/components/job-page/periodic-child.hbs
+++ b/ui/app/templates/components/job-page/periodic-child.hbs
@@ -22,9 +22,9 @@
         </span>
       </:before-namespace>
     </jobPage.ui.StatsBox>
-    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} />
+    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} @focusedGroup={{@focusedGroup}} />
     <jobPage.ui.PlacementFailures />
-    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} />
+    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} @focusGroup={{@focusGroup}} />
     <jobPage.ui.RecentAllocations @activeTask={{@activeTask}} @setActiveTaskQueryParam={{@setActiveTaskQueryParam}} />
     <jobPage.ui.Meta />
   </jobPage.ui.Body>

--- a/ui/app/templates/components/job-page/service.hbs
+++ b/ui/app/templates/components/job-page/service.hbs
@@ -10,8 +10,8 @@
     <jobPage.ui.StatsBox />
     <jobPage.ui.DasRecommendations />
     <jobPage.ui.PlacementFailures />
-    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} />
-    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} />
+    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} @focusedGroup={{@focusedGroup}} />
+    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} @focusGroup={{@focusGroup}} />
     <jobPage.ui.RecentAllocations @activeTask={{@activeTask}} @setActiveTaskQueryParam={{@setActiveTaskQueryParam}} />
     <jobPage.ui.Meta />
   </jobPage.ui.Body>

--- a/ui/app/templates/components/job-page/sysbatch.hbs
+++ b/ui/app/templates/components/job-page/sysbatch.hbs
@@ -9,8 +9,8 @@
     <jobPage.ui.Title />
     <jobPage.ui.StatsBox />
     <jobPage.ui.PlacementFailures />
-    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} />
-    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} />
+    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} @focusedGroup={{@focusedGroup}} />
+    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} @focusGroup={{@focusGroup}} />
     <jobPage.ui.RecentAllocations @activeTask={{@activeTask}} @setActiveTaskQueryParam={{@setActiveTaskQueryParam}} />
     <jobPage.ui.Meta />
   </jobPage.ui.Body>

--- a/ui/app/templates/components/job-page/system.hbs
+++ b/ui/app/templates/components/job-page/system.hbs
@@ -10,8 +10,8 @@
     <jobPage.ui.StatsBox />
     <jobPage.ui.DasRecommendations />
     <jobPage.ui.PlacementFailures />
-    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} />
-    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} />
+    <jobPage.ui.StatusPanel @statusMode={{@statusMode}} @setStatusMode={{@setStatusMode}} @focusedGroup={{@focusedGroup}} />
+    <jobPage.ui.TaskGroups @sortProperty={{@sortProperty}} @sortDescending={{@sortDescending}} @focusGroup={{@focusGroup}} />
     <jobPage.ui.RecentAllocations @activeTask={{@activeTask}} @setActiveTaskQueryParam={{@setActiveTaskQueryParam}} />
     <jobPage.ui.Meta />
   </jobPage.ui.Body>

--- a/ui/app/templates/components/task-group-row.hbs
+++ b/ui/app/templates/components/task-group-row.hbs
@@ -6,7 +6,7 @@
 <tr class="task-group-row is-interactive" data-test-task-group
   {{on "mouseover" (fn this.onHover @taskGroup)}}
   {{on "mouseout" (fn this.onHover null)}}
-  {{on "click" (action this.gotoTaskGroup @taskGroup)}}
+  {{on "click" (action this.click)}}
   {{keyboard-shortcut 
     enumerated=true
     action=(action this.gotoTaskGroup @taskGroup)

--- a/ui/app/templates/components/task-group-row.hbs
+++ b/ui/app/templates/components/task-group-row.hbs
@@ -3,46 +3,51 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<td data-test-task-group-name={{this.taskGroup.name}}>
-  <LinkTo @route="jobs.job.task-group" @models={{array this.taskGroup.job this.taskGroup}} class="is-primary">
-    {{this.taskGroup.name}}
-  </LinkTo>
-</td>
-<td data-test-task-group-count class="nowrap">
-  {{this.count}}
-  {{#if this.taskGroup.scaling}}
-  <div
-    data-test-scale-controls
-    class="button-bar is-shadowless is-text bumper-left {{if (or this.runningDeployment (cannot "scale job" namespace=this.namespace)) "tooltip multiline"}}"
-    aria-label={{this.tooltipText}}>
-      <button
-        data-test-scale="decrement"
-        role="button"
-        aria-label="decrement"
-        class="button is-xsmall is-light"
-        disabled={{or this.isMinimum this.runningDeployment (cannot "scale job" namespace=this.namespace)}}
-        onclick={{action "countDown"}}
-        type="button">
-        {{x-icon "minus-plain" class="is-text"}}
-      </button>
-      <button
-        data-test-scale-controls-increment
-        data-test-scale="increment"
-        role="button"
-        aria-label="increment"
-        class="button is-xsmall is-light"
-        disabled={{or this.isMaximum this.runningDeployment (cannot "scale job" namespace=this.namespace)}}
-        onclick={{action "countUp"}}
-        type="button">
-        {{x-icon "plus-plain" class="is-text"}}
-      </button>
-    </div>
-  {{/if}}
-</td>
-<td data-test-task-group-allocs>
-  <div class="inline-chart"><AllocationStatusBar @allocationContainer={{this.taskGroup.summary}} @isNarrow={{true}} /></div>
-</td>
-<td data-test-task-group-volume>{{if this.taskGroup.volumes.length "Yes"}}</td>
-<td data-test-task-group-cpu>{{format-scheduled-hertz this.taskGroup.reservedCPU}}</td>
-<td data-test-task-group-mem>{{format-scheduled-bytes this.taskGroup.reservedMemory start="MiB"}}</td>
-<td data-test-task-group-disk>{{format-scheduled-bytes this.taskGroup.reservedEphemeralDisk start="MiB"}}</td>
+<tr class="task-group-row is-interactive" data-test-task-group
+  {{on "mouseover" (fn this.onHover @taskGroup)}}
+  {{on "mouseout" (fn this.onHover null)}}
+>
+  <td data-test-task-group-name={{@taskGroup.name}}>
+    <LinkTo @route="jobs.job.task-group" @models={{array @taskGroup.job @taskGroup}} class="is-primary">
+      {{@taskGroup.name}}
+    </LinkTo>
+  </td>
+  <td data-test-task-group-count class="nowrap">
+    {{this.count}}
+    {{#if @taskGroup.scaling}}
+    <div
+      data-test-scale-controls
+      class="button-bar is-shadowless is-text bumper-left {{if (or this.runningDeployment (cannot "scale job" namespace=this.namespace)) "tooltip multiline"}}"
+      aria-label={{this.tooltipText}}>
+        <button
+          data-test-scale="decrement"
+          role="button"
+          aria-label="decrement"
+          class="button is-xsmall is-light"
+          disabled={{or this.isMinimum this.runningDeployment (cannot "scale job" namespace=this.namespace)}}
+          onclick={{action "countDown"}}
+          type="button">
+          {{x-icon "minus-plain" class="is-text"}}
+        </button>
+        <button
+          data-test-scale-controls-increment
+          data-test-scale="increment"
+          role="button"
+          aria-label="increment"
+          class="button is-xsmall is-light"
+          disabled={{or this.isMaximum this.runningDeployment (cannot "scale job" namespace=this.namespace)}}
+          onclick={{action "countUp"}}
+          type="button">
+          {{x-icon "plus-plain" class="is-text"}}
+        </button>
+      </div>
+    {{/if}}
+  </td>
+  <td data-test-task-group-allocs>
+    <div class="inline-chart"><AllocationStatusBar @allocationContainer={{@taskGroup.summary}} @isNarrow={{true}} /></div>
+  </td>
+  <td data-test-task-group-volume>{{if @taskGroup.volumes.length "Yes"}}</td>
+  <td data-test-task-group-cpu>{{format-scheduled-hertz @taskGroup.reservedCPU}}</td>
+  <td data-test-task-group-mem>{{format-scheduled-bytes @taskGroup.reservedMemory start="MiB"}}</td>
+  <td data-test-task-group-disk>{{format-scheduled-bytes @taskGroup.reservedEphemeralDisk start="MiB"}}</td>
+</tr>

--- a/ui/app/templates/components/task-group-row.hbs
+++ b/ui/app/templates/components/task-group-row.hbs
@@ -6,6 +6,11 @@
 <tr class="task-group-row is-interactive" data-test-task-group
   {{on "mouseover" (fn this.onHover @taskGroup)}}
   {{on "mouseout" (fn this.onHover null)}}
+  {{on "click" (action this.gotoTaskGroup @taskGroup)}}
+  {{keyboard-shortcut 
+    enumerated=true
+    action=(action this.gotoTaskGroup @taskGroup)
+  }}
 >
   <td data-test-task-group-name={{@taskGroup.name}}>
     <LinkTo @route="jobs.job.task-group" @models={{array @taskGroup.job @taskGroup}} class="is-primary">

--- a/ui/app/templates/jobs/job/index.hbs
+++ b/ui/app/templates/jobs/job/index.hbs
@@ -14,4 +14,6 @@
   setActiveTaskQueryParam=this.setActiveTaskQueryParam
   statusMode=this.statusMode
   setStatusMode=this.setStatusMode
+  focusGroup=this.focusGroup
+  focusedGroup=this.focusedGroup
 }}

--- a/ui/tests/acceptance/actions-test.js
+++ b/ui/tests/acceptance/actions-test.js
@@ -325,7 +325,7 @@ module('Acceptance | actions', function (hooks) {
 
     // head back into the job, and into a task
     await Actions.visitIndex({ id: 'actionable-job' });
-    await click('[data-test-task-group="actionable-group"] a');
+    await click('[data-test-task-group-name="actionable-group"] a');
     await click('.task-name');
     // Click global button
     await Actions.globalButton.click();


### PR DESCRIPTION
- Adds a group label tooltip where applicable (non system, non sysbatch jobs)
- Adds a hover handle to Task Group rows as a bit of a hidden feature: when hovered, the job status panel allocations that match said group will stay fully visible, and others will fade to 30%.
<img width="969" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/22ecff0a-5559-4fc7-9ddd-dbcb2c1dc776">
<img width="250" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/f61c7880-97bd-489a-9313-da91ba92f0f7">

Resolves #19314