### PR TITLE
Support insecure flag on artifact

### DIFF
--- a/.changelog/20126.txt
+++ b/.changelog/20126.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+artifact: Added support for downloading artifacts without validating the TLS certificate
+```

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -856,16 +856,20 @@ func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
 
 // TaskArtifact is used to download artifacts before running a task.
 type TaskArtifact struct {
-	GetterSource  *string           `mapstructure:"source" hcl:"source,optional"`
-	GetterOptions map[string]string `mapstructure:"options" hcl:"options,block"`
-	GetterHeaders map[string]string `mapstructure:"headers" hcl:"headers,block"`
-	GetterMode    *string           `mapstructure:"mode" hcl:"mode,optional"`
-	RelativeDest  *string           `mapstructure:"destination" hcl:"destination,optional"`
+	GetterSource   *string           `mapstructure:"source" hcl:"source,optional"`
+	GetterOptions  map[string]string `mapstructure:"options" hcl:"options,block"`
+	GetterHeaders  map[string]string `mapstructure:"headers" hcl:"headers,block"`
+	GetterMode     *string           `mapstructure:"mode" hcl:"mode,optional"`
+	GetterInsecure *bool             `mapstructure:"insecure" hcl:"insecure,optional"`
+	RelativeDest   *string           `mapstructure:"destination" hcl:"destination,optional"`
 }
 
 func (a *TaskArtifact) Canonicalize() {
 	if a.GetterMode == nil {
 		a.GetterMode = pointerOf("any")
+	}
+	if a.GetterInsecure == nil {
+		a.GetterInsecure = pointerOf(false)
 	}
 	if a.GetterSource == nil {
 		// Shouldn't be possible, but we don't want to panic

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -317,6 +317,7 @@ func TestTask_Artifact(t *testing.T) {
 	}
 	a.Canonicalize()
 	must.Eq(t, "file", *a.GetterMode)
+	must.Eq(t, false, *a.GetterInsecure)
 	must.Eq(t, "local/foo.txt", filepath.ToSlash(*a.RelativeDest))
 	must.Nil(t, a.GetterOptions)
 	must.Nil(t, a.GetterHeaders)

--- a/client/allocrunner/taskrunner/getter/params.go
+++ b/client/allocrunner/taskrunner/getter/params.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-getter"
 )
 
@@ -36,6 +35,7 @@ type parameters struct {
 
 	// Artifact
 	Mode        getter.ClientMode   `json:"artifact_mode"`
+	Insecure    bool                `json:"artifact_insecure"`
 	Source      string              `json:"artifact_source"`
 	Destination string              `json:"artifact_destination"`
 	Headers     map[string][]string `json:"artifact_headers"`
@@ -102,6 +102,8 @@ func (p *parameters) Equal(o *parameters) bool {
 		return false
 	case p.Mode != o.Mode:
 		return false
+	case p.Insecure != o.Insecure:
+		return false
 	case p.Source != o.Source:
 		return false
 	case p.Destination != o.Destination:
@@ -130,7 +132,6 @@ const (
 func (p *parameters) client(ctx context.Context) *getter.Client {
 	httpGetter := &getter.HttpGetter{
 		Netrc:  true,
-		Client: cleanhttp.DefaultClient(),
 		Header: p.Headers,
 
 		// Do not support the custom X-Terraform-Get header and
@@ -162,8 +163,8 @@ func (p *parameters) client(ctx context.Context) *getter.Client {
 		Src:             p.Source,
 		Dst:             p.Destination,
 		Mode:            p.Mode,
+		Insecure:        p.Insecure,
 		Umask:           umask,
-		Insecure:        false,
 		DisableSymlinks: true,
 		Decompressors:   decompressors,
 		Getters: map[string]getter.Getter{

--- a/client/allocrunner/taskrunner/getter/params_test.go
+++ b/client/allocrunner/taskrunner/getter/params_test.go
@@ -27,6 +27,7 @@ const paramsAsJSON = `
   "disable_filesystem_isolation": true,
   "set_environment_variables": "",
   "artifact_mode": 2,
