### PR TITLE
migrate GHA workflows to using single runner labels

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -4,11 +4,7 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
-    - custom
-    - xl
-    - 22.04
-    - linux
-    - xxl
-    - 20.04
     - custom-windows-medium
     - windows-2019-16core
+    - custom-linux-xxl-nomad-20.04
+    - custom-linux-xl-nomad-22.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
 
   build-other:
     needs: [get-go-version, get-product-version]
-    runs-on: [ custom, linux, xxl, 20.04 ]
+    runs-on: custom-linux-xxl-nomad-20.04
     strategy:
       matrix:
         goos: [windows]
@@ -128,7 +128,7 @@ jobs:
 
   build-linux:
     needs: [get-go-version, get-product-version]
-    runs-on: [ custom, linux, xxl, 20.04 ]
+    runs-on: custom-linux-xxl-nomad-20.04
     strategy:
       matrix:
         goos: [linux]
@@ -304,7 +304,7 @@ jobs:
     needs:
       - get-product-version
       - build-linux
-    runs-on: [ custom, linux, xxl, 20.04 ]
+    runs-on: custom-linux-xxl-nomad-20.04
     strategy:
       matrix:
         arch: ["arm64", "amd64"]

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -85,7 +85,7 @@ jobs:
           make dev
   tests-api:
     needs: [mods]
-    runs-on: [custom, xl, 22.04]
+    runs-on: custom-linux-xl-nomad-22.04
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
👋 Greetings!

To align with Github’s removal of custom labels on larger runners, this PR is removing extra custom labels defined in your Github Actions. Moving forward, only one label (the github runner name) will be needed to ensure the appropriate larger runner is used for your GHA job.
