### PR TITLE
docs: correct ACL requirements for CSI plugins

### DIFF
--- a/website/content/api-docs/plugins.mdx
+++ b/website/content/api-docs/plugins.mdx
@@ -22,9 +22,9 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | ACL Required                |
-| ---------------- | --------------------------- |
-| `YES`            | `namespace:csi-list-plugin` |
+| Blocking Queries | ACL Required  |
+|------------------|---------------|
+| `YES`            | `plugin:read` |
 
 ### Parameters
 
@@ -70,9 +70,11 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | ACL Required                |
-| ---------------- | --------------------------- |
-| `YES`            | `namespace:csi-read-plugin` |
+| Blocking Queries | ACL Required                                                    |
+|------------------|-----------------------------------------------------------------|
+| `YES`            | `plugin:read`,                                                  |
+|                  | `namespace:*`<br />Allocations listed are filtered by namespace |
+
 
 ### Sample Request
 


### PR DESCRIPTION
CSI plugins are not namespaced, and there's no "list plugin" ACL. Instead, listing and reading plugins require the `plugin:read` ACL.

Noticed this while working on https://github.com/hashicorp/nomad/pull/20551