### PR TITLE
[ui] Add "stopped" as a valid status on jobs index/job detail

### DIFF
--- a/.changelog/23328.txt
+++ b/.changelog/23328.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: adds a Stopped label for jobs that a user has manually stopped
+```

--- a/nomad/job_endpoint_statuses.go
+++ b/nomad/job_endpoint_statuses.go
@@ -219,7 +219,8 @@ func jobStatusesJobFromJob(ws memdb.WatchSet, store *state.StateStore, job *stru
 		GroupCountSum:    0,
 		ChildStatuses:    nil,
 		LatestDeployment: nil,
-		Stop: 				job.Stop,
+		Stop:             job.Stop,
+		Status:           job.Status,
 	}
 
 	// the GroupCountSum will map to how many allocations we expect to run

--- a/nomad/job_endpoint_statuses.go
+++ b/nomad/job_endpoint_statuses.go
@@ -219,6 +219,7 @@ func jobStatusesJobFromJob(ws memdb.WatchSet, store *state.StateStore, job *stru
 		GroupCountSum:    0,
 		ChildStatuses:    nil,
 		LatestDeployment: nil,
+		Stop: 				job.Stop,
 	}
 
 	// the GroupCountSum will map to how many allocations we expect to run

--- a/nomad/structs/job.go
+++ b/nomad/structs/job.go
@@ -97,7 +97,8 @@ type JobStatusesJob struct {
 	// ParentID is set on child (batch) jobs, specifying the parent job ID
 	ParentID         string
 	LatestDeployment *JobStatusesLatestDeployment
-	Stop bool // has the job been manually stopped?
+	Stop             bool // has the job been manually stopped?
+	Status           string
 }
 
 // JobStatusesAlloc contains a subset of Allocation info.

--- a/nomad/structs/job.go
+++ b/nomad/structs/job.go
@@ -97,6 +97,7 @@ type JobStatusesJob struct {
 	// ParentID is set on child (batch) jobs, specifying the parent job ID
 	ParentID         string
 	LatestDeployment *JobStatusesLatestDeployment
+	Stop bool // has the job been manually stopped?
 }
 
 // JobStatusesAlloc contains a subset of Allocation info.

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -205,8 +205,8 @@ export default class JobStatusPanelSteadyComponent extends Component {
 
   /**
    * @typedef {Object} CurrentStatus
-   * @property {"Healthy"|"Failed"|"Degraded"|"Recovering"|"Complete"|"Running"} label - The current status of the job
-   * @property {"highlight"|"success"|"warning"|"critical"} state -
+   * @property {"Healthy"|"Failed"|"Degraded"|"Recovering"|"Complete"|"Running"|"Stopped"} label - The current status of the job
+   * @property {"highlight"|"success"|"warning"|"critical"|"neutral"} state -
    */
 
   /**
@@ -216,6 +216,13 @@ export default class JobStatusPanelSteadyComponent extends Component {
   get currentStatus() {
     // If all allocs are running, the job is Healthy
     const totalAllocs = this.totalAllocs;
+
+    if (this.job.status === 'dead' && this.job.stopped) {
+      return {
+        label: 'Stopped',
+        state: 'neutral',
+      };
+    }
 
     if (this.job.type === 'batch' || this.job.type === 'sysbatch') {
       // If all the allocs are complete, the job is Complete

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -241,7 +241,7 @@ export default class Job extends Model {
     }
 
     // if manually stopped by a user:
-    if (this.stopped) {
+    if (this.status === 'dead' && this.stopped) {
       return {
         label: 'Stopped',
         state: 'neutral',

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -32,6 +32,7 @@ export default class Job extends Model {
   @attr('number') modifyIndex;
   @attr('date') submitTime;
   @attr('string') nodePool; // Jobs are related to Node Pools either directly or via its Namespace, but no relationship.
+  @attr('boolean') stopped;
   @attr() ui;
 
   @attr('number') groupCountSum;
@@ -89,7 +90,7 @@ export default class Job extends Model {
 
   /**
    * @typedef {Object} CurrentStatus
-   * @property {"Healthy"|"Failed"|"Deploying"|"Degraded"|"Recovering"|"Complete"|"Running"|"Removed"} label - The current status of the job
+   * @property {"Healthy"|"Failed"|"Deploying"|"Degraded"|"Recovering"|"Complete"|"Running"|"Removed"|"Stopped"} label - The current status of the job
    * @property {"highlight"|"success"|"warning"|"critical"|"neutral"} state -
    */
 
@@ -224,6 +225,7 @@ export default class Job extends Model {
    * - Degraded: A deployment is not taking place, and some allocations are failed, lost, or unplaced
    * - Failed: All allocations are failed, lost, or unplaced
    * - Removed: The job appeared in our initial query, but has since been garbage collected
+   * - Stopped: The job has been manually stopped (and not purged or yet garbage collected) by a user
    * @returns {CurrentStatus}
    */
   /**
@@ -236,6 +238,14 @@ export default class Job extends Model {
     // If deploying:
     if (this.latestDeploymentSummary?.IsActive) {
       return { label: 'Deploying', state: 'highlight' };
+    }
+
+    // if manually stopped by a user:
+    if (this.stopped) {
+      return {
+        label: 'Stopped',
+        state: 'neutral',
+      };
     }
 
     // If the job was requested initially, but a subsequent request for it was

--- a/ui/app/serializers/job.js
+++ b/ui/app/serializers/job.js
@@ -62,6 +62,12 @@ export default class JobSerializer extends ApplicationSerializer {
       });
     }
 
+    // job.stop is reserved as a method (points to adapter method) so we rename it here
+    if (hash.Stop) {
+      hash.Stopped = hash.Stop;
+      delete hash.Stop;
+    }
+
     return super.normalize(typeHash, hash);
   }
 

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -307,7 +307,7 @@ export default function () {
             });
           job.ChildStatuses = children ? children.mapBy('Status') : null;
           job.Datacenters = j.Datacenters;
-          job.DeploymentID = j.DeploymentID;
+          job.LatestDeployment = j.LatestDeployment;
           job.GroupCountSum = j.TaskGroups.mapBy('Count').reduce(
             (a, b) => a + b,
             0

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -205,6 +205,8 @@ export default Factory.extend({
   // When true, the job will simulate a "scheduled" block's paused state
   withPausedTasks: false,
 
+  latestDeployment: null,
+
   afterCreate(job, server) {
     Ember.assert(
       '[Mirage] No node pools! make sure node pools are created before jobs',
@@ -317,6 +319,18 @@ export default Factory.extend({
             activeDeployment: job.activeDeployment,
           });
         });
+    }
+
+    if (job.activeDeployment) {
+      job.latestDeployment = {
+        IsActive: true,
+        Status: 'running',
+        StatusDescription: 'Deployment is running',
+        RequiresPromotion: false,
+        AllAutoPromote: true,
+        JobVersion: 1,
+        ID: faker.random.uuid(),
+      };
     }
 
     if (!job.shallow) {


### PR DESCRIPTION
Our recent changes to how we label jobs in the UI considers any job "failed" if none of its expected allocations are running or pending, and it's not in active deployment.

This is coincidentally both true for jobs that failed because a user clicked the "stop" button, and also for jobs that failed because of the universe conspiring against us generally.

Luckily, jobs already had a nice `Stop` boolean to indicate the manual, deliberate stopping of a job (until it gets garbage collected, and provided it didn't have a "purge" flag passed in).

This PR observes that boolean and displays a new "Stopped" status in the UI in two places:

<img width="743" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/31b9c615-8c77-4095-a26c-988bd49c586b">
<img width="510" alt="image" src="https://github.com/hashicorp/nomad/assets/713991/96a84396-0e3d-469a-8e0b-d2c5c9dddc42">

resolves #22101 