### PR TITLE
client: add cpu scanner over /proc/cpuinfo

### DIFF
--- a/.changelog/19612.txt
+++ b/.changelog/19612.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where cpu fingerprinter would not consider /proc/cpuinfo
+```


### PR DESCRIPTION
This PR restores a previous behavior where CPU performance characteristics
were also scanned from the `/proc/cpuinfo` special file.

These numbers are not reliable - they represent the live processor speed
for each core at the time of sampling. To hopefully find a reasonable
guess of the base speed we average the sample across all cores and use
that value. As such these values are the used as the 3rd tier of precedence,
where first try get values from sysfs, then smbios, then here.

Fixes #19468
