### PR TITLE
Doc-only: Added note that Autoscaler Enterprise does not support reloading

### DIFF
--- a/website/content/tools/autoscaling/agent.mdx
+++ b/website/content/tools/autoscaling/agent.mdx
@@ -78,6 +78,8 @@ following actions.
 - reconfigure the remaining plugins with the configuration defined in their
   `config` parameter.
 
+~> Note that currently Nomad Autoscaler Enterprise does not support reloading the [`nomad`][autoscaler_agent_nomad] block.
+
 ## General Parameters
 
 - `enable_debug` `(bool: false)` - Specifies if the debugging HTTP endpoints


### PR DESCRIPTION
of the nomad block

License checker does not support SIGHUP reloading and therefore this statement is not currently accurate for autoscaler enterprise.