### PR TITLE
[ui] Squashing Ember deprecations

### DIFF
--- a/ui/app/machines/evaluations.js
+++ b/ui/app/machines/evaluations.js
@@ -8,6 +8,7 @@ import { assign, createMachine, send } from 'xstate';
 // Docs on using statecharts:  https://xstate.js.org/docs/packages/xstate-fsm/#api
 export default createMachine(
   {
+    predictableActionArguments: true,
     id: 'evaluations_ui',
     context: { evaluation: null },
     type: 'parallel',

--- a/ui/app/serializers/task-event.js
+++ b/ui/app/serializers/task-event.js
@@ -8,9 +8,5 @@ import classic from 'ember-classic-decorator';
 
 @classic
 export default class TaskEventSerializer extends ApplicationSerializer {
-  attrs = {
-    message: 'DisplayMessage',
-  };
-
   separateNanos = ['Time'];
 }


### PR DESCRIPTION
Getting pretty tired of these party-poopers:
![image](https://github.com/hashicorp/nomad/assets/713991/1086d185-354d-4cc7-85d2-e14a8709e7b3)

Note: a few of the other deprecation warnings are such that an upgrade to Ember 4+ is warranted if we want them to go away badly enough. This gets rid of the noisiest one (without having to mess with our deprecation-workflow.js file)