### PR TITLE
docs: remove Docker `cpuset_cpus` config

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -84,22 +84,6 @@ The `docker` driver supports the following configuration in the job spec. Only
   }
   ```
 
-- `cpuset_cpus` <sup>Beta</sup> - (Optional) CPUs in which to allow execution
-  (0-3, 0,1). Limit the specific CPUs or cores a container can use. A
-  comma-separated list or hyphen-separated range of CPUs a container can use, if
-  you have more than one CPU. The first CPU is numbered 0. A valid value might
-  be 0-3 (to use the first, second, third, and fourth CPU) or 1,3 (to use the
-  second and fourth CPU).
-
-Note: `cpuset_cpus` pins the workload to the CPUs but doesn't give the workload
-exclusive access to those CPUs.
-
-```hcl
-config {
-  cpuset_cpus = "0-3"
-}
-```
-
 - `dns_search_domains` - (Optional) A list of DNS search domains for
   the container to use. If you are using bridge networking mode with a
   `network` block in the task group, you must set all DNS options in


### PR DESCRIPTION
Nomad 1.7 refactored how CPU cores are assigned to tasks, making the Docker-specific `cpuset_cpus` configuration no longer used.

Closes #19815