### PR TITLE
events: emit event when job is deleted

### DIFF
--- a/.changelog/19903.txt
+++ b/.changelog/19903.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: emit `JobDeregistered` event when job is deregistered with `purge`
+```

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -125,6 +125,19 @@ func eventFromChange(change memdb.Change) (structs.Event, bool) {
 					ACLBindingRule: before,
 				},
 			}, true
+		case "jobs":
+			before, ok := change.Before.(*structs.Job)
+			if !ok {
+				return structs.Event{}, false
+			}
+			return structs.Event{
+				Topic:     structs.TopicJob,
+				Key:       before.ID,
+				Namespace: before.Namespace,
+				Payload: &structs.JobEvent{
+					Job: before,
+				},
+			}, true
 		case "nodes":
 			before, ok := change.Before.(*structs.Node)
 			if !ok {

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -726,7 +726,7 @@ func TestEventsFromChanges_WithDeletion(t *testing.T) {
 	event := eventsFromChanges(nil, changes)
 	require.NotNil(t, event)
 
-	require.Len(t, event.Events, 1)
+	require.Len(t, event.Events, 2)
 }
 
 func TestEventsFromChanges_WithNodeDeregistration(t *testing.T) {


### PR DESCRIPTION
When jobs are deregistered with the `purge` flag they are immediately deleted from the state store instead of just updated to be marked as stopped.

Without tracking job deletions the event stream would not receive a `JobDeregistered` event when `purge` was set.

Ref. #19834