### PR TITLE
CNI: fix deprecation warnings

### DIFF
--- a/client/allocrunner/networking_cni.go
+++ b/client/allocrunner/networking_cni.go
@@ -99,7 +99,7 @@ func (c *cniNetworkConfigurator) Setup(ctx context.Context, alloc *structs.Alloc
 	// in one of them to fail. This rety attempts to overcome those erroneous failures.
 	const retry = 3
 	var firstError error
-	var res *cni.CNIResult
+	var res *cni.Result
 	for attempt := 1; ; attempt++ {
 		var err error
 		if res, err = c.cni.Setup(ctx, alloc.ID, spec.Path, cni.WithCapabilityPortMap(getPortMapping(alloc, c.ignorePortMappingHostIP))); err != nil {
@@ -127,10 +127,10 @@ func (c *cniNetworkConfigurator) Setup(ctx context.Context, alloc *structs.Alloc
 
 }
 
-// cniToAllocNet converts a CNIResult to an AllocNetworkStatus or returns an
+// cniToAllocNet converts a cni.Result to an AllocNetworkStatus or returns an
 // error. The first interface and IP with a sandbox and address set are
 // preferred. Failing that the first interface with an IP is selected.
-func (c *cniNetworkConfigurator) cniToAllocNet(res *cni.CNIResult) (*structs.AllocNetworkStatus, error) {
+func (c *cniNetworkConfigurator) cniToAllocNet(res *cni.Result) (*structs.AllocNetworkStatus, error) {
 	if len(res.Interfaces) == 0 {
 		return nil, fmt.Errorf("failed to configure network: no interfaces found")
 	}

--- a/client/allocrunner/networking_cni_test.go
+++ b/client/allocrunner/networking_cni_test.go
@@ -127,12 +127,12 @@ func TestCNI_forceCleanup(t *testing.T) {
 	})
 }
 
-// TestCNI_cniToAllocNet_NoInterfaces asserts an error is returned if CNIResult
+// TestCNI_cniToAllocNet_NoInterfaces asserts an error is returned if cni.Result
 // contains no interfaces.
 func TestCNI_cniToAllocNet_NoInterfaces(t *testing.T) {
 	ci.Parallel(t)
 
-	cniResult := &cni.CNIResult{}
+	cniResult := &cni.Result{}
 
 	// Only need a logger
 	c := &cniNetworkConfigurator{
@@ -150,7 +150,7 @@ func TestCNI_cniToAllocNet_Fallback(t *testing.T) {
 
 	// Calico's CNI plugin v3.12.3 has been observed to return the
 	// following:
-	cniResult := &cni.CNIResult{
+	cniResult := &cni.Result{
 		Interfaces: map[string]*cni.Config{
 			"cali39179aa3-74": {},
 			"eth0": {
@@ -181,7 +181,7 @@ func TestCNI_cniToAllocNet_Fallback(t *testing.T) {
 func TestCNI_cniToAllocNet_Invalid(t *testing.T) {
 	ci.Parallel(t)
 
-	cniResult := &cni.CNIResult{
+	cniResult := &cni.Result{
 		Interfaces: map[string]*cni.Config{
 			"eth0": {},
 			"veth1": {


### PR DESCRIPTION
We updated our `go-cni` dependency in #17582 but this left deprecation warnings on the `cni.CNIResult` type (now `cni.Result`).

(Nothing user-facing in here, so no changelog entry)