### PR TITLE
docs: skipping a major release is fine

### DIFF
--- a/website/content/docs/upgrade/index.mdx
+++ b/website/content/docs/upgrade/index.mdx
@@ -12,9 +12,8 @@ Nomad is designed to be flexible and resilient when upgrading from one Nomad
 version to the next. Upgrades should cause neither a Nomad nor a service
 outage. However, there are some restrictions to be aware of before upgrading:
 
-- Nomad strives to be backward compatible for at least 1 point release, so
-  Nomad v1.6.x hosts work with v1.5.x hosts. Upgrading 2 point releases
-  (for example, from v1.4.0 to v1.6.0) may work but is untested and unsupported.
+- Nomad strives to be backward compatible for at least 2 point release, so
+  Nomad v1.7.x works with v1.5.x.
 
   - Nomad does _not_ support downgrading at this time. Downgrading clients
     requires draining allocations and removing the [data directory][data_dir].


### PR DESCRIPTION
Nomad has always placed an extremely high priority on backward compatibility. We have always aimed to support N-2 major releases and usually gone above and beyond that.

The new https://www.hashicorp.com/long-term-support policy also mentions that N-2 is what we have always supported, so it's probably time for our docs to reflect that reality.