### PR TITLE
tests: fix broken test in deploymentwatcher backport

### DIFF
--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -2011,7 +2011,7 @@ func TestWatcher_PurgeDeployment(t *testing.T) {
 	j := mock.Job()
 	d := mock.Deployment()
 	d.JobID = j.ID
-	must.NoError(t, m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j))
+	must.NoError(t, m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), j))
 	must.NoError(t, m.state.UpsertDeployment(m.nextIndex(), d))
 
 	// require that we get a call to UpsertDeploymentStatusUpdate


### PR DESCRIPTION
The test added in #20348 for the deployment watcher was backported to 1.5.x but is hitting a compilation error because the signature of a state store method was changed.