### PR TITLE
docker: default to hyper-v isolation on Windows

### DIFF
--- a/.changelog/23452.txt
+++ b/.changelog/23452.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+docker: default to hyper-v isolation mode on Windows
+```

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -389,12 +389,9 @@ var (
 		"ipc_mode":           hclspec.NewAttr("ipc_mode", "string", false),
 		"ipv4_address":       hclspec.NewAttr("ipv4_address", "string", false),
 		"ipv6_address":       hclspec.NewAttr("ipv6_address", "string", false),
-		"isolation": hclspec.NewDefault(
-			hclspec.NewAttr("isolation", "string", false),
-			hclspec.NewLiteral("hyper-v"),
-		),
-		"labels": hclspec.NewAttr("labels", "list(map(string))", false),
-		"load":   hclspec.NewAttr("load", "string", false),
+		"isolation":          hclspec.NewAttr("isolation", "string", false),
+		"labels":             hclspec.NewAttr("labels", "list(map(string))", false),
+		"load":               hclspec.NewAttr("load", "string", false),
 		"logging": hclspec.NewBlock("logging", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"type":   hclspec.NewAttr("type", "string", false),
 			"driver": hclspec.NewAttr("driver", "string", false),

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -389,9 +389,12 @@ var (
 		"ipc_mode":           hclspec.NewAttr("ipc_mode", "string", false),
 		"ipv4_address":       hclspec.NewAttr("ipv4_address", "string", false),
 		"ipv6_address":       hclspec.NewAttr("ipv6_address", "string", false),
-		"isolation":          hclspec.NewAttr("isolation", "string", false),
-		"labels":             hclspec.NewAttr("labels", "list(map(string))", false),
-		"load":               hclspec.NewAttr("load", "string", false),
+		"isolation": hclspec.NewDefault(
+			hclspec.NewAttr("isolation", "string", false),
+			hclspec.NewLiteral("hyper-v"),
+		),
+		"labels": hclspec.NewAttr("labels", "list(map(string))", false),
+		"load":   hclspec.NewAttr("load", "string", false),
 		"logging": hclspec.NewBlock("logging", false, hclspec.NewObject(map[string]*hclspec.Spec{
 			"type":   hclspec.NewAttr("type", "string", false),
 			"driver": hclspec.NewAttr("driver", "string", false),

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -978,9 +978,8 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 	}
 
 	// Only windows supports alternative isolations modes
-	isolationMode := driverConfig.Isolation
-	if runtime.GOOS != "windows" && isolationMode != "" {
-		return c, fmt.Errorf("Failed to create container configuration, cannot use isolation mode \"%s\" on %s", isolationMode, runtime.GOOS)
+	if runtime.GOOS != "windows" {
+		driverConfig.Isolation = ""
 	}
 
 	memory, memoryReservation := memoryLimits(driverConfig.MemoryHardLimit, task.Resources.NomadResources.Memory)

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -988,11 +988,11 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 			return c, fmt.Errorf("Failed to create container configuration, cannot use isolation mode \"%s\" on %s", driverConfig.Isolation, runtime.GOOS)
 		}
 	} else {
-		if !slices.Contains(windowsIsolationModes, driverConfig.Isolation) {
-			return c, fmt.Errorf("Unsupported isolation mode \"%s\"", driverConfig.Isolation)
-		}
 		if driverConfig.Isolation == "" {
 			driverConfig.Isolation = windowsIsolationModeHyperV
+		}
+		if !slices.Contains(windowsIsolationModes, driverConfig.Isolation) {
+			return c, fmt.Errorf("Unsupported isolation mode \"%s\"", driverConfig.Isolation)
 		}
 	}
 

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -81,7 +81,7 @@ const (
 	dockerLabelNodeID           = "com.hashicorp.nomad.node_id"
 	dockerLabelParentJobID      = "com.hashicorp.nomad.parent_job_id"
 	windowsIsolationModeProcess = "process"
-	windowsIsolationModeHyperV  = "hyper-v"
+	windowsIsolationModeHyperV  = "hyperv"
 )
 
 type pauseContainerStore struct {

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -149,7 +149,7 @@ The `docker` driver supports the following configuration in the job spec. Only
   the container.
 
 - `isolation` - (Optional) One of `"hyper-v"`, `"process"`, or `"default"`
-  (which is the same as `process`). Enables [Windows isolation][] modes.
+  (which is the same as `hyper-v`). Enables [Windows isolation][] modes.
 
 - `sysctl` - (Optional) A key-value map of sysctl configurations to set to the
   containers on start.

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -148,8 +148,9 @@ The `docker` driver supports the following configuration in the job spec. Only
 - `interactive` - (Optional) `true` or `false` (default). Keep STDIN open on
   the container.
 
-- `isolation` - (Optional) One of `"hyper-v"`, `"process"`, or `"default"`
-  (which is the same as `hyper-v`). Enables [Windows isolation][] modes.
+- `isolation` - (Optional) Specifies [Windows isolation][] mode: `"hyper-v"` or
+  `"process"`. Defaults to `"hyper-v"`.
+
 
 - `sysctl` - (Optional) A key-value map of sysctl configurations to set to the
   containers on start.

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -148,8 +148,8 @@ The `docker` driver supports the following configuration in the job spec. Only
 - `interactive` - (Optional) `true` or `false` (default). Keep STDIN open on
   the container.
 
-- `isolation` - (Optional) Specifies [Windows isolation][] mode: `"hyper-v"` or
-  `"process"`. Defaults to `"hyper-v"`.
+- `isolation` - (Optional) Specifies [Windows isolation][] mode: `"hyperv"` or
+  `"process"`. Defaults to `"hyperv"`.
 
 
 - `sysctl` - (Optional) A key-value map of sysctl configurations to set to the

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -78,6 +78,12 @@ provide a more secure environment for these jobs, and this behavior can be
 overridden by setting the new `windows_allow_insecure_container_admin` Docker
 plugin configuration option to `true` or by setting `privileged=true`.
 
+#### New default isolation mode for Docker on Windows
+
+Nomad 1.7.10 changes the default isolation mode for Docker tasks on Windows from
+`process` to `hyper-v`, since `hyper-v` provides a much more secure execution
+environment.
+
 ## Nomad 1.7.2
 
 Nomad 1.7.2 fixes a critical bug in CPU fingerprinting in Nomad 1.7.0 and
@@ -236,6 +242,12 @@ with [Process Isolation][] that run as `ContainerAdmin`. This is in order to
 provide a more secure environment for these jobs, and this behavior can be
 overridden by setting the new `windows_allow_insecure_container_admin` Docker
 plugin configuration option to `true` or by setting `privileged=true`.
+
+#### New default isolation mode for Docker on Windows
+
+Nomad 1.6.13 changes the default isolation mode for Docker tasks on Windows from
+`process` to `hyper-v`, since `hyper-v` provides a much more secure execution
+environment.
 
 ## Nomad 1.6.0
 

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -26,7 +26,7 @@ plugin configuration option to `true` or by setting `privileged=true`.
 #### New default isolation mode for Docker on Windows
 
 Nomad 1.8.2 changes the default isolation mode for Docker tasks on Windows from
-`process` to `hyper-v`, since `hyper-v` provides a much more secure execution
+`process` to `hyperv`, since `hyperv` provides a much more secure execution
 environment.
 
 ## Nomad 1.8.1
@@ -81,7 +81,7 @@ plugin configuration option to `true` or by setting `privileged=true`.
 #### New default isolation mode for Docker on Windows
 
 Nomad 1.7.10 changes the default isolation mode for Docker tasks on Windows from
-`process` to `hyper-v`, since `hyper-v` provides a much more secure execution
+`process` to `hyperv`, since `hyperv` provides a much more secure execution
 environment.
 
 ## Nomad 1.7.2
@@ -246,7 +246,7 @@ plugin configuration option to `true` or by setting `privileged=true`.
 #### New default isolation mode for Docker on Windows
 
 Nomad 1.6.13 changes the default isolation mode for Docker tasks on Windows from
-`process` to `hyper-v`, since `hyper-v` provides a much more secure execution
+`process` to `hyperv`, since `hyperv` provides a much more secure execution
 environment.
 
 ## Nomad 1.6.0

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -23,6 +23,12 @@ provide a more secure environment for these jobs, and this behavior can be
 overridden by setting the new `windows_allow_insecure_container_admin` Docker
 plugin configuration option to `true` or by setting `privileged=true`.
 
+#### New default isolation mode for Docker on Windows
+
+Nomad 1.8.2 changes the default isolation mode for Docker tasks on Windows from
+`process` to `hyper-v`, since `hyper-v` provides a much more secure execution
+environment.
+
 ## Nomad 1.8.1
 
 <EnterpriseAlert inline />


### PR DESCRIPTION
We should default to `hyper-v` isolation mode on Windows, as suggested in discussions between @tgross and @angrycub. 