### PR TITLE
docs: clarify "best effort" for ephemeral disk migration

### DIFF
--- a/website/content/docs/job-specification/ephemeral_disk.mdx
+++ b/website/content/docs/job-specification/ephemeral_disk.mdx
@@ -39,11 +39,17 @@ documentation][] for more information.
   best-effort attempt to migrate the data from the previous allocation, even if
   the previous allocation was on another client. Enabling `migrate`
   automatically enables `sticky` as well. During data migration, the task will
-  block starting until the data migration has completed. Migration is atomic and
-  any partially migrated data will be removed if an error is encountered. Note
-  that data migration will not take place if a client garbage collects a failed
-  allocation or if the allocation has been intentionally stopped via `nomad
-  alloc stop`, because the original allocation has already been removed.
+  block starting until the data migration has completed.
+
+  Successful migration requires that the clients can reach each other directly
+  over the Nomad HTTP port. Any failure of the transfer will result in data
+  loss, so this feature is only suitable for data that can be recreated at the
+  destination (for example, cache data). Migration is atomic and any partially
+  migrated data will be removed from the destination if an error is
+  encountered. Note that data migration will not take place if a client garbage
+  collects a failed allocation or if the allocation has been intentionally
+  stopped via `nomad alloc stop`, because the original allocation has already
+  been removed.
 
 - `size` `(int: 300)` - Specifies the size of the ephemeral disk in MB. The
   current Nomad ephemeral storage implementation does not enforce this limit;


### PR DESCRIPTION
The docs for ephemeral disk migration use the term "best effort" without outlining the requirements or the cases under which the migration can fail. Update the docs to make it obvious that ephemeral disk migration is subject to data loss.

Fixes: https://github.com/hashicorp/nomad/issues/20355
Preview link: https://nomad-nsel0s9mv-hashicorp.vercel.app/nomad/docs/job-specification/ephemeral_disk#migrate