### PR TITLE
jobspec: time based task execution

### DIFF
--- a/.changelog/22201.txt
+++ b/.changelog/22201.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+jobspec: Add a schedule{} block for time based task execution (Enterprise)
+```

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -253,7 +253,6 @@ func (a *Allocations) GetPauseState(alloc *Allocation, q *QueryOptions, task str
 	var resp AllocGetPauseResponse
 	qm, err := a.client.query("/v1/client/allocation/"+alloc.ID+"/pause", &resp, q)
 	state := resp.ScheduleState
-	// TODO convert into simplified state
 	return state, qm, err
 }
 

--- a/api/task_sched.go
+++ b/api/task_sched.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package api
+
+type TaskSchedule struct {
+	Cron *TaskScheduleCron `hcl:"cron,block"`
+}
+
+type TaskScheduleCron struct {
+	Start    string `hcl:"start,optional"`
+	End      string `hcl:"end,optional"`
+	Timezone string `hcl:"timezone,optional"`
+}

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -801,6 +801,8 @@ type Task struct {
 	Identities []*WorkloadIdentity `hcl:"identity,block"`
 
 	Actions []*Action `hcl:"action,block"`
+
+	Schedule *TaskSchedule `hcl:"schedule,block"`
 }
 
 func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {

--- a/client/allocrunner/alloc_runner_ce.go
+++ b/client/allocrunner/alloc_runner_ce.go
@@ -1,0 +1,21 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+// +build !ent
+
+package allocrunner
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func (ar *allocRunner) SetTaskPauseState(string, structs.TaskScheduleState) error {
+	return fmt.Errorf("Enterprise only")
+}
+
+func (ar *allocRunner) GetTaskPauseState(taskName string) (structs.TaskScheduleState, error) {
+	return "", fmt.Errorf("Enterprise only")
+}

--- a/client/allocrunner/interfaces/runner.go
+++ b/client/allocrunner/interfaces/runner.go
@@ -49,6 +49,8 @@ type AllocRunner interface {
 	StatsReporter() AllocStatsReporter
 	Listener() *cstructs.AllocListener
 	GetAllocDir() allocdir.Interface
+	SetTaskPauseState(taskName string, ps structs.TaskScheduleState) error
+	GetTaskPauseState(taskName string) (structs.TaskScheduleState, error)
 }
 
 // TaskStateHandler exposes a handler to be called when a task's state changes

--- a/client/allocrunner/taskrunner/sched_hook.go
+++ b/client/allocrunner/taskrunner/sched_hook.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package taskrunner
+
+const (
+	// taskPauseHookName is the name of the task pause schedule hook. As an
+	// enterprise only feature the implementation is split between
+	// sched_hook_ce.go and sched_hook_ent.
+	taskPauseHookName = "pause"
+)

--- a/client/allocrunner/taskrunner/sched_hook_ce.go
+++ b/client/allocrunner/taskrunner/sched_hook_ce.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+
+package taskrunner
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+type pauseHook struct{}
+
+func (pauseHook) Name() string { return taskPauseHookName }
+
+func newPauseHook(...any) pauseHook {
+	return pauseHook{}
+}
+
+type pauseGate struct{}
+
+func newPauseGate(...any) *pauseGate {
+	return &pauseGate{}
+}
+
+func (*pauseGate) Wait() error {
+	return nil
+}
+
+func (tr *TaskRunner) SetTaskPauseState(structs.TaskScheduleState) error {
+	return fmt.Errorf("Enterprise only")
+}

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -282,7 +282,7 @@ type TaskRunner struct {
 	users dynamic.Pool
 
 	// pauser controls whether the task should be run or stopped based on a
-	// schedule. Enterprise only.
+	// schedule. (Enterprise)
 	pauser *pauseGate
 }
 
@@ -620,7 +620,7 @@ MAIN:
 			goto RESTART
 		}
 
-		// Enterprise only - Unblocks when the task runner is allowed to continue.
+		// Unblocks when the task runner is allowed to continue. (Enterprise)
 		if err := tr.pauser.Wait(); err != nil {
 			tr.logger.Error("pause scheduled failed", "error", err)
 			tr.restartTracker.SetStartError(err)

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -190,8 +190,7 @@ func (tr *TaskRunner) initHooks() {
 		tr.runnerHooks = append(tr.runnerHooks, newRemoteTaskHook(tr, hookLogger))
 	}
 
-	// Enterprise only - If this task has a pause schedule, initialize the pause
-	// watcher.
+	// If this task has a pause schedule, initialize the pause (Enterprise)
 	if task.Schedule != nil {
 		tr.runnerHooks = append(tr.runnerHooks, newPauseHook(tr, hookLogger))
 	}

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -189,6 +189,12 @@ func (tr *TaskRunner) initHooks() {
 	if tr.driverCapabilities.RemoteTasks {
 		tr.runnerHooks = append(tr.runnerHooks, newRemoteTaskHook(tr, hookLogger))
 	}
+
+	// Enterprise only - If this task has a pause schedule, initialize the pause
+	// watcher.
+	if task.Schedule != nil {
+		tr.runnerHooks = append(tr.runnerHooks, newPauseHook(tr, hookLogger))
+	}
 }
 
 func (tr *TaskRunner) emitHookError(err error, hookName string) {

--- a/client/client.go
+++ b/client/client.go
@@ -969,6 +969,24 @@ func (c *Client) SignalAllocation(allocID, task, signal string) error {
 	return ar.Signal(task, signal)
 }
 
+// PauseAllocation sets the pause state of the given task for the allocation.
+func (c *Client) PauseAllocation(allocID, task string, scheduleState structs.TaskScheduleState) error {
+	ar, err := c.getAllocRunner(allocID)
+	if err != nil {
+		return err
+	}
+	return ar.SetTaskPauseState(task, scheduleState)
+}
+
+// GetPauseAllocation gets the pause state of the  given task for the allocation.
+func (c *Client) GetPauseAllocation(allocID, task string) (structs.TaskScheduleState, error) {
+	ar, err := c.getAllocRunner(allocID)
+	if err != nil {
+		return "", err
+	}
+	return ar.GetTaskPauseState(task)
+}
+
 // CollectAllocation garbage collects a single allocation on a node. Returns
 // true if alloc was found and garbage collected; otherwise false.
 func (c *Client) CollectAllocation(allocID string) bool {

--- a/client/client_interface_test.go
+++ b/client/client_interface_test.go
@@ -165,3 +165,11 @@ func (ar *emptyAllocRunner) LatestAllocStats(taskFilter string) (*cstructs.Alloc
 		Timestamp: 0,
 	}, nil
 }
+
+func (ar *emptyAllocRunner) SetTaskPauseState(taskName string, ps structs.TaskScheduleState) error {
+	return nil
+}
+
+func (ar *emptyAllocRunner) GetTaskPauseState(taskName string) (structs.TaskScheduleState, error) {
+	return "", nil
+}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1139,7 +1139,8 @@ func (a *Agent) setupClient() error {
 		a.consulCatalog,     // self service discovery
 		a.consulProxiesFunc, // supported Envoy versions fingerprinting
 		a.consulServices,    // workload service discovery
-		nil)
+		nil,                 // use the standard set of rpcs
+	)
 	if err != nil {
 		return fmt.Errorf("client setup failed: %v", err)
 	}

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1411,6 +1411,11 @@ func ApiTaskToStructsTask(job *structs.Job, group *structs.TaskGroup,
 		act := ApiActionToStructsAction(job, action)
 		structsTask.Actions = append(structsTask.Actions, act)
 	}
+
+	if apiTask.Schedule != nil {
+		sched := apiScheduleToStructsSchedule(apiTask.Schedule)
+		structsTask.Schedule = sched
+	}
 }
 
 // apiWaitConfigToStructsWaitConfig is a copy and type conversion between the API
@@ -1459,6 +1464,21 @@ func ApiActionToStructsAction(job *structs.Job, action *api.Action) *structs.Act
 		Args:    slices.Clone(action.Args),
 		Command: action.Command,
 	}
+}
+
+func apiScheduleToStructsSchedule(s *api.TaskSchedule) *structs.TaskSchedule {
+	if s.Cron == nil {
+		return nil
+	}
+
+	sched := &structs.TaskSchedule{
+		Cron: &structs.TaskScheduleCron{
+			Start:    s.Cron.Start,
+			End:      s.Cron.End,
+			Timezone: s.Cron.Timezone,
+		},
+	}
+	return sched
 }
 
 func ApiResourcesToStructs(in *api.Resources) *structs.Resources {

--- a/command/alloc_pause.go
+++ b/command/alloc_pause.go
@@ -1,0 +1,207 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
+)
+
+type AllocPauseCommand struct {
+	Meta
+}
+
+func (c *AllocPauseCommand) Help() string {
+	helpText := `
+Usage: nomad alloc pause [options] <allocation> <task>
+
+  Set the pause state of an allocation. This command is used to suspend the
+  operation of a specific alloc and its subtasks. If no task is provided then
+  all of the allocations subtasks will assume the new pause state.
+
+  When ACLs are enabled, this command requires a token with the 'write-job'
+  capability for the allocation's namespace.
+
+General Options:
+
+` + generalOptionsUsage(usageOptsDefault) + `
+
+Pause Specific Options:
+
+  -state=<state>
+    Specify the schedule state to apply to a task. Must be one of pause, run,
+	or scheduled. When set to pause the task is halted but the client reports
+	to the server that the task is still running. When set to run the task is
+	started regardless of the task schedule. When in scheduled state the task
+	respects the task schedule state in the task configuration. Defaults to
+	pause.
+
+  -status
+    Get the current task schedule state status.
+
+  -task=<task-name>
+    Specify the individual task that the action will apply to. If task name is
+    given with both an argument and the '-task' option, preference is given to
+    the '-task' option.
+
+  -verbose
+    Show full information.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *AllocPauseCommand) Name() string { return "alloc pause" }
+
+func (c *AllocPauseCommand) Run(args []string) int {
+	var verbose, status bool
+	var action, task string
+
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.BoolVar(&verbose, "verbose", false, "")
+	flags.StringVar(&action, "state", "pause", "")
+	flags.BoolVar(&status, "status", false, "")
+	flags.StringVar(&task, "task", "", "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Check that we got exactly one alloc
+	args = flags.Args()
+	if len(args) < 1 || len(args) > 2 {
+		c.Ui.Error("This command takes up to two arguments: <alloc-id> <task>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	allocID := args[0]
+
+	// Truncate the id unless full length is required
+	length := shortId
+	if verbose {
+		length = fullId
+	}
+
+	// Ensure the specified action is valid
+	actions := []string{"pause", "run", "scheduled"}
+	if !slices.Contains(actions, action) {
+		c.Ui.Error(fmt.Sprintf("Pause action must be one of %q, %q, or %q but got %q",
+			"pause", "run", "scheduled", action,
+		))
+		return 1
+	}
+
+	// Query the allocation info
+	if len(allocID) == 1 {
+		c.Ui.Error("Alloc ID must contain at least two characters.")
+		return 1
+	}
+
+	allocID = sanitizeUUIDPrefix(allocID)
+
+	// Get the HTTP Client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	allocs, _, err := client.Allocations().PrefixList(allocID)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying allocation: %v", err))
+		return 1
+	}
+
+	if len(allocs) == 0 {
+		c.Ui.Error(fmt.Sprintf("No allocation(s) with prefix or id %q found", allocID))
+		return 1
+	}
+
+	if len(allocs) > 1 {
+		out := formatAllocListStubs(allocs, verbose, length)
+		c.Ui.Error(fmt.Sprintf("Prefix matched multiple allocations\n\n%s", out))
+		return 1
+	}
+
+	// Prefix lookup matched a single allocation, yay
+	q := &api.QueryOptions{Namespace: allocs[0].Namespace}
+	alloc, _, err := client.Allocations().Info(allocs[0].ID, q)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying allocation: %s", err))
+		return 1
+	}
+
+	// If -task is not provided then fallback to reading the task name from args
+	if task == "" && len(args) >= 2 {
+		task = args[1]
+	}
+
+	// Ensure the task (if specified) exists in the allocation
+	if task != "" {
+		err = validateTaskExistsInAllocation(task, alloc)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+	}
+
+	// If this is a -status request, fetch & print the status, then exit
+	if status {
+		query := &api.QueryOptions{
+			Params: map[string]string{"task": task},
+		}
+		state, _, err := client.Allocations().GetPauseState(alloc, query, task)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error getting task pause state: %s", err))
+			return 1
+		}
+		c.Ui.Info(fmt.Sprintf("Pause state: %q", state))
+		return 0
+	}
+
+	// Send the pause state
+	err = client.Allocations().SetPauseState(alloc, nil, task, action)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error setting pause state: %s", err))
+		return 1
+	}
+
+	return 0
+}
+
+func (c *AllocPauseCommand) Synopsis() string {
+	return "Pause a running allocation"
+}
+
+func (c *AllocPauseCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-mode":    complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+		},
+	)
+}
+
+func (c *AllocPauseCommand) AutocompleteArgs() complete.Predictor {
+	// Here we only autocomplete allocation names.
+	// In a similar comment we remark about autocompleting tasks one day.
+	// Wouldn't that be nice?
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := c.Meta.Client()
+		if err != nil {
+			return nil
+		}
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Allocs, nil)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Allocs]
+	})
+}

