### PR TITLE
structs: fix test for empty DNS configuration

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2851,7 +2851,7 @@ func (d *DNSConfig) IsZero() bool {
 	if d == nil {
 		return true
 	}
-	return len(d.Options) == 0 || len(d.Searches) == 0 || len(d.Servers) == 0
+	return len(d.Options) == 0 && len(d.Searches) == 0 && len(d.Servers) == 0
 }
 
 // NetworkResource is used to represent available network

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -7482,6 +7482,7 @@ func TestDNSConfig_Equal(t *testing.T) {
 
 	must.Equal[*DNSConfig](t, nil, nil)
 	must.NotEqual[*DNSConfig](t, nil, new(DNSConfig))
+	must.NotEqual[*DNSConfig](t, nil, &DNSConfig{Servers: []string{"8.8.8.8"}})
 
 	must.StructEqual(t, &DNSConfig{
 		Servers:  []string{"8.8.8.8", "8.8.4.4"},


### PR DESCRIPTION
The `DNSConfig.IsZero` method incorrectly returns true if any of the fields are empty, rather than if all of them are empty.

The only code path that consumes this method is on the client, where it's used as part of equality checks on the allocation network status to set the priority of allocation updates to the server. Hypothetically, if the network hook modified only the DNS configuration and no task states were emitted, it would be possible to miss an allocation update. In practice this appears to be impossible, but we should fix the bug so that there aren't errors in future consumers.

---

* Backported only to 1.6.x and 1.7.x because this code doesn't exist in 1.5.x.
* I don't have a changelog here because this isn't user-visible as far as I can tell