### PR TITLE
client: cleanup empty task directory when using unveil filesystem isolation

### DIFF
--- a/.changelog/23237.txt
+++ b/.changelog/23237.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where empty task directories would be left behind
+```

--- a/client/allocdir/task_dir.go
+++ b/client/allocdir/task_dir.go
@@ -349,6 +349,14 @@ func (t *TaskDir) Unmount() error {
 		}
 	}
 
+	// delete the task's parent alloc mounts dir if it exists
+	if dir := filepath.Dir(t.MountsAllocDir); pathExists(dir) {
+		if err := os.RemoveAll(dir); err != nil {
+			mErr.Errors = append(mErr.Errors,
+				fmt.Errorf("failed to remove the task alloc mounts dir %q: %w", dir, err))
+		}
+	}
+
 	if pathExists(t.SecretsDir) {
 		if err := removeSecretDir(t.SecretsDir); err != nil {
 			mErr = multierror.Append(mErr,


### PR DESCRIPTION
This PR fixes a bug where Nomad client would leave behind an empty directory
created on behalf of tasks making use of the unveil filesystem isolation
mode (i.e. using exec2 task driver). Once unmounting is complete, we should
remember to also delete the directory.

Fixes #22433
