### PR TITLE
cli: fix handling of scaling jobs which don't generate evals.

### DIFF
--- a/command/job_scale_test.go
+++ b/command/job_scale_test.go
@@ -130,6 +130,44 @@ func TestJobScaleCommand_MultiGroup(t *testing.T) {
 	}
 }
 
+func TestJobScaleCommand_Parameterized(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, client, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+	testutil.WaitForResult(func() (bool, error) {
+		nodes, _, err := client.Nodes().List(nil)
+		if err != nil {
+			return false, err
+		}
+		if len(nodes) == 0 {
+			return false, fmt.Errorf("missing node")
+		}
+		if _, ok := nodes[0].Drivers["mock_driver"]; !ok {
+			return false, fmt.Errorf("mock_driver not ready")
+		}
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("err: %s", err)
+	})
+
+	ui := cli.NewMockUi()
+	cmd := &JobScaleCommand{Meta: Meta{Ui: ui}}
+
+	// Create and register a parameterized job. The parent jobs do not create
+	// evaluations, even when scaled.
+	job := testJob("parameterized_job")
+	job.ParameterizedJob = &api.ParameterizedJobConfig{}
+
+	_, _, err := client.Jobs().Register(job, nil)
+	must.NoError(t, err)
+
+	// Scale the parent job and ensure the output matches what we expect.
+	code := cmd.Run([]string{"-address=" + url, "parameterized_job", "2"})
+	must.Eq(t, 0, code)
+	must.StrContains(t, ui.OutputWriter.String(), "Job scale successful")
+}
+
 func TestJobScaleCommand_ACL(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
In some cases, Nomad job scaling will not generate evaluations such as parameterized jobs. This change fixes the CLI behaviour in this case, and copies the job run command for consistency.