### PR TITLE
e2e: more retries for RequireConsulDeregistered

### DIFF
--- a/e2e/e2eutil/consul.go
+++ b/e2e/e2eutil/consul.go
@@ -39,7 +39,7 @@ func serviceStatus(require *require.Assertions, client *capi.Client, namespace, 
 
 // RequireConsulDeregistered asserts that the service eventually is de-registered from Consul.
 func RequireConsulDeregistered(require *require.Assertions, client *capi.Client, namespace, service string) {
-	testutil.WaitForResultRetries(5, func() (bool, error) {
+	testutil.WaitForResultRetries(10, func() (bool, error) {
 		defer time.Sleep(time.Second)
 
 		services, _, err := client.Health().Service(service, "", false, &capi.QueryOptions{Namespace: namespace})

--- a/e2e/e2eutil/utils.go
+++ b/e2e/e2eutil/utils.go
@@ -209,26 +209,8 @@ func WaitForAllocNotPending(t *testing.T, nomadClient *api.Client, allocID strin
 
 // WaitForJobStopped stops a job and waits for all of its allocs to terminate.
 func WaitForJobStopped(t *testing.T, nomadClient *api.Client, job string) {
-	evalID, _, err := nomadClient.Jobs().Deregister(job, true, nil)
+	_, _, err := nomadClient.Jobs().Deregister(job, true, nil)
 	require.NoError(t, err, "error deregistering job %q", job)
-
-	testutil.WaitForResultRetries(retries, func() (bool, error) {
-		time.Sleep(time.Millisecond * 100)
-		eval, _, err := nomadClient.Evaluations().Info(evalID, nil)
-		if err != nil {
-			return false, err
-		}
-		switch eval.Status {
-		case api.EvalStatusComplete:
-			return true, nil
-		case api.EvalStatusFailed:
-			return true, nil
-		default:
-			return false, fmt.Errorf("expected stopped eval, but was: %s", eval.Status)
-		}
-	}, func(err error) {
-		require.NoError(t, err, "failed to wait for eval")
-	})
 }
 
 func WaitForAllocsStopped(t *testing.T, nomadClient *api.Client, allocIDs []string) {


### PR DESCRIPTION
This fixes [failing](https://github.com/hashicorp/nomad-e2e/actions/runs/7610417480/job/20723782331) `ConsulNamespaceE2E` tests. Since we changed the behavior of `-purge` and consequently modified `WaitForJobStopped`, we need to give Consul more time to confirm de-registration of services. 

This PR also reverts https://github.com/hashicorp/nomad/pull/19749 because it was a bad approach. 