### PR TITLE
Prevent NPE when service lacks identity

### DIFF
--- a/.changelog/19986.txt
+++ b/.changelog/19986.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: Prevent NPE when service lacks identity
+```

--- a/nomad/structs/workload_id.go
+++ b/nomad/structs/workload_id.go
@@ -312,7 +312,10 @@ type WIHandle struct {
 	WorkloadType       WorkloadType
 }
 
-func (w WIHandle) Equal(o WIHandle) bool {
+func (w *WIHandle) Equal(o WIHandle) bool {
+	if w == nil {
+		return false
+	}
 	return w.IdentityName == o.IdentityName &&
 		w.WorkloadIdentifier == o.WorkloadIdentifier &&
 		w.WorkloadType == o.WorkloadType


### PR DESCRIPTION
Fixes a null pointer exception if `Alloc.SignIdentities` was called for any service and any service lacked an identity.

Fixes #19986