### PR TITLE
CSI: add support for wildcard namespaces on `plugin status`

### DIFF
--- a/.changelog/20551.txt
+++ b/.changelog/20551.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+csi: Added support for wildcard namespace to `plugin status` command
+```

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -1834,7 +1834,6 @@ func (v *CSIPlugin) Get(args *structs.CSIPluginGetRequest, reply *structs.CSIPlu
 				for _, a := range plug.Allocations {
 					if ns == structs.AllNamespacesSentinel || a.Namespace == ns {
 						if aclObj.AllowNsOp(a.Namespace, acl.NamespaceCapabilityReadJob) {
-							fmt.Println("allow for", a.Namespace)
 							as = append(as, a)
 						}
 					}

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -1795,7 +1795,8 @@ func (v *CSIPlugin) Get(args *structs.CSIPluginGetRequest, reply *structs.CSIPlu
 		return structs.ErrPermissionDenied
 	}
 
-	withAllocs := aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityReadJob)
+	ns := args.RequestNamespace()
+	withAllocs := aclObj.AllowNsOp(ns, acl.NamespaceCapabilityReadJob)
 
 	if args.ID == "" {
 		return fmt.Errorf("missing plugin ID")
@@ -1819,18 +1820,23 @@ func (v *CSIPlugin) Get(args *structs.CSIPluginGetRequest, reply *structs.CSIPlu
 				return nil
 			}
 
+			// if we're not allowed access to the namespace at all, we skip this
+			// copy as an optimization. withAllocs will be true for the wildcard
+			// namespace
 			if withAllocs {
 				plug, err = snap.CSIPluginDenormalize(ws, plug.Copy())
 				if err != nil {
 					return err
 				}
 
-				// Filter the allocation stubs by our namespace. withAllocs
-				// means we're allowed
+				// Filter the allocation stubs by allowed namespace
 				var as []*structs.AllocListStub
 				for _, a := range plug.Allocations {
-					if a.Namespace == args.RequestNamespace() {
-						as = append(as, a)
+					if ns == structs.AllNamespacesSentinel || a.Namespace == ns {
+						if aclObj.AllowNsOp(a.Namespace, acl.NamespaceCapabilityReadJob) {
+							fmt.Println("allow for", a.Namespace)
+							as = append(as, a)
+						}
 					}
 				}
 				plug.Allocations = as


### PR DESCRIPTION
The `nomad plugin status :plugin_id` command lists allocations that implement the plugin being queried. This list is filtered by the `-namespace` flag as usual. Cluster admins will likely deploy plugins to a single namespace, but for convenience they may want to have the wildcard namespace set in their command environment.

Add support for handling the wildcard namespace to the CSI plugin RPC handler.

Fixes: https://github.com/hashicorp/nomad/issues/20537