### PR TITLE
Fix wording of ACL error message

### DIFF
--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -927,7 +927,7 @@ func (a *ACLPolicyJobACLFieldIndex) FromObject(obj interface{}) (bool, []byte, e
 	jobID := policy.JobACL.JobID
 	if jobID == "" {
 		return false, nil, fmt.Errorf(
-			"object %#v is not a valid ACLPolicy: JobACL.JobID without Namespace", obj)
+			"object %#v is not a valid ACLPolicy: Namespace without JobID", obj)
 	}
 
 	val := ns + "\x00" + jobID + "\x00"


### PR DESCRIPTION
When creating a job ACL, you must supply a job ID if you supply a namespace.  If you try to give a namespace without a job ID, the error states "JobACL.JobID without Namespace", which is the opposite of what really happened.