### PR TITLE
Enable numeric pagination tokens

### DIFF
--- a/nomad/state/paginator/paginator.go
+++ b/nomad/state/paginator/paginator.go
@@ -4,7 +4,9 @@
 package paginator
 
 import (
+	"cmp"
 	"fmt"
+	"strconv"
 
 	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -26,6 +28,7 @@ type Paginator struct {
 	perPage        int32
 	itemCount      int32
 	seekingToken   string
+	seekingUint    uint64
 	nextToken      string
 	reverse        bool
 	nextTokenFound bool
@@ -54,12 +57,16 @@ func NewPaginator(iter Iterator, tokenizer Tokenizer, filters []Filter,
 		filters = append(filters, evaluator)
 	}
 
+	// attempt to convert token to uint for iterators ordered numerically
+	seekingUint, _ := strconv.ParseUint(opts.NextToken, 10, 64)
+
 	return &Paginator{
 		iter:           iter,
 		tokenizer:      tokenizer,
 		filters:        filters,
 		perPage:        opts.PerPage,
 		seekingToken:   opts.NextToken,
+		seekingUint:    seekingUint,
 		reverse:        opts.Reverse,
 		nextTokenFound: opts.NextToken == "",
 		appendFunc:     appendFunc,
@@ -96,15 +103,25 @@ func (p *Paginator) next() (interface{}, paginatorState) {
 	}
 	token := p.tokenizer.GetToken(raw)
 
-	// have we found the token we're seeking (if any)?
-	p.nextToken = token
+	var compared int
+
+	switch t := token.(type) {
+	case string:
+		p.nextToken = t
+		compared = cmp.Compare(t, p.seekingToken)
+	case uint64:
+		p.nextToken = strconv.FormatUint(t, 10)
+		compared = cmp.Compare(t, p.seekingUint)
+	default:
+		panic("unknown token type, neither string nor uint64")
+	}
 
 	var passedToken bool
 
 	if p.reverse {
-		passedToken = token > p.seekingToken
+		passedToken = compared == 1 // token > p.seekingToken
 	} else {
-		passedToken = token < p.seekingToken
+		passedToken = compared == -1 // token < p.seekingToken
 	}
 
 	if !p.nextTokenFound && passedToken {

--- a/nomad/state/paginator/paginator.go
+++ b/nomad/state/paginator/paginator.go
@@ -57,7 +57,9 @@ func NewPaginator(iter Iterator, tokenizer Tokenizer, filters []Filter,
 		filters = append(filters, evaluator)
 	}
 
-	// attempt to convert token to uint for iterators ordered numerically
+	// attempt to convert token to uint for iterators ordered numerically.
+	// it's safe to ignore the error here because the `next` method ignores
+	// this field for string tokens and 0 is valid for an unset numeric token.
 	seekingUint, _ := strconv.ParseUint(opts.NextToken, 10, 64)
 
 	return &Paginator{

--- a/nomad/state/paginator/paginator_test.go
+++ b/nomad/state/paginator/paginator_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 func TestPaginator(t *testing.T) {
@@ -105,16 +105,16 @@ func TestPaginator(t *testing.T) {
 					return nil
 				},
 			)
-			require.NoError(t, err)
+			must.NoError(t, err)
 
 			nextToken, err := paginator.Page()
 			if tc.expectedError == "" {
-				require.NoError(t, err)
-				require.Equal(t, tc.expected, results)
-				require.Equal(t, tc.expectedNextToken, nextToken)
+				must.NoError(t, err)
+				must.Eq(t, tc.expected, results)
+				must.Eq(t, tc.expectedNextToken, nextToken)
 			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedError)
+				must.Error(t, err)
+				must.ErrorContains(t, err, tc.expectedError)
 			}
 		})
 	}

--- a/nomad/state/paginator/tokenizer.go
+++ b/nomad/state/paginator/tokenizer.go
@@ -12,7 +12,7 @@ import (
 // tokens to the Paginator.
 type Tokenizer interface {
 	// GetToken returns the pagination token for the given element.
-	GetToken(interface{}) string
+	GetToken(interface{}) any
 }
 
 // IDGetter is the interface that must be implemented by structs that need to
@@ -78,7 +78,7 @@ func NewStructsTokenizer(_ Iterator, opts StructsTokenizerOptions) StructsTokeni
 	}
 }
 
