### PR TITLE
plugins: fix nomadTopologyToProto panic on systems that don't support NUMA

### DIFF
--- a/.changelog/23399.txt
+++ b/.changelog/23399.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugins: Fix panic on systems that don't support NUMA
+```

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -89,7 +89,8 @@ jobs:
             github.com/hashicorp/nomad/drivers/docker \
             github.com/hashicorp/nomad/client/lib/fifo \
             github.com/hashicorp/nomad/client/logmon \
-            github.com/hashicorp/nomad/client/allocrunner/taskrunner/template
+            github.com/hashicorp/nomad/client/allocrunner/taskrunner/template \
+            github.com/hashicorp/nomad/plugins/base
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: results.xml

--- a/client/lib/numalib/topology.go
+++ b/client/lib/numalib/topology.go
@@ -164,9 +164,6 @@ func (st *Topology) SupportsNUMA() bool {
 
 // GetNodes returns the set of NUMA Node IDs.
 func (st *Topology) GetNodes() *idset.Set[hw.NodeID] {
-	if !st.SupportsNUMA() {
-		return nil
-	}
 	if st.nodeIDs.Empty() {
 		st.nodeIDs = idset.From[hw.NodeID](st.Nodes)
 	}

--- a/plugins/base/base_test.go
+++ b/plugins/base/base_test.go
@@ -55,6 +55,19 @@ func Test_nomadTopologyToProto(t *testing.T) {
 		OverrideTotalCompute:   90_000,
 		OverrideWitholdCompute: 2000,
 	}, pb)
+
+	// make sure we don't panic in case of empty nodes, vide
+	// https://github.com/hashicorp/nomad/issues/23385
+	top2 := &numalib.Topology{}
+
+	pb2 := nomadTopologyToProto(top2)
+	must.Eq(t, &proto.ClientTopology{
+		NodeIds:                []uint32{},
+		Distances:              &proto.ClientTopologySLIT{Dimension: 0, Values: []uint32{}},
+		Cores:                  nil,
+		OverrideTotalCompute:   0,
+		OverrideWitholdCompute: 0,
+	}, pb2)
 }
 
 func Test_nomadTopologyFromProto(t *testing.T) {


### PR DESCRIPTION
After changes introduced in https://github.com/hashicorp/nomad/pull/23284 we no longer need to make a `if !st.SupportsNUMA()` check in the `GetNodes()` topology method. In fact this check will now cause panic in [`nomadTopologyToProto`](https://github.com/hashicorp/nomad/blob/7cf63326322c92074dab53321c32ddee92627bcd/plugins/base/base.go#L166) method on systems that don't support NUMA. 

Fixes #23385 
Internal ref: https://hashicorp.atlassian.net/browse/NET-10134