### PR TITLE
client: fix unallocated CPU metric when reserved cpu is set.

### DIFF
--- a/.changelog/20543.txt
+++ b/.changelog/20543.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fix unallocated CPU metric calculation when client reserved CPU is set
+```

--- a/client/client.go
+++ b/client/client.go
@@ -3252,7 +3252,11 @@ func (c *Client) setGaugeForAllocationStats(nodeID string, baseLabels []metrics.
 	// Emit unallocated
 	unallocatedMem := total.Memory.MemoryMB - res.Memory.MemoryMB - allocated.Flattened.Memory.MemoryMB
 	unallocatedDisk := total.Disk.DiskMB - res.Disk.DiskMB - allocated.Shared.DiskMB
-	unallocatedCpu := int64(total.Processors.Topology.UsableCompute()) - res.Cpu.CpuShares - allocated.Flattened.Cpu.CpuShares
+
+	// The UsableCompute function call already subtracts and accounts for any
+	// reserved CPU within the client configuration. Therefore, we do not need
+	// to subtract that here.
+	unallocatedCpu := int64(total.Processors.Topology.UsableCompute()) - allocated.Flattened.Cpu.CpuShares
 
 	metrics.SetGaugeWithLabels([]string{"client", "unallocated", "memory"}, float32(unallocatedMem), baseLabels)
 	metrics.SetGaugeWithLabels([]string{"client", "unallocated", "disk"}, float32(unallocatedDisk), baseLabels)


### PR DESCRIPTION
closes #20521 