### PR TITLE
docs: Autoscaling agent 404 and navigation fix

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -2133,10 +2133,6 @@
             "href": "/tools/autoscaling/agent/policy_eval"
           },
           {
-            "title": "source",
-            "href": "/tools/autoscaling/agent/source"
-          },
-          {
             "title": "strategy",
             "href": "/tools/autoscaling/agent/strategy"
           },

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -84,4 +84,9 @@ module.exports = [
     destination: '/nomad/docs/integrations/consul/service-mesh',
     permanent: true,
   },
+  {
+    source: '/nomad/tools/autoscaling/agent/source',
+    destination: '/nomad/tools/autoscaling/agent/policy',
+    permanent: true,
+  },
 ]


### PR DESCRIPTION
This PR removes a reference page's listing in the main navigation file, which caused a 404 and created a navigation quirk. 

It also adds a redirect. According to [this PR merged in 2022](https://github.com/hashicorp/nomad/pull/14947), the content of the `source` page is now part of the `policy` page.