### PR TITLE
[ui] Better UX with filter expressions in the jobs index search box

### DIFF
--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -574,5 +574,21 @@ export default class JobsIndexController extends Controller {
     this.updateFilter();
   }
 
+  // A list of combinatorial filters to show off filter expressions
+  // Make use of our various operators, and our various known keys
+  @computed('filter')
+  get exampleFilter() {
+    let examples = [
+      '(Status == dead) and (Type != batch)',
+      '(Version != 0) and (Namespace == default)',
+      '(StatusDescription not contains "progress deadline")',
+      '(Region != global) and (NodePool is not empty)',
+      '(Namespace != myNamespace) and (Status != running)',
+      'NodePool is not empty',
+      '(dc1 in Datacenters) or (dc2 in Datacenters)',
+    ];
+    return examples[Math.floor(Math.random() * examples.length)];
+  }
+
   //#endregion filtering and searching
 }

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -554,5 +554,13 @@ export default class JobsIndexController extends Controller {
     }
   }
 
+  get humanizedFilterError() {
+    let baseString = `No jobs match your current filter selection: ${this.filter}.`;
+    if (this.model.error) {
+      return `${baseString} ${this.model.error}`;
+    }
+    return baseString;
+  }
+
   //#endregion filtering and searching
 }

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -550,7 +550,7 @@ export default class JobsIndexController extends Controller {
       this.searchText = newFilter;
     } else {
       // If it's a string without a filter operator, assume the user is trying to look up a job name
-      this.searchText = `Name contains ${newFilter}`;
+      this.searchText = `Name contains "${newFilter}"`;
     }
   }
 

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -28,6 +28,7 @@ export default class JobsIndexController extends Controller {
   constructor() {
     super(...arguments);
     this.pageSize = this.userSettings.pageSize;
+    this.rawSearchText = this.searchText || '';
   }
 
   queryParams = [
@@ -451,6 +452,7 @@ export default class JobsIndexController extends Controller {
 
     // Combine all unmatched filter parts into the searchText
     this.searchText = unmatchedFilters.join(' and ');
+    this.rawSearchText = this.searchText;
   }
 
   @computed(
@@ -497,9 +499,11 @@ export default class JobsIndexController extends Controller {
 
   @tracked filter = '';
   @tracked searchText = '';
+  @tracked rawSearchText = '';
 
   @action resetFilters() {
     this.searchText = '';
+    this.rawSearchText = '';
     this.filterFacets.forEach((group) => {
       group.options.forEach((option) => {
         set(option, 'checked', false);

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -543,7 +543,7 @@ export default class JobsIndexController extends Controller {
 
     // Check for any operator surrounded by spaces
     let isFilterExpression = operators.some((op) =>
-      newFilter.includes(` ${op} `)
+      newFilter.includes(` ${op}`)
     );
 
     if (isFilterExpression) {
@@ -556,10 +556,22 @@ export default class JobsIndexController extends Controller {
 
   get humanizedFilterError() {
     let baseString = `No jobs match your current filter selection: ${this.filter}.`;
-    if (this.model.error) {
-      return `${baseString} ${this.model.error}`;
+    if (this.model.error?.humanized) {
+      return `${baseString} ${this.model.error.humanized}`;
     }
     return baseString;
+  }
+
+  @action correctFilterKey({ incorrectKey, correctKey }) {
+    this.searchText = this.searchText.replace(incorrectKey, correctKey);
+    this.rawSearchText = this.searchText;
+    this.updateFilter();
+  }
+
+  @action suggestFilter({ example }) {
+    this.searchText = example;
+    this.rawSearchText = this.searchText;
+    this.updateFilter();
   }
 
   //#endregion filtering and searching

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -138,7 +138,7 @@ export default class IndexRoute extends Route.extend(
       JobModifyIndex: 'JobModifyIndex',
     };
 
-    error.errors.forEach((err) => {
+    error.errors?.forEach((err) => {
       this.notifications.add({
         title: err.title,
         message: err.detail,
@@ -154,15 +154,21 @@ export default class IndexRoute extends Route.extend(
       err?.detail.includes("couldn't find key") ||
       err?.detail.includes('failed to read filter expression')
     ) {
+      this.watchList.jobsIndexDetailsController.abort();
+      this.watchList.jobsIndexIDsController.abort();
       // eslint-disable-next-line
       this.controllerFor('jobs.index').set('jobIDs', []);
       // eslint-disable-next-line
       this.controllerFor('jobs.index').set('jobs', []);
+      // eslint-disable-next-line
+      this.controllerFor('jobs.index').watchJobs.cancelAll();
+      // eslint-disable-next-line
+      this.controllerFor('jobs.index').watchJobIDs.cancelAll();
 
-      let humanizedError = err.detail;
+      let humanizedError = err.detail || '';
       let errorLink = null;
 
-      if (err.detail.includes('failed to read filter expression')) {
+      if (humanizedError.includes('failed to read filter expression')) {
         errorLink = {
           label: 'Learn more about Filter Expressions',
           url: 'https://developer.hashicorp.com/nomad/api-docs#creating-expressions',

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -164,7 +164,9 @@ export default class IndexRoute extends Route.extend(
       Ember.testing ? 0 : DEFAULT_THROTTLE
     );
 
-    controller.parseFilter();
+    if (!this.hasBeenInitialized) {
+      controller.parseFilter();
+    }
 
     this.hasBeenInitialized = true;
   }

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -237,7 +237,6 @@ export default class IndexRoute extends Route.extend(
       this.controllerFor('jobs.index').watchJobIDs.cancelAll();
 
       let humanized = err.detail || '';
-      let errorLink = null;
 
       // Two ways we can help users here:
       // 1. They slightly mis-typed a key, so we should offer a correction
@@ -245,42 +244,32 @@ export default class IndexRoute extends Route.extend(
       let correction = null;
       let suggestion = null;
 
-      if (humanized.includes('failed to read filter expression')) {
-        errorLink = {
-          label: 'Learn more about Filter Expressions',
-          url: 'https://developer.hashicorp.com/nomad/api-docs#creating-expressions',
-        };
-      } else {
-        const keyMatch = err.detail.match(
-          /couldn't find key: struct field with name "([^"]+)"/
-        );
-        if (keyMatch && keyMatch[1]) {
-          const incorrectKey = keyMatch[1];
-          const correctKey = knownKeys.find(
-            (key) =>
-              key.key ===
-              `${incorrectKey.charAt(0).toUpperCase()}${incorrectKey
-                .slice(1)
-                .toLowerCase()}`
-          )?.key;
-          if (correctKey) {
-            // humanized = `Did you mean "${correctKey}"?`;
-            correction = {
-              incorrectKey,
-              correctKey,
-            };
-          } else {
-            // let possibleKeys = Object.values(knownKeys).join('", "');
-            humanized = `Did you mistype a key? Valid keys include:`; // "${possibleKeys}".`;
-            suggestion = knownKeys;
-          }
+      const keyMatch = err.detail.match(
+        /couldn't find key: struct field with name "([^"]+)"/
+      );
+      if (keyMatch && keyMatch[1]) {
+        const incorrectKey = keyMatch[1];
+        const correctKey = knownKeys.find(
+          (key) =>
+            key.key ===
+            `${incorrectKey.charAt(0).toUpperCase()}${incorrectKey
+              .slice(1)
+              .toLowerCase()}`
+        )?.key;
+        if (correctKey) {
+          correction = {
+            incorrectKey,
+            correctKey,
+          };
+        } else {
+          humanized = `Did you mistype a key? Valid keys include:`;
+          suggestion = knownKeys;
         }
       }
 
       return {
         error: {
           humanized,
-          errorLink,
           correction,
           suggestion,
         },

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -11,7 +11,7 @@
         <Hds::SegmentedGroup as |S|>
 
           <JobSearchBox
-            @searchText={{this.searchText}}
+            @searchText={{this.rawSearchText}}
             @onSearchTextChange={{queue
               this.updateSearchText
               this.updateFilter
@@ -275,7 +275,7 @@
         {{#if this.filter}}
           <A.Header data-test-empty-jobs-list-headline @title="No Matches" />
           <A.Body
-            @text="No jobs match your current filter selection."
+            @text="No jobs match your current filter selection: {{this.filter}}"
           />
         <A.Footer @hasDivider={{true}}>
           <Hds::Button

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -274,9 +274,46 @@
       <Hds::ApplicationState data-test-empty-jobs-list as |A|>
         {{#if this.filter}}
           <A.Header data-test-empty-jobs-list-headline @title="No Matches" />
-          <A.Body
-            @text={{this.humanizedFilterError}}
-          />
+          <A.Body>
+            {{this.humanizedFilterError}}
+            <br><br>
+            {{#if this.model.error.correction}}
+              Did you mean
+              <Hds::Button
+                @text={{this.model.error.correction.correctKey}}
+                @isInline={{true}}
+                @color="tertiary"
+                @icon="bulb"
+                @iconPosition="trailing"
+                {{on "click" (action this.correctFilterKey this.model.error.correction)}}
+
+              />?
+            {{else if this.model.error.suggestion}}
+              <ul>
+              {{#each this.model.error.suggestion as |suggestion|}}
+                <li><Hds::Button
+                  @text={{suggestion.key}}
+                  @isInline={{true}}
+                  @size="small"
+                  @color="tertiary"
+                  @icon="bulb"
+                  {{on "click" (action this.suggestFilter suggestion)}}
+                /></li>
+              {{/each}}
+              </ul>
+            {{else}}
+            {{!-- This is the "Nothing was found for your otherwise valid filter" option. Give them suggestions --}}
+              Did you know: you can try using filter expressions to search through your jobs.
+              Try <Hds::Button
+                @text="(Status == dead) and (Type != batch)"
+                @isInline={{true}}
+                @color="tertiary"
+                @icon="bulb"
+                @iconPosition="trailing"
+                {{on "click" (action this.suggestFilter (hash example="(Status == dead) and (Type != batch)"))}}
+              />
+            {{/if}}
+          </A.Body>
         <A.Footer @hasDivider={{true}}>
           <Hds::Button
             @text="Reset Filters"
@@ -289,8 +326,8 @@
           {{!-- TODO: HDS4.0, convert to F.LinkStandalone --}}
           <Hds::Link::Standalone @icon="plus" @text="Run a New Job" @route="jobs.run" 
             @iconPosition="trailing" />
-          {{#if this.model.errorLink}}
-            <Hds::Link::Standalone @icon="alert-triangle" @text={{this.model.errorLink.label}} @href="{{this.model.errorLink.url}}" @iconPosition="trailing" />
+          {{#if this.model.error.errorLink}}
+            <Hds::Link::Standalone @icon="alert-triangle" @text={{this.model.error.errorLink.label}} @href="{{this.model.error.errorLink.url}}" @iconPosition="trailing" />
           {{/if}}
         </A.Footer>
         {{else}}

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -305,12 +305,14 @@
             {{!-- This is the "Nothing was found for your otherwise valid filter" option. Give them suggestions --}}
               Did you know: you can try using filter expressions to search through your jobs.
               Try <Hds::Button
-                @text="(Status == dead) and (Type != batch)"
+                @text={{this.exampleFilter}}
                 @isInline={{true}}
                 @color="tertiary"
                 @icon="bulb"
                 @iconPosition="trailing"
-                {{on "click" (action this.suggestFilter (hash example="(Status == dead) and (Type != batch)"))}}
+                {{on "click" (action this.suggestFilter
+                  (hash example=this.exampleFilter)
+                )}}
               />
             {{/if}}
           </A.Body>
@@ -324,11 +326,11 @@
           />
 
           {{!-- TODO: HDS4.0, convert to F.LinkStandalone --}}
+          <Hds::Link::Standalone @icon="docs" @text="Learn more about Filter Expressions" @href="https://developer.hashicorp.com/nomad/api-docs#creating-expressions" @iconPosition="trailing" />
+
           <Hds::Link::Standalone @icon="plus" @text="Run a New Job" @route="jobs.run" 
             @iconPosition="trailing" />
-          {{#if this.model.error.errorLink}}
-            <Hds::Link::Standalone @icon="alert-triangle" @text={{this.model.error.errorLink.label}} @href="{{this.model.error.errorLink.url}}" @iconPosition="trailing" />
-          {{/if}}
+
         </A.Footer>
         {{else}}
           <A.Header data-test-empty-jobs-list-headline @title="No Jobs" />

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -275,7 +275,7 @@
         {{#if this.filter}}
           <A.Header data-test-empty-jobs-list-headline @title="No Matches" />
           <A.Body
-            @text="No jobs match your current filter selection: {{this.filter}}"
+            @text={{this.humanizedFilterError}}
           />
         <A.Footer @hasDivider={{true}}>
           <Hds::Button
@@ -289,6 +289,9 @@
           {{!-- TODO: HDS4.0, convert to F.LinkStandalone --}}
           <Hds::Link::Standalone @icon="plus" @text="Run a New Job" @route="jobs.run" 
             @iconPosition="trailing" />
+          {{#if this.model.errorLink}}
+            <Hds::Link::Standalone @icon="alert-triangle" @text={{this.model.errorLink.label}} @href="{{this.model.errorLink.url}}" @iconPosition="trailing" />
+          {{/if}}
         </A.Footer>
         {{else}}
           <A.Header data-test-empty-jobs-list-headline @title="No Jobs" />

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -280,6 +280,7 @@
             {{#if this.model.error.correction}}
               Did you mean
               <Hds::Button
+                data-test-filter-correction
                 @text={{this.model.error.correction.correctKey}}
                 @isInline={{true}}
                 @color="tertiary"
@@ -292,6 +293,7 @@
               <ul>
               {{#each this.model.error.suggestion as |suggestion|}}
                 <li><Hds::Button
+                  data-test-filter-suggestion
                   @text={{suggestion.key}}
                   @isInline={{true}}
                   @size="small"
@@ -305,6 +307,7 @@
             {{!-- This is the "Nothing was found for your otherwise valid filter" option. Give them suggestions --}}
               Did you know: you can try using filter expressions to search through your jobs.
               Try <Hds::Button
+                data-test-filter-random-suggestion
                 @text={{this.exampleFilter}}
                 @isInline={{true}}
                 @color="tertiary"

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -68,11 +68,10 @@ export default function () {
 
   const withPagination = function (fn, tokenProperty = 'ModifyIndex') {
     return function (schema, request) {
-      // if not a 200, ditch
-      if (request.status !== 200) {
-        return fn.apply(this, arguments);
-      }
       let response = fn.apply(this, arguments);
+      if (response.code && response.code !== 200) {
+        return response;
+      }
       let perPage = parseInt(request.queryParams.per_page || 25);
       let page = parseInt(request.queryParams.page || 1);
       let totalItems = response.length;
@@ -189,6 +188,7 @@ export default function () {
             'CreateIndex',
             'ModifyIndex',
             'JobModifyIndex',
+            'ParentID',
           ];
 
           // Simulate a failure if a filterCondition's field is not among the allowed

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -1290,6 +1290,40 @@ module('Acceptance | jobs list', function (hooks) {
 
         localStorage.removeItem('nomadPageSize');
       });
+
+      test('Searching with a bad filter expression gives hints', async function (assert) {
+        localStorage.setItem('nomadPageSize', '10');
+        createJobs(server, 10);
+        await JobsList.visit();
+
+        // Try with "type" instead of "Type"
+        await JobsList.search.fillIn('type == foo');
+        assert
+          .dom('[data-test-empty-jobs-list]')
+          .includesText(
+            'No jobs match your current filter selection: type == foo'
+          );
+        assert.dom('[data-test-filter-correction]').exists();
+        await percySnapshot(assert);
+
+        await JobsList.search.fillIn('foo != bar');
+        assert
+          .dom('[data-test-empty-jobs-list]')
+          .includesText('Did you mistype a key?');
+        assert.dom('[data-test-filter-suggestion]').exists();
+        await percySnapshot(assert);
+
+        await JobsList.search.fillIn('Name == surelyDoesntExist');
+        assert
+          .dom('[data-test-empty-jobs-list]')
+          .includesText(
+            'No jobs match your current filter selection: Name == surelyDoesntExist'
+          );
+        assert.dom('[data-test-filter-random-suggestion]').exists();
+        await percySnapshot(assert);
+
+        localStorage.removeItem('nomadPageSize');
+      });
     });
     module('Filtering', function () {
       test('Filtering by namespace filters the list', async function (assert) {

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -186,7 +186,7 @@ module('Acceptance | jobs list', function (hooks) {
 
     assert.equal(
       currentURL(),
-      '/jobs?filter=Name%20contains%20foobar',
+      '/jobs?filter=Name%20contains%20%22foobar%22',
       'No page query param'
     );
   });
@@ -1020,7 +1020,7 @@ module('Acceptance | jobs list', function (hooks) {
         assert.ok(
           server.pretender.handledRequests.find((req) =>
             decodeURIComponent(req.url).includes(
-              '?filter=Name contains something-that-surely-doesnt-exist'
+              '?filter=Name contains "something-that-surely-doesnt-exist"'
             )
           ),
           'A request was made with a filter query param that assumed job name'


### PR DESCRIPTION
In the jobs index search box, we interpret non-expression-looking strings as filter expressions of `Name contains ________` type.

This is neat and probably how users expect searching for jobs to work (just type in a job name, that job shows up) but we are being over-eager with our solution, notably by prepending "Name contains" in the search box before your cursor. This is particularly troublesome if you were doing something like typing "Type contains sys" but stopped for a moment while thinking about what the operator should be. You'd end up with "Name contains Type" before you know it.

Instead, we make that search / apply the filter expression in the URL and API call, but keep the search box itself untouched.

Secondly, we now give users suggestions for when they attempt a filter expression that's lowercase (writing "type contains foo" yields "Did you mean Type?") and prompt them for when their key is generally not valid (typing "foo != bar" yields a list of possible filter expression keys)

No filter:
![image](https://github.com/hashicorp/nomad/assets/713991/b77eddf7-af43-40b5-a545-6a17b417c281)

Single word filter, note the URL's filter expression:
![image](https://github.com/hashicorp/nomad/assets/713991/bd8c825d-6bc3-4c94-9a10-05addd66f8d1)

Mistyped/lowercased expression key:
![image](https://github.com/hashicorp/nomad/assets/713991/b0539179-9960-4b5e-98d1-2be950925f48)

Not at all an expression key:
![image](https://github.com/hashicorp/nomad/assets/713991/0534bf37-8522-4db2-b1f4-ab168c55d708)
