### PR TITLE
[ui] Fixes an issue where shift+num would not open an eval on the evaluations index table

### DIFF
--- a/.changelog/20047.txt
+++ b/.changelog/20047.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed an issue where keynav would not trigger evaluation sidebar expand
+```

--- a/ui/app/controllers/evaluations/index.js
+++ b/ui/app/controllers/evaluations/index.js
@@ -72,7 +72,8 @@ export default class EvaluationsController extends Controller {
       e instanceof MouseEvent ||
       (e instanceof KeyboardEvent &&
         (e.code === 'Enter' || e.code === 'Space')) ||
-      !e
+      !e ||
+      e === 'keynav'
     ) {
       this.statechart.send('LOAD_EVALUATION', { evaluation });
     }

--- a/ui/app/templates/evaluations/index.hbs
+++ b/ui/app/templates/evaluations/index.hbs
@@ -86,7 +86,7 @@
             <td data-test-id
                 {{keyboard-shortcut 
                   enumerated=true
-                  action=(fn this.handleEvaluationClick row.model)
+                  action=(fn this.handleEvaluationClick row.model "keynav")
                 }}
             >
               {{row.model.shortId}}


### PR DESCRIPTION
Because we have multiple links on the Evaluations page table (to open the eval in a sidebar, and also to open the job to which the eval is related), we used a keyboard event "keyup" binding to let a user do something like tab + enter or tab + space to open the sidebar.

This predated the general keyboard navigation convention in the Nomad UI of shift+01, shift+02 to open a list row item action. The "which key was pressed" guard on opening the sidebar prevents this sidebar from opening with shift+n, and this PR fixes that by passing in an explicit "keynav" string on command.

<img width="1195" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/e1802a59-0303-419c-a978-2382cd60e259">
