### PR TITLE
ci: use go-modtool with config file

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -140,7 +140,7 @@ deps:  ## Install build and development dependencies
 	go install github.com/hashicorp/go-changelog/cmd/changelog-build@latest
 	go install golang.org/x/tools/cmd/stringer@v0.1.12
 	go install github.com/hashicorp/hc-install/cmd/hc-install@v0.6.1
-	go install github.com/shoenig/go-modtool@v0.1.1
+	go install github.com/shoenig/go-modtool@v0.2.0
 
 .PHONY: lint-deps
 lint-deps: ## Install linter dependencies
@@ -249,10 +249,7 @@ tidy: ## Tidy up the go mod files
 	@cd tools && go mod tidy
 	@cd api && go mod tidy
 	@echo "==> Tidy nomad module"
-	@go-modtool \
-		--replace-comment="Pinned dependencies are noted in github.com/hashicorp/nomad/issues/11826." \
-		--subs-comment="Nomad is built using the current source of the API module." \
-		-w fmt go.mod
+	@go-modtool -config=ci/modtool.toml fmt go.mod
 	@go mod tidy
 
 .PHONY: dev

--- a/ci/modtool.toml
+++ b/ci/modtool.toml
@@ -1,0 +1,3 @@
+ReplaceComment    = "Pinned dependencies are noted in github.com/hashicorp/nomad/issues/11826."
+SubmodulesComment = "Nomad is built using the current source of the API module."
+WriteFile         = true


### PR DESCRIPTION
added support for a config file instead of passing arguments to flags in https://github.com/shoenig/go-modtool/releases/tag/v0.2.0

this will be nice when we invoke the `merge` utility in the merge script, so that we don't have to keep the arguments to the flags in sync in two places