### PR TITLE
[ui] Random exec assignment chooses from only those with a matching taskGroup, if provided

### DIFF
--- a/.changelog/19878.txt
+++ b/.changelog/19878.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix an issue where a same-named task from a different group could be selected when the user clicks Exec from a task group page where multiple allocations would be valid
+```

--- a/ui/app/controllers/exec.js
+++ b/ui/app/controllers/exec.js
@@ -80,7 +80,10 @@ export default class ExecController extends Controller {
     if (this.allocationShortId) {
       allocation = this.allocations.findBy('shortId', this.allocationShortId);
     } else {
-      allocation = this.allocations.find((allocation) =>
+      let allocationPool = this.taskGroupName
+        ? this.allocations.filterBy('taskGroupName', this.taskGroupName)
+        : this.allocations;
+      allocation = allocationPool.find((allocation) =>
         allocation.states
           .filterBy('isActive')
           .mapBy('name')


### PR DESCRIPTION
Resolves #10962 

Previously, when selecting Exec from a group page in the UI (or selecting a task group/task from the exec window's left sidebar), we go over a given job's allocations until we find one that is active and whose name matches the selected one.

This becomes a problem in situations where a user has multiple (differently-named) groups, whose tasks share a name between them.

This PR filters down to the group name in question.