### PR TITLE
Revert e4e70b086a304e4e80496d95f514a4de6e926b3b.

### DIFF
--- a/api/operator.go
+++ b/api/operator.go
@@ -266,13 +266,13 @@ func (op *Operator) Snapshot(q *QueryOptions) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	digest := resp.Header.Get("Digest")
 
 	cr, err := newChecksumValidatingReader(resp.Body, digest)
 	if err != nil {
 		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
This broke the operator snapshot command.