### PR TITLE
client: fixup how alloc mounts directory are setup

### DIFF
--- a/client/allocdir/fs_linux.go
+++ b/client/allocdir/fs_linux.go
@@ -42,6 +42,9 @@ func mountDir(old, next string, uid, gid int, mode os.FileMode) error {
 	if err := unix.Mount(old, next, "", uintptr(opts), ""); err != nil {
 		return err
 	}
+	if err := os.Chmod(next, mode); err != nil {
+		return err
+	}
 	return os.Chown(next, uid, gid)
 }
 

--- a/client/allocrunner/taskrunner/task_dir_hook.go
+++ b/client/allocrunner/taskrunner/task_dir_hook.go
@@ -91,9 +91,9 @@ func setEnvvars(envBuilder *taskenv.Builder, fsi fsisolation.Mode, taskDir *allo
 	switch fsi {
 	case fsisolation.Unveil:
 		// Use mount paths
-		envBuilder.SetAllocDir(filepath.Join(taskDir.MountsAllocDir, "alloc"))
+		envBuilder.SetAllocDir(taskDir.MountsAllocDir)
 		envBuilder.SetTaskLocalDir(filepath.Join(taskDir.MountsTaskDir, "local"))
-		envBuilder.SetSecretsDir(filepath.Join(taskDir.SecretsDir, "secrets"))
+		envBuilder.SetSecretsDir(taskDir.MountsSecretsDir)
 	case fsisolation.None:
 		// Use host paths
 		envBuilder.SetAllocDir(taskDir.SharedAllocDir)

--- a/plugins/drivers/testutils/testing.go
+++ b/plugins/drivers/testutils/testing.go
@@ -267,9 +267,9 @@ func SetEnvvars(envBuilder *taskenv.Builder, fsmode fsisolation.Mode, taskDir *a
 	switch fsmode {
 	case fsisolation.Unveil:
 		// Use mounts host paths
-		envBuilder.SetAllocDir(filepath.Join(taskDir.MountsAllocDir, "alloc"))
+		envBuilder.SetAllocDir(taskDir.MountsAllocDir)
 		envBuilder.SetTaskLocalDir(filepath.Join(taskDir.MountsTaskDir, "local"))
-		envBuilder.SetSecretsDir(filepath.Join(taskDir.SecretsDir, "secrets"))
+		envBuilder.SetSecretsDir(taskDir.SecretsDir)
 	case fsisolation.None:
 		// Use host paths
 		envBuilder.SetAllocDir(taskDir.SharedAllocDir)


### PR DESCRIPTION
This PR overhauls how the taskdir is setup when the FS isolation mode is `Unveil`.

It's most of the fix for https://github.com/hashicorp/nomad-driver-exec2/issues/15 but also fixes more than the secrets directory (which was never being mounted in the first place).

The deeper problem was the structure did not match what one would find in the other task drivers, from the perspective of the `$PWD` of a launched task. The previous structure is hard to explain.

The new structure is as follows in this example:

The `-alloc_dir` (and combined `-alloc_mounts_dir` since we're in `dev` mode)
```
[drwx--x--x root    ]  /tmp/NomadClient3997332079

```

The allocation directory, named by the `<alloc id>`. This is created for all allocations, regardless of driver. This structure is unchanged.

```
├── [drwxr-xr-x root    ]  61d329b6-d5c6-abb6-0ee6-abd043dd2e85
│   ├── [drwx--x--- 82227   ]  alloc
│   │   ├── [drwxrwxrwx nobody  ]  data
│   │   ├── [drwxrwxrwx nobody  ]  logs
│   │   │   ├── [prw------- 82227   ]  .sleep.stderr.fifo
│   │   │   ├── [prw------- 82227   ]  .sleep.stdout.fifo
│   │   │   ├── [-rw-r--r-- root    ]  sleep.stderr.0
│   │   │   └── [-rw-r--r-- root    ]  sleep.stdout.0
│   │   └── [drwxrwxrwx nobody  ]  tmp
│   └── [drwx--x--- 82227   ]  sleep
│       ├── [drwx--x--- 82227   ]  alloc
│       │   ├── [drwxrwxrwx nobody  ]  data
│       │   ├── [drwxrwxrwx nobody  ]  logs
│       │   │   ├── [prw------- 82227   ]  .sleep.stderr.fifo
│       │   │   ├── [prw------- 82227   ]  .sleep.stdout.fifo
│       │   │   ├── [-rw-r--r-- root    ]  sleep.stderr.0
│       │   │   └── [-rw-r--r-- root    ]  sleep.stdout.0
│       │   └── [drwxrwxrwx nobody  ]  tmp
│       ├── [drwxrwxrwx nobody  ]  local
│       ├── [drwxrwxrwx nobody  ]  private
│       │   └── [-rw-r--r-- root    ]  .nomad-mount
│       ├── [drwx--x--- 82227   ]  secrets
│       │   ├── [-rw-r--r-- root    ]  .nomad-mount
│       │   └── [srw-rw-rw- root    ]  api.sock
│       └── [drwxrwxrwt nobody  ]  tmp
```

This next tree is created only when using Unveil isolation mode.

The task directory created under `-alloc_mounts_dir`, named by `<alloc-id>-<task-name>`. This top level directory is `chmod 0o710` owned by the `task.User` (which may be a dynamic UID).

```
└── [drwx--x--- 82227   ]  61d329b6-d5c6-abb6-0ee6-abd043dd2e85-sleep
    ├── [drwx--x--- 82227   ]  alloc
    │   ├── [drwxrwxrwx nobody  ]  data
    │   ├── [drwxrwxrwx nobody  ]  logs
    │   │   ├── [prw------- 82227   ]  .sleep.stderr.fifo
    │   │   ├── [prw------- 82227   ]  .sleep.stdout.fifo
    │   │   ├── [-rw-r--r-- root    ]  sleep.stderr.0
    │   │   └── [-rw-r--r-- root    ]  sleep.stdout.0
    │   └── [drwxrwxrwx nobody  ]  tmp
    ├── [drwxrwxrwx nobody  ]  local
    ├── [drwxr-xr-x root    ]  private
    ├── [drwx--x--- 82227   ]  secrets
    │   ├── [-rw-r--r-- root    ]  .nomad-mount
    │   └── [srw-rw-rw- root    ]  api.sock
    └── [drwxrwxrwt nobody  ]  tmp
```

The environment of the launched task looks like,

```
NOMAD_TASK_DIR    =/tmp/NomadClient181731996/edffd509-9337-8237-d85c-e46137f43ae6-mytask/local
TMPDIR            =/tmp/NomadClient181731996/edffd509-9337-8237-d85c-e46137f43ae6-mytask/tmp
NOMAD_SECRETS_DIR =/tmp/NomadClient181731996/edffd509-9337-8237-d85c-e46137f43ae6-mytask/secrets
NOMAD_ALLOC_DIR   =/tmp/NomadClient181731996/edffd509-9337-8237-d85c-e46137f43ae6-mytask/alloc
```

Also fixed are the order of unmount calls in `TaskDir.Unmount` - it is important to unmount the dirs of the `-alloc_mounts_dir` tree before unmounting the dirs of the `-alloc_dir` dirs, because the former are mounts into the later, and going out of order will result in device busy errors.