### PR TITLE
cli: remove extraneous trailing newline from `nomad fmt`

### DIFF
--- a/command/fmt.go
+++ b/command/fmt.go
@@ -280,7 +280,7 @@ func (f *FormatCommand) processFile(path string, r io.Reader) {
 	}
 
 	if f.writeStdout {
-		f.Ui.Output(string(out))
+		formattedFile.WriteTo(os.Stdout)
 	}
 }
 


### PR DESCRIPTION
When `nomad fmt` writes to stdout instead of overwriting a file, the command was using the `UI` output, which appends an extra newline. This results in extra trailing newlines when using `nomad fmt` as part of a pipeline or editor plugin.

Update the command to write directly to stdout when in the stdout mode.

Fixes: https://github.com/hashicorp/nomad/issues/20307