### PR TITLE
docker: use correct effective cpuset filename on legacy cgroups v1 systems

### DIFF
--- a/.changelog/20294.txt
+++ b/.changelog/20294.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fixed a bug where cpuset cgroup would not be updated on cgroup v1 systems
+```

--- a/drivers/docker/cpuset_test.go
+++ b/drivers/docker/cpuset_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/client/testutil"
 	"github.com/shoenig/test/must"
 )
 
@@ -41,4 +42,22 @@ func Test_cpuset_watch(t *testing.T) {
 	doneCh <- true
 
 	must.Eq(t, 1, hits)
+}
+
+func Test_effectiveCpusetFile_cgroupsv1(t *testing.T) {
+	testutil.CgroupsCompatibleV1(t)
+
+	ci.Parallel(t)
+
+	result := effectiveCpusetFile()
+	must.Eq(t, "cpuset.effective_cpus", result)
+}
+
+func Test_effectiveCpusetFile_cgroupsv2(t *testing.T) {
+	testutil.CgroupsCompatibleV2(t)
+
+	ci.Parallel(t)
+
+	result := effectiveCpusetFile()
+	must.Eq(t, "cpuset.cpus.effective", result)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/20293