### PR TITLE
Fix nil pointer dereference if alloc has nil Job

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1876,6 +1876,14 @@ func TestClient_hasLocalState(t *testing.T) {
 
 	c.stateDB = cstate.NewMemDB(c.logger)
 
+	t.Run("nil Job", func(t *testing.T) {
+		alloc := mock.BatchAlloc()
+		alloc.Job = nil
+		c.stateDB.PutAllocation(alloc)
+
+		require.False(t, c.hasLocalState(alloc))
+	})
+
 	t.Run("plain alloc", func(t *testing.T) {
 		alloc := mock.BatchAlloc()
 		c.stateDB.PutAllocation(alloc)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4770,6 +4770,9 @@ func (j *Job) Warnings() error {
 
 // LookupTaskGroup finds a task group by name
 func (j *Job) LookupTaskGroup(name string) *TaskGroup {
+	if j == nil {
+		return nil
+	}
 	for _, tg := range j.TaskGroups {
 		if tg.Name == name {
 			return tg


### PR DESCRIPTION
We encountered the following on one of our production hosts: