### PR TITLE
client/allocdir: use an interface in place of AllocDir structs

### DIFF
--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -127,8 +127,8 @@ func (a *AllocDir) ShareDirPath() string {
 }
 
 func (a *AllocDir) GetTaskDir(task string) *TaskDir {
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.mu.RLock()
+	defer a.mu.RUnlock()
 	return a.TaskDirs[task]
 }
 

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -132,7 +132,7 @@ type allocRunner struct {
 	stateDB cstate.StateDB
 
 	// allocDir is used to build the allocations directory structure.
-	allocDir *allocdir.AllocDir
+	allocDir allocdir.Interface
 
 	// runnerHooks are alloc runner lifecycle hooks that should be run on state
 	// transitions.
@@ -264,7 +264,14 @@ func NewAllocRunner(config *config.AllocRunnerConfig) (interfaces.AllocRunner, e
 	ar.allocBroadcaster = cstructs.NewAllocBroadcaster(ar.logger)
 
 	// Create alloc dir
-	ar.allocDir = allocdir.NewAllocDir(ar.logger, config.ClientConfig.AllocDir, alloc.ID)
+	//
+	// TODO(shoenig): need to decide what version of alloc dir to use, and the
+	// return value should probably now be an interface
+	ar.allocDir = allocdir.NewAllocDir(
+		ar.logger,
+		config.ClientConfig.AllocDir,
+		alloc.ID,
+	)
 
 	ar.taskCoordinator = tasklifecycle.NewCoordinator(ar.logger, tg.Tasks, ar.waitCh)
 
@@ -432,7 +439,7 @@ func (ar *allocRunner) setAlloc(updated *structs.Allocation) {
 }
 
 // GetAllocDir returns the alloc dir which is safe for concurrent use.
-func (ar *allocRunner) GetAllocDir() *allocdir.AllocDir {
+func (ar *allocRunner) GetAllocDir() allocdir.Interface {
 	return ar.allocDir
 }
 

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -106,8 +106,12 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 	// Create a new taskenv.Builder which is used by hooks that mutate them to
 	// build new taskenv.TaskEnv.
 	newEnvBuilder := func() *taskenv.Builder {
-		return taskenv.NewBuilder(config.Node, ar.Alloc(), nil, config.Region).
-			SetAllocDir(ar.allocDir.AllocDir)
+		return taskenv.NewBuilder(
+			config.Node,
+			ar.Alloc(),
+			nil,
+			config.Region,
+		).SetAllocDir(ar.allocDir.AllocDirPath())
 	}
 
 	// Create a taskenv.TaskEnv which is used for read only purposes by the

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -1641,8 +1641,8 @@ func TestAllocRunner_Destroy(t *testing.T) {
 	require.Nil(t, ts)
 
 	// Assert the alloc directory was cleaned
-	if _, err := os.Stat(ar.(*allocRunner).allocDir.AllocDir); err == nil {
-		require.Fail(t, "alloc dir still exists: %v", ar.(*allocRunner).allocDir.AllocDir)
+	if _, err := os.Stat(ar.(*allocRunner).allocDir.AllocDirPath()); err == nil {
+		require.Fail(t, "alloc dir still exists: %v", ar.(*allocRunner).allocDir.AllocDirPath())
 	} else if !os.IsNotExist(err) {
 		require.Failf(t, "expected NotExist error", "found %v", err)
 	}
@@ -1700,9 +1700,9 @@ func TestAllocRunner_MoveAllocDir(t *testing.T) {
 
 	// Step 2. Modify its directory
 	task := alloc.Job.TaskGroups[0].Tasks[0]
-	dataFile := filepath.Join(ar.GetAllocDir().SharedDir, "data", "data_file")
+	dataFile := filepath.Join(ar.GetAllocDir().ShareDirPath(), "data", "data_file")
 	os.WriteFile(dataFile, []byte("hello world"), os.ModePerm)
-	taskDir := ar.GetAllocDir().TaskDirs[task.Name]
+	taskDir := ar.GetAllocDir().GetTaskDir(task.Name)
 	taskLocalFile := filepath.Join(taskDir.LocalDir, "local_file")
 	os.WriteFile(taskLocalFile, []byte("good bye world"), os.ModePerm)
 
@@ -1727,11 +1727,11 @@ func TestAllocRunner_MoveAllocDir(t *testing.T) {
 	WaitForClientState(t, ar, structs.AllocClientStatusComplete)
 
 	// Ensure that data from ar was moved to ar2
-	dataFile = filepath.Join(ar2.GetAllocDir().SharedDir, "data", "data_file")
+	dataFile = filepath.Join(ar2.GetAllocDir().ShareDirPath(), "data", "data_file")
 	fileInfo, _ := os.Stat(dataFile)
 	require.NotNilf(t, fileInfo, "file %q not found", dataFile)
 
-	taskDir = ar2.GetAllocDir().TaskDirs[task.Name]
+	taskDir = ar2.GetAllocDir().GetTaskDir(task.Name)
 	taskLocalFile = filepath.Join(taskDir.LocalDir, "local_file")
 	fileInfo, _ = os.Stat(taskLocalFile)
 	require.NotNilf(t, fileInfo, "file %q not found", dataFile)
@@ -1987,8 +1987,8 @@ func TestAllocRunner_TerminalUpdate_Destroy(t *testing.T) {
 		}
 
 		// Check the alloc directory still exists
-		if _, err := os.Stat(ar.GetAllocDir().AllocDir); err != nil {
-			return false, fmt.Errorf("alloc dir destroyed: %v", ar.GetAllocDir().AllocDir)
+		if _, err := os.Stat(ar.GetAllocDir().AllocDirPath()); err != nil {
+			return false, fmt.Errorf("alloc dir destroyed: %v", ar.GetAllocDir().AllocDirPath())
 		}
 
 		return true, nil
@@ -2011,8 +2011,8 @@ func TestAllocRunner_TerminalUpdate_Destroy(t *testing.T) {
 		}
 
 		// Check the alloc directory was cleaned
-		if _, err := os.Stat(ar.GetAllocDir().AllocDir); err == nil {
-			return false, fmt.Errorf("alloc dir still exists: %v", ar.GetAllocDir().AllocDir)
+		if _, err := os.Stat(ar.GetAllocDir().AllocDirPath()); err == nil {
+			return false, fmt.Errorf("alloc dir still exists: %v", ar.GetAllocDir().AllocDirPath())
 		} else if !os.IsNotExist(err) {
 			return false, fmt.Errorf("stat err: %v", err)
 		}

--- a/client/allocrunner/allocdir_hook.go
+++ b/client/allocrunner/allocdir_hook.go
@@ -4,18 +4,18 @@
 package allocrunner
 
 import (
-	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/allocdir"
 )
 
 // allocDirHook creates and destroys the root directory and shared directories
 // for an allocation.
 type allocDirHook struct {
-	allocDir *allocdir.AllocDir
-	logger   log.Logger
+	allocDir allocdir.Interface
+	logger   hclog.Logger
 }
 
-func newAllocDirHook(logger log.Logger, allocDir *allocdir.AllocDir) *allocDirHook {
+func newAllocDirHook(logger hclog.Logger, allocDir allocdir.Interface) *allocDirHook {
 	ad := &allocDirHook{
 		allocDir: allocDir,
 	}

--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -19,7 +19,7 @@ import (
 
 type consulHook struct {
 	alloc                   *structs.Allocation
-	allocdir                *allocdir.AllocDir
+	allocdir                allocdir.Interface
 	widmgr                  widmgr.IdentityManager
 	consulConfigs           map[string]*structsc.ConsulConfig
 	consulClientConstructor func(*structsc.ConsulConfig, log.Logger) (consul.Client, error)
@@ -30,7 +30,7 @@ type consulHook struct {
 
 type consulHookConfig struct {
 	alloc    *structs.Allocation
-	allocdir *allocdir.AllocDir
+	allocdir allocdir.Interface
 	widmgr   widmgr.IdentityManager
 
 	// consulConfigs is a map of cluster names to Consul configs

--- a/client/allocrunner/interfaces/runner.go
+++ b/client/allocrunner/interfaces/runner.go
@@ -48,7 +48,7 @@ type AllocRunner interface {
 	GetTaskDriverCapabilities(taskName string) (*drivers.Capabilities, error)
 	StatsReporter() AllocStatsReporter
 	Listener() *cstructs.AllocListener
-	GetAllocDir() *allocdir.AllocDir
+	GetAllocDir() allocdir.Interface
 }
 
 // TaskStateHandler exposes a handler to be called when a task's state changes

--- a/client/allocrunner/migrate_hook.go
+++ b/client/allocrunner/migrate_hook.go
@@ -15,12 +15,16 @@ import (
 // diskMigrationHook migrates ephemeral disk volumes. Depends on alloc dir
 // being built but must be run before anything else manipulates the alloc dir.
 type diskMigrationHook struct {
-	allocDir     *allocdir.AllocDir
+	allocDir     allocdir.Interface
 	allocWatcher config.PrevAllocMigrator
 	logger       log.Logger
 }
 
-func newDiskMigrationHook(logger log.Logger, allocWatcher config.PrevAllocMigrator, allocDir *allocdir.AllocDir) *diskMigrationHook {
+func newDiskMigrationHook(
+	logger log.Logger,
+	allocWatcher config.PrevAllocMigrator,
+	allocDir allocdir.Interface,
+) *diskMigrationHook {
 	h := &diskMigrationHook{
 		allocDir:     allocDir,
 		allocWatcher: allocWatcher,

--- a/client/allocwatcher/alloc_watcher.go
+++ b/client/allocwatcher/alloc_watcher.go
@@ -44,7 +44,7 @@ type terminated interface {
 // AllocRunnerMeta provides metadata about an AllocRunner such as its alloc and
 // alloc dir.
 type AllocRunnerMeta interface {
-	GetAllocDir() *allocdir.AllocDir
+	GetAllocDir() allocdir.Interface
 	Listener() *cstructs.AllocListener
 	Alloc() *structs.Allocation
 }
@@ -192,7 +192,7 @@ type localPrevAlloc struct {
 	sticky bool
 
 	// prevAllocDir is the alloc dir for the previous alloc
-	prevAllocDir *allocdir.AllocDir
+	prevAllocDir allocdir.Interface
 
 	// prevListener allows blocking for updates to the previous alloc
 	prevListener *cstructs.AllocListener
@@ -262,7 +262,7 @@ func (p *localPrevAlloc) Wait(ctx context.Context) error {
 }
 
 // Migrate from previous local alloc dir to destination alloc dir.
-func (p *localPrevAlloc) Migrate(ctx context.Context, dest *allocdir.AllocDir) error {
+func (p *localPrevAlloc) Migrate(ctx context.Context, dest allocdir.Interface) error {
 	if !p.sticky {
 		// Not a sticky volume, nothing to migrate
 		return nil
@@ -425,7 +425,7 @@ func (p *remotePrevAlloc) Wait(ctx context.Context) error {
 
 // Migrate alloc data from a remote node if the new alloc has migration enabled
 // and the old alloc hasn't been GC'd.
-func (p *remotePrevAlloc) Migrate(ctx context.Context, dest *allocdir.AllocDir) error {
+func (p *remotePrevAlloc) Migrate(ctx context.Context, dest allocdir.Interface) error {
 	if !p.migrate {
 		// Volume wasn't configured to be migrated, return early
 		return nil
@@ -677,7 +677,7 @@ type NoopPrevAlloc struct{}
 func (NoopPrevAlloc) Wait(context.Context) error { return nil }
 
 // Migrate returns nil immediately.
-func (NoopPrevAlloc) Migrate(context.Context, *allocdir.AllocDir) error { return nil }
+func (NoopPrevAlloc) Migrate(context.Context, allocdir.Interface) error { return nil }
 
 func (NoopPrevAlloc) IsWaiting() bool   { return false }
 func (NoopPrevAlloc) IsMigrating() bool { return false }

--- a/client/allocwatcher/alloc_watcher_test.go
+++ b/client/allocwatcher/alloc_watcher_test.go
@@ -29,7 +29,7 @@ import (
 // fakeAllocRunner implements AllocRunnerMeta
 type fakeAllocRunner struct {
 	alloc       *structs.Allocation
-	AllocDir    *allocdir.AllocDir
+	AllocDir    allocdir.Interface
 	Broadcaster *cstructs.AllocBroadcaster
 }
 
@@ -49,7 +49,7 @@ func newFakeAllocRunner(t *testing.T, logger hclog.Logger) *fakeAllocRunner {
 	}
 }
 
-func (f *fakeAllocRunner) GetAllocDir() *allocdir.AllocDir {
+func (f *fakeAllocRunner) GetAllocDir() allocdir.Interface {
 	return f.AllocDir
 }
 

--- a/client/client_interface_test.go
+++ b/client/client_interface_test.go
@@ -151,7 +151,7 @@ func (ar *emptyAllocRunner) GetTaskDriverCapabilities(taskName string) (*drivers
 
 func (ar *emptyAllocRunner) StatsReporter() interfaces.AllocStatsReporter { return ar }
 func (ar *emptyAllocRunner) Listener() *cstructs.AllocListener            { return nil }
-func (ar *emptyAllocRunner) GetAllocDir() *allocdir.AllocDir              { return nil }
+func (ar *emptyAllocRunner) GetAllocDir() allocdir.Interface              { return nil }
 
 // LatestAllocStats lets this empty runner implement AllocStatsReporter
 func (ar *emptyAllocRunner) LatestAllocStats(taskFilter string) (*cstructs.AllocResourceUsage, error) {

--- a/client/config/arconfig.go
+++ b/client/config/arconfig.go
@@ -141,5 +141,5 @@ type PrevAllocMigrator interface {
 	IsMigrating() bool
 
 	// Migrate data from previous alloc
-	Migrate(ctx context.Context, dest *allocdir.AllocDir) error
+	Migrate(ctx context.Context, dest allocdir.Interface) error
 }


### PR DESCRIPTION
This PR replace `*allocdir.AllocDir` with `allocdir.Interface` such that we
may eventually have another implementation of alloc directories. This is
in support of the exec2 driver, which will need an implementation of the
alloc directory incompatible with the current version.

Preliminary work for https://github.com/hashicorp/team-nomad/issues/373

No backport; for 1.8