### PR TITLE
drain: use authenticated ID as source of drained-by metadata

### DIFF
--- a/.changelog/20317.txt
+++ b/.changelog/20317.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+drain: Fixed a bug where Workload Identity tokens could not be used to drain a node
+```
+
+```release-note:bug
+state: Fixed a bug where restarting a server could fail if the Raft logs include a drain update that used a now-expired token
+```

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -481,31 +481,8 @@ func (n *nomadFSM) applyDrainUpdate(reqType structs.MessageType, buf []byte, ind
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	accessorId := ""
-	if req.AuthToken != "" {
-		token, err := n.state.ACLTokenBySecretID(nil, req.AuthToken)
-		if err != nil {
-			n.logger.Error("error looking up ACL token from drain update", "error", err)
-			return fmt.Errorf("error looking up ACL token: %v", err)
-		}
-		if token == nil {
-			node, err := n.state.NodeBySecretID(nil, req.AuthToken)
-			if err != nil {
-				n.logger.Error("error looking up node for drain update", "error", err)
-				return fmt.Errorf("error looking up node for drain update: %v", err)
-			}
-			if node == nil {
-				n.logger.Error("token did not exist during node drain update")
-				return fmt.Errorf("token did not exist during node drain update")
-			}
-			accessorId = node.ID
-		} else {
-			accessorId = token.AccessorID
-		}
-	}
-
 	if err := n.state.UpdateNodeDrain(reqType, index, req.NodeID, req.DrainStrategy, req.MarkEligible, req.UpdatedAt,
-		req.NodeEvent, req.Meta, accessorId); err != nil {
+		req.NodeEvent, req.Meta, req.Identity); err != nil {
 		n.logger.Error("UpdateNodeDrain failed", "error", err)
 		return err
 	}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -482,7 +482,7 @@ func (n *nomadFSM) applyDrainUpdate(reqType structs.MessageType, buf []byte, ind
 	}
 
 	if err := n.state.UpdateNodeDrain(reqType, index, req.NodeID, req.DrainStrategy, req.MarkEligible, req.UpdatedAt,
-		req.NodeEvent, req.Meta, req.Identity); err != nil {
+		req.NodeEvent, req.Meta, req.UpdatedBy); err != nil {
 		n.logger.Error("UpdateNodeDrain failed", "error", err)
 		return err
 	}

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -777,7 +777,10 @@ func (n *Node) UpdateDrain(args *structs.NodeUpdateDrainRequest,
 		return fmt.Errorf("node event must not be set")
 	}
 
-	// Look for the node
+	// The AuthenticatedIdentity is unexported so won't be written via
+	// Raft. Record the identity string so it can be written to LastDrain
+	args.Identity = args.GetIdentity().String()
+
 	snap, err := n.srv.fsm.State().Snapshot()
 	if err != nil {
 		return err

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -779,7 +779,7 @@ func (n *Node) UpdateDrain(args *structs.NodeUpdateDrainRequest,
 
 	// The AuthenticatedIdentity is unexported so won't be written via
 	// Raft. Record the identity string so it can be written to LastDrain
-	args.Identity = args.GetIdentity().String()
+	args.UpdatedBy = args.GetIdentity().String()
 
 	snap, err := n.srv.fsm.State().Snapshot()
 	if err != nil {

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1585,10 +1585,11 @@ func TestClientEndpoint_UpdateDrain(t *testing.T) {
 	require.Equal(NodeDrainEventDrainSet, out.Events[1].Message)
 	require.NotNil(out.LastDrain)
 	require.Equal(structs.DrainMetadata{
-		StartedAt: out.LastDrain.UpdatedAt,
-		UpdatedAt: out.LastDrain.StartedAt,
-		Status:    structs.DrainStatusDraining,
-		Meta:      map[string]string{"message": "this node is not needed"},
+		StartedAt:  out.LastDrain.UpdatedAt,
+		UpdatedAt:  out.LastDrain.StartedAt,
+		Status:     structs.DrainStatusDraining,
+		Meta:       map[string]string{"message": "this node is not needed"},
+		AccessorID: "token:acls-disabled",
 	}, *out.LastDrain)
 
 	// before+deadline should be before the forced deadline
@@ -1632,10 +1633,11 @@ func TestClientEndpoint_UpdateDrain(t *testing.T) {
 	require.NotNil(out.LastDrain)
 	require.False(out.LastDrain.UpdatedAt.Before(out.LastDrain.StartedAt))
 	require.Equal(structs.DrainMetadata{
-		StartedAt: out.LastDrain.StartedAt,
-		UpdatedAt: out.LastDrain.UpdatedAt,
-		Status:    structs.DrainStatusCanceled,
-		Meta:      map[string]string{"cancelled": "yes"},
+		StartedAt:  out.LastDrain.StartedAt,
+		UpdatedAt:  out.LastDrain.UpdatedAt,
+		Status:     structs.DrainStatusCanceled,
+		Meta:       map[string]string{"cancelled": "yes"},
+		AccessorID: "token:acls-disabled",
 	}, *out.LastDrain)
 
 	// Check that calling UpdateDrain with the same DrainStrategy does not emit
@@ -1700,10 +1702,11 @@ func TestClientEndpoint_UpdatedDrainAndCompleted(t *testing.T) {
 	require.NotNil(out.LastDrain)
 	firstDrainUpdate := out.LastDrain.UpdatedAt
 	require.Equal(structs.DrainMetadata{
-		StartedAt: firstDrainUpdate,
-		UpdatedAt: firstDrainUpdate,
-		Status:    structs.DrainStatusDraining,
-		Meta:      map[string]string{"message": "first drain"},
+		StartedAt:  firstDrainUpdate,
+		UpdatedAt:  firstDrainUpdate,
+		Status:     structs.DrainStatusDraining,
+		Meta:       map[string]string{"message": "first drain"},
+		AccessorID: "token:acls-disabled",
 	}, *out.LastDrain)
 
 	time.Sleep(1 * time.Second)
@@ -1721,10 +1724,11 @@ func TestClientEndpoint_UpdatedDrainAndCompleted(t *testing.T) {
 	secondDrainUpdate := out.LastDrain.UpdatedAt
 	require.True(secondDrainUpdate.After(firstDrainUpdate))
 	require.Equal(structs.DrainMetadata{
-		StartedAt: firstDrainUpdate,
-		UpdatedAt: secondDrainUpdate,
-		Status:    structs.DrainStatusDraining,
-		Meta:      map[string]string{"message": "second drain"},
+		StartedAt:  firstDrainUpdate,
+		UpdatedAt:  secondDrainUpdate,
+		Status:     structs.DrainStatusDraining,
+		Meta:       map[string]string{"message": "second drain"},
+		AccessorID: "token:acls-disabled",
 	}, *out.LastDrain)
 
 	time.Sleep(1 * time.Second)
@@ -1747,10 +1751,11 @@ func TestClientEndpoint_UpdatedDrainAndCompleted(t *testing.T) {
 
 	require.True(out.LastDrain.UpdatedAt.After(secondDrainUpdate))
 	require.Equal(structs.DrainMetadata{
-		StartedAt: firstDrainUpdate,
-		UpdatedAt: out.LastDrain.UpdatedAt,
-		Status:    structs.DrainStatusComplete,
-		Meta:      map[string]string{"message": "second drain"},
+		StartedAt:  firstDrainUpdate,
+		UpdatedAt:  out.LastDrain.UpdatedAt,
+		Status:     structs.DrainStatusComplete,
+		Meta:       map[string]string{"message": "second drain"},
+		AccessorID: "token:acls-disabled",
 	}, *out.LastDrain)
 }
 
@@ -1875,7 +1880,7 @@ func TestClientEndpoint_UpdateDrain_ACL(t *testing.T) {
 		require.Nil(msgpackrpc.CallWithCodec(codec, "Node.UpdateDrain", dereg, &resp), "RPC")
 		out, err := state.NodeByID(nil, node.ID)
 		require.NoError(err)
-		require.Equal(validToken.AccessorID, out.LastDrain.AccessorID)
+		require.Equal("token:"+validToken.AccessorID, out.LastDrain.AccessorID)
 	}
 
 	// Try with a invalid token
@@ -1895,7 +1900,7 @@ func TestClientEndpoint_UpdateDrain_ACL(t *testing.T) {
 		require.Nil(msgpackrpc.CallWithCodec(codec, "Node.UpdateDrain", dereg, &resp), "RPC")
 		out, err := state.NodeByID(nil, node.ID)
 		require.NoError(err)
-		require.Equal(root.AccessorID, out.LastDrain.AccessorID)
+		require.Equal("token:"+root.AccessorID, out.LastDrain.AccessorID)
 	}
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -660,6 +660,10 @@ type NodeUpdateDrainRequest struct {
 	// Meta is user-provided metadata relating to the drain operation
 	Meta map[string]string
 
+	// Identity represents the AuthenticatedIdentity of the request, so that we
+	// can record it in the LastDrain data without re-authenticating in the FSM.
+	Identity string
+
 	WriteRequest
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -660,9 +660,9 @@ type NodeUpdateDrainRequest struct {
 	// Meta is user-provided metadata relating to the drain operation
 	Meta map[string]string
 
-	// Identity represents the AuthenticatedIdentity of the request, so that we
+	// UpdatedBy represents the AuthenticatedIdentity of the request, so that we
 	// can record it in the LastDrain data without re-authenticating in the FSM.
-	Identity string
+	UpdatedBy string
 
 	WriteRequest
 }


### PR DESCRIPTION
When a node is set to drain, the state store reads the auth token off the request to record `LastDrain` metadata about the token used to drain the node. This code path in the state store can't correctly handle signed Workload Identity tokens or bearer tokens that may have expired (for example, while restarting a server and applying uncompacted Raft logs).

Rather than re-authenticating the request at the time of FSM apply, record the string derived from the authenticated identity as part of the Raft log entry.

Fixes: https://github.com/hashicorp/nomad/issues/17471