### PR TITLE
Permit Consul Connect Gateways to be used with podman

### DIFF
--- a/.changelog/20611.txt
+++ b/.changelog/20611.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+consul/connect: Attempt autodetection of podman task driver for Connect gateways
+```

--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -375,7 +375,7 @@ func groupConnectHook(job *structs.Job, g *structs.TaskGroup) error {
 				customizedTLS := service.Connect.IsCustomizedTLS()
 
 				task := newConnectGatewayTask(prefix, service.Name,
-					service.GetConsulClusterName(g), netHost, customizedTLS)
+					service.GetConsulClusterName(g), groupConnectGuessTaskDriver(g), netHost, customizedTLS)
 				g.Tasks = append(g.Tasks, task)
 
 				// the connect.sidecar_task block can also be used to configure
@@ -494,7 +494,7 @@ func gatewayBindAddressesIngressForBridge(ingress *structs.ConsulIngressConfigEn
 	return addresses
 }
 
-func newConnectGatewayTask(prefix, service, cluster string, netHost, customizedTls bool) *structs.Task {
+func newConnectGatewayTask(prefix, service, cluster string, driver string, netHost, customizedTls bool) *structs.Task {
 	constraints := structs.Constraints{
 		connectGatewayVersionConstraint(cluster),
 		connectListenerConstraint(cluster),
@@ -506,7 +506,7 @@ func newConnectGatewayTask(prefix, service, cluster string, netHost, customizedT
 		// Name is used in container name so must start with '[A-Za-z0-9]'
 		Name:          fmt.Sprintf("%s-%s", prefix, service),
 		Kind:          structs.NewTaskKind(prefix, service),
-		Driver:        "docker",
+		Driver:        driver,
 		Config:        connectGatewayDriverConfig(netHost),
 		ShutdownDelay: 5 * time.Second,
 		LogConfig: &structs.LogConfig{

--- a/nomad/job_endpoint_hook_connect_test.go
+++ b/nomad/job_endpoint_hook_connect_test.go
@@ -201,7 +201,7 @@ func TestJobEndpointConnect_groupConnectHook_IngressGateway_BridgeNetwork(t *tes
 	expTG.Tasks = []*structs.Task{
 		// inject the gateway task
 		newConnectGatewayTask(structs.ConnectIngressPrefix, "my-gateway",
-			structs.ConsulDefaultCluster, false, true),
+			structs.ConsulDefaultCluster, "docker", false, true),
 	}
 	expTG.Services[0].Name = "my-gateway"
 	expTG.Tasks[0].Canonicalize(job, expTG)
@@ -241,7 +241,7 @@ func TestJobEndpointConnect_groupConnectHook_IngressGateway_HostNetwork(t *testi
 	expTG.Tasks = []*structs.Task{
 		// inject the gateway task
 		newConnectGatewayTask(structs.ConnectIngressPrefix, "my-gateway",
-			structs.ConsulDefaultCluster, true, false),
+			structs.ConsulDefaultCluster, "docker", true, false),
 	}
 	expTG.Services[0].Name = "my-gateway"
 	expTG.Tasks[0].Canonicalize(job, expTG)
@@ -344,7 +344,7 @@ func TestJobEndpointConnect_groupConnectHook_TerminatingGateway(t *testing.T) {
 	expTG.Tasks = []*structs.Task{
 		// inject the gateway task
 		newConnectGatewayTask(structs.ConnectTerminatingPrefix, "my-gateway",
-			structs.ConsulDefaultCluster, false, false),
+			structs.ConsulDefaultCluster, "docker", false, false),
 	}
 	expTG.Services[0].Name = "my-gateway"
 	expTG.Tasks[0].Canonicalize(job, expTG)
@@ -379,7 +379,7 @@ func TestJobEndpointConnect_groupConnectHook_MeshGateway(t *testing.T) {
 	expTG.Tasks = []*structs.Task{
 		// inject the gateway task
 		newConnectGatewayTask(structs.ConnectMeshPrefix, "my-gateway",
-			structs.ConsulDefaultCluster, false, false),
+			structs.ConsulDefaultCluster, "docker", false, false),
 	}
 	expTG.Services[0].Name = "my-gateway"
 	expTG.Services[0].PortLabel = "public_port"
@@ -770,7 +770,7 @@ func TestJobEndpointConnect_newConnectGatewayTask_host(t *testing.T) {
 
 	t.Run("ingress", func(t *testing.T) {
 		task := newConnectGatewayTask(structs.ConnectIngressPrefix, "foo",
-			structs.ConsulDefaultCluster, true, false)
+			structs.ConsulDefaultCluster, "docker", true, false)
 		must.Eq(t, "connect-ingress-foo", task.Name)
 		must.Eq(t, "connect-ingress:foo", string(task.Kind))
 		must.Eq(t, "${attr.consul.version}", task.Constraints[0].LTarget)
@@ -781,7 +781,7 @@ func TestJobEndpointConnect_newConnectGatewayTask_host(t *testing.T) {
 
 	t.Run("terminating", func(t *testing.T) {
 		task := newConnectGatewayTask(structs.ConnectTerminatingPrefix, "bar",
-			structs.ConsulDefaultCluster, true, false)
+			structs.ConsulDefaultCluster, "docker", true, false)
 		must.Eq(t, "connect-terminating-bar", task.Name)
 		must.Eq(t, "connect-terminating:bar", string(task.Kind))
 		must.Eq(t, "${attr.consul.version}", task.Constraints[0].LTarget)
@@ -793,7 +793,7 @@ func TestJobEndpointConnect_newConnectGatewayTask_host(t *testing.T) {
 	// this case can only happen on ENT but gets run in CE code
 	t.Run("terminating nondefault (ENT)", func(t *testing.T) {
 		task := newConnectGatewayTask(structs.ConnectTerminatingPrefix, "bar",
-			"nondefault", true, false)
+			"nondefault", "docker", true, false)
 		must.Eq(t, "connect-terminating-bar", task.Name)
 		must.Eq(t, "connect-terminating:bar", string(task.Kind))
 		must.Eq(t, "${attr.consul.nondefault.version}", task.Constraints[0].LTarget)
@@ -807,7 +807,7 @@ func TestJobEndpointConnect_newConnectGatewayTask_bridge(t *testing.T) {
 	ci.Parallel(t)
 
 	task := newConnectGatewayTask(structs.ConnectIngressPrefix, "service1",
-		structs.ConsulDefaultCluster, false, false)
+		structs.ConsulDefaultCluster, "docker", false, false)
 	require.NotContains(t, task.Config, "network_mode")
 }
 


### PR DESCRIPTION
Enable use of Consul Connect Gateways (ingresss/terminating/mesh) with podman task driver.

task driver for Connect-enabled tasks for sidecar services which used podman if any other task in the same task group was using podman or fell back to docker otherwise.

That PR did not consider consul connect gateways, which remained hardcoded to using docker task driver always.

This change applies the same heuristic also to gateway tasks, enabling use of podman.

Limitations: The heuristic only works where the task group containing the gateway also contains a podman task. Therefore it does not work for the ingress example in the docs
(https://developer.hashicorp.com/nomad/docs/job-specification/gateway#ingress-gateway) which uses connect native and requires the gateway be in a separate task.

I've updated existing tests to assume the docker driver, but have not yet added any new tests to verify the auto-detection of podman.