### PR TITLE
[ui] Adds a copy button to Action output

### DIFF
--- a/.changelog/19496.txt
+++ b/.changelog/19496.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Added a copy button on Action output
+```

--- a/ui/app/components/action-card.hbs
+++ b/ui/app/components/action-card.hbs
@@ -72,6 +72,7 @@
     {{/if}}
     {{#if this.instance.messages.length}}
       <code tabindex="0">
+        <Hds::Copy::Button class="copy-button" @text="Copy" @isIconOnly={{true}} @textToCopy={{this.instance.messages}} />
         <pre {{did-update this.anchorToBottom this.instance.messages}}>
           {{this.instance.messages}}
         </pre>

--- a/ui/app/styles/components/actions.scss
+++ b/ui/app/styles/components/actions.scss
@@ -128,6 +128,7 @@
           height: 200px;
           border-radius: 6px;
           resize: vertical;
+          position: relative;
           pre {
             background-color: transparent;
             color: unset;
@@ -140,6 +141,15 @@
             height: 1px;
             margin-top: -1px;
             visibility: hidden;
+          }
+          .copy-button {
+            position: sticky;
+            top: 0.5rem;
+            margin-right: 0.5rem;
+            margin-left: auto;
+            width: max-content;
+            height: 32px;
+            margin-bottom: -32px;
           }
         }
       }


### PR DESCRIPTION
A happy little button on some happy little output

Stays sticky when/if you scroll

Copies action output to clipboard

![image](https://github.com/hashicorp/nomad/assets/713991/c326f9a0-e69b-4c24-8e85-787f5ef829db)
