### PR TITLE
consul: fix constraints for non-default clusters (ENT)

### DIFF
--- a/.changelog/19449.txt
+++ b/.changelog/19449.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul (Enterprise): Fixed a bug where implicit Consul constraints were not specific to non-default Consul clusters
+```

--- a/nomad/job_endpoint_hook_connect_test.go
+++ b/nomad/job_endpoint_hook_connect_test.go
@@ -112,11 +112,11 @@ func TestJobEndpointConnect_groupConnectGuessTaskDriver(t *testing.T) {
 func TestJobEndpointConnect_newConnectSidecarTask(t *testing.T) {
 	ci.Parallel(t)
 
-	task := newConnectSidecarTask("redis", "podman")
+	task := newConnectSidecarTask("redis", "podman", structs.ConsulDefaultCluster)
 	must.Eq(t, "connect-proxy-redis", task.Name)
 	must.Eq(t, "podman", task.Driver)
 
-	task2 := newConnectSidecarTask("db", "docker")
+	task2 := newConnectSidecarTask("db", "docker", structs.ConsulDefaultCluster)
 	must.Eq(t, "connect-proxy-db", task2.Name)
 	must.Eq(t, "docker", task2.Driver)
 }
@@ -154,8 +154,8 @@ func TestJobEndpointConnect_groupConnectHook(t *testing.T) {
 	// Expected tasks
 	tgExp := job.TaskGroups[0].Copy()
 	tgExp.Tasks = []*structs.Task{
-		newConnectSidecarTask("backend", "docker"),
-		newConnectSidecarTask("admin", "docker"),
+		newConnectSidecarTask("backend", "docker", structs.ConsulDefaultCluster),
+		newConnectSidecarTask("admin", "docker", structs.ConsulDefaultCluster),
 	}
 	tgExp.Services[0].Name = "backend"
 	tgExp.Services[1].Name = "admin"
@@ -200,7 +200,8 @@ func TestJobEndpointConnect_groupConnectHook_IngressGateway_BridgeNetwork(t *tes
 	expTG := job.TaskGroups[0].Copy()
 	expTG.Tasks = []*structs.Task{
 		// inject the gateway task
-		newConnectGatewayTask(structs.ConnectIngressPrefix, "my-gateway", false, true),
+		newConnectGatewayTask(structs.ConnectIngressPrefix, "my-gateway",
+			structs.ConsulDefaultCluster, false, true),
 	}
 	expTG.Services[0].Name = "my-gateway"
 	expTG.Tasks[0].Canonicalize(job, expTG)
@@ -239,7 +240,8 @@ func TestJobEndpointConnect_groupConnectHook_IngressGateway_HostNetwork(t *testi
 	expTG := job.TaskGroups[0].Copy()
 	expTG.Tasks = []*structs.Task{
 		// inject the gateway task
-		newConnectGatewayTask(structs.ConnectIngressPrefix, "my-gateway", true, false),
+		newConnectGatewayTask(structs.ConnectIngressPrefix, "my-gateway",
+			structs.ConsulDefaultCluster, true, false),
 	}
 	expTG.Services[0].Name = "my-gateway"
 	expTG.Tasks[0].Canonicalize(job, expTG)
@@ -305,8 +307,8 @@ func TestJobEndpointConnect_groupConnectHook_IngressGateway_CustomTask(t *testin
 			ShutdownDelay: 5 * time.Second,
 			KillSignal:    "SIGHUP",
 			Constraints: structs.Constraints{
-				connectGatewayVersionConstraint(),
-				connectListenerConstraint(),
+				connectGatewayVersionConstraint(structs.ConsulDefaultCluster),
+				connectListenerConstraint(structs.ConsulDefaultCluster),
 			},
 		},
 	}
@@ -341,7 +343,8 @@ func TestJobEndpointConnect_groupConnectHook_TerminatingGateway(t *testing.T) {
 	expTG := job.TaskGroups[0].Copy()
 	expTG.Tasks = []*structs.Task{
 		// inject the gateway task
-		newConnectGatewayTask(structs.ConnectTerminatingPrefix, "my-gateway", false, false),
+		newConnectGatewayTask(structs.ConnectTerminatingPrefix, "my-gateway",
+			structs.ConsulDefaultCluster, false, false),
 	}
 	expTG.Services[0].Name = "my-gateway"
 	expTG.Tasks[0].Canonicalize(job, expTG)
@@ -375,7 +378,8 @@ func TestJobEndpointConnect_groupConnectHook_MeshGateway(t *testing.T) {
 	expTG := job.TaskGroups[0].Copy()
 	expTG.Tasks = []*structs.Task{
 		// inject the gateway task
-		newConnectGatewayTask(structs.ConnectMeshPrefix, "my-gateway", false, false),
+		newConnectGatewayTask(structs.ConnectMeshPrefix, "my-gateway",
+			structs.ConsulDefaultCluster, false, false),
 	}
 	expTG.Services[0].Name = "my-gateway"
 	expTG.Services[0].PortLabel = "public_port"
@@ -694,20 +698,36 @@ func TestJobEndpointConnect_newConnectGatewayTask_host(t *testing.T) {
 	ci.Parallel(t)
 
 	t.Run("ingress", func(t *testing.T) {
-		task := newConnectGatewayTask(structs.ConnectIngressPrefix, "foo", true, false)
-		require.Equal(t, "connect-ingress-foo", task.Name)
-		require.Equal(t, "connect-ingress:foo", string(task.Kind))
-		require.Equal(t, ">= 1.8.0", task.Constraints[0].RTarget)
-		require.Equal(t, "host", task.Config["network_mode"])
+		task := newConnectGatewayTask(structs.ConnectIngressPrefix, "foo",
+			structs.ConsulDefaultCluster, true, false)
+		must.Eq(t, "connect-ingress-foo", task.Name)
+		must.Eq(t, "connect-ingress:foo", string(task.Kind))
+		must.Eq(t, "${attr.consul.version}", task.Constraints[0].LTarget)
+		must.Eq(t, ">= 1.8.0", task.Constraints[0].RTarget)
+		must.Eq(t, "host", task.Config["network_mode"])
 		require.Nil(t, task.Lifecycle)
 	})
 
 	t.Run("terminating", func(t *testing.T) {
-		task := newConnectGatewayTask(structs.ConnectTerminatingPrefix, "bar", true, false)
-		require.Equal(t, "connect-terminating-bar", task.Name)
-		require.Equal(t, "connect-terminating:bar", string(task.Kind))
-		require.Equal(t, ">= 1.8.0", task.Constraints[0].RTarget)
-		require.Equal(t, "host", task.Config["network_mode"])
+		task := newConnectGatewayTask(structs.ConnectTerminatingPrefix, "bar",
+			structs.ConsulDefaultCluster, true, false)
+		must.Eq(t, "connect-terminating-bar", task.Name)
+		must.Eq(t, "connect-terminating:bar", string(task.Kind))
+		must.Eq(t, "${attr.consul.version}", task.Constraints[0].LTarget)
+		must.Eq(t, ">= 1.8.0", task.Constraints[0].RTarget)
+		must.Eq(t, "host", task.Config["network_mode"])
+		require.Nil(t, task.Lifecycle)
+	})
+
+	// this case can only happen on ENT but gets run in CE code
+	t.Run("terminating nondefault (ENT)", func(t *testing.T) {
+		task := newConnectGatewayTask(structs.ConnectTerminatingPrefix, "bar",
+			"nondefault", true, false)
+		must.Eq(t, "connect-terminating-bar", task.Name)
+		must.Eq(t, "connect-terminating:bar", string(task.Kind))
+		must.Eq(t, "${attr.consul.nondefault.version}", task.Constraints[0].LTarget)
+		must.Eq(t, ">= 1.8.0", task.Constraints[0].RTarget)
+		must.Eq(t, "host", task.Config["network_mode"])
 		require.Nil(t, task.Lifecycle)
 	})
 }
@@ -715,7 +735,8 @@ func TestJobEndpointConnect_newConnectGatewayTask_host(t *testing.T) {
 func TestJobEndpointConnect_newConnectGatewayTask_bridge(t *testing.T) {
 	ci.Parallel(t)
 
-	task := newConnectGatewayTask(structs.ConnectIngressPrefix, "service1", false, false)
+	task := newConnectGatewayTask(structs.ConnectIngressPrefix, "service1",
+		structs.ConsulDefaultCluster, false, false)
 	require.NotContains(t, task.Config, "network_mode")
 }
 


### PR DESCRIPTION
The Connect-related constraints injected by the Connect job mutating hook do not account for non-default `consul` blocks (for Nomad Enterprise). This works when both the default and non-default clusters are available and are the same version, but not when they do not.

Fixes: https://github.com/hashicorp/nomad/issues/19442