### PR TITLE
services: retry failed Nomad service deregistrations from client

### DIFF
--- a/.changelog/20596.txt
+++ b/.changelog/20596.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+services: Added retry to Nomad service deregistration RPCs during alloc stop
+```


### PR DESCRIPTION
When the allocation is stopped, we deregister the service in the alloc runner's `PreKill` hook. This ensures we delete the service registration and wait for the shutdown delay before shutting down the tasks, so that workloads can drain their connections. However, the call to remove the workload only logs errors and never retries them.

Add a short retry loop to the `RemoveWorkload` method for Nomad services, so that transient errors give us an extra opportunity to deregister the service before the tasks are stopped, before we need to fall back to the data integrity improvements implemented in #20590.

Ref: https://github.com/hashicorp/nomad/issues/16616