### PR TITLE
docker: update image in TestDockerDriver_Start_Image_HTTPS

### DIFF
--- a/drivers/docker/driver_unix_test.go
+++ b/drivers/docker/driver_unix_test.go
@@ -712,7 +712,7 @@ func TestDockerDriver_Start_Image_HTTPS(t *testing.T) {
 	testutil.DockerCompatible(t)
 
 	taskCfg := TaskConfig{
-		Image:            "https://gcr.io/google_containers/pause:0.8.0",
+		Image:            "https://gcr.io/google_containers/pause:3.2",
 		ImagePullTimeout: "5m",
 	}
 	task := &drivers.TaskConfig{


### PR DESCRIPTION
fixes:
```
    driver_unix_test.go:731: 
        	Error Trace:	/home/runner/work/nomad/nomad/drivers/docker/driver_unix_test.go:731
        	Error:      	Received unexpected error:
        	            	rpc error: code = FailedPrecondition desc = Failed to pull `gcr.io/google_containers/pause:0.8.0`: [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of gcr.io/google_containers/pause:0.8.0 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```