### PR TITLE
ui: fix `AllocationRow` for job without action

### DIFF
--- a/ui/app/templates/components/allocation-row.hbs
+++ b/ui/app/templates/components/allocation-row.hbs
@@ -137,4 +137,6 @@
     @error={{this.statsError}}
   />
 </td>
-<td class="job-actions-cell" />
+{{#if this.model.job.actions.length}}
+  <td class="job-actions-cell" />
+{{/if}}

--- a/ui/app/templates/components/job-deployment/deployment-allocations.hbs
+++ b/ui/app/templates/components/job-deployment/deployment-allocations.hbs
@@ -7,7 +7,7 @@
   <div class="boxed-section-head">
     Allocations
   </div>
-  <div class="boxed-section-body {{if this.job.allocations.length "is-full-bleed"}}">
+  <div class="boxed-section-body {{if @deployment.allocations.length "is-full-bleed"}}">
     {{#if @deployment.allocations.length}}
       <ListTable @source={{@deployment.allocations}} @class="allocations" as |t|>
         <t.head>


### PR DESCRIPTION
The allocation table header sometimes conditionally renders the `Actions` table column, but the allocation row would render it unconditionally, resulting in broken tables when rendering allocations for jobs without actions, where rows had more columns than the header.

Also fix the conditional class for the deployments allocation table to read `length` from the right value.

Before:

<img width="1226" alt="image" src="https://github.com/hashicorp/nomad/assets/775380/b2f8b90a-17f8-4185-9681-28326c4dcdc2">
<img width="1218" alt="image" src="https://github.com/hashicorp/nomad/assets/775380/f7294b3b-63b5-4138-b566-e2d228e49e69">
<img width="1250" alt="image" src="https://github.com/hashicorp/nomad/assets/775380/8b6a607a-2598-44ea-a27f-c9cb628dbb4d">

After:

<img width="1216" alt="image" src="https://github.com/hashicorp/nomad/assets/775380/cd2a8322-c3bb-40e3-81df-46ce1f17b5f5">
<img width="1231" alt="image" src="https://github.com/hashicorp/nomad/assets/775380/e81b875d-7681-412e-88f4-ebb7194f6944">
<img width="1235" alt="image" src="https://github.com/hashicorp/nomad/assets/775380/620e9884-4aab-4328-b36b-22bde28be9dc">

