### PR TITLE
Small docs updates: bai rkt, cya openapi, lol ephemeral_disk "examples"

### DIFF
--- a/website/content/docs/job-specification/ephemeral_disk.mdx
+++ b/website/content/docs/job-specification/ephemeral_disk.mdx
@@ -53,21 +53,6 @@ documentation][] for more information.
   attempt to place the updated allocation on the same machine. This will move
   the `local/` and `alloc/data` directories to the new allocation.
 
-## `ephemeral_disk` Examples
-
-The following examples only show the `ephemeral_disk` blocks. Remember that the
-`ephemeral_disk` block is only valid in the placements listed above.
-
-### Sticky Volumes
-
-This example shows enabling sticky volumes with Nomad using ephemeral disks:
-
-```hcl
-ephemeral_disk {
-  sticky = true
-}
-```
-
 [resources]: /nomad/docs/job-specification/resources 'Nomad resources Job Specification'
 [filesystem internals]: /nomad/docs/concepts/filesystem#templates-artifacts-and-dispatch-payloads 'Filesystem internals documentation'
 [logs documentation]: /nomad/docs/job-specification/logs 'Nomad logs Job Specification'

--- a/website/content/plugins/drivers/community/rkt.mdx
+++ b/website/content/plugins/drivers/community/rkt.mdx
@@ -5,10 +5,8 @@ description: The rkt task driver is used to run application containers using rkt
 ---
 
 ~> **Deprecation Warning!**
-Nomad introduced the rkt driver in version 0.2.0. The rkt project had some
-early adoption; in recent times user adoption has trended away from rkt towards
-other projects. Project activity has declined and there are unpatched CVEs.
-The project has been [archived by the CNCF](https://github.com/rkt/rkt/issues/4004#issuecomment-507358362)
+Rkt has ended and the project has been [archived by the
+CNCF](https://github.com/rkt/rkt/issues/4004#issuecomment-507358362)
 
 Nomad 0.11 converted the rkt driver to an external driver. We will not prioritize features
 or pull requests that affect the rkt driver. The external driver is available as an [open source

--- a/website/content/tools/index.mdx
+++ b/website/content/tools/index.mdx
@@ -19,7 +19,6 @@ The following external tools are currently available for Nomad and maintained by
 - [Levant](https://github.com/hashicorp/levant) - A templating and deployment tool for HashiCorp Nomad jobs that provides realtime feedback and detailed failure messages upon deployment issues.
 - [Nomad Pack](https://github.com/hashicorp/nomad-pack) - An official package manager and templating tool for Nomad, currently a Tech Preview.
 - [Nomad Pack GitHub Action](https://github.com/marketplace/actions/setup-hashicorp-nomad-pack) - A GitHub Action for Nomad Pack.
-- [OpenAPI](https://github.com/hashicorp/nomad-openapi) - An OpenAPI/Swagger spec for Nomad, allowing for programmatic generation of SDKs and documentation. Includes a reference implementation in Go built on top of a generated client.
 
 ## Community Tools
 


### PR DESCRIPTION
* Clarify that rkt is dead and done in docs. (the awkward "has ended" wording is from the rkt repo)
* Remove OpenAPI spec from tools list since it's been deprecated for a while (and thanks to openai I now cannot type openapi correctly on the first try)
* `ephemeral_disk` had a completely useless example section at the bottom :shrug: 