### PR TITLE
cni: allow users to set CNI args in job spec

### DIFF
--- a/.changelog/23538.txt
+++ b/.changelog/23538.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cni: allow users to input CNI args in job specification
+```

--- a/api/resources.go
+++ b/api/resources.go
@@ -143,7 +143,7 @@ type DNSConfig struct {
 	Searches []string `mapstructure:"searches" hcl:"searches,optional"`
 	Options  []string `mapstructure:"options" hcl:"options,optional"`
 }
-type CNIArgs struct {
+type CNIConfig struct {
 	Args map[string]string `hcl:"args,optional"`
 }
 
@@ -163,8 +163,8 @@ type NetworkResource struct {
 	// XXX Deprecated. Please do not use. The field will be removed in Nomad
 	// 0.13 and is only being kept to allow any references to be removed before
 	// then.
-	MBits *int     `hcl:"mbits,optional"`
-	CNI   *CNIArgs `hcl:"cni,block"`
+	MBits *int       `hcl:"mbits,optional"`
+	CNI   *CNIConfig `hcl:"cni,block"`
 }
 
 // COMPAT(0.13)

--- a/api/resources.go
+++ b/api/resources.go
@@ -143,6 +143,9 @@ type DNSConfig struct {
 	Searches []string `mapstructure:"searches" hcl:"searches,optional"`
 	Options  []string `mapstructure:"options" hcl:"options,optional"`
 }
+type CNIArgs struct {
+	Args map[string]string `hcl:"args,optional"`
+}
 
 // NetworkResource is used to describe required network
 // resources of a given task.
@@ -160,7 +163,8 @@ type NetworkResource struct {
 	// XXX Deprecated. Please do not use. The field will be removed in Nomad
 	// 0.13 and is only being kept to allow any references to be removed before
 	// then.
-	MBits *int `hcl:"mbits,optional"`
+	MBits *int     `hcl:"mbits,optional"`
+	CNI   *CNIArgs `hcl:"cni,block"`
 }
 
 // COMPAT(0.13)

--- a/client/allocrunner/networking_cni.go
+++ b/client/allocrunner/networking_cni.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/go-set/v2"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -28,6 +27,7 @@ import (
 	"github.com/coreos/go-iptables/iptables"
 	consulIPTables "github.com/hashicorp/consul/sdk/iptables"
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/envoy"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -103,8 +103,8 @@ const (
 )
 
 // Adds user inputted custom CNI args to cniArgs map
-func addCustomCNIArgs(tg *structs.TaskGroup, cniArgs map[string]string) {
-	for _, net := range tg.Networks {
+func addCustomCNIArgs(networks []*structs.NetworkResource, cniArgs map[string]string) {
+	for _, net := range networks {
 		if net.CNI == nil {
 			continue
 		}
@@ -112,7 +112,6 @@ func addCustomCNIArgs(tg *structs.TaskGroup, cniArgs map[string]string) {
 			cniArgs[k] = v
 		}
 	}
-
 }
 
 // Setup calls the CNI plugins with the add action
@@ -129,7 +128,7 @@ func (c *cniNetworkConfigurator) Setup(ctx context.Context, alloc *structs.Alloc
 
 	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
 
-	addCustomCNIArgs(tg, cniArgs)
+	addCustomCNIArgs(tg.Networks, cniArgs)
 
 	portMaps := getPortMapping(alloc, c.ignorePortMappingHostIP)
 

--- a/client/allocrunner/networking_cni_test.go
+++ b/client/allocrunner/networking_cni_test.go
@@ -205,33 +205,13 @@ func TestCNI_cniToAllocNet_Invalid(t *testing.T) {
 	require.Nil(t, allocNet)
 }
 
-// TestCNI_addCustomCNIArgs fails if given a task group with a
-// network resource including CNI Args calling addCustomCNIArgs does not
-// result in the expected map of CNI Args created.
 func TestCNI_addCustomCNIArgs(t *testing.T) {
 	ci.Parallel(t)
 	cniArgs := map[string]string{
-		// CNI plugins are called one after the other with the same set of
-		// arguments. Passing IgnoreUnknown=true signals to plugins that they
-		// should ignore any arguments they don't understand
-		"IgnoreUnknown": "true",
+		"default": "yup",
 	}
-	alloc := mock.ConnectAlloc()
 
-	alloc.AllocatedResources.Shared.Networks = []*structs.NetworkResource{
-		{
-			Mode: "bridge",
-			CNI: &structs.CNIArgs{
-				Args: map[string]string{
-					"first_arg": "example",
-					"new_arg":   "example_2",
-				},
-			},
-		},
-	}
-	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
-	tg.Networks = []*structs.NetworkResource{{
-		Mode: "bridge",
+	network := []*structs.NetworkResource{{
 		CNI: &structs.CNIArgs{
 			Args: map[string]string{
 				"first_arg": "example",
@@ -239,50 +219,31 @@ func TestCNI_addCustomCNIArgs(t *testing.T) {
 			},
 		},
 	}}
-	addCustomCNIArgs(tg, cniArgs)
-	var actualMap = map[string]string{
-		"IgnoreUnknown": "true",
-		"first_arg":     "example",
-		"new_arg":       "example_2",
+	addCustomCNIArgs(network, cniArgs)
+	var expectMap = map[string]string{
+		"default":   "yup",
+		"first_arg": "example",
+		"new_arg":   "example_2",
 	}
-	test.Eq(t, actualMap, cniArgs)
+	test.Eq(t, expectMap, cniArgs)
 
 }
 
-// TestCNI_noCNIArgs fails if given a task group with a
-// network resource with no CNI Args specified, calling addCustomCNIArgs does not
-// result in a map with no args (except for "IgnoreUnknown" :"true").
 func TestCNI_noCNIArgs(t *testing.T) {
 	ci.Parallel(t)
 
 	cniArgs := map[string]string{
-		// CNI plugins are called one after the other with the same set of
-		// arguments. Passing IgnoreUnknown=true signals to plugins that they
-		// should ignore any arguments they don't understand
-		"IgnoreUnknown": "true",
+		"default": "yup",
 	}
-	alloc := mock.ConnectAlloc()
 
-	alloc.AllocatedResources.Shared.Networks = []*structs.NetworkResource{
-		{
-			Mode: "bridge",
-			CNI: &structs.CNIArgs{
-				Args: map[string]string{
-					"first_arg": "example",
-					"new_arg":   "example_2",
-				},
-			},
-		},
-	}
-	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
-	tg.Networks = []*structs.NetworkResource{{
+	network := []*structs.NetworkResource{{
 		Mode: "bridge",
 	}}
-	addCustomCNIArgs(tg, cniArgs)
-	var actualMap = map[string]string{
-		"IgnoreUnknown": "true",
+	addCustomCNIArgs(network, cniArgs)
+	var expectMap = map[string]string{
+		"default": "yup",
 	}
-	test.Eq(t, actualMap, cniArgs)
+	test.Eq(t, expectMap, cniArgs)
 
 }
 

--- a/client/allocrunner/networking_cni_test.go
+++ b/client/allocrunner/networking_cni_test.go
@@ -211,40 +211,45 @@ func TestCNI_addCustomCNIArgs(t *testing.T) {
 		"default": "yup",
 	}
 
-	network := []*structs.NetworkResource{{
-		CNI: &structs.CNIArgs{
+	networkWithArgs := []*structs.NetworkResource{{
+		CNI: &structs.CNIConfig{
 			Args: map[string]string{
 				"first_arg": "example",
 				"new_arg":   "example_2",
 			},
 		},
 	}}
-	addCustomCNIArgs(network, cniArgs)
-	var expectMap = map[string]string{
-		"default":   "yup",
-		"first_arg": "example",
-		"new_arg":   "example_2",
-	}
-	test.Eq(t, expectMap, cniArgs)
-
-}
-
-func TestCNI_noCNIArgs(t *testing.T) {
-	ci.Parallel(t)
-
-	cniArgs := map[string]string{
-		"default": "yup",
-	}
-
-	network := []*structs.NetworkResource{{
+	networkWithoutArgs := []*structs.NetworkResource{{
 		Mode: "bridge",
 	}}
-	addCustomCNIArgs(network, cniArgs)
-	var expectMap = map[string]string{
-		"default": "yup",
+	testCases := []struct {
+		name      string
+		network   []*structs.NetworkResource
+		expectMap map[string]string
+	}{
+		{
+			name:    "cni args not specified",
+			network: networkWithoutArgs,
+			expectMap: map[string]string{
+				"default": "yup",
+			},
+		}, {
+			name:    "cni args specified",
+			network: networkWithArgs,
+			expectMap: map[string]string{
+				"default":   "yup",
+				"first_arg": "example",
+				"new_arg":   "example_2",
+			},
+		},
 	}
-	test.Eq(t, expectMap, cniArgs)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			addCustomCNIArgs(tc.network, cniArgs)
+			test.Eq(t, tc.expectMap, cniArgs)
 
+		})
+	}
 }
 
 func TestCNI_setupTproxyArgs(t *testing.T) {

--- a/client/taskenv/network.go
+++ b/client/taskenv/network.go
@@ -13,6 +13,7 @@ import (
 // Current interoperable fields:
 //   - Hostname
 //   - DNS
+//   - CNI
 func InterpolateNetworks(taskEnv *TaskEnv, networks structs.Networks) structs.Networks {
 
 	// Guard against not having a valid taskEnv. This can be the case if the
@@ -31,6 +32,12 @@ func InterpolateNetworks(taskEnv *TaskEnv, networks structs.Networks) structs.Ne
 			interpolated[i].DNS.Servers = taskEnv.ParseAndReplace(interpolated[i].DNS.Servers)
 			interpolated[i].DNS.Searches = taskEnv.ParseAndReplace(interpolated[i].DNS.Searches)
 			interpolated[i].DNS.Options = taskEnv.ParseAndReplace(interpolated[i].DNS.Options)
+		}
+		if interpolated[i].CNI != nil {
+			for k, v := range interpolated[i].CNI.Args {
+				interpolated[i].CNI.Args[k] = taskEnv.ReplaceEnv(v)
+
+			}
 		}
 	}
 

--- a/client/taskenv/network_test.go
+++ b/client/taskenv/network_test.go
@@ -88,37 +88,25 @@ func Test_InterpolateNetworks(t *testing.T) {
 			inputTaskEnv: testEnv,
 			inputNetworks: structs.Networks{
 				{
-					CNI: &structs.CNIArgs{
-						Args: map[string]string{"static": "example"},
+					CNI: &structs.CNIConfig{
+						Args: map[string]string{
+							"static": "example",
+							"second": "${foo}-opt",
+						},
 					},
 				},
 			},
 			expectedOutputNetworks: structs.Networks{
 				{
-					CNI: &structs.CNIArgs{
-						Args: map[string]string{"static": "example"},
+					CNI: &structs.CNIConfig{
+						Args: map[string]string{
+							"static": "example",
+							"second": "bar-opt",
+						},
 					},
 				},
 			},
-			name: "non-interpolated cni args",
-		},
-		{
-			inputTaskEnv: testEnv,
-			inputNetworks: structs.Networks{
-				{
-					CNI: &structs.CNIArgs{
-						Args: map[string]string{"static": "${foo}-opt"},
-					},
-				},
-			},
-			expectedOutputNetworks: structs.Networks{
-				{
-					CNI: &structs.CNIArgs{
-						Args: map[string]string{"static": "bar-opt"},
-					},
-				},
-			},
-			name: "interpolated cni args",
+			name: "interpolated and non-interpolated cni args",
 		},
 	}
 

--- a/client/taskenv/network_test.go
+++ b/client/taskenv/network_test.go
@@ -84,6 +84,42 @@ func Test_InterpolateNetworks(t *testing.T) {
 			},
 			name: "interpolated dns servers",
 		},
+		{
+			inputTaskEnv: testEnv,
+			inputNetworks: structs.Networks{
+				{
+					CNI: &structs.CNIArgs{
+						Args: map[string]string{"static": "example"},
+					},
+				},
+			},
+			expectedOutputNetworks: structs.Networks{
+				{
+					CNI: &structs.CNIArgs{
+						Args: map[string]string{"static": "example"},
+					},
+				},
+			},
+			name: "non-interpolated cni args",
+		},
+		{
+			inputTaskEnv: testEnv,
+			inputNetworks: structs.Networks{
+				{
+					CNI: &structs.CNIArgs{
+						Args: map[string]string{"static": "${foo}-opt"},
+					},
+				},
+			},
+			expectedOutputNetworks: structs.Networks{
+				{
+					CNI: &structs.CNIArgs{
+						Args: map[string]string{"static": "bar-opt"},
+					},
+				},
+			},
+			name: "interpolated cni args",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1553,6 +1553,11 @@ func ApiNetworkResourceToStructs(in []*api.NetworkResource) []*structs.NetworkRe
 				Options:  nw.DNS.Options,
 			}
 		}
+		if nw.CNI != nil {
+			out[i].CNI = &structs.CNIArgs{
+				Args: nw.CNI.Args,
+			}
+		}
 
 		if l := len(nw.DynamicPorts); l != 0 {
 			out[i].DynamicPorts = make([]structs.Port, l)

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1554,7 +1554,7 @@ func ApiNetworkResourceToStructs(in []*api.NetworkResource) []*structs.NetworkRe
 			}
 		}
 		if nw.CNI != nil {
-			out[i].CNI = &structs.CNIArgs{
+			out[i].CNI = &structs.CNIConfig{
 				Args: nw.CNI.Args,
 			}
 		}

--- a/nomad/structs/cni_config.go
+++ b/nomad/structs/cni_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package structs
 
 import "reflect"

--- a/nomad/structs/cni_config.go
+++ b/nomad/structs/cni_config.go
@@ -3,7 +3,9 @@
 
 package structs
 
-import "reflect"
+import (
+	"maps"
+)
 
 type CNIConfig struct {
 	Args map[string]string
@@ -26,5 +28,5 @@ func (d *CNIConfig) Equal(o *CNIConfig) bool {
 	if d == nil || o == nil {
 		return d == o
 	}
-	return reflect.DeepEqual(d.Args, o.Args)
+	return maps.Equal(d.Args, o.Args)
 }

--- a/nomad/structs/cni_config.go
+++ b/nomad/structs/cni_config.go
@@ -5,11 +5,11 @@ package structs
 
 import "reflect"
 
-type CNIArgs struct {
+type CNIConfig struct {
 	Args map[string]string
 }
 
-func (d *CNIArgs) Copy() *CNIArgs {
+func (d *CNIConfig) Copy() *CNIConfig {
 	if d == nil {
 		return nil
 	}
@@ -17,12 +17,12 @@ func (d *CNIArgs) Copy() *CNIArgs {
 	for k, v := range d.Args {
 		newMap[k] = v
 	}
-	return &CNIArgs{
+	return &CNIConfig{
 		Args: newMap,
 	}
 }
 
-func (d *CNIArgs) Equal(o *CNIArgs) bool {
+func (d *CNIConfig) Equal(o *CNIConfig) bool {
 	if d == nil || o == nil {
 		return d == o
 	}

--- a/nomad/structs/cni_config.go
+++ b/nomad/structs/cni_config.go
@@ -1,0 +1,27 @@
+package structs
+
+import "reflect"
+
+type CNIArgs struct {
+	Args map[string]string
+}
+
+func (d *CNIArgs) Copy() *CNIArgs {
+	if d == nil {
+		return nil
+	}
+	newMap := make(map[string]string)
+	for k, v := range d.Args {
+		newMap[k] = v
+	}
+	return &CNIArgs{
+		Args: newMap,
+	}
+}
+
+func (d *CNIArgs) Equal(o *CNIArgs) bool {
+	if d == nil || o == nil {
+		return d == o
+	}
+	return reflect.DeepEqual(d.Args, o.Args)
+}

--- a/nomad/structs/cni_config_test.go
+++ b/nomad/structs/cni_config_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package structs
 
 import (

--- a/nomad/structs/cni_config_test.go
+++ b/nomad/structs/cni_config_test.go
@@ -1,0 +1,25 @@
+package structs
+
+import (
+	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
+	"testing"
+)
+
+func TestCNIConfig_Equal(t *testing.T) {
+	ci.Parallel(t)
+
+	must.Equal[*CNIArgs](t, nil, nil)
+	must.NotEqual[*CNIArgs](t, nil, new(CNIArgs))
+	must.NotEqual[*CNIArgs](t, nil, &CNIArgs{Args: map[string]string{"first": "second"}})
+
+	must.StructEqual(t, &CNIArgs{
+		Args: map[string]string{
+			"arg":     "example_1",
+			"new_arg": "example_2",
+		},
+	}, []must.Tweak[*CNIArgs]{{
+		Field: "Args",
+		Apply: func(c *CNIArgs) { c.Args = map[string]string{"different": "arg"} },
+	}})
+}

--- a/nomad/structs/cni_config_test.go
+++ b/nomad/structs/cni_config_test.go
@@ -12,17 +12,17 @@ import (
 func TestCNIConfig_Equal(t *testing.T) {
 	ci.Parallel(t)
 
-	must.Equal[*CNIArgs](t, nil, nil)
-	must.NotEqual[*CNIArgs](t, nil, new(CNIArgs))
-	must.NotEqual[*CNIArgs](t, nil, &CNIArgs{Args: map[string]string{"first": "second"}})
+	must.Equal[*CNIConfig](t, nil, nil)
+	must.NotEqual[*CNIConfig](t, nil, new(CNIConfig))
+	must.NotEqual[*CNIConfig](t, nil, &CNIConfig{Args: map[string]string{"first": "second"}})
 
-	must.StructEqual(t, &CNIArgs{
+	must.StructEqual(t, &CNIConfig{
 		Args: map[string]string{
 			"arg":     "example_1",
 			"new_arg": "example_2",
 		},
-	}, []must.Tweak[*CNIArgs]{{
+	}, []must.Tweak[*CNIConfig]{{
 		Field: "Args",
-		Apply: func(c *CNIArgs) { c.Args = map[string]string{"different": "arg"} },
+		Apply: func(c *CNIConfig) { c.Args = map[string]string{"different": "arg"} },
 	}})
 }

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -2712,14 +2712,14 @@ func (d *DNSConfig) Diff(other *DNSConfig, contextual bool) *ObjectDiff {
 
 // Diff returns a diff of two CNIConfig structs
 func (d *CNIConfig) Diff(other *CNIConfig, contextual bool) *ObjectDiff {
-	if d.Equal(other) {
-		return nil
-	}
 	if d == nil {
 		d = &CNIConfig{}
 	}
 	if other == nil {
 		other = &CNIConfig{}
+	}
+	if d.Equal(other) {
+		return nil
 	}
 
 	return primitiveObjectDiff(d.Args, other.Args, nil, "CNIConfig", contextual)

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -2663,6 +2663,10 @@ func (n *NetworkResource) Diff(other *NetworkResource, contextual bool) *ObjectD
 		diff.Objects = append(diff.Objects, dnsDiff)
 	}
 
+	if cniDiff := n.CNI.Diff(other.CNI, contextual); cniDiff != nil {
+		diff.Objects = append(diff.Objects, cniDiff)
+	}
+
 	return diff
 }
 
@@ -2704,6 +2708,21 @@ func (d *DNSConfig) Diff(other *DNSConfig, contextual bool) *ObjectDiff {
 	diff.Fields = fieldDiffs(oldPrimitiveFlat, newPrimitiveFlat, contextual)
 
 	return diff
+}
+
+// Diff returns a diff of two CNIArgs structs
+func (d *CNIArgs) Diff(other *CNIArgs, contextual bool) *ObjectDiff {
+	if d.Equal(other) {
+		return nil
+	}
+	if d == nil {
+		d = &CNIArgs{}
+	}
+	if other == nil {
+		other = &CNIArgs{}
+	}
+
+	return primitiveObjectDiff(d.Args, other.Args, nil, "CNIArgs", contextual)
 }
 
 func disconectStrategyDiffs(old, new *DisconnectStrategy, contextual bool) *ObjectDiff {

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -2710,19 +2710,19 @@ func (d *DNSConfig) Diff(other *DNSConfig, contextual bool) *ObjectDiff {
 	return diff
 }
 
-// Diff returns a diff of two CNIArgs structs
-func (d *CNIArgs) Diff(other *CNIArgs, contextual bool) *ObjectDiff {
+// Diff returns a diff of two CNIConfig structs
+func (d *CNIConfig) Diff(other *CNIConfig, contextual bool) *ObjectDiff {
 	if d.Equal(other) {
 		return nil
 	}
 	if d == nil {
-		d = &CNIArgs{}
+		d = &CNIConfig{}
 	}
 	if other == nil {
-		other = &CNIArgs{}
+		other = &CNIConfig{}
 	}
 
-	return primitiveObjectDiff(d.Args, other.Args, nil, "CNIArgs", contextual)
+	return primitiveObjectDiff(d.Args, other.Args, nil, "CNIConfig", contextual)
 }
 
 func disconectStrategyDiffs(old, new *DisconnectStrategy, contextual bool) *ObjectDiff {

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -5221,24 +5221,15 @@ func TestTaskGroupDiff(t *testing.T) {
 				},
 			},
 		},
-		{TestCase: "TaskGroup CNI edited",
+		{TestCase: "TaskGroup CNI added",
 			Contextual: false,
 			Old: &TaskGroup{
-				Networks: Networks{
-					{
-						DNS: &DNSConfig{
-							Servers: []string{"1.1.1.1"},
-						},
-					},
-				},
+				Networks: Networks{},
 			},
 			New: &TaskGroup{
 				Networks: Networks{
 					{
-						DNS: &DNSConfig{
-							Servers: []string{"1.1.1.1"},
-						},
-						CNI: &CNIArgs{
+						CNI: &CNIConfig{
 							Args: map[string]string{
 								"example": "example1",
 							},
@@ -5256,19 +5247,7 @@ func TestTaskGroupDiff(t *testing.T) {
 
 							{
 								Type: DiffTypeAdded,
-								Name: "DNS",
-								Fields: []*FieldDiff{
-									{
-										Type: DiffTypeAdded,
-										Name: "Servers",
-										Old:  "",
-										New:  "1.1.1.1",
-									},
-								},
-							},
-							{
-								Type: DiffTypeAdded,
-								Name: "CNIArgs",
+								Name: "CNIConfig",
 								Fields: []*FieldDiff{
 									{
 										Type: DiffTypeAdded,
@@ -5280,10 +5259,196 @@ func TestTaskGroupDiff(t *testing.T) {
 							},
 						},
 					},
+				},
+			},
+		},
+		{TestCase: "TaskGroup CNI deleted",
+			Contextual: false,
+			Old: &TaskGroup{
+				Networks: Networks{
+					{
+						CNI: &CNIConfig{
+							Args: map[string]string{
+								"example": "example1",
+							},
+						},
+					},
+				},
+			},
+			New: &TaskGroup{
+				Networks: Networks{},
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
 					{
 						Type: DiffTypeDeleted,
 						Name: "Network",
 						Objects: []*ObjectDiff{
+
+							{
+								Type: DiffTypeDeleted,
+								Name: "CNIConfig",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeDeleted,
+										Name: "example",
+										Old:  "example1",
+										New:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{TestCase: "TaskGroup CNI edited",
+			Contextual: false,
+			Old: &TaskGroup{
+				Networks: Networks{
+					{
+						CNI: &CNIConfig{
+							Args: map[string]string{
+								"example": "example1",
+							},
+						},
+					},
+				},
+			},
+			New: &TaskGroup{
+				Networks: Networks{
+					{
+						CNI: &CNIConfig{
+							Args: map[string]string{
+								"example": "example2",
+							},
+						},
+					},
+				},
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "Network",
+						Objects: []*ObjectDiff{
+
+							{
+								Type: DiffTypeAdded,
+								Name: "CNIConfig",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "example",
+										Old:  "",
+										New:  "example2",
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: DiffTypeDeleted,
+						Name: "Network",
+						Objects: []*ObjectDiff{
+
+							{
+								Type: DiffTypeDeleted,
+								Name: "CNIConfig",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeDeleted,
+										Name: "example",
+										Old:  "example1",
+										New:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{TestCase: "TaskGroup Networks edited behavior",
+			Contextual: false,
+			Old: &TaskGroup{
+				Networks: Networks{
+					{
+						DNS: &DNSConfig{
+							Servers: []string{"1.1.1.1"},
+						},
+					},
+				},
+			},
+			New: &TaskGroup{
+				Networks: Networks{
+					{
+						DNS: &DNSConfig{
+							Servers: []string{"1.1.1.1"},
+						},
+						DynamicPorts: []Port{
+							{
+								Label:       "bar",
+								To:          8081,
+								HostNetwork: "public",
+							},
+						},
+					},
+				},
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "Network",
+						Objects: []*ObjectDiff{
+
+							{
+								Type: DiffTypeAdded,
+								Name: "Dynamic Port",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "HostNetwork",
+										Old:  "",
+										New:  "public",
+									},
+									{
+										Type: DiffTypeAdded,
+										Name: "Label",
+										Old:  "",
+										New:  "bar",
+									},
+									{
+										Type: DiffTypeAdded,
+										Name: "To",
+										Old:  "",
+										New:  "8081",
+									},
+								},
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "DNS",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "Servers",
+										Old:  "",
+										New:  "1.1.1.1",
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: DiffTypeDeleted,
+						Name: "Network",
+						Objects: []*ObjectDiff{
+
 							{
 								Type: DiffTypeDeleted,
 								Name: "DNS",

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -5221,6 +5221,86 @@ func TestTaskGroupDiff(t *testing.T) {
 				},
 			},
 		},
+		{TestCase: "TaskGroup CNI edited",
+			Contextual: false,
+			Old: &TaskGroup{
+				Networks: Networks{
+					{
+						DNS: &DNSConfig{
+							Servers: []string{"1.1.1.1"},
+						},
+					},
+				},
+			},
+			New: &TaskGroup{
+				Networks: Networks{
+					{
+						DNS: &DNSConfig{
+							Servers: []string{"1.1.1.1"},
+						},
+						CNI: &CNIArgs{
+							Args: map[string]string{
+								"example": "example1",
+							},
+						},
+					},
+				},
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeAdded,
+						Name: "Network",
+						Objects: []*ObjectDiff{
+
+							{
+								Type: DiffTypeAdded,
+								Name: "DNS",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "Servers",
+										Old:  "",
+										New:  "1.1.1.1",
+									},
+								},
+							},
+							{
+								Type: DiffTypeAdded,
+								Name: "CNIArgs",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeAdded,
+										Name: "example",
+										Old:  "",
+										New:  "example1",
+									},
+								},
+							},
+						},
+					},
+					{
+						Type: DiffTypeDeleted,
+						Name: "Network",
+						Objects: []*ObjectDiff{
+							{
+								Type: DiffTypeDeleted,
+								Name: "DNS",
+								Fields: []*FieldDiff{
+									{
+										Type: DiffTypeDeleted,
+										Name: "Servers",
+										Old:  "1.1.1.1",
+										New:  "",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, c := range cases {

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -5371,7 +5371,7 @@ func TestTaskGroupDiff(t *testing.T) {
 				},
 			},
 		},
-		{TestCase: "TaskGroup Networks edited behavior",
+		{TestCase: "Editing Networks deletes and re-adds",
 			Contextual: false,
 			Old: &TaskGroup{
 				Networks: Networks{

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2872,6 +2872,7 @@ type NetworkResource struct {
 	DNS           *DNSConfig // DNS Configuration
 	ReservedPorts []Port     // Host Reserved ports
 	DynamicPorts  []Port     // Host Dynamically assigned ports
+	CNI           *CNIArgs   //CNIArgs Configuration
 }
 
 func (n *NetworkResource) Hash() uint32 {
@@ -7147,6 +7148,7 @@ func (tg *TaskGroup) validateNetworks() error {
 	portLabels := make(map[string]string)
 	// host_network -> static port tracking
 	staticPortsIndex := make(map[string]map[int]string)
+	cniArgKeys := set.New[string](len(tg.Networks))
 
 	for _, net := range tg.Networks {
 		for _, port := range append(net.ReservedPorts, net.DynamicPorts...) {
@@ -7184,6 +7186,18 @@ func (tg *TaskGroup) validateNetworks() error {
 			} else if port.To > math.MaxUint16 {
 				err := fmt.Errorf("Port %q cannot be mapped to a port (%d) greater than %d", port.Label, port.To, math.MaxUint16)
 				mErr.Errors = append(mErr.Errors, err)
+			}
+		}
+		// Validate the cniArgs in each network resource. Make sure there are no duplicate Args in
+		// different network resources
+		if net.CNI != nil {
+			for k, _ := range net.CNI.Args {
+				if cniArgKeys.Contains(k) {
+					err := fmt.Errorf("duplicate CNI arg %v", k)
+					mErr.Errors = append(mErr.Errors, err)
+				} else {
+					cniArgKeys.Insert(k)
+				}
 			}
 		}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7191,7 +7191,7 @@ func (tg *TaskGroup) validateNetworks() error {
 		// Validate the cniArgs in each network resource. Make sure there are no duplicate Args in
 		// different network resources
 		if net.CNI != nil {
-			for k, _ := range net.CNI.Args {
+			for k := range net.CNI.Args {
 				if cniArgKeys.Contains(k) {
 					err := fmt.Errorf("duplicate CNI arg %v", k)
 					mErr.Errors = append(mErr.Errors, err)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7189,14 +7189,22 @@ func (tg *TaskGroup) validateNetworks() error {
 			}
 		}
 		// Validate the cniArgs in each network resource. Make sure there are no duplicate Args in
-		// different network resources
+		// different network resources or illegal characters (;) in key or value ;)
 		if net.CNI != nil {
-			for k := range net.CNI.Args {
+			for k, v := range net.CNI.Args {
 				if cniArgKeys.Contains(k) {
 					err := fmt.Errorf("duplicate CNI arg %q", k)
 					mErr.Errors = append(mErr.Errors, err)
 				} else {
 					cniArgKeys.Insert(k)
+				}
+				if strings.Contains(k, ";") {
+					err := fmt.Errorf("invalid ';' character in CNI arg key %q", k)
+					mErr.Errors = append(mErr.Errors, err)
+				}
+				if strings.Contains(v, ";") {
+					err := fmt.Errorf("invalid ';' character in CNI arg value %q", v)
+					mErr.Errors = append(mErr.Errors, err)
 				}
 			}
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2872,7 +2872,7 @@ type NetworkResource struct {
 	DNS           *DNSConfig // DNS Configuration
 	ReservedPorts []Port     // Host Reserved ports
 	DynamicPorts  []Port     // Host Dynamically assigned ports
-	CNI           *CNIArgs   //CNIArgs Configuration
+	CNI           *CNIConfig // CNIConfig Configuration
 }
 
 func (n *NetworkResource) Hash() uint32 {
@@ -7193,7 +7193,7 @@ func (tg *TaskGroup) validateNetworks() error {
 		if net.CNI != nil {
 			for k := range net.CNI.Args {
 				if cniArgKeys.Contains(k) {
-					err := fmt.Errorf("duplicate CNI arg %v", k)
+					err := fmt.Errorf("duplicate CNI arg %q", k)
 					mErr.Errors = append(mErr.Errors, err)
 				} else {
 					cniArgKeys.Insert(k)

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2020,10 +2020,10 @@ func TestTaskGroupNetwork_Validate(t *testing.T) {
 				Name: "testing-duplicate-cni-arg-keys",
 				Networks: []*NetworkResource{
 					{
-						CNI: &CNIArgs{Args: map[string]string{"static": "first_value"}},
+						CNI: &CNIConfig{Args: map[string]string{"static": "first_value"}},
 					},
 					{
-						CNI: &CNIArgs{Args: map[string]string{"static": "new_value"}},
+						CNI: &CNIConfig{Args: map[string]string{"static": "new_value"}},
 					},
 				},
 			},
@@ -2034,13 +2034,13 @@ func TestTaskGroupNetwork_Validate(t *testing.T) {
 				Name: "testing-valid-cni-arg-keys",
 				Networks: []*NetworkResource{
 					{
-						CNI: &CNIArgs{Args: map[string]string{"static": "first_value"}},
+						CNI: &CNIConfig{Args: map[string]string{"static": "first_value"}},
 					},
 					{
-						CNI: &CNIArgs{Args: map[string]string{"new_key": "new_value"}},
+						CNI: &CNIConfig{Args: map[string]string{"new_key": "new_value"}},
 					},
 					{
-						CNI: &CNIArgs{Args: map[string]string{"newest_key": "new_value", "second_key": "second_value"}},
+						CNI: &CNIConfig{Args: map[string]string{"newest_key": "new_value", "second_key": "second_value"}},
 					},
 				},
 			},
@@ -2216,7 +2216,7 @@ func TestTask_Validate_Resources(t *testing.T) {
 								HostNetwork: "loopback",
 							},
 						},
-						CNI: &CNIArgs{map[string]string{"static": "new_val"}},
+						CNI: &CNIConfig{map[string]string{"static": "new_val"}},
 					},
 				},
 			},
@@ -2349,7 +2349,7 @@ func TestNetworkResource_Copy(t *testing.T) {
 						HostNetwork: "public",
 					},
 				},
-				CNI: &CNIArgs{Args: map[string]string{"foo": "bar", "hello": "world"}},
+				CNI: &CNIConfig{Args: map[string]string{"foo": "bar", "hello": "world"}},
 			},
 			name: "fully populated input check",
 		},

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2045,6 +2045,28 @@ func TestTaskGroupNetwork_Validate(t *testing.T) {
 				},
 			},
 		},
+		{
+			TG: &TaskGroup{
+				Name: "testing-invalid-character-cni-arg-key",
+				Networks: []*NetworkResource{
+					{
+						CNI: &CNIConfig{Args: map[string]string{"static;": "first_value"}},
+					},
+				},
+			},
+			ErrContains: "invalid ';' character in CNI arg key \"static;",
+		},
+		{
+			TG: &TaskGroup{
+				Name: "testing-invalid-character-cni-arg-value",
+				Networks: []*NetworkResource{
+					{
+						CNI: &CNIConfig{Args: map[string]string{"static": "first_value;"}},
+					},
+				},
+			},
+			ErrContains: "invalid ';' character in CNI arg value \"first_value;",
+		},
 	}
 
 	for i := range cases {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2015,6 +2015,36 @@ func TestTaskGroupNetwork_Validate(t *testing.T) {
 			},
 			ErrContains: "Hostname is not a valid DNS name",
 		},
+		{
+			TG: &TaskGroup{
+				Name: "testing-duplicate-cni-arg-keys",
+				Networks: []*NetworkResource{
+					{
+						CNI: &CNIArgs{Args: map[string]string{"static": "first_value"}},
+					},
+					{
+						CNI: &CNIArgs{Args: map[string]string{"static": "new_value"}},
+					},
+				},
+			},
+			ErrContains: "duplicate CNI arg",
+		},
+		{
+			TG: &TaskGroup{
+				Name: "testing-valid-cni-arg-keys",
+				Networks: []*NetworkResource{
+					{
+						CNI: &CNIArgs{Args: map[string]string{"static": "first_value"}},
+					},
+					{
+						CNI: &CNIArgs{Args: map[string]string{"new_key": "new_value"}},
+					},
+					{
+						CNI: &CNIArgs{Args: map[string]string{"newest_key": "new_value", "second_key": "second_value"}},
+					},
+				},
+			},
+		},
 	}
 
 	for i := range cases {
@@ -2186,6 +2216,7 @@ func TestTask_Validate_Resources(t *testing.T) {
 								HostNetwork: "loopback",
 							},
 						},
+						CNI: &CNIArgs{map[string]string{"static": "new_val"}},
 					},
 				},
 			},
@@ -2318,6 +2349,7 @@ func TestNetworkResource_Copy(t *testing.T) {
 						HostNetwork: "public",
 					},
 				},
+				CNI: &CNIArgs{Args: map[string]string{"foo": "bar", "hello": "world"}},
 			},
 			name: "fully populated input check",
 		},

--- a/website/content/docs/job-specification/network.mdx
+++ b/website/content/docs/job-specification/network.mdx
@@ -89,6 +89,8 @@ All other operating systems use the `host` networking mode.
   DNS configuration from the client host. DNS configuration is only supported on
   Linux clients at this time. Note that if you are using a `mode="cni/*`, these
   values will override any DNS configuration the CNI plugins return.
