### PR TITLE
vault: load default config for tasks without vault

### DIFF
--- a/.changelog/19439.txt
+++ b/.changelog/19439.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault: Fixed a bug that caused `template` blocks to ignore Nomad configuration for Vault and use the default address of `https://127.0.0.1:8200` when the job does not have a `vault` block defined
+```


### PR DESCRIPTION
It is often expected that a task that needs access to Vault defines a `vault` block to specify the Vault policy to use to derive a token.

But in some scenarios, like when the Nomad client is connected to a local Vault agent that is responsible for authn/authz, the task is not required to defined a `vault` block.

In these situations, the `default` Vault cluster should be used to render the template.

Closes https://github.com/hashicorp/nomad/issues/19380