### PR TITLE
docs: add note about `*` namespace on autoscaling

### DIFF
--- a/website/content/tools/autoscaling/agent.mdx
+++ b/website/content/tools/autoscaling/agent.mdx
@@ -17,7 +17,9 @@ The Nomad Autoscaler currently has limited support for
 [Nomad Namespaces][nomad_namespaces]. The `nomad` configuration below supports
 specifying a namespace; if configured with a namespace, the Autoscaler will
 retrieve scaling policies and perform autoscaling only for jobs in that
-namespace. A future version will include support for multiple namespaces.
+namespace. If the special wildcard namespace value `*` is used, the Autoscaler
+agent will retrieve scaling policies from all namespaces. A future version will
+include support for multiple namespaces.
 
 ## Nomad ACLs
 

--- a/website/content/tools/autoscaling/agent/nomad.mdx
+++ b/website/content/tools/autoscaling/agent/nomad.mdx
@@ -26,7 +26,7 @@ nomad {
 - `region` `(string: "global")` - The region of the Nomad servers to connect with.
 
 - `namespace` `(string: "")` - The target namespace for queries and actions bound
-  to a namespace.
+  to a namespace. If set to `*` all namespaces are queried.
 
 - `token` `(string: "")` - The SecretID of an ACL token to use to authenticate
   API requests with.


### PR DESCRIPTION
Explain the behaviour when the wildcard namespace value `*` is used to configure the Nomad Autoscaler agent.

Ref.: https://github.com/hashicorp/nomad-autoscaler/issues/65#issuecomment-1620018801