### PR TITLE
resources: new oom_score_adj field

### DIFF
--- a/api/resources.go
+++ b/api/resources.go
@@ -18,6 +18,7 @@ type Resources struct {
 	Networks    []*NetworkResource `hcl:"network,block"`
 	Devices     []*RequestedDevice `hcl:"device,block"`
 	NUMA        *NUMAResource      `hcl:"numa,block"`
+	OOMScoreAdj *int               `hcl:"oom_score_adj,optional"`
 
 	// COMPAT(0.10)
 	// XXX Deprecated. Please do not use. The field will be removed in Nomad
@@ -45,6 +46,11 @@ func (r *Resources) Canonicalize() {
 		r.CPU = pointerOf(0)
 	}
 
+	// default oom_score_adj is 0, and it can never be negative
+	if r.OOMScoreAdj == nil {
+		r.OOMScoreAdj = pointerOf(0)
+	}
+
 	if r.MemoryMB == nil {
 		r.MemoryMB = defaultResources.MemoryMB
 	}
@@ -61,9 +67,10 @@ func (r *Resources) Canonicalize() {
 // and should be kept in sync.
 func DefaultResources() *Resources {
 	return &Resources{
-		CPU:      pointerOf(100),
-		Cores:    pointerOf(0),
-		MemoryMB: pointerOf(300),
+		CPU:         pointerOf(100),
+		Cores:       pointerOf(0),
+		MemoryMB:    pointerOf(300),
+		OOMScoreAdj: pointerOf(0),
 	}
 }
 
@@ -74,9 +81,10 @@ func DefaultResources() *Resources {
 // IN nomad/structs/structs.go and should be kept in sync.
 func MinResources() *Resources {
 	return &Resources{
-		CPU:      pointerOf(1),
-		Cores:    pointerOf(0),
-		MemoryMB: pointerOf(10),
+		CPU:         pointerOf(1),
+		Cores:       pointerOf(0),
+		MemoryMB:    pointerOf(10),
+		OOMScoreAdj: pointerOf(0),
 	}
 }
 
@@ -102,6 +110,9 @@ func (r *Resources) Merge(other *Resources) {
 	}
 	if other.NUMA != nil {
 		r.NUMA = other.NUMA.Copy()
+	}
+	if other.OOMScoreAdj != nil {
+		r.OOMScoreAdj = other.OOMScoreAdj
 	}
 }
 

--- a/api/resources_test.go
+++ b/api/resources_test.go
@@ -29,9 +29,10 @@ func TestResources_Canonicalize(t *testing.T) {
 				MemoryMB: pointerOf(1024),
 			},
 			expected: &Resources{
-				CPU:      pointerOf(0),
-				Cores:    pointerOf(2),
-				MemoryMB: pointerOf(1024),
+				CPU:         pointerOf(0),
+				Cores:       pointerOf(2),
+				MemoryMB:    pointerOf(1024),
+				OOMScoreAdj: pointerOf(0),
 			},
 		},
 		{
@@ -41,9 +42,10 @@ func TestResources_Canonicalize(t *testing.T) {
 				MemoryMB: pointerOf(1024),
 			},
 			expected: &Resources{
-				CPU:      pointerOf(500),
-				Cores:    pointerOf(0),
-				MemoryMB: pointerOf(1024),
+				CPU:         pointerOf(500),
+				Cores:       pointerOf(0),
+				MemoryMB:    pointerOf(1024),
+				OOMScoreAdj: pointerOf(0),
 			},
 		},
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2424,6 +2424,7 @@ type Resources struct {
 	Networks    Networks
 	Devices     ResourceDevices
 	NUMA        *NUMA
+	OOMScoreAdj int
 }
 
 const (
@@ -2436,9 +2437,10 @@ const (
 // be kept in sync.
 func DefaultResources() *Resources {
 	return &Resources{
-		CPU:      100,
-		Cores:    0,
-		MemoryMB: 300,
+		CPU:         100,
+		Cores:       0,
+		MemoryMB:    300,
+		OOMScoreAdj: 0,
 	}
 }
 
@@ -2449,9 +2451,10 @@ func DefaultResources() *Resources {
 // api/resources.go and should be kept in sync.
 func MinResources() *Resources {
 	return &Resources{
-		CPU:      1,
-		Cores:    0,
-		MemoryMB: 10,
+		CPU:         1,
+		Cores:       0,
+		MemoryMB:    10,
+		OOMScoreAdj: 0,
 	}
 }
 
@@ -2494,6 +2497,10 @@ func (r *Resources) Validate() error {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("MemoryMaxMB value (%d) should be larger than MemoryMB value (%d)", r.MemoryMaxMB, r.MemoryMB))
 	}
 
+	if r.OOMScoreAdj < 0 {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("OOMScoreAdj value (%d) must be a positive integer", r.OOMScoreAdj))
+	}
+
 	return mErr.ErrorOrNil()
 }
 
@@ -2521,6 +2528,9 @@ func (r *Resources) Merge(other *Resources) {
 	if len(other.Devices) != 0 {
 		r.Devices = other.Devices
 	}
+	if other.OOMScoreAdj > 0 {
+		r.OOMScoreAdj = other.OOMScoreAdj
+	}
 }
 
 // Equal Resources.
@@ -2540,7 +2550,8 @@ func (r *Resources) Equal(o *Resources) bool {
 		r.DiskMB == o.DiskMB &&
 		r.IOPS == o.IOPS &&
 		r.Networks.Equal(&o.Networks) &&
-		r.Devices.Equal(&o.Devices)
+		r.Devices.Equal(&o.Devices) &&
+		r.OOMScoreAdj == o.OOMScoreAdj
 }
 
 // ResourceDevices are part of Resources.
@@ -2637,6 +2648,7 @@ func (r *Resources) Copy() *Resources {
 		Networks:    r.Networks.Copy(),
 		Devices:     r.Devices.Copy(),
 		NUMA:        r.NUMA.Copy(),
+		OOMScoreAdj: r.OOMScoreAdj,
 	}
 }
 
