### PR TITLE
[ui] Add word wrap to new job run page and policy editor, fix on existing job defn pages

### DIFF
--- a/ui/app/components/policy-editor.hbs
+++ b/ui/app/components/policy-editor.hbs
@@ -19,6 +19,18 @@
 	<div class="boxed-section">
 		<div class="boxed-section-head">
 			Policy Definition
+			<div class="pull-right" style="display: flex">
+				<span class="header-toggle">
+					<Hds::Form::Toggle::Field
+						{{keyboard-shortcut label="Toggle word wrap" action=this.toggleWrap pattern=(array "w" "w") menuLevel=true }}
+						checked={{this.wrapped}}
+						{{on "change" this.toggleWrap}}
+					as |F|>
+						<F.Label>Word Wrap</F.Label>
+					</Hds::Form::Toggle::Field>
+				</span>
+			</div>
+
 		</div>
 		<div class="boxed-section-body is-full-bleed">
 
@@ -33,6 +45,7 @@
           onUpdate=this.updatePolicyRules
           autofocus=false
 					extraKeys=(hash Cmd-Enter=this.save)
+					lineWrapping=this.wrapped
 				}} />
 		</div>
 	</div>

--- a/ui/app/components/policy-editor.js
+++ b/ui/app/components/policy-editor.js
@@ -7,11 +7,19 @@ import Component from '@glimmer/component';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { alias } from '@ember/object/computed';
+import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
 
 export default class PolicyEditorComponent extends Component {
   @service notifications;
   @service router;
   @service store;
+
+  @localStorageProperty('nomadShouldWrapCode', false) wrapped;
+
+  @action
+  toggleWrap() {
+    this.wrapped = !this.wrapped;
+  }
 
   @alias('args.policy') policy;
 

--- a/ui/app/modifiers/code-mirror.js
+++ b/ui/app/modifiers/code-mirror.js
@@ -28,11 +28,20 @@ export default class CodeMirrorModifier extends Modifier {
   element = null;
   args = {};
 
+  // A change to the element or args' properties on the {{code-mirror}} modifier will
+  // trigger modify() here; we can use this to set up the editor and make any other
+  // explicit changes needed.
   modify(element, positional, named) {
     if (!this.element) {
       this.element = element;
       this.args = { positional, named };
       this._setup();
+    }
+
+    if (this._editor) {
+      if (named.lineWrapping !== this._editor.getOption('lineWrapping')) {
+        this._editor.setOption('lineWrapping', named.lineWrapping);
+      }
     }
   }
 

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -6,7 +6,6 @@
 <div class="boxed-section">
   <div class="boxed-section-head">
     Job Definition
-    {{#if @data.cancelable}}
     <div class="pull-right" style="display: flex">
       <span class="header-toggle">
         <Hds::Form::Toggle::Field
@@ -17,6 +16,8 @@
           <F.Label>Word Wrap</F.Label>
         </Hds::Form::Toggle::Field>
       </span>
+    {{#if @data.cancelable}}
+
       <Tooltip
         @condition={{unless @data.hasSpecification true false}}
         @isFullText={{true}}
@@ -54,8 +55,8 @@
         >
           Cancel
         </button>
-    </div>
     {{/if}}
+    </div>
   </div>
   <div class="boxed-section-body is-full-bleed">
     <div


### PR DESCRIPTION
Adds the Word Wrap toggle to the "Run job" page in the UI, as well as the Policy Editor (for management tokens).

It was already added when editing or viewing an existing job definition, but the editor's config appears to have been bugged. The `modify()` changes here fix that.

<img width="837" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/9b314e8c-dc09-40c4-878b-cf1ab79dab74">
<img width="1090" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/2293a20a-67ed-42ab-b4bd-ec9a01cfc714">


Resolves #19532 