### PR TITLE
modifyIndex-based pagination

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -220,12 +220,6 @@ export default class JobAdapter extends WatchableNamespaceIDs {
 
     const signal = get(options, 'adapterOptions.abortController.signal');
 
-    // when GETting our jobs list, we want to sort in reverse order, because
-    // the sort property is ModifyIndex and we want the most recent jobs first.
-    if (method === 'GET') {
-      query.reverse = true;
-    }
-
     return this.ajax(url, method, {
       signal,
       data: query,

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -148,7 +148,7 @@ export default class JobsIndexController extends Controller {
       let prevPageToken = await this.loadPreviousPageToken();
       // If there's no nextToken, we're at the "start" of our list and can drop the cursorAt
       if (!prevPageToken.meta.nextToken) {
-        this.cursorAt = null;
+        this.cursorAt = undefined;
       } else {
         // cursorAt should be the highest modifyIndex from the previous query.
         // This will immediately fire the route model hook with the new cursorAt
@@ -162,7 +162,7 @@ export default class JobsIndexController extends Controller {
       }
       this.cursorAt = this.nextToken;
     } else if (page === 'first') {
-      this.cursorAt = null;
+      this.cursorAt = undefined;
     } else if (page === 'last') {
       let prevPageToken = await this.loadPreviousPageToken(true);
       this.cursorAt = prevPageToken
@@ -248,7 +248,7 @@ export default class JobsIndexController extends Controller {
   async loadPreviousPageToken(last = false) {
     let next_token = +this.cursorAt + 1;
     if (last) {
-      next_token = null;
+      next_token = undefined;
     }
     let prevPageToken = await this.store.query(
       'job',

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -91,7 +91,6 @@ export default class JobsIndexController extends Controller {
       'name',
       this.system.shouldShowNamespaces ? 'namespace' : null,
       'status',
-      'modify index',
       'type',
       this.system.shouldShowNodepools ? 'node pool' : null, // TODO: implement on system service
       'priority',
@@ -164,7 +163,7 @@ export default class JobsIndexController extends Controller {
     } else if (page === 'first') {
       this.cursorAt = undefined;
     } else if (page === 'last') {
-      let prevPageToken = await this.loadPreviousPageToken(true);
+      let prevPageToken = await this.loadPreviousPageToken({ last: true });
       this.cursorAt = prevPageToken
         .sortBy('modifyIndex')
         .get('lastObject').modifyIndex;
@@ -245,7 +244,7 @@ export default class JobsIndexController extends Controller {
   // Ask for the previous #page_size jobs, starting at the first job that's currently shown
   // on our page, and the last one in our list should be the one we use for our
   // subsequent nextToken.
-  async loadPreviousPageToken(last = false) {
+  async loadPreviousPageToken({ last = false } = {}) {
     let next_token = +this.cursorAt + 1;
     if (last) {
       next_token = undefined;

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -91,6 +91,7 @@ export default class JobsIndexController extends Controller {
       'name',
       this.system.shouldShowNamespaces ? 'namespace' : null,
       'status',
+      'modify index',
       'type',
       this.system.shouldShowNodepools ? 'node pool' : null, // TODO: implement on system service
       'priority',

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -33,7 +33,6 @@ export default class JobsIndexController extends Controller {
     super(...arguments);
     this.pageSize = this.userSettings.pageSize;
   }
-  reverse = false;
 
   queryParams = [
     'cursorAt',
@@ -146,21 +145,28 @@ export default class JobsIndexController extends Controller {
       // overwrite this controller's jobIDs, leverage its index, and
       // restart a blocking watchJobIDs here.
       let prevPageToken = await this.loadPreviousPageToken();
-      if (prevPageToken.length > 1) {
-        // if there's only one result, it'd be the job you passed into it as your nextToken (and the first shown on your current page)
-        const [id, namespace] = JSON.parse(prevPageToken.lastObject.id);
-        // If there's no nextToken, we're at the "start" of our list and can drop the cursorAt
-        if (!prevPageToken.meta.nextToken) {
-          this.cursorAt = null;
-        } else {
-          this.cursorAt = `${namespace}.${id}`;
-        }
+      // If there's no nextToken, we're at the "start" of our list and can drop the cursorAt
+      if (!prevPageToken.meta.nextToken) {
+        this.cursorAt = null;
+      } else {
+        // cursorAt should be the highest modifyIndex from the previous query.
+        // This will immediately fire the route model hook with the new cursorAt
+        this.cursorAt = prevPageToken
+          .sortBy('modifyIndex')
+          .get('lastObject').modifyIndex;
       }
     } else if (page === 'next') {
       if (!this.nextToken) {
         return;
       }
       this.cursorAt = this.nextToken;
+    } else if (page === 'first') {
+      this.cursorAt = null;
+    } else if (page === 'last') {
+      let prevPageToken = await this.loadPreviousPageToken(true);
+      this.cursorAt = prevPageToken
+        .sortBy('modifyIndex')
+        .get('lastObject').modifyIndex;
     }
   }
 
@@ -235,13 +241,19 @@ export default class JobsIndexController extends Controller {
       });
   }
 
-  async loadPreviousPageToken() {
+  // Ask for the previous #page_size jobs, starting at the first job that's currently shown
+  // on our page, and the last one in our list should be the one we use for our
+  // subsequent nextToken.
+  async loadPreviousPageToken(last = false) {
+    let next_token = +this.cursorAt + 1;
+    if (last) {
+      next_token = null;
+    }
     let prevPageToken = await this.store.query(
       'job',
       {
-        prev_page_query: true, // TODO: debugging only!
-        next_token: this.cursorAt,
-        per_page: this.pageSize + 1,
+        next_token,
+        per_page: this.pageSize,
         reverse: true,
       },
       {

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -288,6 +288,7 @@
             {{on "click" (action this.gotoJob B.data)}}
             class="job-row is-interactive {{if B.data.assumeGC "assume-gc"}}"
             data-test-job-row={{B.data.plainId}}
+            data-test-modify-index={{B.data.modifyIndex}}
           >
             {{!-- {{#each this.tableColumns as |column|}}
               <B.Td>{{get B.data (lowercase column.label)}}</B.Td>
@@ -319,9 +320,6 @@
               {{#unless B.data.childStatuses}}
                 <Hds::Badge @text="{{capitalize B.data.aggregateAllocStatus.label}}" @color={{B.data.aggregateAllocStatus.state}} @size="large" />
               {{/unless}}
-            </B.Td>
-            <B.Td data-test-job-modify-index>
-               {{B.data.modifyIndex}}
             </B.Td>
             <B.Td data-test-job-type>
               {{B.data.type}}
@@ -375,6 +373,7 @@
               @icon="chevrons-left"
               @iconPosition="leading"
               disabled={{not this.cursorAt}}
+              data-test-pager="first"
               {{on "click" (action this.handlePageChange "first")}}
             />
           </span>
@@ -390,6 +389,7 @@
               @icon="chevron-left"
               @iconPosition="leading"
               disabled={{not this.cursorAt}}
+              data-test-pager="previous"
               {{on "click" (action this.handlePageChange "prev")}}
             />
           </span>
@@ -405,6 +405,7 @@
               @icon="chevron-right"
               @iconPosition="trailing"
               disabled={{not this.nextToken}}
+              data-test-pager="next"
               {{on "click" (action this.handlePageChange "next")}}
             />
           </span>
@@ -420,6 +421,7 @@
               @iconPosition="trailing"
               @size="small"
               disabled={{not this.nextToken}}
+              data-test-pager="last"
               {{on "click" (action this.handlePageChange "last")}}
             />
           </span>
@@ -428,16 +430,6 @@
           <PageSizeSelect @onChange={{this.handlePageSizeChange}} />
         </div>
       </section>
-      {{!-- <Hds::Pagination::Compact
-        @onPageChange={{action this.handlePageChange}}
-        @isDisabledPrev={{not this.cursorAt}}
-        @isDisabledNext={{not this.nextToken}}
-        @sizeSelectorLabel="Per page"
-        @showSizeSelector={{true}}
-        @onPageSizeChange={{this.handlePageSizeChange}}
-        @pageSizes={{array 10 25 50}}
-        @currentPageSize={{this.pageSize}}
-      /> --}}
     {{else}}
       <Hds::ApplicationState data-test-empty-jobs-list as |A|>
         {{!-- TODO: differentiate between "empty because there's nothing" and "empty because you have filtered/searched" --}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -264,6 +264,7 @@
               @color="primary"
               @icon="sync"
               {{on "click" (perform this.updateJobList)}}
+              data-test-updates-pending-button
             />
           {{/if}}
         </Hds::ButtonSet>

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -301,7 +301,7 @@
                 @model={{B.data.idWithNamespace}}
                 class="is-primary"
               >
-                {{B.data.name}} ({{B.data.modifyIndex}})
+                {{B.data.name}}
                 {{!-- TODO: going to lose .meta with statuses endpoint! --}}
                 {{#if B.data.meta.structured.pack}}
                   <span data-test-pack-tag class="tag is-pack">
@@ -319,6 +319,9 @@
               {{#unless B.data.childStatuses}}
                 <Hds::Badge @text="{{capitalize B.data.aggregateAllocStatus.label}}" @color={{B.data.aggregateAllocStatus.state}} @size="large" />
               {{/unless}}
+            </B.Td>
+            <B.Td data-test-job-modify-index>
+               {{B.data.modifyIndex}}
             </B.Td>
             <B.Td data-test-job-type>
               {{B.data.type}}
@@ -367,7 +370,10 @@
           >
             <Hds::Button
               @text="First"
-              @color="secondary"
+              @color="tertiary"
+              @size="small"
+              @icon="chevrons-left"
+              @iconPosition="leading"
               disabled={{not this.cursorAt}}
               {{on "click" (action this.handlePageChange "first")}}
             />
@@ -378,8 +384,11 @@
             action=(action this.handlePageChange "prev")}}
           >
             <Hds::Button
-              @text="Prev"
-              @color="secondary"
+              @text="Previous"
+              @color="tertiary"
+              @size="small"
+              @icon="chevron-left"
+              @iconPosition="leading"
               disabled={{not this.cursorAt}}
               {{on "click" (action this.handlePageChange "prev")}}
             />
@@ -391,7 +400,10 @@
           >
             <Hds::Button
               @text="Next"
-              @color="secondary"
+              @color="tertiary"
+              @size="small"
+              @icon="chevron-right"
+              @iconPosition="trailing"
               disabled={{not this.nextToken}}
               {{on "click" (action this.handlePageChange "next")}}
             />
@@ -403,7 +415,10 @@
           >
             <Hds::Button
               @text="Last"
-              @color="secondary"
+              @color="tertiary"
+              @icon="chevrons-right"
+              @iconPosition="trailing"
+              @size="small"
               disabled={{not this.nextToken}}
               {{on "click" (action this.handlePageChange "last")}}
             />

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -301,7 +301,7 @@
                 @model={{B.data.idWithNamespace}}
                 class="is-primary"
               >
-                {{B.data.name}}
+                {{B.data.name}} ({{B.data.modifyIndex}})
                 {{!-- TODO: going to lose .meta with statuses endpoint! --}}
                 {{#if B.data.meta.structured.pack}}
                   <span data-test-pack-tag class="tag is-pack">
@@ -361,6 +361,18 @@
       <section id="jobs-list-pagination">
         <div class="nav-buttons">
           <span {{keyboard-shortcut
+            label="First Page"
+            pattern=(array "{" "{")
+            action=(action this.handlePageChange "first")}}
+          >
+            <Hds::Button
+              @text="First"
+              @color="secondary"
+              disabled={{not this.cursorAt}}
+              {{on "click" (action this.handlePageChange "first")}}
+            />
+          </span>
+          <span {{keyboard-shortcut
             label="Previous Page"
             pattern=(array "[" "[")
             action=(action this.handlePageChange "prev")}}
@@ -382,6 +394,18 @@
               @color="secondary"
               disabled={{not this.nextToken}}
               {{on "click" (action this.handlePageChange "next")}}
+            />
+          </span>
+          <span {{keyboard-shortcut
+            label="Last Page"
+            pattern=(array "}" "}")
+            action=(action this.handlePageChange "last")}}
+          >
+            <Hds::Button
+              @text="Last"
+              @color="secondary"
+              disabled={{not this.nextToken}}
+              {{on "click" (action this.handlePageChange "last")}}
             />
           </span>
         </div>

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function (environment) {
 
     APP: {
       blockingQueries: true,
-      mirageScenario: 'smallCluster',
+      mirageScenario: 'jobsIndexTestCluster', //TODO: 'smallCluster',
       mirageWithNamespaces: true,
       mirageWithTokens: true,
       mirageWithRegions: true,

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function (environment) {
 
     APP: {
       blockingQueries: true,
-      mirageScenario: 'jobsIndexTestCluster', //TODO: 'smallCluster',
+      mirageScenario: 'smallCluster',
       mirageWithNamespaces: true,
       mirageWithTokens: true,
       mirageWithRegions: true,

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -117,11 +117,10 @@ export default function () {
     withBlockingSupport(
       function ({ jobs }, req) {
         const namespace = req.queryParams.namespace || 'default';
-        let startAt = req.queryParams.next_token || 0;
+        let nextToken = req.queryParams.next_token || 0;
         let reverse = req.queryParams.reverse === 'true';
         const json = this.serialize(jobs.all());
         let sortedJson = json
-          .sort((a, b) => b.ID.localeCompare(a.ID))
           .sort((a, b) =>
             reverse
               ? a.ModifyIndex - b.ModifyIndex
@@ -134,9 +133,11 @@ export default function () {
               : job.NamespaceID === namespace;
           })
           .map((job) => filterKeys(job, 'TaskGroups', 'NamespaceID'));
-        if (startAt) {
+        if (nextToken) {
           sortedJson = sortedJson.filter((job) =>
-            reverse ? job.ModifyIndex >= startAt : job.ModifyIndex <= startAt
+            reverse
+              ? job.ModifyIndex >= nextToken
+              : job.ModifyIndex <= nextToken
           );
         }
         return sortedJson;

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -47,12 +47,10 @@ export default function () {
         handler = withPagination(handler, tokenProperty);
       }
 
-      let response = handler.apply(this, arguments);
-
       // Get the original response
       let { url } = request;
       url = url.replace(/index=\d+[&;]?/, '');
-      response = handler.apply(this, arguments);
+      let response = handler.apply(this, arguments);
 
       // Get and increment the appropriate index
       nomadIndices[url] || (nomadIndices[url] = 2);

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -30,7 +30,7 @@ export function filesForPath(allocFiles, filterPath) {
 export default function () {
   this.timing = 0; // delay for each request, automatically set to 0 during testing
 
-  this.logging = true; // TODO: window.location.search.includes('mirage-logging=true');
+  this.logging = window.location.search.includes('mirage-logging=true');
 
   this.namespace = 'v1';
   this.trackRequests = Ember.testing;

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -30,19 +30,29 @@ export function filesForPath(allocFiles, filterPath) {
 export default function () {
   this.timing = 0; // delay for each request, automatically set to 0 during testing
 
-  this.logging = window.location.search.includes('mirage-logging=true');
+  this.logging = true; // TODO: window.location.search.includes('mirage-logging=true');
 
   this.namespace = 'v1';
   this.trackRequests = Ember.testing;
 
   const nomadIndices = {}; // used for tracking blocking queries
   const server = this;
-  const withBlockingSupport = function (fn) {
+  const withBlockingSupport = function (
+    fn,
+    { pagination = false, tokenProperty = 'ModifyIndex' } = {}
+  ) {
     return function (schema, request) {
+      let handler = fn;
+      if (pagination) {
+        handler = withPagination(handler, tokenProperty);
+      }
+
+      let response = handler.apply(this, arguments);
+
       // Get the original response
       let { url } = request;
       url = url.replace(/index=\d+[&;]?/, '');
-      const response = fn.apply(this, arguments);
+      response = handler.apply(this, arguments);
 
       // Get and increment the appropriate index
       nomadIndices[url] || (nomadIndices[url] = 2);
@@ -55,6 +65,34 @@ export default function () {
         return response;
       }
       return new Response(200, { 'x-nomad-index': index }, response);
+    };
+  };
+
+  const withPagination = function (fn, tokenProperty = 'ModifyIndex') {
+    return function (schema, request) {
+      let response = fn.apply(this, arguments);
+      let perPage = parseInt(request.queryParams.per_page || 25);
+      let page = parseInt(request.queryParams.page || 1);
+      let totalItems = response.length;
+      let totalPages = Math.ceil(totalItems / perPage);
+      let hasMore = page < totalPages;
+
+      let paginatedItems = response.slice((page - 1) * perPage, page * perPage);
+
+      let nextToken = null;
+      if (hasMore) {
+        nextToken = response[page * perPage][tokenProperty];
+      }
+
+      if (nextToken) {
+        return new Response(
+          200,
+          { 'x-nomad-nexttoken': nextToken },
+          paginatedItems
+        );
+      } else {
+        return new Response(200, {}, paginatedItems);
+      }
     };
   };
 
@@ -76,23 +114,35 @@ export default function () {
 
   this.get(
     '/jobs/statuses',
-    withBlockingSupport(function ({ jobs }, req) {
-      let per_page = req.queryParams.per_page || 20;
-      const namespace = req.queryParams.namespace || 'default';
-
-      const json = this.serialize(jobs.all());
-      return json
-        .sort((a, b) => b.ID.localeCompare(a.ID))
-        .sort((a, b) => b.ModifyIndex - a.ModifyIndex)
-        .filter((job) => {
-          if (namespace === '*') return true;
-          return namespace === 'default'
-            ? !job.NamespaceID || job.NamespaceID === 'default'
-            : job.NamespaceID === namespace;
-        })
-        .map((job) => filterKeys(job, 'TaskGroups', 'NamespaceID'))
-        .slice(0, per_page);
-    })
+    withBlockingSupport(
+      function ({ jobs }, req) {
+        const namespace = req.queryParams.namespace || 'default';
+        let startAt = req.queryParams.next_token || 0;
+        let reverse = req.queryParams.reverse === 'true';
+        const json = this.serialize(jobs.all());
+        let sortedJson = json
+          .sort((a, b) => b.ID.localeCompare(a.ID))
+          .sort((a, b) =>
+            reverse
+              ? a.ModifyIndex - b.ModifyIndex
+              : b.ModifyIndex - a.ModifyIndex
+          )
+          .filter((job) => {
+            if (namespace === '*') return true;
+            return namespace === 'default'
+              ? !job.NamespaceID || job.NamespaceID === 'default'
+              : job.NamespaceID === namespace;
+          })
+          .map((job) => filterKeys(job, 'TaskGroups', 'NamespaceID'));
+        if (startAt) {
+          sortedJson = sortedJson.filter((job) =>
+            reverse ? job.ModifyIndex >= startAt : job.ModifyIndex <= startAt
+          );
+        }
+        return sortedJson;
+      },
+      { pagination: true, tokenProperty: 'ModifyIndex' }
+    )
   );
 
   this.post(

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -62,11 +62,16 @@ function jobsIndexTestCluster(server) {
   faker.seed(1);
   server.createList('agent', 1, 'withConsulLink', 'withVaultLink');
   server.createList('node', 1);
-  server.createList('job', 1, {
-    namespaceId: 'default',
-    resourceSpec: Array(1).fill('M: 256, C: 500'),
-    groupAllocCount: 1,
-  });
+
+  const jobsToCreate = 55;
+  for (let i = 0; i < jobsToCreate; i++) {
+    server.create('job', {
+      namespaceId: 'default',
+      resourceSpec: Array(1).fill('M: 256, C: 500'),
+      groupAllocCount: 1,
+      modifyIndex: i + 1,
+    });
+  }
 }
 
 function smallCluster(server) {

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -735,4 +735,27 @@ module('Acceptance | jobs list', function (hooks) {
   //     assert.equal(currentURL(), '/jobs/run');
   //   });
   // }
+
+  // module('Pagination', function (hooks) {
+  //   hooks.beforeEach(function () {
+  //     const jobsToCreate = 55;
+  //     for (let i = 0; i < jobsToCreate; i++) {
+  //       server.create('job', {
+  //         namespaceId: 'default',
+  //         resourceSpec: Array(1).fill('M: 256, C: 500'),
+  //         groupAllocCount: 1,
+  //         modifyIndex: i + 1,
+  //         createAllocations: false,
+  //       });
+  //     }
+  //   });
+
+  //   // module('Buttons are appropriately disabled', function () {
+  //     test('when there are no jobs', async function (assert) {
+  //       await JobsList.visit();
+  //       assert.ok(JobsList.prevPage.isDisabled, 'Prev page button is disabled');
+  //       assert.ok(JobsList.nextPage.isDisabled, 'Next page button is disabled');
+  //     });
+  //   // });
+  // });
 });

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -1016,7 +1016,7 @@ module('Acceptance | jobs list', function (hooks) {
         let updatedJob = assert.async(); // watch for this to say "My tests oughta be passing by now"
         const duelingQueryUpdateTime = 200;
 
-        assert.timeout(2000);
+        assert.timeout(500);
 
         setTimeout(async () => {
           // Order should now be 11-2
@@ -1116,7 +1116,7 @@ module('Acceptance | jobs list', function (hooks) {
         let updatedUnshownJob = assert.async(); // watch for this to say "My tests oughta be passing by now"
         const duelingQueryUpdateTime = 200;
 
-        assert.timeout(2000);
+        assert.timeout(500);
 
         setTimeout(async () => {
           // Order should still be be 10-1

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -1015,6 +1015,9 @@ module('Acceptance | jobs list', function (hooks) {
 
         let updatedJob = assert.async(); // watch for this to say "My tests oughta be passing by now"
         const duelingQueryUpdateTime = 200;
+
+        assert.timeout(2000);
+
         setTimeout(async () => {
           // Order should now be 11-2
           rows = document.querySelectorAll('.job-row');
@@ -1112,6 +1115,9 @@ module('Acceptance | jobs list', function (hooks) {
 
         let updatedUnshownJob = assert.async(); // watch for this to say "My tests oughta be passing by now"
         const duelingQueryUpdateTime = 200;
+
+        assert.timeout(2000);
+
         setTimeout(async () => {
           // Order should still be be 10-1
           rows = document.querySelectorAll('.job-row');

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -1033,7 +1033,7 @@ module('Acceptance | jobs list', function (hooks) {
             'Jobs are sorted by modify index'
           );
 
-          // Simulate one of the on-page jobs getting its modify-index bumped. It should remain in place.
+          // Simulate one of the on-page jobs getting its modify-index bumped. It should bump to the top of the list.
           let existingJobToUpdate = server.db.jobs.findBy(
             (job) => job.modifyIndex === 5
           );
@@ -1049,7 +1049,7 @@ module('Acceptance | jobs list', function (hooks) {
             assert.deepEqual(
               modifyIndexes,
               [12, 11, 10, 9, 8, 7, 6, 4, 3, 2],
-              'Jobs are sorted by modify index, on-page job remains in-place, and off-page pending'
+              'Jobs are sorted by modify index, on-page job moves up to the top, and off-page pending'
             );
             updatedOnPageJob();
 

--- a/ui/tests/pages/jobs/list.js
+++ b/ui/tests/pages/jobs/list.js
@@ -48,9 +48,6 @@ export default create({
     clickName: clickable('[data-test-job-name] a'),
   }),
 
-  nextPage: clickable('[data-test-pager="next"]'),
-  prevPage: clickable('[data-test-pager="prev"]'),
-
   isEmpty: isPresent('[data-test-empty-jobs-list]'),
   emptyState: {
     headline: text('[data-test-empty-jobs-list-headline]'),


### PR DESCRIPTION
- Adds support for the new modifyIndex-based pagination provided by the /statuses endpoint with a custom First/Prev/Next/Last pagination template on the jobs index
- Adds a new `withPagination` hook for Mirage endpoints (that builds on top of `withBlockingSupport`) that takes a customizable property to paginate upon and provide as `x-nomad-nexttoken`
