### PR TITLE
job endpoint: fix implicit constraint mutation for task-level services

### DIFF
--- a/.changelog/22229.txt
+++ b/.changelog/22229.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+job endpoint: fix implicit constraint mutation for task-level services
+```

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -450,9 +450,9 @@ func mutateConstraint[T hasConstraints](matcher constraintMatcher, taskOrTG T, c
 
 	// If we didn't find a suitable constraint match, add one.
 	if !found {
-		currentConstraints := taskOrTG.GetConstraints()
-		newConstraints := append(currentConstraints, constraint)
-		taskOrTG.SetConstraints(newConstraints)
+		constraints := taskOrTG.GetConstraints()
+		constraints = append(constraints, constraint)
+		taskOrTG.SetConstraints(constraints)
 	}
 }
 

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -333,12 +333,12 @@ func (jobImpliedConstraints) Mutate(j *structs.Job) (*structs.Job, []error, erro
 				if service.IsConsul() {
 					mutateConstraint(constraintMatcherLeft, tg, consulConstraintFn(service))
 				}
+			}
 
-				for _, task := range tg.Tasks {
-					for _, service := range task.Services {
-						if service.IsConsul() {
-							mutateConstraint(constraintMatcherLeft, tg, consulConstraintFn(service))
-						}
+			for _, task := range tg.Tasks {
+				for _, service := range task.Services {
+					if service.IsConsul() {
+						mutateConstraint(constraintMatcherLeft, task, consulConstraintFn(service))
 					}
 				}
 			}
@@ -414,9 +414,17 @@ const (
 	constraintMatcherLeft
 )
 
+// both Tasks and TaskGroups can have constraints, and since current (1.22) Go
+// still doesn't allow us accessing fields of generic type structs, we have to
+// resort to an interface
+type hasConstraints interface {
+	GetConstraints() []*structs.Constraint
+	SetConstraints([]*structs.Constraint)
+}
+
 // mutateConstraint is a generic mutator used to set implicit constraints
 // within the task group if they are needed.
-func mutateConstraint(matcher constraintMatcher, taskGroup *structs.TaskGroup, constraint *structs.Constraint) {
+func mutateConstraint[T hasConstraints](matcher constraintMatcher, taskOrTG T, constraint *structs.Constraint) {
 
 	var found bool
 
@@ -425,14 +433,14 @@ func mutateConstraint(matcher constraintMatcher, taskGroup *structs.TaskGroup, c
 	// therefore we do it here.
 	switch matcher {
 	case constraintMatcherFull:
-		for _, c := range taskGroup.Constraints {
+		for _, c := range taskOrTG.GetConstraints() {
 			if c.Equal(constraint) {
 				found = true
 				break
 			}
 		}
 	case constraintMatcherLeft:
-		for _, c := range taskGroup.Constraints {
+		for _, c := range taskOrTG.GetConstraints() {
 			if c.LTarget == constraint.LTarget {
 				found = true
 				break
@@ -442,7 +450,9 @@ func mutateConstraint(matcher constraintMatcher, taskGroup *structs.TaskGroup, c
 
 	// If we didn't find a suitable constraint match, add one.
 	if !found {
-		taskGroup.Constraints = append(taskGroup.Constraints, constraint)
+		currentConstraints := taskOrTG.GetConstraints()
+		newConstraints := append(currentConstraints, constraint)
+		taskOrTG.SetConstraints(newConstraints)
 	}
 }
 

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -1118,6 +1118,48 @@ func Test_jobImpliedConstraints_Mutate(t *testing.T) {
 			expectedOutputError:    nil,
 		},
 		{
+			name: "task-level service",
+			inputJob: &structs.Job{
+				Name: "example",
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "example-group-1",
+						Tasks: []*structs.Task{
+							{
+								Name: "example-task-1",
+								Services: []*structs.Service{
+									{
+										Name: "example-task-service-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedOutputJob: &structs.Job{
+				Name: "example",
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "example-group-1",
+						Tasks: []*structs.Task{
+							{
+								Name: "example-task-1",
+								Services: []*structs.Service{
+									{
+										Name: "example-task-service-1",
+									},
+								},
+								Constraints: []*structs.Constraint{consulServiceDiscoveryConstraint},
+							},
+						},
+					},
+				},
+			},
+			expectedOutputWarnings: nil,
+			expectedOutputError:    nil,
+		},
+		{
 			name: "task group with numa block",
 			inputJob: &structs.Job{
 				Name: "numa",

--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -89,6 +89,13 @@ func Job() *structs.Job {
 								Args:    []string{"hello world"},
 							},
 						},
+						Constraints: []*structs.Constraint{
+							{
+								LTarget: "${attr.consul.version}",
+								RTarget: ">= 1.8.0",
+								Operand: structs.ConstraintSemver,
+							},
+						},
 						Services: []*structs.Service{
 							{
 								Name:      "${TASK}-frontend",

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7543,6 +7543,14 @@ func (tg *TaskGroup) GetDisconnectStopTimeout() *time.Duration {
 	return nil
 }
 
+func (tg *TaskGroup) GetConstraints() []*Constraint {
+	return tg.Constraints
+}
+
+func (tg *TaskGroup) SetConstraints(newConstraints []*Constraint) {
+	tg.Constraints = newConstraints
+}
+
 // CheckRestart describes if and when a task should be restarted based on
 // failing health checks.
 type CheckRestart struct {
@@ -8375,6 +8383,14 @@ func (t *Task) Warnings() error {
 	}
 
 	return mErr.ErrorOrNil()
+}
+
+func (t *Task) GetConstraints() []*Constraint {
+	return t.Constraints
+}
+
+func (t *Task) SetConstraints(newConstraints []*Constraint) {
+	t.Constraints = newConstraints
 }
 
 // TaskKind identifies the special kinds of tasks using the following format:


### PR DESCRIPTION
Fixes a regression in Nomad 1.7 which caused task-level services no longer having created implicit Consul constraints. 

Resolves #22190 