### PR TITLE
docs: describe cgroup controller requirements

### DIFF
--- a/website/content/docs/drivers/exec.mdx
+++ b/website/content/docs/drivers/exec.mdx
@@ -222,6 +222,11 @@ hugetlb 1
 pids 1
 ```
 
+Nomad can only use cgroups to control resources if all the required controllers
+are available. If one or more required cgroups are unavailable, Nomad will
+disable resource controls that require cgroups entirely. See the documentation
+on [cgroup controller requirements][] for more details.
+
 ### Chroot
 
 The chroot is populated with data in the following directories from the host
@@ -274,3 +279,4 @@ is available to your process by reading [`NOMAD_CPU_CORES`][runtime_env].
 [volume_mount]: /nomad/docs/job-specification/volume_mount
 [cores]: /nomad/docs/job-specification/resources#cores
 [runtime_env]: /nomad/docs/runtime/environment#job-related-variables
+[cgroup controller requirements]: /nomad/docs/install/production/requirements#hardening-nomad

--- a/website/content/docs/drivers/java.mdx
+++ b/website/content/docs/drivers/java.mdx
@@ -221,6 +221,11 @@ running as root, many of these mechanisms cannot be used.
 As a baseline, the Java jars will be run inside a Java Virtual Machine,
 providing a minimum amount of isolation.
 
+Nomad can only use cgroups to control resources if all the required controllers
+are available. If one or more required cgroups are unavailable, Nomad will
+disable resource controls that require cgroups entirely. See the documentation
+on [cgroup controller requirements][] for more details.
+
 ### Chroot
 
 The chroot created on Linux is populated with data in the following
@@ -254,3 +259,4 @@ This list is configurable through the agent client
 [no_net_raw]: /nomad/docs/upgrade/upgrade-specific#nomad-1-1-0-rc1-1-0-5-0-12-12
 [allow_caps]: /nomad/docs/drivers/java#allow_caps
 [docker_caps]: https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
+[cgroup controller requirements]: /nomad/docs/install/production/requirements#hardening-nomad

--- a/website/content/docs/install/index.mdx
+++ b/website/content/docs/install/index.mdx
@@ -229,6 +229,21 @@ net.bridge.bridge-nf-call-iptables = 1
 ```
 
 </CodeBlockConfig>
+
+<h3>Verify cgroup controllers</h3>
+
+On Linux, Nomad uses cgroups to control resource usage of tasks. If one or more
+required cgroups are unavailable, Nomad will disable resource controls that
+require cgroups entirely. With cgroups v2, you can verify that you have all
+required controllers as follows:
+
+```shell-session
+$ cat /sys/fs/cgroup/cgroup.controllers
+cpuset cpu io memory pids
+```
+
+See the documentation on [cgroup controller requirements][] for more details.
+
 </Tab>
 
 <Tab heading="macOS">
@@ -306,8 +321,24 @@ net.bridge.bridge-nf-call-iptables = 1
 ```
 
 </CodeBlockConfig>
+
+<h3>Verify cgroup controllers</h3>
+
+On Linux, Nomad uses cgroups to control resource usage of tasks. If one or more
+required cgroups are unavailable, Nomad will disable resource controls that
+require cgroups entirely. With cgroups v2, you can verify that you have all
+required controllers as follows:
+
+```shell-session
+$ cat /sys/fs/cgroup/cgroup.controllers
+cpuset cpu io memory pids
+```
+
+See the documentation on [cgroup controller requirements][] for more details.
+
 </Tab>
 </Tabs>
+
 
 ## Verify the Installation
 
@@ -403,3 +434,4 @@ and ensuring `GOPATH/bin` is within your `PATH`. A copy of
 
 [gpg-key]: https://apt.releases.hashicorp.com/gpg "HashiCorp GPG key"
 [go-version]: https://github.com/hashicorp/nomad/blob/main/.go-version
+[cgroup controller requirements]: /nomad/docs/install/production/requirements#hardening-nomad

--- a/website/content/docs/install/production/requirements.mdx
+++ b/website/content/docs/install/production/requirements.mdx
@@ -121,6 +121,35 @@ net.bridge.bridge-nf-call-ip6tables = 1
 net.bridge.bridge-nf-call-iptables = 1
 ```
 
+## Cgroup Controllers
+
+On Linux, Nomad uses cgroups to control access to resources like CPU and
+memory. Nomad can support both [cgroups v2][] and the legacy [cgroups
+v1][]. When Nomad clients start, they will determine the available cgroup
+controllers and include the attribute `os.cgroups.version` in their
+fingerprint.
+
+Nomad can only use cgroups to control resources if all the required controllers
+are available. If one or more required cgroups are unavailable, Nomad will
+disable resource controls that require cgroups entirely. You will most often see
+missing controllers on platforms used outside of datacenters, such as Raspberry
+Pi or similar hobbyist computers.
+
+On cgroups v2, you can verify that you have all required controllers as follows:
+
+```shell-session
+$ cat /sys/fs/cgroup/cgroup.controllers
+cpuset cpu io memory pids
+```
+
+On legacy cgroups v1, you can look for this same list of required controllers as
+directories under the directory `/sys/fs/cgroup`.
+
+To enable missing cgroups, add the appropriate boot command line arguments. For
+example, to enable the `cpuset` cgroup, you'll need to add `cgroup_cpuset=1
+cgroup_enable=cpuset`. These arguments should be added wherever specified by
+your bootloader.
+
 ## Hardening Nomad
 
 As noted in the [Security Model][] guide, Nomad is not **secure-by-default**.
@@ -230,4 +259,6 @@ in automated pipelines for [CLI operations][docs_cli], such as
 [`nomad job plan`]: /nomad/docs/commands/job/plan
 [`nomad fmt`]: /nomad/docs/commands/fmt
 [mTLS]: /nomad/tutorials/transport-security/security-enable-tls
-[ephemeral disk migration]: /nomad/docs/job-specification/ephemeral_disk#migrate
+[ephemeral disk migration]: /nomad/docs/job-specification/ephemeral_disk#migrat
+[cgroups v1]: https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/cgroups.html
+[cgroups v2]: https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html


### PR DESCRIPTION
Nomad can only use cgroups to control resource requirements if all the cgroups controllers are actually enabled. Add this to our requirements documentation as well as the impacted `exec` and `java` task drivers.

Ref https://github.com/hashicorp/nomad/issues/19481#issuecomment-1858011764
Preview links:
* https://nomad-64er2mu82-hashicorp.vercel.app/nomad/docs/install
* https://nomad-64er2mu82-hashicorp.vercel.app/nomad/docs/install/production/requirements#cgroup-controllers
* https://nomad-64er2mu82-hashicorp.vercel.app/nomad/docs/drivers/java#resource-isolation
* https://nomad-64er2mu82-hashicorp.vercel.app/nomad/docs/drivers/exec#resource-isolation