### PR TITLE
vault: ignore `allow_unauthenticated` config if identity is set

### DIFF
--- a/.changelog/19585.txt
+++ b/.changelog/19585.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault: Fixed a bug where `allow_unauthenticated` was enforced when a `default_identity` was set
+```

--- a/nomad/job_endpoint_hook_vault.go
+++ b/nomad/job_endpoint_hook_vault.go
@@ -38,7 +38,7 @@ func (h jobVaultHook) Validate(job *structs.Job) ([]error, error) {
 				return nil, fmt.Errorf("Vault %q not enabled but used in the job",
 					vaultBlock.Cluster)
 			}
-			if !vconf.AllowsUnauthenticated() {
+			if vconf.DefaultIdentity == nil && !vconf.AllowsUnauthenticated() {
 				requiresToken = true
 			}
 		}

--- a/website/content/docs/configuration/vault.mdx
+++ b/website/content/docs/configuration/vault.mdx
@@ -140,7 +140,8 @@ agents with [`server.enabled`] set to `true`.
   Specifies the default workload identity configuration to use when a task with
   a `vault` block does not specify an [`identity`][jobspec_identity] block
   named `vault_<name>`, where `<name>` matches the value of this `vault` block
-  [`name`](#name) parameter.
+  [`name`](#name) parameter. Setting a default identity causes the value of
+  `allow_unauthenticated` to be ignored.
 
 ### Deprecated Parameters
 


### PR DESCRIPTION
When the server's `vault` block has a default identity, we don't check the user's Vault token (and in fact, we warn them on job submit if they've provided one). But the validation hook still checks for a token if `allow_unauthenticated` is set to true. This is a misconfiguration but there's no reason for Nomad not to do the expected thing here.

Fixes: https://github.com/hashicorp/nomad/issues/19565