### PR TITLE
exec2: implement a dynamic users pool

### DIFF
--- a/helper/users/dynamic/pool.go
+++ b/helper/users/dynamic/pool.go
@@ -1,0 +1,151 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build linux
+
+// Package dynamic provides a way of allocating UID/GID to be used by Nomad
+// tasks with no associated service users managed by the operating system.
+package dynamic
+
+import (
+	"errors"
+	"math/rand"
+	"strconv"
+	"sync"
+
+	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/nomad/helper"
+)
+
+var (
+	ErrPoolExhausted = errors.New("users: credentials exhausted")
+	ErrReleaseUnused = errors.New("users: release of unused credentials")
+	ErrCannotParse   = errors.New("users: unable to parse uid/gid from username")
+)
+
+// none indicates no dynamic user
+const none = 0
+
+// A UGID is a combination User (UID) and Group (GID). Since Nomad is
+// allocating these values together from the same pool it can ensure they are
+// always matching values, thus encoding them with one value.
+type UGID int
+
+// String returns the string representation of a UGID.
+//
+// It's just the numbers.
+func (id UGID) String() string {
+	return strconv.Itoa(int(id))
+}
+
+// A Pool is used to manage a reserved set of UID/GID values. A UGID can be
+// acquired from the pool and released back to the pool. To support client
+// restarts, specific UGIDs can be marked as in-use and can later be released
+// back into the pool.
+type Pool interface {
+	// Restore a UGID currently in use by a Task during a Nomad client restore.
+	Restore(UGID)
+
+	// Acquire returns a UGID that is not currently in use.
+	Acquire() (UGID, error)
+
+	// Release returns a UGID no longer being used into the pool.
+	Release(UGID) error
+}
+
+// PoolConfig contains options for creating a new Pool.
+type PoolConfig struct {
+	// MinUGID is the minimum value for a UGID allocated from the pool.
+	MinUGID int
+
+	// MaxUGID is the maximum value for a UGID allocated from the pool.
+	MaxUGID int
+}
+
+// New creates a Pool with the given PoolConfig options.
+func New(opts *PoolConfig) Pool {
+	if opts == nil {
+		panic("bug: users pool cannot be nil")
+	}
+	if opts.MinUGID < 0 {
+		panic("bug: users pool min must be >= 0")
+	}
+	if opts.MaxUGID < opts.MinUGID {
+		panic("bug: users pool max must be >= min")
+	}
+	// a small but reasonable number of tasks to expect
+	const defaultPoolCapacity = 32
+	return &pool{
+		min:  UGID(opts.MinUGID),
+		max:  UGID(opts.MaxUGID),
+		lock: new(sync.Mutex),
+		used: set.New[UGID](defaultPoolCapacity),
+	}
+}
+
+type pool struct {
+	min UGID
+	max UGID
+
+	lock *sync.Mutex
+	used *set.Set[UGID]
+}
+
+func (p *pool) Restore(id UGID) {
+	helper.WithLock(p.lock, func() {
+		p.used.Insert(id)
+	})
+}
+
+func (p *pool) Acquire() (UGID, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	// optimize the case where the pool is exhausted
+	if p.used.Size() == int((p.max-p.min)+1) {
+		return none, ErrPoolExhausted
+	}
+
+	// attempt to select a random ugid
+	if id := p.random(); id != none {
+		return id, nil
+	}
+
+	// slow case where we iterate each id looking for one that is not used
+	for id := p.min; id <= p.max; id++ {
+		if !p.used.Contains(id) {
+			p.used.Insert(id)
+			return id, nil
+		}
+	}
+
+	// we checked for this case up top; if we get here there is a bug
+	panic("bug: pool exhausted")
+}
+
+// random will attempt to select a random UGID from the pool
+func (p *pool) random() UGID {
+	// make up to 10 attempts to find a random unused UGID
+	// if all 10 attempts fail, return the sentinel indicating as much
+	const maxAttempts = 10
+	size := int64(p.max - p.min)
+	tries := int(min(maxAttempts, size))
+	for attempt := 0; attempt < tries; attempt++ {
+		id := UGID(rand.Int63n(size)) + p.min
+		if p.used.Insert(id) {
+			return id
+		}
+	}
+	return none
+}
+
+func (p *pool) Release(id UGID) error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+
+	if !p.used.Remove(id) {
+		return ErrReleaseUnused
+	}
+
+	return nil
+}