@@ -2662,6 +2674,7 @@ func (r *Resources) Add(delta *Resources) {
 		r.MemoryMaxMB += delta.MemoryMB
 	}
 	r.DiskMB += delta.DiskMB
+	r.OOMScoreAdj += delta.OOMScoreAdj
 
 	for _, n := range delta.Networks {
 		// Find the matching interface by IP or CIDR

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2158,6 +2158,7 @@ func TestTask_Validate_Resources(t *testing.T) {
 				MemoryMB:    1000,
 				MemoryMaxMB: 2000,
 				IOPS:        1000,
+				OOMScoreAdj: 3,
 				Networks: []*NetworkResource{
 					{
 						Mode:   "host",
@@ -2223,6 +2224,13 @@ func TestTask_Validate_Resources(t *testing.T) {
 				MemoryMaxMB: -1,
 			},
 		},
+		{
+			name: "oom_score_adj with a negative value",
+			res: &Resources{
+				OOMScoreAdj: -3,
+			},
+			err: "OOMScoreAdj value (-3) must be a positive integer",
+		},
 	}
 
 	for i := range cases {
@@ -2230,10 +2238,10 @@ func TestTask_Validate_Resources(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.res.Validate()
 			if tc.err == "" {
-				require.NoError(t, err)
+				must.NoError(t, err)
 			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.err)
+				must.Error(t, err)
+				must.StrContains(t, err.Error(), tc.err)
 			}
 		})
 	}


### PR DESCRIPTION
Adds an `oom_score_adj` field to [resources](https://www.nomadproject.io/docs/job-specification/resources) that only accepts positive values. A task can mark itself as more likely to be OOM killed, but not less likely.

Resolves https://github.com/hashicorp/nomad/issues/11087