### PR TITLE
acl: token global mode can not be changed

### DIFF
--- a/command/acl_token_update.go
+++ b/command/acl_token_update.go
@@ -32,9 +32,6 @@ Update Options:
   -type="client"
     Sets the type of token. Must be one of "client" or "management".
 
-  -global=false
-    Toggles the global mode of the token. Global tokens are replicated to all regions.
-
   -policy=""
     Specifies a policy to associate with the token. Can be specified multiple times,
     but only with client type tokens.
@@ -48,7 +45,6 @@ func (c *ACLTokenUpdateCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{
 			"name":   complete.PredictAnything,
 			"type":   complete.PredictAnything,
-			"global": complete.PredictNothing,
 			"policy": complete.PredictAnything,
 		})
 }
@@ -65,13 +61,11 @@ func (*ACLTokenUpdateCommand) Name() string { return "acl token update" }
 
 func (c *ACLTokenUpdateCommand) Run(args []string) int {
 	var name, tokenType string
-	var global bool
 	var policies []string
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.StringVar(&name, "name", "", "")
 	flags.StringVar(&tokenType, "type", "", "")
-	flags.BoolVar(&global, "global", false, "")
 	flags.Var((funcVar)(func(s string) error {
 		policies = append(policies, s)
 		return nil
@@ -111,11 +105,6 @@ func (c *ACLTokenUpdateCommand) Run(args []string) int {
 
 	if tokenType != "" {
 		token.Type = tokenType
-	}
-
-	// This will default to false if the user does not specify it
-	if global != token.Global {
-		token.Global = global
 	}
 
 	if len(policies) != 0 {

--- a/website/content/api-docs/acl/tokens.mdx
+++ b/website/content/api-docs/acl/tokens.mdx
@@ -193,7 +193,7 @@ The table below shows this endpoint's support for
 
 - `Global` `(bool: <optional>)` - If true, indicates this token should be
   replicated globally to all regions. Otherwise, this token is created local to
-  the target region.
+  the target region. This can not be changed after token creation.
 
 - `ExpirationTime` `(time: "")` - If set, this represents the point after which
   a token should be considered revoked and is eligible for destruction. The

--- a/website/content/docs/commands/acl/token/create.mdx
+++ b/website/content/docs/commands/acl/token/create.mdx
@@ -29,7 +29,7 @@ The `acl token create` command requires no arguments.
   "management".
 
 - `-global`: Sets the global mode of the token. Global tokens are replicated
-  to all regions. This can not be changed after creation. Defaults false.
+  to all regions. This can not be changed after creation. Defaults to false.
 
 - `-policy`: Specifies a policy to associate with the token. Can be specified
   multiple times, but only with client type tokens.

--- a/website/content/docs/commands/acl/token/create.mdx
+++ b/website/content/docs/commands/acl/token/create.mdx
@@ -28,8 +28,8 @@ The `acl token create` command requires no arguments.
 - `-type`: Sets the type of token. Must be one of "client" (default), or
   "management".
 
-- `-global`: Toggles the global mode of the token. Global tokens are replicated
-  to all regions. Defaults false.
+- `-global`: Sets the global mode of the token. Global tokens are replicated
+  to all regions. This can not be changed after creation. Defaults false.
 
 - `-policy`: Specifies a policy to associate with the token. Can be specified
   multiple times, but only with client type tokens.

--- a/website/content/docs/commands/acl/token/update.mdx
+++ b/website/content/docs/commands/acl/token/update.mdx
@@ -21,14 +21,11 @@ The `acl token update` command requires an existing token's accessor ID.
 
 @include 'general_options_no_namespace.mdx'
 
-## Create Options
+## Update Options
 
 - `-name`: Sets the human readable name for the ACL token.
 
 - `-type`: Sets the type of token. Must be one of "client" or "management".
-
-- `-global`: Toggles the global mode of the token. Global tokens are replicated
-  to all regions. Defaults false.
 
 - `-policy`: Specifies a policy to associate with the token. Can be specified
   multiple times, but only with client type tokens.


### PR DESCRIPTION
True up `nomad acl token update` CLI and some docs with most docs and API reality.

Most API docs already rightly say "Note that a token cannot be switched from global to local or visa versa."

Here's what happens if you try:

```
$ nomad acl token update -global=false $accessor
Error updating token: Unexpected response code: 400 (token 0 invalid: 1 error occurred:
        * cannot toggle global mode)
```