### PR TITLE
docs: make it clear that federation features require ACLs

### DIFF
--- a/website/content/docs/commands/acl/index.mdx
+++ b/website/content/docs/commands/acl/index.mdx
@@ -11,6 +11,10 @@ The `acl` command is used to interact with ACL policies and tokens. Learn more
 about using Nomad's ACL system in the [Secure Nomad with Access Control
 guide][secure-guide].
 
+In [federated][] clusters, all ACL updates are forwarded to the
+[`authoritative_region`][] and replicated to non-authoritative regions. This
+requires that ACLs have been bootstrapped in the authoritative region.
+
 ## Usage
 
 Usage: `nomad acl <subcommand> [options]`
@@ -72,3 +76,5 @@ subcommands are available:
 [roleinfo]: /nomad/docs/commands/acl/role/info
 [rolelist]: /nomad/docs/commands/acl/role/list
 [secure-guide]: /nomad/tutorials/access-control
+[federated]: /nomad/tutorials/manage-clusters/federation
+[`authoritative_region`]: /nomad/docs/configuration/server#authoritative_region

--- a/website/content/docs/commands/namespace/index.mdx
+++ b/website/content/docs/commands/namespace/index.mdx
@@ -28,8 +28,14 @@ subcommands are available:
 - [`namespace list`][list] - List available namespaces
 - [`namespace status`][status] - Display a namespace's status
 
+In [federated][] clusters, all namespace updates are forwarded to the
+[`authoritative_region`][] and replicated to non-authoritative regions. This
+requires that ACLs have been bootstrapped in the authoritative region.
+
 [apply]: /nomad/docs/commands/namespace/apply 'Create or update a namespace'
 [delete]: /nomad/docs/commands/namespace/delete 'Delete a namespace'
 [inspect]: /nomad/docs/commands/namespace/inspect 'Inspect a namespace'
 [list]: /nomad/docs/commands/namespace/list 'List available namespaces'
 [status]: /nomad/docs/commands/namespace/status "Display a namespace's status"
+[federated]: /nomad/tutorials/manage-clusters/federation
+[`authoritative_region`]: /nomad/docs/configuration/server#authoritative_region

--- a/website/content/docs/commands/server/join.mdx
+++ b/website/content/docs/commands/server/join.mdx
@@ -24,6 +24,10 @@ specified, then an attempt will be made to join each one. If one or more nodes
 are joined successfully, the exit code will be 0. Otherwise, the exit code will
 be 1.
 
+Joining servers in different regions will [federate][] the regions. This assumes
+that ACLs have been bootstrapped in the authoritative region. See [Configure for
+multiple regions][] in the ACLs tutorial.
+
 ## General Options
 
 @include 'general_options_no_namespace.mdx'
@@ -36,3 +40,6 @@ Join the local server to a remote server:
 $ nomad server join 10.0.0.8:4648
 Joined 1 servers successfully
 ```
+
+[federate]: /nomad/tutorials/manage-clusters/federation
+[Configure for multiple regions]: /nomad/tutorials/access-control/access-control-bootstrap#configure-for-multiple-regions

--- a/website/content/docs/configuration/acl.mdx
+++ b/website/content/docs/configuration/acl.mdx
@@ -51,8 +51,12 @@ acl {
   because of an outage, the TTL will be ignored and the cached value used.
 
 - `replication_token` `(string: "")` - Specifies the Secret ID of the ACL token
-  to use for replicating policies and tokens. This is used by servers in non-authoritative
-  region to mirror the policies and tokens into the local region from [authoritative_region][authoritative-region].
+  to use for replicating policies and tokens. This is used by servers in
+  non-authoritative region to mirror the policies and tokens into the local
+  region from the [`authoritative_region`][authoritative-region]. Setting
+  `replication_token` requires that ACLs have been bootstrapped in the
+  authoritative region. See [Configure for multiple regions][] in the ACLs
+  tutorial.
 
 - `token_min_expiration_ttl` `(string: "1m")` - Specifies the lowest acceptable
   TTL value for an ACL token when setting expiration. This is used by the Nomad
@@ -64,3 +68,4 @@ acl {
 
 [secure-guide]: /nomad/tutorials/access-control
 [authoritative-region]: /nomad/docs/configuration/server#authoritative_region
+[Configure for multiple regions]: /nomad/tutorials/access-control/access-control-bootstrap#configure-for-multiple-regions

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -29,10 +29,13 @@ server {
 
 ## `server` Parameters
 
-- `authoritative_region` `(string: "")` - Specifies the authoritative region, which
-  provides a single source of truth for global configurations such as ACL Policies and
-  global ACL tokens. Non-authoritative regions will replicate from the authoritative
-  to act as a mirror. By default, the local region is assumed to be authoritative.
+- `authoritative_region` `(string: "")` - Specifies the authoritative region,
+  which provides a single source of truth for global configurations such as ACL
+  Policies and global ACL tokens. Non-authoritative regions will replicate from
+  the authoritative to act as a mirror. By default, the local region is assumed
+  to be authoritative. Setting `authoritative_region` assumes that ACLs have
+  been bootstrapped in the authoritative region. See [Configure for multiple
+  regions][] in the ACLs tutorial.
 
 - `bootstrap_expect` `(int: required)` - Specifies the number of server nodes to
   wait for before bootstrapping. It is most common to use the odd-numbered
@@ -512,3 +515,4 @@ work.
 [disconnect.lost_after]: /nomad/docs/job-specification/disconnect#lost_after
 [herd]: https://en.wikipedia.org/wiki/Thundering_herd_problem
 [wi]: /nomad/docs/concepts/workload-identity
+[Configure for multiple regions]: /nomad/tutorials/access-control/access-control-bootstrap#configure-for-multiple-regions

--- a/website/content/docs/other-specifications/acl-policy.mdx
+++ b/website/content/docs/other-specifications/acl-policy.mdx
@@ -482,3 +482,5 @@ agent {
 [host_volumes]: /nomad/docs/configuration/client#host_volume-block
 [api_plugins]: /nomad/api-docs/plugins/
 [Variables]: /nomad/docs/concepts/variables
+[federated]: /nomad/tutorials/manage-clusters/federation
+[`authoritative_region`]: /nomad/docs/configuration/server#authoritative_region

--- a/website/content/docs/other-specifications/namespace.mdx
+++ b/website/content/docs/other-specifications/namespace.mdx
@@ -19,6 +19,10 @@ namespace apply`][cli_ns_apply] CLI command.
 Unlike [Job specifications][jobspecs], Namespace specifications do *not*
 support [HCL2][hcl2] features like functions.
 
+In [federated][] clusters, all updates to namespaces are forwarded to the
+[`authoritative_region`][] and replicated to non-authoritative regions. This
+requires that ACLs have been bootstrapped in the authoritative region.
+
 Example namespace specification:
 
 ```hcl
@@ -148,3 +152,5 @@ consul {
 [cli_ns_apply]: /nomad/docs/commands/namespace/apply
 [hcl2]: /nomad/docs/job-specification/hcl2
 [jobspecs]: /nomad/docs/job-specification
+[federated]: /nomad/tutorials/manage-clusters/federation
+[`authoritative_region`]: /nomad/docs/configuration/server#authoritative_region


### PR DESCRIPTION
Our documentation has a hidden assumption that users know that federation replication requires ACLs to be enabled and bootstrapped. Add notes at some of the places users are likely to look for it.

A separate follow-up PR to the federation tutorial should point to the ACL multi-region tutorial as well.

Fixes: https://github.com/hashicorp/nomad/issues/20128