### PR TITLE
[ui] don't assume that an allocation has a task events array when checking if it hasBeenRestarted

### DIFF
--- a/.changelog/20383.txt
+++ b/.changelog/20383.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix an issue where the job status box would error if an allocation had no task events
+```

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -81,9 +81,9 @@ export default class Allocation extends Model {
 
   get hasBeenRestarted() {
     return this.states
-      .map((s) => s.events.content)
+      .map((s) => s.events?.content)
       .flat()
-      .find((e) => e.type === 'Restarting');
+      .find((e) => e?.type === 'Restarting');
   }
 
   @attr healthChecks;


### PR DESCRIPTION
the hasBeenRestarted allocation property checks against its task events, which can sometimes be null

This can result on a job-index-page error when calculating the `filteredAllocations` to show (we don't show those allocations as "failed" that have been restarted/rescheduled if other more recent ones exist, up to a job's desired count)


(The `?.` is a defensive pattern that fails truthiness checks when the object in question doesn't exist, so `s.events?.content` will return `null` instead of erroring)