### PR TITLE
e2e: add prerelease builds to Consul/Vault compatibility tests

### DIFF
--- a/e2e/consulcompat/run_ce_test.go
+++ b/e2e/consulcompat/run_ce_test.go
@@ -16,11 +16,9 @@ import (
 // versions of Consul CE
 func usable(v, minimum *version.Version) bool {
 	switch {
-	case v.Prerelease() != "":
+	case v.LessThan(minimum):
 		return false
 	case v.Metadata() != "":
-		return false
-	case v.LessThan(minimum):
 		return false
 	default:
 		return true

--- a/e2e/consulcompat/shared_download_test.go
+++ b/e2e/consulcompat/shared_download_test.go
@@ -19,9 +19,6 @@ import (
 	"github.com/shoenig/test/must"
 )
 
-// TODO: it would be good if we can add the latest non-GA'd beta/release
-// candidate version as well; that'll give us some lead time on any breaking
-// changes
 const (
 	binDir           = "consul-bins"
 	minConsulVersion = "1.16.0"

--- a/e2e/vaultcompat/run_ce_test.go
+++ b/e2e/vaultcompat/run_ce_test.go
@@ -17,8 +17,6 @@ import (
 // versions of Vault CE
 func usable(v, minimum *version.Version) bool {
 	switch {
-	case v.Prerelease() != "":
-		return false
 	case v.Metadata() != "":
 		return false
 	case v.LessThan(minimum):


### PR DESCRIPTION
Update the Consul/Vault build downloader functions so that we include the current prerelease build (if any) in our E2E compatibility testing we do on each PR. This will automatically cycle out when the GA build is released, because that build is "higher" in the sorted set.