### PR TITLE
update PKI example in template spec with the new pkiCert function

### DIFF
--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -640,8 +640,8 @@ multiple templates watching the same path return the same data.
 ```hcl
 template {
   data = <<EOH
-{{ with secret "pki/issue/foo" "common_name=foo.service.consul" "ip_sans=127.0.0.1" }}
-{{- .Data.certificate -}}
+{{ with pkiCert "pki/issue/foo" "common_name=foo.service.consul" "ip_sans=127.0.0.1" }}
+{{- .Cert -}}
 {{ end }}
 EOH
   destination   = "${NOMAD_SECRETS_DIR}/certificate.crt"
@@ -650,8 +650,8 @@ EOH
 
 template {
   data = <<EOH
-{{ with secret "pki/issue/foo" "common_name=foo.service.consul" "ip_sans=127.0.0.1" }}
-{{- .Data.issuing_ca -}}
+{{ with pkiCert "pki/issue/foo" "common_name=foo.service.consul" "ip_sans=127.0.0.1" }}
+{{- .CA -}}
 {{ end }}
 EOH
   destination   = "${NOMAD_SECRETS_DIR}/ca.crt"
@@ -660,8 +660,8 @@ EOH
 
 template {
   data = <<EOH
-{{ with secret "pki/issue/foo" "common_name=foo.service.consul" "ip_sans=127.0.0.1" }}
-{{- .Data.private_key -}}
+{{ with pkiCert "pki/issue/foo" "common_name=foo.service.consul" "ip_sans=127.0.0.1" }}
+{{- .Key -}}
 {{ end }}
 EOH
   destination   = "${NOMAD_SECRETS_DIR}/private_key.key"
@@ -681,10 +681,10 @@ directory.
 ```hcl
 template {
   data = <<EOH
-{{ with secret "pki/issue/foo" "common_name=foo.service.consul" "ip_sans=127.0.0.1" "format=pem" }}
-{{ .Data.certificate }}
-{{ .Data.issuing_ca }}
-{{ .Data.private_key }}{{ end }}
+{{ with pkiCert "pki/issue/foo" "common_name=foo.service.consul" "ip_sans=127.0.0.1" "format=pem" }}
+{{ .Cert }}
+{{ .CA }}
+{{ .Key }}{{ end }}
 EOH
   destination   = "${NOMAD_SECRETS_DIR}/bundle.pem"
   change_mode   = "restart"


### PR DESCRIPTION
Since `consul-template` ~0.29 (current version 0.35, 0.29 is in Nomad since 1.4.0) there's a dedicated function, `pkiCert`, for certificates. It handles them better (most notably doesn't rotate at startup if there's an already existing certificate which is still valid, which in a Nomad context could result in lots of unneeded rotations.