### PR TITLE
deps: update consul-template to 0.37.4 to fix resource leak

### DIFF
--- a/.changelog/20234.txt
+++ b/.changelog/20234.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+deps: Updated consul-template dependency to 0.37.4 to fix a resource leak
+```

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	github.com/gosuri/uilive v0.0.4
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/hashicorp/cap v0.2.0
-	github.com/hashicorp/consul-template v0.37.2
+	github.com/hashicorp/consul-template v0.37.4
 	github.com/hashicorp/consul/api v1.26.1
 	github.com/hashicorp/consul/sdk v0.15.0
 	github.com/hashicorp/cronexpr v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -603,8 +603,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vb
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/cap v0.2.0 h1:Cgr1iDczX17y0PNF5VG+bWTtDiimYL8F18izMPbWNy4=
 github.com/hashicorp/cap v0.2.0/go.mod h1:zb3VvIFA0lM2lbmO69NjowV9dJzJnZS89TaM9blXPJA=
-github.com/hashicorp/consul-template v0.37.2 h1:9Ex0KbcuscmZzDQOPAK4/9LSiOTqIbRcwyotaIiTykk=
-github.com/hashicorp/consul-template v0.37.2/go.mod h1:ckdzFLHdF/1A4L11ifxkzy3gXHeF1YbKSbXkN6W33+s=
+github.com/hashicorp/consul-template v0.37.4 h1:NBGei65WKxeaTZ3e6VJUyefITgg5fAQ6Auxar+8L2h0=
+github.com/hashicorp/consul-template v0.37.4/go.mod h1:ckdzFLHdF/1A4L11ifxkzy3gXHeF1YbKSbXkN6W33+s=
 github.com/hashicorp/consul/api v1.10.1-0.20230925152502-e5f5fc9301c7 h1:VjNJGdw+esQUaPG2J1DiT/rEN21/1GQfHb3CvPQlD8U=
 github.com/hashicorp/consul/api v1.10.1-0.20230925152502-e5f5fc9301c7/go.mod h1:+pNEP6hQgkrBLjQlYLI13/tyyb1GK3MGVw1PC/IHk9M=
 github.com/hashicorp/consul/sdk v0.15.0 h1:2qK9nDrr4tiJKRoxPGhm6B7xJjLVIQqkjiab2M4aKjU=


### PR DESCRIPTION
A Nomad user reported an issue where template runner `View.poll` goroutines were being leaked when using templates with many dependencies. This resource leak was fixed in consul-template 0.37.4.

Fixes: https://github.com/hashicorp/nomad/issues/20163