--- a/command/alloc_pause.go
+++ b/command/alloc_pause.go
@@ -177,7 +177,7 @@ func (c *AllocPauseCommand) Run(args []string) int {
 }
 
 func (c *AllocPauseCommand) Synopsis() string {
-	return "Pause a running allocation"
+	return "Pause a running task"
 }
 
 func (c *AllocPauseCommand) AutocompleteFlags() complete.Flags {

--- a/command/alloc_pause_test.go
+++ b/command/alloc_pause_test.go
@@ -14,9 +14,3 @@ func TestAllocPauseCommand_Implements(t *testing.T) {
 	ci.Parallel(t)
 	var _ cli.Command = &AllocPauseCommand{}
 }
-
-func TestAllocPauseCommand_Fails(t *testing.T) {
-	ci.Parallel(t)
-
-	t.Log("TODO")
-}

--- a/command/alloc_pause_test.go
+++ b/command/alloc_pause_test.go
@@ -1,0 +1,22 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/mitchellh/cli"
+)
+
+func TestAllocPauseCommand_Implements(t *testing.T) {
+	ci.Parallel(t)
+	var _ cli.Command = &AllocPauseCommand{}
+}
+
+func TestAllocPauseCommand_Fails(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Log("TODO")
+}

--- a/command/commands.go
+++ b/command/commands.go
@@ -255,6 +255,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"alloc pause": func() (cli.Command, error) {
+			return &AllocPauseCommand{
+				Meta: meta,
+			}, nil
+		},
 		"alloc stop": func() (cli.Command, error) {
 			return &AllocStopCommand{
 				Meta: meta,

--- a/nomad/client_alloc_endpoint.go
+++ b/nomad/client_alloc_endpoint.go
@@ -146,6 +146,112 @@ func (a *ClientAllocations) Signal(args *structs.AllocSignalRequest, reply *stru
 	return NodeRpc(state.Session, "Allocations.Signal", args, reply)
 }
 
+func (a *ClientAllocations) SetPauseState(args *structs.AllocPauseRequest, reply *structs.GenericResponse) error {
+	args.QueryOptions.AllowStale = true
+	authErr := a.srv.Authenticate(nil, args)
+
+	// Potentially forward to a different region.
+	if done, err := a.srv.forward("ClientAllocations.SetPauseState", args, args, reply); done {
+		return err
+	}
+	a.srv.MeasureRPCRate("client_allocations", structs.RateMetricWrite, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
+	}
+	defer metrics.MeasureSince([]string{"nomad", "client_allocations", "pause_set"}, time.Now())
+
+	// Verify the arguments.
+	if args.AllocID == "" {
+		return errors.New("missing AllocID")
+	}
+
+	// Find the allocation.
+	snap, err := a.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	alloc, err := getAlloc(snap, args.AllocID)
+	if err != nil {
+		return err
+	}
+
+	// Check namespace submit-job permission.
+	if aclObj, err := a.srv.ResolveACL(args); err != nil {
+		return err
+	} else if !aclObj.AllowNsOp(alloc.Namespace, acl.NamespaceCapabilitySubmitJob) {
+		return structs.ErrPermissionDenied
+	}
+
+	// Make sure the node is valid and new enough to support RPC
+	_, err = getNodeForRpc(snap, alloc.NodeID)
+	if err != nil {
+		return err
+	}
+
+	// Get the connection to the client
+	state, ok := a.srv.getNodeConn(alloc.NodeID)
+	if !ok {
+		return findNodeConnAndForward(a.srv, alloc.NodeID, "ClientAllocations.SetPauseState", args, reply)
+	}
+
+	// Make the RPC
+	return NodeRpc(state.Session, "Allocations.SetPauseState", args, reply)
+}
+
+func (a *ClientAllocations) GetPauseState(args *structs.AllocGetPauseStateRequest, reply *structs.AllocGetPauseStateResponse) error {
+	args.QueryOptions.AllowStale = true
+	authErr := a.srv.Authenticate(nil, args)
+
+	// Potentially forward to a different region.
+	if done, err := a.srv.forward("ClientAllocations.GetPauseState", args, args, reply); done {
+		return err
+	}
+	a.srv.MeasureRPCRate("client_allocations", structs.RateMetricRead, args)
+	if authErr != nil {
+		return structs.ErrPermissionDenied
+	}
+	defer metrics.MeasureSince([]string{"nomad", "client_allocations", "pause_get"}, time.Now())
+
+	// Verify the arguments.
+	if args.AllocID == "" {
+		return errors.New("missing AllocID")
+	}
+
+	// Find the allocation.
+	snap, err := a.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	alloc, err := getAlloc(snap, args.AllocID)
+	if err != nil {
+		return err
+	}
+
+	// Check namespace read-job permission.
+	if aclObj, err := a.srv.ResolveACL(args); err != nil {
+		return err
+	} else if !aclObj.AllowNsOp(alloc.Namespace, acl.NamespaceCapabilityReadJob) {
+		return structs.ErrPermissionDenied
+	}
+
+	// Make sure the node is valid and new enough to support RPC
+	_, err = getNodeForRpc(snap, alloc.NodeID)
+	if err != nil {
+		return err
+	}
+
+	// Get the connection to the client
+	state, ok := a.srv.getNodeConn(alloc.NodeID)
+	if !ok {
+		return findNodeConnAndForward(a.srv, alloc.NodeID, "ClientAllocations.GetPauseState", args, reply)
+	}
+
+	// Make the RPC
+	return NodeRpc(state.Session, "Allocations.GetPauseState", args, reply)
+}
+
 // GarbageCollect is used to garbage collect an allocation on a client.
 func (a *ClientAllocations) GarbageCollect(args *structs.AllocSpecificRequest, reply *structs.GenericResponse) error {
 	// We only allow stale reads since the only potentially stale information is

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -88,6 +88,7 @@ func NewJobEndpoints(s *Server, ctx *RPCContext) *Job {
 			&jobValidate{srv: s},
 			&memoryOversubscriptionValidate{srv: s},
 			jobNumaHook{},
+			&jobSchedHook{},
 		},
 	}
 }

--- a/nomad/job_endpoint_hook_sched.go
+++ b/nomad/job_endpoint_hook_sched.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package nomad
+
+// jobSchedHook implements a job Validating admission controller.
+//
+// The implementation of Validate are in the _ce/_ent files.
+type jobSchedHook struct{}
+
+func (jobSchedHook) Name() string {
+	return "schedule"
+}

--- a/nomad/job_endpoint_hook_sched_ce.go
+++ b/nomad/job_endpoint_hook_sched_ce.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+
+package nomad
+
+import (
+	"errors"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func (jobSchedHook) Validate(job *structs.Job) ([]error, error) {
+	for _, tg := range job.TaskGroups {
+		for _, task := range tg.Tasks {
+			if task.Schedule != nil {
+				return nil, errors.New("task schedules requires Nomad Enterprise")
+			}
+		}
+	}
+	return nil, nil
+}

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -1249,6 +1249,40 @@ func Test_jobImpliedConstraints_Mutate(t *testing.T) {
 			expectedOutputError:    nil,
 			name:                   "task group with tproxy",
 		},
+		{
+			name: "task with schedule",
+			inputJob: &structs.Job{
+				Name: "example",
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "group-with-schedule",
+						Tasks: []*structs.Task{
+							{
+								Name:     "task-with-schedule",
+								Schedule: &structs.TaskSchedule{}, // non-nil
+							},
+						},
+					},
+				},
+			},
+			expectedOutputJob: &structs.Job{
+				Name: "example",
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "group-with-schedule",
+						Tasks: []*structs.Task{
+							{
+								Name:     "task-with-schedule",
+								Schedule: &structs.TaskSchedule{},
+							},
+						},
+						Constraints: []*structs.Constraint{taskScheduleConstraint},
+					},
+				},
+			},
+			expectedOutputWarnings: nil,
+			expectedOutputError:    nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/nomad/job_endpoint_statuses.go
+++ b/nomad/job_endpoint_statuses.go
@@ -267,6 +267,7 @@ func jobStatusesJobFromJob(ws memdb.WatchSet, store *state.StateStore, job *stru
 			NodeID:         a.NodeID,
 			JobVersion:     a.Job.Version,
 			FollowupEvalID: a.FollowupEvalID,
+			HasPausedTask:  a.HasAnyPausedTasks(),
 		}
 		if a.DeploymentStatus != nil {
 			jsa.DeploymentStatus.Canary = a.DeploymentStatus.IsCanary()

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -587,6 +587,11 @@ func (t *Task) Diff(other *Task, contextual bool) (*TaskDiff, error) {
 		diff.Objects = append(diff.Objects, vDiffs...)
 	}
 
+	// Schedule diff
+	if sDiff := scheduleDiff(t.Schedule, other.Schedule, contextual); sDiff != nil {
+		diff.Objects = append(diff.Objects, sDiff)
+	}
+
 	return diff, nil
 }
 
