### PR TITLE
docs/jobspec: Fix "task" block placement

### DIFF
--- a/website/content/docs/job-specification/job.mdx
+++ b/website/content/docs/job-specification/job.mdx
@@ -28,6 +28,10 @@ job "docs" {
 
   group "example" {
     # ...
+    
+    task "docs" {
+      # ...
+    }
   }
 
   meta {
@@ -45,10 +49,6 @@ job "docs" {
   priority = 100
 
   region = "north-america"
-
-  task "docs" {
-    # ...
-  }
 
   update {
     # ...


### PR DESCRIPTION
The `task` block should be inside the `group` block. The example in the page places the `task` block directly under `job`.