### PR TITLE
fingerprint: eliminate spurious warning logs with Consul CE

### DIFF
--- a/client/fingerprint/consul.go
+++ b/client/fingerprint/consul.go
@@ -98,7 +98,7 @@ func (f *ConsulFingerprint) fingerprintImpl(cfg *config.ConsulConfig, resp *Fing
 	for attr, extractor := range state.extractors {
 		if s, ok := extractor(info); !ok {
 			logger.Warn("unable to fingerprint consul", "attribute", attr)
-		} else {
+		} else if s != "" {
 			resp.AddAttribute(attr, s)
 		}
 	}
@@ -311,5 +311,5 @@ func (cfs *consulFingerprintState) partition(info agentconsul.Self) (string, boo
 		}
 		return p, true
 	}
-	return "", false
+	return "", true // prevent warnings on Consul CE
 }

--- a/client/fingerprint/consul_test.go
+++ b/client/fingerprint/consul_test.go
@@ -454,7 +454,7 @@ func TestConsulFingerprint_partition(t *testing.T) {
 		p, ok := cfs.partition(agentconsul.Self{
 			"Config": {"Version": "v1.9.5"},
 		})
-		must.False(t, ok)
+		must.True(t, ok)
 		must.Eq(t, "", p)
 	})
 
@@ -478,7 +478,7 @@ func TestConsulFingerprint_partition(t *testing.T) {
 		p, ok := cfs.partition(agentconsul.Self{
 			"Config": {},
 		})
-		must.False(t, ok)
+		must.True(t, ok)
 		must.Eq(t, "", p)
 	})
 
@@ -486,7 +486,7 @@ func TestConsulFingerprint_partition(t *testing.T) {
 		p, ok := cfs.partition(agentconsul.Self{
 			"Config": {"Version": "***"},
 		})
-		must.False(t, ok)
+		must.True(t, ok)
 		must.Eq(t, "", p)
 	})
 }


### PR DESCRIPTION
Support for fingerprinting the Consul admin partition was added in #19485. But when the client fingerprints Consul CE, it gets a valid fingerprint and working Consul but with a warn-level log. Return "ok" from the partition extractor, but also ensure that we only add the Consul attribute if it actually has a value.

Fixes: https://github.com/hashicorp/nomad/issues/19756