### PR TITLE
[ui] Searching and filtering options

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -255,7 +255,12 @@ export default class JobAdapter extends WatchableNamespaceIDs {
   urlForQuery(query, modelName, method) {
     let baseUrl = `/${this.namespace}/jobs/statuses`;
     if (method === 'POST' && query.index) {
-      return `${baseUrl}?index=${query.index}`;
+      baseUrl += baseUrl.includes('?') ? '&' : '?';
+      baseUrl += `index=${query.index}`;
+    }
+    if (method === 'POST' && query.jobs) {
+      baseUrl += baseUrl.includes('?') ? '&' : '?';
+      baseUrl += 'namespace=*';
     }
     return baseUrl;
   }

--- a/ui/app/components/job-search-box.hbs
+++ b/ui/app/components/job-search-box.hbs
@@ -1,0 +1,14 @@
+<Hds::Form::TextInput::Base
+  @type="search"
+  @value=""
+  aria-label="Job Search"
+  placeholder="eg. Hello World"
+  @icon="search"
+  @width="300px"
+  {{on "input" (action this.updateFilter)}}
+  {{keyboard-shortcut 
+    label="Search Jobs"
+    pattern=(array "Shift+F")
+    action=(action this.focus)
+  }}
+/>

--- a/ui/app/components/job-search-box.hbs
+++ b/ui/app/components/job-search-box.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<Hds::Form::TextInput::Base
+<@S.TextInput
   @type="search"
   @value={{@searchText}}
   aria-label="Job Search"
@@ -16,5 +16,5 @@
     pattern=(array "Shift+F")
     action=(action this.focus)
   }}
-  data-test-job-search
+  data-test-jobs-search
 />

--- a/ui/app/components/job-search-box.hbs
+++ b/ui/app/components/job-search-box.hbs
@@ -5,12 +5,12 @@
 
 <Hds::Form::TextInput::Base
   @type="search"
-  @value={{@filter}}
+  @value={{@searchText}}
   aria-label="Job Search"
   placeholder="eg. Hello World"
   @icon="search"
   @width="300px"
-  {{on "input" (action this.updateFilter)}}
+  {{on "input" (action this.updateSearchText)}}
   {{keyboard-shortcut 
     label="Search Jobs"
     pattern=(array "Shift+F")

--- a/ui/app/components/job-search-box.hbs
+++ b/ui/app/components/job-search-box.hbs
@@ -5,7 +5,7 @@
 
 <Hds::Form::TextInput::Base
   @type="search"
-  @value=""
+  @value={{@filter}}
   aria-label="Job Search"
   placeholder="eg. Hello World"
   @icon="search"

--- a/ui/app/components/job-search-box.hbs
+++ b/ui/app/components/job-search-box.hbs
@@ -7,7 +7,7 @@
   @type="search"
   @value={{@searchText}}
   aria-label="Job Search"
-  placeholder="eg. Hello World"
+  placeholder="Name contains myJob"
   @icon="search"
   @width="300px"
   {{on "input" (action this.updateSearchText)}}

--- a/ui/app/components/job-search-box.hbs
+++ b/ui/app/components/job-search-box.hbs
@@ -1,3 +1,8 @@
+{{!
+  Copyright (c) HashiCorp, Inc.
+  SPDX-License-Identifier: BUSL-1.1
+~}}
+
 <Hds::Form::TextInput::Base
   @type="search"
   @value=""
@@ -11,4 +16,5 @@
     pattern=(array "Shift+F")
     action=(action this.focus)
   }}
+  data-test-job-search
 />

--- a/ui/app/components/job-search-box.js
+++ b/ui/app/components/job-search-box.js
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 // @ts-check
 
 import Component from '@glimmer/component';

--- a/ui/app/components/job-search-box.js
+++ b/ui/app/components/job-search-box.js
@@ -18,18 +18,12 @@ export default class JobSearchBoxComponent extends Component {
   element = null;
 
   @action
-  updateFilter(event) {
-    debounce(
-      this,
-      // this.args.onFilterChange(event.target.value),
-      this.sendUpdate,
-      event.target.value,
-      DEBOUNCE_MS
-    );
+  updateSearchText(event) {
+    debounce(this, this.sendUpdate, event.target.value, DEBOUNCE_MS);
   }
 
   sendUpdate(value) {
-    this.args.onFilterChange(value);
+    this.args.onSearchTextChange(value);
   }
 
   @action

--- a/ui/app/components/job-search-box.js
+++ b/ui/app/components/job-search-box.js
@@ -1,0 +1,40 @@
+// @ts-check
+
+import Component from '@glimmer/component';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
+import { debounce } from '@ember/runloop';
+
+const DEBOUNCE_MS = 500;
+
+export default class JobSearchBoxComponent extends Component {
+  @service keyboard;
+
+  element = null;
+
+  @action
+  updateFilter(event) {
+    debounce(
+      this,
+      // this.args.onFilterChange(event.target.value),
+      this.sendUpdate,
+      event.target.value,
+      DEBOUNCE_MS
+    );
+  }
+
+  sendUpdate(value) {
+    this.args.onFilterChange(value);
+  }
+
+  @action
+  focus(element) {
+    element.focus();
+    // Because the element is an input,
+    // and the "hide hints" part of our keynav implementation is on keyUp,
+    // but the focus action happens on keyDown,
+    // and the keynav explicitly ignores key input while focused in a text input,
+    // we need to manually hide the hints here.
+    this.keyboard.displayHints = false;
+  }
+}

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -387,8 +387,6 @@ export default class JobsIndexController extends Controller {
       }
     });
 
