### PR TITLE
test: change some helpers testing.T to .TB

### DIFF
--- a/nomad/rpc_test.go
+++ b/nomad/rpc_test.go
@@ -41,7 +41,7 @@ import (
 
 // rpcClient is a test helper method to return a ClientCodec to use to make rpc
 // calls to the passed server.
-func rpcClient(t *testing.T, s *Server) rpc.ClientCodec {
+func rpcClient(t testing.TB, s *Server) rpc.ClientCodec {
 	t.Helper()
 	addr := s.config.RPCAddr
 	conn, err := net.DialTimeout("tcp", addr.String(), time.Second)
@@ -55,7 +55,7 @@ func rpcClient(t *testing.T, s *Server) rpc.ClientCodec {
 
 // rpcClientWithTLS is a test helper method to return a ClientCodec to use to
 // make RPC calls to the passed server via mTLS
-func rpcClientWithTLS(t *testing.T, srv *Server, cfg *config.TLSConfig) rpc.ClientCodec {
+func rpcClientWithTLS(t testing.TB, srv *Server, cfg *config.TLSConfig) rpc.ClientCodec {
 	t.Helper()
 
 	// configure TLS, ignoring client-side validation

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -25,7 +25,7 @@ var (
 	nodeNumber int32 = 0
 )
 
-func TestACLServer(t testing.T, cb func(*Config)) (*Server, *structs.ACLToken, func()) {
+func TestACLServer(t testing.TB, cb func(*Config)) (*Server, *structs.ACLToken, func()) {
 	server, cleanup := TestServer(t, func(c *Config) {
 		c.ACLEnabled = true
 		if cb != nil {
@@ -40,7 +40,7 @@ func TestACLServer(t testing.T, cb func(*Config)) (*Server, *structs.ACLToken, f
 	return server, token, cleanup
 }
 
-func TestServer(t testing.T, cb func(*Config)) (*Server, func()) {
+func TestServer(t testing.TB, cb func(*Config)) (*Server, func()) {
 	s, c, err := TestServerErr(t, cb)
 	must.NoError(t, err, must.Sprint("failed to start test server"))
 	return s, c
@@ -48,7 +48,7 @@ func TestServer(t testing.T, cb func(*Config)) (*Server, func()) {
 
 // TestConfigForServer provides a fully functional Config to pass to NewServer()
 // It can be changed beforehand to induce different behavior such as specific errors.
-func TestConfigForServer(t testing.T) *Config {
+func TestConfigForServer(t testing.TB) *Config {
 	t.Helper()
 
 	// Setup the default settings
@@ -121,7 +121,7 @@ func TestConfigForServer(t testing.T) *Config {
 	return config
 }
 
-func TestServerErr(t testing.T, cb func(*Config)) (*Server, func(), error) {
+func TestServerErr(t testing.TB, cb func(*Config)) (*Server, func(), error) {
 	config := TestConfigForServer(t)
 	// Invoke the callback if any
 	if cb != nil {
@@ -181,7 +181,7 @@ func TestServerErr(t testing.T, cb func(*Config)) (*Server, func(), error) {
 	return nil, nil, fmt.Errorf("error starting test server: %w", err)
 }
 
-func TestJoin(t testing.T, servers ...*Server) {
+func TestJoin(t testing.TB, servers ...*Server) {
 	for i := 0; i < len(servers)-1; i++ {
 		addr := fmt.Sprintf("127.0.0.1:%d",
 			servers[i].config.SerfConfig.MemberlistConfig.BindPort)


### PR DESCRIPTION
TB interface instead of T struct, so they can be used in Benchmarks too.

I bumped into these while benchmarking an RPC, but have refrained from creeping to other helpers.