### PR TITLE
doc: specify ca cert needs to be shared

### DIFF
--- a/website/content/docs/integrations/vault/acl.mdx
+++ b/website/content/docs/integrations/vault/acl.mdx
@@ -295,7 +295,8 @@ your Vault and Nomad clusters are configured and deployed.
 It is highly recommended to use [mutual TLS][tutorial_mtls] in production
 deployments of Nomad. With mTLS enabled, the [`tls.verify_https_client`][]
 configuration must be set to `false` since it is not possible to provide client
-certificates to the Vault auth method.
+certificates to the Vault auth method. Vault must also be configured to trust
+the CA certificate used to sign Nomad's mTLS certificate.
 
 Alternatively, you may expose Nomad's JWKS URL from a proxy or a load balancer
 that handles the mutual TLS connection to Nomad and exposes the JWKS URL

--- a/website/content/docs/integrations/vault/acl.mdx
+++ b/website/content/docs/integrations/vault/acl.mdx
@@ -295,8 +295,10 @@ your Vault and Nomad clusters are configured and deployed.
 It is highly recommended to use [mutual TLS][tutorial_mtls] in production
 deployments of Nomad. With mTLS enabled, the [`tls.verify_https_client`][]
 configuration must be set to `false` since it is not possible to provide client
-certificates to the Vault auth method. Vault must also be configured to trust
-the CA certificate used to sign Nomad's mTLS certificate.
+certificates to the Vault auth method. Nomad's CA certificate should be
+specified in the Vault auth method's
+[jwks_ca_pem](https://developer.hashicorp.com/vault/api-docs/auth/jwt#jwks_ca_pem)
+parameter.
 
 Alternatively, you may expose Nomad's JWKS URL from a proxy or a load balancer
 that handles the mutual TLS connection to Nomad and exposes the JWKS URL

--- a/website/content/docs/integrations/vault/acl.mdx
+++ b/website/content/docs/integrations/vault/acl.mdx
@@ -297,7 +297,7 @@ deployments of Nomad. With mTLS enabled, the [`tls.verify_https_client`][]
 configuration must be set to `false` since it is not possible to provide client
 certificates to the Vault auth method. Nomad's CA certificate should be
 specified in the Vault auth method's
-[jwks_ca_pem](https://developer.hashicorp.com/vault/api-docs/auth/jwt#jwks_ca_pem)
+[`jwks_ca_pem`](https://developer.hashicorp.com/vault/api-docs/auth/jwt#jwks_ca_pem)
 parameter.
 
 Alternatively, you may expose Nomad's JWKS URL from a proxy or a load balancer


### PR DESCRIPTION
(Certificate management is the worst.)

Had some confusion from a user thinking they _had_ to use a lb/proxy to configure the Vault integration. I noticed our docs about mTLS/verify_client lacked mentioning that Vault needs to trust Nomad's CA, so I added some words to hopefully make that more clear? The words do not seem like good words so if you have gooder words please suggest them.