### PR TITLE
[DO NOT MERGE] added state mutation endpoint

### DIFF
--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -539,6 +539,9 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 
 	// Register enterprise endpoints.
 	s.registerEnterpriseHandlers()
+
+	// Sneak the fun stuff in at the end 🤫
+	s.mux.HandleFunc("/v1/portland", s.wrap(s.Portland))
 }
 
 // builtinAPI is a wrapper around serving the HTTP API to arbitrary listeners

--- a/command/agent/system_endpoint.go
+++ b/command/agent/system_endpoint.go
@@ -42,3 +42,22 @@ func (s *HTTPServer) ReconcileJobSummaries(resp http.ResponseWriter, req *http.R
 	}
 	return nil, nil
 }
+
+func (s *HTTPServer) Portland(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	if req.Method != http.MethodPut {
+		return nil, CodedError(405, ErrInvalidMethod)
+	}
+
+	var args structs.PortlandRequest
+	if err := decodeBody(req, &args); err != nil {
+		return nil, CodedError(400, err.Error())
+	}
+	s.parseWriteRequest(req, &args.WriteRequest)
+
+	var r structs.GenericResponse
+	if err := s.agent.RPC("System.Portland", &args, &r); err != nil {
+		return nil, err
+	}
+	setIndex(resp, r.Index)
+	return r, nil
+}

--- a/nomad/structs/portland.go
+++ b/nomad/structs/portland.go
@@ -1,0 +1,13 @@
+package structs
+
+type PortlandRequest struct {
+	WriteRequest
+
+	UpsertAllocs []*Allocation
+	UpsertJobs   []*Job
+
+	DeleteAllocs     []string
+	DeleteJobs       []NamespacedID
+	DeleteNodes      []string
+	DeleteNamespaces []string
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -132,6 +132,10 @@ const (
 	// Namespace types were moved from enterprise and therefore start at 64
 	NamespaceUpsertRequestType MessageType = 64
 	NamespaceDeleteRequestType MessageType = 65
+
+	//TODO(schmichael) Might get rebased for a long time so pick a number
+	//unlikely to collide
+	PortlandRequestType MessageType = 99
 )
 
 const (

--- a/nomad/system_endpoint.go
+++ b/nomad/system_endpoint.go
@@ -79,3 +79,29 @@ func (s *System) ReconcileJobSummaries(args *structs.GenericRequest, reply *stru
 	reply.Index = index
 	return nil
 }
+
+// Portland gl;hf 🏴🏴🏴
+func (s *System) Portland(args *structs.PortlandRequest, reply *structs.GenericResponse) error {
+	authErr := s.srv.Authenticate(s.ctx, args)
+	if done, err := s.srv.forward("System.Portland", args, args, reply); done {
+		return err
+	}
+	s.srv.MeasureRPCRate("system", structs.RateMetricWrite, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
+	}
+
+	// Check management level permissions
+	if aclObj, err := s.srv.ResolveACL(args); err != nil {
+		return err
+	} else if !aclObj.IsManagement() {
+		return structs.ErrPermissionDenied
+	}
+
+	_, index, err := s.srv.raftApply(structs.PortlandRequestType, args)
+	if err != nil {
+		return fmt.Errorf("Portland failed, moving to Amsterdam: %v", err)
+	}
+	reply.Index = index
+	return nil
+}


### PR DESCRIPTION
PUT a structs.PortlandRequest to /v1/portland to manipulate the statestore.

This is purely for hacking hence the very silly naming scheme. It's difficult to even test if it's working because it's easy to create unreachable objects.