### PR TITLE
state store: better handling of job deletion

### DIFF
--- a/.changelog/19609.txt
+++ b/.changelog/19609.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+state: Fixed a bug where purged jobs would not get new deployments
+```

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -546,7 +546,6 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 			stoppedAlloc, lostAlloc,
 			activeJobRunningAlloc, activeJobLostAlloc, activeJobCompletedEvalCompletedAlloc,
 			stoppedJobStoppedAlloc, stoppedJobLostAlloc,
-			purgedJobCompleteAlloc,
 		},
 		[]*structs.Allocation{},
 	)
@@ -576,7 +575,6 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 			stoppedAlloc, lostAlloc,
 			activeJobRunningAlloc, activeJobLostAlloc, activeJobCompletedEvalCompletedAlloc,
 			stoppedJobStoppedAlloc, stoppedJobLostAlloc,
-			purgedJobCompleteAlloc,
 		},
 		[]*structs.Allocation{},
 	)
@@ -609,7 +607,6 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 		[]*structs.Allocation{
 			activeJobLostAlloc, activeJobCompletedEvalCompletedAlloc,
 			stoppedJobLostAlloc, stoppedJobLostAlloc,
-			purgedJobCompleteAlloc,
 		})
 }
 

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -596,7 +596,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 	//    than that of the job).
 	//	3. The active job remains since it is active, even though the allocations are otherwise
 	//      eligible for GC. However, the inactive allocation is GCed for it.
-	//	4. The eval and allocation for the purged job are GCed.
+	//	4. The eval and allocation for the purged job are deleted.
 	assertCorrectJobEvalAlloc(
 		memdb.NewWatchSet(),
 		[]*structs.Job{deadJob, activeJob, stoppedJob},
@@ -607,6 +607,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 		[]*structs.Allocation{
 			activeJobLostAlloc, activeJobCompletedEvalCompletedAlloc,
 			stoppedJobLostAlloc, stoppedJobLostAlloc,
+			purgedJobCompleteAlloc,
 		})
 }
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1984,7 +1984,7 @@ func (s *StateStore) DeleteJobTxn(index uint64, namespace, jobID string, txn Txn
 			continue
 		}
 		eval.Status = structs.EvalStatusComplete
-		eval.StatusDescription = fmt.Sprintf("evaluation deleted while purging job %s", job.ID)
+		eval.StatusDescription = fmt.Sprintf("job %s deleted", job.ID)
 
 		// Insert the eval
 		if err := txn.Insert("evals", eval); err != nil {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1979,10 +1979,11 @@ func (s *StateStore) DeleteJobTxn(index uint64, namespace, jobID string, txn Txn
 			continue
 		}
 
-		eval := existing.(*structs.Evaluation).Copy()
-		if eval.Status != structs.EvalStatusPending {
+		if existing.(*structs.Evaluation).Status != structs.EvalStatusPending {
 			continue
 		}
+
+		eval := existing.(*structs.Evaluation).Copy()
 		eval.Status = structs.EvalStatusComplete
 		eval.StatusDescription = fmt.Sprintf("job %s deleted", job.ID)
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1901,16 +1901,8 @@ func (s *StateStore) DeleteJobTxn(index uint64, namespace, jobID string, txn Txn
 	}
 
 	for _, deployment := range deployments {
-		existing, err := txn.First("deployment", "id", deployment.ID)
-		if err != nil {
-			return fmt.Errorf("deployment lookup failed: %v", err)
-		}
-		if existing == nil {
-			return fmt.Errorf("deployment not found")
-		}
-
 		// Delete the deployment
-		if err := txn.Delete("deployment", existing); err != nil {
+		if err := txn.Delete("deployment", deployment); err != nil {
 			return fmt.Errorf("deployment delete failed: %v", err)
 		}
 		if err := txn.Insert("index", &IndexEntry{"deployment", index}); err != nil {
@@ -1938,6 +1930,7 @@ func (s *StateStore) DeleteJobTxn(index uint64, namespace, jobID string, txn Txn
 			continue
 		}
 		eval.Status = structs.EvalStatusComplete
+		eval.StatusDescription = fmt.Sprintf("evaluation deleted while purging job %s", job.ID)
 
 		// Insert the eval
 		if err := txn.Insert("evals", eval); err != nil {
@@ -1955,16 +1948,7 @@ func (s *StateStore) DeleteJobTxn(index uint64, namespace, jobID string, txn Txn
 	}
 
 	for _, alloc := range allocs {
-		existing, err := txn.First("allocs", "id", alloc.ID)
-		if err != nil {
-			return fmt.Errorf("alloc lookup failed: %v", err)
-		}
-		if existing == nil {
-			return fmt.Errorf("alloc not found")
-		}
-
-		// Delete the alloc
-		if err := txn.Delete("allocs", existing); err != nil {
+		if err := txn.Delete("allocs", alloc); err != nil {
 			return fmt.Errorf("deployment delete failed: %v", err)
 		}
 		if err := txn.Insert("index", &IndexEntry{"allocs", index}); err != nil {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -806,6 +806,18 @@ func (s *StateStore) DeleteDeployment(index uint64, deploymentIDs []string) erro
 	txn := s.db.WriteTxn(index)
 	defer txn.Abort()
 
+	err := s.DeleteDeploymentTxn(index, deploymentIDs, txn)
+	if err == nil {
+		return txn.Commit()
+	}
+
+	return err
+}
+
+// DeleteDeploymentTxn is used to delete a set of deployments by ID, like
+// DeleteDeployment but in a transaction. Useful when making multiple
+// modifications atomically.
+func (s *StateStore) DeleteDeploymentTxn(index uint64, deploymentIDs []string, txn Txn) error {
 	if len(deploymentIDs) == 0 {
 		return nil
 	}
@@ -817,7 +829,7 @@ func (s *StateStore) DeleteDeployment(index uint64, deploymentIDs []string) erro
 			return fmt.Errorf("deployment lookup failed: %v", err)
 		}
 		if existing == nil {
-			return fmt.Errorf("deployment not found")
+			continue
 		}
 
 		// Delete the deployment
@@ -830,7 +842,50 @@ func (s *StateStore) DeleteDeployment(index uint64, deploymentIDs []string) erro
 		return fmt.Errorf("index update failed: %v", err)
 	}
 
-	return txn.Commit()
+	return nil
+}
+
+// DeleteAlloc is used to delete a set of allocations by ID
+func (s *StateStore) DeleteAlloc(index uint64, allocIDs []string) error {
+	txn := s.db.WriteTxn(index)
+	defer txn.Abort()
+
+	err := s.DeleteAllocTxn(index, allocIDs, txn)
+	if err == nil {
+		return txn.Commit()
+	}
+
+	return err
+}
+
+// DeleteAllocTxn is used to delete a set of allocs by ID, like DeleteALloc but
+// in a transaction. Useful when making multiple modifications atomically.
+func (s *StateStore) DeleteAllocTxn(index uint64, allocIDs []string, txn Txn) error {
+	if len(allocIDs) == 0 {
+		return nil
+	}
+
+	for _, allocID := range allocIDs {
+		// Lookup the alloc
+		existing, err := txn.First("allocs", "id", allocID)
+		if err != nil {
+			return fmt.Errorf("alloc lookup failed: %v", err)
+		}
+		if existing == nil {
+			continue
+		}
+
+		// Delete the alloc
+		if err := txn.Delete("allocs", existing); err != nil {
+			return fmt.Errorf("alloc delete failed: %v", err)
+		}
+	}
+
+	if err := txn.Insert("index", &IndexEntry{"allocs", index}); err != nil {
+		return fmt.Errorf("index update failed: %v", err)
+	}
+
+	return nil
 }
 
 // UpsertScalingEvent is used to insert a new scaling event.
@@ -1900,14 +1955,13 @@ func (s *StateStore) DeleteJobTxn(index uint64, namespace, jobID string, txn Txn
 		return fmt.Errorf("deployment lookup for job %s failed: %v", job.ID, err)
 	}
 
-	for _, deployment := range deployments {
-		// Delete the deployment
-		if err := txn.Delete("deployment", deployment); err != nil {
-			return fmt.Errorf("deployment delete failed: %v", err)
-		}
-		if err := txn.Insert("index", &IndexEntry{"deployment", index}); err != nil {
-			return fmt.Errorf("index update failed: %v", err)
-		}
+	deploymentIDs := []string{}
+	for _, d := range deployments {
+		deploymentIDs = append(deploymentIDs, d.ID)
+	}
+
+	if err := s.DeleteDeploymentTxn(index, deploymentIDs, txn); err != nil {
+		return err
 	}
 
 	// Mark all "pending" evals for this job as "complete"
@@ -1947,13 +2001,13 @@ func (s *StateStore) DeleteJobTxn(index uint64, namespace, jobID string, txn Txn
 		return fmt.Errorf("alloc lookup for job %s failed: %v", job.ID, err)
 	}
 
-	for _, alloc := range allocs {
-		if err := txn.Delete("allocs", alloc); err != nil {
-			return fmt.Errorf("deployment delete failed: %v", err)
-		}
-		if err := txn.Insert("index", &IndexEntry{"allocs", index}); err != nil {
-			return fmt.Errorf("index update failed: %v", err)
-		}
+	allocIDs := []string{}
+	for _, a := range allocs {
+		allocIDs = append(allocIDs, a.ID)
+	}
+
+	if err := s.DeleteAllocTxn(index, allocIDs, txn); err != nil {
+		return err
 	}
 
 	// Cleanup plugins registered by this job, before we delete the summary

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -7107,7 +7107,7 @@ func TestStateStore_AllocsForRegisteredJob(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	expected := len(allocs) + len(allocs1)
+	expected := len(allocs1) // state.DeleteJob corresponds to stop -purge, so all allocs from the original job should be gone
 	if len(out) != expected {
 		t.Fatalf("expected: %v, actual: %v", expected, len(out))
 	}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -4272,11 +4272,10 @@ func TestStateStore_CSIPlugin_Lifecycle(t *testing.T) {
 			controllersHealthy:     1,
 			nodesHealthy:           2,
 			controllersExpected:    0,
-			nodesExpected:          2,
+			nodesExpected:          0,
 		})
 		require.True(t, plug.ControllerRequired)
 		require.False(t, plug.IsEmpty())
-
 
 		for _, node := range nodes {
 			updateNodeFn(node.ID, func(node *structs.Node) {
@@ -4290,7 +4289,7 @@ func TestStateStore_CSIPlugin_Lifecycle(t *testing.T) {
 			controllersHealthy:     0,
 			nodesHealthy:           2,
 			controllersExpected:    0,
-			nodesExpected:          2,
+			nodesExpected:          0,
 		})
 		require.True(t, plug.ControllerRequired)
 		require.False(t, plug.IsEmpty())

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -4272,31 +4272,11 @@ func TestStateStore_CSIPlugin_Lifecycle(t *testing.T) {
 			controllersHealthy:     1,
 			nodesHealthy:           2,
 			controllersExpected:    0,
-			nodesExpected:          0,
+			nodesExpected:          2,
 		})
 		require.True(t, plug.ControllerRequired)
 		require.False(t, plug.IsEmpty())
 
-		updateAllocsFn(allocIDs, SERVER,
-			func(alloc *structs.Allocation) {
-				alloc.DesiredStatus = structs.AllocDesiredStatusStop
-			})
-
-		updateAllocsFn(allocIDs, CLIENT,
-			func(alloc *structs.Allocation) {
-				alloc.ClientStatus = structs.AllocClientStatusComplete
-			})
-
-		plug = checkPlugin(pluginCounts{
-			controllerFingerprints: 1,
-			nodeFingerprints:       2,
-			controllersHealthy:     1,
-			nodesHealthy:           2,
-			controllersExpected:    0,
-			nodesExpected:          0,
-		})
-		require.True(t, plug.ControllerRequired)
-		require.False(t, plug.IsEmpty())
 
 		for _, node := range nodes {
 			updateNodeFn(node.ID, func(node *structs.Node) {
@@ -4310,7 +4290,7 @@ func TestStateStore_CSIPlugin_Lifecycle(t *testing.T) {
 			controllersHealthy:     0,
 			nodesHealthy:           2,
 			controllersExpected:    0,
-			nodesExpected:          0,
+			nodesExpected:          2,
 		})
 		require.True(t, plug.ControllerRequired)
 		require.False(t, plug.IsEmpty())


### PR DESCRIPTION
When jobs are deleted with `-purge`, all their deployments and allocations should be deleted from the state store, and the evals status should be set to `complete`. Otherwise we end up in a situation where users could re-submit previously failing jobs, but these new jobs would not get deployments allocated unless `system gc` got called. 

Fixes #10502