### PR TITLE
test: fix test datarace within helper broker.

### DIFF
--- a/helper/broker/notify_test.go
+++ b/helper/broker/notify_test.go
@@ -46,12 +46,12 @@ func TestGenericNotifier(t *testing.T) {
 	var notifiedWG sync.WaitGroup
 
 	for i := 0; i < 6; i++ {
-		go func(wg *sync.WaitGroup) {
-			wg.Add(1)
+		notifiedWG.Add(1)
+		go func() {
 			msg := notifier.WaitForChange(3 * time.Second)
 			require.Equal(t, "we got an update and not a timeout", msg)
-			wg.Done()
-		}(&notifiedWG)
+			notifiedWG.Done()
+		}()
 	}
 
 	// Ensure the routines have had time to start before sending the notify

--- a/helper/broker/notify_test.go
+++ b/helper/broker/notify_test.go
@@ -48,9 +48,9 @@ func TestGenericNotifier(t *testing.T) {
 	for i := 0; i < 6; i++ {
 		notifiedWG.Add(1)
 		go func() {
+			defer notifiedWG.Done()
 			msg := notifier.WaitForChange(3 * time.Second)
 			require.Equal(t, "we got an update and not a timeout", msg)
-			notifiedWG.Done()
 		}()
 	}
 


### PR DESCRIPTION
<details>
  <summary>Data race stack trace</summary>

```
==================
WARNING: DATA RACE
Write at 0x00c0000a9698 by goroutine 7:
  runtime.racewrite()
      <autogenerated>:1 +0x10
  github.com/hashicorp/nomad/helper/broker.TestGenericNotifier()
      /Users/jrasell/Projects/Go/nomad/helper/broker/notify_test.go:62 +0x6b8
  testing.tRunner()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1648 +0x40

Previous read at 0x00c0000a9698 by goroutine 19:
  runtime.raceread()
      <autogenerated>:1 +0x10
  github.com/hashicorp/nomad/helper/broker.TestGenericNotifier.func2()
      /Users/jrasell/Projects/Go/nomad/helper/broker/notify_test.go:50 +0x3c
  github.com/hashicorp/nomad/helper/broker.TestGenericNotifier.func5()
      /Users/jrasell/Projects/Go/nomad/helper/broker/notify_test.go:54 +0x44

Goroutine 7 (running) created at:
  testing.(*T).Run()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1648 +0x5e8
  testing.runTests.func1()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:2054 +0x80
  testing.tRunner()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1595 +0x1b0
  testing.runTests()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:2052 +0x6e4
  testing.(*M).Run()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1925 +0x9ec
  main.main()
      _testmain.go:47 +0x294

Goroutine 19 (running) created at:
  github.com/hashicorp/nomad/helper/broker.TestGenericNotifier()
      /Users/jrasell/Projects/Go/nomad/helper/broker/notify_test.go:49 +0x520
  testing.tRunner()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1648 +0x40
==================
--- FAIL: TestGenericNotifier (0.50s)
    testing.go:1465: race detected during execution of test
FAIL
FAIL	github.com/hashicorp/nomad/helper/broker	0.759s
FAIL
```

</details>