-func (it StructsTokenizer) GetToken(raw interface{}) string {
+func (it StructsTokenizer) GetToken(raw interface{}) any {
 	if raw == nil {
 		return ""
 	}

--- a/nomad/state/paginator/tokenizer.go
+++ b/nomad/state/paginator/tokenizer.go
@@ -33,6 +33,12 @@ type CreateIndexGetter interface {
 	GetCreateIndex() uint64
 }
 
+// ModifyIndexGetter is the interface that must be implemented by structs that
+// need to have their ModifyIndex as part of the pagination token.
+type ModifyIndexGetter interface {
+	GetModifyIndex() uint64
+}
+
 // StructsTokenizerOptions is the configuration provided to a StructsTokenizer.
 //
 // These are some of the common use cases:
@@ -58,10 +64,18 @@ type CreateIndexGetter interface {
 //	    WithNamespace:   true,
 //	    WithCreateIndex: true,
 //	}
+//
+// For structs that can be sorted by the order they were modified, set
+// `OnlyModifyIndex` to `true` and exclude all other options:
+//
+//	StructsTokenizerOptions {
+//	    OnlyModifyIndex: true,
+//	}
 type StructsTokenizerOptions struct {
 	WithCreateIndex bool
 	WithNamespace   bool
 	WithID          bool
+	OnlyModifyIndex bool
 }
 
 // StructsTokenizer is an pagination token generator that can create different
@@ -81,6 +95,10 @@ func NewStructsTokenizer(_ Iterator, opts StructsTokenizerOptions) StructsTokeni
 func (it StructsTokenizer) GetToken(raw interface{}) any {
 	if raw == nil {
 		return ""
+	}
+
+	if it.opts.OnlyModifyIndex {
+		return raw.(ModifyIndexGetter).GetModifyIndex()
 	}
 
 	parts := []string{}

--- a/nomad/state/paginator/tokenizer_test.go
+++ b/nomad/state/paginator/tokenizer_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/nomad/mock"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 func TestStructsTokenizer(t *testing.T) {
@@ -76,7 +76,7 @@ func TestStructsTokenizer(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			tokenizer := StructsTokenizer{opts: tc.opts}
-			require.Equal(t, tc.expected, tokenizer.GetToken(j))
+			must.Eq(t, tc.expected, tokenizer.GetToken(j))
 		})
 	}
 }

--- a/nomad/state/paginator/tokenizer_test.go
+++ b/nomad/state/paginator/tokenizer_test.go
@@ -20,7 +20,7 @@ func TestStructsTokenizer(t *testing.T) {
 	cases := []struct {
 		name     string
 		opts     StructsTokenizerOptions
-		expected string
+		expected any
 	}{
 		{
 			name: "ID",
@@ -61,6 +61,15 @@ func TestStructsTokenizer(t *testing.T) {
 				WithNamespace:   true,
 			},
 			expected: fmt.Sprintf("%v.%v", j.CreateIndex, j.Namespace),
+		},
+		{
+			name: "ModifyIndex",
+			opts: StructsTokenizerOptions{
+				OnlyModifyIndex: true,
+				// note: all others options will be ignored
+				WithNamespace: true,
+			},
+			expected: j.ModifyIndex,
 		},
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4518,6 +4518,15 @@ func (j *Job) GetCreateIndex() uint64 {
 	return j.CreateIndex
 }
 
+// GetModifyIndex implements the ModifyIndexGetter interface, required for
+// pagination.
+func (j *Job) GetModifyIndex() uint64 {
+	if j == nil {
+		return 0
+	}
+	return j.ModifyIndex
+}
+
 // Canonicalize is used to canonicalize fields in the Job. This should be
 // called when registering a Job.
 func (j *Job) Canonicalize() {


### PR DESCRIPTION
For #19339 we will be creating a state index that sorts jobs by `ModifyIndex`, in order to show most-recently-changed jobs at the top of the Nomad web UI, while continuing to sort appropriately with pagination.

The current pagination logic assumes all `NextToken`s are `string`s, which results in odd paging behavior (including infinite loops!) when the token is actually a number, due to lexicographical ordering, e.g. `"10" < "2"`

This doesn't go as far as fully generalizing the `Paginator`/`Tokenizer` relationship (as might be done with `comparable` or `cmp.Ordered` generics), but it adds support for `uint64` tokens for my immediate use case, and opens a door for further future flexibility.