### PR TITLE
fix exhausted node metrics reporting in preemption

### DIFF
--- a/.changelog/20346.txt
+++ b/.changelog/20346.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+scheduler: Record exhausted node metrics for devices when preemption fails to find an allocation to evict
+```

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -444,6 +444,7 @@ OUTER:
 
 					if devicePreemptions == nil {
 						iter.ctx.Logger().Named("binpack").Debug("preemption not possible", "requested_device", req)
+						iter.ctx.Metrics().ExhaustedNode(option.Node, fmt.Sprintf("devices: %s", err))
 						netIdx.Release()
 						continue OUTER
 					}
@@ -460,6 +461,7 @@ OUTER:
 					offer, sumAffinities, err = devAllocator.AssignDevice(req)
 					if offer == nil {
 						iter.ctx.Logger().Named("binpack").Debug("unexpected error, unable to create device offer after considering preemption", "error", err)
+						iter.ctx.Metrics().ExhaustedNode(option.Node, fmt.Sprintf("devices: %s", err))
 						continue OUTER
 					}
 				}


### PR DESCRIPTION
If preemption is enabled, Nomad doesn't report back the `devices: no devices match request` when it does not find an allocation to evict. 

This allows admins to check why allocations are not being placed when preemption is configured in Nomad.
