### PR TITLE
api: add missing `AllocDirStats` field in Go API

### DIFF
--- a/.changelog/20261.txt
+++ b/.changelog/20261.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fixed a bug where `AllocDirStats` field was missing from Reads Stats client API
+```

--- a/.changelog/20261.txt
+++ b/.changelog/20261.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-api: Fixed a bug where `AllocDirStats` field was missing from Reads Stats client API
+api: Fixed a bug where `AllocDirStats` field was missing from Read Stats client API
 ```

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -783,6 +783,7 @@ type HostStats struct {
 	Memory           *HostMemoryStats
 	CPU              []*HostCPUStats
 	DiskStats        []*HostDiskStats
+	AllocDirStats    *HostDiskStats
 	DeviceStats      []*DeviceGroupStats
 	Uptime           uint64
 	CPUTicksConsumed float64

--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -153,6 +153,27 @@ func TestNodes_Info(t *testing.T) {
 	must.GreaterEq(t, 1, len(result.Events))
 }
 
+func TestNode_Stats(t *testing.T) {
+	testutil.Parallel(t)
+
+	c, s := makeClient(t, nil, func(c *testutil.TestServerConfig) {
+		c.DevMode = true
+	})
+	defer s.Stop()
+	nodesAPI := c.Nodes()
+	nodeID := oneNodeFromNodeList(t, nodesAPI).ID
+
+	stats, err := nodesAPI.Stats(nodeID, nil)
+	must.NoError(t, err)
+
+	// there isn't much we can reliably check here except that the values are
+	// populated
+	must.NotNil(t, stats.Memory)
+	must.NonZero(t, stats.Memory.Available)
+	must.NotNil(t, stats.AllocDirStats)
+	must.NonZero(t, stats.AllocDirStats.Size)
+}
+
 func TestNodes_NoSecretID(t *testing.T) {
 	testutil.Parallel(t)
 


### PR DESCRIPTION
The JSON response for the Read Stats client API includes an `AllocDirStats` field. This field is missing in the `api` package, so consumers of the Go API can't use it to read the values we're getting back from the HTTP server.

Fixes: https://github.com/hashicorp/nomad/issues/20246