### PR TITLE
Adds vault role to JWT claims if specified in jobspec

### DIFF
--- a/.changelog/19535.txt
+++ b/.changelog/19535.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity: Added vault_role to JWT workload identity claims if specified in jobspec
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -11317,6 +11317,7 @@ type IdentityClaims struct {
 
 	ConsulNamespace string `json:"consul_namespace,omitempty"`
 	VaultNamespace  string `json:"vault_namespace,omitempty"`
+	VaultRole       string `json:"vault_role,omitempty"`
 
 	jwt.Claims
 }
@@ -11327,7 +11328,6 @@ type IdentityClaims struct {
 // ID claim is random (nondeterministic) so multiple calls with the same values
 // will not return equal claims by design. JWT IDs should never collide.
 func NewIdentityClaims(job *Job, alloc *Allocation, wihandle *WIHandle, wid *WorkloadIdentity, now time.Time) *IdentityClaims {
-
 	tg := job.LookupTaskGroup(alloc.TaskGroup)
 	if tg == nil {
 		return nil
@@ -11399,7 +11399,9 @@ func NewIdentityClaims(job *Job, alloc *Allocation, wihandle *WIHandle, wid *Wor
 
 		if wid.IsVault() && task.Vault != nil {
 			claims.VaultNamespace = task.Vault.Namespace
+			claims.VaultRole = task.Vault.Role
 		}
+
 	} else if wid.IsConsul() && tg.Consul != nil {
 		claims.ConsulNamespace = tg.Consul.Namespace
 	}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -8014,6 +8014,7 @@ func TestNewIdentityClaims(t *testing.T) {
 						},
 						Vault: &Vault{
 							Namespace: "vault-namespace",
+							Role:      "role-from-spec-group",
 						},
 						Identity: &WorkloadIdentity{
 							Name:     "default-identity",
@@ -8087,6 +8088,7 @@ func TestNewIdentityClaims(t *testing.T) {
 						},
 						Vault: &Vault{
 							Namespace: "vault-namespace",
+							Role:      "role-from-spec-consul-group",
 						},
 						Identity: &WorkloadIdentity{
 							Name:     "default-identity",
@@ -8166,6 +8168,7 @@ func TestNewIdentityClaims(t *testing.T) {
 			Namespace:      "default",
 			JobID:          "job",
 			TaskName:       "task",
+			VaultRole:      "", // not specified in jobspec
 			Claims: jwt.Claims{
 				Subject:  "global:default:job:group:task:vault_default",
 				Audience: jwt.Audience{"vault.io"},
@@ -8208,6 +8211,7 @@ func TestNewIdentityClaims(t *testing.T) {
 			Namespace:      "default",
 			JobID:          "job",
 			TaskName:       "consul-vault-task",
+			VaultRole:      "role-from-spec-group",
 			Claims: jwt.Claims{
 				Subject:  "global:default:job:group:consul-vault-task:vault_default",
 				Audience: jwt.Audience{"vault.io"},
@@ -8272,6 +8276,7 @@ func TestNewIdentityClaims(t *testing.T) {
 			Namespace: "default",
 			JobID:     "job",
 			TaskName:  "task",
+			VaultRole: "", // not specified in jobspec
 			Claims: jwt.Claims{
 				Subject:  "global:default:job:consul-group:task:vault_default",
 				Audience: jwt.Audience{"vault.io"},
@@ -8316,6 +8321,7 @@ func TestNewIdentityClaims(t *testing.T) {
 			Namespace:      "default",
 			JobID:          "job",
 			TaskName:       "consul-vault-task",
+			VaultRole:      "role-from-spec-consul-group",
 			Claims: jwt.Claims{
 				Subject:  "global:default:job:consul-group:consul-vault-task:vault_default",
 				Audience: jwt.Audience{"vault.io"},
@@ -8365,6 +8371,7 @@ func TestNewIdentityClaims(t *testing.T) {
 
 		for _, s := range tg.Services {
 			path := path + "/services/" + s.Name
+
 			testCases = append(testCases, testCase{
 				name:           path,
 				group:          tg.Name,

--- a/website/content/docs/concepts/workload-identity.mdx
+++ b/website/content/docs/concepts/workload-identity.mdx
@@ -38,6 +38,23 @@ instead of the task name.
 }
 ```
 
+Workload identities for tasks that use Vault have an additional claim for
+[`vault.role`][jobspec_vault_role] if a role is specified in the job.
+
+-> **Note:** This claim will *not* be added if the role is inherited from
+the [agent configuration][vault_role_agent_config] and is not present
+in the Nomad job specification.
+
+```json
+{
+  "nomad_namespace": "default",
+  "nomad_job_id": "example",
+  "nomad_allocation_id": "8623ac7a-28ba-20c3-24a6-e615a39bbbf3",
+  "nomad_service": "example-cache-redis"
+  "vault_role": "nomad-jwt-login"
+}
+```
+
 ### Nomad Enterprise <EnterpriseAlert inline />
 
 In Nomad Enterprise, tasks and services with a [`consul`][jobspec_consul] block
@@ -54,7 +71,7 @@ block that does it, have an additional claim called `consul_namespace`.
 }
 ```
 
-Similarly, tasks with a [`vault.namespace`][] value have the additional claim
+Similarly, tasks with a [`vault.namespace`][jobspec_vault_ns] value have the additional claim
 `vault_namespace`.
 
 ```json
@@ -159,6 +176,9 @@ integration pages for more information.
 [identity-block]: /nomad/docs/job-specification/identity
 [jobspec_consul]: /nomad/docs/job-specification/consul
 [jobspec_consul_ns]: /nomad/docs/job-specification/consul#namespace
+[jobspec_vault_ns]: /nomad/docs/job-specification/vault#namespace
+[jobspec_vault_role]: /nomad/docs/job-specification/vault#role
+[vault_role_agent_config]: /nomad/docs/configuration/vault#create_from_role
 [plan applier]: /nomad/docs/concepts/scheduling/scheduling
 [JSON Web Token (JWT)]: https://datatracker.ietf.org/doc/html/rfc7519
 [Task Access to Variables]: /nomad/docs/concepts/variables#task-access-to-variables


### PR DESCRIPTION
Adds vault_role as an attribute in the JWT if, and only if, the role is specified in the jobspec. This would allow Vault users to interpolate the Vault role in their templated policies. This could be generally useful, but was primarily added to unblock a specific customer. They have verified that this fix (including the constraint below) would unblock JWT-based Vault auth for their setup.

Ideally, we could add the role regardless of where it is specified, but since the server is minting the JWTs and the client has the default fallback auth_role values, it is difficult to insert the role into the JWT claims if it is using the fallback. There is also a potential syncing issue if you update config and then restart Nomad. To get around these issues, Vault Namespaces have the same constraint (only adding to claims if in the jobspec), so we're adding the same constraint to the role JWT claim.