### PR TITLE
consul: include admin partition in JWT login requests

### DIFF
--- a/.changelog/22226.txt
+++ b/.changelog/22226.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul: Fixed a bug where Consul admin partition was not used to login via Consul JWT auth method
+```

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -130,7 +130,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 			allocdir:                ar.allocDir,
 			widmgr:                  ar.widmgr,
 			consulConfigs:           ar.clientConfig.GetConsulConfigs(hookLogger),
-			consulClientConstructor: consul.NewConsulClient,
+			consulClientConstructor: consul.NewConsulClientFactory(config.Node),
 			hookResources:           ar.hookResources,
 			envBuilder:              newEnvBuilder,
 			logger:                  hookLogger,

--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -23,7 +23,7 @@ type consulHook struct {
 	allocdir                allocdir.Interface
 	widmgr                  widmgr.IdentityManager
 	consulConfigs           map[string]*structsc.ConsulConfig
-	consulClientConstructor func(*structsc.ConsulConfig, log.Logger) (consul.Client, error)
+	consulClientConstructor consul.ConsulClientFunc
 	hookResources           *cstructs.AllocHookResources
 	envBuilder              *taskenv.Builder
 
@@ -39,7 +39,7 @@ type consulHookConfig struct {
 	consulConfigs map[string]*structsc.ConsulConfig
 	// consulClientConstructor injects the function that will return a consul
 	// client (eases testing)
-	consulClientConstructor func(*structsc.ConsulConfig, log.Logger) (consul.Client, error)
+	consulClientConstructor consul.ConsulClientFunc
 
 	// hookResources is used for storing and retrieving Consul tokens
 	hookResources *cstructs.AllocHookResources


### PR DESCRIPTION
When logging into a JWT auth method, we need to explicitly supply the Consul admin partition if the local Consul agent is in a partition. We can't derive this from agent configuration because the Consul agent's configuration is canonical, so instead we get the partition from the fingerprint (if available). This changeset updates the Consul client constructor so that we close over the partition from the fingerprint.

Ref: https://hashicorp.atlassian.net/browse/NET-9451