### PR TITLE
[ui] Fix a bug where promotion would be asked with no new canaries

### DIFF
--- a/.changelog/20408.txt
+++ b/.changelog/20408.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix a bug where the UI would prompt a user to promote a deployment with unplaced canaries
+```

--- a/ui/app/components/job-status/panel/deploying.js
+++ b/ui/app/components/job-status/panel/deploying.js
@@ -42,8 +42,9 @@ export default class JobStatusPanelDeployingComponent extends Component {
     const relevantAllocs = this.job.allocations.filter(
       (a) => !a.isOld && a.isCanary && !a.hasBeenRescheduled
     );
-    return relevantAllocs.every(
-      (a) => a.clientStatus === 'running' && a.isHealthy
+    return (
+      relevantAllocs.length &&
+      relevantAllocs.every((a) => a.clientStatus === 'running' && a.isHealthy)
     );
   }
 

--- a/ui/tests/integration/components/job-page/service-test.js
+++ b/ui/tests/integration/components/job-page/service-test.js
@@ -227,11 +227,25 @@ module('Integration | Component | job-page/service', function (hooks) {
     this.server.create('node');
     const mirageJob = makeMirageJob(this.server, { activeDeployment: true });
 
-    await this.store.findAll('job');
+    const fullId = JSON.stringify([mirageJob.name, 'default']);
+    await this.store.findRecord('job', fullId);
 
     const job = this.store.peekAll('job').findBy('plainId', mirageJob.id);
+    this.server.db.jobs.update(mirageJob.id, {
+      activeDeployment: true,
+      noDeployments: true,
+    });
     const deployment = await job.get('latestDeployment');
 
+    server.create('allocation', {
+      jobId: mirageJob.id,
+      deploymentId: deployment.id,
+      clientStatus: 'running',
+      deploymentStatus: {
+        Healthy: true,
+        Canary: true,
+      },
+    });
     this.setProperties(commonProperties(job));
     await render(commonTemplate);
 
@@ -259,9 +273,25 @@ module('Integration | Component | job-page/service', function (hooks) {
     this.server.create('node');
     const mirageJob = makeMirageJob(this.server, { activeDeployment: true });
 
-    await this.store.findAll('job');
+    const fullId = JSON.stringify([mirageJob.name, 'default']);
+    await this.store.findRecord('job', fullId);
 
     const job = this.store.peekAll('job').findBy('plainId', mirageJob.id);
+    this.server.db.jobs.update(mirageJob.id, {
+      activeDeployment: true,
+      noDeployments: true,
+    });
+    const deployment = await job.get('latestDeployment');
+
+    server.create('allocation', {
+      jobId: mirageJob.id,
+      deploymentId: deployment.id,
+      clientStatus: 'running',
+      deploymentStatus: {
+        Healthy: true,
+        Canary: true,
+      },
+    });
 
     this.setProperties(commonProperties(job));
     await render(commonTemplate);


### PR DESCRIPTION
The "Are all your canaries healthy?" part of the "should we prompt the user to manually promote their deployment" depended on an `array.every` check without a condition that the array have some members.

This meant that, as shown in #20308, a user can run into a situation where a new canary allocation fails to place, but the system insists that "there are no unhealthy canaries!" so it's manual promotion time.

This checks for at least one new-version allocation with canary status that hasn't been rescheduled before flipping `canariesHealthy` to true. If there are none, the user will continue to be met with a "Your deployment's canaries are still being health checked" pending status.