### PR TITLE
mbits: filter mbits out of diff

### DIFF
--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -2523,7 +2523,7 @@ func (r *Resources) Diff(other *Resources, contextual bool) *ObjectDiff {
 func (n *NetworkResource) Diff(other *NetworkResource, contextual bool) *ObjectDiff {
 	diff := &ObjectDiff{Type: DiffTypeNone, Name: "Network"}
 	var oldPrimitiveFlat, newPrimitiveFlat map[string]string
-	filter := []string{"Device", "CIDR", "IP"}
+	filter := []string{"Device", "CIDR", "IP", "MBits"}
 
 	if reflect.DeepEqual(n, other) {
 		return nil
@@ -2628,6 +2628,10 @@ func disconectStrategyDiffs(old, new *DisconnectStrategy, contextual bool) *Obje
 // networkResourceDiffs diffs a set of NetworkResources. If contextual diff is enabled,
 // non-changed fields will still be returned.
 func networkResourceDiffs(old, new []*NetworkResource, contextual bool) []*ObjectDiff {
+	// This function will not allow Network Resources to have a diffType of DiffTypeEdited
+	// as hash keys for old and new would only be equivalent if new and old are equivalent
+	// (no changes found between them). Despite this behavior, a hash must be used to find possible
+	// differences between new and old since Network Resources are not ordered.
 	makeSet := func(objects []*NetworkResource) map[string]*NetworkResource {
 		objMap := make(map[string]*NetworkResource, len(objects))
 		for _, obj := range objects {

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -4399,12 +4399,6 @@ func TestTaskGroupDiff(t *testing.T) {
 								New:  "bar",
 							},
 							{
-								Type: DiffTypeAdded,
-								Name: "MBits",
-								Old:  "",
-								New:  "200",
-							},
-							{
 								Type: DiffTypeNone,
 								Name: "Mode",
 								Old:  "",
@@ -4458,12 +4452,6 @@ func TestTaskGroupDiff(t *testing.T) {
 								Type: DiffTypeDeleted,
 								Name: "Hostname",
 								Old:  "foo",
-								New:  "",
-							},
-							{
-								Type: DiffTypeDeleted,
-								Name: "MBits",
-								Old:  "100",
 								New:  "",
 							},
 							{
@@ -6087,14 +6075,6 @@ func TestTaskDiff(t *testing.T) {
 							{
 								Type: DiffTypeAdded,
 								Name: "Network",
-								Fields: []*FieldDiff{
-									{
-										Type: DiffTypeAdded,
-										Name: "MBits",
-										Old:  "",
-										New:  "200",
-									},
-								},
 								Objects: []*ObjectDiff{
 									{
 										Type: DiffTypeAdded,
@@ -6143,14 +6123,6 @@ func TestTaskDiff(t *testing.T) {
 							{
 								Type: DiffTypeDeleted,
 								Name: "Network",
-								Fields: []*FieldDiff{
-									{
-										Type: DiffTypeDeleted,
-										Name: "MBits",
-										Old:  "100",
-										New:  "",
-									},
-								},
 								Objects: []*ObjectDiff{
 									{
 										Type: DiffTypeDeleted,


### PR DESCRIPTION
Currently, the MBits field is not filtered and therefore always shown in diffs (regardless of MBits even being defined in an old or new network resource), and after finding that it is a deprecated field, this pr adds MBits to the list of filtered fields so it will not be shown as a diff. 