### PR TITLE
docs: expand impact of `verify_https_client=false`

### DIFF
--- a/website/content/docs/concepts/security.mdx
+++ b/website/content/docs/concepts/security.mdx
@@ -95,11 +95,10 @@ recommendations accordingly.
 
 #### Requirements
 
-- **[mTLS enabled](/nomad/tutorials/transport-security/security-enable-tls)**
-
-  - Mutual TLS (mTLS) enables [mutual
-    authentication](https://en.wikipedia.org/wiki/Mutual_authentication) with
-    security properties to prevent the following problems:
+- **[mTLS enabled](/nomad/tutorials/transport-security/security-enable-tls)** -
+  Mutual TLS (mTLS) enables [mutual
+  authentication](https://en.wikipedia.org/wiki/Mutual_authentication) with
+  security properties to prevent the following problems:
 
   * Unauthorized access because both server and clients must provide valid TLS
     [X.509](https://en.wikipedia.org/wiki/X.509) certificates signed by the same
@@ -133,6 +132,12 @@ recommendations accordingly.
     Nomad agent HTTP server to use TLS instead of mTLS. This is safe if ACLs are
     enabled and is recommended if you are using the Nomad web UI to avoid the
     difficulty of distributing client certificates to browsers.
+
+    Some API endpoints, such as [`/v1/metrics`][api_metrics] and
+    [`/v1/status/peers`][api_status_peers], can be accessed without an ACL
+    token and may be exposed to anyone with access to the Nomad HTTP address
+    when using `tls.verify_https_client=false`. You can use a reverse proxy or
+    other external means to restrict access to them.
 
 - **[ACLs enabled](/nomad/tutorials/access-control)** - The
   access control list (ACL) system provides a capability-based control
@@ -335,5 +340,7 @@ There are two main components to consider to for external threats in a Nomad clu
 | **4648** / TCP + UDP | Servers | [gossip](/nomad/docs/concepts/gossip) protocol to manage server membership using [Serf](https://www.serf.io/).                                                                           |
 
 
+[api_metrics]: /nomad/api-docs/metrics
+[api_status_peers]: /nomad/api-docs/status#list-peers
 [Variables]: /nomad/docs/concepts/variables
 [verify_https_client]: /nomad/docs/configuration/tls#verify_https_client


### PR DESCRIPTION
When Nomad is configured with `verify_https_client=false` endpoints that do not require an ACL token can be accessed without any other type of authentication. Expand the docs to mention this effect.

Closes https://github.com/hashicorp/nomad/issues/19870