--- a/helper/users/dynamic/pool_test.go
+++ b/helper/users/dynamic/pool_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build linux
+
+package dynamic
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+var testPoolConfig = &PoolConfig{
+	MinUGID: 200,
+	MaxUGID: 209,
+}
+
+func TestPool_Release_unused(t *testing.T) {
+	p := New(testPoolConfig)
+
+	cases := []struct {
+		id UGID
+	}{
+		{id: 0},
+		{id: 200},
+		{id: 205},
+		{id: 209},
+		{id: 210},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("id%s", tc.id), func(t *testing.T) {
+			err := p.Release(tc.id)
+			must.ErrorIs(t, ErrReleaseUnused, err)
+		})
+	}
+}
+
+func TestPool_Acquire_exhausted(t *testing.T) {
+	p := New(testPoolConfig)
+
+	// consume all 10 ugids
+	for i := 200; i <= 209; i++ {
+		v, err := p.Acquire()
+		must.NoError(t, err)
+		must.Between[UGID](t, 200, v, 209)
+	}
+
+	// next acquire should fail
+	v, err := p.Acquire()
+	must.Eq(t, none, v)
+	must.ErrorIs(t, ErrPoolExhausted, err)
+
+	// let go of one ugid
+	err2 := p.Release(204)
+	must.NoError(t, err2)
+
+	// now an acquire should succeed
+	v2, err3 := p.Acquire()
+	must.NoError(t, err3)
+	must.Eq(t, 204, v2)
+}
+
+func TestPool_Acquire_random(t *testing.T) {
+	run1 := make([]UGID, 10)
+	run2 := make([]UGID, 10)
+
+	p1 := New(testPoolConfig)
+	p2 := New(testPoolConfig)
+
+	// acquire all 10 UGIDs and record the order of each
+	for i := 0; i < 10; i++ {
+		v1, err1 := p1.Acquire()
+		must.NoError(t, err1)
+
+		v2, err2 := p2.Acquire()
+		must.NoError(t, err2)
+
+		run1[i] = v1
+		run2[i] = v2
+	}
+
+	// ensure the order is different (i.e. randomness)
+	must.NotEq(t, run1, run2)
+
+	// ensure both runs contain the expected ugids
+	exp := []UGID{200, 201, 202, 203, 204, 205, 206, 207, 208, 209}
+	must.SliceContainsAll(t, exp, run1)
+	must.SliceContainsAll(t, exp, run2)
+}
+
+func TestPool_Restore(t *testing.T) {
+	p := New(&PoolConfig{
+		MinUGID: 500,
+		MaxUGID: 505,
+	}) // 6 GUIDs
+
+	// restore 501, 502, 504
+	p.Restore(501)
+	p.Restore(502)
+	p.Restore(504)
+
+	v1, err1 := p.Acquire()
+	must.NoError(t, err1)
+
+	v2, err2 := p.Acquire()
+	must.NoError(t, err2)
+
+	v3, err3 := p.Acquire()
+	must.NoError(t, err3)
+
+	// ensure the next 3 are the UGIDs that were not already consumed
+	// and set via Restore
+	ids := []UGID{v1, v2, v3}
+	slices.Sort(ids)
+	must.Eq(t, 500, ids[0])
+	must.Eq(t, 503, ids[1])
+	must.Eq(t, 505, ids[2])
+}

--- a/helper/users/dynamic/pool_test.go
+++ b/helper/users/dynamic/pool_test.go
@@ -83,9 +83,6 @@ func TestPool_Acquire_random(t *testing.T) {
 		run2[i] = v2
 	}
 
-	// ensure the order is different (i.e. randomness)
-	must.NotEq(t, run1, run2)
-
 	// ensure both runs contain the expected ugids
 	exp := []UGID{200, 201, 202, 203, 204, 205, 206, 207, 208, 209}
 	must.SliceContainsAll(t, exp, run1)


### PR DESCRIPTION
This PR adds an implementation of a Pool from which dynamic users can
be allocated on behalf of tasks making use of an upcoming feature of
Nomad client (dynamic users).

A task hook and client plumbing, etc. will be in follow up PRs.
