### PR TITLE
testing: fix the value of NOMAD_SECRETS_DIR in test harness

### DIFF
--- a/plugins/drivers/testutils/testing.go
+++ b/plugins/drivers/testutils/testing.go
@@ -269,7 +269,7 @@ func SetEnvvars(envBuilder *taskenv.Builder, fsmode fsisolation.Mode, taskDir *a
 		// Use mounts host paths
 		envBuilder.SetAllocDir(taskDir.MountsAllocDir)
 		envBuilder.SetTaskLocalDir(filepath.Join(taskDir.MountsTaskDir, "local"))
-		envBuilder.SetSecretsDir(taskDir.SecretsDir)
+		envBuilder.SetSecretsDir(taskDir.MountsSecretsDir)
 	case fsisolation.None:
 		// Use host paths
 		envBuilder.SetAllocDir(taskDir.SharedAllocDir)


### PR DESCRIPTION
This PR fixes the value of NOMAD_SECRETS_DIR to be the alloc_mounts
secrets directory instead of the real secrets directory, which is protected
by root 0700 even when running tests.

Needed for https://github.com/hashicorp/nomad-driver-exec2/issues/29
