### PR TITLE
Fix Sentinel UI link to point to Sentinel Enforcement Levels

### DIFF
--- a/ui/app/components/sentinel-policy-editor.hbs
+++ b/ui/app/components/sentinel-policy-editor.hbs
@@ -52,7 +52,7 @@
 	<div>
 		<Hds::Form::Radio::Group @layout="horizontal" @name="method-demo1" {{on "change" this.updatePolicyEnforcementLevel}} as |G|>
 		<G.Legend>Enforcement Level</G.Legend>
-		<G.HelperText>See  <Hds::Link::Inline @href="https://developer.hashicorp.com/nomad/tutorials/access-control/access-control-tokens#token-types">Sentinel Policy documentation</Hds::Link::Inline> for more information.</G.HelperText>
+		<G.HelperText>See  <Hds::Link::Inline @href="https://developer.hashicorp.com/sentinel/docs/concepts/enforcement-levels">Sentinel Policy documentation</Hds::Link::Inline> for more information.</G.HelperText>
 		<G.RadioField
 			@id="advisory"
 			checked={{eq @policy.enforcementLevel "advisory"}}


### PR DESCRIPTION
Currently the UI page managing a single Sentinel policy, in the "Enforcement Levels" part, links to ACL Token Types instead of Sentinel Enforcement Levels.