### PR TITLE
exec2: more tweaks to driver harness

### DIFF
--- a/helper/subproc/subproc.go
+++ b/helper/subproc/subproc.go
@@ -15,13 +15,16 @@ import (
 
 const (
 	// ExitSuccess indicates the subprocess completed successfully.
-	ExitSuccess = iota
+	ExitSuccess = 0
 
 	// ExitFailure indicates the subprocess terminated unsuccessfully.
-	ExitFailure
+	ExitFailure = 1
 
 	// ExitTimeout indicates the subprocess timed out before completion.
-	ExitTimeout
+	ExitTimeout = 2
+
+	// ExitNotRunnable indicates a command cannot be run.
+	ExitNotRunnable = 127 // bash-ism
 )
 
 // MainFunc is the function that runs for this sub-process.


### PR DESCRIPTION
Also add an explicit exit code to subproc package for when a child
process is instructed to run an unrunnable command (i.e. cannot be
found or is not executable) - with the 127 return code folks using bash
are familiar with
