### PR TITLE
acl: remove timestamps from `WhoAmI` response

### DIFF
--- a/.changelog/19578.txt
+++ b/.changelog/19578.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: Fixed a bug where 1.5 and 1.6 clients could not access Nomad Variables and Services via templates
+```

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -2182,6 +2182,16 @@ func (a *ACL) WhoAmI(args *structs.GenericRequest, reply *structs.ACLWhoAmIRespo
 	}
 
 	reply.Identity = args.GetIdentity()
+
+	// COMPAT: originally these were time.Time objects but switching to go-jose
+	// changed them to int64 which aren't compatible with Nomad versions
+	// <1.7. These aren't used by any existing callers of this handler.
+	if reply.Identity.Claims != nil {
+		reply.Identity.Claims.Expiry = nil
+		reply.Identity.Claims.IssuedAt = nil
+		reply.Identity.Claims.NotBefore = nil
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
In Nomad 1.7 we updated our JWT library to go-jose, but this changed the wire format of the embedded struct we have in the `IdentityClaims` struct that we return as part of the `WhoAmI` RPC response. This wasn't originally intended to be sent over the wire but other changes in Nomad 1.5+ added a caller to the client. The library change causes a deserialization error on Nomad 1.5 and 1.6 clients, which prevents access to Nomad Variables and SD via template blocks.

Removed the incompatible fields from the response, which are unused by any current caller. In a future version of Nomad, we'll likely remove the `WhoAmI` callers from the client in lieu of using the public keys the clients have to check auth.

Fixes: https://github.com/hashicorp/nomad/issues/19555
See also: https://github.com/hashicorp/nomad/issues/19580