### PR TITLE
connect: fix missing diff of expose block

### DIFF
--- a/.changelog/19990.txt
+++ b/.changelog/19990.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: Fixed a bug where `expose` blocks would not appear in `job plan` diff output
+```

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -1639,6 +1639,10 @@ func consulProxyDiff(old, new *ConsulProxy, contextual bool) *ObjectDiff {
 		diff.Objects = append(diff.Objects, upDiffs...)
 	}
 
+	if exposeDiff := consulProxyExposeDiff(old.Expose, new.Expose, contextual); exposeDiff != nil {
+		diff.Objects = append(diff.Objects, exposeDiff)
+	}
+
 	// diff the config blob
 	if cDiff := configDiff(old.Config, new.Config, contextual); cDiff != nil {
 		diff.Objects = append(diff.Objects, cDiff)
@@ -1710,6 +1714,40 @@ func consulProxyUpstreamDiff(prev, next ConsulUpstream, contextual bool) *Object
 	// diff the mesh gateway primitive object
 	if mDiff := primitiveObjectDiff(prev.MeshGateway, next.MeshGateway, nil, "MeshGateway", contextual); mDiff != nil {
 		diff.Objects = append(diff.Objects, mDiff)
+	}
+
+	return diff
+}
+
+func consulProxyExposeDiff(prev, next *ConsulExposeConfig, contextual bool) *ObjectDiff {
+	diff := &ObjectDiff{Type: DiffTypeNone, Name: "Expose"}
+
+	if reflect.DeepEqual(prev, next) {
+		return nil
+	} else if prev == nil || prev.Equal(&ConsulExposeConfig{}) {
+		prev = &ConsulExposeConfig{}
+		diff.Type = DiffTypeAdded
+	} else if next == nil || next.Equal(&ConsulExposeConfig{}) {
+		next = &ConsulExposeConfig{}
+		diff.Type = DiffTypeDeleted
+	} else {
+		diff.Type = DiffTypeEdited
+	}
+
+	var prevPaths, nextPaths []any
+	if prev != nil {
+		prevPaths = interfaceSlice(prev.Paths)
+	}
+	if next != nil {
+		nextPaths = interfaceSlice(next.Paths)
+	}
+
+	if pathDiff := primitiveObjectSetDiff(
+		prevPaths,
+		nextPaths,
+		nil, "Paths",
+		contextual); pathDiff != nil {
+		diff.Objects = append(diff.Objects, pathDiff...)
 	}
 
 	return diff

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -3276,6 +3276,14 @@ func TestTaskGroupDiff(t *testing.T) {
 											},
 										},
 									},
+									Expose: &ConsulExposeConfig{
+										Paths: []ConsulExposePath{{
+											Path:          "/health",
+											Protocol:      "http",
+											LocalPathPort: 9001,
+											ListenerPort:  "api_expose_healthcheck",
+										}},
+									},
 									Config: map[string]interface{}{
 										"foo": "qux",
 									},
@@ -3666,6 +3674,42 @@ func TestTaskGroupDiff(t *testing.T) {
 																		Name: "Mode",
 																		Old:  "",
 																		New:  "remote",
+																	},
+																},
+															},
+														},
+													},
+													{
+														Type: DiffTypeAdded,
+														Name: "Expose",
+														Objects: []*ObjectDiff{
+															{
+																Type: DiffTypeAdded,
+																Name: "Paths",
+																Fields: []*FieldDiff{
+																	{
+																		Type: DiffTypeAdded,
+																		Name: "ListenerPort",
+																		Old:  "",
+																		New:  "api_expose_healthcheck",
+																	},
+																	{
+																		Type: DiffTypeAdded,
+																		Name: "LocalPathPort",
+																		Old:  "",
+																		New:  "9001",
+																	},
+																	{
+																		Type: DiffTypeAdded,
+																		Name: "Path",
+																		Old:  "",
+																		New:  "/health",
+																	},
+																	{
+																		Type: DiffTypeAdded,
+																		Name: "Protocol",
+																		Old:  "",
+																		New:  "http",
 																	},
 																},
 															},

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -173,7 +173,7 @@ func (sc *ServiceCheck) Equal(o *ServiceCheck) bool {
 		return false
 	}
 
-	if sc.PortLabel != o.Path {
+	if sc.PortLabel != o.PortLabel {
 		return false
 	}
 


### PR DESCRIPTION
While working on https://github.com/hashicorp/nomad/issues/10628 I discovered that the `expose` block was missing an implementation of Diff, which means it doesn't show up correctly in `job plan` output.

I've also fixed a field comparison bug in `ServiceCheck.Equal` that doesn't appear to impact any production code.