### PR TITLE
exec2: update documentation with oom_score_adj settings

### DIFF
--- a/website/content/plugins/drivers/exec2.mdx
+++ b/website/content/plugins/drivers/exec2.mdx
@@ -270,9 +270,10 @@ enabled in plugin configuration.
 
 ```hcl
 config {
-	command = "/usr/bin/cat"
-	args    = ["/etc/os-release"]
-	unveil  = ["r:/etc/os-release"]
+  command       = "/usr/bin/cat"
+  args          = ["/etc/os-release"]
+  unveil        = ["r:/etc/os-release"]
+  oom_score_adj = 500
 }
 ```
 
@@ -281,6 +282,8 @@ config {
   to `command`
 - `unveil` - (list(string): optional) - list of additional filesystem paths to
   provide access to the task (requires `unveil_by_task` in plugin config).
+- `oom_score_adj` - (optional) - The likelihood of the task being OOM killed,
+  must be a positive integer. Defaults to `0`.
 
 ##### cpu
 


### PR DESCRIPTION
Mirrors README updates from https://github.com/hashicorp/nomad-driver-exec2/pull/40