### PR TITLE
deployment watcher: fix goroutine leak when job is purged

### DIFF
--- a/.changelog/20348.txt
+++ b/.changelog/20348.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+deployments: Fixed a goroutine leak when jobs are purged
+```


### PR DESCRIPTION
The deployment watcher on the leader makes blocking queries to detect when the set of active deployments changes. It takes the resulting list of deployments and adds or removes watchers based on whether the deployment is active. But when a job is purged, the deployment will be deleted. This unblocks the query but the query result only shows the remaining deployments.

When the query unblocks, ensure that all active watchers have a corresponding deployment in state. If not, remove the watcher so that the goroutine stops.

Fixes: https://github.com/hashicorp/nomad/issues/19988