### PR TITLE
Clarify some docs pages

### DIFF
--- a/website/content/docs/job-specification/hcl2/variables.mdx
+++ b/website/content/docs/job-specification/hcl2/variables.mdx
@@ -14,12 +14,14 @@ job to be customized without altering the job's own source code.
 When you declare variables in the same file as the job specification, you
 can set their values using CLI options and environment variables.
 
--> **Note:** For brevity, input variables are often referred to as just
-"variables" or "Nomad variables" when it is clear from context what sort of
-variable is being discussed. Other kinds of variables in Nomad include
-_environment variables_ (set by the shell where Nomad runs) and _expression
-variables_ (used to indirectly represent a value in an
-[expression](/nomad/docs/job-specification/hcl2/expressions)).
+-> **Note:** For brevity, input variables are sometimes referred to as just
+"variables" when it is clear from context what sort of variable is being discussed
+(related to HCL job files). They should not be confused with [Nomad Variables]
+(/nomad/docs/concepts/variables), which are useful for storing small pieces of configuration or 
+secret data accessible from Jobs at runtime.
+Other kinds of variables in Nomad include [_environment variables_](https://developer.hashicorp.com/nomad/docs/runtime/environment) 
+(set by the shell where Nomad runs) and _expression variables_ (used to indirectly represent a
+value in an [expression](/nomad/docs/job-specification/hcl2/expressions)).
 
 ## Declaring an Input Variable
 

--- a/website/content/docs/job-specification/hcl2/variables.mdx
+++ b/website/content/docs/job-specification/hcl2/variables.mdx
@@ -15,13 +15,13 @@ When you declare variables in the same file as the job specification, you
 can set their values using CLI options and environment variables.
 
 -> **Note:** For brevity, input variables are sometimes referred to as just
-"variables" when it is clear from context what sort of variable is being discussed
-(related to HCL job files). They should not be confused with [Nomad Variables]
-(/nomad/docs/concepts/variables), which are useful for storing small pieces of configuration or 
-secret data accessible from Jobs at runtime.
-Other kinds of variables in Nomad include [_environment variables_](https://developer.hashicorp.com/nomad/docs/runtime/environment) 
-(set by the shell where Nomad runs) and _expression variables_ (used to indirectly represent a
-value in an [expression](/nomad/docs/job-specification/hcl2/expressions)).
+"variables" when it is clear from context what sort of variable is being
+discussed (related to HCL job files). They should not be confused with [Nomad
+Variables][], which are useful for storing small pieces of configuration or
+secret data accessible from Jobs at runtime.  Other kinds of variables in Nomad
+include [_environment variables_][] (set by the shell where Nomad runs) and
+_expression variables_ (used to indirectly represent a value in an
+[expression][]).
 
 ## Declaring an Input Variable
 
@@ -329,3 +329,8 @@ this behavior optional :
 |             var.foo             | error, "foo needs to be set" |       null       |        xy        |
 | `NOMAD_VAR_foo=yz`<br />var.foo |              yz              |        yz        |        yz        |
 |   `-var foo=yz`<br />var.foo    |              yz              |        yz        |        yz        |
+
+
+[Nomad Variables]: /nomad/docs/concepts/variables
+[_environment variables_]: /nomad/docs/runtime/environment
+[expression]: /nomad/docs/job-specification/hcl2/expressions

--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -69,7 +69,7 @@ refer to the [Learn Go Template Syntax][gt_learn] guide.
 
 - `destination` `(string: <required>)` - Specifies the location where the
   resulting template should be rendered, relative to the [task working
-  directory]. Only drivers without filesystem isolation (ex. `raw_exec`) or
+  directory][]. Only drivers without filesystem isolation (ex. `raw_exec`) or
   that build a chroot in the task working directory (ex. `exec`) can render
   templates outside of the `NOMAD_ALLOC_DIR`, `NOMAD_TASK_DIR`, or
   `NOMAD_SECRETS_DIR`. For more details on how `destination` interacts with
@@ -123,11 +123,11 @@ refer to the [Learn Go Template Syntax][gt_learn] guide.
   different delimiter that does not conflict with the output file itself.
 
 - `source` `(string: "")` - Specifies the path to the template to be rendered.
-  One of `source` or `data` must be specified, but not both. This source can
-  be fetched using an [`artifact`][artifact] resource. The template must exist in the
-  [task working directory](/nomad/docs/concepts/filesystem#templates-artifacts-and-dispatch-payloads)
-  prior to starting the task; it is not possible to reference a template whose source is inside 
-  a Docker container, for example.
+  One of `source` or `data` must be specified, but not both. This source can be
+  fetched using an [`artifact`][artifact] resource. The template must exist in
+  the [task working directory][] prior to starting the task; it is not possible
+  to reference a template whose source is inside a Docker container, for
+  example.
 
 - `splay` `(string: "5s")` - Specifies a random amount of time to wait between
   0 ms and the given splay value before invoking the change mode. This is
@@ -399,13 +399,17 @@ EOH
 
 ### Nomad Variables
 
-  ~> **Warning:** Using the Nomad integration results in an implicit dependency 
-  on the Nomad servers. If the control plane is unavailable (e.g. a client becoming isolated),
-  after some retries, running allocations will be stopped. Refer to the
-  [`nomad_retry`](/nomad/docs/configuration/client#nomad_retry) client configuration option
-  for more details and to adjust the retry behaviour.
+<Warning>
 
-Nomad [variables] can be queried using the `nomadVar`, `nomadVarList`,
+Using the Nomad integration results in an implicit dependency on the Nomad
+servers. If the Nomad servers are unavailable (for example, a client is
+disconnected), then after some retries, running allocations will be
+stopped. Refer to the [`template.nomad_retry`][] client configuration option for
+more details and to adjust the retry behaviour.
+
+</Warning>
+
+Nomad [variables][] can be queried using the `nomadVar`, `nomadVarList`,
 `nomadVarListSafe`, and `nomadVarExists` functions.
 
 #### `nomadVarList` and `nomadVarListSafe`
@@ -574,10 +578,14 @@ EOH
 
 ## Consul Integration
 
-  ~> **Warning:** Using the Consul integration results in an implicit dependency 
-  on Consul. If Consul is unavailable, the job will fail to start, and after some 
-  retries, running allocations will be stopped. Refer to the [`consul_retry`](/nomad/docs/configuration/client#consul_retry)
-  client configuration option for more details and to adjust the retry behaviour.
+<Warning>
+
+Using the Consul integration results in an implicit dependency on Consul. If
+Consul is unavailable, then after some retries, running allocations will be
+stopped. Refer to the [`template.consul_retry`][] client configuration option
+for more details and to adjust the retry behaviour.
+
+</Warning>
 
 ### Consul KV
 
@@ -634,10 +642,14 @@ upstream {{ .Name | toLower }} {
 
 ## Vault Integration
 
-  ~> **Warning:** Using the Vault integration results in an implicit dependency 
-  on Vault. If Vault is unavailable, the job will fail to start, and after some 
-  retries, running allocations will be stopped. Refer to the [`vault_retry`](/nomad/docs/configuration/client#vault_retry)
-  client configuration option for more details and to adjust the retry behaviour.
+<Warning>
+
+Using the Vault integration results in an implicit dependency on Vault. If
+Vault is unavailable, then after some retries, running allocations will be
+stopped. Refer to the [`template.vault_retry`][] client configuration option
+for more details and to adjust the retry behaviour.
+
+</Warning>
 
 ### PKI Certificate
 
@@ -802,3 +814,6 @@ options](/nomad/docs/configuration/client#options):
 [variables]: /nomad/docs/concepts/variables
 [workload identity]: /nomad/docs/concepts/workload-identity
 [`time.Time`]: https://pkg.go.dev/time#Time
+[`template.nomad_retry`]: /nomad/docs/configuration/client#nomad_retry
+[`template.consul_retry`]: /nomad/docs/configuration/client#consul_retry
+[`template.vault_retry`]: /nomad/docs/configuration/client#vault_retry

--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -402,7 +402,7 @@ EOH
   ~> **Warning:** Using the Nomad integration results in an implicit dependency 
   on the Nomad servers. If the control plane is unavailable (e.g. a client becoming isolated),
   after some retries, running allocations will be stopped. Refer to the
-  [`nomad_retry`](/nomad/docs/configuration/client#nomad_retry)client configuration option
+  [`nomad_retry`](/nomad/docs/configuration/client#nomad_retry) client configuration option
   for more details and to adjust the retry behaviour.
 
 Nomad [variables] can be queried using the `nomadVar`, `nomadVarList`,

--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -399,6 +399,12 @@ EOH
 
 ### Nomad Variables
 
+  ~> **Warning:** Using the Nomad integration results in an implicit dependency 
+  on the Nomad servers. If the control plane is unavailable (e.g. a client becoming isolated),
+  after some retries, running allocations will be stopped. Refer to the
+  [`nomad_retry`](/nomad/docs/configuration/client#nomad_retry)client configuration option
+  for more details and to adjust the retry behaviour.
+
 Nomad [variables] can be queried using the `nomadVar`, `nomadVarList`,
 `nomadVarListSafe`, and `nomadVarExists` functions.
 
@@ -568,6 +574,11 @@ EOH
 
 ## Consul Integration
 
+  ~> **Warning:** Using the Consul integration results in an implicit dependency 
+  on Consul. If Consul is unavailable, the job will fail to start, and after some 
+  retries, running allocations will be stopped. Refer to the [`consul_retry`](/nomad/docs/configuration/client#consul_retry)
+  client configuration option for more details and to adjust the retry behaviour.
+
 ### Consul KV
 
 Consul KV values can be accessed using the [`key`][ct_api_key] function to
@@ -622,6 +633,11 @@ upstream {{ .Name | toLower }} {
 ```
 
 ## Vault Integration
+
+  ~> **Warning:** Using the Vault integration results in an implicit dependency 
+  on Vault. If Vault is unavailable, the job will fail to start, and after some 
+  retries, running allocations will be stopped. Refer to the [`vault_retry`](/nomad/docs/configuration/client#vault_retry)
+  client configuration option for more details and to adjust the retry behaviour.
 
 ### PKI Certificate
 

--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -124,9 +124,10 @@ refer to the [Learn Go Template Syntax][gt_learn] guide.
 
 - `source` `(string: "")` - Specifies the path to the template to be rendered.
   One of `source` or `data` must be specified, but not both. This source can
-  optionally be fetched using an [`artifact`][artifact] resource. This template
-  must exist on the machine prior to starting the task; it is not possible to
-  reference a template that's source is inside a Docker container, for example.
+  be fetched using an [`artifact`][artifact] resource. The template must exist in the
+  [task working directory](/nomad/docs/concepts/filesystem#templates-artifacts-and-dispatch-payloads)
+  prior to starting the task; it is not possible to reference a template whose source is inside 
+  a Docker container, for example.
 
 - `splay` `(string: "5s")` - Specifies a random amount of time to wait between
   0 ms and the given splay value before invoking the change mode. This is


### PR DESCRIPTION
Hey everyone,

A couple of small clarifications in a couple of docs:

- add a warning to `templates` that using Nomad/Consul/Vault results in a heavy dependency
- clarify that HCL2 input variables and Nomad Variables are different
- improve the wording on the `template` source param

Adrian