### PR TITLE
docs: updates link to Consul WLI migration docs

### DIFF
--- a/website/content/docs/configuration/consul.mdx
+++ b/website/content/docs/configuration/consul.mdx
@@ -365,7 +365,7 @@ namespace "nomad-ns" {
 [`service.cluster`]: /nomad/docs/job-specification/service#cluster
 [identity_block]: /nomad/docs/job-specification/identity
 [`template`]: /nomad/docs/job-specification/template
-[Migrating to Using Workload Identity with Consul]: /nomad/docs/integrations/consul-integration#migrating-to-using-workload-identity-with-consul
+[Migrating to Using Workload Identity with Consul]: /nomad/docs/integrations/consul/acl#migrating-to-using-workload-identity-with-consul
 [auth-method]: /consul/docs/security/acl/auth-methods/jwt
 [`client.enabled`]: /nomad/docs/configuration/client#enabled
 [`server.enabled`]: /nomad/docs/configuration/server#enabled


### PR DESCRIPTION
Fixes #19747.

 - Updates the link from ../configuration/consul to workload identity migration docs.