### PR TITLE
docs: add deprecation notice to `cron` on `docs/job-specification/periodic`

### DIFF
--- a/website/content/docs/job-specification/periodic.mdx
+++ b/website/content/docs/job-specification/periodic.mdx
@@ -34,17 +34,16 @@ consistent evaluation when Nomad spans multiple time zones.
 
 ## `periodic` Parameters
 
-- `cron` (_deprecated_: Replaced by `crons` in 1.6.2) `(string: <optional>)` - Specifies a cron expression configuring the
+- `cron` (_deprecated_: Replaced by `crons` in 1.6.2) `(string)` - Specifies a cron expression configuring the
   interval to launch the job. In addition to [cron-specific formats][cron], this
-  option also includes predefined expressions such as `@daily` or `@weekly`.
+  option also includes predefined expressions such as `@daily` or `@weekly`. Either `cron` or `crons` must be set, but not both.
 
 - `crons` - A list of cron expressions configuring the intervals the job is
   launched at. The job runs at the next earliest time that matches any of the
   expressions. Supports predefined expressions such as `@daily` and
   `@weekly`. Refer to [the
   documentation](https://github.com/hashicorp/cronexpr#implementation) for full
-  details about the supported cron specs and the predefined expressions.
-  Conflicts with `cron`.
+  details about the supported cron specs and the predefined expressions. Either `cron` or `crons` must be set, but not both.
 
 - `prohibit_overlap` `(bool: false)` - Specifies if this job should wait until
   previous instances of this job have completed. This only applies to this job;

--- a/website/content/docs/job-specification/periodic.mdx
+++ b/website/content/docs/job-specification/periodic.mdx
@@ -34,7 +34,7 @@ consistent evaluation when Nomad spans multiple time zones.
 
 ## `periodic` Parameters
 
-- `cron` `(string: <required>)` - Specifies a cron expression configuring the
+- `cron` (_deprecated_: Replaced by `crons` in 1.6.2) `(string: <optional>)` - Specifies a cron expression configuring the
   interval to launch the job. In addition to [cron-specific formats][cron], this
   option also includes predefined expressions such as `@daily` or `@weekly`.
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/nomad/issues/23391

There are quite a few different approaches to mark deprecation across the docs, I picked this as it was the most explicit parameter-level option in my opinion.

Screenshot below:

![Screenshot from 2024-06-23 21-46-17](https://github.com/hashicorp/nomad/assets/26534322/173a398e-91d8-4972-ae27-b45c175177f3)

Other refs:

- The PR that added the original deprecation notice to the tool itself https://github.com/hashicorp/nomad/pull/17858
- Changelog entry mentioning that PR for Nomad 1.6.2 https://github.com/hashicorp/nomad/blob/main/CHANGELOG.md#162-september-13-2023
