### PR TITLE
state: fix state store corruption in plan apply

### DIFF
--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -466,6 +466,7 @@ func (s *StateStore) UpsertPlanResults(msgType structs.MessageType, index uint64
 
 	// handle upgrade path
 	for _, alloc := range allocsToUpsert {
+		alloc = alloc.Copy()
 		alloc.Canonicalize()
 	}
 


### PR DESCRIPTION
The state store's `UpsertPlanResults` method canonicalizes allocations in order to upgrade them to a new version. But the method does not copy the allocation before doing so, which can potentially corrupt the state store. This hasn't been implicated in any known user-facing bugs, but was detected when running Nomad under a build with the Go toolchain's data race detection enabled.

Noticed while working on https://github.com/hashicorp/nomad/pull/19932, but it looks like this bug has existed since 0.10.4