### PR TITLE
[docs] Add action name restrictions and correct auth method and role name restrictions

### DIFF
--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -28,8 +28,8 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `Name` `(string: <required>)` - Name is the identifier of the ACL auth method.
-  The name can contain alphanumeric characters, dashes, and underscores. This
-  name must be unique and must not exceed 128 characters.
+  The name can contain alphanumeric characters and dashes. This name must be
+  unique and must not exceed 128 characters.
 
 - `Type` `(string: <required>)` - ACL auth method type, supports `OIDC` and `JWT`.
 
@@ -219,7 +219,7 @@ queries](/nomad/api-docs#blocking-queries) and [required ACLs](/nomad/api-docs#a
 ### Parameters
 
 - `Name` `(string: <required>)` - Names is the identifier of the ACL auth
-  method.  The name can contain alphanumeric characters, dashes, and underscores.
+  method.  The name can contain alphanumeric characters and dashes.
   This name must be unique and must not exceed 128 characters.
 
 - `Type` `(string: <required>)` - ACL auth role SSO identifier. Currently, the

--- a/website/content/api-docs/acl/roles.mdx
+++ b/website/content/api-docs/acl/roles.mdx
@@ -28,7 +28,7 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `Name` `(string: <required>)` - Specifies the human-readable name of the ACL
-  Role. The name can contain alphanumeric characters, dashes, and underscores.
+  Role. The name can contain alphanumeric characters and dashes.
   This name must be unique and must not exceed 128 characters.
 
 - `Description` `(string: <optional>)` - A free form human-readable description
@@ -102,7 +102,7 @@ The table below shows this endpoint's support for
   updated. Must match payload body and request path.
 
 - `Name` `(string: <required>)` - Specifies the human-readable name of the ACL
-  Role. The name can contain alphanumeric characters, dashes, and underscores.
+  Role. The name can contain alphanumeric characters and dashes.
   This name must be unique a must not exceed 128 characters.
 
 - `Description` `(string: <optional>)` - A free form human-readable description

--- a/website/content/docs/commands/acl/auth-method/update.mdx
+++ b/website/content/docs/commands/acl/auth-method/update.mdx
@@ -23,8 +23,8 @@ The `acl auth-method update` command requires an existing method's name.
 ## Update Options
 
 - `-name`: Sets the human-readable name for the ACL Role. It is required and
-  can contain alphanumeric characters, dashes, and underscores. This name must
-  be unique and must not exceed 128 characters.
+  can contain alphanumeric characters and dashes. This name must be unique and
+  must not exceed 128 characters.
 
 - `-description`: A free form text description of the role that must not exceed
   256 characters.

--- a/website/content/docs/commands/acl/role/create.mdx
+++ b/website/content/docs/commands/acl/role/create.mdx
@@ -24,8 +24,8 @@ via flags detailed below.
 ## Create Options
 
 - `-name`: Sets the human-readable name for the ACL Role. It is required and
-  can contain alphanumeric characters, dashes, and underscores. This name must
-  be unique and must not exceed 128 characters.
+  can contain alphanumeric characters and dashes. This name must be unique and
+  must not exceed 128 characters.
 
 - `-description`: A free form text description of the role that must not exceed
   256 characters.

--- a/website/content/docs/commands/acl/role/update.mdx
+++ b/website/content/docs/commands/acl/role/update.mdx
@@ -23,8 +23,8 @@ The `acl role update` command requires an existing role's ID.
 ## Update Options
 
 - `-name`: Sets the human-readable name for the ACL Role. It is required and
-  can contain alphanumeric characters, dashes, and underscores. This name must
-  be unique and must not exceed 128 characters.
+  can contain alphanumeric characters and dashes. This name must be unique and
+  must not exceed 128 characters.
 
 - `-description`: A free form text description of the role that must not exceed
   256 characters.

--- a/website/content/docs/job-specification/action.mdx
+++ b/website/content/docs/job-specification/action.mdx
@@ -12,6 +12,9 @@ The `action` block allows job authors to define custom commands. These commands
 can be executed by operators with the necessary permissions on a running
 allocation, offering a controlled way to interact with tasks.
 
+The name of the action can contain alphanumeric characters and dashes. This
+name must be unique within its task and must not exceed 128 characters.
+
 ## `action` Parameters
 
 - `command` `(string: <required>)` - Specifies the command to be executed.


### PR DESCRIPTION
Started by updating the Actions docs, and after coming across `regexp.MustCompile("^[a-zA-Z0-9-]{1,128}$")` and testing locally, realized that the docs on Roles and Auth Methods indicated underscores being allowed in names, so correcting that here too.