### PR TITLE
cli: fix return code when job deployment succeeds

### DIFF
--- a/.changelog/19876.txt
+++ b/.changelog/19876.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fix return code when `nomad job run` succeeds after a blocked eval
+```

--- a/command/monitor.go
+++ b/command/monitor.go
@@ -306,6 +306,9 @@ func (m *monitor) monitor(evalID string) int {
 		if err != nil || status != api.DeploymentStatusSuccessful {
 			return 1
 		}
+		if status == api.DeploymentStatusSuccessful {
+			schedFailure = false
+		}
 	}
 
 	// Treat scheduling failures specially using a dedicated exit code.


### PR DESCRIPTION
When a job eval is blocked due to missing capacity, the `nomad job run` command will monitor the deployment, which may succeed once additional capacity is made available.

But the current implementation would return `2` even when the deployment succeeded because it only took the first eval status into account.

This commit updates the eval monitoring logic to reset the scheduling error state if the deployment eventually succeeds.

Closes #19780
Closes #12784