### PR TITLE
[ui] Generalized namespace handling, generalized facet searching, node pools facet search

### DIFF
--- a/.changelog/23468.txt
+++ b/.changelog/23468.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: allow for multiple namespaces in jobs index filters
+```

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -449,14 +449,14 @@ export default class JobsIndexController extends Controller {
   @computed('namespaceFacet.{filter,options}')
   get filteredNamespaceOptions() {
     return this.namespaceFacet.options.filter((ns) =>
-      ns.key.toLowerCase().includes(this.namespaceFacet.filter)
+      ns.key.toLowerCase().includes(this.namespaceFacet.filter.toLowerCase())
     );
   }
 
   @computed('nodePoolFacet.{filter,options}')
   get filteredNodePoolOptions() {
     return this.nodePoolFacet.options.filter((np) =>
-      np.key.toLowerCase().includes(this.nodePoolFacet.filter)
+      np.key.toLowerCase().includes(this.nodePoolFacet.filter.toLowerCase())
     );
   }
 

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -46,6 +46,7 @@ export default class IndexRoute extends Route.extend(
       queryParams.next_token = queryParams.cursorAt;
     }
     queryParams.per_page = queryParams.pageSize;
+    queryParams.namespace = '*';
 
     /* eslint-disable ember/no-controller-access-in-routes */
     let filter = this.controllerFor('jobs.index').filter;

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -27,9 +27,6 @@ export default class IndexRoute extends Route.extend(
   @service notifications;
 
   queryParams = {
-    qpNamespace: {
-      refreshModel: true,
-    },
     cursorAt: {
       refreshModel: true,
     },
@@ -55,9 +52,6 @@ export default class IndexRoute extends Route.extend(
     if (filter) {
       queryParams.filter = filter;
     }
-    // namespace
-    queryParams.namespace = queryParams.qpNamespace;
-    delete queryParams.qpNamespace;
     delete queryParams.pageSize;
     delete queryParams.cursorAt;
 
@@ -218,7 +212,7 @@ export default class IndexRoute extends Route.extend(
       });
     });
 
-    let err = error.errors[0];
+    let err = error.errors?.objectAt(0);
     // if it's an innocuous-enough seeming "You mistyped something while searching" error,
     // handle it with a notification and don't throw. Otherwise, throw.
     if (

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -38,53 +38,49 @@
               @color="secondary"
               @count={{get (filter-by "checked" true group.options) "length"}}
             />
-            {{#each group.options as |option|}}
-              <dd.Checkbox
-                {{on "change" (fn this.toggleOption option)}}
-                @value={{option.key}}
-                checked={{option.checked}}
-                data-test-dropdown-option={{option.key}}
-              >
-                {{option.key}}
-              </dd.Checkbox>
+            {{#if group.filterable}}
+              <dd.Header @hasDivider={{true}}>
+                <Hds::Form::TextInput::Base
+                  @type="search"
+                  placeholder="Filter {{group.label}}"
+                  @value={{group.filter}}
+                  {{autofocus}}
+                  {{on "input" (action (mut group.filter) value="target.value") }}
+                  data-test-namespace-filter-searchbox
+                />
+              </dd.Header>
+              {{#each (get this (concat "filtered" (capitalize group.label) "Options")) as |option|}}
+                <dd.Checkbox
+                  {{on "change" (fn this.toggleOption option)}}
+                  @value={{option.key}}
+                  checked={{option.checked}}
+                  data-test-dropdown-option={{option.key}}
+                >
+                  {{option.key}}
+                </dd.Checkbox>
+              {{else}}
+                <dd.Generic data-test-dropdown-empty>
+                  No {{group.label}} filters match {{group.filter}}
+                </dd.Generic>
+              {{/each}}
             {{else}}
-              <dd.Generic data-test-dropdown-empty>
-                No {{group.label}} filters
-              </dd.Generic>
-            {{/each}}
+              {{#each group.options as |option|}}
+                <dd.Checkbox
+                  {{on "change" (fn this.toggleOption option)}}
+                  @value={{option.key}}
+                  checked={{option.checked}}
+                  data-test-dropdown-option={{option.key}}
+                >
+                  {{option.key}}
+                </dd.Checkbox>
+              {{else}}
+                <dd.Generic data-test-dropdown-empty>
+                  No {{group.label}} filters
+                </dd.Generic>
+              {{/each}}
+            {{/if}}
           </S.Dropdown>
         {{/each}}
-
-        {{#if this.system.shouldShowNamespaces}}
-          <S.Dropdown data-test-facet="Namespace" @height="300px" as |dd|>
-            <dd.ToggleButton
-              @text="Namespace"
-              @color="secondary"
-              @badge={{get (find-by "checked" true this.namespaceFacet.options) "label"}}
-            />
-            <dd.Header @hasDivider={{true}}>
-              <Hds::Form::TextInput::Base
-                @type="search"
-                placeholder="Filter Namespaces"
-                @value={{this.namespaceFilter}}
-                {{autofocus}}
-                {{on "input" (action this.filterNamespaces )}}
-                data-test-namespace-filter-searchbox
-              />
-            </dd.Header>
-            {{#each this.shownNamespaces as |option|}}
-              <dd.Radio
-                name={{option.key}}
-                {{on "change" (fn this.toggleNamespaceOption option dd)}}
-                @value={{option.key}}
-                checked={{option.checked}}
-                data-test-dropdown-option={{option.key}}
-              >
-                {{option.label}}
-              </dd.Radio>
-            {{/each}}
-          </S.Dropdown>
-        {{/if}}
 
         {{#if this.filter}}
           <S.Button
@@ -122,7 +118,6 @@
           disabled={{not (can "run job")}}
           title={{if (can "run job") null "You don’t have permission to run jobs"}}
           @route="jobs.run"
-          @query={{hash namespace=this.qpNamespace}}
         />
       </div>
 

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -117,7 +117,7 @@ export default function () {
     '/jobs/statuses',
     withBlockingSupport(
       function ({ jobs }, req) {
-        const namespace = req.queryParams.namespace || 'default';
+        const namespace = req.queryParams.namespace || '*';
         let nextToken = req.queryParams.next_token || 0;
         let reverse = req.queryParams.reverse === 'true';
         const json = this.serialize(jobs.all());
@@ -149,7 +149,12 @@ export default function () {
                   field: condition.split(' ')[0],
                   operator: '==',
                   parts: condition.split(' or ').map((part) => {
-                    return part.split(' ')[2];
+                    return (
+                      part
+                        .split(' ')[2]
+                        // mirage only: strip quotes
+                        .replace(/['"]+/g, '')
+                    );
                   }),
                 };
               } else {


### PR DESCRIPTION
Changes the jobs index page's Namespaces dropdown from single select (radio buttons) to checkboxes (multiple OR-based selection)

![image](https://github.com/hashicorp/nomad/assets/713991/d33ff9e1-3441-4eeb-be92-74be54e3dc6f)

Also fixes an error noted in #23445  where node pools and namespaces with `-` characters would not filter correctly



Resolves NET-10159