@@ -650,6 +655,19 @@ func actionDiffs(old, new []*Action, contextual bool) []*ObjectDiff {
 	sort.Sort(ObjectDiffs(diffs))
 
 	return diffs
+}
+
+func scheduleDiff(old, new *TaskSchedule, contextual bool) *ObjectDiff {
+	if reflect.DeepEqual(old, new) {
+		return nil
+	}
+	if old == nil {
+		old = &TaskSchedule{}
+	}
+	if new == nil {
+		new = &TaskSchedule{}
+	}
+	return primitiveObjectDiff(old.Cron, new.Cron, nil, "Schedule", contextual)
 }
 
 func (t *TaskDiff) GoString() string {

--- a/nomad/structs/job.go
+++ b/nomad/structs/job.go
@@ -109,7 +109,7 @@ type JobStatusesAlloc struct {
 	JobVersion       uint64
 	FollowupEvalID   string
 	// HasPausedTask is true if any of the tasks in the allocation
-	// are Paused (Enterprise feature)
+	// are Paused (Enterprise)
 	HasPausedTask bool
 }
 

--- a/nomad/structs/job.go
+++ b/nomad/structs/job.go
@@ -108,6 +108,9 @@ type JobStatusesAlloc struct {
 	DeploymentStatus JobStatusesDeployment
 	JobVersion       uint64
 	FollowupEvalID   string
+	// HasPausedTask is true if any of the tasks in the allocation
+	// are Paused (Enterprise feature)
+	HasPausedTask bool
 }
 
 // JobStatusesDeployment contains a subset of AllocDeploymentStatus info.
@@ -271,5 +274,20 @@ func (j *Job) RequiredTransparentProxy() set.Collection[string] {
 		}
 	}
 
