### PR TITLE
[ui] Two small UI quality of life changes

### DIFF
--- a/.changelog/19377.txt
+++ b/.changelog/19377.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: dont allow new jobspec download until template is populated, and remove group count from jobs index
+```

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -114,6 +114,6 @@
     @text="Save as .nomad.hcl"
     @color="secondary"
     {{on "click" @fns.onSaveFile}}
-
+    disabled={{not @data.job._newDefinition}}
   />
 </Hds::ButtonSet>

--- a/ui/app/templates/components/job-page/parts/children.hbs
+++ b/ui/app/templates/components/job-page/parts/children.hbs
@@ -52,9 +52,6 @@
           <t.sort-by @prop="status">
             Status
           </t.sort-by>
-          <th>
-            Groups
-          </th>
           <th class="is-3">
             Summary
           </th>

--- a/ui/app/templates/components/job-row.hbs
+++ b/ui/app/templates/components/job-row.hbs
@@ -53,13 +53,6 @@
     {{this.job.priority}}
   </td>
 {{/if}}
-<td data-test-job-task-groups>
-  {{#if this.job.taskGroupCount}}
-    {{this.job.taskGroupCount}}
-  {{else}}
-    --
-  {{/if}}
-</td>
 <td data-test-job-allocations>
   <div class="inline-chart">
     {{#if this.job.hasChildren}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -155,9 +155,6 @@
           <t.sort-by @prop="priority">
             Priority
           </t.sort-by>
-          <th>
-            Groups
-          </th>
           <th class="is-3">
             Summary
           </th>

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -63,7 +63,6 @@ module('Acceptance | jobs list', function (hooks) {
   test('each job row should contain information about the job', async function (assert) {
     server.createList('job', 2);
     const job = server.db.jobs.sortBy('modifyIndex').reverse()[0];
-    const taskGroups = server.db.taskGroups.where({ jobId: job.id });
 
     await JobsList.visit();
 
@@ -76,7 +75,6 @@ module('Acceptance | jobs list', function (hooks) {
     assert.equal(jobRow.status, job.status, 'Status');
     assert.equal(jobRow.type, typeForJob(job), 'Type');
     assert.equal(jobRow.priority, job.priority, 'Priority');
-    assert.equal(jobRow.taskGroups, taskGroups.length, '# Groups');
   });
 
   test('each job row should link to the corresponding job', async function (assert) {


### PR DESCRIPTION
- Disables the "Download as .nomad.hcl" button when running a job through the UI until the template has content (otherwise, you could download a blank file)
- Removes the # of groups column from the jobs index page table