### PR TITLE
docs: update ACL policy example spec to remove plugin write cap.

### DIFF
--- a/website/content/docs/other-specifications/acl-policy.mdx
+++ b/website/content/docs/other-specifications/acl-policy.mdx
@@ -64,7 +64,7 @@ host_volume "*" {
 }
 
 plugin {
-  policy = "write"
+  policy = "read"
 }
 ```
 


### PR DESCRIPTION
closes #23270 