### PR TITLE
docs: fix s/envoy-bootstrap-error redirect

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -30,16 +30,22 @@ module.exports = [
   },
   */
 
-	/**
-	 * /s/* redirects for useful links that need a stable URL but we may need to
-	 * change its destination in the future.
-	 */
-	{
-		source: '/nomad/s/vault-workload-identity-migration',
-		destination:
+  /**
+   * /s/* redirects for useful links that need a stable URL but we may need to
+   * change its destination in the future.
+   */
+  {
+    source: '/nomad/s/envoy-bootstrap-error',
+    destination:
+      'https://developer.hashicorp.com/nomad/docs/integrations/consul/service-mesh#troubleshooting',
+    permanent: false,
+  },
+  {
+    source: '/nomad/s/vault-workload-identity-migration',
+    destination:
       'https://developer.hashicorp.com/nomad/docs/integrations/vault/acl#migrating-to-using-workload-identity-with-vault',
-		permanent: false,
-	},
+    permanent: false,
+  },
   // Rename and re-arrange Autoscaling Internals section
   {
     source: '/nomad/tools/autoscaling/internals/:path*',


### PR DESCRIPTION
And cleanup whitespace

We use this s link in a log message: https://github.com/hashicorp/nomad/blob/v1.7.4/client/allocrunner/taskrunner/envoy_bootstrap_hook.go#L382