### PR TITLE
cli: add `-jwks-ca-file` to Vault/Consul setup commands

### DIFF
--- a/.changelog/20518.txt
+++ b/.changelog/20518.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add `-jwks-ca-file` argument to `setup consul/vault` commands
+```

--- a/website/content/docs/commands/setup/consul.mdx
+++ b/website/content/docs/commands/setup/consul.mdx
@@ -32,6 +32,9 @@ nomad setup consul [options]
 - `-jwks-url`: URL of Nomad's JWKS endpoint contacted by Consul to verify JWT
   signatures. Defaults to `http://localhost:4646/.well-known/jwks.json`.
 
+- `-jwks-ca-file`: Path to a CA certificate file that will be used to validate
+  the JWKS URL if it uses TLS.
+
 - `-destroy`: Removes all configuration components this command created from the
   Consul cluster.
 

--- a/website/content/docs/commands/setup/vault.mdx
+++ b/website/content/docs/commands/setup/vault.mdx
@@ -39,6 +39,9 @@ nomad setup vault [options]
 - `-jwks-url`: URL of Nomad's JWKS endpoint contacted by Consul to verify JWT
   signatures. Defaults to `http://localhost:4646/.well-known/jwks.json`.
 
+- `-jwks-ca-file`: Path to a CA certificate file that will be used to validate
+  the JWKS URL if it uses TLS.
+
 - `-destroy`: Removes all configuration components this command created from the
   Consul cluster.
 


### PR DESCRIPTION
When setting up auth methods for Consul and Vault in production environments, we can typically assume that the CA certificate for the JWKS endpoint will be in the host certificate store (as part of the usual configuration management cluster admins needs to do). But for quick demos with `-dev` agents, this won't be the case.

Add a `-jwks-ca-file` parameter to the setup commands so that we can use this tool to quickly setup WI with `-dev` agents running TLS.