### PR TITLE
docs: fix incorrect dispatch payload limit in API docs

### DIFF
--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -1774,7 +1774,7 @@ The table below shows this endpoint's support for
   IDs.
 
 - `Payload` `(string: "")` - Specifies a base64 encoded string containing the
-  payload. This is limited to 65536 bytes (64KiB).
+  payload. This is limited to 16384 bytes (16KiB).
 
 - `Meta` `(meta<string|string>: nil)` - Specifies arbitrary metadata to pass to
   the job.


### PR DESCRIPTION
The dispatch payload limit is limited to 16KiB, not 64KiB. It's correct in the command docs but incorrect in the API docs. It looks like this was accidentally updated in https://github.com/hashicorp/nomad/commit/c2491e9146ae5db92bb04d2eda2b5ccd58d07851 which was supposed to be for the Variables payload size.

Ref: https://github.com/hashicorp/nomad/blob/v1.7.7/nomad/job_endpoint.go#L36-L38
Fixes: https://github.com/hashicorp/nomad/issues/20432