### PR TITLE
driver/qemu: populate OOM killed exit result.

### DIFF
--- a/.changelog/19830.txt
+++ b/.changelog/19830.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+driver/qemu: Ensure the OOM killed response is populated when the task exits
+```

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -743,8 +743,9 @@ func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *dr
 		}
 	} else {
 		result = &drivers.ExitResult{
-			ExitCode: ps.ExitCode,
-			Signal:   ps.Signal,
+			ExitCode:  ps.ExitCode,
+			Signal:    ps.Signal,
+			OOMKilled: ps.OOMKilled,
 		}
 	}
 


### PR DESCRIPTION
related #19829 and https://github.com/hashicorp/nomad/pull/19818