### PR TITLE
[ui] Bugfix: Browser resize no longer makes jobs index summary viz grow forever

### DIFF
--- a/ui/app/components/job-status/allocation-status-row.hbs
+++ b/ui/app/components/job-status/allocation-status-row.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <div class="allocation-status-row  {{if @compact "compact"}}">
-  {{#if (or this.showSummaries @compact)}}
+  {{#if this.showSummaries}}
     <div class="alloc-status-summaries"
       {{did-insert this.captureElement}}
       {{window-resize this.reflow}}

--- a/ui/app/components/job-status/allocation-status-row.js
+++ b/ui/app/components/job-status/allocation-status-row.js
@@ -10,6 +10,7 @@ import { tracked } from '@glimmer/tracking';
 
 const ALLOC_BLOCK_WIDTH = 32;
 const ALLOC_BLOCK_GAP = 10;
+const COMPACT_INTER_SUMMARY_GAP = 7;
 
 export default class JobStatusAllocationStatusRowComponent extends Component {
   @tracked width = 0;
@@ -27,14 +28,33 @@ export default class JobStatusAllocationStatusRowComponent extends Component {
 
   get showSummaries() {
     return (
+      this.args.compact ||
       this.allocBlockSlots * (ALLOC_BLOCK_WIDTH + ALLOC_BLOCK_GAP) -
         ALLOC_BLOCK_GAP >
-      this.width
+        this.width
     );
   }
 
+  // When we calculate how much width to give to a row in our viz,
+  // we want to also offset the gap BETWEEN summaries. The way that css grid
+  // works, a gap only appears between 2 elements, not at the start or end of a row.
+  // Thus, we need to calculate total gap space using the number of summaries shown.
+  get numberOfSummariesShown() {
+    return Object.values(this.args.allocBlocks)
+      .flatMap((statusObj) => Object.values(statusObj))
+      .flatMap((healthObj) => Object.values(healthObj))
+      .filter((allocs) => allocs.length > 0).length;
+  }
+
   calcPerc(count) {
-    return (count / this.allocBlockSlots) * this.width;
+    if (this.args.compact) {
+      const totalGaps =
+        (this.numberOfSummariesShown - 1) * COMPACT_INTER_SUMMARY_GAP;
+      const usableWidth = this.width - totalGaps;
+      return (count / this.allocBlockSlots) * usableWidth;
+    } else {
+      return (count / this.allocBlockSlots) * this.width;
+    }
   }
 
   @action reflow(element) {

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -334,7 +334,7 @@
               {{B.data.allocations.length}} total <br />
               {{B.data.groupCountSum}} desired
               <hr /> --}}
-              <div class="job-status-panel">
+              <div class="job-status-panel compact">
                 {{#unless B.data.assumeGC}}
                   {{#if B.data.childStatuses}}
                     {{B.data.childStatuses.length}} child jobs;<br />


### PR DESCRIPTION
This hasn't been an issue for the (same components used) viz on Job deploy/status panels, as they are elements with fixed size and css block-level scoping.

Table cells, on the other hand, change their sizes dynamically. Even force-setting the size of the particular cell where this visualization sits wasn't enough to prevent this bug from happening.

What would happen is, it would re-calculate the width of the containing element every time you resize your browser (good!) but a combination of "the nature of table cells is such that they derive their width from their contents" (bad!) and "I wasn't taking the inter-block-gaps into consideration when determining width/ratios" (bad!) meant that this was a funky looking bug.

This fixes that last part, and makes the whole issue go away!

To test the fix:
- Try resizing your screen on [the deployment from base](https://nomad-storybook-and-guxwi9by6-hashicorp.vercel.app/ui/jobs)
- Try resizing your screen on [the deployment for this PR](https://nomad-storybook-and-j7d8kiaew-hashicorp.vercel.app/ui/jobs)