### PR TITLE
[f-gh-208] Force recreation and redeployment of task if volume label changes

### DIFF
--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -251,6 +251,11 @@ type VolumeMount struct {
 	SELinuxLabel    string
 }
 
+// Hash is a very basic string based implementation of a hasher.
+func (v *VolumeMount) Hash() string {
+	return fmt.Sprintf("%#+v", v)
+}
+
 func (v *VolumeMount) Equal(o *VolumeMount) bool {
 	if v == nil || o == nil {
 		return v == o

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -438,23 +438,7 @@ func volumeMountsUpdated(a, b []*structs.VolumeMount) comparison {
 		return same
 	}
 
-	bVMMap := helper.SliceToMap[map[string]*structs.VolumeMount](b,
-		func(vm *structs.VolumeMount) string {
-			return vm.Volume
-		})
-
-	for _, atvm := range a {
-		if c := volumeMountUpdated(atvm, bVMMap[atvm.Volume]); c.modified {
-			return c
-		}
-		delete(bVMMap, atvm.Volume)
-	}
-
-	if len(bVMMap) > 0 {
-		return difference("volume mount added", nil, bVMMap)
-	}
-
-	return same
+	return difference("volume mounts", a, b)
 }
 
 // volumeMountUpdated returns true if the definition of the volume mount

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -439,6 +439,10 @@ func connectServiceUpdated(servicesA, servicesB []*structs.Service) comparison {
 // volumeMountUpdated returns true if the definition of the volume mount
 // has been updated in a manner that will requires the task to be recreated.
 func volumeMountUpdated(mountA, mountB *structs.VolumeMount) comparison {
+	if mountA != nil && mountB == nil {
+		difference("volume mount removed", mountA, mountB)
+	}
+
 	if mountA != nil && mountB != nil &&
 		mountA.SELinuxLabel != mountB.SELinuxLabel {
 		return difference("volume mount selinux label", mountA.SELinuxLabel, mountB.SELinuxLabel)

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -547,6 +547,27 @@ func TestTasksUpdated(t *testing.T) {
 	// Compare changed Template ErrMissingKey
 	j30.TaskGroups[0].Tasks[0].Templates[0].ErrMissingKey = true
 	must.True(t, tasksUpdated(j29, j30, name).modified)
+
+	// Compare volume mounts
+	j31 := mock.Job()
+	j31.TaskGroups[0].Tasks[0].VolumeMounts = []*structs.VolumeMount{
+		{
+			Volume:       "myvolume",
+			SELinuxLabel: "z",
+		},
+	}
+
+	j32 := j31.Copy()
+	must.False(t, tasksUpdated(j31, j32, name).modified)
+
+	j32.TaskGroups[0].Tasks[0].VolumeMounts = []*structs.VolumeMount{
+		{
+			Volume:       "myvolume",
+			SELinuxLabel: "",
+		},
+	}
+
+	must.True(t, tasksUpdated(j31, j32, name).modified)
 }
 
 func TestTasksUpdated_connectServiceUpdated(t *testing.T) {

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -571,7 +571,7 @@ func TestTasksUpdated(t *testing.T) {
 
 	must.True(t, tasksUpdated(j31, j32, name).modified)
 
-	// Remove volume mount
+	// Add volume mount
 	j32.TaskGroups[0].Tasks[0].VolumeMounts = nil
 
 	must.True(t, tasksUpdated(j31, j32, name).modified)

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -548,8 +548,13 @@ func TestTasksUpdated(t *testing.T) {
 	j30.TaskGroups[0].Tasks[0].Templates[0].ErrMissingKey = true
 	must.True(t, tasksUpdated(j29, j30, name).modified)
 
-	// Compare volume mounts
+	// Compare identical volume mounts
 	j31 := mock.Job()
+	j32 := j31.Copy()
+
+	must.False(t, tasksUpdated(j31, j32, name).modified)
+
+	// Modify volume mounts
 	j31.TaskGroups[0].Tasks[0].VolumeMounts = []*structs.VolumeMount{
 		{
 			Volume:       "myvolume",
@@ -557,15 +562,17 @@ func TestTasksUpdated(t *testing.T) {
 		},
 	}
 
-	j32 := j31.Copy()
-	must.False(t, tasksUpdated(j31, j32, name).modified)
-
 	j32.TaskGroups[0].Tasks[0].VolumeMounts = []*structs.VolumeMount{
 		{
 			Volume:       "myvolume",
 			SELinuxLabel: "",
 		},
 	}
+
+	must.True(t, tasksUpdated(j31, j32, name).modified)
+
+	// Remove volume mount
+	j32.TaskGroups[0].Tasks[0].VolumeMounts = nil
 
 	must.True(t, tasksUpdated(j31, j32, name).modified)
 }

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -572,6 +572,14 @@ func TestTasksUpdated(t *testing.T) {
 	must.True(t, tasksUpdated(j31, j32, name).modified)
 
 	// Add volume mount
+	j32.TaskGroups[0].Tasks[0].VolumeMounts = append(j32.TaskGroups[0].Tasks[0].VolumeMounts,
+		&structs.VolumeMount{
+			Volume:       "myvolume2",
+			SELinuxLabel: "Z",
+		})
+
+	// Remove volume mount
+	j32 = j31.Copy()
 	j32.TaskGroups[0].Tasks[0].VolumeMounts = nil
 
 	must.True(t, tasksUpdated(j31, j32, name).modified)


### PR DESCRIPTION
In a [past PR](https://github.com/hashicorp/nomad/pull/19886), a new parameter was introduced as part of the volume mount configuration in the task definition. It controls a security feature in case SELinux is being used. In case the job definition changes, the security feature needs to be reevaluated and the podman plugin in charge of doing the mount re run. This PR forces the scheduler to restart the allocations in case of a change in the job definition.

For more information, refer to the [ticket](https://github.com/hashicorp/nomad-driver-podman/pull/208).