### PR TITLE
[ui] Read-based checks for viewing templates and write-based checks for saving them

### DIFF
--- a/.changelog/23458.txt
+++ b/.changelog/23458.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix an issue where access to Job Templates in the UI was restricted to variable.write access
+```

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -16,7 +16,7 @@
           Paste or author HCL or JSON to submit to your cluster, or select from a list of templates. A plan will be requested before the job is submitted. You can also attach a job spec by uploading a job file or dragging &amp; dropping a file to the editor.
         </p>
 
-        {{#if (can "write variable" path="*" namespace="*")}}
+        {{#if (can "read variable" path="nomad/job-templates/*" namespace="*")}}
           <Hds::ButtonSet>
             <label
               class="job-spec-upload hds-button hds-button--color-secondary hds-button--size-medium"

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -101,14 +101,16 @@
     data-test-plan
     @text="Plan"
   />
-  {{#if @data.job.isNew}}
-    <Hds::Button
-      @text="Save as template"
-      @color="secondary"
-      @route="jobs.run.templates.new"
-      {{on "click" @fns.onSaveAs}}
-      data-test-save-as-template
-    />
+  {{#if (can "write variable" path="nomad/job-templates/*" namespace="*")}}
+    {{#if @data.job.isNew}}
+      <Hds::Button
+        @text="Save as template"
+        @color="secondary"
+        @route="jobs.run.templates.new"
+        {{on "click" @fns.onSaveAs}}
+        data-test-save-as-template
+      />
+    {{/if}}
   {{/if}}
   <Hds::Button
     @text="Save as .nomad.hcl"

--- a/ui/app/templates/jobs/run/templates/manage.hbs
+++ b/ui/app/templates/jobs/run/templates/manage.hbs
@@ -20,8 +20,11 @@
             <:body as |B|>
                 <B.Tr>
                     <B.Td>
-                        {{#if B.data.isDefaultJobTemplate}}
-                            {{format-template-label B.data.path}}
+                        {{#if (or
+                          B.data.isDefaultJobTemplate
+                          (not (can "write variable" path="nomad/job-templates/*" namespace="*"))
+                        )}}
+                          {{format-template-label B.data.path}}
                         {{else}}
 													<LinkTo @route="jobs.run.templates.template" @model={{concat B.data.path "@" B.data.namespace}} data-test-edit-template={{B.data.path}}>
 														{{format-template-label B.data.path}}


### PR DESCRIPTION
This adds nuance to the ACL policy checks for a user to be able to see Job Templates (which are specifically-named Nomad Variables behind the scenes).

The way it works today has some specific checks in place:
- to even get into the job templates section, you have to first click the "Run Job" button, which only exists if you have the `submit-job` ACL capability, or a general `"write"` policy.
- Once there, we only show you a "Choose from template" button if you can write variables to `*`.

I think the original intent here was to do up-front checks for full CRUD access, but this PR moves that access check a little downstream. Here, you'll see that the check to see the "Choose from template" button requires specifically `read variable` access (and I could be convinced to make it `list variables`, but that would make the subsequent page pretty useless), and the `write variable` check is moved downstream to the "save as template" button, and to manually edit a given job template via the Management page.

Here is a sample ACL policy to test with:

```
namespace "default" {
  policy = "read"
  capabilities = ["submit-job"]
  variables {
    # give read access to all job templates related to this namespace
    path "nomad/job-templates/*" {
      capabilities = ["read","list","write"]
    }
    path "*" {
      capabilities = ["write","list"]
    }
  }
}
```
^--- the `submit-job` capability is in place, so the "Run Job" button will be present. Also, the `nomad/job-templates/*` rule has both `read` and `write`, which will show both a "Choose from template" and a "Save as template" button. Remove either read or write to see how buttons disappear accordingly.

### User has read and write, but not delete, variable capability:
![image](https://github.com/hashicorp/nomad/assets/713991/c65ee790-987f-4056-874d-529814e1ed21)

### User has `read variables` for `nomad/job-templates/*`:
![image](https://github.com/hashicorp/nomad/assets/713991/9cb95464-5536-4019-88d2-1c783a1d42a2)

### User has `write variables` for `nomad/job-templates/*`:
![image](https://github.com/hashicorp/nomad/assets/713991/f76cdbe0-4044-4489-980f-b3ef6b91e487)



Resolves #23438 