### PR TITLE
Task pause schedule (CE part)

### DIFF
--- a/api/task_sched.go
+++ b/api/task_sched.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+type TaskSchedule struct {
+	Cron *TaskScheduleCron `hcl:"cron,block"`
+}
+
+type TaskScheduleCron struct {
+	Start    string `hcl:"start,optional"`
+	Stop     string `hcl:"stop,optional"`
+	Timezone string `hcl:"timezone,optional"`
+}

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -801,6 +801,8 @@ type Task struct {
 	Identities []*WorkloadIdentity `hcl:"identity,block"`
 
 	Actions []*Action `hcl:"action,block"`
+
+	Schedule *TaskSchedule `hcl:"schedule,block"`
 }
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1425,6 +1425,11 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 		act := ApiActionToStructsAction(job, action)
 		structsTask.Actions = append(structsTask.Actions, act)
 	}
+
+	if apiTask.Schedule != nil {
+		sched := apiScheduleToStructsSchedule(apiTask.Schedule)
+		structsTask.Schedule = sched
+	}
 }
 
 // apiWaitConfigToStructsWaitConfig is a copy and type conversion between the API
@@ -1472,6 +1477,21 @@ func ApiActionToStructsAction(job *structs.Job, action *api.Action) *structs.Act
 		Name:    action.Name,
 		Args:    slices.Clone(action.Args),
 		Command: action.Command,
+	}
+}
+
+func apiScheduleToStructsSchedule(s *api.TaskSchedule) *structs.TaskSchedule {
+	if s.Cron == nil {
+		// Since cron is the only field, drop the whole schedule block if its empty
+		return nil
+	}
+
+	return &structs.TaskSchedule{
+		Cron: &structs.TaskScheduleCron{
+			Start:    s.Cron.Start,
+			Stop:     s.Cron.Stop,
+			Timezone: s.Cron.Timezone,
+		},
 	}
 }
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -88,6 +88,7 @@ func NewJobEndpoints(s *Server, ctx *RPCContext) *Job {
 			&jobValidate{srv: s},
 			&memoryOversubscriptionValidate{srv: s},
 			jobNumaHook{},
+			jobSchedHook{},
 		},
 	}
 }

--- a/nomad/job_endpoint_hook_sched.go
+++ b/nomad/job_endpoint_hook_sched.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nomad
+
+// jobSchedHook implements a job Validating admission controller.
+//
+// The implementation of Validate are in the _ce/_ent files.
+type jobSchedHook struct{}
+
+func (jobSchedHook) Name() string {
+	return "schedule"
+}

--- a/nomad/job_endpoint_hook_sched_ce.go
+++ b/nomad/job_endpoint_hook_sched_ce.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+
+package nomad
+
+import (
+	"errors"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func (jobSchedHook) Validate(job *structs.Job) ([]error, error) {
+	for _, tg := range job.TaskGroups {
+		for _, task := range tg.Tasks {
+			if task.Schedule != nil {
+				return nil, errors.New("task schedules requires Nomad Enterprise")
+			}
+		}
+	}
+	return nil, nil
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7700,6 +7700,9 @@ type Task struct {
 
 	// Alloc-exec-like runnable commands
 	Actions []*Action
+
+	// Schedule for pausing tasks. Enterprise only.
+	Schedule *TaskSchedule
 }
 
 func (t *Task) UsesCores() bool {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8856,6 +8856,10 @@ type TaskState struct {
 	// Experimental -  TaskHandle is based on drivers.TaskHandle and used
 	// by remote task drivers to migrate task handles between allocations.
 	TaskHandle *TaskHandle
+
+	// Enterprise Only - Paused is set to the paused state of the task. See
+	// task_sched.go
+	Paused TaskScheduleState
 }
 
 // NewTaskState returns a TaskState initialized in the Pending state.
@@ -9034,6 +9038,10 @@ const (
 	// TaskSkippingShutdownDelay indicates that the task operation was
 	// configured to ignore the shutdown delay value set for the tas.
 	TaskSkippingShutdownDelay = "Skipping shutdown delay"
+
+	// TaskRunning indicates a task is running due to a schedule or schedule
+	// override. Enterprise only.
+	TaskRunning = "Running"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data

--- a/nomad/structs/task_sched.go
+++ b/nomad/structs/task_sched.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package structs
+
+type TaskSchedule struct {
+	Cron *TaskScheduleCron
+}
+
+type TaskScheduleCron struct {
+	Start    string
+	Stop     string
+	Timezone string
+}

--- a/nomad/structs/task_sched.go
+++ b/nomad/structs/task_sched.go
@@ -3,6 +3,45 @@
 
 package structs
 
+type TaskScheduleState string
+
+func (t TaskScheduleState) Stop() bool {
+	switch t {
+	case TaskScheduleStateForcePause:
+		return true
+	case TaskScheduleStateSchedPause:
+		return true
+	}
+
+	return false
+}
+
+func (t TaskScheduleState) Event() *TaskEvent {
+	switch t {
+	case TaskScheduleStateForcePause:
+		return NewTaskEvent(TaskKilling).
+			SetDisplayMessage("Pausing due to override")
+	case TaskScheduleStateSchedPause:
+		return NewTaskEvent(TaskKilling).
+			SetDisplayMessage("Pausing due to schedule")
+	case TaskScheduleStateForceRun:
+		return NewTaskEvent(TaskRunning).
+			SetDisplayMessage("Running due to override")
+	case TaskScheduleStateRun:
+		return NewTaskEvent(TaskRunning).
+			SetDisplayMessage("Running due to schedule")
+	}
+
+	return nil
+}
+
+const (
+	TaskScheduleStateRun        TaskScheduleState = ""
+	TaskScheduleStateForceRun   TaskScheduleState = "force_run"
+	TaskScheduleStateSchedPause TaskScheduleState = "scheduled_pause"
+	TaskScheduleStateForcePause TaskScheduleState = "force_pause"
+)
+
 type TaskSchedule struct {
 	Cron *TaskScheduleCron
 }


### PR DESCRIPTION
CE portion of the enterprise Task Pause Schedules feature. WIP.

Sample jobspec:

```hcl
job "example" {
  group "haha" {
    task "business" {
      schedule {
        cron {
          # Start 9:30am EST Weekdays
          start = "0 30 9 * * MON-FRI *"

          # Stop 4pm EST Weekdays
          stop = "0 0 16 * * MON-FRI *"

          # Start and Stop are EST timezone
          timezone = "EST"
        }
      }

      driver = "raw_exec"

      config {
        command = "/bin/bash"
        args    = ["-c", "echo running; date; sleep 90000"]
      }
    }
  }
}
```
```