### PR TITLE
state: enable more reverse sorting

### DIFF
--- a/helper/raftutil/fsm.go
+++ b/helper/raftutil/fsm.go
@@ -206,7 +206,7 @@ func StateAsMap(store *state.StateStore) map[string][]interface{} {
 		"Indexes":          toArray(store.Indexes()),
 		"JobSummaries":     toArray(store.JobSummaries(nil)),
 		"JobVersions":      toArray(store.JobVersions(nil)),
-		"Jobs":             toArray(store.Jobs(nil)),
+		"Jobs":             toArray(store.Jobs(nil, state.SortDefault)),
 		"Nodes":            toArray(store.Nodes(nil)),
 		"PeriodicLaunches": toArray(store.PeriodicLaunches(nil)),
 		"SITokenAccessors": toArray(store.SITokenAccessors(nil)),

--- a/helper/raftutil/sample_test.go
+++ b/helper/raftutil/sample_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler"
 	"github.com/kr/pretty"
@@ -24,7 +25,6 @@ func TestSampleInvariant(t *testing.T) {
 	fsm, err := NewFSM(path)
 	require.NoError(t, err)
 
-	state := fsm.State()
 	for {
 		idx, _, err := fsm.ApplyNext()
 		if err == ErrNoMoreLogs {
@@ -35,7 +35,7 @@ func TestSampleInvariant(t *testing.T) {
 		// Test invariant for each entry
 
 		// For example, test job summary numbers against running jobs
-		summary, err := state.JobSummaryByID(nil, ns, parentID)
+		summary, err := fsm.State().JobSummaryByID(nil, ns, parentID)
 		require.NoError(t, err)
 
 		if summary == nil {
@@ -46,7 +46,7 @@ func TestSampleInvariant(t *testing.T) {
 		summaryCount := summary.Children.Running + summary.Children.Pending + summary.Children.Dead
 		jobCountByParent := 0
 
-		iter, err := state.Jobs(nil)
+		iter, err := fsm.State().Jobs(nil, state.SortDefault)
 		require.NoError(t, err)
 		for {
 			rawJob := iter.Next()

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1970,7 +1970,7 @@ func (n *nomadFSM) failLeakedDeployments(store *state.StateStore) error {
 func (n *nomadFSM) reconcileQueuedAllocations(index uint64) error {
 	// Get all the jobs
 	ws := memdb.NewWatchSet()
-	iter, err := n.state.Jobs(ws)
+	iter, err := n.state.Jobs(ws, state.SortDefault)
 	if err != nil {
 		return err
 	}
@@ -2531,7 +2531,7 @@ func (s *nomadSnapshot) persistJobs(sink raft.SnapshotSink,
 	encoder *codec.Encoder) error {
 	// Get all the jobs
 	ws := memdb.NewWatchSet()
-	jobs, err := s.snap.Jobs(ws)
+	jobs, err := s.snap.Jobs(ws, state.SortDefault)
 	if err != nil {
 		return err
 	}

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1432,6 +1432,8 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 	}
 	allow := aclObj.AllowNsOpFunc(acl.NamespaceCapabilityListJobs)
 
+	sort := state.QueryOptionSort(args.QueryOptions)
+
 	// Setup the blocking query
 	opts := blockingOptions{
 		queryOpts: &args.QueryOptions,
@@ -1451,11 +1453,11 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 				return err
 			} else {
 				if prefix := args.QueryOptions.Prefix; prefix != "" {
-					iter, err = state.JobsByIDPrefix(ws, namespace, prefix)
+					iter, err = state.JobsByIDPrefix(ws, namespace, prefix, sort)
 				} else if namespace != structs.AllNamespacesSentinel {
-					iter, err = state.JobsByNamespace(ws, namespace)
+					iter, err = state.JobsByNamespace(ws, namespace, sort)
 				} else {
-					iter, err = state.Jobs(ws)
+					iter, err = state.Jobs(ws, sort)
 				}
 				if err != nil {
 					return err
@@ -2063,7 +2065,7 @@ func (j *Job) Dispatch(args *structs.JobDispatchRequest, reply *structs.JobDispa
 	// Avoid creating new dispatched jobs for retry requests, by using the idempotency token
 	if args.IdempotencyToken != "" {
 		// Fetch all jobs that match the parameterized job ID prefix
-		iter, err := snap.JobsByIDPrefix(ws, parameterizedJob.Namespace, parameterizedJob.ID)
+		iter, err := snap.JobsByIDPrefix(ws, parameterizedJob.Namespace, parameterizedJob.ID, state.SortDefault)
 		if err != nil {
 			errMsg := "failed to retrieve jobs for idempotency check"
 			j.logger.Error(errMsg, "error", err)

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -1438,13 +1438,13 @@ func (s *Server) publishJobStatusMetrics(stopCh chan struct{}) {
 			return
 		case <-timer.C:
 			timer.Reset(s.config.StatsCollectionInterval)
-			state, err := s.State().Snapshot()
+			snap, err := s.State().Snapshot()
 			if err != nil {
 				s.logger.Error("failed to get state", "error", err)
 				continue
 			}
 			ws := memdb.NewWatchSet()
-			iter, err := state.Jobs(ws)
+			iter, err := snap.Jobs(ws, state.SortDefault)
 			if err != nil {
 				s.logger.Error("failed to get job statuses", "error", err)
 				continue

--- a/nomad/namespace_endpoint.go
+++ b/nomad/namespace_endpoint.go
@@ -182,7 +182,7 @@ func (n *Namespace) namespaceTerminalLocally(namespace string) (bool, error) {
 		return false, err
 	}
 
-	iter, err := snap.JobsByNamespace(nil, namespace)
+	iter, err := snap.JobsByNamespace(nil, namespace, state.SortDefault)
 	if err != nil {
 		return false, err
 	}

--- a/nomad/node_pool_endpoint.go
+++ b/nomad/node_pool_endpoint.go
@@ -412,6 +412,7 @@ func (n *NodePool) ListJobs(args *structs.NodePoolJobsRequest, reply *structs.No
 	}
 	allowNsFunc := aclObj.AllowNsOpFunc(acl.NamespaceCapabilityListJobs)
 	namespace := args.RequestNamespace()
+	sort := state.QueryOptionSort(args.QueryOptions)
 
 	// Setup the blocking query. This largely mirrors the Jobs.List RPC but with
 	// an additional paginator filter for the node pool.
@@ -449,7 +450,7 @@ func (n *NodePool) ListJobs(args *structs.NodePoolJobsRequest, reply *structs.No
 				if namespace == structs.AllNamespacesSentinel {
 					iter, err = store.JobsByPool(ws, args.Name)
 				} else {
-					iter, err = store.JobsByNamespace(ws, namespace)
+					iter, err = store.JobsByNamespace(ws, namespace, sort)
 					filters = append(filters,
 						paginator.GenericFilter{
 							Allow: func(raw interface{}) (bool, error) {

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -20,6 +20,7 @@ import (
 
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper/snapshot"
+	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -810,11 +811,10 @@ func (op *Operator) UpgradeCheckVaultWorkloadIdentity(
 		return structs.ErrPermissionDenied
 	}
 
-	state := op.srv.fsm.State()
 	ws := memdb.NewWatchSet()
 
 	// Check for jobs that use Vault but don't have an identity for Vault.
-	jobsIter, err := state.Jobs(ws)
+	jobsIter, err := op.srv.State().Jobs(ws, state.SortDefault)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve jobs: %w", err)
 	}
@@ -847,7 +847,7 @@ func (op *Operator) UpgradeCheckVaultWorkloadIdentity(
 	reply.JobsWithoutVaultIdentity = jobs
 
 	// Find nodes that don't support workload identities for Vault.
-	nodesIter, err := state.Nodes(ws)
+	nodesIter, err := op.srv.State().Nodes(ws)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve nodes: %w", err)
 	}
@@ -865,7 +865,7 @@ func (op *Operator) UpgradeCheckVaultWorkloadIdentity(
 	reply.OutdatedNodes = nodes
 
 	// Retrieve Vault tokens that were created by Nomad servers.
-	vaultTokensIter, err := state.VaultAccessors(ws)
+	vaultTokensIter, err := op.srv.State().VaultAccessors(ws)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve Vault token accessors: %w", err)
 	}

--- a/nomad/search_endpoint.go
+++ b/nomad/search_endpoint.go
@@ -381,7 +381,7 @@ func sortSet(matches []fuzzyMatch) {
 func getResourceIter(context structs.Context, aclObj *acl.ACL, namespace, prefix string, ws memdb.WatchSet, store *state.StateStore) (memdb.ResultIterator, error) {
 	switch context {
 	case structs.Jobs:
-		return store.JobsByIDPrefix(ws, namespace, prefix)
+		return store.JobsByIDPrefix(ws, namespace, prefix, state.SortDefault)
 	case structs.Evals:
 		return store.EvalsByIDPrefix(ws, namespace, prefix, state.SortDefault)
 	case structs.Allocs:
@@ -439,10 +439,10 @@ func getFuzzyResourceIterator(context structs.Context, aclObj *acl.ACL, namespac
 	switch context {
 	case structs.Jobs:
 		if wildcard(namespace) {
-			iter, err := store.Jobs(ws)
+			iter, err := store.Jobs(ws, state.SortDefault)
 			return nsCapIterFilter(iter, err, aclObj)
 		}
-		return store.JobsByNamespace(ws, namespace)
+		return store.JobsByNamespace(ws, namespace, state.SortDefault)
 
 	case structs.Allocs:
 		if wildcard(namespace) {

--- a/nomad/state/sorting.go
+++ b/nomad/state/sorting.go
@@ -1,0 +1,43 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package state
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// SortOption represents how results can be sorted.
+type SortOption bool
+
+const (
+	// SortDefault indicates that the result should be returned using the
+	// default go-memdb ResultIterator order.
+	SortDefault SortOption = false
+
+	// SortReverse indicates that the result should be returned using the
+	// reversed go-memdb ResultIterator order.
+	SortReverse SortOption = true
+)
+
+// QueryOptionSort returns the appropriate SortOption for given QueryOptions.
+func QueryOptionSort(qo structs.QueryOptions) SortOption {
+	return SortOption(qo.Reverse)
+}
+
+// getSorted executes either txn.Get() or txn.GetReverse()
+// depending on the provided SortOption.
+func getSorted(txn *txn, sort SortOption, table, index string, args ...any) (memdb.ResultIterator, error) {
+	switch sort {
+	case SortDefault:
+		return txn.Get(table, index, args...)
+	case SortReverse:
+		return txn.GetReverse(table, index, args...)
+	default:
+		// this should never happen, since SortOption is bool
+		return nil, fmt.Errorf("unknown sort option: %v", sort)
+	}
+}

--- a/nomad/state/sorting_test.go
+++ b/nomad/state/sorting_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package state
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+func TestGetSorted(t *testing.T) {
+	store, err := NewStateStore(&StateStoreConfig{
+		JobTrackedVersions: 1,
+
+		Logger: hclog.L().Named("TestGetSorted"),
+	})
+	must.NoError(t, err)
+
+	jobs := make([]*structs.Job, 3)
+	jobs[0] = mock.Job()
+	jobs[0].ID = "ayyy"
+	jobs[1] = mock.Job()
+	jobs[1].ID = "beee"
+	jobs[2] = mock.Job()
+	jobs[2].ID = "ceee"
+
+	txn := store.db.WriteTxn(100)
+	for _, j := range jobs {
+		must.NoError(t, txn.Insert("jobs", j))
+	}
+	must.NoError(t, txn.Commit())
+
+	for _, tc := range []struct {
+		name    string
+		reverse bool
+		expect  []string
+	}{
+		// with jobs "id" index, they should be in lexicographical order by ID
+		{"default", false, []string{"ayyy", "beee", "ceee"}},
+		{"reverse", true, []string{"ceee", "beee", "ayyy"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			txn = store.db.ReadTxn()
+
+			// also tangentially test QueryOptionSort
+			sort := QueryOptionSort(structs.QueryOptions{
+				Reverse: tc.reverse,
+			})
+
+			// method under test
+			iter, err := getSorted(txn, sort, "jobs", "id")
+			must.NoError(t, err)
+
+			got := make([]string, len(jobs))
+			for x, _ := range jobs {
+				raw := iter.Next()
+				job := raw.(*structs.Job)
+				got[x] = job.ID
+			}
+
+			must.Eq(t, tc.expect, got)
+		})
+	}
+}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -29,19 +29,6 @@ import (
 // This can be a read or write transaction.
 type Txn = *txn
 
-// SortOption represents how results can be sorted.
-type SortOption bool
-
-const (
-	// SortDefault indicates that the result should be returned using the
-	// default go-memdb ResultIterator order.
-	SortDefault SortOption = false
-
-	// SortReverse indicates that the result should be returned using the
-	// reversed go-memdb ResultIterator order.
-	SortReverse SortOption = true
-)
-
 // NodeUpsertOption represents options to configure a NodeUpsert operation.
 type NodeUpsertOption uint8
 
@@ -2272,14 +2259,14 @@ func (s *StateStore) JobByIDTxn(ws memdb.WatchSet, namespace, id string, txn Txn
 
 // JobsByIDPrefix is used to lookup a job by prefix. If querying all namespaces
 // the prefix will not be filtered by an index.
-func (s *StateStore) JobsByIDPrefix(ws memdb.WatchSet, namespace, id string) (memdb.ResultIterator, error) {
+func (s *StateStore) JobsByIDPrefix(ws memdb.WatchSet, namespace, id string, sort SortOption) (memdb.ResultIterator, error) {
 	if namespace == structs.AllNamespacesSentinel {
 		return s.jobsByIDPrefixAllNamespaces(ws, id)
 	}
 
 	txn := s.db.ReadTxn()
 
-	iter, err := txn.Get("jobs", "id_prefix", namespace, id)
+	iter, err := getSorted(txn, sort, "jobs", "id_prefix", namespace, id)
 	if err != nil {
 		return nil, fmt.Errorf("job lookup failed: %v", err)
 	}
@@ -2397,11 +2384,11 @@ func (s *StateStore) JobVersions(ws memdb.WatchSet) (memdb.ResultIterator, error
 }
 
 // Jobs returns an iterator over all the jobs
-func (s *StateStore) Jobs(ws memdb.WatchSet) (memdb.ResultIterator, error) {
+func (s *StateStore) Jobs(ws memdb.WatchSet, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
 
 	// Walk the entire jobs table
-	iter, err := txn.Get("jobs", "id")
+	iter, err := getSorted(txn, sort, "jobs", "id")
 	if err != nil {
 		return nil, err
 	}
@@ -2412,15 +2399,14 @@ func (s *StateStore) Jobs(ws memdb.WatchSet) (memdb.ResultIterator, error) {
 }
 
 // JobsByNamespace returns an iterator over all the jobs for the given namespace
-func (s *StateStore) JobsByNamespace(ws memdb.WatchSet, namespace string) (memdb.ResultIterator, error) {
+func (s *StateStore) JobsByNamespace(ws memdb.WatchSet, namespace string, sort SortOption) (memdb.ResultIterator, error) {
 	txn := s.db.ReadTxn()
-	return s.jobsByNamespaceImpl(ws, namespace, txn)
+	return s.jobsByNamespaceImpl(ws, namespace, txn, sort)
 }
 
 // jobsByNamespaceImpl returns an iterator over all the jobs for the given namespace
-func (s *StateStore) jobsByNamespaceImpl(ws memdb.WatchSet, namespace string, txn *txn) (memdb.ResultIterator, error) {
-	// Walk the entire jobs table
-	iter, err := txn.Get("jobs", "id_prefix", namespace, "")
+func (s *StateStore) jobsByNamespaceImpl(ws memdb.WatchSet, namespace string, txn *txn, sort SortOption) (memdb.ResultIterator, error) {
+	iter, err := getSorted(txn, sort, "jobs", "id_prefix", namespace, "")
 	if err != nil {
 		return nil, err
 	}
@@ -6936,7 +6922,7 @@ func (s *StateStore) DeleteNamespaces(index uint64, names []string) error {
 		}
 
 		// Ensure that the namespace doesn't have any non-terminal jobs
-		iter, err := s.jobsByNamespaceImpl(nil, name, txn)
+		iter, err := s.jobsByNamespaceImpl(nil, name, txn, SortDefault)
 		if err != nil {
 			return err
 		}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -2985,7 +2985,7 @@ func TestStateStore_Jobs(t *testing.T) {
 	}
 
 	ws := memdb.NewWatchSet()
-	iter, err := state.Jobs(ws)
+	iter, err := state.Jobs(ws, SortDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3065,7 +3065,7 @@ func TestStateStore_JobsByIDPrefix(t *testing.T) {
 	}
 
 	ws := memdb.NewWatchSet()
-	iter, err := state.JobsByIDPrefix(ws, job.Namespace, job.ID)
+	iter, err := state.JobsByIDPrefix(ws, job.Namespace, job.ID, SortDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3087,7 +3087,7 @@ func TestStateStore_JobsByIDPrefix(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	iter, err = state.JobsByIDPrefix(ws, job.Namespace, "re")
+	iter, err = state.JobsByIDPrefix(ws, job.Namespace, "re", SortDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3112,7 +3112,7 @@ func TestStateStore_JobsByIDPrefix(t *testing.T) {
 	}
 
 	ws = memdb.NewWatchSet()
-	iter, err = state.JobsByIDPrefix(ws, job.Namespace, "r")
+	iter, err = state.JobsByIDPrefix(ws, job.Namespace, "r", SortDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3122,7 +3122,7 @@ func TestStateStore_JobsByIDPrefix(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	iter, err = state.JobsByIDPrefix(ws, job.Namespace, "ri")
+	iter, err = state.JobsByIDPrefix(ws, job.Namespace, "ri", SortDefault)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -3172,9 +3172,9 @@ func TestStateStore_JobsByIDPrefix_Namespaces(t *testing.T) {
 
 	// Try full match
 	ws := memdb.NewWatchSet()
-	iter1, err := state.JobsByIDPrefix(ws, ns1.Name, jobID)
+	iter1, err := state.JobsByIDPrefix(ws, ns1.Name, jobID, SortDefault)
 	require.NoError(t, err)
-	iter2, err := state.JobsByIDPrefix(ws, ns2.Name, jobID)
+	iter2, err := state.JobsByIDPrefix(ws, ns2.Name, jobID, SortDefault)
 	require.NoError(t, err)
 
 	jobsNs1 := gatherJobs(iter1)
@@ -3184,9 +3184,9 @@ func TestStateStore_JobsByIDPrefix_Namespaces(t *testing.T) {
 	require.Len(t, jobsNs2, 1)
 
 	// Try prefix
-	iter1, err = state.JobsByIDPrefix(ws, ns1.Name, "re")
+	iter1, err = state.JobsByIDPrefix(ws, ns1.Name, "re", SortDefault)
 	require.NoError(t, err)
-	iter2, err = state.JobsByIDPrefix(ws, ns2.Name, "re")
+	iter2, err = state.JobsByIDPrefix(ws, ns2.Name, "re", SortDefault)
 	require.NoError(t, err)
 
 	jobsNs1 = gatherJobs(iter1)
@@ -3201,9 +3201,9 @@ func TestStateStore_JobsByIDPrefix_Namespaces(t *testing.T) {
 	require.True(t, watchFired(ws))
 
 	ws = memdb.NewWatchSet()
-	iter1, err = state.JobsByIDPrefix(ws, ns1.Name, "r")
+	iter1, err = state.JobsByIDPrefix(ws, ns1.Name, "r", SortDefault)
 	require.NoError(t, err)
-	iter2, err = state.JobsByIDPrefix(ws, ns2.Name, "r")
+	iter2, err = state.JobsByIDPrefix(ws, ns2.Name, "r", SortDefault)
 	require.NoError(t, err)
 
 	jobsNs1 = gatherJobs(iter1)
@@ -3211,7 +3211,7 @@ func TestStateStore_JobsByIDPrefix_Namespaces(t *testing.T) {
 	require.Len(t, jobsNs1, 2)
 	require.Len(t, jobsNs2, 1)
 
-	iter1, err = state.JobsByIDPrefix(ws, ns1.Name, "ri")
+	iter1, err = state.JobsByIDPrefix(ws, ns1.Name, "ri", SortDefault)
 	require.NoError(t, err)
 
 	jobsNs1 = gatherJobs(iter1)
@@ -3241,9 +3241,9 @@ func TestStateStore_JobsByNamespace(t *testing.T) {
 
 	// Create watchsets so we can test that update fires the watch
 	watches := []memdb.WatchSet{memdb.NewWatchSet(), memdb.NewWatchSet()}
-	_, err := state.JobsByNamespace(watches[0], ns1.Name)
+	_, err := state.JobsByNamespace(watches[0], ns1.Name, SortDefault)
 	require.NoError(t, err)
-	_, err = state.JobsByNamespace(watches[1], ns2.Name)
+	_, err = state.JobsByNamespace(watches[1], ns2.Name, SortDefault)
 	require.NoError(t, err)
 
 	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job1))
@@ -3254,9 +3254,9 @@ func TestStateStore_JobsByNamespace(t *testing.T) {
 	require.True(t, watchFired(watches[1]))
 
 	ws := memdb.NewWatchSet()
-	iter1, err := state.JobsByNamespace(ws, ns1.Name)
+	iter1, err := state.JobsByNamespace(ws, ns1.Name, SortDefault)
 	require.NoError(t, err)
-	iter2, err := state.JobsByNamespace(ws, ns2.Name)
+	iter2, err := state.JobsByNamespace(ws, ns2.Name, SortDefault)
 	require.NoError(t, err)
 
 	var out1 []*structs.Job


### PR DESCRIPTION
No one asked for this, but I did it while building out the new job statuses endpoint.  I ended up using a different (new) index there, so this may be considered extra unnecessary, and it only actually adds sorting to jobs endpoint, but I think it moves the ball forward slightly, so here it is.

I could be convinced to either:
* go further, add sorting to more endpoints
* go backwards, throw out everything except the new lil helpers I want to use

If we keep this, should I backport it?  Seems like something that could cause backport headaches down the road if I don't.