### PR TITLE
docs: fix typo in alloc exec CLI docs page.

### DIFF
--- a/website/content/docs/commands/alloc/exec.mdx
+++ b/website/content/docs/commands/alloc/exec.mdx
@@ -17,7 +17,7 @@ The `alloc exec` command runs a command in a running allocation.
 nomad alloc exec [options] <allocation> <command> [<args>...]
 ```
 
-The nomad exec command can be use to run commands inside a running task/allocation.
+The nomad exec command can be used to run commands inside a running task/allocation.
 
 Use cases are for inspecting container state, debugging a failed application
 without needing ssh access into the node that's running the allocation.


### PR DESCRIPTION
closes #23390 