### PR TITLE
job statuses: fix filtering for namespace parameter

### DIFF
--- a/.changelog/23456.txt
+++ b/.changelog/23456.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed support for namespace parameter on job statuses API
+```

--- a/nomad/job_endpoint_statuses.go
+++ b/nomad/job_endpoint_statuses.go
@@ -70,12 +70,10 @@ func (j *Job) Statuses(
 	} else if err != nil {
 		return err
 	}
-	// since the state index we're using doesn't include namespace,
-	// explicitly add the user-provided ns to our filter if needed.
-	// (allowableNamespaces will be nil if the caller sent a mgmt token)
-	if allowableNamespaces == nil &&
-		namespace != "" &&
-		namespace != structs.AllNamespacesSentinel {
+	// since the state index we're using doesn't include namespace, explicitly
+	// set the user-provided ns to our filter if needed.  we've already verified
+	// that the user has access to the specific namespace above
+	if namespace != "" && namespace != structs.AllNamespacesSentinel {
 		allowableNamespaces = map[string]bool{
 			namespace: true,
 		}


### PR DESCRIPTION
The job statuses endpoint does not filter jobs by the namespace query parameter unless the user passes a management token. The RPC handler creates a filter based on all the allowed namespaces but improperly conditions reducing this down to only the requested set on there being a management token. Note this does not give the user access to jobs they shouldn't have, only ignores the parameter.

Remove the RPC handler's extra condition that prevents using the requested namespace. This is safe because we specifically check the ACL for that namespace earlier in the handler.

Fixes: https://github.com/hashicorp/nomad/issues/23370