+	return result
+}
+
+// RequiredScheduleTask collects any groups within the job that have
+// tasks with a schedule{} block for time based task execution (Enterprise)
+func (j *Job) RequiredScheduleTask() set.Collection[string] {
+	result := set.New[string](len(j.TaskGroups))
+	for _, tg := range j.TaskGroups {
+		for _, t := range tg.Tasks {
+			if t.Schedule != nil {
+				result.Insert(tg.Name)
+				break // to next TaskGroup
+			}
+		}
+	}
 	return result
 }

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -4,6 +4,7 @@
 package structs
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"reflect"
@@ -356,6 +357,79 @@ func (di *DriverInfo) HealthCheckEquals(other *DriverInfo) bool {
 	}
 
 	return true
+}
+
+// ScheduleStateApplyRequest is used to set the pause state of a specific task running
+// on Client.
+type ScheduleStateApplyRequest struct {
+	QueryOptions // Client RPCs must use QueryOptions
+
+	// NodeID is the node being targeted by this request (or the node receiving
+	// this request if NodeID is empty).
+	NodeID string
+
+	// AllocID is the allocation being targeted by this request.
+	AllocID string
+
+	// TaskName is the name of the task being targeted by this request.
+	TaskName string
+
+	// State is the state to apply to the task being targeted by this request.
+	ScheduleState TaskScheduleState
+}
+
+func (r *ScheduleStateApplyRequest) Validate() error {
+	if r.AllocID == "" {
+		return errors.New("alloc id must be set")
+	}
+
+	if r.TaskName == "" {
+		return errors.New("task name must be set")
+	}
+
+	switch r.ScheduleState {
+	case TaskScheduleStateRun:
+	case TaskScheduleStateForceRun:
+	case TaskScheduleStateSchedPause:
+	case TaskScheduleStateForcePause:
+	default:
+		return errors.New("not a valid task schedule state")
+	}
+
+	return nil
+}
+
+// ScheduleStateReadRequest is used to read the current pause state of a specific
+// task running on a client.
+type ScheduleStateReadRequest struct {
+	QueryOptions // Client RPCs must use QueryOptions
+
+	// NodeID is the node being targeted by this request (or the node receiving
+	// this request if NodeID is empty).
+	NodeID string
+
+	// AllocID is the allocation being targeted by this request.
+	AllocID string
+
+	// TaskName is the name of the task being targeted by this request.
+	TaskName string
+}
+
+func (r *ScheduleStateReadRequest) Validate() error {
+	if r.AllocID == "" {
+		return errors.New("alloc id must be set")
+	}
+
+	if r.TaskName == "" {
+		return errors.New("task name must be set")
+	}
+
+	return nil
+}
+
+// ScheduleStateResponse contains the current pause state of a specific task.
+type ScheduleStateResponse struct {
+	ScheduleState TaskScheduleState
 }
 
 // NodeMetaApplyRequest is used to update Node metadata on Client agents.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9081,7 +9081,7 @@ const (
 	TaskSkippingShutdownDelay = "Skipping shutdown delay"
 
 	// TaskRunning indicates a task is running due to a schedule or schedule
