### PR TITLE
test: fix test datarace within driver shared eventer.

### DIFF
--- a/drivers/shared/eventer/eventer_test.go
+++ b/drivers/shared/eventer/eventer_test.go
@@ -119,5 +119,8 @@ func TestEventer_iterateConsumers(t *testing.T) {
 	ev1, ok := <-consumer
 	require.False(ok)
 	require.Nil(ev1)
+
+	e.consumersLock.RLock()
 	require.Equal(0, len(e.consumers))
+	e.consumersLock.RUnlock()
 }


### PR DESCRIPTION
<details>
  <summary>Data race stack trace</summary>

```
WARNING: DATA RACE
Read at 0x00c0001be128 by goroutine 20:
  github.com/hashicorp/nomad/drivers/shared/eventer.TestEventer_iterateConsumers()
      /Users/jrasell/Projects/Go/nomad/drivers/shared/eventer/eventer_test.go:122 +0x600
  testing.tRunner()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1648 +0x40

Previous write at 0x00c0001be128 by goroutine 25:
  github.com/hashicorp/nomad/drivers/shared/eventer.(*Eventer).iterateConsumers()
      /Users/jrasell/Projects/Go/nomad/drivers/shared/eventer/eventer.go:113 +0x514
  github.com/hashicorp/nomad/drivers/shared/eventer.TestEventer_iterateConsumers.func2()
      /Users/jrasell/Projects/Go/nomad/drivers/shared/eventer/eventer_test.go:117 +0x4c

Goroutine 20 (running) created at:
  testing.(*T).Run()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1648 +0x5e8
  testing.runTests.func1()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:2054 +0x80
  testing.tRunner()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1595 +0x1b0
  testing.runTests()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:2052 +0x6e4
  testing.(*M).Run()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1925 +0x9ec
  main.main()
      _testmain.go:49 +0x294

Goroutine 25 (finished) created at:
  github.com/hashicorp/nomad/drivers/shared/eventer.TestEventer_iterateConsumers()
      /Users/jrasell/Projects/Go/nomad/drivers/shared/eventer/eventer_test.go:115 +0x5a4
  testing.tRunner()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1595 +0x1b0
  testing.(*T).Run.func1()
      /Users/jrasell/.asdf/installs/golang/1.21.6/go/src/testing/testing.go:1648 +0x40
==================
```

</details>