+  "artifact_insecure": false,
   "artifact_source": "https://example.com/file.txt",
   "artifact_destination": "local/out.txt",
   "artifact_headers": {

--- a/client/allocrunner/taskrunner/getter/sandbox.go
+++ b/client/allocrunner/taskrunner/getter/sandbox.go
@@ -38,6 +38,7 @@ func (s *Sandbox) Get(env interfaces.EnvReplacer, artifact *structs.TaskArtifact
 	}
 
 	mode := getMode(artifact)
+	insecure := isInsecure(artifact)
 	headers := getHeaders(env, artifact)
 	allocDir, taskDir := getWritableDirs(env)
 
@@ -56,6 +57,7 @@ func (s *Sandbox) Get(env interfaces.EnvReplacer, artifact *structs.TaskArtifact
 
 		// artifact configuration
 		Mode:        mode,
+		Insecure:    insecure,
 		Source:      source,
 		Destination: destination,
 		Headers:     headers,

--- a/client/allocrunner/taskrunner/getter/util.go
+++ b/client/allocrunner/taskrunner/getter/util.go
@@ -84,6 +84,10 @@ func getMode(artifact *structs.TaskArtifact) getter.ClientMode {
 	}
 }
 
+func isInsecure(artifact *structs.TaskArtifact) bool {
+	return artifact.GetterInsecure
+}
+
 func getHeaders(env interfaces.EnvReplacer, artifact *structs.TaskArtifact) map[string][]string {
 	m := artifact.GetterHeaders
 	if len(m) == 0 {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1355,11 +1355,12 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 		for _, ta := range apiTask.Artifacts {
 			structsTask.Artifacts = append(structsTask.Artifacts,
 				&structs.TaskArtifact{
-					GetterSource:  *ta.GetterSource,
-					GetterOptions: maps.Clone(ta.GetterOptions),
-					GetterHeaders: maps.Clone(ta.GetterHeaders),
-					GetterMode:    *ta.GetterMode,
-					RelativeDest:  *ta.RelativeDest,
+					GetterSource:   *ta.GetterSource,
+					GetterOptions:  maps.Clone(ta.GetterOptions),
+					GetterHeaders:  maps.Clone(ta.GetterHeaders),
+					GetterMode:     *ta.GetterMode,
+					GetterInsecure: *ta.GetterInsecure,
+					RelativeDest:   *ta.RelativeDest,
 				})
 		}
 	}

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -5627,6 +5627,12 @@ func TestTaskDiff(t *testing.T) {
 							},
 							{
 								Type: DiffTypeAdded,
+								Name: "GetterInsecure",
+								Old:  "",
+								New:  "false",
+							},
+							{
+								Type: DiffTypeAdded,
 								Name: "GetterMode",
 								Old:  "",
 								New:  "file",
@@ -5659,6 +5665,13 @@ func TestTaskDiff(t *testing.T) {
 								Type: DiffTypeDeleted,
 								Name: "GetterHeaders[User]",
 								Old:  "user1",
+								New:  "",
+							},
+
+							{
+								Type: DiffTypeDeleted,
+								Name: "GetterInsecure",
+								Old:  "false",
 								New:  "",
 							},
 							{

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9449,6 +9449,10 @@ type TaskArtifact struct {
 	// Defaults to "any" but can be set to "file" or "dir".
 	GetterMode string
 
+	// GetterInsecure is a flag to disable SSL certificate verification when
+	// downloading the artifact using go-getter.
+	GetterInsecure bool
+
 	// RelativeDest is the download destination given relative to the task's
 	// directory.
 	RelativeDest string
@@ -9467,6 +9471,8 @@ func (ta *TaskArtifact) Equal(o *TaskArtifact) bool {
 		return false
 	case ta.GetterMode != o.GetterMode:
 		return false
+	case ta.GetterInsecure != o.GetterInsecure:
+		return false
 	case ta.RelativeDest != o.RelativeDest:
 		return false
 	}
@@ -9478,11 +9484,12 @@ func (ta *TaskArtifact) Copy() *TaskArtifact {
 		return nil
 	}
 	return &TaskArtifact{
-		GetterSource:  ta.GetterSource,
-		GetterOptions: maps.Clone(ta.GetterOptions),
-		GetterHeaders: maps.Clone(ta.GetterHeaders),
-		GetterMode:    ta.GetterMode,
-		RelativeDest:  ta.RelativeDest,
+		GetterSource:   ta.GetterSource,
+		GetterOptions:  maps.Clone(ta.GetterOptions),
+		GetterHeaders:  maps.Clone(ta.GetterHeaders),
+		GetterMode:     ta.GetterMode,
+		GetterInsecure: ta.GetterInsecure,
+		RelativeDest:   ta.RelativeDest,
 	}
 }
 
@@ -9522,6 +9529,7 @@ func (ta *TaskArtifact) Hash() string {
 	hashStringMap(h, ta.GetterHeaders)
 
 	_, _ = h.Write([]byte(ta.GetterMode))
+	_, _ = h.Write([]byte(strconv.FormatBool(ta.GetterInsecure)))
 	_, _ = h.Write([]byte(ta.RelativeDest))
 	return base64.RawStdEncoding.EncodeToString(h.Sum(nil))
 }

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -4785,6 +4785,16 @@ func TestTaskArtifact_Hash(t *testing.T) {
 			GetterMode:   "g",
 			RelativeDest: "i",
 		},
+		{
+			GetterSource: "b",
+			GetterOptions: map[string]string{
+				"c": "c",
+				"d": "e",
+			},
+			GetterMode:     "g",
+			GetterInsecure: true,
+			RelativeDest:   "i",
+		},
 	}
 
 	// Map of hash to source


### PR DESCRIPTION
Hey, I'm so glad this is my first PR to nomad. 🎉

this PR supports an insecure flag for artifact download as described in #19883 

The artifact block now supports an insecure flag like the example below. this flag will prevent the go-getter from validating the TLS certificate. 

```
      artifact {
        source        = "https://expired.badssl.com/"
        destination = "local/some-directory"
        insecure     = true
      }
```

Closes #19883