### PR TITLE
[ui] Adds group-name tooltips to deploying and steady-state job panels

### DIFF
--- a/.changelog/19601.txt
+++ b/.changelog/19601.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Added group name to allocation tooltips on job status panel
+```

--- a/ui/app/components/job-status/allocation-status-block.hbs
+++ b/ui/app/components/job-status/allocation-status-block.hbs
@@ -3,6 +3,13 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
+{{!--
+  Exists as a "middleman" between AllocationStatusRow and IndividualAllocation
+  only when showSummaries in AllocationStatusRow is true (i.e. when the math of how
+  many allocations to show in each block is done x minWidth of each alloc exceeds
+  available space)
+--}}
+
 <div
   class="allocation-status-block {{unless this.countToShow "rest-only"}}"
   style={{html-safe (concat "width: " @width "px")}}

--- a/ui/app/components/job-status/individual-allocation.hbs
+++ b/ui/app/components/job-status/individual-allocation.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 <Hds::TooltipButton
-  @text={{this.tooltipText}}
+  @text={{or this.tooltipText ""}}
   aria-label="Allocation"
   @extraTippyOptions={{hash trigger=(if (eq @status "unplaced") "manual")}}
 >

--- a/ui/app/components/job-status/individual-allocation.hbs
+++ b/ui/app/components/job-status/individual-allocation.hbs
@@ -3,8 +3,10 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 <Hds::TooltipButton
-  @text="{{if this.showClient (concat this.nodeName " - " (get @allocation "shortId")) (get @allocation "shortId")}}"
-aria-label="Allocation" @extraTippyOptions={{hash trigger=(if (eq @status "unplaced") "manual")}}>
+  @text={{this.tooltipText}}
+  aria-label="Allocation"
+  @extraTippyOptions={{hash trigger=(if (eq @status "unplaced") "manual")}}
+>
   <ConditionalLinkTo
     @condition={{not (eq @status "unplaced")}}
     @route="allocations.allocation"

--- a/ui/app/components/job-status/individual-allocation.js
+++ b/ui/app/components/job-status/individual-allocation.js
@@ -10,8 +10,21 @@ import { alias } from '@ember/object/computed';
 export default class JobStatusIndividualAllocationComponent extends Component {
   @alias('args.allocation.job.type') jobType;
   @alias('args.allocation.node.name') nodeName;
+  @alias('args.allocation.taskGroup.name') groupName;
+  @alias('args.allocation.job.taskGroups') taskGroups;
+  @alias('args.allocation.shortId') shortId;
 
   get showClient() {
     return this.jobType === 'system' || this.jobType === 'sysbatch';
+  }
+
+  get tooltipText() {
+    if (this.showClient) {
+      return `${this.nodeName} - ${this.shortId}`;
+    } else if (this.groupName && this.taskGroups?.length > 1) {
+      return `${this.groupName} - ${this.shortId}`;
+    } else {
+      return this.shortId;
+    }
   }
 }


### PR DESCRIPTION
Adds tooltips to non-system/sysbatch jobs' allocation blocks when hovered:

![image](https://github.com/hashicorp/nomad/assets/713991/576f74db-832c-4efb-a727-7bb0308a8b4b)

Resolves #19314 (and supercedes #19328 
