### PR TITLE
build: fix broken link to Nomad in docker documentation

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -7,11 +7,11 @@ case "$1" in
   "agent" )
     if [[ -z "${NOMAD_SKIP_DOCKER_IMAGE_WARN}" ]]
     then
-      echo "==============================================================================================="
-      echo "!! Running Nomad clients inside Docker containers is not supported.                          !!"
-      echo "!! Refer to https://developer.hashicorp.com/nomad/s/nomad-in-docker for more information.    !!"
-      echo "!! Set the NOMAD_SKIP_DOCKER_IMAGE_WARN environment variable to skip this warning.           !!"
-      echo "==============================================================================================="
+      echo "======================================================================================================================================="
+      echo "!! Running Nomad clients inside Docker containers is not supported.                                                                  !!"
+      echo "!! Refer to https://developer.hashicorp.com/nomad/docs/install/production/requirements#running-nomad-in-docker for more information. !!"
+      echo "!! Set the NOMAD_SKIP_DOCKER_IMAGE_WARN environment variable to skip this warning.                                                   !!"
+      echo "======================================================================================================================================="
       echo ""
       sleep 2
     fi


### PR DESCRIPTION
## Why

During this update https://github.com/hashicorp/nomad/pull/16247, the new URL points to a page that doesn't exist and shows the 404 page.

Whenever I ran the Docker image `hashicorp/nomad`, it showed logs like this, but the URL was invalid.

```
...
nomad-server-3  | ===============================================================================================
nomad-server-3  | !! Running Nomad clients inside Docker containers is not supported.                          !!
nomad-server-3  | !! Refer to https://developer.hashicorp.com/nomad/s/nomad-in-docker for more information.    !!
...
```

I guess, the URL should be [this](https://developer.hashicorp.com/nomad/docs/install/production/requirements#running-nomad-in-docker).