### PR TITLE
api: use the task in Allocations.GetPauseState

### DIFF
--- a/.changelog/23377.txt
+++ b/.changelog/23377.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: (Enterprise) fixed Allocations.GetPauseState method discarding the task argument
+```

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -251,7 +251,7 @@ func (a *Allocations) SetPauseState(alloc *Allocation, q *QueryOptions, task, st
 // The ?task=<task> query parameter must be set.
 func (a *Allocations) GetPauseState(alloc *Allocation, q *QueryOptions, task string) (string, *QueryMeta, error) {
 	var resp AllocGetPauseResponse
-	qm, err := a.client.query("/v1/client/allocation/"+alloc.ID+"/pause", &resp, q)
+	qm, err := a.client.query("/v1/client/allocation/"+alloc.ID+"/pause?task="+task, &resp, q)
 	state := resp.ScheduleState
 	return state, qm, err
 }


### PR DESCRIPTION
Without this, the method just doesn't work. :upside_down_face: 

For context, the "pause" state is the state of a task that has a [schedule{} block](https://developer.hashicorp.com/nomad/docs/job-specification/schedule) on it (enterprise feature).