### PR TITLE
Surfaces errors from namespace delete properly

### DIFF
--- a/.changelog/19483.txt
+++ b/.changelog/19483.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+namespaces: Failed delete calls no longer return success codes
+```

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1479,6 +1479,7 @@ func (n *nomadFSM) applyNamespaceDelete(buf []byte, index uint64) interface{} {
 
 	if err := n.state.DeleteNamespaces(index, req.Namespaces); err != nil {
 		n.logger.Error("DeleteNamespaces failed", "error", err)
+		return err
 	}
 
 	return nil

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -3305,6 +3305,36 @@ func TestFSM_DeleteNamespaces(t *testing.T) {
 	assert.Nil(out)
 }
 
+func TestFSM_DeleteNamespaces_ErrorSurfacing(t *testing.T) {
+	assert := assert.New(t)
+	ci.Parallel(t)
+	fsm := testFSM(t)
+
+	ns1 := mock.Namespace()
+	// force a failure by making this the default
+	ns1.Name = "default"
+	assert.Nil(fsm.State().UpsertNamespaces(1000, []*structs.Namespace{ns1}))
+
+	req := structs.NamespaceDeleteRequest{
+		Namespaces: []string{ns1.Name},
+	}
+
+	buf, err := structs.Encode(structs.NamespaceDeleteRequestType, req)
+	require.NoError(t, err)
+
+	resp := fsm.Apply(makeLog(buf))
+	if resp == nil {
+		t.Fatalf("no resp: %v", resp)
+	}
+	err, ok := resp.(error)
+	if !ok {
+		t.Fatalf("resp not of error type: %T %v", resp, resp)
+	}
+	if !strings.Contains(err.Error(), "default namespace can not be deleted") {
+		t.Fatalf("bad error: %v", err)
+	}
+}
+
 func TestFSM_SnapshotRestore_Namespaces(t *testing.T) {
 	ci.Parallel(t)
 	// Add some state


### PR DESCRIPTION
Adds a "return err" that was accidentally dropped shortly after the Namespace OSS migration.

fixes https://github.com/hashicorp/nomad/issues/19414