### PR TITLE
transparent proxy: add jobspec support

### DIFF
--- a/command/agent/consul/connect.go
+++ b/command/agent/consul/connect.go
@@ -145,8 +145,13 @@ func connectSidecarProxy(info structs.AllocInfo, proxy *structs.ConsulProxy, cPo
 	if err != nil {
 		return nil, err
 	}
+	mode := api.ProxyModeDefault
+	if proxy.TransparentProxy != nil {
+		mode = api.ProxyModeTransparent
+	}
 
 	return &api.AgentServiceConnectProxyConfig{
+		Mode:                mode,
 		LocalServiceAddress: proxy.LocalServiceAddress,
 		LocalServicePort:    proxy.LocalServicePort,
 		Config:              connectProxyConfig(proxy.Config, cPort, info),

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1867,6 +1867,7 @@ func apiConnectSidecarServiceProxyToStructs(in *api.ConsulProxy) *structs.Consul
 		LocalServicePort:    in.LocalServicePort,
 		Upstreams:           apiUpstreamsToStructs(in.Upstreams),
 		Expose:              apiConsulExposeConfigToStructs(expose),
+		TransparentProxy:    apiConnectTransparentProxyToStructs(in.TransparentProxy),
 		Config:              maps.Clone(in.Config),
 	}
 }
@@ -1915,6 +1916,21 @@ func apiConsulExposeConfigToStructs(in *api.ConsulExposeConfig) *structs.ConsulE
 
 	return &structs.ConsulExposeConfig{
 		Paths: apiConsulExposePathsToStructs(paths),
+	}
+}
+
+func apiConnectTransparentProxyToStructs(in *api.ConsulTransparentProxy) *structs.ConsulTransparentProxy {
+	if in == nil {
+		return nil
+	}
+	return &structs.ConsulTransparentProxy{
+		UID:                  in.UID,
+		OutboundPort:         in.OutboundPort,
+		ExcludeInboundPorts:  in.ExcludeInboundPorts,
+		ExcludeOutboundPorts: in.ExcludeOutboundPorts,
+		ExcludeOutboundCIDRs: in.ExcludeOutboundCIDRs,
+		ExcludeUIDs:          in.ExcludeUIDs,
+		NoDNS:                in.NoDNS,
 	}
 }
 

--- a/jobspec/parse_service.go
+++ b/jobspec/parse_service.go
@@ -769,6 +769,7 @@ func parseProxy(o *ast.ObjectItem) (*api.ConsulProxy, error) {
 		"local_service_port",
 		"upstreams",
 		"expose",
+		"transparent_proxy",
 		"config",
 	}
 
@@ -784,6 +785,7 @@ func parseProxy(o *ast.ObjectItem) (*api.ConsulProxy, error) {
 
 	delete(m, "upstreams")
 	delete(m, "expose")
+	delete(m, "transparent_proxy")
 	delete(m, "config")
 
 	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
@@ -824,6 +826,16 @@ func parseProxy(o *ast.ObjectItem) (*api.ConsulProxy, error) {
 			return nil, err
 		} else {
 			proxy.Expose = e
+		}
+	}
+
+	if tpo := listVal.Filter("transparent_proxy"); len(tpo.Items) > 1 {
+		return nil, fmt.Errorf("only 1 transparent_proxy object supported")
+	} else if len(tpo.Items) == 1 {
+		if tp, err := parseTproxy(tpo.Items[0]); err != nil {
+			return nil, err
+		} else {
+			proxy.TransparentProxy = tp
 		}
 	}
 
@@ -917,6 +929,41 @@ func parseExposePath(epo *ast.ObjectItem) (*api.ConsulExposePath, error) {
 	}
 
 	return &path, nil
