### PR TITLE
numa: account for incorrect core number on topology.insert

### DIFF
--- a/.changelog/19383.txt
+++ b/.changelog/19383.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fix a panic in building CPU topology when inaccurate CPU data is provided
+```

--- a/client/lib/numalib/detect_linux.go
+++ b/client/lib/numalib/detect_linux.go
@@ -125,7 +125,9 @@ func (*Sysfs) discoverCores(st *Topology) {
 				max, _ := getNumeric[hw.KHz](cpuMaxFile, core)
 				base, _ := getNumeric[hw.KHz](cpuBaseFile, core)
 				siblings, _ := getIDSet[hw.CoreID](cpuSiblingFile, core)
-				st.insert(node, socket, core, gradeOf(siblings), max, base)
+				if err := st.insert(node, socket, core, gradeOf(siblings), max, base); err != nil {
+					return err
+				}
 				return nil
 			})
 			return nil

--- a/client/lib/numalib/detect_linux_test.go
+++ b/client/lib/numalib/detect_linux_test.go
@@ -18,14 +18,26 @@ import (
 // containers, virtualization guests
 func badSysData(path string) ([]byte, error) {
 	return map[string][]byte{
-		nodeOnline:     []byte("invalid data"),
-		cpuOnline:      []byte("1,3"),
-		distanceFile:   []byte("invalid data"),
-		cpulistFile:    []byte("invalid data"),
-		cpuMaxFile:     []byte("3200000"),
-		cpuBaseFile:    []byte("3200000"),
-		cpuSocketFile:  []byte("0"),
-		cpuSiblingFile: []byte("0,2"),
+		"/sys/devices/system/node/online":                            []byte("0"),
+		"/sys/devices/system/cpu/online":                             []byte("1,3"),
+		"/sys/devices/system/node/node0/distance":                    []byte("10"),
+		"/sys/devices/system/node/node0/cpulist":                     []byte("0-3"),
+		"/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu0/cpufreq/base_frequency":        []byte("2100000"),
+		"/sys/devices/system/cpu/cpu0/topology/physical_package_id":  []byte("0"),
+		"/sys/devices/system/cpu/cpu0/topology/thread_siblings_list": []byte("0,2"),
+		"/sys/devices/system/cpu/cpu1/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu1/cpufreq/base_frequency":        []byte("2100000"),
+		"/sys/devices/system/cpu/cpu1/topology/physical_package_id":  []byte("0"),
+		"/sys/devices/system/cpu/cpu1/topology/thread_siblings_list": []byte("1,3"),
+		"/sys/devices/system/cpu/cpu2/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu2/cpufreq/base_frequency":        []byte("2100000"),
+		"/sys/devices/system/cpu/cpu2/topology/physical_package_id":  []byte("0"),
+		"/sys/devices/system/cpu/cpu2/topology/thread_siblings_list": []byte("0,2"),
+		"/sys/devices/system/cpu/cpu3/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu3/cpufreq/base_frequency":        []byte("2100000"),
+		"/sys/devices/system/cpu/cpu3/topology/physical_package_id":  []byte("0"),
+		"/sys/devices/system/cpu/cpu3/topology/thread_siblings_list": []byte("1,3"),
 	}[path], nil
 }
 
@@ -33,39 +45,40 @@ func goodSysData(path string) ([]byte, error) {
 	return map[string][]byte{
 		"/sys/devices/system/node/online":                            []byte("0-1"),
 		"/sys/devices/system/cpu/online":                             []byte("0-3"),
-		"/sys/devices/system/node0/distance":                         []byte("10"),
-		"/sys/devices/system/node0/cpulist":                          []byte("0-3"),
-		"/sys/devices/system/node1/distance":                         []byte("10"),
-		"/sys/devices/system/node1/cpulist":                          []byte("0-3"),
-		"/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq":      []byte("3200000"),
-		"/sys/devices/system/cpu/cpu0/cpufreq/base_frequency":        []byte("3200000"),
+		"/sys/devices/system/node/node0/distance":                    []byte("10"),
+		"/sys/devices/system/node/node0/cpulist":                     []byte("0-3"),
+		"/sys/devices/system/node/node1/distance":                    []byte("10"),
+		"/sys/devices/system/node/node1/cpulist":                     []byte("0-3"),
+		"/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu0/cpufreq/base_frequency":        []byte("2100000"),
 		"/sys/devices/system/cpu/cpu0/topology/physical_package_id":  []byte("0"),
 		"/sys/devices/system/cpu/cpu0/topology/thread_siblings_list": []byte("0,2"),
-		"/sys/devices/system/cpu/cpu1/cpufreq/cpuinfo_max_freq":      []byte("3200000"),
-		"/sys/devices/system/cpu/cpu1/cpufreq/base_frequency":        []byte("3200000"),
+		"/sys/devices/system/cpu/cpu1/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu1/cpufreq/base_frequency":        []byte("2100000"),
 		"/sys/devices/system/cpu/cpu1/topology/physical_package_id":  []byte("0"),
-		"/sys/devices/system/cpu/cpu1/topology/thread_siblings_list": []byte("0,2"),
-		"/sys/devices/system/cpu/cpu2/cpufreq/cpuinfo_max_freq":      []byte("3200000"),
-		"/sys/devices/system/cpu/cpu2/cpufreq/base_frequency":        []byte("3200000"),
+		"/sys/devices/system/cpu/cpu1/topology/thread_siblings_list": []byte("1,3"),
+		"/sys/devices/system/cpu/cpu2/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu2/cpufreq/base_frequency":        []byte("2100000"),
 		"/sys/devices/system/cpu/cpu2/topology/physical_package_id":  []byte("0"),
 		"/sys/devices/system/cpu/cpu2/topology/thread_siblings_list": []byte("0,2"),
-		"/sys/devices/system/cpu/cpu3/cpufreq/cpuinfo_max_freq":      []byte("3200000"),
-		"/sys/devices/system/cpu/cpu3/cpufreq/base_frequency":        []byte("3200000"),
+		"/sys/devices/system/cpu/cpu3/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu3/cpufreq/base_frequency":        []byte("2100000"),
 		"/sys/devices/system/cpu/cpu3/topology/physical_package_id":  []byte("0"),
-		"/sys/devices/system/cpu/cpu3/topology/thread_siblings_list": []byte("0,2"),
+		"/sys/devices/system/cpu/cpu3/topology/thread_siblings_list": []byte("1,3"),
 	}[path], nil
 }
 
 func TestSysfs_discoverOnline(t *testing.T) {
 	st := NewTopology(&idset.Set[hw.NodeID]{}, SLIT{}, []Core{})
 	goodIDSet := idset.From[hw.NodeID]([]uint8{0, 1})
+	oneNode := idset.From[hw.NodeID]([]uint8{0})
 
 	tests := []struct {
 		name          string
 		readerFunc    pathReaderFn
 		expectedIDSet *idset.Set[hw.NodeID]
 	}{
-		{"lxc values", badSysData, idset.Empty[hw.NodeID]()},
+		{"lxc values", badSysData, oneNode},
 		{"good values", goodSysData, goodIDSet},
 	}
 	for _, tt := range tests {
@@ -94,7 +107,7 @@ func TestSysfs_discoverCosts(t *testing.T) {
 		}},
 		{"two nodes and good sys data", twoNodes, goodSysData, SLIT{
 			[]Cost{0, 0},
-			[]Cost{0, 0},
+			[]Cost{10, 0},
 		}},
 	}
 	for _, tt := range tests {
@@ -109,16 +122,75 @@ func TestSysfs_discoverCosts(t *testing.T) {
 
 func TestSysfs_discoverCores(t *testing.T) {
 	st := NewTopology(idset.Empty[hw.NodeID](), SLIT{}, []Core{})
-	// twoNodes := idset.From[hw.NodeID]([]uint8{1, 3})
+	oneNode := idset.From[hw.NodeID]([]uint8{0})
+	twoNodes := idset.From[hw.NodeID]([]uint8{1, 3})
 
 	tests := []struct {
 		name             string
-		onlineCores      *idset.Set[hw.CoreID]
 		nodeIDs          *idset.Set[hw.NodeID]
 		readerFunc       pathReaderFn
 		expectedTopology *Topology
 	}{
-		{"empty node IDs", idset.Empty[hw.CoreID](), idset.Empty[hw.NodeID](), os.ReadFile, &Topology{}},
+		{"empty core and node IDs", idset.Empty[hw.NodeID](), os.ReadFile, &Topology{}},
+		{"empty node IDs", idset.Empty[hw.NodeID](), goodSysData, &Topology{}},
+		{"one node and bad sys data", oneNode, badSysData, &Topology{
+			NodeIDs: oneNode,
+			Cores: []Core{
+				{
+					SocketID:  0,
+					NodeID:    0,
+					ID:        0,
+					Grade:     Performance,
+					BaseSpeed: 2100,
+					MaxSpeed:  3500,
+				},
+				{
+					SocketID:  0,
+					NodeID:    0,
+					ID:        1,
+					Grade:     Performance,
+					BaseSpeed: 2100,
+					MaxSpeed:  3500,
+				},
+			},
+		}}, // issue#19372
+		{"two nodes and good sys data", twoNodes, goodSysData, &Topology{
+			NodeIDs: twoNodes,
+			Cores: []Core{
+				{
+					SocketID:  1,
+					NodeID:    0,
+					ID:        0,
+					Grade:     Performance,
+					BaseSpeed: 2100,
+					MaxSpeed:  3500,
+				},
+				{
+					SocketID:  1,
+					NodeID:    0,
+					ID:        1,
+					Grade:     Performance,
+					BaseSpeed: 2100,
+					MaxSpeed:  3500,
+				},
+				{
+					SocketID:  1,
+					NodeID:    0,
+					ID:        2,
+					Grade:     Performance,
+					BaseSpeed: 2100,
+					MaxSpeed:  3500,
+				},
+				{
+					SocketID:  1,
+					NodeID:    0,
+					ID:        3,
+					Grade:     Performance,
+					BaseSpeed: 2100,
+					MaxSpeed:  3500,
+				},
+			},
+		}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/client/lib/numalib/detect_linux_test.go
+++ b/client/lib/numalib/detect_linux_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build linux
+
+package numalib
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
+	"github.com/shoenig/test/must"
+)
+
+// badValues are example values from sysfs on unsupported platforms, e.g.,
+// containers, virtualization guests
+func badValues(path string) ([]byte, error) {
+	return map[string][]byte{
+		nodeOnline:     []byte("invalid or corrupted node online info"),
+		cpuOnline:      []byte("1,3"),
+		distanceFile:   []byte("invalid or corrupted distances"),
+		cpulistFile:    []byte("invalid or corrupted cpu list"),
+		cpuMaxFile:     []byte("3200000"),
+		cpuBaseFile:    []byte("3200000"),
+		cpuSocketFile:  []byte("0"),
+		cpuSiblingFile: []byte("0,2"),
+	}[path], nil
+}
+
+func goodValues(path string) ([]byte, error) {
+	return map[string][]byte{
+		nodeOnline:     []byte("0"),
+		cpuOnline:      []byte("0-3"),
+		distanceFile:   []byte("10"),
+		cpulistFile:    []byte("0-3"),
+		cpuMaxFile:     []byte("3200000"),
+		cpuBaseFile:    []byte("3200000"),
+		cpuSocketFile:  []byte("0"),
+		cpuSiblingFile: []byte("0,2"),
+	}[path], nil
+}
+

--- a/client/lib/numalib/detect_linux_test.go
+++ b/client/lib/numalib/detect_linux_test.go
@@ -41,3 +41,32 @@ func goodValues(path string) ([]byte, error) {
 	}[path], nil
 }
 
+func TestSysfs_discoverOnline(t *testing.T) {
+
+	type args struct {
+		st         *Topology
+		readerFunc pathReaderFn
+	}
+
+	st := NewTopology(&idset.Set[hw.NodeID]{}, SLIT{}, []Core{})
+	lxcTest := args{st, badValues}
+	goodTest := args{st, goodValues}
+	goodIDSet := idset.From[hw.NodeID]([]uint8{0})
+
+	tests := []struct {
+		name          string
+		args          args
+		expectedIDSet *idset.Set[hw.NodeID]
+	}{
+		{"lxc values", lxcTest, idset.Empty[hw.NodeID]()},
+		{"good values", goodTest, goodIDSet},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sy := &Sysfs{}
+			sy.discoverOnline(tt.args.st, tt.args.readerFunc)
+			must.Eq(t, tt.expectedIDSet, tt.args.st.NodeIDs)
+		})
+	}
+}
+

--- a/client/lib/numalib/detect_linux_test.go
+++ b/client/lib/numalib/detect_linux_test.go
@@ -19,9 +19,9 @@ import (
 func badSysData(path string) ([]byte, error) {
 	return map[string][]byte{
 		"/sys/devices/system/node/online":                            []byte("0"),
-		"/sys/devices/system/cpu/online":                             []byte("1,3"),
+		"/sys/devices/system/cpu/online":                             []byte("1,3"), // cpuOnline data indicates 2 CPU IDs online: 1 and 3
 		"/sys/devices/system/node/node0/distance":                    []byte("10"),
-		"/sys/devices/system/node/node0/cpulist":                     []byte("0-3"),
+		"/sys/devices/system/node/node0/cpulist":                     []byte("0-3"), // cpuList data indicates 4 CPU cores available on node0 (can't be true)
 		"/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
 		"/sys/devices/system/cpu/cpu0/cpufreq/base_frequency":        []byte("2100000"),
 		"/sys/devices/system/cpu/cpu0/topology/physical_package_id":  []byte("0"),
@@ -133,6 +133,8 @@ func TestSysfs_discoverCores(t *testing.T) {
 	}{
 		{"empty core and node IDs", idset.Empty[hw.NodeID](), os.ReadFile, &Topology{}},
 		{"empty node IDs", idset.Empty[hw.NodeID](), goodSysData, &Topology{}},
+
+		// issue#19372
 		{"one node and bad sys data", oneNode, badSysData, &Topology{
 			NodeIDs: oneNode,
 			Cores: []Core{
@@ -153,7 +155,7 @@ func TestSysfs_discoverCores(t *testing.T) {
 					MaxSpeed:  3500,
 				},
 			},
-		}}, // issue#19372
+		}},
 		{"two nodes and good sys data", twoNodes, goodSysData, &Topology{
 			NodeIDs: twoNodes,
 			Cores: []Core{

--- a/client/lib/numalib/topology.go
+++ b/client/lib/numalib/topology.go
@@ -63,6 +63,12 @@ type Topology struct {
 	OverrideWitholdCompute hw.MHz
 }
 
+// NewTopology is a constructor for the Topology object, only used in tests for
+// mocking.
+func NewTopology(nodeIDs *idset.Set[hw.NodeID], distances SLIT, cores []Core) *Topology {
+	return &Topology{NodeIDs: nodeIDs, Distances: distances, Cores: cores}
+}
+
 // A Core represents one logical (vCPU) core on a processor. Basically the slice
 // of cores detected should match up with the vCPU description in cloud providers.
 type Core struct {
@@ -152,21 +158,15 @@ func (st *Topology) NodeCores(node hw.NodeID) *idset.Set[hw.CoreID] {
 	return result
 }
 
-func (st *Topology) insert(node hw.NodeID, socket hw.SocketID, core hw.CoreID, grade CoreGrade, max, base hw.KHz) error {
-	if int(core) <= len(st.Cores) {
-		st.Cores[core] = Core{
-			NodeID:    node,
-			SocketID:  socket,
-			ID:        core,
-			Grade:     grade,
-			MaxSpeed:  max.MHz(),
-			BaseSpeed: base.MHz(),
-		}
-	} else {
-		return fmt.Errorf("incorrect core number")
+func (st *Topology) insert(node hw.NodeID, socket hw.SocketID, core hw.CoreID, grade CoreGrade, max, base hw.KHz) {
+	st.Cores[core] = Core{
+		NodeID:    node,
+		SocketID:  socket,
+		ID:        core,
+		Grade:     grade,
+		MaxSpeed:  max.MHz(),
+		BaseSpeed: base.MHz(),
 	}
-
-	return nil
 }
 
 func (st *Topology) String() string {

--- a/client/lib/numalib/topology.go
+++ b/client/lib/numalib/topology.go
@@ -152,15 +152,21 @@ func (st *Topology) NodeCores(node hw.NodeID) *idset.Set[hw.CoreID] {
 	return result
 }
 
-func (st *Topology) insert(node hw.NodeID, socket hw.SocketID, core hw.CoreID, grade CoreGrade, max, base hw.KHz) {
-	st.Cores[core] = Core{
-		NodeID:    node,
-		SocketID:  socket,
-		ID:        core,
-		Grade:     grade,
-		MaxSpeed:  max.MHz(),
-		BaseSpeed: base.MHz(),
+func (st *Topology) insert(node hw.NodeID, socket hw.SocketID, core hw.CoreID, grade CoreGrade, max, base hw.KHz) error {
+	if int(core) <= len(st.Cores) {
+		st.Cores[core] = Core{
+			NodeID:    node,
+			SocketID:  socket,
+			ID:        core,
+			Grade:     grade,
+			MaxSpeed:  max.MHz(),
+			BaseSpeed: base.MHz(),
+		}
+	} else {
+		return fmt.Errorf("incorrect core number")
 	}
+
+	return nil
 }
 
 func (st *Topology) String() string {


### PR DESCRIPTION
Unsupported environments like containers or guests OSs inside LXD can incorrectly number of available cores thus leading to numalib having trouble detecting cores and panicking. This code adds tests for linux sysfs detection methods and fixes the panic from #19372. 