### PR TITLE
consul: refactor job mutation hook

### DIFF
--- a/nomad/job_endpoint_hook_consul.go
+++ b/nomad/job_endpoint_hook_consul.go
@@ -30,3 +30,63 @@ func (jobConsulHook) validateTaskPartitionMatchesGroup(groupPartition string, ta
 	}
 	return nil
 }
+
+// mutateImpl ensures that the job's Consul blocks have been configured with the
+// correct Consul cluster if unset, and sets constraints on the Consul admin
+// partition if set. This should be called by the Mutate method.
+func (jobConsulHook) mutateImpl(job *structs.Job, defaultCluster string) (*structs.Job, []error, error) {
+	for _, group := range job.TaskGroups {
+		if group.Consul != nil {
+			if group.Consul.Cluster == "" {
+				group.Consul.Cluster = defaultCluster
+			}
+			if group.Consul.Partition != "" {
+				group.Constraints = append(group.Constraints,
+					newConsulPartitionConstraint(group.Consul.Cluster, group.Consul.Partition))
+			}
+		}
+
+		for _, service := range group.Services {
+			if service.IsConsul() && service.Cluster == "" {
+				service.Cluster = defaultCluster
+			}
+		}
+
+		for _, task := range group.Tasks {
+			if task.Consul != nil {
+				if task.Consul.Cluster == "" {
+					task.Consul.Cluster = defaultCluster
+				}
+				if task.Consul.Partition != "" {
+					task.Constraints = append(task.Constraints,
+						newConsulPartitionConstraint(task.Consul.Cluster, task.Consul.Partition))
+				}
+			}
+			for _, service := range task.Services {
+				if service.IsConsul() && service.Cluster == "" {
+					service.Cluster = defaultCluster
+				}
+			}
+		}
+	}
+
+	return job, nil, nil
+}
+
+// newConsulPartitionConstraint produces a constraint on the Consul admin
+// partition, based on the cluster name. In Nomad CE this will always be in the
+// default cluster.
+func newConsulPartitionConstraint(cluster, partition string) *structs.Constraint {
+	if cluster == structs.ConsulDefaultCluster || cluster == "" {
+		return &structs.Constraint{
+			LTarget: "${attr.consul.partition}",
+			RTarget: partition,
+			Operand: "=",
+		}
+	}
+	return &structs.Constraint{
+		LTarget: "${attr.consul." + cluster + ".partition}",
+		RTarget: partition,
+		Operand: "=",
+	}
+}

--- a/nomad/job_endpoint_hook_consul.go
+++ b/nomad/job_endpoint_hook_consul.go
@@ -34,7 +34,7 @@ func (jobConsulHook) validateTaskPartitionMatchesGroup(groupPartition string, ta
 // mutateImpl ensures that the job's Consul blocks have been configured with the
 // correct Consul cluster if unset, and sets constraints on the Consul admin
 // partition if set. This should be called by the Mutate method.
-func (jobConsulHook) mutateImpl(job *structs.Job, defaultCluster string) (*structs.Job, []error, error) {
+func (jobConsulHook) mutateImpl(job *structs.Job, defaultCluster string) *structs.Job {
 	for _, group := range job.TaskGroups {
 		if group.Consul != nil {
 			if group.Consul.Cluster == "" {
@@ -70,7 +70,7 @@ func (jobConsulHook) mutateImpl(job *structs.Job, defaultCluster string) (*struc
 		}
 	}
 
-	return job, nil, nil
+	return job
 }
 
 // newConsulPartitionConstraint produces a constraint on the Consul admin

--- a/nomad/job_endpoint_hook_consul_ce.go
+++ b/nomad/job_endpoint_hook_consul_ce.go
@@ -96,51 +96,8 @@ func (h jobConsulHook) validateCluster(name string) error {
 	return nil
 }
 
-func consulPartitionConstraint(partition string) *structs.Constraint {
-	return &structs.Constraint{
-		LTarget: "${attr.consul.partition}",
-		RTarget: partition,
-		Operand: "=",
-	}
-}
-
 // Mutate ensures that the job's Consul cluster has been configured to be the
 // default Consul cluster if unset
 func (j jobConsulHook) Mutate(job *structs.Job) (*structs.Job, []error, error) {
-	for _, group := range job.TaskGroups {
-		if group.Consul != nil {
-			if group.Consul.Cluster == "" {
-				group.Consul.Cluster = structs.ConsulDefaultCluster
-			}
-			if group.Consul.Partition != "" {
-				group.Constraints = append(group.Constraints,
-					consulPartitionConstraint(group.Consul.Partition))
-			}
-		}
-
-		for _, service := range group.Services {
-			if service.IsConsul() && service.Cluster == "" {
-				service.Cluster = structs.ConsulDefaultCluster
-			}
-		}
-
-		for _, task := range group.Tasks {
-			if task.Consul != nil {
-				if task.Consul.Cluster == "" {
-					task.Consul.Cluster = structs.ConsulDefaultCluster
-				}
-				if task.Consul.Partition != "" {
-					task.Constraints = append(task.Constraints,
-						consulPartitionConstraint(task.Consul.Partition))
-				}
-			}
-			for _, service := range task.Services {
-				if service.IsConsul() && service.Cluster == "" {
-					service.Cluster = structs.ConsulDefaultCluster
-				}
-			}
-		}
-	}
-
-	return job, nil, nil
+	return j.mutateImpl(job, structs.ConsulDefaultCluster)
 }

--- a/nomad/job_endpoint_hook_consul_ce.go
+++ b/nomad/job_endpoint_hook_consul_ce.go
@@ -99,5 +99,5 @@ func (h jobConsulHook) validateCluster(name string) error {
 // Mutate ensures that the job's Consul cluster has been configured to be the
 // default Consul cluster if unset
 func (j jobConsulHook) Mutate(job *structs.Job) (*structs.Job, []error, error) {
-	return j.mutateImpl(job, structs.ConsulDefaultCluster)
+	return j.mutateImpl(job, structs.ConsulDefaultCluster), nil, nil
 }


### PR DESCRIPTION
The job mutation logic for Nomad CE and Nomad ENT are nearly identical except for a prelude that grabs the correct default cluster. Factor this out into a method that can be shared between both code bases.

Ref: discussion in https://github.com/hashicorp/nomad-enterprise/pull/1367/files#r1447861412