### PR TITLE
systemd: comment on OOMScoreAdjust in service unit

### DIFF
--- a/.release/linux/package/usr/lib/systemd/system/nomad.service
+++ b/.release/linux/package/usr/lib/systemd/system/nomad.service
@@ -37,6 +37,12 @@ Restart=on-failure
 RestartSec=2
 
 TasksMax=infinity
+
+# Nomad Server agents should never be force killed,
+# so here we disable OOM (out of memory) killing for this unit.
+# However, you may wish to change this for Client agents, since
+# the workloads that Nomad places may be more important
+# than the Nomad agent itself.
 OOMScoreAdjust=-1000
 
 [Install]


### PR DESCRIPTION
We were asked about this specifically due to client agents not getting OOM killed, so this comment adds some context on why this is set, and when/why you might want to change it.

related: #6672

cc: @davemay99 