-	// override. Enterprise only.
+	// override. (Enterprise)
 	TaskRunning = "Running"
 )
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1183,6 +1183,26 @@ type AllocSignalRequest struct {
 	QueryOptions
 }
 
+// AllocPauseRequest is used to set the pause state of a task in an allocation.
+type AllocPauseRequest struct {
+	AllocID       string
+	Task          string
+	ScheduleState TaskScheduleState
+	QueryOptions
+}
+
+// AllocGetPauseStateRequest is used to get the pause state of a task in an allocation.
+type AllocGetPauseStateRequest struct {
+	AllocID string
+	Task    string
+	QueryOptions
+}
+
+// AllocGetPauseStateResponse contains the pause state of a task in an allocation.
+type AllocGetPauseStateResponse struct {
+	ScheduleState TaskScheduleState
+}
+
 // AllocsGetRequest is used to query a set of allocations
 type AllocsGetRequest struct {
 	AllocIDs []string
@@ -7706,6 +7726,9 @@ type Task struct {
 
 	// Alloc-exec-like runnable commands
 	Actions []*Action
+
+	// Schedule for pausing tasks. Enterprise only.
+	Schedule *TaskSchedule
 }
 
 func (t *Task) UsesCores() bool {
@@ -8870,6 +8893,10 @@ type TaskState struct {
 	// Experimental -  TaskHandle is based on drivers.TaskHandle and used
 	// by remote task drivers to migrate task handles between allocations.
 	TaskHandle *TaskHandle
+
+	// Enterprise Only - Paused is set to the paused state of the task. See
+	// task_sched.go
+	Paused TaskScheduleState
 }
 
 // NewTaskState returns a TaskState initialized in the Pending state.
@@ -8964,6 +8991,10 @@ const (
 	// used to determine the running length of the task.
 	TaskStarted = "Started"
 
+	// TaskPausing indicates the task is being killed, but will be
+	// started again to await the next start of its task schedule (Enterprise).
+	TaskPausing = "Pausing"
+
 	// TaskTerminated indicates that the task was started and exited.
 	TaskTerminated = "Terminated"
 
@@ -9048,6 +9079,10 @@ const (
 	// TaskSkippingShutdownDelay indicates that the task operation was
 	// configured to ignore the shutdown delay value set for the tas.
 	TaskSkippingShutdownDelay = "Skipping shutdown delay"
+
+	// TaskRunning indicates a task is running due to a schedule or schedule
+	// override. Enterprise only.
+	TaskRunning = "Running"
 )
 
 // TaskEvent is an event that effects the state of a task and contains meta-data
@@ -11499,6 +11534,23 @@ func (a *Allocation) LastStartOfTask(taskName string) time.Time {
 	}
 
 	return task.StartedAt
+}
+
+// HasAnyPausedTasks returns true if any of the TaskStates on the alloc
+// are Paused (Enterprise feature) either due to a schedule or being forced.
+func (a *Allocation) HasAnyPausedTasks() bool {
+	if a == nil {
+		return false
+	}
+	for _, ts := range a.TaskStates {
+		if ts == nil {
+			continue
+		}
+		if ts.Paused.Stop() {
+			return true
+		}
+	}
+	return false
 }
 
 // IdentityClaims are the input to a JWT identifying a workload. It

--- a/nomad/structs/task_sched.go
+++ b/nomad/structs/task_sched.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/cronexpr"
 )
 
+// TaskScheduleState represents the scheduled execution state of a task (Enterprise)
 type TaskScheduleState string
 
 func (t TaskScheduleState) Stop() bool {

--- a/nomad/structs/task_sched.go
+++ b/nomad/structs/task_sched.go
@@ -1,0 +1,163 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package structs
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/cronexpr"
+)
+
+type TaskScheduleState string
+
+func (t TaskScheduleState) Stop() bool {
+	switch t {
+	case TaskScheduleStateForcePause:
+		return true
+	case TaskScheduleStateSchedPause:
+		return true
+	}
+
+	return false
+}
+
+func (t TaskScheduleState) Event() *TaskEvent {
+	switch t {
+	case TaskScheduleStateForcePause:
+		return NewTaskEvent(TaskPausing).
+			SetDisplayMessage("Pausing due to override")
+	case TaskScheduleStateSchedPause:
+		return NewTaskEvent(TaskPausing).
+			SetDisplayMessage("Pausing due to schedule")
+	case TaskScheduleStateForceRun:
+		return NewTaskEvent(TaskRunning).
+			SetDisplayMessage("Running due to override")
+	case TaskScheduleStateRun:
+		return NewTaskEvent(TaskRunning).
+			SetDisplayMessage("Running due to schedule")
+	}
+
+	return nil
+}
+
+const (
+	TaskScheduleStateRun        TaskScheduleState = ""
+	TaskScheduleStateForceRun   TaskScheduleState = "force_run"
+	TaskScheduleStateSchedPause TaskScheduleState = "scheduled_pause"
+	TaskScheduleStateForcePause TaskScheduleState = "force_pause"
+	// TaskScheduleStateSchedResume is a transitory state that will become
+	// either SchedPause or (sched) Run
+	TaskScheduleStateSchedResume TaskScheduleState = "schedule_resume"
+)
+
+// TaskSchedule allows specifying a time based execution schedule for tasks.
+//
+// Enterprise only.
+type TaskSchedule struct {
+	Cron *TaskScheduleCron
+}
+
+func (t *TaskSchedule) Validate() error {
+	if t.Cron == nil {
+		return errors.New("must specify cron block")
+	}
+
+	const (
+		startFields     = 6
+		endFields       = 2
+		restrictedChars = "/,"
+	)
+
+	if strings.Count(t.Cron.Start, " ") != (startFields - 1) {
+		return fmt.Errorf("cron.start must contain %d fields", startFields)
+	}
+	if strings.Count(t.Cron.End, " ") != (endFields - 1) {
+		return fmt.Errorf("cron.end must contain %d fields", endFields)
+	}
+	if strings.ContainsAny(t.Cron.Start, restrictedChars) {
+		return fmt.Errorf("cron.start must not contain %q", restrictedChars)
+	}
+	if strings.ContainsAny(t.Cron.End, restrictedChars) {
+		return fmt.Errorf("cron.end must not contain %q", restrictedChars)
+	}
+
+	return nil
+}
+
+func (t *TaskSchedule) Next(from time.Time) (start, end time.Duration, err error) {
+	return t.Cron.Next(from)
+}
+
+type TaskScheduleCron struct {
+	// Start is a stripped-down cron syntax, e.g.
+	// "0 30 9 * * MON-FRI *"
+	// is weekdays @ 09:30:00
+	Start string
+	// End is the end time in "{minute} {hour}" format, e.g.
+	// "30 9"
+	// is 09:30 AM
+	// The End time *must* come after the Start time.
+	// If you need something to happen overnight,
+	// you may change the Timezone.
+	End string
+	// Timezone is the zone of time.
+	Timezone string
+}
+
+func (t TaskScheduleCron) String() string {
+	return fmt.Sprintf("<Start='%s', End='%s', Timezone='%s'>",
+		t.Start, t.End, t.Timezone)
+}
+
+func (t TaskScheduleCron) GetTimezone() string {
+	if t.Timezone == "" {
+		return "Local" // https://pkg.go.dev/time#LoadLocation
+	}
+	return t.Timezone
+}
+
+func (t TaskScheduleCron) Next(from time.Time) (time.Duration, time.Duration, error) {
+	// where are we?
+	location, err := time.LoadLocation(t.GetTimezone())
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid timezone in schedule: %w", err)
+	}
+	from = from.In(location)
+
+	// values should be pre-validated by this point
+	start, err := cronexpr.Parse(t.Start)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid start time in schedule: %q; %w", t.Start, err)
+	}
+	// get end time for prev to see if we're within the run schedule,
+	// and from next to get the next pause time.
+	end, err := cronexpr.Parse(t.End + " * * * *") // TODO: if we want to exclude seconds, prefix "* " + t.End here
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid end time in schedule: %q; %w", t.End, err)
+	}
+
+	// next end must be later than next start on the same day
+	if end.Next(from).Day() > start.Next(from).Day() {
+		return 0, 0, fmt.Errorf("end cannot be sooner than start")
+	}
+
+	startNext := start.Next(from)
+	// we'll check the previous start to see if we are currently between it
+	// and the previous run's end, i.e. it should be running right now!
+	startPrev := start.Next(from.Add(-24 * time.Hour))
+
+	// generate ends from starts, so they always come after
+	endNext := end.Next(startNext)
+	endPrev := end.Next(startPrev)
+
+	// we're in the midst of it right now!
+	if startPrev.Before(from) && endPrev.After(from) {
+		return 0, endPrev.Sub(from), nil
+	}
+
+	return startNext.Sub(from), endNext.Sub(from), nil
+}

