### PR TITLE
[ui] Fix keynav when selecting a task from an allocation route

### DIFF
--- a/ui/app/controllers/allocations/allocation/index.js
+++ b/ui/app/controllers/allocations/allocation/index.js
@@ -163,6 +163,9 @@ export default class IndexController extends Controller.extend(Sortable) {
 
   @action
   taskClick(allocation, task, event) {
+    if (!(event instanceof Event)) {
+      event = null;
+    }
     lazyClick([() => this.send('gotoTask', allocation, task), event]);
   }
 


### PR DESCRIPTION
On a page like this one...
<img width="1124" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/59d1c759-413c-41e4-a515-c6a35f0231b8">

You can both click on, and also use `Shift+01`, to open the task shown.

If you click the link (the underlined word itself that says "task") this is a simple href and your browser handles it.

On the other hand, if you click on the rest of the row, or type `Shift+01`, a function runs that uses Ember's router service to move you to the right spot.

Knowing what that spot is depends on knowing both the task and the allocation (since the eventual URL is `/allocations/:ALLOC_ID/:TASK_ID`)

This differs from most of the other keyboard shortcuts throughout the app in that there are multiple params passed into the router function (normally you just say "go to a job with :JOB_ID" etc.)

Noticed that this stopped working today, and dug into why. Here are the param patterns of first a `Shift+01` press, and then a click:

<img width="654" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/d75daad4-6d46-4dc5-b102-c988c473a271">

Notice the 3rd parameter: it's the `<tr>` element itself in the keypress, and the expected `PointerEvent` on click. At some point I think I added an "always include the element on keypress as the last/rest param" rule to the keyboard service without considering that not all keynav events are limited to 2 params.

Without this PR, `Shift+01` would result in this error, and no routing taking place: 
<img width="663" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/d3397099-fe1d-45d5-b375-c9498fe00e47">

This fixes the issue by checking that the `event` param is actually an Event. If it's not, it gets set to null, which `lazyClick()` handles correctly.