-    console.log('availablenamespaces', availableNamespaces);
-
     return {
       label: 'Namespace',
       options: availableNamespaces,
@@ -465,7 +463,6 @@ export default class JobsIndexController extends Controller {
     'typeFacet.options.@each.checked'
   )
   get computedFilter() {
-    console.log('compFilter');
     let parts = this.searchText ? [this.searchText] : [];
     this.filterFacets.forEach((group) => {
       let groupParts = [];

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -384,7 +384,7 @@ export default class JobsIndexController extends Controller {
       this.filter = newFilter;
     } else {
       // If it's a string without a filter operator, assume the user is trying to look up a job name
-      this.filter = `Name contains "${newFilter}"`;
+      this.filter = `Name contains ${newFilter}`;
     }
   }
 

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -41,6 +41,7 @@ export default class JobsIndexController extends Controller {
     { qpNamespace: 'namespace' },
     // 'type',
     // 'searchTerm',
+    'filter',
   ];
 
   isForbidden = false;
@@ -123,6 +124,7 @@ export default class JobsIndexController extends Controller {
   // #region pagination
   @tracked cursorAt;
   @tracked nextToken; // route sets this when new data is fetched
+  @tracked filter;
 
   /**
    *
@@ -342,4 +344,49 @@ export default class JobsIndexController extends Controller {
     }
   }
   //#endregion querying
+
+  //#region filtering and searching
+
+  /**
+   * Updates the filter based on the input, distinguishing between simple job names and filter expressions.
+   * A simple check for operators with surrounding spaces is used to identify filter expressions.
+   *
+   * @param {string} newFilter - The new filter string entered by the user.
+   */
+  @action
+  updateFilter(newFilter) {
+    if (!newFilter) {
+      this.filter = '';
+      return;
+    }
+
+    newFilter = newFilter.trim();
+
+    const operators = [
+      '==',
+      '!=',
+      'contains',
+      'not contains',
+      'is empty',
+      'is not empty',
+      'matches',
+      'not matches',
+      'in',
+      'not in',
+    ];
+
+    // Check for any operator surrounded by spaces
+    let isFilterExpression = operators.some((op) =>
+      newFilter.includes(` ${op} `)
+    );
+
+    if (isFilterExpression) {
+      this.filter = newFilter;
+    } else {
+      // If it's a string without a filter operator, assume the user is trying to look up a job name
+      this.filter = `Name contains "${newFilter}"`;
+    }
+  }
+
+  //#endregion filtering and searching
 }

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -331,13 +331,13 @@ export default class JobsIndexController extends Controller {
     label: 'Type',
     options: [
       {
-        key: 'service',
-        string: 'Type == service',
+        key: 'batch',
+        string: 'Type == batch',
         checked: false,
       },
       {
-        key: 'batch',
-        string: 'Type == batch',
+        key: 'service',
+        string: 'Type == service',
         checked: false,
       },
       {

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -486,8 +486,9 @@ export default class JobsIndexController extends Controller {
 
   // Radio button set
   @action
-  toggleNamespaceOption(option) {
+  toggleNamespaceOption(option, dropdown) {
     this.qpNamespace = option.key;
+    dropdown.close();
   }
 
   @action

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -149,9 +149,16 @@ export default class IndexRoute extends Route.extend(
       });
     });
 
-    return {
-      error,
-    };
+    // if it's an innocuous-enough seeming "You mistyped something while searching" error,
+    // handle it with a notification and don't throw. Otherwise, throw.
+    if (
+      error.errors[0].detail.includes("couldn't find key") ||
+      error.errors[0].detail.includes('failed to read filter expression')
+    ) {
+      return error;
+    } else {
+      throw error;
+    }
   }
 
   setupController(controller, model) {

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -13,7 +13,6 @@ import { watchAll } from 'nomad-ui/utils/properties/watch';
 import WithWatchers from 'nomad-ui/mixins/with-watchers';
 import notifyForbidden from 'nomad-ui/utils/notify-forbidden';
 import WithForbiddenState from 'nomad-ui/mixins/with-forbidden-state';
-import codesForError from '../../utils/codes-for-error';
 import { action } from '@ember/object';
 import Ember from 'ember';
 
@@ -69,6 +68,7 @@ export default class IndexRoute extends Route.extend(
     queryParams.next_token = queryParams.cursorAt;
     queryParams.per_page = queryParams.pageSize;
 
+    /* eslint-disable ember/no-controller-access-in-routes */
     let filter = this.controllerFor('jobs.index').filter;
     if (filter) {
       queryParams.filter = filter;
@@ -76,8 +76,6 @@ export default class IndexRoute extends Route.extend(
     // namespace
     queryParams.namespace = queryParams.qpNamespace;
     delete queryParams.qpNamespace;
-    console.log('filter, in model hook, is', filter);
-    console.log('and namespace is', queryParams.namespace);
     delete queryParams.pageSize;
     delete queryParams.cursorAt; // TODO: hacky, should be done in the serializer/adapter?
 

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -37,6 +37,9 @@ export default class IndexRoute extends Route.extend(
     pageSize: {
       refreshModel: true,
     },
+    filter: {
+      refreshModel: true,
+    },
   };
 
   hasBeenInitialized = false;
@@ -54,6 +57,7 @@ export default class IndexRoute extends Route.extend(
     let currentParams = this.getCurrentParams(); // TODO: how do these differ from passed params?
     this.watchList.jobsIndexIDsController.abort();
     this.watchList.jobsIndexIDsController = new AbortController();
+    console.log('model', currentParams);
     let jobs = await this.store
       .query('job', currentParams, {
         adapterOptions: {

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -41,24 +41,6 @@ export default class IndexRoute extends Route.extend(
     filter: {
       refreshModel: true,
     },
-    // searchText: {
-    //   refreshModel: true,
-    // },
-    // status: {
-    //   refreshModel: true,
-    // },
-    // type: {
-    //   refreshModel: true,
-    // },
-    // status_dead: {
-    //   refreshModel: true,
-    // },
-    // status_running: {
-    //   refreshModel: true,
-    // },
-    // status_pending: {
-    //   refreshModel: true,
-    // },
   };
 
   hasBeenInitialized = false;
@@ -85,7 +67,6 @@ export default class IndexRoute extends Route.extend(
     delete queryParams.searchText;
     delete queryParams.status;
     delete queryParams.type;
-    // console.log('final queryParams in model hook is', queryParams);
     return { ...queryParams };
   }
 
@@ -106,11 +87,9 @@ export default class IndexRoute extends Route.extend(
         nodePools: this.store.findAll('node-pool'),
       });
     } catch (error) {
-      console.log('error', error);
       try {
         notifyForbidden(this)(error);
       } catch (secondaryError) {
-        console.log('Secondary Error caught', secondaryError);
         return this.handleErrors(error);
       }
     }
@@ -139,7 +118,6 @@ export default class IndexRoute extends Route.extend(
    * @returns {Object}
    */
   handleErrors(error) {
-    console.log('handling error', error);
     error.errors.forEach((err) => {
       this.notifications.add({
         title: err.title,

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -39,27 +39,27 @@ export default class IndexRoute extends Route.extend(
     pageSize: {
       refreshModel: true,
     },
-    // filter: {
+    filter: {
+      refreshModel: true,
+    },
+    // searchText: {
     //   refreshModel: true,
     // },
-    searchText: {
-      refreshModel: true,
-    },
-    status: {
-      refreshModel: true,
-    },
-    type: {
-      refreshModel: true,
-    },
-    status_dead: {
-      refreshModel: true,
-    },
-    status_running: {
-      refreshModel: true,
-    },
-    status_pending: {
-      refreshModel: true,
-    },
+    // status: {
+    //   refreshModel: true,
+    // },
+    // type: {
+    //   refreshModel: true,
+    // },
+    // status_dead: {
+    //   refreshModel: true,
+    // },
+    // status_running: {
+    //   refreshModel: true,
+    // },
+    // status_pending: {
+    //   refreshModel: true,
+    // },
   };
 
   hasBeenInitialized = false;
@@ -195,6 +195,8 @@ export default class IndexRoute extends Route.extend(
       this.getCurrentParams(),
       Ember.testing ? 0 : DEFAULT_THROTTLE
     );
+
+    controller.parseFilter();
 
     this.hasBeenInitialized = true;
   }

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -65,7 +65,9 @@ export default class IndexRoute extends Route.extend(
 
   getCurrentParams() {
     let queryParams = this.paramsFor(this.routeName); // Get current query params
-    queryParams.next_token = queryParams.cursorAt;
+    if (queryParams.cursorAt) {
+      queryParams.next_token = queryParams.cursorAt;
+    }
     queryParams.per_page = queryParams.pageSize;
 
     /* eslint-disable ember/no-controller-access-in-routes */
@@ -83,10 +85,6 @@ export default class IndexRoute extends Route.extend(
     delete queryParams.searchText;
     delete queryParams.status;
     delete queryParams.type;
-    // TODO: excessive
-    delete queryParams.status_dead;
-    delete queryParams.status_running;
-    delete queryParams.status_pending;
     // console.log('final queryParams in model hook is', queryParams);
     return { ...queryParams };
   }
@@ -154,16 +152,6 @@ export default class IndexRoute extends Route.extend(
     return {
       error,
     };
-
-    // const errorCodes = codesForError(error);
-    // if (errorCodes.includes('500')) {
-    //   console.log('ye goofed lad', error, errorCodes);
-    // } else {
-    //   console.log('ye goofed lad but not that bad', error, errorCodes);
-    // }
-    // return {
-    //   error: error,
-    // }
   }
 
   setupController(controller, model) {

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -26,8 +26,6 @@ export default class IndexRoute extends Route.extend(
   @service watchList;
   @service notifications;
 
-  // perPage = 10;
-
   queryParams = {
     qpNamespace: {
       refreshModel: true,
@@ -61,17 +59,13 @@ export default class IndexRoute extends Route.extend(
     queryParams.namespace = queryParams.qpNamespace;
     delete queryParams.qpNamespace;
     delete queryParams.pageSize;
-    delete queryParams.cursorAt; // TODO: hacky, should be done in the serializer/adapter?
+    delete queryParams.cursorAt;
 
-    // Delete QPs that go into filter
-    delete queryParams.searchText;
-    delete queryParams.status;
-    delete queryParams.type;
     return { ...queryParams };
   }
 
   async model(/*params*/) {
-    let currentParams = this.getCurrentParams(); // TODO: how do these differ from passed params?
+    let currentParams = this.getCurrentParams();
     this.watchList.jobsIndexIDsController.abort();
     this.watchList.jobsIndexIDsController = new AbortController();
     try {

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -85,7 +85,7 @@ export default class IndexRoute extends Route.extend(
     delete queryParams.status_dead;
     delete queryParams.status_running;
     delete queryParams.status_pending;
-    console.log('final queryParams in model hook is', queryParams);
+    // console.log('final queryParams in model hook is', queryParams);
     return { ...queryParams };
   }
 
@@ -93,7 +93,6 @@ export default class IndexRoute extends Route.extend(
     let currentParams = this.getCurrentParams(); // TODO: how do these differ from passed params?
     this.watchList.jobsIndexIDsController.abort();
     this.watchList.jobsIndexIDsController = new AbortController();
-    console.log('model', currentParams);
     try {
       let jobs = await this.store.query('job', currentParams, {
         adapterOptions: {
@@ -146,6 +145,7 @@ export default class IndexRoute extends Route.extend(
         title: err.title,
         message: err.detail,
         color: 'critical',
+        timeout: 8000,
       });
     });
 

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -73,7 +73,11 @@ export default class IndexRoute extends Route.extend(
     if (filter) {
       queryParams.filter = filter;
     }
+    // namespace
+    queryParams.namespace = queryParams.qpNamespace;
+    delete queryParams.qpNamespace;
     console.log('filter, in model hook, is', filter);
+    console.log('and namespace is', queryParams.namespace);
     delete queryParams.pageSize;
     delete queryParams.cursorAt; // TODO: hacky, should be done in the serializer/adapter?
 

--- a/ui/app/routes/optimize.js
+++ b/ui/app/routes/optimize.js
@@ -24,10 +24,6 @@ export default class OptimizeRoute extends Route {
   async model() {
     const summaries = await this.store.findAll('recommendation-summary');
     const jobs = await RSVP.all(summaries.mapBy('job'));
-    console.log(
-      'partial?',
-      jobs.filter((job) => job).map((j) => j.isPartial)
-    );
     const [namespaces] = await RSVP.all([
       this.store.findAll('namespace'),
       ...jobs
@@ -36,8 +32,9 @@ export default class OptimizeRoute extends Route {
         .map((j) => j.reload()),
     ]);
 
-    // also reload the /allocations for each job
-    // TODO: this might be the trick? Run a full test.
+    // reload the /allocations for each job,
+    // as the jobs-index-provided ones are less detailed than what
+    // the optimize/recommendation components require
     await RSVP.all(
       jobs
         .filter((job) => job)

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -155,11 +155,11 @@ export default class JobSerializer extends ApplicationSerializer {
       : hash.PlainId;
 
     if (hash._aggregate && hash.Allocs) {
-      // Friday morning TODO: this is the source of the failing optimization test.
-      // Without this, our jobs index page makes an /allocations lookup, unnecessarily, for every job in the list.
-      // But with it, our "partially hydrated" concept for the Optimize page doesn't really work.
-
       // Manually push allocations to store
+      // These allocations have enough information to be useful on a jobs index page,
+      // but less than the /allocations endpoint for an individual job might give us.
+      // As such, pages like /optimize require a specific call to the endpoint
+      // of any jobs' allocations to get more detailed information.
       hash.Allocs.forEach((alloc) => {
         this.store.push({
           data: {

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -155,6 +155,10 @@ export default class JobSerializer extends ApplicationSerializer {
       : hash.PlainId;
 
     if (hash._aggregate && hash.Allocs) {
+      // Friday morning TODO: this is the source of the failing optimization test.
+      // Without this, our jobs index page makes an /allocations lookup, unnecessarily, for every job in the list.
+      // But with it, our "partially hydrated" concept for the Optimize page doesn't really work.
+
       // Manually push allocations to store
       hash.Allocs.forEach((alloc) => {
         this.store.push({

--- a/ui/app/styles/components/jobs-list.scss
+++ b/ui/app/styles/components/jobs-list.scss
@@ -7,6 +7,10 @@
 // Over time, we can phase most of these custom styles out as Helios components
 // adapt to more use-cases (like custom footer, etc).
 
+#jobs-list-header {
+  z-index: $z-base;
+}
+
 #jobs-list-actions {
   margin-bottom: 1rem;
 }

--- a/ui/app/styles/components/jobs-list.scss
+++ b/ui/app/styles/components/jobs-list.scss
@@ -13,6 +13,12 @@
 
 #jobs-list-actions {
   margin-bottom: 1rem;
+  // If the screen is made very small, don't try to multi-line the text,
+  // instead wrap the flex and let dropdowns/buttons go on a new line.
+  .hds-segmented-group {
+    flex-wrap: wrap;
+    gap: 0.5rem 0;
+  }
 }
 
 #jobs-list-pagination {

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -25,14 +25,9 @@
                 @text={{group.label}}
                 @color="secondary"
                 @count={{get (filter-by "checked" true group.options) "length"}}
-                {{!-- @badge={{or this.selection[group.qp].length false}} --}}
               />
               {{#each group.options as |option|}}
                 <dd.Checkbox
-                  {{!-- {{on "change" (queue
-                    (fn (mut option.checked) (not option.checked))
-                    this.updateFilter
-                  )}} --}}
                   {{on "change" (fn this.toggleOption option)}}
                   @value={{option.key}}
                   checked={{option.checked}}
@@ -169,14 +164,7 @@
             {{#if this.system.shouldShowNodepools}}
               <B.Td data-test-job-node-pool>{{B.data.nodePool}}</B.Td>
             {{/if}}
-            <B.Td data-test-job-priority>
-              {{B.data.priority}}
-            </B.Td>
             <B.Td>
-              {{!-- {{get (filter-by 'clientStatus' 'running' B.data.allocations) "length"}} running <br />
-              {{B.data.allocations.length}} total <br />
-              {{B.data.groupCountSum}} desired
-              <hr /> --}}
               <div class="job-status-panel compact">
                 {{#unless B.data.assumeGC}}
                   {{#if B.data.childStatuses}}
@@ -189,7 +177,6 @@
                       @allocBlocks={{B.data.allocBlocks}}
                       @steady={{true}}
                       @compact={{true}}
-                      {{!-- @runningAllocs={{B.data.runningAllocs}} --}}
                       @runningAllocs={{B.data.allocBlocks.running.healthy.nonCanary.length}}
                       @groupCountSum={{B.data.expectedRunningAllocCount}}
                     />
@@ -305,35 +292,4 @@
         {{/if}}
       </Hds::ApplicationState>
     {{/if}}
-  {{!-- <hr />
-  Options:<br />
-  {{#each this.filterFacets as |group groupIndex|}}
-    {{group.label}}<br />
-    {{#each group.options as |option optionIndex|}}
-      {{option.key}}: {{option.checked}}<br />
-    {{/each}}
-  {{/each}}
-  <hr />
-  Next token is {{this.nextToken}}<br />
-  Model.jobs length: {{this.model.jobs.length}}<br />
-  Controller.jobs length: {{this.jobs.length}}<br />
-  Job IDs to watch for ({{this.jobIDs.length}}): {{#each this.jobIDs as |id|}}{{id.id}} | {{/each}}<br />
-  Pending Job IDs to watch for ({{this.pendingJobIDs.length}}): {{#each this.pendingJobIDs as |id|}}{{id.id}} | {{/each}}<br />
-  <Hds::Form::Toggle::Field
-    name="jostle"
-    @id="jostle"
-    checked={{this.liveUpdatesEnabled}}
-    {{on "change" (action (mut this.liveUpdatesEnabled) (not this.liveUpdatesEnabled))}}
-    as |F|>
-    <F.Label>Live update new/removed jobs?</F.Label>
-  </Hds::Form::Toggle::Field>
-  {{this.liveUpdatesEnabled}}<br />
-  <hr />
-  Local watchlist<br />
-  jobQueryIndex: {{this.jobQueryIndex}}<br />
-  jobAllocsQueryIndex: {{this.jobAllocsQueryIndex}}<br />
-
-  <hr /> --}}
-
-
 </section>

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -52,8 +52,8 @@
               />
               {{#each this.namespaceFacet.options as |option|}}
                 <dd.Radio
-                  name="namespace"
-                  {{on "change" (fn this.toggleNamespaceOption option)}}
+                  name={{option.key}}
+                  {{on "change" (fn this.toggleNamespaceOption option dd)}}
                   @value={{option.key}}
                   checked={{option.checked}}
                   data-test-dropdown-option={{option.key}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -5,7 +5,7 @@
 
 {{page-title "Jobs"}}
 <section class="section">
-    <Hds::PageHeader as |PH|>
+    <Hds::PageHeader id="jobs-list-header" as |PH|>
       <PH.Actions id="jobs-list-actions">
 
         <Hds::SegmentedGroup as |S|>
@@ -20,33 +20,54 @@
           />
 
           {{#each this.filterFacets as |group|}}
-          <S.Dropdown as |dd|>
-            <dd.ToggleButton
-              @text={{group.label}}
-              @color="secondary"
-              @count={{get (filter-by "checked" true group.options) "length"}}
-              {{!-- @badge={{or this.selection[group.qp].length false}} --}}
-            />
-            {{#each group.options as |option|}}
-              <dd.Checkbox
-                {{!-- {{on "change" (queue
-                  (fn (mut option.checked) (not option.checked))
-                  this.updateFilter
-                )}} --}}
-                {{on "change" (fn this.toggleOption option)}}
-                @value={{option.key}}
-                checked={{option.checked}}
-                data-test-dropdown-option={{option.key}}
-              >
-                {{option.key}}
-              </dd.Checkbox>
-            {{else}}
-              <dd.Generic data-test-dropdown-empty>
-                No {{group.label}} filters
-              </dd.Generic>
-            {{/each}}
-          </S.Dropdown>
+            <S.Dropdown as |dd|>
+              <dd.ToggleButton
+                @text={{group.label}}
+                @color="secondary"
+                @count={{get (filter-by "checked" true group.options) "length"}}
+                {{!-- @badge={{or this.selection[group.qp].length false}} --}}
+              />
+              {{#each group.options as |option|}}
+                <dd.Checkbox
+                  {{!-- {{on "change" (queue
+                    (fn (mut option.checked) (not option.checked))
+                    this.updateFilter
+                  )}} --}}
+                  {{on "change" (fn this.toggleOption option)}}
+                  @value={{option.key}}
+                  checked={{option.checked}}
+                  data-test-dropdown-option={{option.key}}
+                >
+                  {{option.key}}
+                </dd.Checkbox>
+              {{else}}
+                <dd.Generic data-test-dropdown-empty>
+                  No {{group.label}} filters
+                </dd.Generic>
+              {{/each}}
+            </S.Dropdown>
           {{/each}}
+
+          {{#if this.system.shouldShowNamespaces}}
+            <S.Dropdown as |dd|>
+              <dd.ToggleButton
+                @text="Namespace"
+                @color="secondary"
+                @badge={{get (find-by "checked" true this.namespaceFacet.options) "label"}}
+              />
+              {{#each this.namespaceFacet.options as |option|}}
+                <dd.Radio
+                  name="namespace"
+                  {{on "change" (fn this.toggleNamespaceOption option)}}
+                  @value={{option.key}}
+                  checked={{option.checked}}
+                  data-test-dropdown-option={{option.key}}
+                >
+                  {{option.label}}
+                </dd.Radio>
+              {{/each}}
+            </S.Dropdown>
+          {{/if}}
 
           {{#if this.filter}}
             <S.Button
@@ -284,7 +305,7 @@
         {{/if}}
       </Hds::ApplicationState>
     {{/if}}
-  <hr />
+  {{!-- <hr />
   Options:<br />
   {{#each this.filterFacets as |group groupIndex|}}
     {{group.label}}<br />
@@ -294,7 +315,6 @@
   {{/each}}
   <hr />
   Next token is {{this.nextToken}}<br />
-  {{!-- Previous tokens ({{this.previousTokens.length}}) are {{this.previousTokens}}<br /> --}}
   Model.jobs length: {{this.model.jobs.length}}<br />
   Controller.jobs length: {{this.jobs.length}}<br />
   Job IDs to watch for ({{this.jobIDs.length}}): {{#each this.jobIDs as |id|}}{{id.id}} | {{/each}}<br />
@@ -313,7 +333,7 @@
   jobQueryIndex: {{this.jobQueryIndex}}<br />
   jobAllocsQueryIndex: {{this.jobAllocsQueryIndex}}<br />
 
-  <hr />
+  <hr /> --}}
 
 
 </section>

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -319,7 +319,7 @@
                 <Hds::Badge @text="{{capitalize B.data.aggregateAllocStatus.label}}" @color={{B.data.aggregateAllocStatus.state}} @size="large" />
               {{/unless}}
             </B.Td>
-            <B.Td data-test-job-type>
+            <B.Td data-test-job-type={{B.data.type}}>
               {{B.data.type}}
             </B.Td>
             {{#if this.system.shouldShowNodepools}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -151,7 +151,7 @@
               {{/if}}
             </B.Td>
             {{#if this.system.shouldShowNamespaces}}
-              <B.Td>{{B.data.namespace.id}}</B.Td>
+              <B.Td data-test-job-namespace>{{B.data.namespace.id}}</B.Td>
             {{/if}}
             <B.Td data-test-job-status>
               {{#unless B.data.childStatuses}}
@@ -262,7 +262,7 @@
     {{else}}
       <Hds::ApplicationState data-test-empty-jobs-list as |A|>
         {{#if this.filter}}
-          <A.Header data-test-empty-jobs-list-headline @title="No Jobs Match Filter" />
+          <A.Header data-test-empty-jobs-list-headline @title="No Matches" />
           <A.Body
             @text="No jobs match your current filter selection."
           />
@@ -292,6 +292,4 @@
         {{/if}}
       </Hds::ApplicationState>
     {{/if}}
-    <hr />
-    Namespace is {{this.qpNamespace}}
 </section>

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -20,7 +20,7 @@
           />
 
           {{#each this.filterFacets as |group|}}
-            <S.Dropdown as |dd|>
+            <S.Dropdown data-test-facet={{group.label}} as |dd|>
               <dd.ToggleButton
                 @text={{group.label}}
                 @color="secondary"
@@ -44,7 +44,7 @@
           {{/each}}
 
           {{#if this.system.shouldShowNamespaces}}
-            <S.Dropdown as |dd|>
+            <S.Dropdown data-test-facet="namespace" as |dd|>
               <dd.ToggleButton
                 @text="Namespace"
                 @color="secondary"
@@ -292,4 +292,6 @@
         {{/if}}
       </Hds::ApplicationState>
     {{/if}}
+    <hr />
+    Namespace is {{this.qpNamespace}}
 </section>

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -44,7 +44,7 @@
           {{/each}}
 
           {{#if this.system.shouldShowNamespaces}}
-            <S.Dropdown data-test-facet="namespace" as |dd|>
+            <S.Dropdown data-test-facet="Namespace" as |dd|>
               <dd.ToggleButton
                 @text="Namespace"
                 @color="secondary"

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -248,12 +248,9 @@
           </div>
 
           <div data-test-jobs-search>
-            <Hds::Form::TextInput::Base
-              @type="search"
-              @value=""
-              aria-label="Job Search"
-              placeholder="eg. Hello World"
-              @icon="search"
+            <JobSearchBox
+              @filter={{this.filter}}
+              @onFilterChange={{this.updateFilter}}
             />
           </div>
 

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -250,13 +250,12 @@
 
 
 
-        <Hds::Dropdown data-test-state-facet as |dd|>
+        {{!-- <Hds::Dropdown data-test-state-facet as |dd|>
           <dd.ToggleButton
             @text="Status"
             @color="secondary"
-            {{!-- @badge={{if (eq this.activeToggles.length this.allToggles.length) false this.activeToggles.length}} --}}
+            @count="3"
           />
-          <dd.Title @text="Status" />
           {{#each this.optionsStatus as |option|}}
             <dd.Checkbox
               {{on "change" (toggle option.qp this)}}
@@ -267,7 +266,35 @@
               {{capitalize option.label}}
             </dd.Checkbox>
           {{/each}}
+        </Hds::Dropdown> --}}
+
+        {{#each this.filterOptions as |group groupIndex|}}
+        <Hds::Dropdown as |dd|>
+          <dd.ToggleButton
+            @text={{group.label}}
+            @color="secondary"
+            {{!-- @badge={{or this.selection[group.qp].length false}} --}}
+          />
+          {{#each group.options as |option optionIndex|}}
+            <dd.Checkbox
+              {{!-- {{on "change" (queue
+                (fn (mut option.checked) (not option.checked))
+                this.updateFilter
+              )}} --}}
+              {{on "change" (fn this.toggleOption groupIndex optionIndex)}}
+              @value={{option.key}}
+              checked={{option.checked}}
+              data-test-dropdown-option={{option.key}}
+            >
+              {{option.key}}
+            </dd.Checkbox>
+          {{else}}
+            <dd.Generic data-test-dropdown-empty>
+              No {{group.label}} filters
+            </dd.Generic>
+          {{/each}}
         </Hds::Dropdown>
+        {{/each}}
 
 
 
@@ -284,9 +311,11 @@
 
           <div data-test-jobs-search>
             <JobSearchBox
-              {{!-- @filter={{this.filter}} --}}
-              @filter={{this.searchText}}
-              @onFilterChange={{this.updateFilter}}
+              @searchText={{this.searchText}}
+              @onSearchTextChange={{queue
+                this.updateSearchText
+                this.updateFilter
+              }}
             />
           </div>
 
@@ -497,6 +526,14 @@
         {{/if}}
       </Hds::ApplicationState>
     {{/if}}
+  <hr />
+  Options:<br />
+  {{#each this.filterOptions as |group groupIndex|}}
+    {{group.label}}<br />
+    {{#each group.options as |option optionIndex|}}
+      {{option.key}}: {{option.checked}}<br />
+    {{/each}}
+  {{/each}}
   <hr />
   Next token is {{this.nextToken}}<br />
   {{!-- Previous tokens ({{this.previousTokens.length}}) are {{this.previousTokens}}<br /> --}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -247,9 +247,45 @@
             />
           </div>
 
+
+
+
+        <Hds::Dropdown data-test-state-facet as |dd|>
+          <dd.ToggleButton
+            @text="Status"
+            @color="secondary"
+            {{!-- @badge={{if (eq this.activeToggles.length this.allToggles.length) false this.activeToggles.length}} --}}
+          />
+          <dd.Title @text="Status" />
+          {{#each this.optionsStatus as |option|}}
+            <dd.Checkbox
+              {{on "change" (toggle option.qp this)}}
+              @value={{option.key}}
+              checked={{get this option.qp}}
+              data-test-dropdown-option={{option.label}}
+            >
+              {{capitalize option.label}}
+            </dd.Checkbox>
+          {{/each}}
+        </Hds::Dropdown>
+
+
+
+
+
+          {{!-- <div data-test-jobs-status>
+            <Hds::Dropdown
+              @label="Status"
+              @options={{this.optionsStatus}}
+              @selection={{this.status}}
+              @onSelect={{action this.setFacetQueryParam "qpType"}}
+            />
+          </div> --}}
+
           <div data-test-jobs-search>
             <JobSearchBox
-              @filter={{this.filter}}
+              {{!-- @filter={{this.filter}} --}}
+              @filter={{this.searchText}}
               @onFilterChange={{this.updateFilter}}
             />
           </div>
@@ -430,17 +466,35 @@
       </section>
     {{else}}
       <Hds::ApplicationState data-test-empty-jobs-list as |A|>
-        {{!-- TODO: differentiate between "empty because there's nothing" and "empty because you have filtered/searched" --}}
-        <A.Header data-test-empty-jobs-list-headline @title="No Jobs" />
-        <A.Body
-          @text="No jobs match your current filter selection."
-        />
+        {{#if this.filter}}
+          <A.Header data-test-empty-jobs-list-headline @title="No Jobs Match Filter" />
+          <A.Body
+            @text="No jobs match your current filter selection."
+          />
         <A.Footer @hasDivider={{true}}>
+          <Hds::Button
+            @text="Reset Filters"
+            @color="tertiary"
+            @icon="arrow-left"
+            @size="small"
+            {{on "click" (action this.resetFilters)}}
+          />
+
           {{!-- TODO: HDS4.0, convert to F.LinkStandalone --}}
-          <Hds::Link::Standalone @icon="arrow-left" @text="Reset Filters" @route="jobs.index" />
           <Hds::Link::Standalone @icon="plus" @text="Run a New Job" @route="jobs.run" 
             @iconPosition="trailing" />
         </A.Footer>
+        {{else}}
+          <A.Header data-test-empty-jobs-list-headline @title="No Jobs" />
+          <A.Body
+            @text="No jobs found."
+          />
+          <A.Footer @hasDivider={{true}}>
+            {{!-- TODO: HDS4.0, convert to F.LinkStandalone --}}
+            <Hds::Link::Standalone @icon="plus" @text="Run a New Job" @route="jobs.run" 
+              @iconPosition="trailing" />
+          </A.Footer>
+        {{/if}}
       </Hds::ApplicationState>
     {{/if}}
   <hr />

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -7,329 +7,87 @@
 <section class="section">
     <Hds::PageHeader as |PH|>
       <PH.Actions id="jobs-list-actions">
-        {{!-- <Hds::SegmentedGroup as |S|>
-          <S.Dropdown data-test-state-facet as |dd|>
-            <dd.ToggleButton
-              @text="State"
-              @color="secondary"
-              @badge={{if (eq this.activeToggles.length this.allToggles.length) false this.activeToggles.length}}
-            />
-            <dd.Title @text="Status" />
-            {{#each this.clientFilterToggles.state as |option|}}
-              <dd.Checkbox
-                {{on "change" (toggle option.qp this)}}
-                @value={{option.label}}
-                @count={{get (filter (action option.filter) this.nodes) "length"}}
-                checked={{get this option.qp}}
-                data-test-dropdown-option={{option.label}}
-              >
-                {{capitalize option.label}}
-              </dd.Checkbox>
-            {{/each}}
-            <dd.Separator />
-            <dd.Title @text="Eligibility" />
-            {{#each this.clientFilterToggles.eligibility as |option|}}
-              <dd.Checkbox
-                {{on "change" (toggle option.qp this)}}
-                @value={{option.label}}
-                @count={{get (filter (action option.filter) this.nodes) "length"}}
-                checked={{get this option.qp}}
-                data-test-dropdown-option={{option.label}}
-              >
-                {{capitalize option.label}}
-              </dd.Checkbox>
-            {{/each}}
-            <dd.Separator />
-            <dd.Title @text="Drain Status" />
-            {{#each this.clientFilterToggles.drainStatus as |option|}}
-              <dd.Checkbox
-                {{on "change" (toggle option.qp this)}}
-                @value={{option.label}}
-                @count={{get (filter (action option.filter) this.nodes) "length"}}
-                checked={{get this option.qp}}
-                data-test-dropdown-option={{option.label}}
-              >
-                {{capitalize option.label}}
-              </dd.Checkbox>
-            {{/each}}
-          </S.Dropdown>
 
-          <S.Dropdown data-test-node-pool-facet as |dd|>
-            <dd.ToggleButton
-              @text="Node Pool"
-              @color="secondary"
-              @badge={{or this.selectionNodePool.length false}}
-            />
-            {{#each this.optionsNodePool key="label" as |option|}}
-              <dd.Checkbox
-                {{on "change" (action this.handleFilterChange
-                  this.selectionNodePool
-                  option.label
-                  "qpNodePool"
-                )}}
-                @value={{option.label}}
-                checked={{includes option.label this.selectionNodePool}}
-                @count={{get (filter-by 'nodePool' option.label this.nodes) "length"}}
-                data-test-dropdown-option={{option.label}}
-              >
-                {{option.label}}
-              </dd.Checkbox>
-            {{else}}
-              <dd.Generic data-test-dropdown-empty>
-                No Node Pool filters
-              </dd.Generic>
-            {{/each}}
-          </S.Dropdown>
+        <Hds::SegmentedGroup as |S|>
 
-          <S.Dropdown data-test-class-facet as |dd|>
-            <dd.ToggleButton
-              @text="Class"
-              @color="secondary"
-              @badge={{or this.selectionClass.length false}}
-            />
-            {{#each this.optionsClass key="label" as |option|}}
-              <dd.Checkbox
-                {{on "change" (action this.handleFilterChange
-                  this.selectionClass
-                  option.label
-                  "qpClass"
-                )}}
-                @value={{option.label}}
-                checked={{includes option.label this.selectionClass}}
-                @count={{get (filter-by 'nodeClass' option.label this.nodes) "length"}}
-                data-test-dropdown-option={{option.label}}
-              >
-                {{option.label}}
-              </dd.Checkbox>
-            {{else}}
-              <dd.Generic data-test-dropdown-empty>
-                No Class filters
-              </dd.Generic>
-            {{/each}}
-          </S.Dropdown>
-
-          <S.Dropdown data-test-datacenter-facet as |dd|>
-            <dd.ToggleButton
-              @text="Datacenter"
-              @color="secondary"
-              @badge={{or this.selectionDatacenter.length false}}
-            />
-            {{#each this.optionsDatacenter key="label" as |option|}}
-              <dd.Checkbox
-                {{on "change" (action this.handleFilterChange
-                  this.selectionDatacenter
-                  option.label
-                  "qpDatacenter"
-                )}}
-                @value={{option.label}}
-                checked={{includes option.label this.selectionDatacenter}}
-                @count={{get (filter-by 'datacenter' option.label this.nodes) "length"}}
-                data-test-dropdown-option={{option.label}}
-              >
-                {{option.label}}
-              </dd.Checkbox>
-            {{else}}
-              <dd.Generic data-test-dropdown-empty>
-                No Datacenter filters
-              </dd.Generic>
-            {{/each}}
-
-          </S.Dropdown>
-
-          <S.Dropdown data-test-version-facet as |dd|>
-            <dd.ToggleButton
-              @text="Version"
-              @color="secondary"
-              @badge={{or this.selectionVersion.length false}}
-            />
-            {{#each this.optionsVersion key="label" as |option|}}
-              <dd.Checkbox
-                {{on "change" (action this.handleFilterChange
-                  this.selectionVersion
-                  option.label
-                  "qpVersion"
-                )}}
-                @value={{option.label}}
-                checked={{includes option.label this.selectionVersion}}
-                @count={{get (filter-by 'version' option.label this.nodes) "length"}}
-                data-test-dropdown-option={{option.label}}
-              >
-                {{option.label}}
-              </dd.Checkbox>
-            {{else}}
-              <dd.Generic data-test-dropdown-empty>
-                No Version filters
-              </dd.Generic>
-            {{/each}}
-          </S.Dropdown>
-
-          <S.Dropdown data-test-volume-facet as |dd|>
-            <dd.ToggleButton
-              @text="Volume"
-              @color="secondary"
-              @badge={{or this.selectionVolume.length false}}
-            />
-            {{#each this.optionsVolume key="label" as |option|}}
-              <dd.Checkbox
-                {{on "change" (action this.handleFilterChange
-                  this.selectionVolume
-                  option.label
-                  "qpVolume"
-                )}}
-                @value={{option.label}}
-                checked={{includes option.label this.selectionVolume}}
-                @count={{get (filter-by 'volume' option.label this.nodes) "length"}}
-                data-test-dropdown-option={{option.label}}
-              >
-                {{option.label}}
-              </dd.Checkbox>
-            {{else}}
-              <dd.Generic data-test-dropdown-empty>
-                No Volume filters
-              </dd.Generic>
-            {{/each}}
-          </S.Dropdown>
-        </Hds::SegmentedGroup>
-       --}}
-
-        <Hds::ButtonSet style="white-space: nowrap;">
-          {{#if this.system.shouldShowNamespaces}}
-            {{!-- <SingleSelectDropdown
-              data-test-namespace-facet
-              @label="Namespace"
-              @options={{this.optionsNamespaces}}
-              @selection={{this.qpNamespace}}
-              @onSelect={{action this.setFacetQueryParam "qpNamespace"}}
-            /> --}}
-
-            <Hds::Dropdown data-test-namespace-facet as |dd|>
-              <dd.ToggleButton
-                @text="Namespace"
-                @color="secondary"
-                @badge={{or this.selectionNamespace.length false}}
-              />
-              {{#each this.optionsNamespace key="label" as |option|}}
-                <dd.Checkbox
-                  {{on "change" (action this.handleFilterChange
-                    this.selectionNamespace
-                    option.label
-                    "qpNamespace"
-                  )}}
-                  @value={{option.label}}
-                  checked={{includes option.label this.selectionDatacenter}}
-                  @count={{get (filter-by 'datacenter' option.label this.nodes) "length"}}
-                  data-test-dropdown-option={{option.label}}
-                >
-                  {{option.label}}
-                </dd.Checkbox>
-              {{else}}
-                <dd.Generic data-test-dropdown-empty>
-                  No Namespaces
-                </dd.Generic>
-              {{/each}}
-            </Hds::Dropdown>
-          {{/if}}
-
-          <div
-            {{keyboard-shortcut
-              label="Run Job"
-              pattern=(array "r" "u" "n")
-              action=(action this.goToRun)
+          <JobSearchBox
+            @searchText={{this.searchText}}
+            @onSearchTextChange={{queue
+              this.updateSearchText
+              this.updateFilter
             }}
-          >
-            <Hds::Button
-              data-test-run-job
-              @text="Run Job"
-              disabled={{not (can "run job")}}
-              title={{if (can "run job") null "You don’t have permission to run jobs"}}
-              @route="jobs.run"
-              @query={{hash namespace=this.qpNamespace}}
-            />
-          </div>
-
-
-
-
-        {{!-- <Hds::Dropdown data-test-state-facet as |dd|>
-          <dd.ToggleButton
-            @text="Status"
-            @color="secondary"
-            @count="3"
+            @S={{S}}
           />
-          {{#each this.optionsStatus as |option|}}
-            <dd.Checkbox
-              {{on "change" (toggle option.qp this)}}
-              @value={{option.key}}
-              checked={{get this option.qp}}
-              data-test-dropdown-option={{option.label}}
-            >
-              {{capitalize option.label}}
-            </dd.Checkbox>
-          {{/each}}
-        </Hds::Dropdown> --}}
 
-        {{#each this.filterOptions as |group groupIndex|}}
-        <Hds::Dropdown as |dd|>
-          <dd.ToggleButton
-            @text={{group.label}}
-            @color="secondary"
-            {{!-- @badge={{or this.selection[group.qp].length false}} --}}
-          />
-          {{#each group.options as |option optionIndex|}}
-            <dd.Checkbox
-              {{!-- {{on "change" (queue
-                (fn (mut option.checked) (not option.checked))
-                this.updateFilter
-              )}} --}}
-              {{on "change" (fn this.toggleOption groupIndex optionIndex)}}
-              @value={{option.key}}
-              checked={{option.checked}}
-              data-test-dropdown-option={{option.key}}
-            >
-              {{option.key}}
-            </dd.Checkbox>
-          {{else}}
-            <dd.Generic data-test-dropdown-empty>
-              No {{group.label}} filters
-            </dd.Generic>
-          {{/each}}
-        </Hds::Dropdown>
-        {{/each}}
-
-
-
-
-
-          {{!-- <div data-test-jobs-status>
-            <Hds::Dropdown
-              @label="Status"
-              @options={{this.optionsStatus}}
-              @selection={{this.status}}
-              @onSelect={{action this.setFacetQueryParam "qpType"}}
+          {{#each this.filterFacets as |group|}}
+          <S.Dropdown as |dd|>
+            <dd.ToggleButton
+              @text={{group.label}}
+              @color="secondary"
+              @count={{get (filter-by "checked" true group.options) "length"}}
+              {{!-- @badge={{or this.selection[group.qp].length false}} --}}
             />
-          </div> --}}
+            {{#each group.options as |option|}}
+              <dd.Checkbox
+                {{!-- {{on "change" (queue
+                  (fn (mut option.checked) (not option.checked))
+                  this.updateFilter
+                )}} --}}
+                {{on "change" (fn this.toggleOption option)}}
+                @value={{option.key}}
+                checked={{option.checked}}
+                data-test-dropdown-option={{option.key}}
+              >
+                {{option.key}}
+              </dd.Checkbox>
+            {{else}}
+              <dd.Generic data-test-dropdown-empty>
+                No {{group.label}} filters
+              </dd.Generic>
+            {{/each}}
+          </S.Dropdown>
+          {{/each}}
 
-          <div data-test-jobs-search>
-            <JobSearchBox
-              @searchText={{this.searchText}}
-              @onSearchTextChange={{queue
-                this.updateSearchText
-                this.updateFilter
-              }}
-            />
-          </div>
-
-          {{#if this.pendingJobIDDiff}}
-            <Hds::Button
+          {{#if this.filter}}
+            <S.Button
+              @text="Reset Filters"
+              @color="critical"
+              @icon="delete"
               @size="medium"
-              @text="Updates Pending"
-              @color="primary"
-              @icon="sync"
-              {{on "click" (perform this.updateJobList)}}
-              data-test-updates-pending-button
+              {{on "click" (action this.resetFilters)}}
             />
           {{/if}}
-        </Hds::ButtonSet>
+
+        </Hds::SegmentedGroup>
+
+        {{#if this.pendingJobIDDiff}}
+          <Hds::Button
+            @size="medium"
+            @text="Updates Pending"
+            @color="primary"
+            @icon="sync"
+            {{on "click" (perform this.updateJobList)}}
+            data-test-updates-pending-button
+          />
+        {{/if}}
+
+        <div
+          {{keyboard-shortcut
+            label="Run Job"
+            pattern=(array "r" "u" "n")
+            action=(action this.goToRun)
+          }}
+        >
+          <Hds::Button
+            data-test-run-job
+            @text="Run Job"
+            disabled={{not (can "run job")}}
+            title={{if (can "run job") null "You don’t have permission to run jobs"}}
+            @route="jobs.run"
+            @query={{hash namespace=this.qpNamespace}}
+          />
+        </div>
+
       </PH.Actions>
     </Hds::PageHeader>
 
@@ -528,7 +286,7 @@
     {{/if}}
   <hr />
   Options:<br />
-  {{#each this.filterOptions as |group groupIndex|}}
+  {{#each this.filterFacets as |group groupIndex|}}
     {{group.label}}<br />
     {{#each group.options as |option optionIndex|}}
       {{option.key}}: {{option.checked}}<br />

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function (environment) {
 
     APP: {
       blockingQueries: true,
-      mirageScenario: 'jobsIndexTestCluster', // TODO:  'smallCluster',
+      mirageScenario: 'smallCluster',
       mirageWithNamespaces: true,
       mirageWithTokens: true,
       mirageWithRegions: true,

--- a/ui/config/environment.js
+++ b/ui/config/environment.js
@@ -36,7 +36,7 @@ module.exports = function (environment) {
 
     APP: {
       blockingQueries: true,
-      mirageScenario: 'smallCluster',
+      mirageScenario: 'jobsIndexTestCluster', // TODO:  'smallCluster',
       mirageWithNamespaces: true,
       mirageWithTokens: true,
       mirageWithRegions: true,

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -30,7 +30,7 @@ export function filesForPath(allocFiles, filterPath) {
 export default function () {
   this.timing = 0; // delay for each request, automatically set to 0 during testing
 
-  this.logging = true; // TODO: window.location.search.includes('mirage-logging=true');
+  this.logging = window.location.search.includes('mirage-logging=true');
 
   this.namespace = 'v1';
   this.trackRequests = Ember.testing;

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -30,7 +30,7 @@ export function filesForPath(allocFiles, filterPath) {
 export default function () {
   this.timing = 0; // delay for each request, automatically set to 0 during testing
 
-  this.logging = window.location.search.includes('mirage-logging=true');
+  this.logging = true; // TODO: window.location.search.includes('mirage-logging=true');
 
   this.namespace = 'v1';
   this.trackRequests = Ember.testing;
@@ -128,7 +128,12 @@ export default function () {
           const filterConditions = req.queryParams.filter
             .split(' and ')
             .map((condition) => {
+              // Dropdowns user parenthesis wrapping; remove them for mock/test purposes
+              if (condition.startsWith('(') && condition.endsWith(')')) {
+                condition = condition.slice(1, -1);
+              }
               const parts = condition.split(' ');
+
               return {
                 field: parts[0],
                 operator: parts[1],

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -154,8 +154,6 @@ export default function () {
               }
             });
 
-          console.log('filterConditions are', filterConditions);
-
           filteredJson = filteredJson.filter((job) => {
             return filterConditions.every((condition) => {
               if (condition.parts) {

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -62,13 +62,14 @@ function jobsIndexTestCluster(server) {
   faker.seed(1);
   server.createList('agent', 1, 'withConsulLink', 'withVaultLink');
   server.createList('node', 1);
+  server.create('node-pool');
 
   const jobsToCreate = 55;
   for (let i = 0; i < jobsToCreate; i++) {
+    let groupCount = Math.floor(Math.random() * 2) + 1;
     server.create('job', {
-      namespaceId: 'default',
-      resourceSpec: Array(1).fill('M: 256, C: 500'),
-      groupAllocCount: 1,
+      resourceSpec: Array(groupCount).fill('M: 256, C: 500'),
+      groupAllocCount: Math.floor(Math.random() * 3) + 1,
       modifyIndex: i + 1,
     });
   }

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -18,7 +18,6 @@ import pageSizeSelect from './behaviors/page-size-select';
 import JobsList from 'nomad-ui/tests/pages/jobs/list';
 import percySnapshot from '@percy/ember';
 import faker from 'nomad-ui/mirage/faker';
-import { clickToggle, clickOption } from 'nomad-ui/tests/helpers/helios';
 
 let managementToken, clientToken;
 

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -1190,6 +1190,38 @@ module('Acceptance | jobs list', function (hooks) {
       });
     });
   });
+
+  module('Searching and Filtering', function () {
+    module('Search', function () {
+      test('Searching reasons about whether you intended a job name or a filter expression', async function (assert) {
+        localStorage.setItem('nomadPageSize', '10');
+        createJobs(server, 10);
+        await JobsList.visit();
+
+        await JobsList.search.fillIn('something-that-surely-doesnt-exist');
+        // check to see that we fired off a request; check handledRequests to find one with a ?filter in it
+        assert.ok(
+          server.pretender.handledRequests.find((req) =>
+            req.url.includes(
+              '?filter=Name%20contains%20something-that-surely-doesnt-exist'
+            )
+          ),
+          'A request was made with a filter query param that assumed job name'
+        );
+
+        await JobsList.search.fillIn('Namespace == ns-2');
+
+        assert.ok(
+          server.pretender.handledRequests.find((req) =>
+            req.url.includes('?filter=Namespace%20==%20ns-2')
+          ),
+          'A request was made with a filter query param for a filter expression as typed'
+        );
+
+        localStorage.removeItem('nomadPageSize');
+      });
+    });
+  });
 });
 
 /**

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -18,6 +18,7 @@ import pageSizeSelect from './behaviors/page-size-select';
 import JobsList from 'nomad-ui/tests/pages/jobs/list';
 import percySnapshot from '@percy/ember';
 import faker from 'nomad-ui/mirage/faker';
+import { clickToggle, clickOption } from 'nomad-ui/tests/helpers/helios';
 
 let managementToken, clientToken;
 
@@ -92,7 +93,6 @@ module('Acceptance | jobs list', function (hooks) {
       'Status'
     );
     assert.equal(jobRow.type, typeForJob(job), 'Type');
-    assert.equal(jobRow.priority, job.priority, 'Priority');
   });
 
   test('each job row should link to the corresponding job', async function (assert) {

--- a/ui/tests/integration/components/job-search-box-test.js
+++ b/ui/tests/integration/components/job-search-box-test.js
@@ -2,25 +2,52 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
+import { fillIn, find, triggerEvent } from '@ember/test-helpers';
+
+const DEBOUNCE_MS = 500;
 
 module('Integration | Component | job-search-box', function (hooks) {
   setupRenderingTest(hooks);
 
-  test('it renders', async function (assert) {
-    // Set any properties with this.set('myProperty', 'value');
-    // Handle any actions with this.set('myAction', function(val) { ... });
+  test('debouncer debounces appropriately', async function (assert) {
+    assert.expect(4);
 
-    await render(hbs`<JobSearchBox />`);
+    let message = '';
 
-    assert.dom(this.element).hasText('');
+    this.set('externalAction', (value) => {
+      message = value;
+    });
 
-    // Template block usage:
-    await render(hbs`
-      <JobSearchBox>
-        template block text
-      </JobSearchBox>
-    `);
-
-    assert.dom(this.element).hasText('template block text');
+    await render(hbs`<JobSearchBox @onFilterChange={{this.externalAction}} />`);
+    const element = find('input');
+    await fillIn('input', 'test1');
+    assert.equal(message, 'test1', 'Initial typing');
+    element.value += ' wont be ';
+    triggerEvent('input', 'input');
+    assert.equal(
+      message,
+      'test1',
+      'Typing has happened within debounce window'
+    );
+    element.value += 'seen ';
+    triggerEvent('input', 'input');
+    await delay(DEBOUNCE_MS - 100);
+    assert.equal(
+      message,
+      'test1',
+      'Typing has happened within debounce window, albeit a little slower'
+    );
+    element.value += 'until now.';
+    triggerEvent('input', 'input');
+    await delay(DEBOUNCE_MS + 100);
+    assert.equal(
+      message,
+      'test1 wont be seen until now.',
+      'debounce window has closed'
+    );
   });
 });
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/ui/tests/integration/components/job-search-box-test.js
+++ b/ui/tests/integration/components/job-search-box-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Component | job-search-box', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function (assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`<JobSearchBox />`);
+
+    assert.dom(this.element).hasText('');
+
+    // Template block usage:
+    await render(hbs`
+      <JobSearchBox>
+        template block text
+      </JobSearchBox>
+    `);
+
+    assert.dom(this.element).hasText('template block text');
+  });
+});

--- a/ui/tests/integration/components/job-search-box-test.js
+++ b/ui/tests/integration/components/job-search-box-test.js
@@ -1,8 +1,14 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import { hbs } from 'ember-cli-htmlbars';
 import { fillIn, find, triggerEvent } from '@ember/test-helpers';
+import { componentA11yAudit } from 'nomad-ui/tests/helpers/a11y-audit';
 
 const DEBOUNCE_MS = 500;
 
@@ -19,6 +25,8 @@ module('Integration | Component | job-search-box', function (hooks) {
     });
 
     await render(hbs`<JobSearchBox @onFilterChange={{this.externalAction}} />`);
+    await componentA11yAudit(this.element, assert);
+
     const element = find('input');
     await fillIn('input', 'test1');
     assert.equal(message, 'test1', 'Initial typing');

--- a/ui/tests/integration/components/job-search-box-test.js
+++ b/ui/tests/integration/components/job-search-box-test.js
@@ -16,7 +16,7 @@ module('Integration | Component | job-search-box', function (hooks) {
   setupRenderingTest(hooks);
 
   test('debouncer debounces appropriately', async function (assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     let message = '';
 
@@ -24,7 +24,9 @@ module('Integration | Component | job-search-box', function (hooks) {
       message = value;
     });
 
-    await render(hbs`<JobSearchBox @onFilterChange={{this.externalAction}} />`);
+    await render(
+      hbs`<Hds::SegmentedGroup as |S|><JobSearchBox @onSearchTextChange={{this.externalAction}} @S={{S}} /></Hds::SegmentedGroup>`
+    );
     await componentA11yAudit(this.element, assert);
 
     const element = find('input');

--- a/ui/tests/pages/components/facet.js
+++ b/ui/tests/pages/components/facet.js
@@ -44,3 +44,16 @@ export const singleFacet = (scope) => ({
     },
   }),
 });
+
+export const hdsFacet = (scope) => ({
+  scope,
+
+  toggle: clickable('.hds-dropdown-toggle-button'),
+
+  options: collection('.hds-dropdown-list-item', {
+    resetScope: true,
+    label: text(),
+    key: attribute('data-test-hds-facet-option'),
+    toggle: clickable('.hds-dropdown-list-item__label'),
+  }),
+});

--- a/ui/tests/pages/jobs/list.js
+++ b/ui/tests/pages/jobs/list.js
@@ -66,9 +66,10 @@ export default create({
   pageSizeSelect: pageSizeSelect(),
 
   facets: {
-    namespace: hdsFacet('[data-test-facet="namespace"]'),
+    namespace: hdsFacet('[data-test-facet="Namespace"]'),
     type: multiFacet('[data-test-type-facet]'),
-    status: multiFacet('[data-test-status-facet]'),
+    // status: multiFacet('[data-test-status-facet]'),
+    status: hdsFacet('[data-test-facet="Status"]'),
     datacenter: multiFacet('[data-test-datacenter-facet]'),
     prefix: multiFacet('[data-test-prefix-facet]'),
   },

--- a/ui/tests/pages/jobs/list.js
+++ b/ui/tests/pages/jobs/list.js
@@ -40,8 +40,6 @@ export default create({
     nodePool: text('[data-test-job-node-pool]'),
     status: text('[data-test-job-status]'),
     type: text('[data-test-job-type]'),
-    priority: text('[data-test-job-priority]'),
-    taskGroups: text('[data-test-job-task-groups]'),
 
     hasNamespace: isPresent('[data-test-job-namespace]'),
     clickRow: clickable(),

--- a/ui/tests/pages/jobs/list.js
+++ b/ui/tests/pages/jobs/list.js
@@ -14,7 +14,7 @@ import {
   visitable,
 } from 'ember-cli-page-object';
 
-import { multiFacet, hdsFacet } from 'nomad-ui/tests/pages/components/facet';
+import { hdsFacet } from 'nomad-ui/tests/pages/components/facet';
 import pageSizeSelect from 'nomad-ui/tests/pages/components/page-size-select';
 
 export default create({
@@ -67,10 +67,8 @@ export default create({
 
   facets: {
     namespace: hdsFacet('[data-test-facet="Namespace"]'),
-    type: multiFacet('[data-test-type-facet]'),
-    // status: multiFacet('[data-test-status-facet]'),
+    type: hdsFacet('[data-test-facet="Type"]'),
     status: hdsFacet('[data-test-facet="Status"]'),
-    datacenter: multiFacet('[data-test-datacenter-facet]'),
-    prefix: multiFacet('[data-test-prefix-facet]'),
+    nodePool: hdsFacet('[data-test-facet="NodePool"]'),
   },
 });

--- a/ui/tests/pages/jobs/list.js
+++ b/ui/tests/pages/jobs/list.js
@@ -14,11 +14,7 @@ import {
   visitable,
 } from 'ember-cli-page-object';
 
-import {
-  multiFacet,
-  singleFacet,
-  hdsFacet,
-} from 'nomad-ui/tests/pages/components/facet';
+import { multiFacet, hdsFacet } from 'nomad-ui/tests/pages/components/facet';
 import pageSizeSelect from 'nomad-ui/tests/pages/components/page-size-select';
 
 export default create({

--- a/ui/tests/pages/jobs/list.js
+++ b/ui/tests/pages/jobs/list.js
@@ -14,7 +14,11 @@ import {
   visitable,
 } from 'ember-cli-page-object';
 
-import { multiFacet, singleFacet } from 'nomad-ui/tests/pages/components/facet';
+import {
+  multiFacet,
+  singleFacet,
+  hdsFacet,
+} from 'nomad-ui/tests/pages/components/facet';
 import pageSizeSelect from 'nomad-ui/tests/pages/components/page-size-select';
 
 export default create({
@@ -23,7 +27,7 @@ export default create({
   visit: visitable('/jobs'),
 
   search: {
-    scope: '[data-test-jobs-search] input',
+    scope: '[data-test-jobs-search]',
     keydown: triggerable('keydown'),
   },
 
@@ -66,7 +70,7 @@ export default create({
   pageSizeSelect: pageSizeSelect(),
 
   facets: {
-    namespace: singleFacet('[data-test-namespace-facet]'),
+    namespace: hdsFacet('[data-test-facet="namespace"]'),
     type: multiFacet('[data-test-type-facet]'),
     status: multiFacet('[data-test-status-facet]'),
     datacenter: multiFacet('[data-test-datacenter-facet]'),


### PR DESCRIPTION
Introduces server-side search and filter to the Jobs index page

![image](https://github.com/hashicorp/nomad/assets/713991/0d6c86b7-9c54-44bd-af6c-2075a2fc1f41)

Uses [Filter Expressions](https://developer.hashicorp.com/nomad/api-docs#filtering) with our /statuses endpoint to achieve job-property-level filtering. 

Translates dropdown toggles and search queries into filter expression syntax to help teach the syntax for future advanced usage

Re-implements quite a lot of test logic that was performed against an "all jobs are always loaded" version of this page to use the "what we ask for is what we get" version.