### PR TITLE
executor: limit the value of CPU shares

### DIFF
--- a/.changelog/19935.txt
+++ b/.changelog/19935.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-client: Ensure the value for CPU weight is within the allowed range
+client: Ensure the value for CPU shares are within the allowed range
 ```

--- a/.changelog/19935.txt
+++ b/.changelog/19935.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Ensure the value for CPU weight is within the allowed range
+```


### PR DESCRIPTION
The value for the executor cgroup CPU weight must be within the limits imposed by the Linux kernel.

Nomad used the task `resource.cpu`, an unbounded value, directly as the cgroup CPU weight, causing it to potentially go outside the imposed values.

This commit clamps the CPU shares values to be within the limits allowed.

Closes https://github.com/hashicorp/nomad/issues/19797