### PR TITLE
users: refactor method for getting UID from username

### DIFF
--- a/helper/users/lookup_linux_test.go
+++ b/helper/users/lookup_linux_test.go
@@ -114,3 +114,19 @@ func TestSocketFileFor_Linux(t *testing.T) {
 		must.Eq(t, 0o666, int(stat.Mode().Perm()))
 	}
 }
+
+func TestLookupUnix_root(t *testing.T) {
+	uid, gid, home, err := LookupUnix("root")
+	must.NoError(t, err)
+	must.Zero(t, uid)         // linux
+	must.Zero(t, gid)         // linux
+	must.Eq(t, "/root", home) // ubuntu specific
+}
+
+func TestLookupUnix_nobody(t *testing.T) {
+	uid, gid, home, err := LookupUnix("nobody")
+	must.NoError(t, err)
+	must.Eq(t, 65534, uid)           // systemd specific
+	must.Eq(t, 65534, gid)           // systemd specific
+	must.Eq(t, "/nonexistent", home) // ubuntu specific
+}


### PR DESCRIPTION
This PR refactors a helper function for getting the UID associated with
a given username to also return the GID and home directory. Also adds
unit tests on the known values of root and nobody user on Ubuntu Linux.
