### PR TITLE
docs: note that plugin policy is required in the UI for CSI volumes

### DIFF
--- a/website/content/docs/other-specifications/acl-policy.mdx
+++ b/website/content/docs/other-specifications/acl-policy.mdx
@@ -461,6 +461,14 @@ agent {
 }
 ```
 
+Additionally, ACL policies for users who can read jobs that mount CSI volumes
+should include the following rules.
+
+```hcl
+plugin {
+  policy = "read"
+}
+```
 
 [Secure Nomad with Access Control]: /nomad/tutorials/access-control
 [hcl]: https://github.com/hashicorp/hcl


### PR DESCRIPTION
The ACL docs have a section explaining that some parts of the UI need slightly wider read permissions than expected. These docs should include that you need `plugin:read` to look at CSI volume pages in the UI.

Fixes: https://github.com/hashicorp/nomad/issues/18527