### PR TITLE
[agent] Use custom compression middleware

### DIFF
--- a/command/agent/middleware/compress.go
+++ b/command/agent/middleware/compress.go
@@ -1,0 +1,167 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package middleware
+
+// Original Source License:
+//   Copyright 2013 The Gorilla Authors. All rights reserved.
+//   Use of this source code is governed by a BSD-style
+//   license that can be found in the LICENSE file.
+//   <https://github.com/gorilla/handlers/blob/v1.5.1/LICENSE>
+
+import (
+	"compress/flate"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/felixge/httpsnoop"
+)
+
+const (
+	hdrAcceptEncoding  = "Accept-Encoding"
+	hdrContentType     = "Content-Type"
+	hdrContentLength   = "Content-Length"
+	hdrContentEncoding = "Content-Encoding"
+	hdrUpgrade         = "Upgrade"
+	hdrVary            = "Vary"
+
+	threshold = 256 // this is an arbitrary value and could be made a configurable
+)
+
+type compressResponseWriter struct {
+	compressor io.Writer
+	w          http.ResponseWriter
+	t          int // small value threshold
+}
+
+func (cw *compressResponseWriter) WriteHeader(c int) {
+	cw.w.Header().Del(hdrContentLength)
+	cw.w.WriteHeader(c)
+}
+
+func (cw *compressResponseWriter) Write(b []byte) (int, error) {
+	h := cw.w.Header()
+	if h.Get(hdrContentType) == "" {
+		h.Set(hdrContentType, http.DetectContentType(b))
+	}
+	h.Del(hdrContentLength)
+	if cw.shouldCompress(&b) {
+		// Write the compressed value
+		return cw.compressor.Write(b)
+	}
+	// Indicate that the value isn't compressed and write it
+	h.Set(hdrContentEncoding, "identity")
+	return cw.w.Write(b)
+}
+func (cw *compressResponseWriter) shouldCompress(b *[]byte) bool {
+	return len(*b) >= cw.t
+}
+
+func (cw *compressResponseWriter) ReadFrom(r io.Reader) (int64, error) {
+	return io.Copy(cw.compressor, r)
+}
+
+type flusher interface {
+	Flush() error
+}
+
+func (cw *compressResponseWriter) Flush() {
+	// Flush compressed data if compressor supports it.
+	if f, ok := cw.compressor.(flusher); ok {
+		_ = f.Flush()
+	}
+	// Flush HTTP response.
+	if f, ok := cw.w.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// CompressHandler gzip compresses HTTP responses for clients that support it
+// via the 'Accept-Encoding' header.
+//
+// Compressing TLS traffic may leak the page contents to an attacker if the
+// page contains user input: http://security.stackexchange.com/a/102015/12208
+func CompressHandler(h http.Handler) http.Handler {
+	return CompressHandlerLevel(h, gzip.DefaultCompression)
+}
+
+// CompressHandlerLevel gzip compresses HTTP responses with specified compression level
+// for clients that support it via the 'Accept-Encoding' header.
+//
+// The compression level should be gzip.DefaultCompression, gzip.NoCompression,
+// or any integer value between gzip.BestSpeed and gzip.BestCompression inclusive.
+// gzip.DefaultCompression is used in case of invalid compression level.
+func CompressHandlerLevel(h http.Handler, level int) http.Handler {
+	if level < gzip.DefaultCompression || level > gzip.BestCompression {
+		level = gzip.DefaultCompression
+	}
+
+	const (
+		gzipEncoding  = "gzip"
+		flateEncoding = "deflate"
+	)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// detect what encoding to use
+		var encoding string
+		for _, curEnc := range strings.Split(r.Header.Get(hdrAcceptEncoding), ",") {
+			curEnc = strings.TrimSpace(curEnc)
+			if curEnc == gzipEncoding || curEnc == flateEncoding {
+				encoding = curEnc
+				break
+			}
+		}
+
+		// always add Accept-Encoding to Vary to prevent intermediate caches corruption
+		w.Header().Add(hdrVary, hdrAcceptEncoding)
+
+		// if we weren't able to identify an encoding we're familiar with, pass on the
+		// request to the handler and return
+		if encoding == "" {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		if r.Header.Get(hdrUpgrade) != "" {
+			h.ServeHTTP(w, r)
+			return
+		}
+
+		// wrap the ResponseWriter with the writer for the chosen encoding
+		var encWriter io.WriteCloser
+		if encoding == gzipEncoding {
+			encWriter, _ = gzip.NewWriterLevel(w, level)
+		} else if encoding == flateEncoding {
+			encWriter, _ = flate.NewWriter(w, level)
+		}
+		defer encWriter.Close()
+
+		w.Header().Set(hdrContentEncoding, encoding)
+		r.Header.Del(hdrAcceptEncoding)
+
+		cw := &compressResponseWriter{
+			w:          w,
+			compressor: encWriter,
+			t:          threshold,
+		}
+
+		w = httpsnoop.Wrap(w, httpsnoop.Hooks{
+			Write: func(httpsnoop.WriteFunc) httpsnoop.WriteFunc {
+				return cw.Write
+			},
+			WriteHeader: func(httpsnoop.WriteHeaderFunc) httpsnoop.WriteHeaderFunc {
+				return cw.WriteHeader
+			},
+			Flush: func(httpsnoop.FlushFunc) httpsnoop.FlushFunc {
+				return cw.Flush
+			},
+			ReadFrom: func(rff httpsnoop.ReadFromFunc) httpsnoop.ReadFromFunc {
+				return cw.ReadFrom
+			},
+		})
+
+		h.ServeHTTP(w, r)
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad
 
-go 1.21
+go 1.22.1
 
 // Pinned dependencies are noted in github.com/hashicorp/nomad/issues/11826.
 replace (
@@ -33,6 +33,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/elazarl/go-bindata-assetfs v1.0.1
 	github.com/fatih/color v1.16.0
+	github.com/felixge/httpsnoop v1.0.3
 	github.com/fsouza/go-dockerclient v1.10.1
 	github.com/go-jose/go-jose/v3 v3.0.3
 	github.com/golang-jwt/jwt/v5 v5.0.0
@@ -189,7 +190,6 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7 // indirect
-	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/go-jose/go-jose/v4 v4.0.1 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect


### PR DESCRIPTION
The compression handler will still compress the response body, even if the response body is small or empty. This is not desirable, because an empty body compresses to 28-30 bytes, wasting both compression effort and network bandwidth for no gain.
