### PR TITLE
test: move NUMA platform scan out of testing global

### DIFF
--- a/client/pluginmanager/drivermanager/testing.go
+++ b/client/pluginmanager/drivermanager/testing.go
@@ -21,20 +21,19 @@ import (
 )
 
 type testManager struct {
-	logger log.Logger
-	loader loader.PluginCatalog
+	logger   log.Logger
+	loader   loader.PluginCatalog
+	topology *numalib.Topology
 }
 
-var (
-	topology = numalib.Scan(numalib.PlatformScanners())
-)
-
 func TestDriverManager(t *testing.T) Manager {
+	topology := numalib.Scan(numalib.PlatformScanners())
 	logger := testlog.HCLogger(t).Named("driver_mgr")
 	pluginLoader := catalog.TestPluginLoader(t)
 	return &testManager{
-		logger: logger,
-		loader: singleton.NewSingletonLoader(logger, pluginLoader),
+		logger:   logger,
+		loader:   singleton.NewSingletonLoader(logger, pluginLoader),
+		topology: topology,
 	}
 }
 
@@ -45,7 +44,7 @@ func (m *testManager) PluginType() string { return base.PluginTypeDriver }
 func (m *testManager) Dispense(driver string) (drivers.DriverPlugin, error) {
 	baseConfig := &base.AgentConfig{
 		Driver: &base.ClientDriverConfig{
-			Topology: topology,
+			Topology: m.topology,
 		},
 	}
 	instance, err := m.loader.Dispense(driver, base.PluginTypeDriver, baseConfig, m.logger)


### PR DESCRIPTION
The `testing.go` test helpers file for the driver manager initializes the NUMA scan as a package-global variable. This causes it to be pulled in even in production builds, so even running commands like `nomad version` will cause the NUMA scan to happen. Move the scan into the test helper setup.

I discovered this while debugging https://github.com/hashicorp/nomad/pull/23284 but this suggests there may be other cases where our `testing.go` test helper files are dragging wasteful startup behaviors into production builds.

---

Before:

```
$ objdump -t $(which nomad) | grep topology
00000000011096e0 l     F .text  00000000000003d0              github.com/hashicorp/nomad/nomad/structs.topologyFromLegacyGeneric
0000000001109e60 l     F .text  00000000000000a5              github.com/hashicorp/nomad/nomad/structs.topologyFromLegacy
0000000001109f20 l     F .text  0000000000000314              github.com/hashicorp/nomad/nomad/structs.topologyFromLegacyLinux
000000000110a240 l     F .text  0000000000000066              github.com/hashicorp/nomad/nomad/structs.topologyFromLegacyLinux.func1
0000000004ba9560 l     O .bss   0000000000000008              github.com/hashicorp/nomad/client/pluginmanager/drivermanager.topology
```

After:

```
$ objdump -t $(which nomad) | grep topology
00000000011096e0 l     F .text  00000000000003d0              github.com/hashicorp/nomad/nomad/structs.topologyFromLegacyGeneric
0000000001109e60 l     F .text  00000000000000a5              github.com/hashicorp/nomad/nomad/structs.topologyFromLegacy
0000000001109f20 l     F .text  0000000000000314              github.com/hashicorp/nomad/nomad/structs.topologyFromLegacyLinux
000000000110a240 l     F .text  0000000000000066              github.com/hashicorp/nomad/nomad/structs.topologyFromLegacyLinux.func1
```