+}
+
+func parseTproxy(epo *ast.ObjectItem) (*api.ConsulTransparentProxy, error) {
+	valid := []string{
+		"uid",
+		"outbound_port",
+		"exclude_inbound_ports",
+		"exclude_outbound_ports",
+		"exclude_outbound_cidrs",
+		"exclude_uids",
+		"no_dns",
+	}
+
+	if err := checkHCLKeys(epo.Val, valid); err != nil {
+		return nil, multierror.Prefix(err, "tproxy ->")
+	}
+
+	var tproxy api.ConsulTransparentProxy
+	var m map[string]interface{}
+	if err := hcl.DecodeObject(&m, epo.Val); err != nil {
+		return nil, err
+	}
+
+	dec, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result: &tproxy,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if err := dec.Decode(m); err != nil {
+		return nil, err
+	}
+
+	return &tproxy, nil
 }
 
 func parseUpstream(uo *ast.ObjectItem) (*api.ConsulUpstream, error) {

--- a/jobspec/parse_test.go
+++ b/jobspec/parse_test.go
@@ -1468,6 +1468,15 @@ func TestParse(t *testing.T) {
 										DestinationName: "upstream2",
 										LocalBindPort:   2002,
 									}},
+									TransparentProxy: &api.ConsulTransparentProxy{
+										UID:                  "101",
+										OutboundPort:         15001,
+										ExcludeInboundPorts:  []string{"www", "9000"},
+										ExcludeOutboundPorts: []uint16{443, 80},
+										ExcludeOutboundCIDRs: []string{"10.0.0.0/8"},
+										ExcludeUIDs:          []string{"10", "1001"},
+										NoDNS:                true,
+									},
 									Config: map[string]interface{}{
 										"foo": "bar",
 									},

--- a/jobspec/test-fixtures/tg-service-connect-proxy.hcl
+++ b/jobspec/test-fixtures/tg-service-connect-proxy.hcl
@@ -40,6 +40,16 @@ job "service-connect-proxy" {
               }
             }
 
+            transparent_proxy {
+              uid                    = "101"
+              outbound_port          = 15001
+              exclude_inbound_ports  = ["www", "9000"]
+              exclude_outbound_ports = [443, 80]
+              exclude_outbound_cidrs = ["10.0.0.0/8"]
+              exclude_uids           = ["10", "1001"]
+              no_dns                 = true
+            }
+
             config {
               foo = "bar"
             }

--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -561,31 +561,66 @@ func groupConnectValidate(g *structs.TaskGroup) error {
 		}
 	}
 