--- a/nomad/structs/task_sched_test.go
+++ b/nomad/structs/task_sched_test.go
@@ -1,0 +1,264 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package structs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test"
+	"github.com/shoenig/test/must"
+)
+
+func TestTaskScheduleCron(t *testing.T) {
+	ci.Parallel(t)
+
+	// lil now helper
+	getFrom := func(t *testing.T, val string) time.Time {
+		t.Helper()
+		from, err := time.Parse(time.RFC3339, val)
+		must.NoError(t, err)
+		return from
+	}
+
+	// july 1st 2024 at 1am is the eternal now.
+	// it is a Monday.
+	eternalNow := "2024-07-01T01:00:00Z"
+
+	cases := []struct {
+		name string
+
+		now, start, end, tz string
+
+		expectNext time.Duration
+		expectEnd  time.Duration
+		err        string
+	}{
+		{
+			name:       "start < now < end",
+			now:        "2024-07-01T01:30:00Z", // 01:30
+			start:      "0 0 1 * * * *",        // 01:00
+			end:        "0 0 2",                // 02:00
+			expectNext: 0,                      // should be running
+			expectEnd:  30 * time.Minute,
+		},
+		{
+			name:       "now < start < end",
+			now:        "2024-07-01T01:00:00Z", // 01:00
+			start:      "0 10 1 * * * *",       // 01:10
+			end:        "0 30 1",               // 01:30
+			expectNext: 10 * time.Minute,       // run in 10 min
+			expectEnd:  30 * time.Minute,
+		},
+		{
+			name:       "start < end < now",
+			now:        "2024-07-01T02:00:00Z", // 02:00
+			start:      "0 0 1 * * * *",        // 01:00
+			end:        "0 30 1",               // 01:30
+			expectNext: 23 * time.Hour,         // run tomorrow @ 1am
+			expectEnd:  23*time.Hour + 30*time.Minute,
+		},
+		{
+			name:  "now < start",
+			now:   "2024-07-01T01:00:00Z", // 01:00
+			start: "0 10 1 * * * *",       // 01:10
+			end:   "0 30 0",               // 00:30
+			err:   "end cannot be sooner than start",
+		},
+		// real-life examples
+		{
+			name:       "before market monday",
+			now:        "2024-07-01T08:00:00-04:00", // 08:00
+			start:      "0 30 9 * * MON-FRI *",      // 09:30
+			end:        "0 0 16",                    // 16:00
+			tz:         "America/New_York",
+			expectNext: time.Hour + 30*time.Minute,
+			expectEnd:  8 * time.Hour,
+		},
+		{
+			name:       "during market monday",
+			now:        "2024-07-01T10:00:00-04:00", // 10:00
+			start:      "0 30 9 * * MON-FRI *",      // 09:30
+			end:        "0 0 16",                    // 16:00
+			tz:         "America/New_York",
+			expectNext: 0, // running now!
+			expectEnd:  6 * time.Hour,
+		},
+		{
+			name:       "after market monday",
+			now:        "2024-07-01T23:00:00-04:00", // 23:00
+			start:      "0 30 9 * * MON-FRI *",      // 09:30
+			end:        "0 0 16",                    // 16:00
+			tz:         "America/New_York",
+			expectNext: 10*time.Hour + 30*time.Minute, // tuesday morning
+			expectEnd:  17 * time.Hour,                // tuesday afternoon
+		},
+		{
+			name:       "during market saturday",    // saturday!
+			now:        "2024-07-06T10:00:00-04:00", // 10:00
+			start:      "0 30 9 * * MON-FRI *",      // 09:30
+			end:        "0 0 16",                    // 16:00
+			tz:         "America/New_York",
+			expectNext: (24+23)*time.Hour + 30*time.Minute, // monday morning
+			expectEnd:  (24 + 24 + 6) * time.Hour,          // monday afternoon
+		},
+		{ // TODO: this one only works because friday farther back than 24h
+			name:       "during market sunday",      // sunday!
+			now:        "2024-07-07T10:00:00-04:00", // 10:00
+			start:      "0 30 9 * * MON-FRI *",      // 09:30
+			end:        "0 0 16",                    // 16:00
+			tz:         "America/New_York",
+			expectNext: 23*time.Hour + 30*time.Minute, // monday morning
+			expectEnd:  (24 + 6) * time.Hour,          // monday afternoon
+		},
+		// errors
+		{
+			name:  "bad tz",
+			start: "any",
+			end:   "any",
+			tz:    "the moon",
+			err:   "invalid timezone in schedule: unknown time zone the moon",
+		},
+		{
+			name:  "no start",
+			start: "",
+			err:   `invalid start time in schedule: ""; missing field(s)`,
+		},
+		{
+			name:  "bad start",
+			start: "x",
+			end:   "any",
+			err:   `invalid start time in schedule: "x"; missing field(s)`,
+		},
+		{
+			name:  "no end",
+			start: "0 0 0 * * * *",
+			end:   "",
+			err:   `invalid end time in schedule: ""; missing field(s)`,
+		},
+		{
+			name:  "bad end",
+			start: "0 0 0 * * * *",
+			end:   "ohno",
+			err:   `invalid end time in schedule: "ohno"; syntax error in minute field: 'ohno'`,
+		},
+		{
+			name:  "bad end minute",
+			start: "0 0 0 * * * *",
+			end:   "s m h",
+			err:   `invalid end time in schedule: "s m h"; syntax error in second field: 's'`,
+		},
+		{
+			name:  "bad end hour",
+			start: "0 0 0 * * * *",
+			end:   "0 1 h",
+			err:   `invalid end time in schedule: "0 1 h"; syntax error in hour field: 'h'`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// default empty test case vals
+			if tc.tz == "" {
+				tc.tz = "UTC"
+			}
+			if tc.now == "" {
+				tc.now = eternalNow
+			}
+
+			from := getFrom(t, tc.now)
+
+			sched := TaskScheduleCron{
+				Start:    tc.start,
+				End:      tc.end,
+				Timezone: tc.tz,
+			}
+			next, end, err := sched.Next(from)
+
+			if tc.err == "" {
+				must.NoError(t, err)
+			} else {
+				must.ErrorContains(t, err, tc.err)
+			}
+			test.Eq(t, tc.expectNext, next, test.Sprint("wrong next"))
+			test.Eq(t, tc.expectEnd, end, test.Sprint("wrong end"))
+		})
+	}
+}
+
+func TestTaskSchedule_Validate(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name  string
+		sched TaskSchedule
+		err   string
+	}{
+		{
+			name: "seconds",
+			sched: TaskSchedule{
+				Cron: &TaskScheduleCron{
+					Start:    "0 00 09 * * * *",
+					End:      "0 30 16",
+					Timezone: "America/New_York",
+				},
+			},
+			err: "cron.start must contain 6 fields",
+		},
+		{
+			name: "slash",
+			sched: TaskSchedule{
+				Cron: &TaskScheduleCron{
+					Start:    "5-59/5 09 * * * *",
+					End:      "2 16",
+					Timezone: "America/New_York",
+				},
+			},
+			err: "cron.start must not contain",
+		},
+		{
+			name: "leading zero",
+			sched: TaskSchedule{
+				Cron: &TaskScheduleCron{
+					Start:    "00 09 * * * *",
+					End:      "30 16",
+					Timezone: "America/New_York",
+				},
+			},
+		},
+		{
+			name: "no leading zero",
+			sched: TaskSchedule{
+				Cron: &TaskScheduleCron{
+					Start:    "5 1 * * * *",
+					End:      "0 2",
+					Timezone: "America/New_York",
+				},
+			},
+		},
+		{
+			name: "eastern",
+			sched: TaskSchedule{
+				Cron: &TaskScheduleCron{
+					Start:    "0 9 * * * *",
+					End:      "30 16",
+					Timezone: "EST5EDT",
+				},
+			},
+		},
+	}
+
+	for i := range cases {
+		tc := cases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.sched.Validate()
+			if tc.err == "" {
+				must.NoError(t, err)
+			} else {
+				must.ErrorContains(t, err, tc.err)
+			}
+		})
+	}
+}

