### PR TITLE
[ui] Jobs Index page min-index and default empty-state styles

### DIFF
--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -246,7 +246,12 @@ export default class JobAdapter extends WatchableNamespaceIDs {
         result.meta.nextToken = headers['x-nomad-nexttoken'];
       }
       if (headers['x-nomad-index']) {
-        result.meta.index = headers['x-nomad-index'];
+        // Query won't block if the index is 0 (see also watch-list.getIndexFor for prior art)
+        if (headers['x-nomad-index'] === '0') {
+          result.meta.index = 1;
+        } else {
+          result.meta.index = headers['x-nomad-index'];
+        }
       }
     }
     return result;

--- a/ui/app/styles/components/empty-message.scss
+++ b/ui/app/styles/components/empty-message.scss
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-.empty-message {
+.empty-message,
+.hds-application-state {
   padding: 1.5rem;
   background: $white-ter;
   border-radius: $radius;
@@ -47,4 +48,8 @@
       color: $grey;
     }
   }
+}
+
+.section .hds-application-state {
+  width: 100%;
 }


### PR DESCRIPTION
Does 2 things on the newly reworked jobs index page:
1. Makes the [default helios empty state component](https://helios.hashicorp.design/components/application-state?tab=code) look more Nomad-ish (grey bg, widened)
2. Makes the minimum ?index on the /statuses request 1, instead of 0, so it successfully blocks instead of polls.

![image](https://github.com/hashicorp/nomad/assets/713991/1f92510b-68ec-46c5-9b78-84a6fe8e34e8)
