### PR TITLE
E2E: skip Vault 1.16.1 for JWT compatibility test

### DIFF
--- a/e2e/vaultcompat/vaultcompat_test.go
+++ b/e2e/vaultcompat/vaultcompat_test.go
@@ -43,6 +43,11 @@ var (
 	// 1.11.0 is when Vault added support for `user_claim_json_pointer`.
 	// https://github.com/hashicorp/vault/pull/15593
 	minJWTVersion = goversion.Must(goversion.NewVersion("1.11.0"))
+
+	// skipJWTVersion is a version that has a known issue with JWT. Once 1.16.2
+	// ships, we can remove this as it won't be downloaded and tested anymore.
+	// See: https://github.com/hashicorp/nomad/issues/20298
+	skipJWTVersion = goversion.Must(goversion.NewVersion("1.16.1"))
 )
 
 func TestVaultCompat(t *testing.T) {
@@ -70,7 +75,7 @@ func testVaultBuild(t *testing.T, b build) {
 			testVaultLegacy(t, b)
 		})
 
-		if version.GreaterThanOrEqual(minJWTVersion) {
+		if version.GreaterThanOrEqual(minJWTVersion) && !version.Equal(skipJWTVersion) {
 			t.Run("jwt", func(t *testing.T) {
 				testVaultJWT(t, b)
 			})


### PR DESCRIPTION
Vault 1.16.1 has a known issue around the JWT auth configuration that will prevent this test from ever passing. Skip testing the JWT code path on 1.16.1. Once 1.16.2 ships it will no longer get skipped.

Ref: https://github.com/hashicorp/nomad/issues/20298