--- a/ui/app/adapters/allocation.js
+++ b/ui/app/adapters/allocation.js
@@ -41,6 +41,29 @@ export default class AllocationAdapter extends Watchable {
       .then(handleFSResponse);
   }
 
+  // note: TaskName vs Task as key for PUT data differs from restart above
+  forcePause(allocation, taskName) {
+    const prefix = `${this.host || '/'}${this.urlPrefix()}`;
+    const url = `${prefix}/client/allocation/${allocation.id}/pause`;
+    return this.ajax(url, 'PUT', {
+      data: taskName && { Task: taskName, ScheduleState: 'pause' },
+    });
+  }
+  forceRun(allocation, taskName) {
+    const prefix = `${this.host || '/'}${this.urlPrefix()}`;
+    const url = `${prefix}/client/allocation/${allocation.id}/pause`;
+    return this.ajax(url, 'PUT', {
+      data: taskName && { Task: taskName, ScheduleState: 'run' },
+    });
+  }
+  reEnableSchedule(allocation, taskName) {
+    const prefix = `${this.host || '/'}${this.urlPrefix()}`;
+    const url = `${prefix}/client/allocation/${allocation.id}/pause`;
+    return this.ajax(url, 'PUT', {
+      data: taskName && { Task: taskName, ScheduleState: 'scheduled' },
+    });
+  }
+
   async check(model) {
     const res = await this.token.authorizedRequest(
       `/v1/client/allocation/${model.id}/checks`

--- a/ui/app/controllers/allocations/allocation/task/index.js
+++ b/ui/app/controllers/allocations/allocation/task/index.js
@@ -43,4 +43,52 @@ export default class IndexController extends Controller {
       this.nomadActions.hasActionPermissions
     );
   }
+
+  @task(function* () {
+    try {
+      yield this.model.forcePause();
+      this.notifications.add({
+        title: 'Task Force Paused',
+        message: 'Task has been force paused',
+        color: 'success',
+      });
+    } catch (err) {
+      this.set('error', {
+        title: 'Could Not Force Pause Task',
+      });
+    }
+  })
+  forcePause;
+
+  @task(function* () {
+    try {
+      yield this.model.forceRun();
+      this.notifications.add({
+        title: 'Task Force Run',
+        message: 'Task has been force run',
+        color: 'success',
+      });
+    } catch (err) {
+      this.set('error', {
+        title: 'Could Not Force Run Task',
+      });
+    }
+  })
+  forceRun;
+
+  @task(function* () {
+    try {
+      yield this.model.reEnableSchedule();
+      this.notifications.add({
+        title: 'Task Put Back On Schedule',
+        message: 'Task has been put back on its configured schedule',
+        color: 'success',
+      });
+    } catch (err) {
+      this.set('error', {
+        title: 'Could Not put back on schedule',
+      });
+    }
+  })
+  reEnableSchedule;
 }

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -225,4 +225,14 @@ export default class Allocation extends Model {
   stat(path) {
     return this.store.adapterFor('allocation').stat(this, path);
   }
+
+  forcePause(taskName) {
+    return this.store.adapterFor('allocation').forcePause(this, taskName);
+  }
+  forceRun(taskName) {
+    return this.store.adapterFor('allocation').forceRun(this, taskName);
+  }
+  reEnableSchedule(taskName) {
+    return this.store.adapterFor('allocation').reEnableSchedule(this, taskName);
+  }
 }

