### PR TITLE
[ui] Remove simulacral allocation stat in favor of live-updating one

### DIFF
--- a/.changelog/23306.txt
+++ b/.changelog/23306.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: unbind job detail running allocations count from job-summary endpoint
+```

--- a/ui/app/components/job-status/panel/steady.hbs
+++ b/ui/app/components/job-status/panel/steady.hbs
@@ -32,7 +32,7 @@
           All allocations have completed successfully
         {{else}}
           <strong>
-              {{@job.runningAllocs ~}}
+              {{this.runningAllocs.length ~}}
               {{#unless this.atMostOneAllocPerNode ~}}
                 {{#if (eq @job.type "batch") ~}}
                   /{{this.totalNonCompletedAllocs}}
@@ -42,7 +42,7 @@
               {{/unless}}
           </strong>
           {{#if (eq @job.type "batch") ~}}Remaining{{/if}}
-          {{pluralize "Allocation" @job.runningAllocs}} Running
+          {{pluralize "Allocation" this.runningAllocs.length}} Running
         {{/if}}
       </h3>
       <JobStatus::AllocationStatusRow @allocBlocks={{this.allocBlocks}} @steady={{true}} />

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -185,6 +185,10 @@ export default class JobStatusPanelSteadyComponent extends Component {
     return this.job.allocations.filter((a) => !a.isOld && a.hasBeenRestarted);
   }
 
+  get runningAllocs() {
+    return this.job.allocations.filter((a) => a.clientStatus === 'running');
+  }
+
   get completedAllocs() {
     return this.job.allocations.filter(
       (a) => !a.isOld && a.clientStatus === 'complete'

--- a/ui/tests/acceptance/job-status-panel-test.js
+++ b/ui/tests/acceptance/job-status-panel-test.js
@@ -979,19 +979,6 @@ module('Acceptance | job status panel', function (hooks) {
         'job',
         JSON.stringify([job.id, 'default'])
       );
-      // Weird Mirage thing: job summary factory is disconnected from its job and therefore allocations.
-      // So we manually create the number here.
-      let summary = await storedJob.get('summary');
-      summary
-        .get('taskGroupSummaries')
-        .objectAt(0)
-        .set(
-          'runningAllocs',
-          server.schema.allocations.where({
-            jobId: job.id,
-            clientStatus: 'running',
-          }).length
-        );
 
       await settled();
 
@@ -1020,17 +1007,8 @@ module('Acceptance | job status panel', function (hooks) {
         nodeId: newNode.id,
       });
 
-      summary
-        .get('taskGroupSummaries')
-        .objectAt(0)
-        .set(
-          'runningAllocs',
-          server.schema.allocations.where({
-            jobId: job.id,
-            clientStatus: 'running',
-          }).length
-        );
-
+      // simulate a blocking query update from /allocations
+      storedJob.allocations.reload();
       await settled();
 
       assert.dom('.running-allocs-title').hasText('4 Allocations Running');


### PR DESCRIPTION
While most of our job status panel allocation numbers use allocations live as they're updated from the /allocations endpoint for a given job, one holdout remained: the the "X Allocations Running" number came from the `job-summary`, which tabulates at a slightly different time than allocations do (and is sometimes susceptible to inaccuracy)

This changes the number in steady-state jobs to be what we actually see among currently running allocations from the /allocations endpoint. This doesn't discriminate between new-version and old-version allocations, only returning the number currently running. 

![image](https://github.com/hashicorp/nomad/assets/713991/0b0d2aa5-7b63-4a6d-a08c-0e72b0d9057c)

Resolves #20627 