### PR TITLE
mock_driver: fix fingreprint key

### DIFF
--- a/client/driver_manager_test.go
+++ b/client/driver_manager_test.go
@@ -174,10 +174,6 @@ func TestDriverManager_NodeAttributes_Run(t *testing.T) {
 			return false, fmt.Errorf("mock_driver driver is not marked as healthy: %+v", d)
 		}
 
-		if d.Attributes["driver.mock_driver"] != "" {
-			return false, fmt.Errorf("mock driver driver attributes contain duplicate health info: %#v", d.Attributes)
-		}
-
 		// check raw_exec
 		if node.Attributes["driver.raw_exec"] == "" {
 			return false, fmt.Errorf("raw_exec is not present in attributes: %#v", node.Attributes)

--- a/drivers/mock/driver.go
+++ b/drivers/mock/driver.go
@@ -345,7 +345,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 		desc = "disabled"
 	} else {
 		health = drivers.HealthStateHealthy
-		attrs["driver.mock"] = pstructs.NewBoolAttribute(true)
+		attrs["driver.mock_driver"] = pstructs.NewBoolAttribute(true)
 		desc = drivers.DriverHealthy
 	}
 

--- a/website/content/api-docs/events.mdx
+++ b/website/content/api-docs/events.mdx
@@ -166,7 +166,6 @@ http://127.0.0.1:4646/v1/event/stream
             "driver.docker.os_type": "linux",
             "driver.docker.runtimes": "runc",
             "driver.docker.version": "19.03.13",
-            "driver.mock": "true",
             "driver.mock_driver": "1",
             "driver.raw_exec": "1",
             "kernel.name": "linux",
@@ -361,15 +360,6 @@ http://127.0.0.1:4646/v1/event/stream
               "Healthy": false,
               "HealthDescription": "Driver must run as root",
               "UpdateTime": "2020-10-15T10:07:37.445601605-04:00"
-            },
-            "mock_driver": {
-              "Attributes": {
-                "driver.mock": "true"
-              },
-              "Detected": true,
-              "Healthy": true,
-              "HealthDescription": "Healthy",
-              "UpdateTime": "2020-10-15T10:07:37.445193068-04:00"
             },
             "qemu": {
               "Attributes": null,

--- a/website/content/api-docs/nodes.mdx
+++ b/website/content/api-docs/nodes.mdx
@@ -203,7 +203,6 @@ $ curl \
     "driver.docker.runtimes": "runc",
     "driver.docker.version": "18.09.6",
     "driver.docker.volumes.enabled": "true",
-    "driver.mock": "true",
     "driver.mock_driver": "1",
     "driver.raw_exec": "1",
     "kernel.name": "linux",
@@ -256,15 +255,6 @@ $ curl \
       "HealthDescription": "Driver must run as root",
       "Healthy": false,
       "UpdateTime": "2019-08-26T12:22:50.687274359+02:00"
-    },
-    "mock_driver": {
-      "Attributes": {
-        "driver.mock": "true"
-      },
-      "Detected": true,
-      "HealthDescription": "Healthy",
-      "Healthy": true,
-      "UpdateTime": "2019-08-26T12:22:50.687978919+02:00"
     },
     "qemu": {
       "Attributes": null,


### PR DESCRIPTION
The `mock_driver` is an internal task driver used mostly for testing and simulating workloads. During the allocrunner v2 work (#4792) its name changed from `mock_driver` to just `mock` and then back to `mock_driver`, but the fingreprint key was kept as `driver.mock`.

This results in tasks configured with `driver = "mock"` to be scheduled (because Nomad thinks the client has a task driver called `mock`), but fail to actually run (because the Nomad client can't find a driver called `mock` in its catalog).

Fingerprinting the right name prevents the job from being scheduled in the first place.

Also removes mentions of the mock driver from documentation since its an internal driver and not available in any production release.

No changelog since this is an internal change.