### PR TITLE
scheduler: fix a bug where we subtract reserved node resources twice

### DIFF
--- a/.changelog/23386.txt
+++ b/.changelog/23386.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fix a bug where reserved resources are not calculated correctly
+```

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -172,6 +172,7 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevi
 	// Check that the node resources (after subtracting reserved) are a
 	// super set of those that are being allocated
 	available := node.NodeResources.Comparable()
+	available.Subtract(node.ReservedResources.Comparable())
 	if superset, dimension := available.Superset(used); !superset {
 		return false, dimension, used, nil
 	}

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -172,7 +172,6 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevi
 	// Check that the node resources (after subtracting reserved) are a
 	// super set of those that are being allocated
 	available := node.NodeResources.Comparable()
-	available.Subtract(node.ReservedResources.Comparable())
 	if superset, dimension := available.Superset(used); !superset {
 		return false, dimension, used, nil
 	}

--- a/nomad/structs/funcs_test.go
+++ b/nomad/structs/funcs_test.go
@@ -105,6 +105,7 @@ func node2k() *Node {
 						Grade:     numalib.Performance,
 						BaseSpeed: 1000,
 					}},
+					OverrideWitholdCompute: 1000, // set by client reserved field
 				},
 			},
 			Memory: NodeMemoryResources{

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3191,7 +3191,7 @@ func (n *NodeResources) Comparable() *ComparableResources {
 	c := &ComparableResources{
 		Flattened: AllocatedTaskResources{
 			Cpu: AllocatedCpuResources{
-				CpuShares:     int64(n.Processors.Topology.UsableCompute()),
+				CpuShares:     int64(n.Processors.Topology.TotalCompute()),
 				ReservedCores: reservableCores,
 			},
 			Memory: AllocatedMemoryResources{


### PR DESCRIPTION
Fixes a bug in the [`nodeResources.Comparable` method](https://github.com/hashicorp/nomad/blob/a0a717342775bce914aeb7ef052e59d3cb6dc41c/nomad/structs/structs.go#L3194), where CPU resources were accidentally offset with reserved resources, whereas functions that use this field expect total CPU resources. 

Fixes #23371 and #23314