### PR TITLE
docs: add note about stub list filtering

### DIFF
--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -123,7 +123,16 @@ parameter with the URL encoded expression when sending requests to HTTP API
 endpoints that support it.
 
 ```shell-session
-$ curl --get https://localhost:4646/v1/<path> --data-urlencode 'filter=<filter expression>'
+$ curl --get https://localhost:4646/v1/<path> \
+    --data-urlencode 'filter=<filter expression>'
+```
+
+The filter expression can also be specified in the
+[`-filter`][cli_operator_api_filter] flag of the
+[`nomad operator api`][cli_operator_api] command.
+
+```shell-session
+$ nomad operator api -filter '<filter expression>' /v1/<path>
 ```
 
 Some endpoints may have other query parameters that are used for filtering, but
@@ -145,7 +154,7 @@ node addresses should use the `HTTPAddr` field of the full node definition
 instead of `Address` field present in the stub.
 
 ```shell-session
-$ curl --get https://localhost:4646/v1/nodes --data-urlencode 'filter=HTTPAddr matches "10.0.0..+"'
+$ nomad operator api -filter 'HTTPAddr matches "10.0.0..+"' /v1/nodes
 ```
 
 ### Creating Expressions
@@ -265,7 +274,7 @@ is executed on the leader.
 Command (Unfiltered)
 
 ```shell-session
-$ curl --request GET https://localhost:4646/v1/jobs
+$ nomad operator api /v1/jobs
 ```
 
 Response (Unfiltered)
@@ -370,9 +379,8 @@ Response (Unfiltered)
 
 Command (Filtered)
 
-```shell
-curl --get https://localhost:4646/v1/jobs \
-    --data-urlencode 'filter=Datacenters contains "dc2"'
+```shell-session
+$ nomad operator api -filter 'Datacenters contains "dc2"' /v1/jobs
 ```
 
 Response (Filtered)
@@ -438,7 +446,7 @@ Response (Filtered)
 Command (Unfiltered)
 
 ```shell-session
-$ curl --request GET https://localhost:4646/v1/deployments
+$ nomad operator api /v1/deployments
 ```
 
 Response (Unfiltered)
@@ -523,9 +531,8 @@ Response (Unfiltered)
 
 Command (Filtered)
 
-```shell
-curl --get https://localhost:4646/v1/deployments \
-    --data-urlencode 'filter=Status != "successful"'
+```shell-session
+$ nomad operator api -filter 'Status != "successful"' /v1/deployments
 ```
 
 Response (Filtered)
@@ -719,3 +726,6 @@ specific response codes are returned but all clients should handle the following
 - 403 marks that the client isn't authenticated for the request.
 - 404 indicates an unknown resource.
 - 5xx means that the client should not expect the request to succeed if retried.
+
+[cli_operator_api]: /nomad/docs/commands/operator/api
+[cli_operator_api_filter]: /nomad/docs/commands/operator/api#filter

--- a/website/content/api-docs/index.mdx
+++ b/website/content/api-docs/index.mdx
@@ -132,6 +132,22 @@ they can't be used with the `filter` query parameter. Doing so will result in a
 database index, so they may be prefereable over an equivalent simple `filter`
 expression due to better resource usage and performance.
 
+### List Stubs
+
+Some list endpoints return a reduced version of the resource being queried.
+This smaller version is called a _stub_ and may have different fields than the
+full resource definition. To allow more expressive filtering operations, the
+filter is applied to the full version, not the stub.
+
+If a request returns an error such as `error finding value in datum` the field
+used in filter expression may need to be adjusted. For example, filtering on
+node addresses should use the `HTTPAddr` field of the full node definition
+instead of `Address` field present in the stub.
+
+```shell-session
+$ curl --get https://localhost:4646/v1/nodes --data-urlencode 'filter=HTTPAddr matches "10.0.0..+"'
+```
+
 ### Creating Expressions
 
 A single expression is a matching operator with a selector and value and they


### PR DESCRIPTION
When filtering list results, the filter expression is applied to the full object, not the stub. This is useful because it allows users to filter the list on fields not present in the object stub. But it can also be confusing because some fields have different names, or only exist in the stub, so the filter expression needs to reference fields not present in returned data.

Filtering on the stub would reduce the confusion, but it would also restrict users to only be able to filter on the fields in the stub, which, by definition, are just a subset of the original fields.

Documenting this behaviour can help users understand unexpected errors and results.

Closes #19871