### PR TITLE
docs: fix Consul ACL requirements

### DIFF
--- a/website/content/docs/integrations/consul/acl.mdx
+++ b/website/content/docs/integrations/consul/acl.mdx
@@ -40,6 +40,7 @@ service_prefix "" {
   policy = "write"
 }
 
+acl  = "write"
 mesh = "write"
 ```
 


### PR DESCRIPTION
Even with the new workload identitiy based flow the Nomad servers still need the `acl = "write"` permission in order to revoke service identity tokens.