### PR TITLE
vault: revert #18998 to fix potential deadlock

### DIFF
--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -112,11 +112,6 @@ type vaultClient struct {
 // vaultClientRenewalRequest is a request object for renewal of both tokens and
 // secret's leases.
 type vaultClientRenewalRequest struct {
-	// renewalLoopCh is used to notify listeners every time the token goes
-	// through the renewal loop. It does not guarantee the renewal was
-	// successful, so listeners should also read from errCh for renewal errors.
-	renewalLoopCh chan struct{}
-
 	// errCh is the channel into which any renewal error will be sent to
 	errCh chan error
 
@@ -358,15 +353,13 @@ func (c *vaultClient) GetConsulACL(token, path string) (*vaultapi.Secret, error)
 	return c.client.Logical().Read(path)
 }
 
-// RenewToken pushes the supplied token to the min-heap for an immediate
-// renewal for a given duration (in seconds) and blocks until the renewal loop
-// has processed it. The token is then renewed periodically until Stop() or
-// StopRenewToken() is called.
-//
-// Any error returned during the periodical renewal will be written to a
-// buffered channel and the channel is returned instead of an actual error.
-// This helps the caller be notified of a renewal failure asynchronously for
-// appropriate actions to be taken.
+// RenewToken renews the supplied token for a given duration (in seconds) and
+// adds it to the min-heap so that it is renewed periodically by the renewal
+// loop. Any error returned during renewal will be written to a buffered
+// channel and the channel is returned instead of an actual error. This helps
+// the caller be notified of a renewal failure asynchronously for appropriate
+// actions to be taken. The caller of this function need not have to close the
+// error channel.
 func (c *vaultClient) RenewToken(token string, increment int) (<-chan error, error) {
 	if token == "" {
 		err := fmt.Errorf("missing token")
@@ -377,63 +370,27 @@ func (c *vaultClient) RenewToken(token string, increment int) (<-chan error, err
 		return nil, err
 	}
 
+	// Create a buffered error channel
+	errCh := make(chan error, 1)
+
 	// Create a renewal request and indicate that the identifier in the
 	// request is a token and not a lease
-	req := &vaultClientRenewalRequest{
-		renewalLoopCh: make(chan struct{}),
-		errCh:         make(chan error, 1),
-		id:            token,
-		isToken:       true,
-		increment:     increment,
+	renewalReq := &vaultClientRenewalRequest{
+		errCh:     errCh,
+		id:        token,
+		isToken:   true,
+		increment: increment,
 	}
 
-	// Push an immediate renewal request to the heap and block until a result
-	// is received.
-	err := c.pushRenewalRequest(req, time.Now())
-	if err != nil {
-		return nil, err
-	}
-
-	select {
-	case err := <-req.errCh:
+	// Perform the renewal of the token and send any error to the dedicated
+	// error channel.
+	if err := c.renew(renewalReq); err != nil {
 		c.logger.Error("error during renewal of token", "error", err)
 		metrics.IncrCounter([]string{"client", "vault", "renew_token_failure"}, 1)
 		return nil, err
-	case <-req.renewalLoopCh:
-		return req.errCh, nil
-	}
-}
-
-// pushRenewalRequest pushes a renewal request to the heap and triggers the
-// renewal loop to re-fetch a new request.
-func (c *vaultClient) pushRenewalRequest(req *vaultClientRenewalRequest, next time.Time) error {
-	c.lock.Lock()
-	defer c.lock.Unlock()
-
-	if !c.running {
-		return errors.New("token renewal loop is not running")
 	}
 
-	if !c.isTracked(req.id) {
-		err := c.heap.Push(req, next)
-		if err != nil {
-			return fmt.Errorf("failed to push renewal request to heap: %v", err)
-		}
-	} else {
-		err := c.heap.Update(req, next)
-		if err != nil {
-			return fmt.Errorf("failed to update renewal request: %v", err)
-		}
-	}
-
-	// Signal an update for the renewal loop to trigger a fresh computation for
-	// the next best candidate for renewal.
-	select {
-	case c.updateCh <- struct{}{}:
-	default:
-	}
-
-	return nil
+	return errCh, nil
 }
 
 // renew is a common method to handle renewal of both tokens and secret leases.
@@ -441,19 +398,9 @@ func (c *vaultClient) pushRenewalRequest(req *vaultClientRenewalRequest, next ti
 // successful, min-heap is updated based on the duration after which it needs
 // renewal again. The next renewal time is randomly selected to avoid spikes in
 // the number of APIs periodically.
-// Only tokens that are present in the heap are renewed.
 func (c *vaultClient) renew(req *vaultClientRenewalRequest) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
-
-	// Always notify listeners that the request has been processed before
-	// exiting.
-	defer func() {
-		select {
-		case req.renewalLoopCh <- struct{}{}:
-		default:
-		}
-	}()
 
 	if req == nil {
 		return fmt.Errorf("nil renewal request")
@@ -477,12 +424,6 @@ func (c *vaultClient) renew(req *vaultClientRenewalRequest) error {
 	if req.increment < 1 {
 		close(req.errCh)
 		return fmt.Errorf("increment cannot be less than 1")
-	}
-
-	// Verify token is still in the heap before proceeding as it may have been
-	// removed while waiting for the renewal timer to tick.
-	if !c.isTracked(req.id) {
-		return nil
 	}
 
 	var renewalErr error
@@ -535,25 +476,60 @@ func (c *vaultClient) renew(req *vaultClientRenewalRequest) error {
 			"error", renewalErr, "period", next)
 	}
 
-	if fatal {
-		// If encountered with an error where in a lease or a
-		// token is not valid at all with vault, and if that
-		// item is tracked by the renewal loop, stop renewing
-		// it by removing the corresponding heap entry.
-		if err := c.heap.Remove(req.id); err != nil {
-			return fmt.Errorf("failed to remove heap entry: %v", err)
+	if c.isTracked(req.id) {
+		if fatal {
+			// If encountered with an error where in a lease or a
+			// token is not valid at all with vault, and if that
+			// item is tracked by the renewal loop, stop renewing
+			// it by removing the corresponding heap entry.
+			if err := c.heap.Remove(req.id); err != nil {
+				return fmt.Errorf("failed to remove heap entry: %v", err)
+			}
+
+			// Report the fatal error to the client
+			req.errCh <- renewalErr
+			close(req.errCh)
+
+			return renewalErr
 		}
 
-		// Report the fatal error to the client
-		req.errCh <- renewalErr
-		close(req.errCh)
+		// If the identifier is already tracked, this indicates a
+		// subsequest renewal. In this case, update the existing
+		// element in the heap with the new renewal time.
+		if err := c.heap.Update(req, next); err != nil {
+			return fmt.Errorf("failed to update heap entry. err: %v", err)
+		}
 
-		return renewalErr
-	}
+		// There is no need to signal an update to the renewal loop
+		// here because this case is hit from the renewal loop itself.
+	} else {
+		if fatal {
+			// If encountered with an error where in a lease or a
+			// token is not valid at all with vault, and if that
+			// item is not tracked by renewal loop, don't add it.
 
-	// Update the element in the heap with the new renewal time.
-	if err := c.heap.Update(req, next); err != nil {
-		return fmt.Errorf("failed to update heap entry. err: %v", err)
+			// Report the fatal error to the client
+			req.errCh <- renewalErr
+			close(req.errCh)
+
+			return renewalErr
+		}
+
+		// If the identifier is not already tracked, this is a first
+		// renewal request. In this case, add an entry into the heap
+		// with the next renewal time.
+		if err := c.heap.Push(req, next); err != nil {
+			return fmt.Errorf("failed to push an entry to heap.  err: %v", err)
+		}
+
+		// Signal an update for the renewal loop to trigger a fresh
+		// computation for the next best candidate for renewal.
+		if c.running {
+			select {
+			case c.updateCh <- struct{}{}:
+			default:
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
https://github.com/hashicorp/nomad/issues/19805 reports an issue where tasks get stuck in `pending` status. Logs shared by the user point that the problem is likely that `vault_hook.Prestart()` never completes.

```
{"log":"    2024-02-09T15:16:40.868Z [TRACE] client.alloc_runner.task_runner: running prestart hook: alloc_id=95eddd7d-*** task=*** name=vault start=\"2024-02-09 15:16:40.868679902 +0000 UTC m=+27.567861561\"\n","stream":"stdout","time":"2024-02-09T15:16:40.868767694Z"}
{"log":"    2024-02-09T15:21:40.746Z [TRACE] client.alloc_runner.runner_hook.alloc_health_watcher: deadline reached; setting unhealthy: alloc_id=95eddd7d-*** deadline=\"2024-02-09 15:21:40.746133303 +0000 UTC m=+327.445314950\"\n","stream":"stdout","time":"2024-02-09T15:21:40.746292101Z"}
```

```
{"log":"    2024-02-12T09:05:52.690Z [TRACE] client.alloc_runner.task_runner: running prestart hook: alloc_id=96dade39-*** task=*** name=vault start=\"2024-02-12 09:05:52.69095185 +0000 UTC m=+24.113560832\"\n","stream":"stdout","time":"2024-02-12T09:05:52.692175834Z"}
... user stops faulty alloc ...
{"log":"    2024-02-12T09:10:12.183Z [TRACE] client.alloc_runner.task_runner: finished prestart hook: alloc_id=96dade39-*** task=*** name=vault end=\"2024-02-12 09:10:12.183310806 +0000 UTC m=+283.605919788\" duration=4m19.492358956s\n","stream":"stdout","time":"2024-02-12T09:10:12.183382225Z"}
```

Following the code path along with the logs, the hook is likely getting stuck waiting for a Vault token:
https://github.com/hashicorp/nomad/blob/1bde7a8fb438cf5579592688b4bd745b139b49ef/client/allocrunner/taskrunner/vault_hook.go#L216-L221

`h.updater.updatedVaultToken(h.future.Get())` only contains one blocking call in `setVaultToken`, but the lock is unlikely to be blocked since the task is still being created.
https://github.com/hashicorp/nomad/blob/1bde7a8fb438cf5579592688b4bd745b139b49ef/client/allocrunner/taskrunner/task_runner_getters.go#L65-L67

`h.updater.updatedVaultToken(h.future.Get())` also triggers the the update hooks, so we would expect log entries that read `running update hooks`, but none is emitted for the task.
https://github.com/hashicorp/nomad/blob/1bde7a8fb438cf5579592688b4bd745b139b49ef/client/allocrunner/taskrunner/vault_hook.go#L54-L55

In addition to deriving a Vault token for the task, `vault_took.Prestart()` also immediately renews it, blocking until the operation completes.
https://github.com/hashicorp/nomad/blob/1bde7a8fb438cf5579592688b4bd745b139b49ef/client/allocrunner/taskrunner/vault_hook.go#L296-L306

#18998 refactored the Vault token renewal loop in order to prevent a possible race condition where expired tokens are re-added to the renewal heap, but I suspect that implementation may have introduced new race conditions.

While trying to reproduce #19805 I bumped into another issue where  the new implementation of `vaultclient.RenewToken()` can get stuck when renewing the same token concurrently. 43bec053ca07a6b9100be92e213bebeadaa18b7a introduces a test for this bug.

This scenario is unlikely to be triggered in a real Nomad cluster because each Vault token is owned by a specific entity (task runners), but it's still a bug and the new implementation may contain others that are responsible for the behaviour observed in #19805.

Since the main issue with Vault renewals was fixed in https://github.com/hashicorp/nomad/pull/18985 I think it's better to rollback this refactored code until we are able to guarantee its correctness.