### PR TITLE
SMRE/BPA Onboarding LTS

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -32,6 +32,7 @@ jobs:
           BACKPORT_MERGE_COMMIT: false
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           ENABLE_VERSION_MANIFESTS: true
+          BACKPORT_LABEL_TEMPLATE: "backport/{{.ent}}{{.target}}+ent"
   backport-ent:
     if: github.event.pull_request.merged && contains(join(github.event.pull_request.labels.*.name), 'backport/ent')
     runs-on: ubuntu-latest

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -32,7 +32,6 @@ jobs:
           BACKPORT_MERGE_COMMIT: false
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
           ENABLE_VERSION_MANIFESTS: true
-          BACKPORT_LABEL_TEMPLATE: "backport/{{.ent}}{{.target}}+ent"
   backport-ent:
     if: github.event.pull_request.merged && contains(join(github.event.pull_request.labels.*.name), 'backport/ent')
     runs-on: ubuntu-latest

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    container: hashicorpdev/backport-assistant:0.3.4
+    container: hashicorpdev/backport-assistant:0.4.1
     steps:
       - name: Backport changes to stable-website
         run: |
@@ -31,11 +31,23 @@ jobs:
           # Enabling this option increased the number of backport failures.
           BACKPORT_MERGE_COMMIT: false
           GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-
+          ENABLE_VERSION_MANIFESTS: true
+  backport-ent:
+    if: github.event.pull_request.merged && contains(join(github.event.pull_request.labels.*.name), 'backport/ent')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger backport for Enterprise
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          repository: hashicorp/consul-enterprise
+          event-type: ent-backport
+          client-payload: ${{ toJson(github.event) }}
   handle-failure:
     needs:
       - backport
-    if: always() && needs.backport.result == 'failure'
+      - backport-ent
+    if: always() && (needs.backport.result == 'failure' || needs.backport-ent.result == 'failure')
     runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -40,7 +40,7 @@ jobs:
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
           token: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
-          repository: hashicorp/consul-enterprise
+          repository: hashicorp/nomad-enterprise
           event-type: ent-backport
           client-payload: ${{ toJson(github.event) }}
   handle-failure:

--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -6,17 +6,17 @@
 
 schema = 1
 active_versions {
-  version "1.8" {
+  version "1.8.x" {
     ce_active = true
     lts       = true
   }
-  version "1.7" {
+  version "1.7.x" {
     ce_active = true
   }
-  version "1.6" {
+  version "1.6.x" {
     ce_active = true
   }
-  version "1.5" {
+  version "1.5.x" {
     ce_active = true
   }
 }

--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -16,7 +16,4 @@ active_versions {
   version "1.6.x" {
     ce_active = true
   }
-  version "1.5.x" {
-    ce_active = true
-  }
 }

--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -1,0 +1,22 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+# This manifest file describes active releases and is consumed by the backport tooling.
+# It is only consumed from the default branch, so backporting changes to this file is not necessary.
+
+schema = 1
+active_versions {
+  version "1.8" {
+    ce_active = true
+    lts       = true
+  }
+  version "1.7" {
+    ce_active = true
+  }
+  version "1.6" {
+    ce_active = true
+  }
+  version "1.5" {
+    ce_active = true
+  }
+}


### PR DESCRIPTION
Configuration changes to use backport assistant with LTS support. These include:

- adding a manifest file for active releases
- adding configuration to send backport to ENT repo

New BPA labels created under the new BPA changes/LTS policy: 

- `backport/ent/1.5.x+ent`
- `backport/ent/1.6.x+ent`
- `backport/ent/1.7.x+ent`
- `backport/ent/1.8.x+ent`