### PR TITLE
docs: recommendation for maximum number of template dependencies

### DIFF
--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -332,6 +332,18 @@ task "task" {
 }
 ```
 
+### Dependencies
+
+For templates that read from Vault, Consul, or Nomad, each item read is called a
+"dependency". All the `template` blocks share the same internal runner which
+de-duplicates dependencies requesting the same item. You should avoid having
+large numbers of dependencies for a given task, as each dependency requires at
+least one concurrent request (a possibly blocking query) to the upstream
+server. If a task has more than 128 dependencies, a warn-level log will appear
+in the Nomad client logs which reports "watching this many dependencies could
+DDoS your servers", referring to the Vault, Consul, or Nomad cluster being
+queried.
+
 ## Nomad Integration
 
 ### Nomad Services


### PR DESCRIPTION
We don't have docs on this, just the warning in the CT logs that suggests 128 is an upper limit (per task, not per template): [runner.go#L304](https://github.com/hashicorp/consul-template/blob/ee19d705e7c12ae05bac4f7302b65ede843c7258/manager/runner.go#L304). Given the debugging we did for https://github.com/hashicorp/nomad/pull/20234 https://github.com/hashicorp/nomad/issues/20163 https://github.com/hashicorp/consul-template/pull/1898 it seems like good advice to have.