### PR TITLE
testing: pull Docker images from mirror

### DIFF
--- a/drivers/docker/driver_unix_test.go
+++ b/drivers/docker/driver_unix_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	dtestutil "github.com/hashicorp/nomad/plugins/drivers/testutils"
+	ntestutil "github.com/hashicorp/nomad/testutil"
 	tu "github.com/hashicorp/nomad/testutil"
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
@@ -667,7 +668,7 @@ func TestDockerDriver_Cleanup(t *testing.T) {
 
 	// using a small image and an specific point release to avoid accidental conflicts with other tasks
 	cfg := newTaskConfig("", []string{"sleep", "100"})
-	cfg.Image = "busybox:1.29.2"
+	cfg.Image = ntestutil.TestDockerImage("busybox", "1.29.2")
 	cfg.LoadImage = ""
 	task := &drivers.TaskConfig{
 		ID:        uuid.Generate(),


### PR DESCRIPTION
In https://github.com/hashicorp/nomad/pull/17401 we added test helpers that would allow `docker` driver tests to pull from a mirror of the Docker Hub registry. Extend the use of this helper to tests that recently hit rate-limiting.

Fixes: https://github.com/hashicorp/nomad/issues/23174