### PR TITLE
docs: Consul Admin partition example and updates

### DIFF
--- a/website/content/docs/job-specification/consul.mdx
+++ b/website/content/docs/job-specification/consul.mdx
@@ -82,10 +82,6 @@ If the Nomad cluster is [configured][config_consul_namespace] to use [Consul Nam
 `CONSUL_NAMESPACE` environment variable will be injected whenever `CONSUL_TOKEN`
 is set.
 
-If the Nomad cluster is [configured][config_consul_namespace] to use [Consul Admin Partitions][], a
-`CONSUL_PARTITION` environment variable will be injected whenever `CONSUL_TOKEN`
-is set.
-
 The [`template`][template] block can use the Consul token as well.
 
 ### `consul` Parameters
@@ -104,7 +100,7 @@ The [`template`][template] block can use the Consul token as well.
 - `partition` `(string: "")` - When this field is set, a constraint will be
   added to the group or task to ensure that the allocation is placed on a Nomad
   client that has a Consul Enterprise agent in the specified Consul [admin
-  partition][]. Note that Consul Community Edition agents are limited to the `default` partition, so only Consul Enterprise users should configure this field.
+  partition][].
 
 ## `consul` Examples
 
@@ -236,15 +232,17 @@ job "docs" {
 
 ### Consul Admin Partition
 
-This example demonstrates how to configure Consul admin partitions for different tasks within a group.
+This example demonstrates how to configure Consul admin partitions for different
+tasks within a group. The Consul client agent must separately specify the admin
+partition in the agent configuration. Refer to the Consul documentation's
+[agent configuration reference][] for more information.
 
 <EnterpriseAlert />
 
-In the following example:
+In the following example, the `template` block in the `web` and `app` tasks use
+the default Consul cluster. It obtains a token that allows it access to the `prod`
+admin partition in Consul.
 
-- The `template` block in the `web` task uses the default Consul cluster. It obtains a token that allows it access to the `engineering` admin partition in Consul. 
-- The `template` block in the `app` task uses the Consul cluster named `prod-apps`. It obtains a token that allows it access to the
-`engineering` Consul admin partition.
 
 ```hcl
 job "docs" {
@@ -253,7 +251,9 @@ job "docs" {
     task "web" {
 
       consul {
-        partition = "engineering"
+        cluster   = "default"
+        namespace = "default"
+        partition = "prod"
       }
 
       template {
@@ -265,8 +265,9 @@ job "docs" {
     task "app" {
 
       consul {
-        partition = "engineering"
-        cluster   = "prod-apps"
+        cluster   = "default"
+        namespace = "default"
+        partition = "prod"
       }
 
       template {
@@ -296,3 +297,4 @@ job "docs" {
 [flag_consul_namespace]: /nomad/docs/commands/job/run#consul-namespace
 [Connect]: /nomad/docs/job-specification/connect
 [admin partition]: /consul/docs/enterprise/admin-partitions
+[agent configuration reference]: (/consul/docs/agent/config/config-files#partition-1)

--- a/website/content/docs/job-specification/consul.mdx
+++ b/website/content/docs/job-specification/consul.mdx
@@ -297,4 +297,4 @@ job "docs" {
 [flag_consul_namespace]: /nomad/docs/commands/job/run#consul-namespace
 [Connect]: /nomad/docs/job-specification/connect
 [admin partition]: /consul/docs/enterprise/admin-partitions
-[agent configuration reference]: (/consul/docs/agent/config/config-files#partition-1)
+[agent configuration reference]: /consul/docs/agent/config/config-files#partition-1

--- a/website/content/docs/job-specification/consul.mdx
+++ b/website/content/docs/job-specification/consul.mdx
@@ -100,7 +100,9 @@ The [`template`][template] block can use the Consul token as well.
 - `partition` `(string: "")` - When this field is set, a constraint will be
   added to the group or task to ensure that the allocation is placed on a Nomad
   client that has a Consul Enterprise agent in the specified Consul [admin
-  partition][].
+  partition][]. Note that Consul Community Edition agents are not assigned to
+  any admin partition, so this field should not be used without Consul
+  Enterprise.
 
 ## `consul` Examples
 
@@ -239,22 +241,23 @@ partition in the agent configuration. Refer to the Consul documentation's
 
 <EnterpriseAlert />
 
-In the following example, the `template` block in the `web` and `app` tasks use
-the default Consul cluster. It obtains a token that allows it access to the `prod`
-admin partition in Consul.
-
+In the following example, the `web` and `app` tasks use the default Consul cluster
+and obtain a token that allows access to the `prod` admin partition in Consul. The
+Consul configuration occurs at the `group` level because tasks are placed together
+on the same Allocation. If you configure tasks with separate `consul` blocks, the
+`partition` field must be the same in both blocks.
 
 ```hcl
 job "docs" {
   group "example" {
 
-    task "web" {
+    consul {
+      cluster   = "default"
+      namespace = "default"
+      partition = "prod"
+    }
 
-      consul {
-        cluster   = "default"
-        namespace = "default"
-        partition = "prod"
-      }
+    task "web" {
 
       template {
         data        = "FRONTEND_NAME={{key \"fe/name\"}}"
@@ -263,12 +266,6 @@ job "docs" {
     }
 
     task "app" {
-
-      consul {
-        cluster   = "default"
-        namespace = "default"
-        partition = "prod"
-      }
 
       template {
         data        = "APP_NAME={{key \"app/name\"}}"

--- a/website/content/docs/job-specification/consul.mdx
+++ b/website/content/docs/job-specification/consul.mdx
@@ -76,9 +76,14 @@ to Using Workload Identity with Consul</a>
 
 The Nomad client will make the Consul token available to the task by writing it
 to the secret directory at `secrets/consul_token` and by injecting a
-`CONSUL_TOKEN` environment variable in the task. If the Nomad cluster is
-[configured][config_consul_namespace] to use [Consul Namespaces][], a
+`CONSUL_TOKEN` environment variable in the task. 
+
+If the Nomad cluster is [configured][config_consul_namespace] to use [Consul Namespaces][], a
 `CONSUL_NAMESPACE` environment variable will be injected whenever `CONSUL_TOKEN`
+is set.
+
+If the Nomad cluster is [configured][config_consul_namespace] to use [Consul Admin Partitions][], a
+`CONSUL_PARTITION` environment variable will be injected whenever `CONSUL_TOKEN`
 is set.
 
 The [`template`][template] block can use the Consul token as well.
@@ -99,9 +104,7 @@ The [`template`][template] block can use the Consul token as well.
 - `partition` `(string: "")` - When this field is set, a constraint will be
   added to the group or task to ensure that the allocation is placed on a Nomad
   client that has a Consul Enterprise agent in the specified Consul [admin
-  partition][]. Note that Consul Community Edition agents are not assigned to
-  any admin partition, so this field should not be used without Consul
-  Enterprise.
+  partition][]. Note that Consul Community Edition agents are limited to the `default` partition, so only Consul Enterprise users should configure this field.
 
 ## `consul` Examples
 
@@ -231,6 +234,51 @@ job "docs" {
 }
 ```
 
+### Consul Admin Partition
+
+This example demonstrates how to configure Consul admin partitions for different tasks within a group.
+
+<EnterpriseAlert />
+
+In the following example:
+
+- The `template` block in the `web` task uses the default Consul cluster. It obtains a token that allows it access to the `engineering` admin partition in Consul. 
+- The `template` block in the `app` task uses the Consul cluster named `prod-apps`. It obtains a token that allows it access to the
+`engineering` Consul admin partition.
+
+```hcl
+job "docs" {
+  group "example" {
+
+    task "web" {
+
+      consul {
+        partition = "engineering"
+      }
+
+      template {
+        data        = "FRONTEND_NAME={{key \"fe/name\"}}"
+        destination = "local/config.txt"
+      }
+    }
+
+    task "app" {
+
+      consul {
+        partition = "engineering"
+        cluster   = "prod-apps"
+      }
+
+      template {
+        data        = "APP_NAME={{key \"app/name\"}}"
+        destination = "local/config.txt"
+      }
+    }
+
+  }
+}
+```
+
 [Consul]: https://www.consul.io/ "Consul by HashiCorp"
 [Workload Identity]: /nomad/docs/concepts/workload-identity
 [`consul.task_identity`]: /nomad/docs/configuration/consul#task_identity
@@ -242,6 +290,7 @@ job "docs" {
 [Migrating to Using Workload Identity with Consul]: /nomad/docs/integrations/consul-integration#migrating-to-using-workload-identity-with-consul
 [config_consul_namespace]: /nomad/docs/configuration/consul#namespace
 [Consul Namespaces]: /consul/docs/enterprise/namespaces
+[Consul Admin Partitions]: /consul/docs/enterprise/admin-partitions
 [template]: /nomad/docs/job-specification/template "Nomad template Job Specification"
 [`consul.name`]: /nomad/docs/configuration/consul#name
 [flag_consul_namespace]: /nomad/docs/commands/job/run#consul-namespace


### PR DESCRIPTION
This PR updates the consul Block page for admin partition support, per [CE-555](https://hashicorp.atlassian.net/browse/CE-555).

The following changes were made to the page:

- Admin partitions example added 
- `CONSUL_PARTITION` environment variable sentence and link added
- Description of a Consul partition was modified. It's not that Consul Community has access to zero admin partitions. There is one admin partition, called `default` that Community edition is limited to.

## Preview

[Link to deployment preview](https://nomad-2ncfwj0sc-hashicorp.vercel.app/nomad/docs/job-specification/consul#consul-admin-partition)



[CE-555]: https://hashicorp.atlassian.net/browse/CE-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