### PR TITLE
[ui] Fix a small regression where accessor is hidden by default when editing a token

### DIFF
--- a/.changelog/19432.txt
+++ b/.changelog/19432.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed an issue where Accessor ID was masked by default when editing a token
+```

--- a/ui/app/components/token-editor.hbs
+++ b/ui/app/components/token-editor.hbs
@@ -83,7 +83,7 @@
 
   {{#unless @token.isNew}}
   <div>
-    <Hds::Form::MaskedInput::Field @isMasked={{false}} @hasCopyButton={{true}} @value={{@token.accessor}} readonly data-test-token-accessor as |F|>
+    <Hds::Form::MaskedInput::Field @isContentMasked={{false}} @hasCopyButton={{true}} @value={{@token.accessor}} readonly data-test-token-accessor as |F|>
       <F.Label>Token Accessor</F.Label>
     </Hds::Form::MaskedInput::Field>
   </div>


### PR DESCRIPTION
When editing or viewing a newly created token, we want the Accessor to be visible (and the secret masked).

The [Helios masked input component](https://helios.hashicorp.design/components/form/masked-input?tab=code#formmaskedinputfield-1) recently changed the property for this from `isMasked` to `isContentMasked`, so updating it here to follow up our [Helios upgrade](https://github.com/hashicorp/nomad/pull/19247):

<img width="894" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/29014725-87a7-4b32-96e5-cf676c48ac41">