+- `cni` <code>([CNIConfig](#cni-parameters): nil)</code> - Sets the custom CNI
+  arguments for a network configuration per allocation, for use with `mode="cni/*`.
 
 ### `port` Parameters
 
@@ -125,6 +127,14 @@ The label of the port is just text - it has no special meaning to Nomad.
 - `servers` `(array<string>: nil)` - Sets the DNS nameservers the allocation uses for name resolution.
 - `searches` `(array<string>: nil)` - Sets the search list for hostname lookup
 - `options` `(array<string>: nil)` - Sets internal resolver variables.
+
+These parameters support [interpolation](/nomad/docs/runtime/interpolation).
+
+## `cni` Parameters
+
+- `args` `(map<string><string>: nil)` - Sets CNI arguments for network configuration.
+   These get turned into `CNI_ARGS` per the
+   [CNI spec](https://www.cni.dev/docs/spec/#parameters).
 
 These parameters support [interpolation](/nomad/docs/runtime/interpolation).
 
@@ -293,6 +303,24 @@ network {
 ```
 
 The Nomad client will build the correct [capabilities arguments](https://github.com/containernetworking/cni/blob/v0.8.0/CONVENTIONS.md#well-known-capabilities) for the portmap plugin based on the defined port blocks.
+
+### CNI Args
+
+The following example specifies CNI args for the custom CNI plugin specified above.
+
+```hcl
+network {
+  mode = "cni/mynet"
+  port "http" {
+    to = 8080
+  }
+  cni {
+    args = {
+     "nomad.region" : "${node.region}"
+    }
+  }
+}
+```
 
 ### Host Networks
 


### PR DESCRIPTION
This PR allows for users to set up CNI args in a job specification through the network block by adding a cni block and specifying an args field. 


Resolves #16197