### PR TITLE
e2e: unflake testTaskImageChroot

### DIFF
--- a/e2e/isolation/input/chroot_docker.nomad
+++ b/e2e/isolation/input/chroot_docker.nomad
@@ -17,7 +17,7 @@ job "chroot_docker" {
         args = [
           "/bin/sh",
           "-c",
-          "echo $NOMAD_ALLOC_DIR; echo $NOMAD_TASK_DIR; echo $NOMAD_SECRETS_DIR; echo $PATH"
+          "echo $NOMAD_ALLOC_DIR; echo $NOMAD_TASK_DIR; echo $NOMAD_SECRETS_DIR; echo $PATH; sleep 2"
         ]
       }
       resources {


### PR DESCRIPTION
assuming this is similar to #19381, this theoretically fixes

```
=== RUN   TestChrootFS/testTaskImageChroot
    assert.go:14: 
        chroot_test.go:69: expected regexp match
        ↪  regex: (?m:^/local\b)
        ↪ string: /alloc
--- FAIL: TestChrootFS/testTaskImageChroot (3.55s)
```

which is expecting stuff in alloc logs of a very-fast docker job.