### PR TITLE
[ui] Namespace added to example test in exec window

### DIFF
--- a/.changelog/20218.txt
+++ b/.changelog/20218.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Show the namespace in the web UI exec command hint
+```

--- a/ui/app/controllers/exec.js
+++ b/ui/app/controllers/exec.js
@@ -121,10 +121,16 @@ export default class ExecController extends Controller {
         'Customize your command, then hit ‘return’ to run.'
       );
       this.terminal.writeln('');
+
+      let namespaceCommandString = '';
+      if (this.namespace && this.namespace !== 'default') {
+        namespaceCommandString = `-namespace ${this.namespace} `;
+      }
+
       this.terminal.write(
-        `$ nomad alloc exec -i -t -task ${escapeTaskName(taskName)} ${
-          this.taskState.allocation.shortId
-        } `
+        `$ nomad alloc exec -i -t ${namespaceCommandString}-task ${escapeTaskName(
+          taskName
+        )} ${this.taskState.allocation.shortId} `
       );
 
       this.terminal.write(ANSI_WHITE);

--- a/ui/tests/acceptance/actions-test.js
+++ b/ui/tests/acceptance/actions-test.js
@@ -339,7 +339,7 @@ module('Acceptance | actions', function (hooks) {
     );
     await percySnapshot(assert, {
       percyCSS: `
-          g.tick { visibility: hidden; };
+          g.tick { visibility: hidden; }
           .recent-events-table td {
             display: none;
           }

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -266,7 +266,7 @@ module('Acceptance | exec', function (hooks) {
   });
 
   test('navigating to a task adds its name to the route, chooses an allocation, and assigns a default command', async function (assert) {
-    await Exec.visitJob({ job: this.job.id });
+    await Exec.visitJob({ job: this.job.id, namespace: this.job.namespaceId });
     await Exec.taskGroups[0].click();
     await Exec.taskGroups[0].tasks[0].click();
 
@@ -282,7 +282,7 @@ module('Acceptance | exec', function (hooks) {
 
     assert.equal(
       currentURL(),
-      `/exec/${this.job.id}/${taskGroup.name}/${task.name}`
+      `/exec/${this.job.id}/${taskGroup.name}/${task.name}?namespace=${this.job.namespaceId}`
     );
     assert.ok(Exec.taskGroups[0].tasks[0].isActive);
 
@@ -332,6 +332,7 @@ module('Acceptance | exec', function (hooks) {
       task_group: taskGroup.name,
       task_name: task.name,
       allocation: allocation.id.split('-')[0],
+      namespace: this.job.namespaceId,
     });
 
     await settled();
@@ -341,6 +342,42 @@ module('Acceptance | exec', function (hooks) {
       `$ nomad alloc exec -i -t -task spaced\\ name\\! ${
         allocation.id.split('-')[0]
       } /bin/bash`
+    );
+  });
+
+  test('a namespace can be specified', async function (assert) {
+    server.create('namespace'); // default
+    let namespace = server.create('namespace', {
+      id: 'should-show-in-example-string',
+    });
+    let job = server.create('job', {
+      namespaceId: namespace.id,
+      createAllocations: true,
+    });
+
+    let taskGroup = job.taskGroups.models.sortBy('name')[0];
+    let task = taskGroup.tasks.models.sortBy('name')[0];
+    let allocations = this.server.db.allocations.where({
+      jobId: job.id,
+      taskGroup: taskGroup.name,
+    });
+    let allocation = allocations[allocations.length - 1];
+
+    await Exec.visitTask({
+      job: job.id,
+      task_group: taskGroup.name,
+      task_name: task.name,
+      allocation: allocation.id.split('-')[0],
+      namespace: namespace.id,
+    });
+
+    await settled();
+
+    assert.equal(
+      window.execTerminal.buffer.active.getLine(4).translateToString().trim(),
+      `$ nomad alloc exec -i -t -namespace should-show-in-example-string -task ${
+        task.name
+      } ${allocation.id.split('-')[0]} /bin/bash`
     );
   });
 
@@ -495,7 +532,7 @@ module('Acceptance | exec', function (hooks) {
 
     this.owner.register('service:sockets', mockSockets);
 
-    await Exec.visitJob({ job: this.job.id });
+    await Exec.visitJob({ job: this.job.id, namespace: this.job.namespaceId });
     await Exec.taskGroups[0].click();
     await Exec.taskGroups[0].tasks[0].click();
 
@@ -557,6 +594,7 @@ module('Acceptance | exec', function (hooks) {
       task_group: taskGroup.name,
       task_name: task.name,
       allocation: allocation.id.split('-')[0],
+      namespace: this.job.namespaceId,
     });
 
     await settled();


### PR DESCRIPTION
Adds a `-namespace $NAMESPACEID` string to the example we show when you exec in a task in the Nomad web UI (when not in the default namespace)

![image](https://github.com/hashicorp/nomad/assets/713991/d2bc2e7d-519f-467c-b3ee-faf39aa80fc0)

Resolves #20213 