### PR TITLE
E2E: extend timeout on CSI snapshot test

### DIFF
--- a/e2e/csi/ebs.go
+++ b/e2e/csi/ebs.go
@@ -4,7 +4,9 @@
 package csi
 
 import (
+	"context"
 	"fmt"
+	"os/exec"
 	"time"
 
 	"github.com/hashicorp/nomad/e2e/e2eutil"
@@ -195,8 +197,12 @@ func (tc *CSIControllerPluginEBSTest) TestVolumeClaim(f *framework.F) {
 // TestSnapshot exercises the snapshot commands.
 func (tc *CSIControllerPluginEBSTest) TestSnapshot(f *framework.F) {
 
-	out, err := e2eutil.Command("nomad", "volume", "snapshot", "create",
-		tc.volumeIDs[0], "snap-"+tc.uuid)
+	// EBS snapshots can take a very long time to run
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	bytes, err := exec.CommandContext(ctx, "nomad", "volume", "snapshot", "create",
+		tc.volumeIDs[0], "snap-"+tc.uuid).CombinedOutput()
+	out := string(bytes)
 	requireNoErrorElseDump(f, err, "could not create volume snapshot", tc.pluginJobIDs)
 
 	snaps, err := e2eutil.ParseColumns(out)


### PR DESCRIPTION
The EBS snapshot operation can take a long time to complete. Recent runs have shown we sometimes get up to the 10s timeout on the context we're giving the CLI command. Extend this so that we're not getting spurious timeouts.

Fixes: https://github.com/hashicorp/nomad/issues/19118

---

Note for reviewers: I'm just trying to get this test green, and not going thru and refactoring to get it off the old framework.

Example run:

```
$ go test -v -count=1 . -run 'TestE2E/CSI/\*csi\.CSIControllerPluginEBSTest'
=== RUN   TestE2E
=== RUN   TestE2E/CSI
=== RUN   TestE2E/CSI/*csi.CSIControllerPluginEBSTest
=== RUN   TestE2E/CSI/*csi.CSIControllerPluginEBSTest/TestNodeDrain
=== RUN   TestE2E/CSI/*csi.CSIControllerPluginEBSTest/TestSnapshot
=== RUN   TestE2E/CSI/*csi.CSIControllerPluginEBSTest/TestVolumeClaim
--- PASS: TestE2E (156.50s)
    --- PASS: TestE2E/CSI (156.50s)
        --- PASS: TestE2E/CSI/*csi.CSIControllerPluginEBSTest (156.50s)
            --- PASS: TestE2E/CSI/*csi.CSIControllerPluginEBSTest/TestNodeDrain (32.40s)
            --- PASS: TestE2E/CSI/*csi.CSIControllerPluginEBSTest/TestSnapshot (8.03s)
            --- PASS: TestE2E/CSI/*csi.CSIControllerPluginEBSTest/TestVolumeClaim (31.64s)
PASS
ok      github.com/hashicorp/nomad/e2e  156.518s
```