### PR TITLE
[ui] Do an early check for mirage-scenario URL param when in mirage mode

### DIFF
--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -1162,6 +1162,17 @@ function getConfigValue(variableName, defaultValue) {
 
 function getScenarioQueryParameter() {
   const params = new URLSearchParams(window.location.search);
-  return params.get('mirage-scenario');
+  const mirageScenario = params.get('mirage-scenario');
+  if (mirageScenario && !(mirageScenario in allScenarios)) {
+    console.error(
+      new Error(
+        `Selected Mirage scenario does not exist.\n\n${mirageScenario} not in list: \n\n\t${Object.keys(
+          allScenarios
+        ).join('\n\t')}`
+      )
+    );
+    return 'smallCluster';
+  }
+  return mirageScenario;
 }
 /* eslint-enable */


### PR DESCRIPTION
Does an early check to see if the passed `?mirage-scenario=${VALUE}` value is found within our const list of scenarios. If not, provide a console error and proceed with the default (smallCluster) scenario.

This:
1. shortens the distance between parsing the URL and checking if it's valid (happens in same function now to prevent possibly adding an unsafe method in the middle later)
2. lets mirage proceed (we `console.error` + set to default instead of `throw`ing)

A (small) fear here is that we might do something like typo our queryParam in the URL and neglect to check our console errors, and proceed without noticing that our intended scenario is actually running as `smallCluster`. I think that's a worthwhile tradeoff.

Resolves #23260 