### PR TITLE
client: consul hook not called for templates

### DIFF
--- a/.changelog/19490.txt
+++ b/.changelog/19490.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: fix a bug where task level Consul hook never gets called
+```

--- a/.changelog/19490.txt
+++ b/.changelog/19490.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-client: fix a bug where task level Consul hook never gets called
+client: Fixed a bug where where the environment variable / file for the Consul token weren't written.
 ```

--- a/client/allocrunner/taskrunner/consul_hook.go
+++ b/client/allocrunner/taskrunner/consul_hook.go
@@ -18,10 +18,9 @@ import (
 )
 
 const (
-	// consulTokenFilePrefix is the begging of the name of the file holding the
-	// Consul SI token inside the task's secret directory. Full name of the file is
-	// always consulTokenFilePrefix_identityName
-	consulTokenFilePrefix = "nomad_consul"
+	// consulTokenFilename is the name of the file holding the Consul SI token
+	// inside the task's secret directory.
+	consulTokenFilename = "consul_token"
 
 	// consulTokenFilePerms is the level of file permissions granted on the file in
 	// the secrets directory for the task
@@ -57,7 +56,7 @@ func (h *consulHook) Prestart(context.Context, *interfaces.TaskPrestartRequest, 
 	tokens := h.hookResources.GetConsulTokens()
 
 	// Write tokens to tasks' secret dirs
-	for cluster, t := range tokens {
+	for _, t := range tokens {
 		for identity, token := range t {
 			// do not write tokens that do not belong to any of this task's
 			// identities
@@ -68,8 +67,7 @@ func (h *consulHook) Prestart(context.Context, *interfaces.TaskPrestartRequest, 
 				continue
 			}
 
-			filename := fmt.Sprintf("%s_%s_%s", consulTokenFilePrefix, cluster, identity)
-			tokenPath := filepath.Join(h.tokenDir, filename)
+			tokenPath := filepath.Join(h.tokenDir, consulTokenFilename)
 			if err := os.WriteFile(tokenPath, []byte(token.SecretID), consulTokenFilePerms); err != nil {
 				mErr.Errors = append(mErr.Errors, fmt.Errorf("failed to write Consul SI token: %w", err))
 			}

--- a/client/allocrunner/taskrunner/consul_hook.go
+++ b/client/allocrunner/taskrunner/consul_hook.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	cstructs "github.com/hashicorp/nomad/client/structs"
-	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -29,10 +28,9 @@ const (
 )
 
 type consulHook struct {
-	task           *structs.Task
-	tokenDir       string
-	hookResources  *cstructs.AllocHookResources
-	taskEnvBuilder *taskenv.Builder
+	task          *structs.Task
+	tokenDir      string
+	hookResources *cstructs.AllocHookResources
 
 	logger log.Logger
 }
@@ -43,7 +41,6 @@ func newConsulHook(logger log.Logger, tr *TaskRunner) *consulHook {
 		tokenDir:      tr.taskDir.SecretsDir,
 		hookResources: tr.allocHookResources,
 	}
-	h.taskEnvBuilder = tr.envBuilder
 	h.logger = logger.Named(h.Name())
 	return h
 }
@@ -74,10 +71,11 @@ func (h *consulHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartR
 				mErr.Errors = append(mErr.Errors, fmt.Errorf("failed to write Consul SI token: %w", err))
 			}
 
-			envs := h.taskEnvBuilder.Build().Map()
-			envs["CONSUL_TOKEN"] = token.SecretID
+			env := map[string]string{
+				"CONSUL_TOKEN": token.SecretID,
+			}
 
-			resp.Env = envs
+			resp.Env = env
 		}
 	}
 

--- a/client/allocrunner/taskrunner/consul_hook.go
+++ b/client/allocrunner/taskrunner/consul_hook.go
@@ -35,11 +35,11 @@ type consulHook struct {
 	logger        log.Logger
 }
 
-func newConsulHook(logger log.Logger, tr *TaskRunner, hookResources *cstructs.AllocHookResources) *consulHook {
+func newConsulHook(logger log.Logger, tr *TaskRunner) *consulHook {
 	h := &consulHook{
 		task:          tr.Task(),
 		tokenDir:      tr.taskDir.SecretsDir,
-		hookResources: hookResources,
+		hookResources: tr.allocHookResources,
 	}
 	h.logger = logger.Named(h.Name())
 	return h

--- a/client/allocrunner/taskrunner/consul_hook.go
+++ b/client/allocrunner/taskrunner/consul_hook.go
@@ -32,6 +32,7 @@ type consulHook struct {
 	task          *structs.Task
 	tokenDir      string
 	hookResources *cstructs.AllocHookResources
+	taskEnv       map[string]string
 	logger        log.Logger
 }
 
@@ -41,6 +42,7 @@ func newConsulHook(logger log.Logger, tr *TaskRunner) *consulHook {
 		tokenDir:      tr.taskDir.SecretsDir,
 		hookResources: tr.allocHookResources,
 	}
+	h.taskEnv = tr.envBuilder.Build().Map()
 	h.logger = logger.Named(h.Name())
 	return h
 }
@@ -71,6 +73,8 @@ func (h *consulHook) Prestart(context.Context, *interfaces.TaskPrestartRequest, 
 			if err := os.WriteFile(tokenPath, []byte(token.SecretID), consulTokenFilePerms); err != nil {
 				mErr.Errors = append(mErr.Errors, fmt.Errorf("failed to write Consul SI token: %w", err))
 			}
+
+			h.taskEnv["CONSUL_TOKEN"] = token.SecretID
 		}
 	}
 

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -109,6 +109,8 @@ func (tr *TaskRunner) initHooks() {
 
 	// If there are templates is enabled, add the hook
 	if len(task.Templates) != 0 {
+		tr.runnerHooks = append(tr.runnerHooks, newConsulHook(hookLogger, tr))
+
 		tr.runnerHooks = append(tr.runnerHooks, newTemplateHook(&templateHookConfig{
 			alloc:               tr.Alloc(),
 			logger:              hookLogger,
@@ -122,8 +124,6 @@ func (tr *TaskRunner) initHooks() {
 			nomadNamespace:      tr.alloc.Job.Namespace,
 			renderOnTaskRestart: task.RestartPolicy.RenderTemplates,
 		}))
-
-		tr.runnerHooks = append(tr.runnerHooks, newConsulHook(hookLogger, tr))
 	}
 
 	// Always add the service hook. A task with no services on initial registration

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -107,10 +107,12 @@ func (tr *TaskRunner) initHooks() {
 	// Get the consul namespace for the TG of the allocation.
 	consulNamespace := tr.alloc.ConsulNamespaceForTask(tr.taskName)
 
+	// Add the consul hook (populates task secret dirs and sets the environment if
+	// consul tokens are present for the task).
+	tr.runnerHooks = append(tr.runnerHooks, newConsulHook(hookLogger, tr))
+
 	// If there are templates is enabled, add the hook
 	if len(task.Templates) != 0 {
-		tr.runnerHooks = append(tr.runnerHooks, newConsulHook(hookLogger, tr))
-
 		tr.runnerHooks = append(tr.runnerHooks, newTemplateHook(&templateHookConfig{
 			alloc:               tr.Alloc(),
 			logger:              hookLogger,

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -122,6 +122,8 @@ func (tr *TaskRunner) initHooks() {
 			nomadNamespace:      tr.alloc.Job.Namespace,
 			renderOnTaskRestart: task.RestartPolicy.RenderTemplates,
 		}))
+
+		tr.runnerHooks = append(tr.runnerHooks, newConsulHook(hookLogger, tr))
 	}
 
 	// Always add the service hook. A task with no services on initial registration

--- a/website/content/docs/job-specification/consul.mdx
+++ b/website/content/docs/job-specification/consul.mdx
@@ -74,12 +74,11 @@ to Using Workload Identity with Consul</a>
 ### Access to Token
 
 The Nomad client will make the Consul token available to the task by writing it
-to the secret directory at
-`secrets/nomad_consul_{$consul_cluster}_{$task_identity_name}` and by injecting
-a `CONSUL_TOKEN` environment variable in the task. If the Nomad cluster is
+to the secret directory at `secrets/consul_token` and by injecting a
+`CONSUL_TOKEN` environment variable in the task. If the Nomad cluster is
 [configured][config_consul_namespace] to use [Consul Namespaces][], a
-`CONSUL_NAMESPACE` environment variable will be injected whenever
-`CONSUL_TOKEN` is set.
+`CONSUL_NAMESPACE` environment variable will be injected whenever `CONSUL_TOKEN`
+is set.
 
 The [`template`][template] block can use the Consul token as well.
 

--- a/website/content/docs/job-specification/consul.mdx
+++ b/website/content/docs/job-specification/consul.mdx
@@ -74,11 +74,12 @@ to Using Workload Identity with Consul</a>
 ### Access to Token
 
 The Nomad client will make the Consul token available to the task by writing it
-to the secret directory at `secrets/consul_token` and by injecting a
-`CONSUL_TOKEN` environment variable in the task. If the Nomad cluster is
+to the secret directory at
+`secrets/nomad_consul_{$consul_cluster}_{$task_identity_name}` and by injecting
+a `CONSUL_TOKEN` environment variable in the task. If the Nomad cluster is
 [configured][config_consul_namespace] to use [Consul Namespaces][], a
-`CONSUL_NAMESPACE` environment variable will be injected whenever `CONSUL_TOKEN`
-is set.
+`CONSUL_NAMESPACE` environment variable will be injected whenever
+`CONSUL_TOKEN` is set.
 
 The [`template`][template] block can use the Consul token as well.
 


### PR DESCRIPTION
Due to some refactoring mishap, task-level Consul hook was never triggered and thus never wrote any secrets in task secret dirs. 

Fixes #19488 