### PR TITLE
Consul Connect: Fix validation with multiple local_bind_socket_paths

### DIFF
--- a/.changelog/22312.txt
+++ b/.changelog/22312.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: fix validation with multiple socket paths
+```


### PR DESCRIPTION
When a consul connect sidecar service is defined with multiple local_bind_socket_path upstreams, validation fails due to duplicate socket address bindings on `:0` being detected:

```
Error submitting job: Unexpected response code: 500 (1 error occurred:
        * Consul Connect services "caddy-https" and "caddy-https" in group "caddy" using same address for upstreams (:0))
```

This patch validates `local_bind_socket_path` upstreams separately from `local_bind_address` sockets.