### PR TITLE
[ui] Adds the token name to the Profile link in the top nav

### DIFF
--- a/.changelog/20539.txt
+++ b/.changelog/20539.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Added token.name information to the top nav for ease of operator debugging
+```

--- a/ui/app/components/profile-navbar-item.hbs
+++ b/ui/app/components/profile-navbar-item.hbs
@@ -7,9 +7,8 @@
   <Hds::Dropdown @color="secondary" class="profile-dropdown"
     {{keyboard-shortcut menuLevel=true pattern=(array "g" "p") }}
     as |dd|>
-    <dd.ToggleIcon @color="secondary" @icon="user-circle" @text="user menu" @size="small" data-test-header-profile-dropdown />
-    <dd.Title @text="Signed In" />
-    <dd.Description @text={{this.token.selfToken.name}} />
+    <dd.ToggleButton @color="secondary" @icon="user-circle" @text={{this.token.selfToken.name}} @size="small" data-test-header-profile-dropdown />
+    <dd.Description @text="Signed In" />
     <dd.Separator />
     <dd.Interactive @route="settings.tokens" @text="Profile" data-test-profile-dropdown-profile-link />
     <dd.Interactive {{on "click" this.signOut}} @text="Sign Out" @color="critical" data-test-profile-dropdown-sign-out-link />


### PR DESCRIPTION
Displays `token.name` in the dropdown button for ease of identification for screenshots, etc.

![image](https://github.com/hashicorp/nomad/assets/713991/70664bd6-88b3-4e34-b829-5949328c37d4)

Resolves #20538 