### PR TITLE
e2e: even more time for exec+java test jobs

### DIFF
--- a/e2e/isolation/pids_test.go
+++ b/e2e/isolation/pids_test.go
@@ -82,7 +82,7 @@ func testJavaNamespacePID(t *testing.T) {
 	job, cleanup := jobs3.Submit(t,
 		"./input/java.hcl",
 		jobs3.WaitComplete("group"),
-		jobs3.Timeout(time.Second*30), // exec prestart can be slow
+		jobs3.Timeout(time.Second*60), // exec prestart + java main
 	)
 	t.Cleanup(cleanup)
 
@@ -94,7 +94,7 @@ func testJavaHostPID(t *testing.T) {
 	job, cleanup := jobs3.Submit(t,
 		"./input/java_host.hcl",
 		jobs3.WaitComplete("group"),
-		jobs3.Timeout(time.Second*30), // exec prestart can be slow
+		jobs3.Timeout(time.Second*60), // exec prestart + java main
 	)
 	t.Cleanup(cleanup)
 
@@ -107,7 +107,7 @@ func testJavaHostPID(t *testing.T) {
 func testJavaNamespaceAllocExec(t *testing.T) {
 	job, cleanup := jobs3.Submit(t,
 		"./input/alloc_exec_java.hcl",
-		jobs3.Timeout(time.Second*30), // exec prestart can be slow
+		jobs3.Timeout(time.Second*60), // exec prestart + java main
 	)
 	t.Cleanup(cleanup)
 


### PR DESCRIPTION
I'm really hoping this is the last change for #16607.

This was the timing on the last run:

```
=== RUN   TestPIDs
=== RUN   TestPIDs/testExecNamespacePID
--- PASS: TestPIDs/testExecNamespacePID (11.42s)
=== RUN   TestPIDs/testExecHostPID
--- PASS: TestPIDs/testExecHostPID (11.44s)
=== RUN   TestPIDs/testExecNamespaceAllocExec
--- PASS: TestPIDs/testExecNamespaceAllocExec (14.96s)
=== RUN   TestPIDs/testJavaNamespacePID
    assert.go:14: 
        jobs3.go:409: expected not to execute this code path
        ↪ PostScript | annotation ↷
        	timeout reached waiting for alloc
--- FAIL: TestPIDs/testJavaNamespacePID (32.38s)
=== RUN   TestPIDs/testJavaHostPID
--- PASS: TestPIDs/testJavaHostPID (24.27s)
=== RUN   TestPIDs/testJavaNamespaceAllocExec
--- PASS: TestPIDs/testJavaNamespaceAllocExec (23.32s)
=== RUN   TestPIDs/testRawExecNoNamespacePID
--- PASS: TestPIDs/testRawExecNoNamespacePID (2.86s)
--- FAIL: TestPIDs (120.86s)
```

so I thiiink this should provide sufficient wiggle room for the java tests, which have an `exec` prestart that builds the binary for the `java` main task to run.