### PR TITLE
[ui] When a job is deleted in the background, wait until redirect before cache unload

### DIFF
--- a/.changelog/23492.txt
+++ b/.changelog/23492.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix an issue where a remotely purged job would prevent redirect from taking place in the web UI
+```

--- a/ui/app/controllers/jobs/job.js
+++ b/ui/app/controllers/jobs/job.js
@@ -23,7 +23,7 @@ export default class JobController extends Controller {
     return this.model;
   }
 
-  @action notFoundJobHandler() {
+  @action async notFoundJobHandler() {
     if (
       this.watchers.job.isError &&
       this.watchers.job.error?.errors?.some((e) => e.status === '404')
@@ -35,8 +35,8 @@ export default class JobController extends Controller {
         color: 'critical',
         sticky: true,
       });
+      await this.router.transitionTo('jobs');
       this.store.unloadRecord(this.job);
-      this.router.transitionTo('jobs');
     }
   }
 }

--- a/ui/app/controllers/jobs/job.js
+++ b/ui/app/controllers/jobs/job.js
@@ -28,15 +28,22 @@ export default class JobController extends Controller {
       this.watchers.job.isError &&
       this.watchers.job.error?.errors?.some((e) => e.status === '404')
     ) {
-      this.notifications.add({
-        title: `Job "${this.job.name}" has been deleted`,
-        message:
-          'The job you were looking at has been deleted; this is usually because it was purged from elsewhere.',
-        color: 'critical',
-        sticky: true,
-      });
-      await this.router.transitionTo('jobs');
-      this.store.unloadRecord(this.job);
+      try {
+        this.notifications.add({
+          title: `Job "${this.job.name}" has been deleted`,
+          message:
+            'The job you were looking at has been deleted; this is usually because it was purged from elsewhere.',
+          color: 'critical',
+          sticky: true,
+        });
+        await this.router.transitionTo('jobs');
+        this.store.unloadRecord(this.job);
+      } catch (err) {
+        if (err.code === 'TRANSITION_ABORTED') {
+          return;
+        }
+        throw err;
+      }
     }
   }
 }


### PR DESCRIPTION
This prevents an issue where, still on the job page, the cache-removed job would have trouble accessing properties and relationships of its now-removed Ember Data object.

Resolves #23410 