### PR TITLE
test: remove spurious print statements

### DIFF
--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -1053,7 +1053,6 @@ func TestDebug_EventStream(t *testing.T) {
 
 	archive := extractArchiveName(testOut.output)
 	require.NotEmpty(t, archive)
-	fmt.Println(archive)
 
 	// TODO dmay: verify evenstream.json output file contains expected content
 }

--- a/nomad/structs/group_test.go
+++ b/nomad/structs/group_test.go
@@ -5,7 +5,6 @@ package structs
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -262,7 +261,6 @@ func TestJobConfig_Validate_MaxClientDisconnect(t *testing.T) {
 
 	err := job.Validate()
 	must.Error(t, errors.Unwrap(err))
-	fmt.Println("what?", err.Error(), "what?")
 	must.StrContains(t, err.Error(), "max_client_disconnect cannot be negative")
 	must.StrContains(t, err.Error(), "Task group cannot be configured with both max_client_disconnect and stop_after_client_disconnect")
 

--- a/scheduler/reconnecting_picker/reconnecting_picker_test.go
+++ b/scheduler/reconnecting_picker/reconnecting_picker_test.go
@@ -4,7 +4,6 @@
 package reconnectingpicker
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -262,7 +261,6 @@ func TestPickReconnectingAlloc_BestScore(t *testing.T) {
 func TestPickReconnectingAlloc_LongestRunning(t *testing.T) {
 	rp := New(hclog.NewNullLogger())
 	now := time.Now()
-	fmt.Println(now)
 	taskGroupNoLeader := &structs.TaskGroup{
 		Name: "taskGroupNoLeader",
 		Tasks: []*structs.Task{

--- a/scheduler/scheduler_system_test.go
+++ b/scheduler/scheduler_system_test.go
@@ -819,8 +819,6 @@ func TestSystemSched_JobModify_RemoveDC(t *testing.T) {
 	node2.Datacenter = "dc2"
 	require.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node2))
 
-	fmt.Println("DC1 node: ", node1.ID)
-	fmt.Println("DC2 node: ", node2.ID)
 	nodes := []*structs.Node{node1, node2}
 
 	// Generate a fake job with allocations


### PR DESCRIPTION
Before:

```
(main)~/src/nomad/nomad/structs$ go test
what? 2 errors occurred:
        * stop_after_client_disconnect must be a positive value
        * Task group web validation failed: 2 errors occurred:
        * Task group cannot be configured with both max_client_disconnect and stop_after_client_disconnect
        * max_client_disconnect cannot be negative



 what?
PASS
ok      github.com/hashicorp/nomad/nomad/structs        0.057s
```

After:
```
 (test-remove-prints)~/src/nomad/nomad/structs$ go test
PASS
ok      github.com/hashicorp/nomad/nomad/structs        0.057s
```