### PR TITLE
auth: respect default `tls.verify_server_hostname=false`

### DIFF
--- a/.changelog/19425.txt
+++ b/.changelog/19425.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth: Fixed a bug where `tls.verify_server_hostname=false` was not respected, leading to authentication failures between Nomad agents
+```

--- a/nomad/auth/auth.go
+++ b/nomad/auth/auth.go
@@ -41,7 +41,7 @@ type Encrypter interface {
 
 type Authenticator struct {
 	aclsEnabled  bool
-	tlsEnabled   bool
+	verifyTLS    bool
 	logger       hclog.Logger
 	getState     StateGetter
 	getLeaderACL LeaderACLGetter
@@ -63,7 +63,7 @@ type AuthenticatorConfig struct {
 	Logger         hclog.Logger
 	GetLeaderACLFn LeaderACLGetter
 	AclsEnabled    bool
-	TLSEnabled     bool
+	VerifyTLS      bool
 	Region         string
 	Encrypter      Encrypter
 }
@@ -71,7 +71,7 @@ type AuthenticatorConfig struct {
 func NewAuthenticator(cfg *AuthenticatorConfig) *Authenticator {
 	return &Authenticator{
 		aclsEnabled:          cfg.AclsEnabled,
-		tlsEnabled:           cfg.TLSEnabled,
+		verifyTLS:            cfg.VerifyTLS,
 		logger:               cfg.Logger.With("auth"),
 		getState:             cfg.StateFn,
 		getLeaderACL:         cfg.GetLeaderACLFn,
@@ -251,7 +251,7 @@ func (s *Authenticator) AuthenticateServerOnly(ctx RPCContext, args structs.Requ
 	identity := &structs.AuthenticatedIdentity{RemoteIP: remoteIP}
 	defer args.SetIdentity(identity) // always set the identity, even on errors
 
-	if s.tlsEnabled && !ctx.IsStatic() {
+	if s.verifyTLS && !ctx.IsStatic() {
 		tlsCert := ctx.Certificate()
 		if tlsCert == nil {
 			return nil, errors.New("missing certificate information")
@@ -294,7 +294,7 @@ func (s *Authenticator) AuthenticateClientOnly(ctx RPCContext, args structs.Requ
 	identity := &structs.AuthenticatedIdentity{RemoteIP: remoteIP}
 	defer args.SetIdentity(identity) // always set the identity, even on errors
 
-	if s.tlsEnabled && !ctx.IsStatic() {
+	if s.verifyTLS && !ctx.IsStatic() {
 		tlsCert := ctx.Certificate()
 		if tlsCert == nil {
 			return nil, errors.New("missing certificate information")
@@ -342,7 +342,7 @@ func (s *Authenticator) AuthenticateClientOnlyLegacy(ctx RPCContext, args struct
 	identity := &structs.AuthenticatedIdentity{RemoteIP: remoteIP}
 	defer args.SetIdentity(identity) // always set the identity, even on errors
 
-	if s.tlsEnabled && !ctx.IsStatic() {
+	if s.verifyTLS && !ctx.IsStatic() {
 		tlsCert := ctx.Certificate()
 		if tlsCert == nil {
 			return nil, errors.New("missing certificate information")

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -446,7 +446,7 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigFunc
 		Logger:         s.logger,
 		GetLeaderACLFn: s.getLeaderAcl,
 		AclsEnabled:    s.config.ACLEnabled,
-		TLSEnabled:     s.config.TLSConfig != nil && s.config.TLSConfig.EnableRPC,
+		VerifyTLS:      s.config.TLSConfig != nil && s.config.TLSConfig.EnableRPC && s.config.TLSConfig.VerifyServerHostname,
 		Region:         s.Region(),
 		Encrypter:      s.encrypter,
 	})


### PR DESCRIPTION
In Nomad 1.7.0, we refactored much of the authentication code to eliminate nil ACLs and create "virtual" ACL objects that can be used to reduce the risk of fail-open security bugs. In doing so, we accidentally dropped support for the default `tls.verify_server_hostname=false` option.

Fix the bug by including the field in the set of conditions we check for the TLS argument we pass into the constructor (this keeps "policy" separate from "mechanism" in the auth code and reduces the number of dimensions we need to test). Change the field name in the Authenticator to better match the intent.

Fixes: https://github.com/hashicorp/nomad/issues/19405