### PR TITLE
alloc exec: fix panics after stream close

### DIFF
--- a/.changelog/19932.txt
+++ b/.changelog/19932.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+exec: Fixed a bug in `alloc exec` where closing websocket streams could cause a panic
+```

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -597,7 +597,7 @@ func (s *HTTPServer) execStreamImpl(ws *websocket.Conn, args *cstructs.AllocExec
 	}()
 
 	// Create a channel for the final result
-	resultCh := make(chan HTTPCodedError)
+	resultCh := make(chan HTTPCodedError, 1)
 
 	// stream response back to the websocket: this should be the only goroutine
 	// that writes to this websocket connection
@@ -661,7 +661,7 @@ func (s *HTTPServer) execStreamImpl(ws *websocket.Conn, args *cstructs.AllocExec
 }
 
 // execStreamHandleError writes a CloseMessage to the websocket if we get an
-// error that isn't a ""close error" caused by the RPC pipe finishing up. Note
+// error that isn't a "close error" caused by the RPC pipe finishing up. Note
 // that this should *only* ever be called in the same goroutine as we're
 // streaming the responses
 func (s *HTTPServer) execStreamHandleError(ws *websocket.Conn, codedErr HTTPCodedError) HTTPCodedError {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -398,7 +398,7 @@ func (s *HTTPServer) jobRunAction(resp http.ResponseWriter, req *http.Request, j
 		return nil, err
 	}
 
-	return s.execStreamImpl(conn, &args)
+	return s.execStream(conn, &args)
 }
 
 func (s *HTTPServer) jobSubmissionCRUD(resp http.ResponseWriter, req *http.Request, jobID string) (*structs.JobSubmission, error) {


### PR DESCRIPTION
In #19172 we added a check on websocket errors to see if they were one of several benign "close" messages. This change inadvertently assumed that other messages used for close would not implement `HTTPCodedError`. When errors like the following are received:

> msgpack decode error [pos 0]: io: read/write on closed pipe"

they are sent from the inner loop as though they were a "real" error, but the channel is already being closed with a "close" message.

This allowed many more attempts to pass thru a previously-undiscovered race condition in the two goroutines that stream RPC responses to the websocket. When the input stream returns an error for any reason (for example, the command we're executing has exited), it will unblock the "outer" goroutine and cause a write to the websocket. If we're concurrently writing the "close error" discussed above, this results in a panic from the websocket library.

This changeset includes two fixes:
* Catch "closed pipe" error correctly so that we're not sending unnecessary error messages.
* Move all writes to the websocket into the same response streaming goroutine. The main handler goroutine will block on a results channel, and the response streaming goroutine will send on that channel with the final error when it's done so it can be reported to the user.

Fixes: https://github.com/hashicorp/nomad/issues/19506

---

In addition to the new unit test and associated websocket test infrastructure, I did some soak testing:

> $ for i in {1..200}; do nomad alloc exec 9ee04c03 echo -n "."; done
> ........................................................................................................................................................................................................%
