### PR TITLE
[ui] When Action output is long enough, keep a user scroll-anchored to the bottom

### DIFF
--- a/.changelog/19452.txt
+++ b/.changelog/19452.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: when an Action has long output, anchor to the latest messages
+```

--- a/ui/app/components/action-card.hbs
+++ b/ui/app/components/action-card.hbs
@@ -71,7 +71,12 @@
       <code><pre>Error: {{this.instance.error}}</pre></code>
     {{/if}}
     {{#if this.instance.messages.length}}
-      <code><pre>{{this.instance.messages}}</pre></code>
+      <code tabindex="0">
+        <pre {{did-update this.anchorToBottom this.instance.messages}}>
+          {{this.instance.messages}}
+        </pre>
+        <div class="anchor" />
+      </code>
     {{else}}
       {{#if (eq this.instance.state "complete")}}
         <p class="no-messages">Action completed with no output</p>

--- a/ui/app/components/action-card.js
+++ b/ui/app/components/action-card.js
@@ -48,4 +48,30 @@ export default class ActionCardComponent extends Component {
     // Either the passed instance, or the peer-selected instance
     return this.selectedPeer || this.args.instance;
   }
+
+  @tracked hasBeenAnchored = false;
+
+  /**
+   * Runs from the action-card template whenever instance.messages updates,
+   * and serves to keep the user's view anchored to the bottom of the messages.
+   * This uses a hidden element and the overflow-anchor css attribute, which
+   * keeps the element visible within the scrollable <code> block parent.
+   * A trick here is that, if the user scrolls up from the bottom of the block,
+   * we don't want to force them down to the bottom again on update, but we do
+   * want to keep them there by default (so they have the latest output).
+   * The hasBeenAnchored flag is used to track this state, and we do a little
+   * trick when the messages get long enough to cause a scroll to start the
+   * anchoring process here.
+   *
+   * @param {HTMLElement} element
+   */
+  @action anchorToBottom(element) {
+    if (this.hasBeenAnchored) return;
+    const parentHeight = element.parentElement.clientHeight;
+    const elementHeight = element.clientHeight;
+    if (elementHeight > parentHeight) {
+      this.hasBeenAnchored = true;
+      element.parentElement.scroll(0, elementHeight);
+    }
+  }
 }

--- a/ui/app/styles/components/actions.scss
+++ b/ui/app/styles/components/actions.scss
@@ -117,14 +117,30 @@
       }
 
       .messages {
+        width: 100%;
         overflow: hidden;
 
-        code > pre {
-          height: 200px;
+        code {
           background-color: #0a0a0a;
           color: whitesmoke;
+          display: block;
+          overflow: auto;
+          height: 200px;
           border-radius: 6px;
           resize: vertical;
+          pre {
+            background-color: transparent;
+            color: unset;
+            overflow-anchor: none;
+            min-height: 100%;
+            white-space: pre-wrap;
+          }
+          .anchor {
+            overflow-anchor: auto;
+            height: 1px;
+            margin-top: -1px;
+            visibility: hidden;
+          }
         }
       }
 


### PR DESCRIPTION
Uses overflow-anchor (shoutout to https://css-tricks.com/books/greatest-css-tricks/pin-scrolling-to-bottom/) to keep long-running or tall Actions outputs in the UI scrolled to the bottom.

Importantly, if the user scrolls AWAY from the bottom, let's say to carefully read an earlier log or copy it, the anchoring behaviour ceases (until they scroll back to the bottom again)

![image](https://github.com/hashicorp/nomad/assets/713991/7897c363-b09b-4ff4-9435-59a468ad711f)

Resolves #19437 