### PR TITLE
e2e: WaitForJobStopped correction

### DIFF
--- a/e2e/e2eutil/utils.go
+++ b/e2e/e2eutil/utils.go
@@ -211,6 +211,11 @@ func WaitForAllocNotPending(t *testing.T, nomadClient *api.Client, allocID strin
 func WaitForJobStopped(t *testing.T, nomadClient *api.Client, job string) {
 	_, _, err := nomadClient.Jobs().Deregister(job, true, nil)
 	require.NoError(t, err, "error deregistering job %q", job)
+
+	// sleep for 3 seconds to make sure things any related events (like Consul
+	// service de-registration) has enough time to happen, because there are
+	// tests that assert such things after stopping jobs.
+	time.Sleep(3 * time.Second)
 }
 
 func WaitForAllocsStopped(t *testing.T, nomadClient *api.Client, allocIDs []string) {


### PR DESCRIPTION
We're getting errors from some tests that assert service de-registration from Consul after calling `WaitForJobStopped`. Before https://github.com/hashicorp/nomad/pull/19744, `WaitForJobStopped` waited for allocs to be stopped too, but since we [changed](https://github.com/hashicorp/nomad/pull/19609) the behavior of `-purge`, there is no wait anymore and Consul-related assertions happen immediately. 

Example of a failing test:
```
=== RUN   TestE2E/ConsulNamespaces/*consul.ConsulNamespacesE2ETest/TestConsulConnectSidecarsMinimalToken
    consul.go:52: 
        	Error Trace:	/home/runner/actions-runner/_work/nomad-e2e/nomad-e2e/nomad/e2e/e2eutil/consul.go:52
        	            				/home/runner/actions-runner/_work/nomad-e2e/nomad-e2e/nomad/testutil/wait.go:68
        	            				/home/runner/actions-runner/_work/nomad-e2e/nomad-e2e/nomad/e2e/e2eutil/consul.go:42
        	            				/home/runner/actions-runner/_work/nomad-e2e/nomad-e2e/nomad/e2e/consul/namespaces.go:246
        	            				/home/runner/actions-runner/_work/nomad-e2e/nomad-e2e/nomad/e2e/consul/namespaces_ent.go:297
        	Error:      	Received unexpected error:
        	            	service count-api: expected empty services but found 1 []*api.ServiceEntry{
        	            	    &api.ServiceEntry{
        	            	        Node: &api.Node{
        	            	            ID:              "d21ce1a2-7718-bc60-9153-4ecf617c338d",
        	            	            Node:            "ip-172-31-94-167",
        	            	            Address:         "172.31.94.167",
        	            	            Datacenter:      "nomad-e2e-shared-hcp-consul",
        	            	            TaggedAddresses: {"lan":"172.31.94.167", "lan_ipv4":"172.31.94.167", "wan":"172.31.94.167", "wan_ipv4":"172.31.94.167"},
        	            	            Meta:            {"consul-network-segment":"", "consul-version":"1.17.0"},
        	            	            CreateIndex:     0x5ad608,
        	            	            ModifyIndex:     0x5ad609,
        	            	            Partition:       "default",
        	            	            PeerName:        "",
        	            	            Locality:        (*api.Locality)(nil),
        	            	        },
        	            	        Service: &api.AgentService{
        	            	            Kind:              "",
        	            	            ID:                "_nomad-task-d4c013af-bc04-2fdf-a930-122c887[363](https://github.com/hashicorp/nomad-e2e/actions/runs/7538512277/job/20519250592#step:22:364)68-group-api-count-api-9001",
        	            	            Service:           "count-api",
        	            	            Tags:              {},
        	            	            Meta:              {"external-source":"nomad"},
        	            	            Port:              9001,
        	            	            Address:           "",
        	            	            SocketPath:        "",
        	            	            TaggedAddresses:   {},
        	            	            Weights:           api.AgentWeights{Passing:1, Warning:1},
        	            	            EnableTagOverride: false,
        	            	            CreateIndex:       0x5ad83b,
        	            	            ModifyIndex:       0x5ad83b,
        	            	            ContentHash:       "",
        	            	            Proxy:             &api.AgentServiceConnectProxyConfig{},
        	            	            Connect:           &api.AgentServiceConnect{},
        	            	            PeerName:          "",
        	            	            Namespace:         "apple",
        	            	            Partition:         "default",
        	            	            Datacenter:        "",
        	            	            Locality:          (*api.Locality)(nil),
        	            	        },
        	            	        Checks: {
        	            	            &api.HealthCheck{
        	            	                Node:        "ip-172-31-94-167",
        	            	                CheckID:     "serfHealth",
        	            	                Name:        "Serf Health Status",
        	            	                Status:      "passing",
        	            	                Notes:       "",
        	            	                Output:      "Agent alive and reachable",
        	            	                ServiceID:   "",
        	            	                ServiceName: "",
        	            	                ServiceTags: {},
        	            	                Type:        "",
        	            	                Namespace:   "default",
        	            	                Partition:   "default",
        	            	                ExposedPort: 0,
        	            	                PeerName:    "",
        	            	                Definition:  api.HealthCheckDefinition{},
        	            	                CreateIndex: 0x5ad608,
        	            	                ModifyIndex: 0x5ad608,
        	            	            },
        	            	            &api.HealthCheck{
        	            	                Node:        "ip-172-31-94-167",
        	            	                CheckID:     "_nomad-check-375f552d70b04bae196f99562ef9aa72264e530b",
        	            	                Name:        "api-health",
        	            	                Status:      "passing",
        	            	                Notes:       "",
        	            	                Output:      "HTTP GET http://172.31.94.167:26051/health: 200 OK Output: Hello, you've hit /health\n",
        	            	                ServiceID:   "_nomad-task-d4c013af-bc04-2fdf-a930-122c88736[368](https://github.com/hashicorp/nomad-e2e/actions/runs/7538512277/job/20519250592#step:22:369)-group-api-count-api-9001",
        	            	                ServiceName: "count-api",
        	            	                ServiceTags: {},
        	            	                Type:        "http",
        	            	                Namespace:   "apple",
        	            	                Partition:   "default",
        	            	                ExposedPort: 0,
        	            	                PeerName:    "",
        	            	                Definition:  api.HealthCheckDefinition{},
        	            	                CreateIndex: 0x5ad83b,
        	            	                ModifyIndex: 0x5ad84b,
        	            	            },
        	            	        },
        	            	    },
        	            	}
        	Test:       	TestE2E/ConsulNamespaces/*consul.ConsulNamespacesE2ETest/TestConsulConnectSidecarsMinimalToken
```

I welcome better suggestions on how to handle this. 