### PR TITLE
docs: describe cloud environments in fingerprint denylist

### DIFF
--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -344,12 +344,14 @@ see the [drivers documentation](/nomad/docs/drivers).
 
 - `"fingerprint.denylist"` `(string: "")` - Specifies a comma-separated list of
   denylisted fingerprinters. If specified, any fingerprinters in the denylist
-  will be disabled.
+  will be disabled. A common use-case for the fingerprint denylist is to disable
+  fingerprinters of irrelevant cloud environments, which can slow down client
+  agent startup time.
 
   ```hcl
   client {
     options = {
-      "fingerprint.denylist" = "network"
+      "fingerprint.denylist" = "env_aws,env_gce,env_azure,env_digitalocean"
     }
   }
   ```


### PR DESCRIPTION
This PR changes the example of the client config option `fingerprint.denylist`
to include all the cloud environment fingerprinters. Each one contains a
2 second HTTP timeout to a metadata endpoint that does not exist if you are not
in that particular cloud. When run in serial on startup, this results in
an 8 second wait where nothing useful is happening.

Closes #16727
