### PR TITLE
docs: note that 1.7.2 yanks 1.7.0-1.7.1 due to CPU fingerprint bug

### DIFF
--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -13,12 +13,18 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 1.7.2
+
+Nomad 1.7.2 fixes a critical bug in CPU fingerprinting in Nomad 1.7.0 and
+1.7.1. You should not install Nomad 1.7.0 or 1.7.1 and instead install the
+latest Nomad 1.7.x version.
+
 ## Nomad 1.7.0
 
 <Warning>
 
 Nomad 1.7.0 contains a critical bug in keyring replication. You should not
-install Nomad 1.7.0 and instead install Nomad 1.7.1.
+install Nomad 1.7.0 and instead install the latest Nomad 1.7.x version.
 
 </Warning>
 


### PR DESCRIPTION
Add a note about the 1.7.0-1.7.1 panics for CPU fingerprinting.