### PR TITLE
state: ensure the job submission table is persisted and restored.

### DIFF
--- a/.changelog/19605.txt
+++ b/.changelog/19605.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Ensure job HCL submission data is persisted and restored during the FSM snapshot process
+```

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -2934,6 +2934,60 @@ func TestFSM_SnapshotRestore_ACLBindingRules(t *testing.T) {
 	must.SliceContainsAll(t, restoredACLBindingRules, mockedACLBindingRoles)
 }
 
+func TestFSM_SnapshotRestore_JobSubmissions(t *testing.T) {
+	ci.Parallel(t)
+
+	// Create our initial FSM which will be snapshotted.
+	fsm := testFSM(t)
+	testState := fsm.State()
+
+	// Create a non-default namespace, so we can later create jobs and
+	// submissions within it.
+	mockNamespace := mock.Namespace()
+	mockNamespace.Name = "platform"
+
+	must.NoError(t, testState.UpsertNamespaces(10, []*structs.Namespace{mockNamespace}))
+
+	// Generate a some mocked jobs and submissions to insert directly into
+	// state.
+	mockJob1 := mock.Job()
+	mockJobSubmission1 := &structs.JobSubmission{
+		Source:         "job{}",
+		Namespace:      mockJob1.Namespace,
+		JobID:          mockJob1.ID,
+		Version:        mockJob1.Version,
+		JobModifyIndex: mockJob1.JobModifyIndex,
+	}
+
+	must.NoError(t, testState.UpsertJob(structs.MsgTypeTestSetup, mockJob1.ModifyIndex, mockJobSubmission1, mockJob1))
+
+	mockJob2 := mock.Job()
+	mockJob2.Namespace = mockNamespace.Name
+	mockJobSubmission2 := &structs.JobSubmission{
+		Source:         "job{}",
+		Namespace:      mockJob2.Namespace,
+		JobID:          mockJob2.ID,
+		Version:        mockJob2.Version,
+		JobModifyIndex: mockJob2.JobModifyIndex,
+	}
+
+	must.NoError(t, testState.UpsertJob(structs.MsgTypeTestSetup, mockJob2.ModifyIndex, mockJobSubmission2, mockJob2))
+
+	// Perform a snapshot restore.
+	restoredFSM := testSnapshotRestore(t, fsm)
+	restoredState := restoredFSM.State()
+
+	jobSubmission1Resp, err := restoredState.JobSubmission(
+		nil, mockJobSubmission1.Namespace, mockJobSubmission1.JobID, mockJobSubmission1.Version)
+	must.NoError(t, err)
+	must.Eq(t, mockJobSubmission1, jobSubmission1Resp)
+
+	jobSubmission2Resp, err := restoredState.JobSubmission(
+		nil, mockJobSubmission2.Namespace, mockJobSubmission2.JobID, mockJobSubmission2.Version)
+	must.NoError(t, err)
+	must.Eq(t, mockJobSubmission2, jobSubmission2Resp)
+}
+
 func TestFSM_ReconcileSummaries(t *testing.T) {
 	ci.Parallel(t)
 	// Add some state

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -25,6 +25,7 @@ const (
 	TableACLAuthMethods       = "acl_auth_methods"
 	TableACLBindingRules      = "acl_binding_rules"
 	TableAllocs               = "allocs"
+	TableJobSubmission        = "job_submission"
 )
 
 const (
@@ -323,7 +324,7 @@ func jobVersionSchema() *memdb.TableSchema {
 // which contain the original source material of each job, per version.
 func jobSubmissionSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: "job_submission",
+		Name: TableJobSubmission,
 		Indexes: map[string]*memdb.IndexSchema{
 			"id": {
 				Name:         "id",

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2093,6 +2093,22 @@ func (s *StateStore) upsertJobVersion(index uint64, job *structs.Job, txn *txn) 
 	return nil
 }
 
+// GetJobSubmissions returns an iterator that contains all job submissions
+// stored within state. This is not currently exposed via RPC and is only used
+// for snapshot persist and restore functionality.
+func (s *StateStore) GetJobSubmissions(ws memdb.WatchSet) (memdb.ResultIterator, error) {
+	txn := s.db.ReadTxn()
+
+	// Walk the entire table to get all job submissions.
+	iter, err := txn.Get(TableJobSubmission, indexID)
+	if err != nil {
+		return nil, fmt.Errorf("job submissions lookup failed: %v", err)
+	}
+	ws.Add(iter.WatchCh())
+
+	return iter, nil
+}
+
 // JobSubmission returns the original HCL/Variables context of a job, if available.
 //
 // Note: it is a normal case for the submission context to be unavailable, in which case

--- a/nomad/state/state_store_restore.go
+++ b/nomad/state/state_store_restore.go
@@ -275,3 +275,12 @@ func (r *StateRestore) ACLBindingRuleRestore(aclBindingRule *structs.ACLBindingR
 	}
 	return nil
 }
+
+// JobSubmissionRestore is used to restore a single job submission into the
+// job_submission table.
+func (r *StateRestore) JobSubmissionRestore(jobSubmission *structs.JobSubmission) error {
+	if err := r.txn.Insert(TableJobSubmission, jobSubmission); err != nil {
+		return fmt.Errorf("job submission insert failed: %v", err)
+	}
+	return nil
+}

--- a/nomad/state/state_store_restore_test.go
+++ b/nomad/state/state_store_restore_test.go
@@ -555,3 +555,27 @@ func TestStateStore_ACLBindingRuleRestore(t *testing.T) {
 	must.NoError(t, err)
 	must.Eq(t, aclBindingRule, out)
 }
+
+func TestStateStore_JobSubmissionRestore(t *testing.T) {
+	ci.Parallel(t)
+	testState := testStateStore(t)
+
+	// Set up our test job submissions.
+	jobSubmission := structs.JobSubmission{
+		Source:    "{job{}}",
+		Namespace: "default",
+		JobID:     "example",
+	}
+
+	restore, err := testState.Restore()
+	must.NoError(t, err)
+	must.NoError(t, restore.JobSubmissionRestore(&jobSubmission))
+	must.NoError(t, restore.Commit())
+
+	// Check the state is now populated as we expect and that we can find the
+	// restored job submission.
+	ws := memdb.NewWatchSet()
+	out, err := testState.JobSubmission(ws, jobSubmission.Namespace, jobSubmission.JobID, jobSubmission.Version)
+	must.NoError(t, err)
+	must.Eq(t, jobSubmission, *out)
+}


### PR DESCRIPTION
Previously the job submission table was not persisted within state snapshots, meaning servers which received a snapshot during a restore process would seemingly lose the HCL submission data for jobs. This changes ensures this table is both persisted and restored.

closes #19561 