### PR TITLE
CNI: fix bugs in parsing strings to port number integers

### DIFF
--- a/client/allocrunner/networking_cni.go
+++ b/client/allocrunner/networking_cni.go
@@ -220,7 +220,7 @@ func (c *cniNetworkConfigurator) setupTransparentProxyArgs(alloc *structs.Alloca
 				proxyOutboundPort = int(tproxy.OutboundPort)
 			} else {
 				outboundPortAttr := c.nodeMeta[envoy.DefaultTransparentProxyOutboundPortParam]
-				parsedOutboundPort, err := strconv.ParseInt(outboundPortAttr, 10, 32)
+				parsedOutboundPort, err := strconv.ParseUint(outboundPortAttr, 10, 16)
 				if err != nil {
 					return nil, fmt.Errorf(
 						"could not parse default_outbound_port %q as port number: %w",
@@ -257,7 +257,7 @@ func (c *cniNetworkConfigurator) setupTransparentProxyArgs(alloc *structs.Alloca
 			// ExcludeInboundPorts can be either a numeric port number or a port
 			// label that we need to convert into a port number
 			for _, portLabel := range tproxy.ExcludeInboundPorts {
-				if _, err := strconv.ParseUint(portLabel, 10, 64); err == nil {
+				if _, err := strconv.ParseUint(portLabel, 10, 16); err == nil {
 					exposePortSet.Insert(portLabel)
 					continue
 				}
@@ -348,7 +348,7 @@ func (c *cniNetworkConfigurator) dnsFromAttrs(cluster string) (string, int) {
 	if !ok || dnsPort == "0" || dnsPort == "-1" {
 		return "", 0
 	}
-	port, err := strconv.ParseInt(dnsPort, 10, 64)
+	port, err := strconv.ParseUint(dnsPort, 10, 16)
 	if err != nil {
 		return "", 0 // note: this will have been checked in fingerprint
 	}

--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -615,7 +615,7 @@ func groupConnectUpstreamsValidate(g *structs.TaskGroup, services []*structs.Ser
 }
 
 func transparentProxyPortLabelValidate(g *structs.TaskGroup, portLabel string) bool {
-	if _, err := strconv.ParseUint(portLabel, 10, 64); err == nil {
+	if _, err := strconv.ParseUint(portLabel, 10, 16); err == nil {
 		return true
 	}
 


### PR DESCRIPTION
Ports are a maximum of uint16, but we have a few places in the recent tproxy code where we were parsing them as 64-bit wide integers and then downcasting them to `int`, which is technically unsafe and triggers code scanning alerts. In practice we've validated the range elsewhere and don't build for 32-bit platforms. This changeset fixes the parsing to make everything a bit more robust and silence the alert.

Fixes: https://github.com/hashicorp/nomad-enterprise/security/code-scanning/444