### PR TITLE
copywrite: fix and add copywrite config enterprise comments.

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -9,8 +9,8 @@ project {
     "command/agent/bindata_assetfs.go",
     "ui/node_modules",
 
-    // Enterprise files do not fall under the open source licensing. OSS-ENT
-    // merge conflicts might happen here, please be sure to put new OSS
+    // Enterprise files do not fall under the open source licensing. CE-ENT
+    // merge conflicts might happen here, please be sure to put new CE
     // exceptions above this comment.
   ]
 }

--- a/api/.copywrite.hcl
+++ b/api/.copywrite.hcl
@@ -4,5 +4,9 @@ project {
   license        = "MPL-2.0"
   copyright_year = 2023
 
-  header_ignore = []
+  header_ignore = [
+    // Enterprise files do not fall under the open source licensing. CE-ENT
+    // merge conflicts might happen here, please be sure to put new CE
+    // exceptions above this comment.
+  ]
 }

--- a/demo/.copywrite.hcl
+++ b/demo/.copywrite.hcl
@@ -4,5 +4,9 @@ project {
   license        = "MPL-2.0"
   copyright_year = 2023
 
-  header_ignore = []
+  header_ignore = [
+    // Enterprise files do not fall under the open source licensing. CE-ENT
+    // merge conflicts might happen here, please be sure to put new CE
+    // exceptions above this comment.
+  ]
 }

--- a/drivers/shared/.copywrite.hcl
+++ b/drivers/shared/.copywrite.hcl
@@ -4,5 +4,9 @@ project {
   license        = "MPL-2.0"
   copyright_year = 2023
 
-  header_ignore = []
+  header_ignore = [
+    // Enterprise files do not fall under the open source licensing. CE-ENT
+    // merge conflicts might happen here, please be sure to put new CE
+    // exceptions above this comment.
+  ]
 }

--- a/jobspec/.copywrite.hcl
+++ b/jobspec/.copywrite.hcl
@@ -4,5 +4,9 @@ project {
   license        = "MPL-2.0"
   copyright_year = 2023
 
-  header_ignore = []
+  header_ignore = [
+    // Enterprise files do not fall under the open source licensing. CE-ENT
+    // merge conflicts might happen here, please be sure to put new CE
+    // exceptions above this comment.
+  ]
 }

--- a/jobspec2/.copywrite.hcl
+++ b/jobspec2/.copywrite.hcl
@@ -4,5 +4,9 @@ project {
   license        = "MPL-2.0"
   copyright_year = 2023
 
-  header_ignore = []
+  header_ignore = [
+    // Enterprise files do not fall under the open source licensing. CE-ENT
+    // merge conflicts might happen here, please be sure to put new CE
+    // exceptions above this comment.
+  ]
 }

--- a/plugins/.copywrite.hcl
+++ b/plugins/.copywrite.hcl
@@ -4,5 +4,9 @@ project {
   license        = "MPL-2.0"
   copyright_year = 2023
 
-  header_ignore = []
+  header_ignore = [
+    // Enterprise files do not fall under the open source licensing. CE-ENT
+    // merge conflicts might happen here, please be sure to put new CE
+    // exceptions above this comment.
+  ]
 }


### PR DESCRIPTION
Nomad CI checks for copywrite headers using multiple config files for specific exemption paths. This means the top-level config file does not take effect when running the copywrite script within these sub-folders. Exempt files therefore need to be added to the sub-config files, along with the top level.