### PR TITLE
docs: fix broken markdown

### DIFF
--- a/website/content/docs/commands/alloc/exec.mdx
+++ b/website/content/docs/commands/alloc/exec.mdx
@@ -70,7 +70,8 @@ root@eb17e557:/data# # ps -ef
 To run a command and stream results without starting an interactive shell, you
 can pass the command and its arguments to exec directly:
 
-```shell-session# run commands without starting an interactive session
+```shell-session
+# run commands without starting an interactive session
 $ nomad alloc exec eb17e557 cat /etc/resolv.conf
 ...
 ```
@@ -88,7 +89,8 @@ $ nomad alloc exec eb17e557 echo $NOMAD_ALLOC_ID # wrong
 Here, we must start a shell in task to interpolate `$NOMAD_ALLOC_ID`, and quote
 command or use the [heredoc syntax][heredoc]
 
-```shell-session# by quoting argument
+```shell-session
+# by quoting argument
 $ nomad alloc exec eb17e557 /bin/sh -c 'echo $NOMAD_ALLOC_ID'
 eb17e557-443e-4c51-c049-5bba7a9850bc
 
@@ -102,7 +104,8 @@ eb17e557-443e-4c51-c049-5bba7a9850bc
 This technique applies when aiming to run a shell pipeline without streaming
 intermediate command output across the network:
 
-```shell-session# e.g. find top appearing lines in some output
+```shell-session
+# e.g. find top appearing lines in some output
 $ nomad alloc exec eb17e557 /bin/sh -c 'cat /output | sort | uniq -c | sort -rn | head -n 5'
 ...
 ```

--- a/website/content/docs/concepts/cpu.mdx
+++ b/website/content/docs/concepts/cpu.mdx
@@ -157,7 +157,7 @@ following environment variables in their runtime environment.
 - `NOMAD_CPU_CORES` - The set of cores in [cpuset][] notation reserved for the
   task. This value is only set if `resources.cores` is configured.
 
-```env
+```sh
 NOMAD_CPU_CORES=3-5
 NOMAD_CPU_LIMIT=9000
 ```


### PR DESCRIPTION
We have some broken markdown code block fences which broke pages once a new syntax highlighter got deployed.