### PR TITLE
[ui] Dont show keyboard hints when a user is trying to take a screenshot

### DIFF
--- a/.changelog/23365.txt
+++ b/.changelog/23365.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Dont show keyboard nav hints when taking a screenshot
+```

--- a/ui/app/services/keyboard.js
+++ b/ui/app/services/keyboard.js
@@ -348,11 +348,8 @@ export default class KeyboardService extends Service {
       const shifted = event.getModifierState('Shift');
       if (type === 'press') {
         if (key === 'Shift') {
-          // if cmd or ctrl are pressed, don't show hints — this is likely a user trying to take a screenshot.
-          if (
-            event.getModifierState('Meta') ||
-            event.getModifierState('Control')
-          ) {
+          // if cmd/windows key is pressed, don't show hints — this is likely a user trying to take a screenshot.
+          if (event.getModifierState('Meta')) {
             return;
           }
           this.displayHints = true;

--- a/ui/app/services/keyboard.js
+++ b/ui/app/services/keyboard.js
@@ -348,6 +348,13 @@ export default class KeyboardService extends Service {
       const shifted = event.getModifierState('Shift');
       if (type === 'press') {
         if (key === 'Shift') {
+          // if cmd or ctrl are pressed, don't show hints — this is likely a user trying to take a screenshot.
+          if (
+            event.getModifierState('Meta') ||
+            event.getModifierState('Control')
+          ) {
+            return;
+          }
           this.displayHints = true;
         } else {
           if (!DISALLOWED_KEYS.includes(key)) {

--- a/ui/tests/acceptance/keyboard-test.js
+++ b/ui/tests/acceptance/keyboard-test.js
@@ -270,6 +270,16 @@ module('Acceptance | keyboard', function (hooks) {
         0,
         'Hints disappear when you release Shift'
       );
+
+      triggerEvent('.page-layout', 'keydown', { key: 'Meta' });
+      await triggerEvent('.page-layout', 'keydown', { key: 'Shift' });
+      assert.equal(
+        document.querySelectorAll('[data-test-keyboard-hint]').length,
+        0,
+        'Hints do not show up when holding down Command+Shift'
+      );
+      await triggerEvent('.page-layout', 'keyup', { key: 'Shift' });
+      await triggerEvent('.page-layout', 'keyup', { key: 'Meta' });
     });
   });
 

--- a/ui/tests/acceptance/keyboard-test.js
+++ b/ui/tests/acceptance/keyboard-test.js
@@ -271,8 +271,10 @@ module('Acceptance | keyboard', function (hooks) {
         'Hints disappear when you release Shift'
       );
 
-      triggerEvent('.page-layout', 'keydown', { key: 'Meta' });
-      await triggerEvent('.page-layout', 'keydown', { key: 'Shift' });
+      await triggerEvent('.page-layout', 'keydown', {
+        key: 'Shift',
+        metaKey: true,
+      });
       assert.equal(
         document.querySelectorAll('[data-test-keyboard-hint]').length,
         0,


### PR DESCRIPTION
Resolves #23361 

## How to test
- Buy a macbook (or pretend)
- Hold down shift, to see hints. Release and they're gone!
- Hold down cmd+shift+4 to take a screenshot
- Note that in holding the command key, the shift key no longer triggers the display of keyboard hints.