### PR TITLE
consul: set partition for gateway config entries

### DIFF
--- a/.changelog/22228.txt
+++ b/.changelog/22228.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+consul: Fixed a bug where gateway config entries were written to the Nomad server agent's Consul partition and not the client's partition
+```
+
+```release-note:bug
+consul: (Enterprise) Fixed a bug where gateway config entries were written before Sentinel policies were enforced
+```

--- a/nomad/structs/connect.go
+++ b/nomad/structs/connect.go
@@ -17,6 +17,7 @@ import (
 // a single Consul namespace.
 type ConsulConfigEntries struct {
 	Cluster     string
+	Partition   string
 	Ingress     map[string]*ConsulIngressConfigEntry
 	Terminating map[string]*ConsulTerminatingConfigEntry
 }
@@ -43,9 +44,15 @@ func (j *Job) ConfigEntries() map[string]*ConsulConfigEntries {
 				if ig := gateway.Ingress; ig != nil {
 					collection[ns].Ingress[service.Name] = ig
 					collection[ns].Cluster = service.Cluster
+					if tg.Consul != nil {
+						collection[ns].Partition = tg.Consul.Partition
+					}
 				} else if term := gateway.Terminating; term != nil {
 					collection[ns].Terminating[service.Name] = term
 					collection[ns].Cluster = service.Cluster
+					if tg.Consul != nil {
+						collection[ns].Partition = tg.Consul.Partition
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When we write Connect gateway configuation entries from the server, we're not passing in the intended partition. This means we're using the server's own partition to submit the configuration entries and this may not match. Note this requires the Nomad server's token has permission to that partition.

Also, move the config entry write after we check Sentinel policies. This allows us to return early if we hit a Sentinel error without making Consul RPCs first.

Ref: https://hashicorp.atlassian.net/browse/NET-9529