### PR TITLE
docs: update raw_exec driver docs and 1.7 upgrade notes

### DIFF
--- a/website/content/docs/drivers/raw_exec.mdx
+++ b/website/content/docs/drivers/raw_exec.mdx
@@ -117,14 +117,6 @@ client {
 - `enabled` - Specifies whether the driver should be enabled or disabled.
   Defaults to `false`.
 
-- `no_cgroups` - Specifies whether the driver should not use
-  cgroups to manage the process group launched by the driver. By default,
-  cgroups are used to manage the process tree to ensure full cleanup of all
-  processes started by the task. The driver uses cgroups by default on
-  Linux and when `/sys/fs/cgroup/freezer/nomad` is writable for the
-  Nomad process. Using a cgroup significantly reduces Nomad's CPU
-  usage when collecting process metrics.
-
 ## Client Options
 
 ~> Note: client configuration options will soon be deprecated. Please use
@@ -132,12 +124,6 @@ client {
 
 - `driver.raw_exec.enable` - Specifies whether the driver should be enabled or
   disabled. Defaults to `false`.
-
-- `driver.raw_exec.no_cgroups` - Specifies whether the driver should not use
-  cgroups to manage the process group launched by the driver. By default,
-  cgroups are used to manage the process tree to ensure full cleanup of all
-  processes started by the task. The driver only uses cgroups when Nomad is
-  launched as root, on Linux and when cgroups are detected.
 
 ## Client Attributes
 
@@ -147,14 +133,14 @@ The `raw_exec` driver will set the following client attributes:
 
 ## Resource Isolation
 
-The `raw_exec` driver provides no isolation.
+The `raw_exec` driver provides no filesystem isolation.
 
-If the launched process creates a new process group, it is possible that Nomad
-will leak processes on shutdown unless the application forwards signals
-properly. Nomad will not leak any processes if cgroups are being used to manage
-the process tree. Cgroups are used on Linux when Nomad is being run with
-appropriate privileges, the cgroup system is mounted and the operator hasn't
-disabled cgroups for the driver.
+If the launched process creates a new process group, it is possible that
+Nomad will leak processes on shutdown unless the application forwards signals
+properly. Nomad will not leak any processes if cgroups are being used to
+manage the process tree. Cgroups are used on Linux when Nomad is being run with
+appropriate privileges, and the cgroup system is mounted.
+
 
 [hardening]: /nomad/docs/install/production/requirements#user-permissions
 [plugin-options]: #plugin-options

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -147,6 +147,19 @@ configuration file is deprecated. Future versions of Nomad will only load
 plugins that have a corresponding [`plugin`](/nomad/docs/configuration/plugin)
 block in the agent configuration file.
 
+#### Changes to `raw_exec`
+
+The `raw_exec` task driver now enforces memory limits via cgroups on Linux
+platforms similar to the `exec` and `docker` task drivers. The driver does
+support memory [oversubscription][oversub], which can be configured in such a
+way to nearly replicate the previously unlimited behavior.
+
+The `no_cgroups` configuration option no longer has any effect. Previously,
+setting `no_cgroups` would disable the mechanism where Nomad used the freezer
+cgroup to halt the process group of a Task before issuing a kill signal to each
+process. Starting in Nomad 1.7.0 this behavior is always enabled (and a similar
+mechanism has always been enabled on cgroups v2 systems).
+
 ## Nomad 1.6.0
 
 #### Enterprise License Validation with BuildDate
@@ -1998,6 +2011,7 @@ deleted and then Nomad 0.3.0 can be launched.
 [node pools]: /nomad/docs/concepts/node-pools
 [node_attributes]: /nomad/docs/runtime/interpolation#node-attributes
 [nvidia]: /nomad/plugins/devices/nvidia
+[oversub]: /nomad/docs/job-specification/resources#memory-oversubscription
 [pki]: /vault/docs/secrets/pki
 [plugin-block]: /nomad/docs/configuration/plugin
 [plugins]: /nomad/plugins/drivers/community


### PR DESCRIPTION
Nomad 1.7 eliminated the functionality of setting `no_cgroups` in the `raw_exec` task driver config. Update docs to reflect this, including the upgrade guide.