### PR TITLE
[docs] Add Sentinel info to version-specific upgrade page

### DIFF
--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -16,8 +16,11 @@ used to document those details separately from the standard upgrade flow.
 ## Nomad 1.8.1 (UNRELEASED)
 
 <EnterpriseAlert inline />
+
 Nomad Enterprise 1.8.1 includes an updated version of the Sentinel library. Users
-that have built custom Sentinel plugins must recompile them using Sentinel SDK v4.
+that have built custom Sentinel plugins must recompile them using an SDK
+supporting Sentinel Plugin Protocol Version 3. Consult the Sentinel
+[SDK Compatibility Matrix](https://github.com/hashicorp/sentinel-sdk?tab=readme-ov-file#sdk-compatibility-matrix) for appropriate Sentinel SDK versions.
 
 ## Nomad 1.8.0
 

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -13,6 +13,12 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 1.8.1 (UNRELEASED)
+
+<EnterpriseAlert inline />
+Nomad Enterprise 1.8.1 includes an updated version of the Sentinel library. Users
+that have built custom Sentinel plugins must recompile them using Sentinel SDK v4.
+
 ## Nomad 1.8.0
 
 #### Deprecated Disconnect Fields


### PR DESCRIPTION
The upgrade to sentinel v0.26 is a breaking change for users of custom Sentinel plugins, requiring rebuilding the plugins with sentinel-sdk v4.
