### PR TITLE
driver/java: populate OOM killed exit result.

### DIFF
--- a/.changelog/19818.txt
+++ b/.changelog/19818.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+driver/java: Ensure the OOM killed response is populated when the task exits
+```

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -593,8 +593,9 @@ func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *dr
 		}
 	} else {
 		result = &drivers.ExitResult{
-			ExitCode: ps.ExitCode,
-			Signal:   ps.Signal,
+			ExitCode:  ps.ExitCode,
+			Signal:    ps.Signal,
+			OOMKilled: ps.OOMKilled,
 		}
 	}
 


### PR DESCRIPTION
The Java driver uses the universal executor, which makes a best effort to identify when a task has been killed due to OOM. This change therefore passes that response within the driver, so that this could become visible to operators via task events and agent telemetry. 