-	if err := groupConnectUpstreamsValidate(g.Name, g.Services); err != nil {
+	if err := groupConnectUpstreamsValidate(g, g.Services); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func groupConnectUpstreamsValidate(group string, services []*structs.Service) error {
+func groupConnectUpstreamsValidate(g *structs.TaskGroup, services []*structs.Service) error {
 	listeners := make(map[string]string) // address -> service
 
+	var connectBlockCount int
+	var hasTproxy bool
+
 	for _, service := range services {
+		if service.Connect != nil {
+			connectBlockCount++
+		}
 		if service.Connect.HasSidecar() && service.Connect.SidecarService.Proxy != nil {
 			for _, up := range service.Connect.SidecarService.Proxy.Upstreams {
 				listener := net.JoinHostPort(up.LocalBindAddress, strconv.Itoa(up.LocalBindPort))
 				if s, exists := listeners[listener]; exists {
 					return fmt.Errorf(
 						"Consul Connect services %q and %q in group %q using same address for upstreams (%s)",
-						service.Name, s, group, listener,
+						service.Name, s, g.Name, listener,
 					)
 				}
 				listeners[listener] = service.Name
 			}
+
+			if tp := service.Connect.SidecarService.Proxy.TransparentProxy; tp != nil {
+				hasTproxy = true
+				for _, portLabel := range tp.ExcludeInboundPorts {
+					if !transparentProxyPortLabelValidate(g, portLabel) {
+						return fmt.Errorf(
+							"Consul Connect transparent proxy port %q must be numeric or one of network.port labels", portLabel)
+					}
+				}
+			}
+
 		}
 	}
+	if hasTproxy && connectBlockCount > 1 {
+		return fmt.Errorf("Consul Connect transparent proxy requires there is only one connect block")
+	}
 	return nil
+}
+
+func transparentProxyPortLabelValidate(g *structs.TaskGroup, portLabel string) bool {
+	if _, err := strconv.ParseUint(portLabel, 10, 64); err == nil {
+		return true
+	}
+
+	for _, network := range g.Networks {
+		for _, reservedPort := range network.ReservedPorts {
+			if reservedPort.Label == portLabel {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func groupConnectSidecarValidate(g *structs.TaskGroup, s *structs.Service) error {

--- a/nomad/structs/connect.go
+++ b/nomad/structs/connect.go
@@ -3,6 +3,13 @@
 
 package structs
 
+import (
+	"fmt"
+	"net/netip"
+	"slices"
+	"strconv"
+)
+
 // ConsulConfigEntries represents Consul ConfigEntry definitions from a job for
 // a single Consul namespace.
 type ConsulConfigEntries struct {
@@ -42,4 +49,124 @@ func (j *Job) ConfigEntries() map[string]*ConsulConfigEntries {
 	}
 
 	return collection
+}
+
+// ConsulTransparentProxy is used to configure the Envoy sidecar for
+// "transparent proxying", which creates IP tables rules inside the network
+// namespace to ensure traffic flows thru the Envoy proxy
+type ConsulTransparentProxy struct {
+
+	// UID of the Envoy proxy. Defaults to the default Envoy proxy container
+	// image user.
+	UID string
+
+	// OutboundPort is the Envoy proxy's outbound listener port. Inbound TCP
+	// traffic hitting the PROXY_IN_REDIRECT chain will be redirected here.
+	// Defaults to 15001.
+	OutboundPort uint16
+
+	// ExcludeInboundPorts is an additional set of ports will be excluded from
+	// redirection to the Envoy proxy. Can be Port.Label or Port.Value. This set
+	// will be added to the ports automatically excluded for the Expose.Port and
+	// Check.Expose fields.
+	ExcludeInboundPorts []string
+
+	// ExcludeOutboundPorts is a set of outbound ports that will not be
+	// redirected to the Envoy proxy, specified as port numbers.
+	ExcludeOutboundPorts []uint16
+
+	// ExcludeOutboundCIDRs is a set of outbound CIDR blocks that will not be
+	// redirected to the Envoy proxy.
+	ExcludeOutboundCIDRs []string
+
+	// ExcludeUIDs is a set of user IDs whose network traffic will not be
+	// redirected through the Envoy proxy.
+	ExcludeUIDs []string
+
+	// NoDNS disables redirection of DNS traffic to Consul DNS. By default NoDNS
+	// is false and transparent proxy will direct DNS traffic to Consul DNS if
+	// available on the client.
+	NoDNS bool
+}
+
+func (tp *ConsulTransparentProxy) Copy() *ConsulTransparentProxy {
+	if tp == nil {
+		return nil
+	}
+	ntp := new(ConsulTransparentProxy)
+	*ntp = *tp
+
+	ntp.ExcludeInboundPorts = slices.Clone(tp.ExcludeInboundPorts)
+	ntp.ExcludeOutboundPorts = slices.Clone(tp.ExcludeOutboundPorts)
+	ntp.ExcludeOutboundCIDRs = slices.Clone(tp.ExcludeOutboundCIDRs)
+	ntp.ExcludeUIDs = slices.Clone(tp.ExcludeUIDs)
+
+	return ntp
+}
+
+func (tp *ConsulTransparentProxy) Validate() error {
+	for _, rawCidr := range tp.ExcludeOutboundCIDRs {
+		_, err := netip.ParsePrefix(rawCidr)
+		if err != nil {
+			// note: error returned always include parsed string
+			return fmt.Errorf("could not parse transparent proxy excluded outbound CIDR as network prefix: %w", err)
+		}
+	}
+
+	requireUIDisUint := func(uidRaw string) error {
+		_, err := strconv.ParseUint(uidRaw, 10, 16)
+		if err != nil {
+			e, ok := err.(*strconv.NumError)
+			if !ok {
+				return fmt.Errorf("invalid user ID %q: %w", uidRaw, err)
+			}
+			return fmt.Errorf("invalid user ID %q: %w", uidRaw, e.Err)
+		}
+		return nil
+	}
+
+	if tp.UID != "" {
+		if err := requireUIDisUint(tp.UID); err != nil {
+			return fmt.Errorf("transparent proxy block has invalid UID field: %w", err)
+		}
+	}
+	for _, uid := range tp.ExcludeUIDs {
+		if err := requireUIDisUint(uid); err != nil {
+			return fmt.Errorf("transparent proxy block has invalid ExcludeUIDs field: %w", err)
+		}
+	}
+
+	// note: ExcludeInboundPorts are validated in connect validation hook
+	// because we need information from the network block
+
+	return nil
+}
+
+func (tp *ConsulTransparentProxy) Equal(o *ConsulTransparentProxy) bool {
+	if tp == nil || o == nil {
+		return tp == o
+	}
+	if tp.UID != o.UID {
+		return false
+	}
+	if tp.OutboundPort != o.OutboundPort {
+		return false
+	}
+	if !slices.Equal(tp.ExcludeInboundPorts, o.ExcludeInboundPorts) {
+		return false
+	}
+	if !slices.Equal(tp.ExcludeOutboundPorts, o.ExcludeOutboundPorts) {
+		return false
+	}
+	if !slices.Equal(tp.ExcludeOutboundCIDRs, o.ExcludeOutboundCIDRs) {
+		return false
+	}
+	if !slices.Equal(tp.ExcludeUIDs, o.ExcludeUIDs) {
+		return false
+	}
+	if tp.NoDNS != o.NoDNS {
+		return false
+	}
+
+	return false
 }

--- a/nomad/structs/connect_test.go
+++ b/nomad/structs/connect_test.go
@@ -66,3 +66,25 @@ func TestConnectTransparentProxy_Validate(t *testing.T) {
 	}
 
 }
+
+func TestConnectTransparentProxy_Equal(t *testing.T) {
+	tp1 := &ConsulTransparentProxy{
+		UID:                  "101",
+		OutboundPort:         1001,
+		ExcludeInboundPorts:  []string{"9000", "443"},
+		ExcludeOutboundPorts: []uint16{443, 80},
+		ExcludeOutboundCIDRs: []string{"10.0.0.0/8", "192.168.1.1"},
+		ExcludeUIDs:          []string{"1001", "10"},
+		NoDNS:                true,
+	}
+	tp2 := &ConsulTransparentProxy{
+		UID:                  "101",
+		OutboundPort:         1001,
+		ExcludeInboundPorts:  []string{"443", "9000"},
+		ExcludeOutboundPorts: []uint16{80, 443},
+		ExcludeOutboundCIDRs: []string{"192.168.1.1", "10.0.0.0/8"},
+		ExcludeUIDs:          []string{"10", "1001"},
+		NoDNS:                true,
+	}
+	must.Equal(t, tp1, tp2)
+}

--- a/nomad/structs/connect_test.go
+++ b/nomad/structs/connect_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,4 +25,44 @@ func TestTaskKind_IsAnyConnectGateway(t *testing.T) {
 		require.False(t, NewTaskKind(ConnectNativePrefix, "foo").IsAnyConnectGateway())
 		require.False(t, NewTaskKind("", "foo").IsAnyConnectGateway())
 	})
+}
+
+func TestConnectTransparentProxy_Validate(t *testing.T) {
+	testCases := []struct {
+		name      string
+		tp        *ConsulTransparentProxy
+		expectErr string
+	}{
+		{
+			name: "empty is valid",
+			tp:   &ConsulTransparentProxy{},
+		},
+		{
+			name:      "invalid CIDR",
+			tp:        &ConsulTransparentProxy{ExcludeOutboundCIDRs: []string{"192.168.1.1"}},
+			expectErr: `could not parse transparent proxy excluded outbound CIDR as network prefix: netip.ParsePrefix("192.168.1.1"): no '/'`,
+		},
+		{
+			name:      "invalid UID",
+			tp:        &ConsulTransparentProxy{UID: "foo"},
+			expectErr: `transparent proxy block has invalid UID field: invalid user ID "foo": invalid syntax`,
+		},
+		{
+			name:      "invalid ExcludeUIDs",
+			tp:        &ConsulTransparentProxy{ExcludeUIDs: []string{"500000"}},
+			expectErr: `transparent proxy block has invalid ExcludeUIDs field: invalid user ID "500000": value out of range`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.tp.Validate()
+			if tc.expectErr != "" {
+				must.EqError(t, err, tc.expectErr)
+			} else {
+				must.NoError(t, err)
+			}
+		})
+	}
+
 }

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -1764,14 +1764,11 @@ func consulProxyExposeDiff(prev, next *ConsulExposeConfig, contextual bool) *Obj
 }
 
 func consulTProxyDiff(prev, next *ConsulTransparentProxy, contextual bool) *ObjectDiff {
-	if prev.Equal(next) {
-		return nil
-	}
 
 	diff := &ObjectDiff{Type: DiffTypeNone, Name: "TransparentProxy"}
 	var oldPrimFlat, newPrimFlat map[string]string
 
-	if prev == nil && next == nil {
+	if prev.Equal(next) {
 		return diff
 	} else if prev == nil {
 		prev = &ConsulTransparentProxy{}
@@ -1808,6 +1805,7 @@ func consulTProxyDiff(prev, next *ConsulTransparentProxy, contextual bool) *Obje
 		"ExcludeOutboundCIDRs", contextual); setDiff != nil && setDiff.Type != DiffTypeNone {
 		diff.Objects = append(diff.Objects, setDiff)
 	}
+
 	if setDiff := stringSetDiff(prev.ExcludeUIDs, next.ExcludeUIDs,
 		"ExcludeUIDs", contextual); setDiff != nil && setDiff.Type != DiffTypeNone {
 		diff.Objects = append(diff.Objects, setDiff)

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/flatmap"
 	"github.com/mitchellh/hashstructure"
 )
@@ -1648,6 +1649,10 @@ func consulProxyDiff(old, new *ConsulProxy, contextual bool) *ObjectDiff {
 		diff.Objects = append(diff.Objects, exposeDiff)
 	}
 
+	if tproxyDiff := consulTProxyDiff(old.TransparentProxy, new.TransparentProxy, contextual); tproxyDiff != nil {
+		diff.Objects = append(diff.Objects, tproxyDiff)
+	}
+
 	// diff the config blob
 	if cDiff := configDiff(old.Config, new.Config, contextual); cDiff != nil {
 		diff.Objects = append(diff.Objects, cDiff)
@@ -1753,6 +1758,59 @@ func consulProxyExposeDiff(prev, next *ConsulExposeConfig, contextual bool) *Obj
 		nil, "Paths",
 		contextual); pathDiff != nil {
 		diff.Objects = append(diff.Objects, pathDiff...)
+	}
+
+	return diff
+}
+
+func consulTProxyDiff(prev, next *ConsulTransparentProxy, contextual bool) *ObjectDiff {
+	if prev.Equal(next) {
+		return nil
+	}
+
+	diff := &ObjectDiff{Type: DiffTypeNone, Name: "TransparentProxy"}
+	var oldPrimFlat, newPrimFlat map[string]string
+
+	if prev == nil && next == nil {
+		return diff
+	} else if prev == nil {
+		prev = &ConsulTransparentProxy{}
+		diff.Type = DiffTypeAdded
+		newPrimFlat = flatmap.Flatten(next, nil, true)
+	} else if next == nil {
+		next = &ConsulTransparentProxy{}
+		diff.Type = DiffTypeDeleted
+		oldPrimFlat = flatmap.Flatten(prev, nil, true)
+	} else {
+		diff.Type = DiffTypeEdited
+		oldPrimFlat = flatmap.Flatten(prev, nil, true)
+		newPrimFlat = flatmap.Flatten(next, nil, true)
+	}
+
+	// diff the primitive fields
+	diff.Fields = fieldDiffs(oldPrimFlat, newPrimFlat, contextual)
+
+	if setDiff := stringSetDiff(prev.ExcludeInboundPorts, next.ExcludeInboundPorts,
+		"ExcludeInboundPorts", contextual); setDiff != nil && setDiff.Type != DiffTypeNone {
+		diff.Objects = append(diff.Objects, setDiff)
+	}
+
+	if setDiff := stringSetDiff(
+		helper.ConvertSlice(prev.ExcludeOutboundPorts, func(a uint16) string { return fmt.Sprint(a) }),
+		helper.ConvertSlice(next.ExcludeOutboundPorts, func(a uint16) string { return fmt.Sprint(a) }),
+		"ExcludeOutboundPorts",
+		contextual,
+	); setDiff != nil && setDiff.Type != DiffTypeNone {
+		diff.Objects = append(diff.Objects, setDiff)
+	}
+
+	if setDiff := stringSetDiff(prev.ExcludeOutboundCIDRs, next.ExcludeOutboundCIDRs,
+		"ExcludeOutboundCIDRs", contextual); setDiff != nil && setDiff.Type != DiffTypeNone {
+		diff.Objects = append(diff.Objects, setDiff)
+	}
+	if setDiff := stringSetDiff(prev.ExcludeUIDs, next.ExcludeUIDs,
+		"ExcludeUIDs", contextual); setDiff != nil && setDiff.Type != DiffTypeNone {
+		diff.Objects = append(diff.Objects, setDiff)
 	}
 
 	return diff

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -10105,6 +10105,10 @@ func TestServicesDiff(t *testing.T) {
 													},
 													Objects: nil,
 												},
+												{
+													Type: DiffTypeNone,
+													Name: "TransparentProxy",
+												},
 											},
 										},
 									},

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -3490,6 +3490,15 @@ func TestTaskGroupDiff(t *testing.T) {
 									Config: map[string]interface{}{
 										"foo": "qux",
 									},
+									TransparentProxy: &ConsulTransparentProxy{
+										UID:                  "101",
+										OutboundPort:         15001,
+										ExcludeInboundPorts:  []string{"www", "9000"},
+										ExcludeOutboundPorts: []uint16{4443},
+										ExcludeOutboundCIDRs: []string{"10.0.0.0/8"},
+										ExcludeUIDs:          []string{"1", "10"},
+										NoDNS:                true,
+									},
 								},
 							},
 							Gateway: &ConsulGateway{
@@ -3915,6 +3924,92 @@ func TestTaskGroupDiff(t *testing.T) {
 																		New:  "http",
 																	},
 																},
