### PR TITLE
WI: ensure Consul hook and WID manager interpolate services

### DIFF
--- a/.changelog/20344.txt
+++ b/.changelog/20344.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul: Fixed a bug where services with interpolation would not get correctly signed Workload Identities
+```

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	cstate "github.com/hashicorp/nomad/client/state"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/client/widmgr"
 	"github.com/hashicorp/nomad/helper/pointer"
@@ -285,8 +286,17 @@ func NewAllocRunner(config *config.AllocRunnerConfig) (interfaces.AllocRunner, e
 	ar.shutdownDelayCtx = shutdownDelayCtx
 	ar.shutdownDelayCancelFn = shutdownDelayCancel
 
+	// Create a *taskenv.Builder for the allocation so the WID manager can
+	// interpolate services with the allocation and tasks as needed
+	envBuilder := taskenv.NewBuilder(
+		config.ClientConfig.Node,
+		ar.Alloc(),
+		nil,
+		config.ClientConfig.Region,
+	).SetAllocDir(ar.allocDir.AllocDirPath())
+
 	// initialize the workload identity manager
-	widmgr := widmgr.NewWIDMgr(ar.widsigner, alloc, ar.stateDB, ar.logger)
+	widmgr := widmgr.NewWIDMgr(ar.widsigner, alloc, ar.stateDB, ar.logger, envBuilder)
 	ar.widmgr = widmgr
 
 	// Initialize the runners hooks.

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -132,7 +132,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 			consulConfigs:           ar.clientConfig.GetConsulConfigs(hookLogger),
 			consulClientConstructor: consul.NewConsulClient,
 			hookResources:           ar.hookResources,
-			taskEnv:                 builtTaskEnv,
+			envBuilder:              newEnvBuilder,
 			logger:                  hookLogger,
 		}),
 		newUpstreamAllocsHook(hookLogger, ar.prevAllocWatcher),

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -114,7 +114,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 		).SetAllocDir(ar.allocDir.AllocDirPath())
 	}
 
-	// Create a taskenv.TaskEnv which is used for read only purposes by the
+	// Create a *taskenv.TaskEnv which is used for read only purposes by the
 	// newNetworkHook and newChecksHook.
 	builtTaskEnv := newEnvBuilder().Build()
 
@@ -132,6 +132,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 			consulConfigs:           ar.clientConfig.GetConsulConfigs(hookLogger),
 			consulClientConstructor: consul.NewConsulClient,
 			hookResources:           ar.hookResources,
+			taskEnv:                 builtTaskEnv,
 			logger:                  hookLogger,
 		}),
 		newUpstreamAllocsHook(hookLogger, ar.prevAllocWatcher),

--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -181,8 +181,8 @@ func (h *consulHook) prepareConsulTokensForServices(services []*structs.Service,
 		}
 
 		// Find signed identity workload.
-		identity := taskenv.InterpolateWIHandle(env, *service.IdentityHandle())
-		jwt, err := h.widmgr.Get(identity)
+		handle := *service.IdentityHandle(env.ReplaceEnv)
+		jwt, err := h.widmgr.Get(handle)
 		if err != nil {
 			mErr = multierror.Append(mErr, fmt.Errorf(
 				"error getting signed identity for service %s: %v",
@@ -196,7 +196,7 @@ func (h *consulHook) prepareConsulTokensForServices(services []*structs.Service,
 			JWT:            jwt.JWT,
 			AuthMethodName: consulConfig.ServiceIdentityAuthMethod,
 			Meta: map[string]string{
-				"requested_by": fmt.Sprintf("nomad_service_%s", identity.InterpolatedWorkloadIdentifier),
+				"requested_by": fmt.Sprintf("nomad_service_%s", handle.InterpolatedWorkloadIdentifier),
 			},
 		}
 		token, err := h.getConsulToken(clusterName, req)

--- a/client/allocrunner/consul_hook_test.go
+++ b/client/allocrunner/consul_hook_test.go
@@ -13,7 +13,9 @@ import (
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/consul"
+	cstate "github.com/hashicorp/nomad/client/state"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/client/widmgr"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -41,45 +43,28 @@ func consulHookTestHarness(t *testing.T) *consulHook {
 			Provider: structs.ServiceProviderConsul,
 			Identity: &structs.WorkloadIdentity{Name: "consul-service_webservice", Audience: []string{"consul.io"}},
 			Cluster:  "default",
-			Name:     "webservice",
-			TaskName: "web",
+			Name:     "${NOMAD_TASK_NAME}service",
+			TaskName: "web", // note: this doesn't interpolate
 		},
 	}
 
-	identitiesToSign := []*structs.WorkloadIdentity{}
-	identitiesToSign = append(identitiesToSign, task.Identities...)
-	for _, service := range task.Services {
-		identitiesToSign = append(identitiesToSign, service.Identity)
-	}
+	// setup mock signer but don't sign identities, as we're going to want them
+	// interpolated by the WIDMgr
+	mockSigner := widmgr.NewMockWIDSigner(nil)
+	db := cstate.NewMemDB(logger)
 
-	// setup mock signer and sign the identities
-	mockSigner := widmgr.NewMockWIDSigner(identitiesToSign)
-	signedIDs, err := mockSigner.SignIdentities(1, []*structs.WorkloadIdentityRequest{
-		{
-			AllocID: alloc.ID,
-			WIHandle: structs.WIHandle{
-				WorkloadIdentifier: task.Name,
-				IdentityName:       task.Identities[0].Name,
-			},
-		},
-		{
-			AllocID: alloc.ID,
-			WIHandle: structs.WIHandle{
-				WorkloadIdentifier: task.Services[0].Name,
-				IdentityName:       task.Services[0].Identity.Name,
-				WorkloadType:       structs.WorkloadTypeService,
-			},
-		},
-	})
-	must.NoError(t, err)
+	// the WIDMgr env builder never has the task available
+	envBuilder := taskenv.NewBuilder(mock.Node(), alloc, nil, "global")
 
-	mockWIDMgr := widmgr.NewMockWIDMgr(signedIDs)
+	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, db, logger, envBuilder)
+	mockWIDMgr.SignForTesting()
 
 	consulConfigs := map[string]*structsc.ConsulConfig{
 		"default": structsc.DefaultConsulConfig(),
 	}
 
 	hookResources := cstructs.NewAllocHookResources()
+	taskEnvBuilder := taskenv.NewBuilder(mock.Node(), alloc, task, "global")
 
 	consulHookCfg := consulHookConfig{
 		alloc:                   alloc,
@@ -88,6 +73,7 @@ func consulHookTestHarness(t *testing.T) *consulHook {
 		consulConfigs:           consulConfigs,
 		consulClientConstructor: consul.NewMockConsulClient,
 		hookResources:           hookResources,
+		taskEnv:                 taskEnvBuilder.Build(),
 		logger:                  logger,
 	}
 	return newConsulHook(consulHookCfg)
@@ -103,13 +89,11 @@ func Test_consulHook_prepareConsulTokensForTask(t *testing.T) {
 	ti := *task.IdentityHandle(wid)
 	jwt, err := hook.widmgr.Get(ti)
 	must.NoError(t, err)
-
 	hashJWT := md5.Sum([]byte(jwt.JWT))
 
 	tests := []struct {
 		name           string
 		task           *structs.Task
-		tokens         map[string]map[string]*consulapi.ACLToken
 		wantErr        bool
 		errMsg         string
 		expectedTokens map[string]map[string]*consulapi.ACLToken
@@ -117,7 +101,6 @@ func Test_consulHook_prepareConsulTokensForTask(t *testing.T) {
 		{
 			name:           "empty task",
 			task:           nil,
-			tokens:         map[string]map[string]*consulapi.ACLToken{},
 			wantErr:        true,
 			errMsg:         "no task specified",
 			expectedTokens: map[string]map[string]*consulapi.ACLToken{},
@@ -125,7 +108,6 @@ func Test_consulHook_prepareConsulTokensForTask(t *testing.T) {
 		{
 			name:    "task with signed identity",
 			task:    task,
-			tokens:  map[string]map[string]*consulapi.ACLToken{},
 			wantErr: false,
 			errMsg:  "",
 			expectedTokens: map[string]map[string]*consulapi.ACLToken{
@@ -144,7 +126,6 @@ func Test_consulHook_prepareConsulTokensForTask(t *testing.T) {
 					{Name: structs.ConsulTaskIdentityNamePrefix + "_default"}},
 				Name: "foo",
 			},
-			tokens:         map[string]map[string]*consulapi.ACLToken{},
 			wantErr:        true,
 			errMsg:         "unable to find token for workload",
 			expectedTokens: map[string]map[string]*consulapi.ACLToken{},
@@ -152,13 +133,14 @@ func Test_consulHook_prepareConsulTokensForTask(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := hook.prepareConsulTokensForTask(tt.task, nil, tt.tokens)
+			tokens := map[string]map[string]*consulapi.ACLToken{}
+			err := hook.prepareConsulTokensForTask(tt.task, nil, tokens)
 			if tt.wantErr {
 				must.Error(t, err)
 				must.ErrorContains(t, err, tt.errMsg)
 			} else {
 				must.NoError(t, err)
-				must.Eq(t, tt.tokens, tt.expectedTokens)
+				must.Eq(t, tt.expectedTokens, tokens)
 			}
 		})
 	}
@@ -170,9 +152,10 @@ func Test_consulHook_prepareConsulTokensForServices(t *testing.T) {
 	hook := consulHookTestHarness(t)
 	task := hook.alloc.LookupTask("web")
 	services := task.Services
-
+	interpolatedServices := taskenv.InterpolateServices(hook.taskEnv, services)
 	hashedJWT := make(map[string]string)
-	for _, s := range services {
+
+	for _, s := range interpolatedServices {
 		widHandle := *s.IdentityHandle()
 		jwt, err := hook.widmgr.Get(widHandle)
 		must.NoError(t, err)
@@ -184,7 +167,6 @@ func Test_consulHook_prepareConsulTokensForServices(t *testing.T) {
 	tests := []struct {
 		name           string
 		services       []*structs.Service
-		tokens         map[string]map[string]*consulapi.ACLToken
 		wantErr        bool
 		errMsg         string
 		expectedTokens map[string]map[string]*consulapi.ACLToken
@@ -192,7 +174,6 @@ func Test_consulHook_prepareConsulTokensForServices(t *testing.T) {
 		{
 			name:           "empty services",
 			services:       nil,
-			tokens:         map[string]map[string]*consulapi.ACLToken{},
 			wantErr:        false,
 			errMsg:         "",
 			expectedTokens: map[string]map[string]*consulapi.ACLToken{},
@@ -200,7 +181,6 @@ func Test_consulHook_prepareConsulTokensForServices(t *testing.T) {
 		{
 			name:     "services with signed identity",
 			services: services,
-			tokens:   map[string]map[string]*consulapi.ACLToken{},
 			wantErr:  false,
 			errMsg:   "",
 			expectedTokens: map[string]map[string]*consulapi.ACLToken{
@@ -224,7 +204,6 @@ func Test_consulHook_prepareConsulTokensForServices(t *testing.T) {
 					TaskName: "web",
 				},
 			},
-			tokens:         map[string]map[string]*consulapi.ACLToken{},
 			wantErr:        true,
 			errMsg:         "unable to find token for workload",
 			expectedTokens: map[string]map[string]*consulapi.ACLToken{},
@@ -232,13 +211,14 @@ func Test_consulHook_prepareConsulTokensForServices(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := hook.prepareConsulTokensForServices(tt.services, nil, tt.tokens)
+			tokens := map[string]map[string]*consulapi.ACLToken{}
+			err := hook.prepareConsulTokensForServices(tt.services, nil, tokens)
 			if tt.wantErr {
 				must.Error(t, err)
 				must.ErrorContains(t, err, tt.errMsg)
 			} else {
 				must.NoError(t, err)
-				must.Eq(t, tt.tokens, tt.expectedTokens)
+				must.Eq(t, tt.expectedTokens, tokens)
 			}
 		})
 	}

--- a/client/allocrunner/consul_hook_test.go
+++ b/client/allocrunner/consul_hook_test.go
@@ -158,7 +158,7 @@ func Test_consulHook_prepareConsulTokensForServices(t *testing.T) {
 	hashedJWT := make(map[string]string)
 
 	for _, s := range services {
-		widHandle := taskenv.InterpolateWIHandle(env, *s.IdentityHandle())
+		widHandle := *s.IdentityHandle(env.ReplaceEnv)
 		jwt, err := hook.widmgr.Get(widHandle)
 		must.NoError(t, err)
 

--- a/client/allocrunner/identity_hook_test.go
+++ b/client/allocrunner/identity_hook_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	cstate "github.com/hashicorp/nomad/client/state"
+	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/client/widmgr"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -47,9 +48,12 @@ func TestIdentityHook_Prerun(t *testing.T) {
 	logger := testlog.HCLogger(t)
 	db := cstate.NewMemDB(logger)
 
+	// the WIDMgr env builder never has the task available
+	envBuilder := taskenv.NewBuilder(mock.Node(), alloc, nil, "global")
+
 	// setup mock signer and WIDMgr
 	mockSigner := widmgr.NewMockWIDSigner(task.Identities)
-	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, db, logger)
+	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, db, logger, envBuilder)
 	allocrunner.widmgr = mockWIDMgr
 	allocrunner.widsigner = mockSigner
 

--- a/client/allocrunner/taskrunner/identity_hook_test.go
+++ b/client/allocrunner/taskrunner/identity_hook_test.go
@@ -81,7 +81,9 @@ func TestIdentityHook_RenewAll(t *testing.T) {
 	logger := testlog.HCLogger(t)
 	db := cstate.NewMemDB(logger)
 	mockSigner := widmgr.NewMockWIDSigner(task.Identities)
-	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, db, logger)
+	envBuilder := taskenv.NewBuilder(mock.Node(), alloc, nil, "global")
+
+	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, db, logger, envBuilder)
 	mockWIDMgr.SetMinWait(time.Second) // fast renewals, because the default is 10s
 	mockLifecycle := trtesting.NewMockTaskHooks()
 
@@ -188,7 +190,8 @@ func TestIdentityHook_RenewOne(t *testing.T) {
 	logger := testlog.HCLogger(t)
 	db := cstate.NewMemDB(logger)
 	mockSigner := widmgr.NewMockWIDSigner(task.Identities)
-	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, db, logger)
+	envBuilder := taskenv.NewBuilder(mock.Node(), alloc, nil, "global")
+	mockWIDMgr := widmgr.NewWIDMgr(mockSigner, alloc, db, logger, envBuilder)
 	mockWIDMgr.SetMinWait(time.Second) // fast renewals, because the default is 10s
 
 	h := &identityHook{

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -137,7 +137,9 @@ func testTaskRunnerConfig(t *testing.T, alloc *structs.Allocation, taskName stri
 	if vault != nil {
 		vaultFunc = func(_ string) (vaultclient.VaultClient, error) { return vault, nil }
 	}
-	envBuilder := taskenv.NewBuilder(mock.Node(), alloc, thisTask, "global")
+	// the envBuilder for the WIDMgr never has access to the task, so don't
+	// include it here
+	envBuilder := taskenv.NewBuilder(mock.Node(), alloc, nil, "global")
 
 	conf := &Config{
 		Alloc:                 alloc,

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	cstate "github.com/hashicorp/nomad/client/state"
 	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/helper"
 	structsc "github.com/hashicorp/nomad/nomad/structs/config"
 
@@ -136,6 +137,7 @@ func testTaskRunnerConfig(t *testing.T, alloc *structs.Allocation, taskName stri
 	if vault != nil {
 		vaultFunc = func(_ string) (vaultclient.VaultClient, error) { return vault, nil }
 	}
+	envBuilder := taskenv.NewBuilder(mock.Node(), alloc, thisTask, "global")
 
 	conf := &Config{
 		Alloc:                 alloc,
@@ -157,7 +159,7 @@ func testTaskRunnerConfig(t *testing.T, alloc *structs.Allocation, taskName stri
 		ServiceRegWrapper:     wrapperMock,
 		Getter:                getter.TestSandbox(t),
 		Wranglers:             proclib.MockWranglers(t),
-		WIDMgr:                widmgr.NewWIDMgr(widsigner, alloc, db, logger),
+		WIDMgr:                widmgr.NewWIDMgr(widsigner, alloc, db, logger, envBuilder),
 		AllocHookResources:    cstructs.NewAllocHookResources(),
 	}
 

--- a/client/allocrunner/taskrunner/vault_hook_test.go
+++ b/client/allocrunner/taskrunner/vault_hook_test.go
@@ -99,8 +99,8 @@ func setupTestVaultHook(t *testing.T, config *vaultHookConfig) *vaultHook {
 	if config.widmgr == nil {
 		db := cstate.NewMemDB(config.logger)
 		signer := widmgr.NewMockWIDSigner(config.task.Identities)
-
-		config.widmgr = widmgr.NewWIDMgr(signer, config.alloc, db, config.logger)
+		envBuilder := taskenv.NewBuilder(mock.Node(), config.alloc, nil, "global")
+		config.widmgr = widmgr.NewWIDMgr(signer, config.alloc, db, config.logger, envBuilder)
 		err := config.widmgr.Run()
 		must.NoError(t, err)
 	}

--- a/client/taskenv/services.go
+++ b/client/taskenv/services.go
@@ -4,7 +4,6 @@
 package taskenv
 
 import (
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -60,7 +59,6 @@ func InterpolateService(taskEnv *TaskEnv, origService *structs.Service) *structs
 	service.CanaryMeta = interpolateMapStringString(taskEnv, service.CanaryMeta)
 	service.TaggedAddresses = interpolateMapStringString(taskEnv, service.TaggedAddresses)
 	interpolateConnect(taskEnv, service.Connect)
-	service.Identity = interpolateIdentity(taskEnv, service.Identity)
 
 	return service
 }
@@ -224,19 +222,15 @@ func interpolateTaskResources(taskEnv *TaskEnv, resources *structs.Resources) {
 	}
 }
 
-func interpolateIdentity(taskEnv *TaskEnv, origIdentity *structs.WorkloadIdentity) *structs.WorkloadIdentity {
-	if origIdentity == nil {
-		return nil
+// InterpolateWIHandle returns a copy of the WIHandle with only the
+// InterpolatedWorkloadIdentifier field interpolated. The original
+// WorkloadIdentifier should never be altered so the server can find
+// uninterpolated services associated with the handle.
+func InterpolateWIHandle(taskEnv *TaskEnv, orig structs.WIHandle) structs.WIHandle {
+	return structs.WIHandle{
+		IdentityName:                   orig.IdentityName,
+		WorkloadIdentifier:             orig.WorkloadIdentifier,
+		WorkloadType:                   orig.WorkloadType,
+		InterpolatedWorkloadIdentifier: taskEnv.ReplaceEnv(orig.WorkloadIdentifier),
 	}
-	identity := origIdentity.Copy()
-	identity.Name = taskEnv.ReplaceEnv(identity.Name)
-	identity.Audience = helper.ConvertSlice(identity.Audience,
-		func(aud string) string { return taskEnv.ReplaceEnv(aud) })
-	identity.ChangeMode = taskEnv.ReplaceEnv(identity.ChangeMode)
-	identity.ChangeSignal = taskEnv.ReplaceEnv(identity.ChangeSignal)
-	identity.ServiceName = taskEnv.ReplaceEnv(identity.ServiceName)
-
-	// note: can't interpolate Env, File, TTL
-
-	return identity
 }

--- a/client/widmgr/mock.go
+++ b/client/widmgr/mock.go
@@ -113,35 +113,3 @@ func (m *MockWIDSigner) SignIdentities(minIndex uint64, req []*structs.WorkloadI
 	}
 	return swids, nil
 }
-
-// MockWIDMgr mocks IdentityManager interface allowing to only get identities
-// signed by the mock signer.
-type MockWIDMgr struct {
-	swids map[structs.WIHandle]*structs.SignedWorkloadIdentity
-}
-
-func NewMockWIDMgr(swids []*structs.SignedWorkloadIdentity) *MockWIDMgr {
-	swidmap := map[structs.WIHandle]*structs.SignedWorkloadIdentity{}
-	for _, id := range swids {
-		swidmap[id.WIHandle] = id
-	}
-	return &MockWIDMgr{swids: swidmap}
-}
-
-// Run does not run a renewal loop in this mock
-func (m MockWIDMgr) Run() error { return nil }
-
-func (m MockWIDMgr) Get(id structs.WIHandle) (*structs.SignedWorkloadIdentity, error) {
-	sid, ok := m.swids[id]
-	if !ok {
-		return nil, fmt.Errorf("unable to find token for workload %q and identity %q", id.WorkloadIdentifier, id.IdentityName)
-	}
-	return sid, nil
-}
-
-// Watch does not do anything, this mock doesn't support watching.
-func (m MockWIDMgr) Watch(identity structs.WIHandle) (<-chan *structs.SignedWorkloadIdentity, func()) {
-	return nil, nil
-}
-
-func (m MockWIDMgr) Shutdown() {}

--- a/client/widmgr/widmgr.go
+++ b/client/widmgr/widmgr.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	cstate "github.com/hashicorp/nomad/client/state"
+	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -53,11 +54,14 @@ type WIDMgr struct {
 	logger hclog.Logger
 }
 
-func NewWIDMgr(signer IdentitySigner, a *structs.Allocation, db cstate.StateDB, logger hclog.Logger) *WIDMgr {
+func NewWIDMgr(signer IdentitySigner, a *structs.Allocation, db cstate.StateDB, logger hclog.Logger, envBuilder *taskenv.Builder) *WIDMgr {
 	widspecs := map[structs.WIHandle]*structs.WorkloadIdentity{}
 	tg := a.Job.LookupTaskGroup(a.TaskGroup)
 
-	for _, service := range tg.Services {
+	allocEnv := envBuilder.Build()
+
+	interpolatedGroupServices := taskenv.InterpolateServices(allocEnv, tg.Services)
+	for _, service := range interpolatedGroupServices {
 		if service.Identity != nil {
 			widspecs[*service.IdentityHandle()] = service.Identity
 		}
@@ -69,7 +73,10 @@ func NewWIDMgr(signer IdentitySigner, a *structs.Allocation, db cstate.StateDB, 
 			widspecs[*task.IdentityHandle(id)] = id
 		}
 
-		for _, service := range task.Services {
+		// update the builder for this task
+		taskEnv := envBuilder.UpdateTask(a, task).Build()
+		interpolatedTaskServices := taskenv.InterpolateServices(taskEnv, task.Services)
+		for _, service := range interpolatedTaskServices {
 			if service.Identity != nil {
 				widspecs[*service.IdentityHandle()] = service.Identity
 			}
@@ -237,6 +244,12 @@ func (m *WIDMgr) restoreStoredIdentities() (bool, error) {
 	}
 
 	return hasExpired, nil
+}
+
+// SignForTesting signs all the identities in m.widspec, typically with the mock
+// signer. This should only be used for testing downstream hooks.
+func (m *WIDMgr) SignForTesting() {
+	m.getInitialIdentities()
 }
 
 // getInitialIdentities fetches all signed identities or returns an error. It

--- a/client/widmgr/widmgr.go
+++ b/client/widmgr/widmgr.go
@@ -60,10 +60,10 @@ func NewWIDMgr(signer IdentitySigner, a *structs.Allocation, db cstate.StateDB, 
 
 	allocEnv := envBuilder.Build()
 
-	interpolatedGroupServices := taskenv.InterpolateServices(allocEnv, tg.Services)
-	for _, service := range interpolatedGroupServices {
+	for _, service := range tg.Services {
 		if service.Identity != nil {
-			widspecs[*service.IdentityHandle()] = service.Identity
+			handle := taskenv.InterpolateWIHandle(allocEnv, *service.IdentityHandle())
+			widspecs[handle] = service.Identity
 		}
 	}
 
@@ -75,10 +75,10 @@ func NewWIDMgr(signer IdentitySigner, a *structs.Allocation, db cstate.StateDB, 
 
 		// update the builder for this task
 		taskEnv := envBuilder.UpdateTask(a, task).Build()
-		interpolatedTaskServices := taskenv.InterpolateServices(taskEnv, task.Services)
-		for _, service := range interpolatedTaskServices {
+		for _, service := range task.Services {
 			if service.Identity != nil {
-				widspecs[*service.IdentityHandle()] = service.Identity
+				handle := taskenv.InterpolateWIHandle(taskEnv, *service.IdentityHandle())
+				widspecs[handle] = service.Identity
 			}
 		}
 	}

--- a/client/widmgr/widmgr.go
+++ b/client/widmgr/widmgr.go
@@ -62,7 +62,7 @@ func NewWIDMgr(signer IdentitySigner, a *structs.Allocation, db cstate.StateDB, 
 
 	for _, service := range tg.Services {
 		if service.Identity != nil {
-			handle := taskenv.InterpolateWIHandle(allocEnv, *service.IdentityHandle())
+			handle := *service.IdentityHandle(allocEnv.ReplaceEnv)
 			widspecs[handle] = service.Identity
 		}
 	}
@@ -77,7 +77,7 @@ func NewWIDMgr(signer IdentitySigner, a *structs.Allocation, db cstate.StateDB, 
 		taskEnv := envBuilder.UpdateTask(a, task).Build()
 		for _, service := range task.Services {
 			if service.Identity != nil {
-				handle := taskenv.InterpolateWIHandle(taskEnv, *service.IdentityHandle())
+				handle := *service.IdentityHandle(taskEnv.ReplaceEnv)
 				widspecs[handle] = service.Identity
 			}
 		}

--- a/client/widmgr/widmgr_test.go
+++ b/client/widmgr/widmgr_test.go
@@ -53,7 +53,11 @@ func TestWIDMgr_Restore(t *testing.T) {
 	signer.mockNow = time.Now().Add(-1 * time.Minute)
 	widSpecs[2].TTL = time.Second
 	signer.setWIDs(widSpecs)
+
 	wiHandle := service.IdentityHandle()
+	wiHandle.InterpolatedWorkloadIdentifier = envBuilder.Build().ReplaceEnv(
+		wiHandle.WorkloadIdentifier)
+
 	mgr.widSpecs[*wiHandle].TTL = time.Second
 
 	// force a re-sign to re-populate the lastToken and save to the db

--- a/client/widmgr/widmgr_test.go
+++ b/client/widmgr/widmgr_test.go
@@ -54,10 +54,7 @@ func TestWIDMgr_Restore(t *testing.T) {
 	widSpecs[2].TTL = time.Second
 	signer.setWIDs(widSpecs)
 
-	wiHandle := service.IdentityHandle()
-	wiHandle.InterpolatedWorkloadIdentifier = envBuilder.Build().ReplaceEnv(
-		wiHandle.WorkloadIdentifier)
-
+	wiHandle := service.IdentityHandle(envBuilder.Build().ReplaceEnv)
 	mgr.widSpecs[*wiHandle].TTL = time.Second
 
 	// force a re-sign to re-populate the lastToken and save to the db

--- a/client/widmgr/widmgr_test.go
+++ b/client/widmgr/widmgr_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	cstate "github.com/hashicorp/nomad/client/state"
+	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -29,9 +30,10 @@ func TestWIDMgr_Restore(t *testing.T) {
 	}
 	alloc.Job.TaskGroups[0].Tasks[0].Services[0].Identity = widSpecs[0]
 	alloc.Job.TaskGroups[0].Tasks[0].Identities = widSpecs[1:]
+	envBuilder := taskenv.NewBuilder(mock.Node(), alloc, nil, "global")
 
 	signer := NewMockWIDSigner(widSpecs)
-	mgr := NewWIDMgr(signer, alloc, db, logger)
+	mgr := NewWIDMgr(signer, alloc, db, logger, envBuilder)
 
 	// restore, but we haven't previously saved to the db
 	hasExpired, err := mgr.restoreStoredIdentities()

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -637,13 +637,13 @@ func (a *Alloc) signServices(
 	// services can be on the level of task groups or tasks
 	for _, tg := range job.TaskGroups {
 		for _, service := range tg.Services {
-			if service.IdentityHandle().Equal(wid) {
+			if service.IdentityHandle(nil).Equal(wid) {
 				return true, a.signIdentities(alloc, service.Identity, idReq, reply, now)
 			}
 		}
 		for _, task := range tg.Tasks {
 			for _, service := range task.Services {
-				if service.IdentityHandle().Equal(wid) {
+				if service.IdentityHandle(nil).Equal(wid) {
 					return true, a.signIdentities(alloc, service.Identity, idReq, reply, now)
 				}
 			}

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -802,15 +802,21 @@ func (s *Service) MakeUniqueIdentityName() string {
 	return fmt.Sprintf("%s_%v-%v", prefix, s.Name, s.PortLabel)
 }
 
+type envReplacer func(string) string
+
 // IdentityHandle returns a WorkloadIdentityHandle which is a pair of service
 // identity name and service name.
-func (s *Service) IdentityHandle() *WIHandle {
+func (s *Service) IdentityHandle(replace envReplacer) *WIHandle {
 	if s.Identity != nil {
-		return &WIHandle{
+		wi := &WIHandle{
 			IdentityName:       s.Identity.Name,
 			WorkloadIdentifier: s.Name,
 			WorkloadType:       WorkloadTypeService,
 		}
+		if replace != nil {
+			wi.InterpolatedWorkloadIdentifier = replace(s.Name)
+		}
+		return wi
 	}
 	return nil
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -11534,6 +11534,9 @@ func NewIdentityClaims(job *Job, alloc *Allocation, wihandle *WIHandle, wid *Wor
 	switch wihandle.WorkloadType {
 	case WorkloadTypeService:
 		serviceName := wihandle.WorkloadIdentifier
+		if wihandle.InterpolatedWorkloadIdentifier != "" {
+			serviceName = wihandle.InterpolatedWorkloadIdentifier
+		}
 		claims.ServiceName = serviceName
 
 		// Find task name if this is a task service.

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -8240,7 +8240,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				name:           path,
 				group:          tg.Name,
 				wid:            s.Identity,
-				wiHandle:       s.IdentityHandle(),
+				wiHandle:       s.IdentityHandle(nil),
 				expectedClaims: expectedClaims[path],
 			})
 		}
@@ -8269,7 +8269,7 @@ func TestNewIdentityClaims(t *testing.T) {
 					name:           path,
 					group:          tg.Name,
 					wid:            s.Identity,
-					wiHandle:       s.IdentityHandle(),
+					wiHandle:       s.IdentityHandle(nil),
 					expectedClaims: expectedClaims[path],
 				})
 			}

--- a/nomad/structs/workload_id.go
+++ b/nomad/structs/workload_id.go
@@ -310,12 +310,18 @@ type WIHandle struct {
 	// WorkloadIdentifier is either a ServiceName or a TaskName
 	WorkloadIdentifier string
 	WorkloadType       WorkloadType
+
+	// InterpolatedWorkloadIdentifier is the WorkloadIdentifier, interpolated by
+	// the client. It is used only to provide an override for the identity
+	// claims
+	InterpolatedWorkloadIdentifier string
 }
 
 func (w *WIHandle) Equal(o WIHandle) bool {
 	if w == nil {
 		return false
 	}
+	// note: we're intentionally ignoring InterpolatedWorkloadIdentifier here
 	return w.IdentityName == o.IdentityName &&
 		w.WorkloadIdentifier == o.WorkloadIdentifier &&
 		w.WorkloadType == o.WorkloadType


### PR DESCRIPTION
Services can have some of their string fields interpolated. The new Workload Identity flow doesn't interpolate the services before requesting signed identities or using those identities to get Consul tokens.

Add support for interpolation to the WID manager and the Consul tokens hook by providing both with a taskenv builder. Add an "interpolate workload" field to the WI handle to allow passing the original workload name to the server so the server can find the correct service to sign.

This changeset also makes two related test improvements:
* Remove the mock WID manager, which was only used in the Consul hook tests and isn't necessary so long as we provide the real WID manager with the mock signer and never call `Run` on it. It wasn't feasible to exercise the correct behavior without this refactor, as the mocks were bypassing the new code.
* Fixed swapped expect-vs-actual assertions on the `consul_hook` tests.

Fixes: https://github.com/hashicorp/nomad/issues/20025


---

Smoke tested with the following jobspec:

<details><summary>jobspec</summary>

```hcl
job "example" {

  group "web" {

    network {
      mode = "bridge"
      port "metrics" {
        to = 9000
      }
      port "www" {
        to = 8001
      }
    }

    service {
      name = "${NOMAD_GROUP_NAME}"
      port = "metrics"
    }

    task "http" {

      driver = "docker"

      service {
        name = "${NOMAD_TASK_NAME}"
        port = "www"
      }

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}
```

</details>

![success](https://github.com/hashicorp/nomad/assets/1409219/4c77ea93-3d37-4414-8004-6cd996680bb4)

