### PR TITLE
task schedule: fix end-of-month validation bug

### DIFF
--- a/.changelog/23329.txt
+++ b/.changelog/23329.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+task schedule: Fixed a bug where schedules wrongly errored as invalid on the last day of the month
+```

--- a/nomad/structs/task_sched.go
+++ b/nomad/structs/task_sched.go
@@ -152,7 +152,7 @@ func (t TaskScheduleCron) Next(from time.Time) (time.Duration, time.Duration, er
 
 	// next end must be on the same day as next start
 	if endNext.Day() > startNext.Day() {
-		return 0, 0, fmt.Errorf("end cannot be sooner than start")
+		return 0, 0, fmt.Errorf("end cannot be sooner than start; end=%q, start=%q", endNext, startNext)
 	}
 
 	// we're in the midst of it right now!

--- a/nomad/structs/task_sched.go
+++ b/nomad/structs/task_sched.go
@@ -141,11 +141,6 @@ func (t TaskScheduleCron) Next(from time.Time) (time.Duration, time.Duration, er
 		return 0, 0, fmt.Errorf("invalid end time in schedule: %q; %w", t.End, err)
 	}
 
-	// next end must be later than next start on the same day
-	if end.Next(from).Day() > start.Next(from).Day() {
-		return 0, 0, fmt.Errorf("end cannot be sooner than start")
-	}
-
 	startNext := start.Next(from)
 	// we'll check the previous start to see if we are currently between it
 	// and the previous run's end, i.e. it should be running right now!
@@ -154,6 +149,11 @@ func (t TaskScheduleCron) Next(from time.Time) (time.Duration, time.Duration, er
 	// generate ends from starts, so they always come after
 	endNext := end.Next(startNext)
 	endPrev := end.Next(startPrev)
+
+	// next end must be on the same day as next start
+	if endNext.Day() > startNext.Day() {
+		return 0, 0, fmt.Errorf("end cannot be sooner than start")
+	}
 
 	// we're in the midst of it right now!
 	if startPrev.Before(from) && endPrev.After(from) {

--- a/nomad/structs/task_sched_test.go
+++ b/nomad/structs/task_sched_test.go
@@ -4,7 +4,6 @@
 package structs
 
 import (
-	"fmt"
 	"testing"
 	"time"
 

--- a/nomad/structs/task_sched_test.go
+++ b/nomad/structs/task_sched_test.go
@@ -4,6 +4,7 @@
 package structs
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -11,6 +12,34 @@ import (
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 )
+
+func FuzzTaskScheduleCron(f *testing.F) {
+	// valid values to compare against varying "now"s
+	sched := TaskScheduleCron{
+		Start:    "0 11 * * * *",
+		End:      "0 13",
+		Timezone: "UTC", // this timezone must match the fake "now" in Fuzz()
+	}
+
+	// seed the corpus with some target "now"s to time-travel to
+	// args: year, month, day, hour, minute
+	f.Add(0, 0, 0, 0, 0)        // zero
+	f.Add(1970, 1, 0, 0, 0)     // epoch start
+	f.Add(2000, 1, 0, 0, 0)     // y2k
+	f.Add(2024, 12, 31, 23, 59) // end of this year
+	f.Add(2038, 1, 19, 3, 0)    // y2kv2
+
+	// regression tests:
+	// schedule should be valid on the last day of the month.
+	f.Add(2024, 6, 30, 12, 0)
+
+	f.Fuzz(func(t *testing.T, year, month, day, hour, minute int) {
+		now := time.Date(year, time.Month(month), day, hour, minute, 0, 0, time.UTC)
+		_, _, err := sched.Next(now)
+		must.NoError(t, err,
+			must.Sprintf("from=%q start=%q end=%q", now, sched.Start, sched.End))
+	})
+}
 
 func TestTaskScheduleCron(t *testing.T) {
 	ci.Parallel(t)
@@ -112,6 +141,14 @@ func TestTaskScheduleCron(t *testing.T) {
 			tz:         "America/New_York",
 			expectNext: 23*time.Hour + 30*time.Minute, // monday morning
 			expectEnd:  (24 + 6) * time.Hour,          // monday afternoon
+		},
+		{
+			name:       "end of the month",     // regression test for false "end cannot be sooner than start"
+			now:        "2024-06-30T10:00:00Z", // june has 30 days
+			start:      "0 9 * * * *",          // start before now
+			end:        "0 11",                 // end after now
+			expectNext: 0,                      // should be running
+			expectEnd:  time.Hour,
 		},
 		// errors
 		{


### PR DESCRIPTION
Fix erroneous "end cannot be sooner than start" error condition on the last day of the month.

By building "`next end` from `from`" instead of "`next end` from `next start`" (we actually use the latter for the schedule), on the last day of any given month, the next `start.Day()` would be `1` (the first of the next month), which is less than the current `end.Day()` -- whatever the last day of the month is, `28-31` -- so it would mistakenly think the user provided improper values.  (I'm sorry, this is really hard to put into plain language... hopefully the code makes sense.)

I happened to be starting some e2e testing (not present in this PR) at the end of May and bumped into this, so formalize with a unit test case, and also include Fuzz testing to try and catch other possible unforeseen gotchas (I got it to catch this one, but fortunately(?) it did not foresee any more).

Fixes #23159