### PR TITLE
consul: fix parsing of `service.cluster` field

### DIFF
--- a/api/services.go
+++ b/api/services.go
@@ -251,7 +251,7 @@ type Service struct {
 	Provider string `hcl:"provider,optional"`
 
 	// Cluster is valid only for Nomad Enterprise with provider: consul
-	Cluster string `hcl:"cluster,optional`
+	Cluster string `hcl:"cluster,optional"`
 }
 
 const (


### PR DESCRIPTION
`go vet` should've caught this, but I think it may not be running in `./api` since it's a separate module. I will try to fix CI in a follow-up PR so it can be backported.