### PR TITLE
docs: Update CNI Plugin versions

### DIFF
--- a/website/content/docs/install/index.mdx
+++ b/website/content/docs/install/index.mdx
@@ -201,7 +201,7 @@ CNI plugins installed.
 The following commands install the CNI reference plugins.
 
 ```shell-session
-$ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/v1.0.0/cni-plugins-linux-$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)"-v1.0.0.tgz && \
+$ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/v1.5.0/cni-plugins-linux-$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)"-v1.5.0.tgz && \
   sudo mkdir -p /opt/cni/bin && \
   sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
 ```


### PR DESCRIPTION
Latest CNI reference plugin versions are now 1.5.0: https://github.com/containernetworking/plugins/releases/tag/v1.5.0