### PR TITLE
remove github.com/hashicorp/nomad/helper/pointer in github.com/hashicorp/nomad/jobspec

### DIFF
--- a/jobspec/parse_task.go
+++ b/jobspec/parse_task.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -494,7 +493,7 @@ func parseTemplates(result *[]*api.Template, list *ast.ObjectList) error {
 			ChangeMode:    stringToPtr("restart"),
 			Splay:         timeToPtr(5 * time.Second),
 			Perms:         stringToPtr("0644"),
-			ErrMissingKey: pointer.Of(false),
+			ErrMissingKey: boolToPtr(false),
 		}
 
 		dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{


### PR DESCRIPTION
the hashicorp/nomad/jobspec library is licensed as MPL-2.0; however, hashicorp/nomad/jobspec imports github.com/hashicorp/nomad/helper/pointer ([src](https://github.com/hashicorp/nomad/blob/fce30f342c681343fdfe712551736a62efc609e3/jobspec/parse_task.go#L15)). github.com/hashicorp/nomad/helper/pointer is licensed at the repo root, and thus BUSL. This removes the dependency on nomad/helper/pointer to address https://github.com/pulumi/pulumi-nomad/issues/193.