### PR TITLE
[bug] Fix cgroup setup for non-default devices

### DIFF
--- a/.changelog/22518.txt
+++ b/.changelog/22518.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-driver: Fix cgroup rule setup for non-default devices
+driver: Fixed a bug where the exec, java, and raw_exec drivers would not configure cgroups to allow access to devices provided by device plugins
 ```

--- a/.changelog/22518.txt
+++ b/.changelog/22518.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+driver: Fix cgroup rule setup for non-default devices
+```

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -677,6 +677,10 @@ func configureIsolation(cfg *runc.Config, command *ExecCommand) error {
 		cfg.Devices = append(cfg.Devices, devs...)
 	}
 
+	for _, device := range cfg.Devices {
+		cfg.Cgroups.Resources.Devices = append(cfg.Cgroups.Resources.Devices, &device.Rule)
+	}
+
 	cfg.Mounts = []*runc.Mount{
 		{
 			Source:      "tmpfs",
@@ -844,10 +848,6 @@ func (l *LibcontainerExecutor) newLibcontainerConfig(command *ExecCommand) (*run
 		Version: "1.0.0",
 	}
 
-	for _, device := range specconv.AllowedDevices {
-		cfg.Cgroups.Resources.Devices = append(cfg.Cgroups.Resources.Devices, &device.Rule)
-	}
-
 	configureCapabilities(cfg, command)
 
 	// children should not inherit Nomad agent oom_score_adj value
@@ -897,6 +897,7 @@ func cmdDevices(driverDevices []*drivers.DeviceConfig) ([]*devices.Device, error
 			return nil, fmt.Errorf("failed to make device out for %s: %v", d.HostPath, err)
 		}
 		ed.Path = d.TaskPath
+		ed.Allow = true // rules will be used to allow devices via cgroups
 		r[i] = ed
 	}
 

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -10,7 +10,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -997,15 +996,12 @@ func TestCgroupDeviceRules(t *testing.T) {
 	executor := execInterface.(*LibcontainerExecutor)
 	cfg, err := executor.newLibcontainerConfig(command)
 	must.NoError(t, err)
-	rules := make([]devices.Rule, len(cfg.Cgroups.Devices))
-	for i, rule := range cfg.Cgroups.Devices {
-		rules[i] = *rule
-	}
-	must.True(t, slices.Contains(rules, devices.Rule{
+
+	must.SliceContains(t, cfg.Cgroups.Devices, &devices.Rule{
 		Type:        'c',
-		Major:       0xa,
+		Major:       0x0a,
 		Minor:       0xe5,
 		Permissions: "rwm",
 		Allow:       true,
-	}))
+	})
 }


### PR DESCRIPTION
Using a device inside a container requires two things:
1. binding the device
2. allowing the device in cgroup rules

The nomad linux executor sets up cgroups only for default devices and does not correctly set up other devices specified in configuration.

This change sets up cgroup rules for all devices needed by the container. An important non-default device that is relevant here is /dev/fuse.

I don't believe this has worked at any point in history; a backport to 1.7 would be appreciated if that's possible.