### PR TITLE
template: improve internal documentation around shutdown

### DIFF
--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -250,10 +250,14 @@ func (tm *TaskTemplateManager) run() {
 		return
 	}
 
-	// Start the runner
+	// Start the runner. We don't defer a call to tm.runner.Stop here so that
+	// the runner can keep dynamic secrets alive during the task's
+	// kill_timeout. We stop the runner in the Stop hook, which is guaranteed to
+	// be called during task kill.
 	go tm.runner.Start()
 
-	// Block till all the templates have been rendered
+	// Block till all the templates have been rendered or until an error has
+	// triggered taskrunner Kill, which closes tm.shutdownCh before we return
 	tm.handleFirstRender()
 
 	// Detect if there was a shutdown.
@@ -313,6 +317,9 @@ WAIT:
 				continue
 			}
 
+			// we don't return here so that we wait for tm.shutdownCh in the
+			// next pass thru the loop; this ensures the callers doesn't unblock
+			// prematurely
 			tm.config.Lifecycle.Kill(context.Background(),
 				structs.NewTaskEvent(structs.TaskKilling).
 					SetFailsTask().
@@ -427,6 +434,9 @@ func (tm *TaskTemplateManager) handleTemplateRerenders(allRenderedTime time.Time
 				continue
 			}
 
+			// we don't return here so that we wait for tm.shutdownCh in the
+			// next pass thru the loop; this ensures the callers doesn't unblock
+			// prematurely
 			tm.config.Lifecycle.Kill(context.Background(),
 				structs.NewTaskEvent(structs.TaskKilling).
 					SetFailsTask().

--- a/client/allocrunner/taskrunner/template_hook.go
+++ b/client/allocrunner/taskrunner/template_hook.go
@@ -192,7 +192,7 @@ func (h *templateHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 	return nil
 }
 
-func (h *templateHook) Poststart(ctx context.Context, req *interfaces.TaskPoststartRequest, resp *interfaces.TaskPoststartResponse) error {
+func (h *templateHook) Poststart(_ context.Context, req *interfaces.TaskPoststartRequest, resp *interfaces.TaskPoststartResponse) error {
 	h.managerLock.Lock()
 	defer h.managerLock.Unlock()
 
@@ -260,7 +260,7 @@ func (h *templateHook) newManager() (unblock chan struct{}, err error) {
 	return unblock, nil
 }
 
-func (h *templateHook) Stop(ctx context.Context, req *interfaces.TaskStopRequest, resp *interfaces.TaskStopResponse) error {
+func (h *templateHook) Stop(_ context.Context, req *interfaces.TaskStopRequest, resp *interfaces.TaskStopResponse) error {
 	h.managerLock.Lock()
 	defer h.managerLock.Unlock()
 
@@ -273,7 +273,7 @@ func (h *templateHook) Stop(ctx context.Context, req *interfaces.TaskStopRequest
 }
 
 // Update is used to handle updates to vault and/or nomad tokens.
-func (h *templateHook) Update(ctx context.Context, req *interfaces.TaskUpdateRequest, resp *interfaces.TaskUpdateResponse) error {
+func (h *templateHook) Update(_ context.Context, req *interfaces.TaskUpdateRequest, resp *interfaces.TaskUpdateResponse) error {
 	h.managerLock.Lock()
 	defer h.managerLock.Unlock()
 


### PR DESCRIPTION
While investigating a report around possible consul-template shutdown issues, which didn't bear fruit, I found that some of the logic around template runner shutdown is unintuitive.

* Add some doc strings to the places where someone might think we should be obviously stopping the runner or returning early.
* Mark context argument for `Poststart`, `Stop`, and `Update` hooks as unused.

No functional code changes.