### PR TITLE
E2E: clean up go mod cache after building `consul-cni`

### DIFF
--- a/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
@@ -82,6 +82,8 @@ sudo chown root:root /opt/cni/bin/consul-cni
 sudo chmod +x /opt/cni/bin/consul-cni
 popd
 popd
+# save us a bunch of disk space
+/usr/local/go/bin/go clean -cache -modcache
 
 # Note: neither service will start on boot because we haven't enabled
 # the systemd unit file and we haven't uploaded any configuration


### PR DESCRIPTION
In #20296 we added a Go tool chain to the AMI we use for E2E tests, so that we can build `consul-cni` for tproxy testing. This is intended to be temporary until `consul-k8s` 1.4.2 is officially released. But the Go cache from building `consul-k8s` uses up roughly 1.5GiB of space and the test machines have fairly small disks. This causes the Nomad clients to aggressively GC client allocations that stop, which breaks tests that run batch workloads and then read their logs.