### PR TITLE
[ui] Small-screen styles for exec window

### DIFF
--- a/.changelog/19332.txt
+++ b/.changelog/19332.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: make the exec window look nicer on mobile screens
+```

--- a/ui/app/styles/components/exec-window.scss
+++ b/ui/app/styles/components/exec-window.scss
@@ -155,3 +155,24 @@
     }
   }
 }
+// Media query for small screens
+@media (max-width: 768px) {
+  .exec-window {
+    width: 100vw;
+    height: 100vh;
+    flex-direction: column;
+    position: static;
+    .task-group-tree {
+      flex: 0 0 auto;
+      min-height: 50px;
+      max-height: 300px;
+      overflow-y: auto;
+      width: 100%;
+    }
+    .terminal-container {
+      flex: 1 0 auto;
+      width: 100%;
+      height: auto;
+    }
+  }
+}

--- a/ui/app/styles/components/exec-window.scss
+++ b/ui/app/styles/components/exec-window.scss
@@ -156,7 +156,7 @@
   }
 }
 // Media query for small screens
-@media (max-width: 768px) {
+@media ($breakpoint-mobile) {
   .exec-window {
     width: 100vw;
     height: 100vh;

--- a/ui/app/styles/core/variables.scss
+++ b/ui/app/styles/core/variables.scss
@@ -65,3 +65,7 @@ $control-padding-vertical: calc(0.375em - #{$control-border-width});
 $control-padding-horizontal: calc(0.625em - #{$control-border-width});
 $button-padding-vertical: calc(0.375em - #{$button-border-width});
 $button-padding-horizontal: 0.75em;
+
+$breakpoint-mobile: 'max-width: 768px';
+$breakpoint-tablet: 'min-width: 769px';
+$breakpoint-desktop: 'min-width: 1088px';


### PR DESCRIPTION
Vertically stacks things so they look nicer on narrow screens

<img width="492" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/925ccece-f6a7-4cfd-b66c-82b8040e67c6">

Resolves #19331 
