### PR TITLE
operator debug: fix pprof interval handling

### DIFF
--- a/.changelog/20206.txt
+++ b/.changelog/20206.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug where `operator debug` did not respect the `-pprof-interval` flag and would take only one profile
+```

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -200,8 +200,8 @@ Debug Options:
 
   -pprof-interval=<pprof-interval>
     The interval between pprof collections. Set interval equal to
-    duration to capture a single snapshot. Defaults to 250ms or
-   -pprof-duration, whichever is less.
+    duration to capture a single snapshot. Defaults to 30s or
+    -pprof-duration, whichever is more.
 
   -server-id=<server1>,<server2>
     Comma separated list of Nomad server names to monitor for logs, API
@@ -372,7 +372,7 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	flags.BoolVar(&allowStale, "stale", false, "")
 	flags.StringVar(&output, "output", "", "")
 	flags.StringVar(&pprofDuration, "pprof-duration", "1s", "")
-	flags.StringVar(&pprofInterval, "pprof-interval", "250ms", "")
+	flags.StringVar(&pprofInterval, "pprof-interval", "30s", "")
 	flags.BoolVar(&c.verbose, "verbose", false, "")
 
 	c.consul = &external{tls: &api.TLSConfig{}}
@@ -439,7 +439,7 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error parsing pprof-interval: %s: %s", pprofInterval, err.Error()))
 		return 1
 	}
-	if pi.Seconds() > pd.Seconds() {
+	if pi.Seconds() < pd.Seconds() {
 		pi = pd
 	}
 	c.pprofInterval = pi
@@ -1036,27 +1036,27 @@ func (c *OperatorDebugCommand) collectPprof(path, id string, client *api.Client,
 
 	// goroutine debug type 1 = legacy text format for human readable output
 	opts.Debug = 1
-	c.savePprofProfile(path, "goroutine", opts, client)
+	c.savePprofProfile(path, "goroutine", opts, client, interval)
 
 	// goroutine debug type 2 = goroutine stacks in panic format
 	opts.Debug = 2
-	c.savePprofProfile(path, "goroutine", opts, client)
+	c.savePprofProfile(path, "goroutine", opts, client, interval)
 
 	// Reset to pprof binary format
 	opts.Debug = 0
 
-	c.savePprofProfile(path, "goroutine", opts, client)    // Stack traces of all current goroutines
-	c.savePprofProfile(path, "trace", opts, client)        // A trace of execution of the current program
-	c.savePprofProfile(path, "heap", opts, client)         // A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample.
-	c.savePprofProfile(path, "allocs", opts, client)       // A sampling of all past memory allocations
-	c.savePprofProfile(path, "threadcreate", opts, client) // Stack traces that led to the creation of new OS threads
+	c.savePprofProfile(path, "goroutine", opts, client, interval)    // Stack traces of all current goroutines
+	c.savePprofProfile(path, "trace", opts, client, interval)        // A trace of execution of the current program
+	c.savePprofProfile(path, "heap", opts, client, interval)         // A sampling of memory allocations of live objects. You can specify the gc GET parameter to run GC before taking the heap sample.
+	c.savePprofProfile(path, "allocs", opts, client, interval)       // A sampling of all past memory allocations
+	c.savePprofProfile(path, "threadcreate", opts, client, interval) // Stack traces that led to the creation of new OS threads
 }
 
 // savePprofProfile retrieves a pprof profile and writes to disk
-func (c *OperatorDebugCommand) savePprofProfile(path string, profile string, opts api.PprofOptions, client *api.Client) {
-	fileName := fmt.Sprintf("%s.prof", profile)
+func (c *OperatorDebugCommand) savePprofProfile(path string, profile string, opts api.PprofOptions, client *api.Client, interval int) {
+	fileName := fmt.Sprintf("%s_%04d.prof", profile, interval)
 	if opts.Debug > 0 {
-		fileName = fmt.Sprintf("%s-debug%d.txt", profile, opts.Debug)
+		fileName = fmt.Sprintf("%s-debug%d_%04d.txt", profile, opts.Debug, interval)
 	}
 
 	bs, err := retrievePprofProfile(profile, opts, client, c.queryOpts())

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -452,14 +452,14 @@ func TestDebug_CapturedFiles(t *testing.T) {
 	}
 
 	pprofFiles := []string{
-		"allocs.prof",
-		"goroutine-debug1.txt",
-		"goroutine-debug2.txt",
-		"goroutine.prof",
-		"heap.prof",
+		"allocs_0000.prof",
+		"goroutine-debug1_0000.txt",
+		"goroutine-debug2_0000.txt",
+		"goroutine_0000.prof",
+		"heap_0000.prof",
 		"profile_0000.prof",
-		"threadcreate.prof",
-		"trace.prof",
+		"threadcreate_0000.prof",
+		"trace_0000.prof",
 	}
 
 	clientFiles := []string{

--- a/website/content/docs/commands/operator/debug.mdx
+++ b/website/content/docs/commands/operator/debug.mdx
@@ -70,10 +70,9 @@ true.
 - `-pprof-duration=<duration>`: Duration for pprof
   collection. Defaults to 1s or `-duration`, whichever is less.
 
-- `-pprof-interval=<pprof-interval>`: The interval between pprof
-    collections. Set interval equal to duration to capture a single
-    snapshot. Defaults to 250ms or `-pprof-duration`, whichever is
-    less.
+- `-pprof-interval=30s`: The interval between pprof collections. Set interval
+    equal to pprof duration to capture a single snapshot. Defaults to 30s or
+    `-pprof-duration`, whichever is more.
 
 - `-server-id=<server1>,<server2>`: Comma separated list of Nomad server names to
   monitor for logs, API outputs, and pprof profiles. Accepts server names, "leader", or


### PR DESCRIPTION
The `nomad operator debug` command saves a CPU profile for each interval, and names these files based on the interval.

The same functions takes a goroutine profile, heap profile, etc. but is missing the logic to interpolate the file name with the interval. This results in the operator debug command making potentially many expensive profile requests, and then overwriting the data. Update the command to save every profile it scrapes, and number them similarly to the existing CPU profile.

Additionally, the command flags for `-pprof-interval` and `-pprof-duration` were validated backwards, which meant that we always coerced the `-pprof-interval` to be the same as the `-pprof-duration`, which always resulted in a single profile being taken at the start of the bundle. Correct the check as well as change the defaults to be more sensible.

Fixes: https://github.com/hashicorp/nomad/issues/20151

---

In addition to fixing up the tests as needed, I've tested this locally as follows.

```
$ nomad operator debug -duration 1m -stale=true -node-id=61c19030  -log-level=trace -pprof-interval=15s
Starting debugger...