--- a/ui/app/models/task-schedule.js
+++ b/ui/app/models/task-schedule.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import Fragment from 'ember-data-model-fragments/fragment';
+import { attr } from '@ember-data/model';
+import { fragmentOwner } from 'ember-data-model-fragments/attributes';
+
+export default class TaskScheduleModel extends Fragment {
+  @fragmentOwner('task') task;
+  @attr() cron;
+}

--- a/ui/app/models/task-state.js
+++ b/ui/app/models/task-state.js
@@ -23,6 +23,7 @@ export default class TaskState extends Fragment {
   @attr('date') startedAt;
   @attr('date') finishedAt;
   @attr('boolean') failed;
+  @attr() paused;
 
   @and('isActive', 'allocation.isRunning') isRunning;
 
@@ -69,5 +70,17 @@ export default class TaskState extends Fragment {
 
   restart() {
     return this.allocation.restart(this.name);
+  }
+
+  forcePause() {
+    return this.allocation.forcePause(this.name);
+  }
+
+  forceRun() {
+    return this.allocation.forceRun(this.name);
+  }
+
+  reEnableSchedule() {
+    return this.allocation.reEnableSchedule(this.name);
   }
 }

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -23,6 +23,8 @@ export default class Task extends Fragment {
 
   @attr() meta;
 
+  @fragment('task-schedule') schedule;
+
   @computed('taskGroup.mergedMeta', 'meta')
   get mergedMeta() {
     return {

--- a/ui/app/styles/core/notifications.scss
+++ b/ui/app/styles/core/notifications.scss
@@ -51,3 +51,36 @@ section.notifications {
     }
   }
 }
+
+.time-based-alert {
+  .hds-alert__content {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto auto;
+    gap: 1rem;
+    align-items: start;
+  }
+
+  .hds-alert__text {
+    grid-column: 1 / 2;
+    grid-row: 1 / 2;
+  }
+
+  .hds-alert__actions {
+    grid-column: 1 / 2;
+    grid-row: 2 / 3;
+  }
+
+  .hds-code-block {
+    grid-column: 2 / 3;
+    grid-row: 1 / 3;
+    justify-self: end;
+    align-self: start;
+  }
+
+  .hds-code-block {
+    pre {
+      background-color: unset;
+    }
+  }
+}

--- a/ui/app/templates/allocations/allocation/task/index.hbs
+++ b/ui/app/templates/allocations/allocation/task/index.hbs
@@ -78,6 +78,35 @@
       {{/if}}
     </PH.Actions>
   </Hds::PageHeader>
+  {{#if this.model.task.schedule}}
+    <Hds::Alert @type="inline" @icon="delay" @color="highlight" class="time-based-alert" as |A|>
+      {{#if (eq this.model.paused '')}}
+        <A.Title>This task is currently running on schedule</A.Title>
+        <A.Description>This task is running as per the defined schedule.</A.Description>
+        <A.Button @text="Force Pause" @color="secondary" {{on "click" (perform this.forcePause)}} />
+        <A.Button @text="Remove from Schedule" @color="secondary" {{on "click" (perform this.forceRun)}}  />
+      {{else if (eq this.model.paused 'scheduled_pause')}}
+        <A.Title>This task is currently paused on schedule</A.Title>
+        <A.Description>This task is paused and will resume on the next scheduled run.</A.Description>
+        <A.Button @text="Force Run" @color="secondary" {{on "click" (perform this.forceRun)}} />
+        <A.Button @text="Remove from Schedule" @color="secondary" {{on "click" (perform this.forcePause)}} />
+      {{else if (eq this.model.paused 'force_pause')}}
+        <A.Title>This task is manually paused</A.Title>
+        <A.Description>This task has been paused manually and is not following the schedule.</A.Description>
+        <A.Button @text="Force Run" @color="secondary" {{on "click" (perform this.forceRun)}} />
+        <A.Button @text="Put Back on Schedule" @color="secondary" {{on "click" (perform this.reEnableSchedule)}} />
+      {{else if (eq this.model.paused 'force_run')}}
+        <A.Title>This task is manually running</A.Title>
+        <A.Description>This task is running manually and is not following the schedule.</A.Description>
+        <A.Button @text="Force Pause" @color="secondary" {{on "click" (perform this.forcePause)}} />
+        <A.Button @text="Put Back on Schedule" @color="secondary" {{on "click" (perform this.reEnableSchedule)}} />
+      {{/if}}
+      <A.Generic>
+        <Hds::CodeBlock @value={{stringify-object this.model.task.schedule.cron}} @hasLineNumbers={{false}} @language="hcl" />
+      </A.Generic>
+    </Hds::Alert>
+    <Hds::Separator />
+  {{/if}}
   <div class="boxed-section is-small">
     <div class="boxed-section-body inline-definitions">
       <span class="label">


### PR DESCRIPTION
this is the CE side of an Enterprise-only feature. a job trying to use this in CE will fail to validate.

to enable daily-scheduled execution entirely client-side, a job may now contain:

```hcl
task "name" {
  schedule {
    cron {
      start    = "0 12 * * * *" # may not include "," or "/"
      end      = "0 16"         # partial cron, with only {minute} {hour}
      timezone = "EST"          # anything in your tzdata
    }
  }
...
```

and everything about the allocation will be placed as usual, but if outside the specified schedule, the taskrunner will block on the client, waiting on the schedule start, before proceeding with the task driver execution, etc.

this includes a taksrunner hook, which watches for the end of the schedule, at which point it will kill the task.

then, restarts-allowing, a new task will start and again block waiting for start, and so on.

this also includes all the plumbing required to pipe API calls through from command->api->agent->server->client, so that tasks can be force-run, force-paused, or resume the schedule on demand.