### PR TITLE
tproxy: add implicit constraint on client version

### DIFF
--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -143,6 +143,14 @@ var (
 		RTarget: ">= 1.4.2",
 		Operand: structs.ConstraintSemver,
 	}
+
+	// tproxyConstraint is an implicit constraint added to jobs making use of
+	// transparent proxy mode
+	tproxyConstraint = &structs.Constraint{
+		LTarget: attrNomadVersion,
+		RTarget: ">= 1.8.0-dev",
+		Operand: structs.ConstraintSemver,
+	}
 )
 
 type admissionController interface {
@@ -335,6 +343,7 @@ func (jobImpliedConstraints) Mutate(j *structs.Job) (*structs.Job, []error, erro
 
 		if transparentProxyTaskGroups.Contains(tg.Name) {
 			mutateConstraint(constraintMatcherLeft, tg, cniConsulConstraint)
+			mutateConstraint(constraintMatcherLeft, tg, tproxyConstraint)
 		}
 	}
 

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -1240,6 +1240,7 @@ func Test_jobImpliedConstraints_Mutate(t *testing.T) {
 							cniLoopbackConstraint,
 							cniPortMapConstraint,
 							cniConsulConstraint,
+							tproxyConstraint,
 						},
 					},
 				},


### PR DESCRIPTION
The new transparent proxy feature already has an implicity constraint on the presence of the CNI plugin. But if the CNI plugin is installed on an older version of Nomad, this isn't sufficient to protect against placing tproxy workloads on clients that can't support it. Add a Nomad version constraint as well.

Fixes: https://github.com/hashicorp/nomad/issues/20614