### PR TITLE
build: use setup-golang@v3 to handle auto caching

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Git config token
         if: endsWith(github.repository, '-enterprise')
         run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
-      - uses: hashicorp/setup-golang@v2
+      - uses: hashicorp/setup-golang@v3
       - name: Run make check
         run: |
           make missing

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Git config token
         if: endsWith(github.repository, '-enterprise')
         run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
-      - uses: hashicorp/setup-golang@915cbca7b66738f9072154ec95e5ee2dfee2c956
+      - uses: hashicorp/setup-golang@v3
       - name: Get Go modules
         run: |
           make bootstrap
@@ -78,7 +78,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: hashicorp/setup-golang@915cbca7b66738f9072154ec95e5ee2dfee2c956
+      - uses: hashicorp/setup-golang@v3
       - name: Run make dev
         run: |
           make bootstrap
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: hashicorp/setup-golang@915cbca7b66738f9072154ec95e5ee2dfee2c956
+      - uses: hashicorp/setup-golang@v3
       - name: Run API tests
         env:
           GOTEST_MOD: api
@@ -113,7 +113,7 @@ jobs:
           - quick
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: hashicorp/setup-golang@915cbca7b66738f9072154ec95e5ee2dfee2c956
+      - uses: hashicorp/setup-golang@v3
       - name: Run Matrix Tests
         env:
           GOTEST_GROUP: ${{matrix.groups}}

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Git config token
         if: endsWith(github.repository, '-enterprise')
         run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
-      - uses: hashicorp/setup-golang@v2
+      - uses: hashicorp/setup-golang@915cbca7b66738f9072154ec95e5ee2dfee2c956
       - name: Get Go modules
         run: |
           make bootstrap
@@ -78,7 +78,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: hashicorp/setup-golang@v2
+      - uses: hashicorp/setup-golang@915cbca7b66738f9072154ec95e5ee2dfee2c956
       - name: Run make dev
         run: |
           make bootstrap
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: hashicorp/setup-golang@v2
+      - uses: hashicorp/setup-golang@915cbca7b66738f9072154ec95e5ee2dfee2c956
       - name: Run API tests
         env:
           GOTEST_MOD: api
@@ -113,7 +113,7 @@ jobs:
           - quick
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      - uses: hashicorp/setup-golang@v2
+      - uses: hashicorp/setup-golang@915cbca7b66738f9072154ec95e5ee2dfee2c956
       - name: Run Matrix Tests
         env:
           GOTEST_GROUP: ${{matrix.groups}}

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Git config token
         if: endsWith(github.repository, '-enterprise')
         run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
-      - uses: hashicorp/setup-golang@v2
+      - uses: hashicorp/setup-golang@v3
       - run: make deps
       - name: Vault Compatability
         run: make integration-test
@@ -59,7 +59,7 @@ jobs:
       - name: Git config token
         if: endsWith(github.repository, '-enterprise')
         run: git config --global url.'https://${{ secrets.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
-      - uses: hashicorp/setup-golang@v2
+      - uses: hashicorp/setup-golang@v3
       - name: Consul Compatability
         run: |
           make deps


### PR DESCRIPTION
Use the latest hashicorp/setup-golang @ v3 which has been fixed to handle the fact that the actions/setup-go action automatically sets up the caching that we had to do manually before.

This should cleanup a bunch of errors showing in recent actions outputs and maybe prevent some double caching.