### PR TITLE
WI: ensure tasks within same alloc get different Consul tokens

### DIFF
--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -157,7 +157,8 @@ func (h *consulHook) prepareConsulTokensForTask(task *structs.Task, tg *structs.
 	if _, ok = tokens[clusterName]; !ok {
 		tokens[clusterName] = make(map[string]*consulapi.ACLToken)
 	}
-	tokens[clusterName][widName] = token
+	tokenName := widName + "/" + task.Name
+	tokens[clusterName][tokenName] = token
 
 	return nil
 }

--- a/client/allocrunner/taskrunner/consul_hook.go
+++ b/client/allocrunner/taskrunner/consul_hook.go
@@ -58,7 +58,7 @@ func (h *consulHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartR
 	// Write tokens to tasks' secret dirs
 	for _, t := range tokens {
 		for tokenName, token := range t {
-			s := strings.Split(tokenName, "/")
+			s := strings.SplitN(tokenName, "/", 2)
 			if len(s) < 2 {
 				continue
 			}

--- a/client/allocrunner/taskrunner/consul_hook_test.go
+++ b/client/allocrunner/taskrunner/consul_hook_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package taskrunner
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+// TestConsulHook ensures we're only writing Consul tokens for the appropriate
+// task's identities
+func TestConsulHook(t *testing.T) {
+
+	alloc := mock.Alloc()
+	task := alloc.LookupTask("web")
+	task.Consul = &structs.Consul{
+		Cluster: "default",
+	}
+	task.Identities = []*structs.WorkloadIdentity{{Name: "consul_default"}}
+
+	resources := cstructs.NewAllocHookResources()
+	resources.SetConsulTokens(map[string]map[string]*api.ACLToken{
+		"default": map[string]*api.ACLToken{
+			"consul_default/web":   &api.ACLToken{SecretID: "foo"},
+			"consul_default/extra": &api.ACLToken{SecretID: "bar"}, // for different task
+			"consul_infra/web":     &api.ACLToken{SecretID: "baz"}, // for different cluster
+			"service_foo":          &api.ACLToken{SecretID: "qux"}, // for service
+		},
+	})
+	taskDir := t.TempDir()
+
+	hook := &consulHook{
+		task:          task,
+		tokenDir:      taskDir,
+		hookResources: resources,
+		logger:        testlog.HCLogger(t),
+	}
+
+	resp := &interfaces.TaskPrestartResponse{}
+	hook.Prestart(context.TODO(), &interfaces.TaskPrestartRequest{}, resp)
+
+	must.FileContains(t, filepath.Join(taskDir, "consul_token"), "foo")
+	must.Eq(t, "foo", resp.Env["CONSUL_TOKEN"])
+}

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -2498,7 +2498,7 @@ func TestTaskRunner_TemplateWorkloadIdentity(t *testing.T) {
 	}
 	conf.AllocHookResources.SetConsulTokens(map[string]map[string]*consulapi.ACLToken{
 		structs.ConsulDefaultCluster: {
-			task.Consul.IdentityName(): {SecretID: "consul-task-token"},
+			task.Consul.IdentityName() + "/web": {SecretID: "consul-task-token"},
 		},
 	})
 	t.Cleanup(cleanup)

--- a/client/allocrunner/taskrunner/template_hook.go
+++ b/client/allocrunner/taskrunner/template_hook.go
@@ -162,7 +162,7 @@ func (h *templateHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 			)
 		}
 
-		consulToken := clusterTokens[consulWIDName]
+		consulToken := clusterTokens[consulWIDName+"/"+req.Task.Name]
 		if consulToken == nil {
 			return fmt.Errorf(
 				"consul tokens for cluster %s and identity %s requested by task %s not found",

--- a/client/allocrunner/taskrunner/template_hook_test.go
+++ b/client/allocrunner/taskrunner/template_hook_test.go
@@ -40,7 +40,7 @@ func Test_templateHook_Prestart_ConsulWI(t *testing.T) {
 	hrTokens.SetConsulTokens(
 		map[string]map[string]*consulapi.ACLToken{
 			structs.ConsulDefaultCluster: {
-				fmt.Sprintf("consul_%s", structs.ConsulDefaultCluster): &consulapi.ACLToken{
+				fmt.Sprintf("consul_%s/web", structs.ConsulDefaultCluster): &consulapi.ACLToken{
 					SecretID: defaultToken,
 				},
 			},
@@ -59,7 +59,7 @@ func Test_templateHook_Prestart_ConsulWI(t *testing.T) {
 	}{
 		{
 			// COMPAT remove in 1.9+
-			name:            "legecy flow",
+			name:            "legacy flow",
 			hr:              hrEmpty,
 			legacyFlow:      true,
 			wantConsulToken: "",


### PR DESCRIPTION
The `consul_hook` in the allocrunner gets a separate Consul token for each task, even if the tasks' identities have the same name, but used the identity name as the key to the alloc hook resources map. This means the last task in the group overwrites the Consul tokens of all other tasks.

Fix this by adding the task name to the key in the allocrunner's `consul_hook`. And update the taskrunner's `consul_hook` and `template_hook` to expect the task name in the key.

Fixes: https://github.com/hashicorp/nomad/issues/20374
Fixes: https://hashicorp.atlassian.net/browse/NOMAD-614

---

In addition to the updated and new tests, I've tested this end-to-end.

<details><summary>jobspec</summary>

```hcl
job "example" {

  group "web" {

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
    }

    service {
      port = "www"
    }

    task "http" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      template {
        data        = "<html>hello, world</html>"
        destination = "local/index.html"
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }

    task "other" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "tail"
        args    = ["-f"]
      }

      template {
        data        = "xyzzy"
        destination = "local/stuff.txt"
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }


  }
}
```

</details>

```
$ nomad job run ./example.nomad.hcl
==> 2024-04-16T14:58:45-04:00: Monitoring evaluation "2f9ae386"
    2024-04-16T14:58:45-04:00: Evaluation triggered by job "example"
    2024-04-16T14:58:46-04:00: Evaluation within deployment: "98d44ff0"
    2024-04-16T14:58:46-04:00: Allocation "5a01ba40" created: node "41e27bc4", group "web"
    2024-04-16T14:58:46-04:00: Evaluation status changed: "pending" -> "complete"
==> 2024-04-16T14:58:46-04:00: Evaluation "2f9ae386" finished with status "complete"
==> 2024-04-16T14:58:46-04:00: Monitoring deployment "98d44ff0"
  ✓ Deployment "98d44ff0" successful

    2024-04-16T14:58:57-04:00
    ID          = 98d44ff0
    Job ID      = example
    Job Version = 0
    Status      = successful
    Description = Deployment completed successfully

    Deployed
    Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
    web         1        1       1        0          2024-04-16T15:08:56-04:00

$ nomad alloc exec -task http 5a01 cat /secrets/consul_token
8925cf07-de35-5bc4-3829-534acdea992d%

$ CONSUL_HTTP_TOKEN=8925cf07-de35-5bc4-3829-534acdea992d consul acl token read -self
AccessorID:       da350855-e3ac-ef55-c7cb-18095a05e324
SecretID:         8925cf07-de35-5bc4-3829-534acdea992d
Partition:        default
Namespace:        default
Description:      token created via login: {"requested_by":"nomad_task_http"}
Local:            true
Auth Method:      nomad-workloads (Namespace: default)
Create Time:      2024-04-16 14:58:45.551428391 -0400 EDT
Roles:
   1bca5a50-02f5-d165-38ee-fa7417a34865 - nomad-tasks-default

$ nomad alloc exec -task other 5a01 cat /secrets/consul_token
ce2ec95b-4c71-0032-2e56-f0d5ffd1c286%

$ CONSUL_HTTP_TOKEN=ce2ec95b-4c71-0032-2e56-f0d5ffd1c286 consul acl token read -self
AccessorID:       7a773850-38ea-71d2-d098-9e8bc3f2f4b9
SecretID:         ce2ec95b-4c71-0032-2e56-f0d5ffd1c286
Partition:        default
Namespace:        default
Description:      token created via login: {"requested_by":"nomad_task_other"}
Local:            true
Auth Method:      nomad-workloads (Namespace: default)
Create Time:      2024-04-16 14:58:45.554431363 -0400 EDT
Roles:
   1bca5a50-02f5-d165-38ee-fa7417a34865 - nomad-tasks-default
```
