### PR TITLE
driver/rawexec: populate OOM killed exit result.

### DIFF
--- a/.changelog/19829.txt
+++ b/.changelog/19829.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+driver/rawexec: Ensure the OOM killed response is populated when the task exits
+```

--- a/drivers/rawexec/driver.go
+++ b/drivers/rawexec/driver.go
@@ -393,8 +393,9 @@ func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *dr
 		}
 	} else {
 		result = &drivers.ExitResult{
-			ExitCode: ps.ExitCode,
-			Signal:   ps.Signal,
+			ExitCode:  ps.ExitCode,
+			Signal:    ps.Signal,
+			OOMKilled: ps.OOMKilled,
 		}
 	}
 


### PR DESCRIPTION
related https://github.com/hashicorp/nomad/pull/19818
closes #19767 