### PR TITLE
docs: update Consul compatibility matrix

### DIFF
--- a/website/content/docs/integrations/consul/index.mdx
+++ b/website/content/docs/integrations/consul/index.mdx
@@ -146,26 +146,16 @@ the [`consul.cluster`][] parameter.
 
 ## Compatibility
 
-Most supported versions of Nomad are compatible with most recent versions of
+All currently supported versions of Nomad are compatible with recent versions of
 Consul, with some exceptions.
 
-* Nomad versions 1.6.0+, 1.5.6+, and 1.4.11+ are compatible with any currently
-  supported version of Consul.
-* Nomad versions 1.4.4 to 1.4.11 and 1.5.0 to 1.5.6 are compatible with any
-  currently supported version of Consul except 1.13.8.
-* Nomad versions 1.4.0 through 1.4.3 are compatible with Consul versions 1.13.0
-  through 1.13.7, and 1.13.9. Changes to Consul service mesh in version 1.14 are
-  incompatible with Nomad 1.4.3 and earlier.
 * Nomad is not compatible with Consul Data Plane.
 
-|                     | Consul 1.13.0 - 1.13.7 | Consul 1.13.8 | Consul 1.13.9 | Consul 1.14.0+ |
-|---------------------|------------------------|---------------|---------------|----------------|
-| Nomad 1.6.0+        | ✅                     | ✅            | ✅            | ✅             |
-| Nomad 1.5.6+        | ✅                     | ✅            | ✅            | ✅             |
-| Nomad 1.5.0-1.5.5   | ✅                     | ❌            | ✅            | ✅             |
-| Nomad 1.4.11-1.4.13 | ✅                     | ✅            | ✅            | ✅             |
-| Nomad 1.4.4-1.4.10  | ✅                     | ❌            | ✅            | ✅             |
-| Nomad 1.4.0-1.4.3   | ✅                     | ❌            | ✅            | ❌             |
+|                   | Consul 1.16.0+ | Consul 1.17.0+ | Consul 1.18.0+ |
+|-------------------|----------------|----------------|----------------|
+| Nomad 1.7.0+      | ✅             | ✅             | ✅             |
+| Nomad 1.6.0+      | ✅             | ✅             | ✅             |
+| Nomad 1.5.0+      | ✅             | ✅             | ✅             |
 
 [Automatic Clustering with Consul]: /nomad/tutorials/manage-clusters/clustering
 [CDP]: /consul/docs/connect/dataplane


### PR DESCRIPTION
Version of Nomad and Consul that were known not to be compatible are no longer supported in general. Update the compatibility matrix for Consul to match.