### PR TITLE
e2e: add test for raw_exec memory_max configuration

### DIFF
--- a/e2e/rawexec/input/oversub.hcl
+++ b/e2e/rawexec/input/oversub.hcl
@@ -1,0 +1,38 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+job "oversub" {
+  type = "batch"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "group" {
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    task "cat" {
+      driver = "raw_exec"
+
+      config {
+        command = "bash"
+        args    = ["-c", "cat /sys/fs/cgroup/$(cat /proc/self/cgroup | cut -d':' -f3)/memory.max"]
+      }
+
+      resources {
+        cpu        = 100
+        memory     = 64
+        memory_max = 128
+      }
+    }
+  }
+}

--- a/e2e/rawexec/rawexec_test.go
+++ b/e2e/rawexec/rawexec_test.go
@@ -18,6 +18,7 @@ func TestRawExec(t *testing.T) {
 	)
 
 	t.Run("testOomAdj", testOomAdj)
+	t.Run("testOversubMemory", testOversubMemory)
 }
 
 func testOomAdj(t *testing.T) {
@@ -26,4 +27,12 @@ func testOomAdj(t *testing.T) {
 
 	logs := job.TaskLogs("group", "cat")
 	must.StrContains(t, logs.Stdout, "0")
+}
+
+func testOversubMemory(t *testing.T) {
+	job, cleanup := jobs3.Submit(t, "./input/oversub.hcl")
+	t.Cleanup(cleanup)
+
+	logs := job.TaskLogs("group", "cat")
+	must.StrContains(t, logs.Stdout, "134217728") // 128 mb memory_max
 }

--- a/website/content/docs/job-specification/resources.mdx
+++ b/website/content/docs/job-specification/resources.mdx
@@ -116,8 +116,9 @@ mechanism for memory pressure is specific to the task driver, operating system,
 and application runtime.
 
 The `memory_max` limit attribute is currently supported by the official
-`docker`, `exec`, and `java` task drivers.  Consult the documentation of
-community-supported task drivers for their memory oversubscription support.
+`raw_exec`, `docker`, `exec`, and `java` task drivers.  Consult the
+documentation of community-supported task drivers for their memory
+oversubscription support.
 
 Memory oversubscription is opt-in. Nomad operators can enable [Memory
 Oversubscription in the scheduler configuration][api_sched_config]. Enterprise


### PR DESCRIPTION
Nomad 1.7 started enforcing memory limits via cgroups on Linux platforms. Add an e2e test demonstrating the use of `memory_max` over subscription. And update the resources docs to mention support for the `raw_exec` driver.