+															},
+														},
+													},
+													{
+														Type: DiffTypeAdded,
+														Name: "TransparentProxy",
+														Objects: []*ObjectDiff{
+															{
+																Type: DiffTypeAdded,
+																Name: "ExcludeInboundPorts",
+																Fields: []*FieldDiff{
+																	{
+																		Type: DiffTypeAdded,
+																		Name: "ExcludeInboundPorts",
+																		Old:  "",
+																		New:  "9000",
+																	},
+																	{
+																		Type: DiffTypeAdded,
+																		Name: "ExcludeInboundPorts",
+																		Old:  "",
+																		New:  "www",
+																	},
+																},
+															},
+															{
+																Type: DiffTypeAdded,
+																Name: "ExcludeOutboundPorts",
+																Fields: []*FieldDiff{
+																	{
+																		Type: DiffTypeAdded,
+																		Name: "ExcludeOutboundPorts",
+																		Old:  "",
+																		New:  "4443",
+																	},
+																},
+															},
+															{
+																Type: DiffTypeAdded,
+																Name: "ExcludeOutboundCIDRs",
+																Fields: []*FieldDiff{
+																	{
+																		Type: DiffTypeAdded,
+																		Name: "ExcludeOutboundCIDRs",
+																		Old:  "",
+																		New:  "10.0.0.0/8",
+																	},
+																},
+															},
+															{
+																Type: DiffTypeAdded,
+																Name: "ExcludeUIDs",
+																Fields: []*FieldDiff{
+																	{
+																		Type: DiffTypeAdded,
+																		Name: "ExcludeUIDs",
+																		Old:  "",
+																		New:  "1",
+																	},
+																	{
+																		Type: DiffTypeAdded,
+																		Name: "ExcludeUIDs",
+																		Old:  "",
+																		New:  "10",
+																	},
+																},
+															},
+														},
+														Fields: []*FieldDiff{
+															{
+																Type: DiffTypeAdded,
+																Name: "NoDNS",
+																Old:  "",
+																New:  "true",
+															},
+															{
+																Type: DiffTypeAdded,
+																Name: "OutboundPort",
+																Old:  "",
+																New:  "15001",
+															},
+															{
+																Type: DiffTypeAdded,
+																Name: "UID",
+																Old:  "",
+																New:  "101",
 															},
 														},
 													},

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -958,6 +958,7 @@ func hashConnect(h hash.Hash, connect *ConsulConnect) {
 			hashString(h, p.LocalServiceAddress)
 			hashString(h, strconv.Itoa(p.LocalServicePort))
 			hashConfig(h, p.Config)
+			hashTProxy(h, p.TransparentProxy)
 			for _, upstream := range p.Upstreams {
 				hashString(h, upstream.DestinationName)
 				hashString(h, upstream.DestinationNamespace)
@@ -1012,6 +1013,22 @@ func hashMeta(h hash.Hash, m map[string]string) {
 
 func hashConfig(h hash.Hash, c map[string]interface{}) {
 	_, _ = fmt.Fprintf(h, "%v", c)
+}
+
+func hashTProxy(h hash.Hash, tp *ConsulTransparentProxy) {
+	if tp == nil {
+		return
+	}
+
+	hashStringIfNonEmpty(h, tp.UID)
+	hashIntIfNonZero(h, "OutboundPort", int(tp.OutboundPort))
+	hashTags(h, tp.ExcludeInboundPorts)
+	for _, port := range tp.ExcludeOutboundPorts {
+		hashIntIfNonZero(h, "ExcludeOutboundPorts", int(port))
+	}
+	hashTags(h, tp.ExcludeOutboundCIDRs)
+	hashTags(h, tp.ExcludeUIDs)
+	hashBool(h, tp.NoDNS, "NoDNS")
 }
 
 // Equal returns true if the structs are recursively equal.
@@ -1186,6 +1203,14 @@ func (c *ConsulConnect) IsMesh() bool {
 	return c.IsGateway() && c.Gateway.Mesh != nil
 }
 
+// HasTransparentProxy checks if a service with a Connect sidecar has a
+// transparent proxy configuration
+func (c *ConsulConnect) HasTransparentProxy() bool {
+	return c.HasSidecar() &&
+		c.SidecarService.Proxy != nil &&
+		c.SidecarService.Proxy.TransparentProxy != nil
+}
+
 // Validate that the Connect block represents exactly one of:
 // - Connect non-native service sidecar proxy
 // - Connect native service
@@ -1200,6 +1225,11 @@ func (c *ConsulConnect) Validate() error {
 	count := 0
 
 	if c.HasSidecar() {
+		if c.HasTransparentProxy() {
+			if err := c.SidecarService.Proxy.TransparentProxy.Validate(); err != nil {
+				return err
+			}
+		}
 		count++
 	}
 
@@ -1221,7 +1251,8 @@ func (c *ConsulConnect) Validate() error {
 		}
 	}
 
-	// The Native and Sidecar cases are validated up at the service level.
+	// Checking against the surrounding task group is validated up at the
+	// service level or job endpint connect validation hook
 
 	return nil
 }
@@ -1508,6 +1539,11 @@ type ConsulProxy struct {
 	// used by task-group level service checks using HTTP or gRPC protocols.
 	Expose *ConsulExposeConfig
 
+	// TransparentProxy configures the Envoy sidecar to use "transparent
+	// proxying", which creates IP tables rules inside the network namespace to
+	// ensure traffic flows thru the Envoy proxy
+	TransparentProxy *ConsulTransparentProxy
+
 	// Config is a proxy configuration. It is opaque to Nomad and passed
 	// directly to Consul.
 	Config map[string]interface{}
@@ -1524,6 +1560,7 @@ func (p *ConsulProxy) Copy() *ConsulProxy {
 		LocalServicePort:    p.LocalServicePort,
 		Expose:              p.Expose.Copy(),
 		Upstreams:           slices.Clone(p.Upstreams),
+		TransparentProxy:    p.TransparentProxy.Copy(),
 		Config:              maps.Clone(p.Config),
 	}
 }
@@ -1547,6 +1584,10 @@ func (p *ConsulProxy) Equal(o *ConsulProxy) bool {
 	}
 
 	if !upstreamsEquals(p.Upstreams, o.Upstreams) {
+		return false
+	}
+
+	if !p.TransparentProxy.Equal(o.TransparentProxy) {
 		return false
 	}
 

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -162,13 +162,13 @@ func TestServiceCheck_validate_FailingTypes(t *testing.T) {
 
 	t.Run("invalid", func(t *testing.T) {
 		err := (&ServiceCheck{
-			Name:                   "check",
-			Type:                   "script",
-			Command:                "/nothing",
-			Interval:               1 * time.Second,
-			Timeout:                2 * time.Second,
-			SuccessBeforePassing:   0,
-			FailuresBeforeWarning:  3,
+			Name:                  "check",
+			Type:                  "script",
+			Command:               "/nothing",
+			Interval:              1 * time.Second,
+			Timeout:               2 * time.Second,
+			SuccessBeforePassing:  0,
+			FailuresBeforeWarning: 3,
 		}).validateConsul()
 		require.EqualError(t, err, `failures_before_warning not supported for check of type "script"`)
 	})
@@ -298,10 +298,10 @@ func TestServiceCheck_validateNomad(t *testing.T) {
 		{
 			name: "failures_before_warning",
 			sc: &ServiceCheck{
-				Type:                   ServiceCheckTCP,
-				FailuresBeforeWarning:  3, // consul only
-				Interval:               3 * time.Second,
-				Timeout:                1 * time.Second,
+				Type:                  ServiceCheckTCP,
+				FailuresBeforeWarning: 3, // consul only
+				Interval:              3 * time.Second,
+				Timeout:               1 * time.Second,
 			},
 			exp: `failures_before_warning may only be set for Consul service checks`,
 		},
@@ -432,6 +432,15 @@ func TestService_Hash(t *testing.T) {
 						LocalBindPort:        29000,
 						Config:               map[string]any{"foo": "bar"},
 					}},
+					TransparentProxy: &ConsulTransparentProxy{
+						UID:                  "101",
+						OutboundPort:         15001,
+						ExcludeInboundPorts:  []string{"www", "9000"},
+						ExcludeOutboundPorts: []uint16{4443},
+						ExcludeOutboundCIDRs: []string{"10.0.0.0/8"},
+						ExcludeUIDs:          []string{"1", "10"},
+						NoDNS:                true,
+					},
 				},
 				Meta: map[string]string{
 					"test-key": "test-value",
@@ -528,6 +537,54 @@ func TestService_Hash(t *testing.T) {
 
 	t.Run("mod connect sidecar proxy upstream config", func(t *testing.T) {
 		try(t, func(s *svc) { s.Connect.SidecarService.Proxy.Upstreams[0].Config = map[string]any{"foo": "baz"} })
+	})
+
+	t.Run("mod connect transparent proxy removed", func(t *testing.T) {
+		try(t, func(s *svc) {
+			s.Connect.SidecarService.Proxy.TransparentProxy = nil
+		})
+	})
+
+	t.Run("mod connect transparent proxy uid", func(t *testing.T) {
+		try(t, func(s *svc) {
+			s.Connect.SidecarService.Proxy.TransparentProxy.UID = "42"
+		})
+	})
+
+	t.Run("mod connect transparent proxy outbound port", func(t *testing.T) {
+		try(t, func(s *svc) {
+			s.Connect.SidecarService.Proxy.TransparentProxy.OutboundPort = 42
+		})
+	})
+
+	t.Run("mod connect transparent proxy inbound ports", func(t *testing.T) {
+		try(t, func(s *svc) {
+			s.Connect.SidecarService.Proxy.TransparentProxy.ExcludeInboundPorts = []string{"443"}
+		})
+	})
+
+	t.Run("mod connect transparent proxy outbound ports", func(t *testing.T) {
+		try(t, func(s *svc) {
+			s.Connect.SidecarService.Proxy.TransparentProxy.ExcludeOutboundPorts = []uint16{42}
+		})
+	})
+
+	t.Run("mod connect transparent proxy outbound cidr", func(t *testing.T) {
+		try(t, func(s *svc) {
+			s.Connect.SidecarService.Proxy.TransparentProxy.ExcludeOutboundCIDRs = []string{"192.168.1.0/24"}
+		})
+	})
+
+	t.Run("mod connect transparent proxy exclude uids", func(t *testing.T) {
+		try(t, func(s *svc) {
+			s.Connect.SidecarService.Proxy.TransparentProxy.ExcludeUIDs = []string{"42"}
+		})
+	})
+
+	t.Run("mod connect transparent proxy no dns", func(t *testing.T) {
+		try(t, func(s *svc) {
+			s.Connect.SidecarService.Proxy.TransparentProxy.NoDNS = false
+		})
 	})
 }
 


### PR DESCRIPTION
Add a transparent proxy block to the existing Connect sidecar service proxy block. This changeset is plumbing required to support transparent proxy configuration on the client, and is first of a series of PRs that will target the `f-tproxy` branch which we intend to ship in Nomad 1.8.

Ref: https://github.com/hashicorp/nomad/issues/10628
Ref: [NMD-191](https://docs.google.com/document/d/1GTC-j6sIgQ3LtYcuoDxnAcluenKZU4WHybth2ngcoOc/edit) (internal link)
