### PR TITLE
ci: run linter in `./api` package

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -161,6 +161,9 @@ check: ## Lint the source code
 	@echo "==> Linting source code..."
 	@golangci-lint run
 
+	@echo "==> Linting ./api source code..."
+	@cd ./api && golangci-lint run --config ../.golangci.yml
+
 	@echo "==> Linting hclog statements..."
 	@hclogvet .
 

--- a/api/agent.go
+++ b/api/agent.go
@@ -310,7 +310,7 @@ func (a *Agent) Monitor(stopCh <-chan struct{}, q *QueryOptions) (<-chan *Stream
 	}
 
 	r.setQueryOptions(q)
-	_, resp, err := requireOK(a.client.doRequest(r))
+	_, resp, err := requireOK(a.client.doRequest(r)) //nolint:bodyclose
 	if err != nil {
 		errCh <- err
 		return nil, errCh

--- a/api/allocations_exec.go
+++ b/api/allocations_exec.go
@@ -109,11 +109,11 @@ func (s *execSession) startConnection() (*websocket.Conn, error) {
 	var conn *websocket.Conn
 
 	if nodeClient != nil {
-		conn, _, _ = nodeClient.websocket(reqPath, q)
+		conn, _, _ = nodeClient.websocket(reqPath, q) //nolint:bodyclose // gorilla/websocket Dialer.DialContext() does not require the body to be closed.
 	}
 
 	if conn == nil {
-		conn, _, err = s.client.websocket(reqPath, q)
+		conn, _, err = s.client.websocket(reqPath, q) //nolint:bodyclose // gorilla/websocket Dialer.DialContext() does not require the body to be closed.
 		if err != nil {
 			return nil, err
 		}

--- a/api/api.go
+++ b/api/api.go
@@ -932,7 +932,7 @@ func (c *Client) rawQuery(endpoint string, q *QueryOptions) (io.ReadCloser, erro
 		return nil, err
 	}
 	r.setQueryOptions(q)
-	_, resp, err := requireOK(c.doRequest(r))
+	_, resp, err := requireOK(c.doRequest(r)) //nolint:bodyclose // Closing the body is the caller's responsibility.
 	if err != nil {
 		return nil, err
 	}
@@ -1036,7 +1036,7 @@ func (c *Client) query(endpoint string, out any, q *QueryOptions) (*QueryMeta, e
 		return nil, err
 	}
 	r.setQueryOptions(q)
-	rtt, resp, err := requireOK(c.doRequest(r))
+	rtt, resp, err := requireOK(c.doRequest(r)) //nolint:bodyclose // Closing the body is the caller's responsibility.
 	if err != nil {
 		return nil, err
 	}
@@ -1061,7 +1061,7 @@ func (c *Client) putQuery(endpoint string, in, out any, q *QueryOptions) (*Query
 	}
 	r.setQueryOptions(q)
 	r.obj = in
-	rtt, resp, err := requireOK(c.doRequest(r))
+	rtt, resp, err := requireOK(c.doRequest(r)) //nolint:bodyclose // Closing the body is the caller's responsibility.
 	if err != nil {
 		return nil, err
 	}
@@ -1092,7 +1092,7 @@ func (c *Client) postQuery(endpoint string, in, out any, q *QueryOptions) (*Quer
 	}
 	r.setQueryOptions(q)
 	r.obj = in
-	rtt, resp, err := requireOK(c.doRequest(r))
+	rtt, resp, err := requireOK(c.doRequest(r)) //nolint:bodyclose // Closing the body is the caller's responsibility.
 	if err != nil {
 		return nil, err
 	}
@@ -1125,7 +1125,7 @@ func (c *Client) write(verb, endpoint string, in, out any, q *WriteOptions) (*Wr
 	}
 	r.setWriteOptions(q)
 	r.obj = in
-	rtt, resp, err := requireOK(c.doRequest(r))
+	rtt, resp, err := requireOK(c.doRequest(r)) //nolint:bodyclose // Closing the body is the caller's responsibility.
 	if err != nil {
 		return nil, err
 	}
@@ -1151,7 +1151,7 @@ func (c *Client) delete(endpoint string, in, out any, q *WriteOptions) (*WriteMe
 	}
 	r.setWriteOptions(q)
 	r.obj = in
-	rtt, resp, err := requireOK(c.doRequest(r))
+	rtt, resp, err := requireOK(c.doRequest(r)) //nolint:bodyclose // Closing the body is the caller's responsibility.
 	if err != nil {
 		return nil, err
 	}

--- a/api/consul.go
+++ b/api/consul.go
@@ -199,7 +199,6 @@ type ConsulMeshGateway struct {
 func (c *ConsulMeshGateway) Canonicalize() {
 	// Mode may be empty string, indicating behavior will defer to Consul
 	// service-defaults config entry.
-	return
 }
 
 func (c *ConsulMeshGateway) Copy() *ConsulMeshGateway {
@@ -630,9 +629,7 @@ type ConsulMeshConfigEntry struct {
 	// nothing in here
 }
 
-func (e *ConsulMeshConfigEntry) Canonicalize() {
-	return
-}
+func (e *ConsulMeshConfigEntry) Canonicalize() {}
 
 func (e *ConsulMeshConfigEntry) Copy() *ConsulMeshConfigEntry {
 	if e == nil {

--- a/api/event_stream.go
+++ b/api/event_stream.go
@@ -186,7 +186,7 @@ func (e *EventStream) Stream(ctx context.Context, topics map[Topic][]string, ind
 		}
 	}
 
-	_, resp, err := requireOK(e.client.doRequest(r))
+	_, resp, err := requireOK(e.client.doRequest(r)) //nolint:bodyclose
 
 	if err != nil {
 		return nil, err

--- a/api/internal/testutil/responsewriter.go
+++ b/api/internal/testutil/responsewriter.go
@@ -53,7 +53,7 @@ func (r *ResponseRecorder) Header() http.Header {
 func (r *ResponseRecorder) HeaderMap() http.Header {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.rr.Result().Header
+	return r.rr.Result().Header //nolint:bodyclose
 }
 
 // Write to the underlying response buffer. Safe to call concurrent with Read.

--- a/api/internal/testutil/server.go
+++ b/api/internal/testutil/server.go
@@ -373,7 +373,7 @@ func (s *TestServer) url(path string) string {
 
 // requireOK checks the HTTP response code and ensures it is acceptable.
 func (s *TestServer) requireOK(resp *http.Response) error {
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("bad status code: %d", resp.StatusCode)
 	}
 	return nil
@@ -381,7 +381,7 @@ func (s *TestServer) requireOK(resp *http.Response) error {
 
 // put performs a new HTTP PUT request.
 func (s *TestServer) put(path string, body io.Reader) *http.Response {
-	req, err := http.NewRequest("PUT", s.url(path), body)
+	req, err := http.NewRequest(http.MethodPut, s.url(path), body)
 	must.NoError(s.t, err)
 
 	resp, err := s.HTTPClient.Do(req)

--- a/api/operator.go
+++ b/api/operator.go
@@ -66,7 +66,7 @@ func (op *Operator) RaftGetConfiguration(q *QueryOptions) (*RaftConfiguration, e
 		return nil, err
 	}
 	r.setQueryOptions(q)
-	_, resp, err := requireOK(op.c.doRequest(r))
+	_, resp, err := requireOK(op.c.doRequest(r)) //nolint:bodyclose
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,7 @@ func (op *Operator) RaftRemovePeerByAddress(address string, q *WriteOptions) err
 
 	r.params.Set("address", address)
 
-	_, resp, err := requireOK(op.c.doRequest(r))
+	_, resp, err := requireOK(op.c.doRequest(r)) //nolint:bodyclose
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (op *Operator) RaftRemovePeerByID(id string, q *WriteOptions) error {
 
 	r.params.Set("id", id)
 
-	_, resp, err := requireOK(op.c.doRequest(r))
+	_, resp, err := requireOK(op.c.doRequest(r)) //nolint:bodyclose
 	if err != nil {
 		return err
 	}
@@ -131,7 +131,7 @@ func (op *Operator) RaftTransferLeadershipByAddress(address string, q *WriteOpti
 
 	r.params.Set("address", address)
 
-	_, resp, err := requireOK(op.c.doRequest(r))
+	_, resp, err := requireOK(op.c.doRequest(r)) //nolint:bodyclose
 	if err != nil {
 		return err
 	}
@@ -151,7 +151,7 @@ func (op *Operator) RaftTransferLeadershipByID(id string, q *WriteOptions) error
 
 	r.params.Set("id", id)
 
-	_, resp, err := requireOK(op.c.doRequest(r))
+	_, resp, err := requireOK(op.c.doRequest(r)) //nolint:bodyclose
 	if err != nil {
 		return err
 	}
@@ -262,18 +262,17 @@ func (op *Operator) Snapshot(q *QueryOptions) (io.ReadCloser, error) {
 		return nil, err
 	}
 	r.setQueryOptions(q)
-	_, resp, err := requireOK(op.c.doRequest(r))
+	_, resp, err := requireOK(op.c.doRequest(r)) //nolint:bodyclose
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	digest := resp.Header.Get("Digest")
 
 	cr, err := newChecksumValidatingReader(resp.Body, digest)
 	if err != nil {
 		io.Copy(io.Discard, resp.Body)
-		resp.Body.Close()
-
 		return nil, err
 	}
 
@@ -355,7 +354,7 @@ func (op *Operator) ApplyLicense(license string, opts *ApplyLicenseOptions, q *W
 	r.setWriteOptions(q)
 	r.body = strings.NewReader(license)
 
-	rtt, resp, err := requireOK(op.c.doRequest(r))
+	rtt, resp, err := requireOK(op.c.doRequest(r)) //nolint:bodyclose
 	if err != nil {
 		return nil, err
 	}
@@ -375,7 +374,7 @@ func (op *Operator) LicenseGet(q *QueryOptions) (*LicenseReply, *QueryMeta, erro
 	req.setQueryOptions(q)
 
 	var reply LicenseReply
-	rtt, resp, err := op.c.doRequest(req)
+	rtt, resp, err := op.c.doRequest(req) //nolint:bodyclose
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/retry.go
+++ b/api/retry.go
@@ -39,7 +39,7 @@ func (c *Client) retryPut(ctx context.Context, endpoint string, in, out any, q *
 	var err error
 	var wm *WriteMeta
 
-	attemptDelay := time.Duration(100 * time.Second) // Avoid a tick before starting
+	attemptDelay := 100 * time.Second // Avoid a tick before starting
 	startTime := time.Now()
 
 	t := time.NewTimer(attemptDelay)
@@ -60,7 +60,7 @@ func (c *Client) retryPut(ctx context.Context, endpoint string, in, out any, q *
 		wm, err = c.put(endpoint, in, out, q)
 
 		// Maximum retry period is up, don't retry
-		if c.config.retryOptions.maxToLastCall != 0 && time.Now().Sub(startTime) > c.config.retryOptions.maxToLastCall {
+		if c.config.retryOptions.maxToLastCall != 0 && time.Since(startTime) > c.config.retryOptions.maxToLastCall {
 			break
 		}
 

--- a/api/search.go
+++ b/api/search.go
@@ -64,7 +64,8 @@ func (s *Search) FuzzySearch(text string, context contexts.Context, q *QueryOpti
 // ID.
 //
 // e.g. A Task-level service would have scope like,
-//   ["<namespace>", "<job>", "<group>", "<task>"]
+//
+//	["<namespace>", "<job>", "<group>", "<task>"]
 type FuzzyMatch struct {
 	ID    string   // ID is UUID or Name of object
 	Scope []string `json:",omitempty"` // IDs of parent objects

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -195,7 +195,7 @@ func NewAffinity(lTarget string, operand string, rTarget string, weight int8) *A
 		LTarget: lTarget,
 		RTarget: rTarget,
 		Operand: operand,
-		Weight:  pointerOf(int8(weight)),
+		Weight:  pointerOf(weight),
 	}
 }
 
@@ -301,7 +301,7 @@ func NewSpreadTarget(value string, percent uint8) *SpreadTarget {
 func NewSpread(attribute string, weight int8, spreadTargets []*SpreadTarget) *Spread {
 	return &Spread{
 		Attribute:    attribute,
-		Weight:       pointerOf(int8(weight)),
+		Weight:       pointerOf(weight),
 		SpreadTarget: spreadTargets,
 	}
 }

--- a/api/variables.go
+++ b/api/variables.go
@@ -235,8 +235,8 @@ func (vars *Variables) readInternal(endpoint string, out **Variable, q *QueryOpt
 	}
 	r.setQueryOptions(q)
 
-	checkFn := requireStatusIn(http.StatusOK, http.StatusNotFound, http.StatusForbidden)
-	rtt, resp, err := checkFn(vars.client.doRequest(r))
+	checkFn := requireStatusIn(http.StatusOK, http.StatusNotFound, http.StatusForbidden) //nolint:bodyclose
+	rtt, resp, err := checkFn(vars.client.doRequest(r))                                  //nolint:bodyclose
 	if err != nil {
 		return nil, err
 	}
@@ -284,12 +284,12 @@ func (vars *Variables) deleteInternal(path string, q *WriteOptions) (*WriteMeta,
 	}
 	r.setWriteOptions(q)
 
-	checkFn := requireStatusIn(http.StatusOK, http.StatusNoContent)
-	rtt, resp, err := checkFn(vars.client.doRequest(r))
-
+	checkFn := requireStatusIn(http.StatusOK, http.StatusNoContent) //nolint:bodyclose
+	rtt, resp, err := checkFn(vars.client.doRequest(r))             //nolint:bodyclose
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	wm := &WriteMeta{RequestTime: rtt}
 	_ = parseWriteMeta(resp, wm)
@@ -305,11 +305,12 @@ func (vars *Variables) deleteChecked(path string, checkIndex uint64, q *WriteOpt
 		return nil, err
 	}
 	r.setWriteOptions(q)
-	checkFn := requireStatusIn(http.StatusOK, http.StatusNoContent, http.StatusConflict)
-	rtt, resp, err := checkFn(vars.client.doRequest(r))
+	checkFn := requireStatusIn(http.StatusOK, http.StatusNoContent, http.StatusConflict) //nolint:bodyclose
+	rtt, resp, err := checkFn(vars.client.doRequest(r))                                  //nolint:bodyclose
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	wm := &WriteMeta{RequestTime: rtt}
 	_ = parseWriteMeta(resp, wm)
@@ -341,8 +342,8 @@ func (vars *Variables) writeChecked(endpoint string, in *Variable, out *Variable
 	r.setWriteOptions(q)
 	r.obj = in
 
-	checkFn := requireStatusIn(http.StatusOK, http.StatusNoContent, http.StatusConflict)
-	rtt, resp, err := checkFn(vars.client.doRequest(r))
+	checkFn := requireStatusIn(http.StatusOK, http.StatusNoContent, http.StatusConflict) //nolint:bodyclose
+	rtt, resp, err := checkFn(vars.client.doRequest(r))                                  //nolint:bodyclose
 
 	if err != nil {
 		return nil, err

--- a/drivers/shared/executor/procstats/list_default.go
+++ b/drivers/shared/executor/procstats/list_default.go
@@ -32,7 +32,7 @@ func List(executorPID int) *set.Set[ProcessID] {
 		nextPPID := stack.Pop()
 		result.Insert(ProcessID(nextPPID))
 
-		p, err := process.NewProcessWithContext(ctx, int32(nextPPID))
+		p, err := process.NewProcessWithContext(ctx, nextPPID)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
[Outstanding errors](https://github.com/hashicorp/nomad/actions/runs/7255037951/job/19764926088?pr=19513#step:6:31):

```
 Error: agent.go:313:46: response body must be closed (bodyclose)
	_, resp, err := requireOK(a.client.doRequest(r))
	                                            ^
Error: allocations_exec.go:112:36: response body must be closed (bodyclose)
		conn, _, _ = nodeClient.websocket(reqPath, q)
		                                 ^
Error: allocations_exec.go:116:36: response body must be closed (bodyclose)
		conn, _, err = s.client.websocket(reqPath, q)
		                                 ^
Error: services.go:254:2: structtag: struct field tag `hcl:"cluster,optional` not compatible with reflect.StructTag.Get: bad syntax for struct tag value (govet)
	Cluster string `hcl:"cluster,optional`
	^
```

`services.go` is fixed in https://github.com/hashicorp/nomad/pull/19510 but I'm not sure how to fix the `bodyclose` errors.