Nomad CLI Version: Nomad v1.7.7-dev
BuildDate 2024-03-22T19:40:43Z
Revision f91127fc5492d930dc61af54fd4f1f2a6f01f109+CHANGES
           Region:
        Namespace:
          Servers: (1/1) [continuity.global]
          Clients: (1/1) [61c19030-0ba7-6927-d9b9-a5b9df52f4e4]
         Interval: 30s
         Duration: 1m
   pprof Interval: 15s

Capturing cluster data...
Consul - Skipping, no API address found
    Capture pprofInterval 0000
    Capture interval 0000
    Capture pprofInterval 0001
    Capture interval 0001
    Capture pprofInterval 0002
    Capture pprofInterval 0003
Created debug archive: nomad-debug-2024-03-22-200116Z.tar.gz
```

This results in the following file tree:

<details><summary>file tree</summary>

```
$ tar -xf nomad-debug-2024-03-22-200116Z.tar.gz
$ tree nomad-debug-2024-03-22-200116Z
nomad-debug-2024-03-22-200116Z
├── client
│   └── 61c19030-0ba7-6927-d9b9-a5b9df52f4e4
│       ├── agent-host.json
│       ├── allocs_0000.prof
│       ├── allocs_0001.prof
│       ├── allocs_0002.prof
│       ├── allocs_0003.prof
│       ├── goroutine_0000.prof
│       ├── goroutine_0001.prof
│       ├── goroutine_0002.prof
│       ├── goroutine_0003.prof
│       ├── goroutine-debug1_0000.txt
│       ├── goroutine-debug1_0001.txt
│       ├── goroutine-debug1_0002.txt
│       ├── goroutine-debug1_0003.txt
│       ├── goroutine-debug2_0000.txt
│       ├── goroutine-debug2_0001.txt
│       ├── goroutine-debug2_0002.txt
│       ├── goroutine-debug2_0003.txt
│       ├── heap_0000.prof
│       ├── heap_0001.prof
│       ├── heap_0002.prof
│       ├── heap_0003.prof
│       ├── monitor.log
│       ├── profile_0000.prof
│       ├── profile_0001.prof
│       ├── profile_0002.prof
│       ├── profile_0003.prof
│       ├── threadcreate_0000.prof
│       ├── threadcreate_0001.prof
│       ├── threadcreate_0002.prof
│       ├── threadcreate_0003.prof
│       ├── trace_0000.prof
│       ├── trace_0001.prof
│       ├── trace_0002.prof
│       └── trace_0003.prof
├── cluster
│   ├── agent-self.json
│   ├── cli-flags.json
│   ├── eventstream.json
│   ├── leader.json
│   ├── members.json
│   ├── namespaces.json
│   ├── nodes.json
│   └── regions.json
├── index.html
├── index.json
├── interval
│   ├── 0000
│   │   ├── allocations.json
│   │   ├── csi-plugins.json
│   │   ├── csi-volumes.json
│   │   ├── deployments.json
│   │   ├── evaluations.json
│   │   ├── jobs.json
│   │   ├── license.json
│   │   ├── metrics.json
│   │   ├── nodes.json
│   │   ├── operator-autopilot-health.json
│   │   ├── operator-raft.json
│   │   └── operator-scheduler.json
│   └── 0001
│       ├── allocations.json
│       ├── csi-plugins.json
│       ├── csi-volumes.json
│       ├── deployments.json
│       ├── evaluations.json
│       ├── jobs.json
│       ├── license.json
│       ├── metrics.json
│       ├── nodes.json
│       ├── operator-autopilot-health.json
│       ├── operator-raft.json
│       └── operator-scheduler.json
└── server
    └── continuity.global
        ├── agent-host.json
        ├── allocs_0000.prof
        ├── allocs_0001.prof
        ├── allocs_0002.prof
        ├── allocs_0003.prof
        ├── goroutine_0000.prof
        ├── goroutine_0001.prof
        ├── goroutine_0002.prof
        ├── goroutine_0003.prof
        ├── goroutine-debug1_0000.txt
        ├── goroutine-debug1_0001.txt
        ├── goroutine-debug1_0002.txt
        ├── goroutine-debug1_0003.txt
        ├── goroutine-debug2_0000.txt
        ├── goroutine-debug2_0001.txt
        ├── goroutine-debug2_0002.txt
        ├── goroutine-debug2_0003.txt
        ├── heap_0000.prof
        ├── heap_0001.prof
        ├── heap_0002.prof
        ├── heap_0003.prof
        ├── monitor.log
        ├── profile_0000.prof
        ├── profile_0001.prof
        ├── profile_0002.prof
        ├── profile_0003.prof
        ├── threadcreate_0000.prof
        ├── threadcreate_0001.prof
        ├── threadcreate_0002.prof
        ├── threadcreate_0003.prof
        ├── trace_0000.prof
        ├── trace_0001.prof
        ├── trace_0002.prof
        └── trace_0003.prof

8 directories, 102 files
```

</details>
