### PR TITLE
[ui] Omit the current-time-displaying components during our visual diff tests

### DIFF
--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -380,7 +380,11 @@ module('Acceptance | ui block', function (hooks) {
     assert
       .dom('[data-test-job-links] a')
       .exists({ count: 2 }, 'Job links exists when defined in HCL');
-    await percySnapshot(assert);
+    await percySnapshot(assert, {
+      percyCSS: `
+        .allocation-row td { display: none; }
+      `,
+    });
   });
 
   test('job sanitizes input', async function (assert) {


### PR DESCRIPTION
Visual diff tests with Percy are generated at test-time, which means that our components show time-sensitive things (like "last updated at" times for allocations) will trigger a "something changed" warning. This hides those time-sensitive things for a recently-added test.