### PR TITLE
docs: clarify data dir default parameters and default creation.

### DIFF
--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -24,7 +24,7 @@ client {
 
 - `alloc_dir` `(string: "")` - Specifies the directory to use for allocation
   data. When this parameter is empty, Nomad will generate the path using the
-  [top-level data_dir][top_level_data_dir] suffixed with "alloc", like
+  [top-level `data_dir`][top_level_data_dir] suffixed with `alloc`, like
   `"/opt/nomad/alloc"`. This must be an absolute path.
 
 - `chroot_env` <code>([ChrootEnv](#chroot_env-parameters): nil)</code> -
@@ -117,7 +117,7 @@ client {
 
 - `state_dir` `(string: "")` - Specifies the directory to use to store client
   state. When this parameter is empty, Nomad will generate the path using the
-  [top-level data_dir][top_level_data_dir] suffixed with "client", like
+  [top-level `data_dir`][top_level_data_dir] suffixed with `client`, like
   `"/opt/nomad/client"`. This must be an absolute path.
 
 - `gc_interval` `(string: "1m")` - Specifies the interval at which Nomad

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -25,7 +25,8 @@ client {
 - `alloc_dir` `(string: "")` - Specifies the directory to use for allocation
   data. When this parameter is empty, Nomad will generate the path using the
   [top-level `data_dir`][top_level_data_dir] suffixed with `alloc`, like
-  `"/opt/nomad/alloc"`. This must be an absolute path.
+  `"/opt/nomad/alloc"`. This must be an absolute path. Nomad will create the
+  directory on the host, if it does not exist when the agent process starts.
 
 - `chroot_env` <code>([ChrootEnv](#chroot_env-parameters): nil)</code> -
   Specifies a key-value mapping that defines the chroot environment for jobs
@@ -118,7 +119,8 @@ client {
 - `state_dir` `(string: "")` - Specifies the directory to use to store client
   state. When this parameter is empty, Nomad will generate the path using the
   [top-level `data_dir`][top_level_data_dir] suffixed with `client`, like
-  `"/opt/nomad/client"`. This must be an absolute path.
+  `"/opt/nomad/client"`. This must be an absolute path. Nomad will create the
+  directory on the host, if it does not exist when the agent process starts.
 
 - `gc_interval` `(string: "1m")` - Specifies the interval at which Nomad
   attempts to garbage collect terminal allocation directories.

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -22,10 +22,10 @@ client {
 
 ## `client` Parameters
 
-- `alloc_dir` `(string: "[data_dir]/alloc")` - Specifies the directory to use
-  for allocation data. By default, this is the top-level
-  [data_dir](/nomad/docs/configuration#data_dir) suffixed with
-  "alloc", like `"/opt/nomad/alloc"`. This must be an absolute path.
+- `alloc_dir` `(string: "")` - Specifies the directory to use for allocation
+  data. When this parameter is empty, Nomad will generate the path using the
+  [top-level data_dir][top_level_data_dir] suffixed with "alloc", like
+  `"/opt/nomad/alloc"`. This must be an absolute path.
 
 - `chroot_env` <code>([ChrootEnv](#chroot_env-parameters): nil)</code> -
   Specifies a key-value mapping that defines the chroot environment for jobs
@@ -115,10 +115,10 @@ client {
   the server address or use go-discover syntax for auto-discovery. See the
   documentation for more detail.
 
-- `state_dir` `(string: "[data_dir]/client")` - Specifies the directory to use
-  to store client state. By default, this is - the top-level
-  [data_dir](/nomad/docs/configuration#data_dir) suffixed with
-  "client", like `"/opt/nomad/client"`. This must be an absolute path.
+- `state_dir` `(string: "")` - Specifies the directory to use to store client
+  state. When this parameter is empty, Nomad will generate the path using the
+  [top-level data_dir][top_level_data_dir] suffixed with "client", like
+  `"/opt/nomad/client"`. This must be an absolute path.
 
 - `gc_interval` `(string: "1m")` - Specifies the interval at which Nomad
   attempts to garbage collect terminal allocation directories.
@@ -744,3 +744,4 @@ client {
 [migrate]: /nomad/docs/job-specification/migrate
 [`nomad node drain -self -no-deadline`]: /nomad/docs/commands/node/drain
 [`TimeoutStopSec`]: https://www.freedesktop.org/software/systemd/man/systemd.service.html#TimeoutStopSec=
+[top_level_data_dir]: /nomad/docs/configuration#data_dir

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -152,7 +152,8 @@ testing.
   agent state. Client nodes use this directory by default to store temporary
   allocation data as well as cluster information. Server nodes use this
   directory to store cluster state, including the replicated log and snapshot
-  data. This must be specified as an absolute path.
+  data. This must be specified as an absolute path. Nomad will create the
+  directory on the host, if it does not exist when the agent process starts.
 
 - `disable_anonymous_signature` `(bool: false)` - Specifies if Nomad should
   provide an anonymous signature for de-duplication with the update check.

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -278,7 +278,7 @@ testing.
 
 - `plugin_dir` `(string: "")` - Specifies the directory to use for looking up
   plugins. When this parameter is empty, Nomad will generate the path using the
-  top-level [data_dir](#data_dir) suffixed with "plugins", like
+  [top-level `data_dir`](#data_dir) suffixed with `plugins`, like
   `"/opt/nomad/plugins"`. This must be an absolute path.
 
 - `plugin` `(`[`Plugin`]`: nil)` - Specifies configuration for a

--- a/website/content/docs/configuration/index.mdx
+++ b/website/content/docs/configuration/index.mdx
@@ -276,10 +276,10 @@ testing.
   value is used to identify individual agents. When specified on a server, the
   name must be unique within the region.
 
-- `plugin_dir` `(string: "[data_dir]/plugins")` - Specifies the directory to
-  use for looking up plugins. By default, this is the top-level
-  [data_dir](#data_dir) suffixed with "plugins", like `"/opt/nomad/plugins"`.
-  This must be an absolute path.
+- `plugin_dir` `(string: "")` - Specifies the directory to use for looking up
+  plugins. When this parameter is empty, Nomad will generate the path using the
+  top-level [data_dir](#data_dir) suffixed with "plugins", like
+  `"/opt/nomad/plugins"`. This must be an absolute path.
 
 - `plugin` `(`[`Plugin`]`: nil)` - Specifies configuration for a
   specific plugin. The plugin block may be repeated, once for each plugin being

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -45,8 +45,8 @@ server {
 
 - `data_dir` `(string: "")` - Specifies the directory to use for server-specific
   data, including the replicated log. When this parameter is empty, Nomad will
-  generate the path using the [top-level data_dir][top_level_data_dir] suffixed
-  with "server", like `"/opt/nomad/server"`. The
+  generate the path using the [top-level `data_dir`][top_level_data_dir] suffixed
+  with `server`, like `"/opt/nomad/server"`. The
   [top-level data_dir][top_level_data_dir] must be set, even when setting this
   value. This must be an absolute path. Nomad will create the directory on the
   host, if it does not exist when the agent process starts.

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -43,11 +43,13 @@ server {
   `1` does not provide any fault tolerance and is not recommended for production
   use cases.
 
-- `data_dir` `(string: "[data_dir]/server")` - Specifies the directory to use
-  for server-specific data, including the replicated log. By default, this is
-  the top-level [data_dir](/nomad/docs/configuration#data_dir) suffixed with "server",
-  like `"/opt/nomad/server"`. The top-level option must be set, even when
-  setting this value. This must be an absolute path.
+- `data_dir` `(string: "")` - Specifies the directory to use for server-specific
+  data, including the replicated log. When this parameter is empty, Nomad will
+  generate the path using the [top-level data_dir][top_level_data_dir] suffixed
+  with "server", like `"/opt/nomad/server"`. The
+  [top-level data_dir][top_level_data_dir] must be set, even when setting this
+  value. This must be an absolute path. Nomad will create the directory on the
+  host, if it does not exist when the agent process starts.
 
 - `enabled` `(bool: false)` - Specifies if this agent should run in server mode.
   All other server options depend on this value being set.
@@ -516,3 +518,4 @@ work.
 [herd]: https://en.wikipedia.org/wiki/Thundering_herd_problem
 [wi]: /nomad/docs/concepts/workload-identity
 [Configure for multiple regions]: /nomad/tutorials/access-control/access-control-bootstrap#configure-for-multiple-regions
+[top_level_data_dir]: /nomad/docs/configuration#data_dir


### PR DESCRIPTION
The data dir parameters for client and server agents confusingly detailed string literal values which were intended to describe interpolated values. This change attempts to remove the confusion and clarify the wording slightly.

closes #20265 