### PR TITLE
[ui] Agent config and User localStorage defaults for filters

### DIFF
--- a/nomad/structs/config/ui.go
+++ b/nomad/structs/config/ui.go
@@ -28,6 +28,9 @@ type UIConfig struct {
 
 	// Label configures UI label styles
 	Label *LabelUIConfig `hcl:"label"`
+
+	// Defaults
+	Defaults *DefaultsUIConfig `hcl:"defaults"`
 }
 
 // only covers the elements of
@@ -133,6 +136,14 @@ type LabelUIConfig struct {
 	TextColor       string `hcl:"text_color"`
 }
 
+// Defaults let you pre-set filter values for the UI configuration
+type DefaultsUIConfig struct {
+	// Namespace is the default namespace to filter by
+	Namespace string `hcl:"namespace"`
+	Region    string `hcl:"region"`
+	NodePool  string `hcl:"node_pool"`
+}
+
 // DefaultUIConfig returns the canonical defaults for the Nomad
 // `ui` configuration.
 func DefaultUIConfig() *UIConfig {
@@ -142,6 +153,7 @@ func DefaultUIConfig() *UIConfig {
 		Vault:                 &VaultUIConfig{},
 		Label:                 &LabelUIConfig{},
 		ContentSecurityPolicy: DefaultCSPConfig(),
+		Defaults:              &DefaultsUIConfig{},
 	}
 }
 
@@ -176,6 +188,7 @@ func (old *UIConfig) Merge(other *UIConfig) *UIConfig {
 	result.Vault = result.Vault.Merge(other.Vault)
 	result.Label = result.Label.Merge(other.Label)
 	result.ContentSecurityPolicy = result.ContentSecurityPolicy.Merge(other.ContentSecurityPolicy)
+	result.Defaults = result.Defaults.Merge(other.Defaults)
 
 	return result
 }
@@ -266,6 +279,37 @@ func (old *LabelUIConfig) Merge(other *LabelUIConfig) *LabelUIConfig {
 	}
 	if other.TextColor != "" {
 		result.TextColor = other.TextColor
+	}
+	return result
+}
+
+func (old *DefaultsUIConfig) Copy() *DefaultsUIConfig {
+	if old == nil {
+		return nil
+	}
+
+	nc := new(DefaultsUIConfig)
+	*nc = *old
+	return nc
+}
+
+func (old *DefaultsUIConfig) Merge(other *DefaultsUIConfig) *DefaultsUIConfig {
+	result := old.Copy()
+	if result == nil {
+		result = &DefaultsUIConfig{}
+	}
+	if other == nil {
+		return result
+	}
+
+	if other.Namespace != "" {
+		result.Namespace = other.Namespace
+	}
+	if other.Region != "" {
+		result.Region = other.Region
+	}
+	if other.NodePool != "" {
+		result.NodePool = other.NodePool
 	}
 	return result
 }

--- a/nomad/structs/config/ui_test.go
+++ b/nomad/structs/config/ui_test.go
@@ -13,6 +13,8 @@ import (
 func TestUIConfig_Merge(t *testing.T) {
 	ci.Parallel(t)
 
+	// TODO: TEST DEFAULTS
+
 	fullConfig := &UIConfig{
 		Enabled: true,
 		Consul: &ConsulUIConfig{

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -610,9 +610,9 @@ export default class JobsIndexController extends Controller {
         set(option, 'checked', false);
       });
     });
-    this.namespaceFacet?.options.forEach((option) => {
-      set(option, 'checked', false);
-    });
+    // this.namespaceFacet?.options.forEach((option) => {
+    //   set(option, 'checked', false);
+    // });
     this.updateFilter();
   }
 

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -438,6 +438,7 @@ export default class JobsIndexController extends Controller {
 
   @tracked nodePoolFacet = {
     label: 'NodePool',
+    key: 'nodePool',
     options: (this.model.nodePools || []).map((nodePool) => ({
       key: nodePool.name,
       string: `NodePool == "${nodePool.name}"`,
@@ -449,6 +450,7 @@ export default class JobsIndexController extends Controller {
 
   @tracked namespaceFacet = {
     label: 'Namespace',
+    key: 'namespace',
     options: [
       ...(this.model.namespaces || []).map((ns) => ({
         key: ns.name,
@@ -610,9 +612,6 @@ export default class JobsIndexController extends Controller {
         set(option, 'checked', false);
       });
     });
-    // this.namespaceFacet?.options.forEach((option) => {
-    //   set(option, 'checked', false);
-    // });
     this.updateFilter();
   }
 
@@ -663,6 +662,26 @@ export default class JobsIndexController extends Controller {
       return `${baseString} ${this.model.error.humanized}`;
     }
     return baseString;
+  }
+
+  // Note: technically this checks for the presence of the defaults in the filter, not the absence of any other filters.
+  // This could be made more accurate by checking for the absence of any other filters, but that would add complexity and probably isn't needed.
+  // The main purpose of this is to be a safety net for "I keep seeing an error and I'm not sure why, I haven't set any filters" for users with agent config defaults.
+  get defaultsResultInNoMatches() {
+    let defaultNamespace = this.model.defaults.namespace;
+    let defaultNodePool = this.model.defaults.nodePool;
+    if (!defaultNamespace.length && !defaultNodePool.length) {
+      return false;
+    }
+    let defaultsPresentInFilter = false;
+    defaultsPresentInFilter =
+      defaultNamespace.every((ns) =>
+        this.filter.includes(`Namespace == "${ns}"`)
+      ) &&
+      defaultNodePool.every((np) =>
+        this.filter.includes(`NodePool == "${np}"`)
+      );
+    return defaultsPresentInFilter;
   }
 
   @action correctFilterKey({ incorrectKey, correctKey }) {

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -668,9 +668,10 @@ export default class JobsIndexController extends Controller {
   // This could be made more accurate by checking for the absence of any other filters, but that would add complexity and probably isn't needed.
   // The main purpose of this is to be a safety net for "I keep seeing an error and I'm not sure why, I haven't set any filters" for users with agent config defaults.
   get defaultsResultInNoMatches() {
+    if (this.model.error) return false;
     let defaultNamespace = this.model.defaults.namespace;
     let defaultNodePool = this.model.defaults.nodePool;
-    if (!defaultNamespace.length && !defaultNodePool.length) {
+    if (!defaultNamespace && !defaultNodePool) {
       return false;
     }
     let defaultsPresentInFilter = false;

--- a/ui/app/controllers/settings/user-settings.js
+++ b/ui/app/controllers/settings/user-settings.js
@@ -6,8 +6,39 @@
 // @ts-check
 import Controller from '@ember/controller';
 import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
+import { alias } from '@ember/object/computed';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+import { inject as service } from '@ember/service';
 
 export default class SettingsUserSettingsController extends Controller {
+  @service notifications;
+
   @localStorageProperty('nomadShouldWrapCode', false) wordWrap;
   @localStorageProperty('nomadLiveUpdateJobsIndex', true) liveUpdateJobsIndex;
+  @localStorageProperty('nomadDefaultNamespace') defaultNamespace;
+  @localStorageProperty('nomadDefaultNodePool') defaultNodePool;
+
+  @alias('model.namespaces') namespaces;
+  @alias('model.nodePools') nodePools;
+
+  @tracked namespaceFilter = '';
+  get filteredNamespaces() {
+    return this.namespaces.filter((ns) =>
+      ns.name.includes(this.namespaceFilter)
+    );
+  }
+
+  @action setDefaultNamespace(ns) {
+    console.log('setDefaultNamespace', ns);
+    this.defaultNamespace = ns;
+
+    this.notifications.add({
+      title: 'Default Namespace Updated',
+      message: ns
+        ? `Default namespace is now ${ns}`
+        : 'Default namespace un-set',
+      color: 'success',
+    });
+  }
 }

--- a/ui/app/controllers/settings/user-settings.js
+++ b/ui/app/controllers/settings/user-settings.js
@@ -8,16 +8,19 @@ import Controller from '@ember/controller';
 import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
 import { alias } from '@ember/object/computed';
 import { tracked } from '@glimmer/tracking';
-import { action } from '@ember/object';
+import { set, action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
 
 export default class SettingsUserSettingsController extends Controller {
   @service notifications;
+  @service system;
 
   @localStorageProperty('nomadShouldWrapCode', false) wordWrap;
   @localStorageProperty('nomadLiveUpdateJobsIndex', true) liveUpdateJobsIndex;
-  @localStorageProperty('nomadDefaultNamespace') defaultNamespace;
-  @localStorageProperty('nomadDefaultNodePool') defaultNodePool;
+  // @localStorageProperty('nomadDefaultNamespace') userDefaultNamespace;
+  @alias('system.userDefaultNamespace') userDefaultNamespace;
+  // @localStorageProperty('nomadDefaultNodePool') defaultNodePool;
 
   @alias('model.namespaces') namespaces;
   @alias('model.nodePools') nodePools;
@@ -29,15 +32,83 @@ export default class SettingsUserSettingsController extends Controller {
     );
   }
 
-  @action setDefaultNamespace(ns) {
-    console.log('setDefaultNamespace', ns);
-    this.defaultNamespace = ns;
+  /**
+   * @type {import ('../../services/system').RenderedDefaults} RenderedDefaults
+   */
+  get globalDefaults() {
+    return this.model.defaults;
+  }
 
+  /**
+   * @type {Array<string>} defaultNamespace
+   */
+  get namespaceDefaults() {
+    return this.globalDefaults.namespace;
+  }
+
+  @computed(
+    'filteredNamespaces.@each.checked',
+    'namespaceDefaults',
+    'namespaceFilter',
+    'namespaces.[]'
+  )
+  get namespaceOptions() {
+    return this.filteredNamespaces.map((ns) => ({
+      label: ns.name,
+      value: ns.name,
+      checked: this.namespaceDefaults.includes(ns.name),
+    }));
+  }
+
+  get namespaceDropdownLabel() {
+    let userDefaultNamespaces = this.userDefaultNamespace
+      ? this.userDefaultNamespace.split(',')
+      : [];
+    let agentDefaultNamespaces = this.system.agentDefaults?.Namespace
+      ? this.system.agentDefaults.Namespace.split(',')
+      : [];
+    if (this.userDefaultNamespace) {
+      return `${userDefaultNamespaces.length} default namespace${
+        userDefaultNamespaces.length > 1 ? 's' : ''
+      } (via localStorage)`;
+    } else if (agentDefaultNamespaces.length) {
+      return `${agentDefaultNamespaces.length} default namespace${
+        agentDefaultNamespaces.length > 1 ? 's' : ''
+      } (via agent config)`;
+    } else {
+      return 'No default namespace set';
+    }
+  }
+
+  @action setAllNamespacesAsDefault() {
+    this.namespaceOptions.forEach((ns) => set(ns, 'checked', true));
+    let checkedNamespaces = this.namespaceOptions.mapBy('label');
+    set(this, 'system.userDefaultNamespace', checkedNamespaces.join(', '));
+    set(this, 'model.defaults.namespace', checkedNamespaces); // explicitly modify the model to trigger a refresh
     this.notifications.add({
       title: 'Default Namespace Updated',
-      message: ns
-        ? `Default namespace is now ${ns}`
-        : 'Default namespace un-set',
+      message: 'All namespaces are now default',
+      color: 'success',
+    });
+  }
+
+  @action setDefaultNamespace(ns, evt) {
+    ns.checked = evt.target.checked;
+    let checkedNamespaces = this.namespaceOptions
+      .filterBy('checked')
+      .mapBy('label');
+    if (!checkedNamespaces.length) {
+      set(this, 'system.userDefaultNamespace', null);
+      // this.model.defaults.namespace = this.system.agentDefaults.Namespace.split(',');
+    } else {
+      set(this, 'system.userDefaultNamespace', checkedNamespaces.join(', '));
+      set(this, 'model.defaults.namespace', checkedNamespaces); // explicitly modify the model to trigger a refresh
+    }
+    this.notifications.add({
+      title: 'Default Namespace Updated',
+      message: ns.checked
+        ? `Namespace ${ns.label} is now default`
+        : `Namespace ${ns.label} is no longer default`,
       color: 'success',
     });
   }

--- a/ui/app/controllers/settings/user-settings.js
+++ b/ui/app/controllers/settings/user-settings.js
@@ -38,7 +38,6 @@ export default class SettingsUserSettingsController extends Controller {
 
   @computed('namespaces', 'nodePoolFilter', 'nodePools.[]')
   get filteredNodepools() {
-    console.log('--filtNodePools', this.nodePools, this.namespaces);
     return this.nodePools.filter((np) => np.name.includes(this.nodePoolFilter));
   }
 
@@ -73,7 +72,7 @@ export default class SettingsUserSettingsController extends Controller {
     return this.filteredNamespaces.map((ns) => ({
       label: ns.name,
       value: ns.name,
-      checked: this.namespaceDefaults.includes(ns.name),
+      checked: this.namespaceDefaults?.includes(ns.name),
     }));
   }
 
@@ -109,7 +108,7 @@ export default class SettingsUserSettingsController extends Controller {
     return this.filteredNodepools.map((np) => ({
       label: np.name,
       value: np.name,
-      checked: this.nodepoolDefaults.includes(np.name),
+      checked: this.nodepoolDefaults?.includes(np.name),
     }));
   }
 
@@ -212,7 +211,6 @@ export default class SettingsUserSettingsController extends Controller {
   }
 
   get sortedRegions() {
-    console.log('sortreg', this.system.regions);
     return this.system.regions.toArray().sort();
   }
 

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -93,6 +93,7 @@ export default class ApplicationRoute extends Route {
       this.store.unloadAll();
     }
 
+    // TODO: This resets region on refresh. Should it?
     this.set('system.activeRegion', queryParam || defaultRegion);
 
     return promises;

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -91,11 +91,10 @@ export default class IndexRoute extends Route.extend(
   async getGlobalDefaults() {
     try {
       let config = await this.system.defaults;
-      console.log('-0--config THROUGH', config);
-      return config; // Adjust based on actual response structure
+      return config;
     } catch (error) {
       console.error('Error fetching global defaults:', error);
-      return null; // Handle error and return a sensible default or null
+      return null;
     }
   }
 
@@ -106,16 +105,8 @@ export default class IndexRoute extends Route.extend(
    */
   establishDefaults(filter, globalDefaults = {}) {
     let namespaceDefaults = globalDefaults.namespace || [];
-    console.log('aye ns', namespaceDefaults, filter);
 
-    // if (!filter.includes('Namespace')) {
-    //   filter = filter
-    //     ? `${filter} and (Namespace == "${namespaceDefaults}")`
-    //     : `(Namespace == "${namespaceDefaults}")`;
-    // }
-
-    // Note: let's rewrite this because there might be multiple namespaceDefaults in an array.
-    // We want to separate each one with an ` or ` operator.
+    let nodePoolDefaults = globalDefaults.nodePool || [];
 
     if (namespaceDefaults.length > 0) {
       if (!filter.includes('Namespace')) {
@@ -126,8 +117,18 @@ export default class IndexRoute extends Route.extend(
           ? `${filter} and (${namespaceFilter})`
           : `(${namespaceFilter})`;
       }
+
+      if (nodePoolDefaults.length > 0) {
+        if (!filter.includes('NodePool')) {
+          let nodePoolFilter = nodePoolDefaults
+            .map((np) => `NodePool == "${np}"`)
+            .join(' or ');
+          filter = filter
+            ? `${filter} and (${nodePoolFilter})`
+            : `(${nodePoolFilter})`;
+        }
+      }
     }
-    console.log('=++ ret', filter);
     return filter;
   }
 
@@ -145,6 +146,7 @@ export default class IndexRoute extends Route.extend(
         jobs,
         namespaces: this.store.findAll('namespace'),
         nodePools: this.store.findAll('node-pool'),
+        defaults: await this.getGlobalDefaults(),
       });
     } catch (error) {
       try {

--- a/ui/app/routes/settings/user-settings.js
+++ b/ui/app/routes/settings/user-settings.js
@@ -1,11 +1,22 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+// @ts-check
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
 
 export default class SettingsUserSettingsRoute extends Route {
+  @service system;
   // Make sure to load namespaces
-  model() {
+  async model() {
+    let defaults = await this.system.defaults;
+    // console.log('defaults', defaults);
     return {
       namespaces: this.store.findAll('namespace'),
       nodePools: this.store.findAll('node-pool'),
+      defaults,
     };
   }
 }

--- a/ui/app/routes/settings/user-settings.js
+++ b/ui/app/routes/settings/user-settings.js
@@ -12,7 +12,6 @@ export default class SettingsUserSettingsRoute extends Route {
   // Make sure to load namespaces
   async model() {
     let defaults = await this.system.defaults;
-    // console.log('defaults', defaults);
     return {
       namespaces: this.store.findAll('namespace'),
       nodePools: this.store.findAll('node-pool'),

--- a/ui/app/routes/settings/user-settings.js
+++ b/ui/app/routes/settings/user-settings.js
@@ -1,0 +1,11 @@
+import Route from '@ember/routing/route';
+
+export default class SettingsUserSettingsRoute extends Route {
+  // Make sure to load namespaces
+  model() {
+    return {
+      namespaces: this.store.findAll('namespace'),
+      nodePools: this.store.findAll('node-pool'),
+    };
+  }
+}

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -135,7 +135,7 @@ export default class SystemService extends Service {
 
   @localStorageProperty('nomadDefaultNamespace') userDefaultNamespace;
   @localStorageProperty('nomadDefaultNodePool') userDefaultNodePool;
-  @localStorageProperty('nomadDefaultRegion') userDefaultRegion;
+  @localStorageProperty('nomadActiveRegion') userDefaultRegion;
 
   @tracked agentDefaults = {};
 
@@ -157,8 +157,8 @@ export default class SystemService extends Service {
        * @type {Defaults}
        */
       // eslint-disable-next-line ember/no-side-effects
-      this.agentDefaults = agent.config.UI.Defaults;
-      if (!this.agentDefaults) return {};
+      this.agentDefaults = agent.config?.UI?.Defaults;
+      // if (!this.agentDefaults) return {}; // TODO: I dont think this is right; I dont want to return empty when no agentDefaults, I may want to consider localStorageProperties
       return {
         region: this.userDefaultRegion || this.agentDefaults.Region,
         namespace: (this.userDefaultNamespace || this.agentDefaults.Namespace)
@@ -171,10 +171,12 @@ export default class SystemService extends Service {
     });
   }
 
-  @computed('regions.[]')
+  @computed('regions.[]', 'userDefaultRegion')
   get activeRegion() {
+    console.log('activeRegion compute', this.userDefaultRegion);
     const regions = this.regions;
-    const region = window.localStorage.nomadActiveRegion;
+    // const region = window.localStorage.nomadActiveRegion;
+    const region = this.userDefaultRegion;
 
     if (regions.includes(region)) {
       return region;
@@ -184,14 +186,17 @@ export default class SystemService extends Service {
   }
 
   set activeRegion(value) {
+    console.log('activeregion set', value);
     if (value == null) {
-      window.localStorage.removeItem('nomadActiveRegion');
+      // window.localStorage.removeItem('nomadActiveRegion');
+      this.userDefaultRegion = null;
       return;
     } else {
-      // All localStorage values are strings. Stringify first so
-      // the return value is consistent with what is persisted.
-      const strValue = value + '';
-      window.localStorage.nomadActiveRegion = strValue;
+      // // All localStorage values are strings. Stringify first so
+      // // the return value is consistent with what is persisted.
+      // const strValue = value + '';
+      // window.localStorage.nomadActiveRegion = strValue;
+      this.userDefaultRegion = value;
     }
   }
 

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -13,6 +13,16 @@ import { namespace } from '../adapters/application';
 import jsonWithDefault from '../utils/json-with-default';
 import classic from 'ember-classic-decorator';
 import { task } from 'ember-concurrency';
+import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
+import { tracked } from '@glimmer/tracking';
+
+/**
+ * @typedef {Object} RenderedDefaults
+ * @property {string} [region]
+ * @property {string[]} [namespace]
+ * @property {string[]} [nodePool]
+ */
+
 @classic
 export default class SystemService extends Service {
   @service token;
@@ -120,6 +130,44 @@ export default class SystemService extends Service {
       promise: token
         .authorizedRawRequest(`/${namespace}/regions`)
         .then(jsonWithDefault([])),
+    });
+  }
+
+  @localStorageProperty('nomadDefaultNamespace') userDefaultNamespace;
+  @localStorageProperty('nomadDefaultNodePool') userDefaultNodePool;
+  @localStorageProperty('nomadDefaultRegion') userDefaultRegion;
+
+  @tracked agentDefaults = {};
+
+  /**
+   * First read agent config for cluster-level defaults,
+   * then check localStorageProperties for user-level overrides.
+   * @type {Promise<RenderedDefaults>}
+   */
+  @computed(
+    'agent',
+    'agentDefaults.{Namespace,NodePool,Region}',
+    'userDefaultNamespace',
+    'userDefaultNodePool',
+    'userDefaultRegion'
+  )
+  get defaults() {
+    return this.agent.then((agent) => {
+      /**
+       * @type {Defaults}
+       */
+      // eslint-disable-next-line ember/no-side-effects
+      this.agentDefaults = agent.config.UI.Defaults;
+      if (!this.agentDefaults) return {};
+      return {
+        region: this.userDefaultRegion || this.agentDefaults.Region,
+        namespace: (this.userDefaultNamespace || this.agentDefaults.Namespace)
+          .split(',')
+          .map((ns) => ns.trim()),
+        nodePool: (this.userDefaultNodePool || this.agentDefaults.NodePool)
+          .split(',')
+          .map((np) => np.trim()),
+      };
     });
   }
 

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -95,7 +95,6 @@ export default class SystemService extends Service {
         .authorizedRawRequest(`/${namespace}/agent/self`)
         .then(jsonWithDefault({}))
         .then((agent) => {
-          console.log('agent', agent);
           if (agent?.config?.Version) {
             const { Version, VersionPrerelease, VersionMetadata } =
               agent.config.Version;
@@ -158,22 +157,14 @@ export default class SystemService extends Service {
        * @type {Defaults}
        */
       // eslint-disable-next-line ember/no-side-effects
-      this.agentDefaults = agent.config?.UI?.Defaults || {};
+      this.agentDefaults = agent?.config?.UI?.Defaults || {};
       return {
-        region: this.userDefaultRegion || this.agentDefaults.Region || '',
-        namespace: (
-          this.userDefaultNamespace ||
-          this.agentDefaults.Namespace ||
-          ''
-        )
-          .split(',')
+        region: this.userDefaultRegion || this.agentDefaults.Region,
+        namespace: (this.userDefaultNamespace || this.agentDefaults.Namespace)
+          ?.split(',')
           .map((ns) => ns.trim()),
-        nodePool: (
-          this.userDefaultNodePool ||
-          this.agentDefaults.NodePool ||
-          ''
-        )
-          .split(',')
+        nodePool: (this.userDefaultNodePool || this.agentDefaults.NodePool)
+          ?.split(',')
           .map((np) => np.trim()),
       };
     });
@@ -181,9 +172,7 @@ export default class SystemService extends Service {
 
   @computed('regions.[]', 'userDefaultRegion')
   get activeRegion() {
-    console.log('activeRegion compute', this.userDefaultRegion);
     const regions = this.regions;
-    // const region = window.localStorage.nomadActiveRegion;
     const region = this.userDefaultRegion;
 
     if (regions.includes(region)) {
@@ -194,16 +183,10 @@ export default class SystemService extends Service {
   }
 
   set activeRegion(value) {
-    console.log('activeregion set', value);
     if (value == null) {
-      // window.localStorage.removeItem('nomadActiveRegion');
       set(this, 'userDefaultRegion', null);
       return;
     } else {
-      // // All localStorage values are strings. Stringify first so
-      // // the return value is consistent with what is persisted.
-      // const strValue = value + '';
-      // window.localStorage.nomadActiveRegion = strValue;
       set(this, 'userDefaultRegion', value);
     }
   }

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -4,6 +4,7 @@
  */
 
 // @ts-check
+import { set } from '@ember/object';
 import Service, { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
@@ -157,14 +158,21 @@ export default class SystemService extends Service {
        * @type {Defaults}
        */
       // eslint-disable-next-line ember/no-side-effects
-      this.agentDefaults = agent.config?.UI?.Defaults;
-      // if (!this.agentDefaults) return {}; // TODO: I dont think this is right; I dont want to return empty when no agentDefaults, I may want to consider localStorageProperties
+      this.agentDefaults = agent.config?.UI?.Defaults || {};
       return {
-        region: this.userDefaultRegion || this.agentDefaults.Region,
-        namespace: (this.userDefaultNamespace || this.agentDefaults.Namespace)
+        region: this.userDefaultRegion || this.agentDefaults.Region || '',
+        namespace: (
+          this.userDefaultNamespace ||
+          this.agentDefaults.Namespace ||
+          ''
+        )
           .split(',')
           .map((ns) => ns.trim()),
-        nodePool: (this.userDefaultNodePool || this.agentDefaults.NodePool)
+        nodePool: (
+          this.userDefaultNodePool ||
+          this.agentDefaults.NodePool ||
+          ''
+        )
           .split(',')
           .map((np) => np.trim()),
       };
@@ -189,14 +197,14 @@ export default class SystemService extends Service {
     console.log('activeregion set', value);
     if (value == null) {
       // window.localStorage.removeItem('nomadActiveRegion');
-      this.userDefaultRegion = null;
+      set(this, 'userDefaultRegion', null);
       return;
     } else {
       // // All localStorage values are strings. Stringify first so
       // // the return value is consistent with what is persisted.
       // const strValue = value + '';
       // window.localStorage.nomadActiveRegion = strValue;
-      this.userDefaultRegion = value;
+      set(this, 'userDefaultRegion', value);
     }
   }
 

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+// @ts-check
 import Service, { inject as service } from '@ember/service';
 import { computed } from '@ember/object';
 import { alias } from '@ember/object/computed';
@@ -31,6 +32,50 @@ export default class SystemService extends Service {
     );
   }
 
+  /**
+   * @typedef {Object} Agent
+   * @property {Config} config
+   * @property {string} version
+   */
+
+  /**
+   * @typedef {Object} Config
+   * @property {UI} UI
+   */
+
+  /**
+   * @typedef {Object} PeerApp
+   * @property {string} BaseUIURL
+   */
+
+  /**
+   * @typedef {Object} UILabel
+   * @property {string} BackgroundColor
+   * @property {string} Text
+   * @property {string} TextColor
+   */
+
+  /**
+   * @typedef {Object} Defaults
+   * @property {string} Region
+   * @property {string} Namespace
+   * @property {string} NodePool
+   */
+
+  /**
+   * @typedef {Object} UI
+   * @property {UILabel} Label
+   * @property {Defaults} Defaults
+   * @property {PeerApp} Consul
+   * @property {PeerApp} Vault
+   * @property {boolean} Enabled
+   * @property {Object} ContentSecurityPolicy
+   */
+
+  /**
+   * Fetches the agent information for the current token
+   * @type {Promise<Agent>}
+   */
   @computed
   get agent() {
     const token = this.token;
@@ -39,6 +84,7 @@ export default class SystemService extends Service {
         .authorizedRawRequest(`/${namespace}/agent/self`)
         .then(jsonWithDefault({}))
         .then((agent) => {
+          console.log('agent', agent);
           if (agent?.config?.Version) {
             const { Version, VersionPrerelease, VersionMetadata } =
               agent.config.Version;

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -49,15 +49,14 @@
                   data-test-namespace-filter-searchbox
                 />
               </dd.Header>
-              {{#each (get this (concat "filtered" (capitalize group.label) "Options")) as |option|}}
+              {{#each (get this (concat "filtered" group.label "Options")) as |option|}}
                 <dd.Checkbox
                   {{on "change" (fn this.toggleOption option)}}
                   @value={{option.key}}
                   checked={{option.checked}}
                   data-test-dropdown-option={{option.key}}
                 >
-                  {{option.key}} {{#if (eq option.key this.defaultNamespace)}}(default){{/if}}
-                  {{!-- TODO: default here no longer works because array --}}
+                  {{option.key}} {{#if (includes option.key (get this.model.defaults group.key))}}(default){{/if}}
                 </dd.Checkbox>
               {{else}}
                 <dd.Generic data-test-dropdown-empty>
@@ -301,7 +300,14 @@
         <A.Body>
           {{this.humanizedFilterError}}
           <br><br>
-          {{#if this.model.error.correction}}
+          {{#if this.defaultsResultInNoMatches}}
+            <Hds::Alert @type="inline" @color="warning" as |A|>
+              {{!-- <A.Title>Default Filters Result in No Matches</A.Title> --}}
+              <A.Description>
+                You have configured default filters that result in no matches. If you see this error often, you can override these on the <LinkTo @route="settings.user-settings">User Settings page</LinkTo>.
+              </A.Description>
+            </Hds::Alert>
+          {{else if this.model.error.correction}}
             Did you mean
             <Hds::Button
               data-test-filter-correction

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -57,6 +57,7 @@
                   data-test-dropdown-option={{option.key}}
                 >
                   {{option.key}} {{#if (eq option.key this.defaultNamespace)}}(default){{/if}}
+                  {{!-- TODO: default here no longer works because array --}}
                 </dd.Checkbox>
               {{else}}
                 <dd.Generic data-test-dropdown-empty>

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -56,7 +56,7 @@
                   checked={{option.checked}}
                   data-test-dropdown-option={{option.key}}
                 >
-                  {{option.key}}
+                  {{option.key}} {{#if (eq option.key this.defaultNamespace)}}(default){{/if}}
                 </dd.Checkbox>
               {{else}}
                 <dd.Generic data-test-dropdown-empty>

--- a/ui/app/templates/settings/user-settings.hbs
+++ b/ui/app/templates/settings/user-settings.hbs
@@ -37,7 +37,7 @@
     </Hds::Form::Label>
     <Hds::Dropdown @height="300px" @listPosition="bottom-left" as |dd|>
       <dd.ToggleButton
-        @text={{or this.defaultNamespace "No default set"}}
+        @text={{this.namespaceDropdownLabel}}
         @color="secondary"
       />
       <dd.Header @hasDivider={{true}}>
@@ -50,15 +50,15 @@
           data-test-namespace-filter-searchbox
         />
       </dd.Header>
-      {{#each this.filteredNamespaces as |option|}}
-        <dd.Radio
-          {{on "change" (fn this.setDefaultNamespace option.id)}}
-          @value={{option.id}}
-          checked={{eq option.id this.defaultNamespace}}
-          data-test-dropdown-option={{option.id}}
+      {{#each this.namespaceOptions as |option|}}
+        <dd.Checkbox
+          {{on "change" (fn this.setDefaultNamespace option)}}
+          @value={{option.label}}
+          checked={{option.checked}}
+          data-test-dropdown-option={{option.label}}
         >
-          {{option.id}}
-        </dd.Radio>
+          {{option.label}} {{#if (includes option.id this.namespaceDefaults)}}(default){{/if}}
+        </dd.Checkbox>
       {{else}}
         <dd.Generic data-test-dropdown-empty>
           No namespaces match {{this.namespaceFilter}}
@@ -66,12 +66,29 @@
       {{/each}}
 
       <dd.Footer>
-        {{#if this.defaultNamespace}}
-          <Hds::Button @text="Unset default namespace" @isFullWidth={{true}} @color="secondary" @size="small" {{on "click" (action this.setDefaultNamespace null)}} />
+        {{#if this.namespaceOptions.length}}
+          <Hds::Button
+            @text="Include {{this.namespaceOptions.length}} {{pluralize "namespace" this.namespaceOptions.length}}"
+            @isFullWidth={{true}}
+            @color="secondary"
+            @size="small"
+            {{on "click" (action this.setAllNamespacesAsDefault)}}
+          />
         {{/if}}
       </dd.Footer>
 
     </Hds::Dropdown>
+    <Hds::Form::HelperText>
+      You can set which namespaces are selected by default in the UI.
+      {{#if this.system.agentDefaults.Namespace}}
+        <br />
+        Your agent configuration has set the default namespace to <strong>{{this.system.agentDefaults.Namespace}}</strong>.
+      {{/if}}
+      {{#if this.system.userDefaultNamespace}}
+        <br />
+        Your user settings have set the default namespace to <strong>{{this.system.userDefaultNamespace}}</strong>.
+      {{/if}}
+    </Hds::Form::HelperText>
 
     </A.Generic>
   </Hds::Alert>

--- a/ui/app/templates/settings/user-settings.hbs
+++ b/ui/app/templates/settings/user-settings.hbs
@@ -31,64 +31,117 @@
         </G.ToggleField>
       </Hds::Form::Toggle::Group>
 
-    <Hds::Separator/>
-    <Hds::Form::Label @controlId="control-ID">
-      Default Namespace
-    </Hds::Form::Label>
-    <Hds::Dropdown @height="300px" @listPosition="bottom-left" as |dd|>
-      <dd.ToggleButton
-        @text={{this.namespaceDropdownLabel}}
-        @color="secondary"
-      />
-      <dd.Header @hasDivider={{true}}>
-        <Hds::Form::TextInput::Base
-          @type="search"
-          placeholder="Filter namespaces"
-          @value={{this.namespaceFilter}}
-          {{autofocus}}
-          {{on "input" (action (mut this.namespaceFilter) value="target.value") }}
-          data-test-namespace-filter-searchbox
-        />
-      </dd.Header>
-      {{#each this.namespaceOptions as |option|}}
-        <dd.Checkbox
-          {{on "change" (fn this.setDefaultNamespace option)}}
-          @value={{option.label}}
-          checked={{option.checked}}
-          data-test-dropdown-option={{option.label}}
-        >
-          {{option.label}} {{#if (includes option.id this.namespaceDefaults)}}(default){{/if}}
-        </dd.Checkbox>
-      {{else}}
-        <dd.Generic data-test-dropdown-empty>
-          No namespaces match {{this.namespaceFilter}}
-        </dd.Generic>
-      {{/each}}
-
-      <dd.Footer>
-        {{#if this.namespaceOptions.length}}
-          <Hds::Button
-            @text="Include {{this.namespaceOptions.length}} {{pluralize "namespace" this.namespaceOptions.length}}"
-            @isFullWidth={{true}}
+      <Hds::Separator/>
+      <Hds::Form::Label>
+        Default Namespace
+        <Hds::Dropdown @height="300px" @listPosition="bottom-left" as |dd|>
+          <dd.ToggleButton
+            @text={{this.namespaceDropdownLabel}}
             @color="secondary"
+          />
+          <dd.Header @hasDivider={{true}}>
+            <Hds::Form::TextInput::Base
+              @type="search"
+              placeholder="Filter namespaces"
+              @value={{this.namespaceFilter}}
+              {{autofocus}}
+              {{on "input" (action (mut this.namespaceFilter) value="target.value") }}
+              data-test-namespace-filter-searchbox
+            />
+          </dd.Header>
+          {{#each this.namespaceOptions as |option|}}
+            <dd.Checkbox
+              {{on "change" (fn this.setDefaultNamespace option)}}
+              @value={{option.label}}
+              checked={{option.checked}}
+              data-test-dropdown-option={{option.label}}
+            >
+              {{option.label}} {{#if (includes option.id this.namespaceDefaults)}}(default){{/if}}
+            </dd.Checkbox>
+          {{else}}
+            <dd.Generic data-test-dropdown-empty>
+              {{#if this.namespaceFilter}}
+                No namespaces match "{{this.namespaceFilter}}"
+              {{else}}
+                No namespaces available
+              {{/if}}
+            </dd.Generic>
+          {{/each}}
+
+          {{!-- TODO: is this useful? --}}
+          {{!-- <dd.Footer>
+            {{#if this.namespaceOptions.length}}
+              <Hds::Button
+                @text="Select All"
+                @isFullWidth={{true}}
+                @color="secondary"
+                @size="small"
+                {{on "click" (action this.setAllNamespacesAsDefault)}}
+              />
+            {{/if}}
+          </dd.Footer> --}}
+
+        </Hds::Dropdown>
+      </Hds::Form::Label>
+      <Hds::Form::HelperText>
+        You can set which namespaces are selected by default in the UI.
+        {{#if this.system.agentDefaults.Namespace}}
+          <br />
+          Your agent configuration has set the default namespace to <strong>{{this.system.agentDefaults.Namespace}}</strong>.
+        {{/if}}
+        {{#if this.system.userDefaultNamespace}}
+          <br />
+          Your user settings have set the default namespace to <strong>{{this.system.userDefaultNamespace}}</strong>.
+
+          <Hds::Button
+            @isInline={{true}}
             @size="small"
-            {{on "click" (action this.setAllNamespacesAsDefault)}}
+            @text="Clear user default namespaces"
+            @color="tertiary"
+            @icon="minus-circle"
+            {{on "click" this.clearUserDefaultNamespaces}}
           />
         {{/if}}
-      </dd.Footer>
+      </Hds::Form::HelperText>
 
-    </Hds::Dropdown>
-    <Hds::Form::HelperText>
-      You can set which namespaces are selected by default in the UI.
-      {{#if this.system.agentDefaults.Namespace}}
-        <br />
-        Your agent configuration has set the default namespace to <strong>{{this.system.agentDefaults.Namespace}}</strong>.
+      {{#if this.system.shouldShowRegions}}      
+        <Hds::Separator/>
+        <Hds::Form::Label>
+          Default Region
+          {{!-- <RegionSwitcher @onChange={{this.setDefaultRegion}} /> --}}
+          <Hds::Dropdown @height="300px" @listPosition="bottom-left" as |dd|>
+            <dd.ToggleButton
+              @text={{or this.system.userDefaultRegion "Set a default region"}}
+              @color="secondary"
+            />
+            {{#each this.sortedRegions as |option|}}
+              {{!-- <dd.Checkbox
+                {{on "change" (fn this.setDefaultRegion option)}}
+                @value={{option.label}}
+                checked={{option.checked}}
+                data-test-dropdown-option={{option.label}}
+              >
+                {{option.label}} {{#if (includes option.id this.regionDefaults)}}(default){{/if}}
+              </dd.Checkbox> --}}
+							<dd.Interactive
+                {{on "click" (action this.setDefaultRegion option)}} @text={{option}}
+              />
+            {{/each}}
+          </Hds::Dropdown>
+        </Hds::Form::Label>
+        <Hds::Form::HelperText>
+          You can set which region is selected by default in the UI.
+          {{#if this.system.agentDefaults.Region}}
+            <br />
+            Your agent configuration has set the default region to <strong>{{this.system.agentDefaults.Region}}</strong>.
+          {{/if}}
+          {{#if this.system.userDefaultRegion}}
+            <br />
+            Your user settings have set the default region to <strong>{{this.system.userDefaultRegion}}</strong> (This updates every time you change regions via the UI)
+          {{/if}}
+        </Hds::Form::HelperText>
+
       {{/if}}
-      {{#if this.system.userDefaultNamespace}}
-        <br />
-        Your user settings have set the default namespace to <strong>{{this.system.userDefaultNamespace}}</strong>.
-      {{/if}}
-    </Hds::Form::HelperText>
 
     </A.Generic>
   </Hds::Alert>

--- a/ui/app/templates/settings/user-settings.hbs
+++ b/ui/app/templates/settings/user-settings.hbs
@@ -67,20 +67,6 @@
               {{/if}}
             </dd.Generic>
           {{/each}}
-
-          {{!-- TODO: is this useful? --}}
-          {{!-- <dd.Footer>
-            {{#if this.namespaceOptions.length}}
-              <Hds::Button
-                @text="Select All"
-                @isFullWidth={{true}}
-                @color="secondary"
-                @size="small"
-                {{on "click" (action this.setAllNamespacesAsDefault)}}
-              />
-            {{/if}}
-          </dd.Footer> --}}
-
         </Hds::Dropdown>
       </Hds::Form::Label>
       <Hds::Form::HelperText>
@@ -100,6 +86,66 @@
             @color="tertiary"
             @icon="minus-circle"
             {{on "click" this.clearUserDefaultNamespaces}}
+          />
+        {{/if}}
+      </Hds::Form::HelperText>
+
+      <Hds::Separator/>
+
+      <Hds::Form::Label>
+        Default Node Pool
+        <Hds::Dropdown @height="300px" @listPosition="bottom-left" as |dd|>
+          <dd.ToggleButton
+            @text={{this.nodepoolDropdownLabel}}
+            @color="secondary"
+          />
+          <dd.Header @hasDivider={{true}}>
+            <Hds::Form::TextInput::Base
+              @type="search"
+              placeholder="Filter node pools"
+              @value={{this.nodepoolFilter}}
+              {{autofocus}}
+              {{on "input" (action (mut this.nodepoolFilter) value="target.value") }}
+              data-test-nodepool-filter-searchbox
+            />
+          </dd.Header>
+          {{#each this.nodepoolOptions as |option|}}
+            <dd.Checkbox
+              {{on "change" (fn this.setDefaultNodePool option)}}
+              @value={{option.label}}
+              checked={{option.checked}}
+              data-test-dropdown-option={{option.label}}
+            >
+              {{option.label}} {{#if (includes option.id this.nodepoolDefaults)}}(default){{/if}}
+            </dd.Checkbox>
+          {{else}}
+            <dd.Generic data-test-dropdown-empty>
+              {{#if this.nodepoolFilter}}
+                No node pools match "{{this.nodepoolFilter}}"
+              {{else}}
+                No node pools available
+              {{/if}}
+            </dd.Generic>
+          {{/each}}
+        </Hds::Dropdown>
+      </Hds::Form::Label>
+      <Hds::Form::HelperText>
+        You can set which node pools are selected by default in the UI.
+        {{#if this.system.agentDefaults.NodePool}}
+          <br />
+          Your agent configuration has set the default node pool to <strong>{{this.system.agentDefaults.NodePool}}</strong>.
+        {{/if}}
+        {{#if this.system.userDefaultNodePool}}
+          <br />
+          Your user settings have set the default node pool to <strong>{{this.system.userDefaultNodePool}}</strong>.
+
+          <Hds::Button
+            @isInline={{true}}
+            @size="small"
+            @text="Clear user default node pools"
+            @color="tertiary"
+            @icon="minus-circle"
+            {{on "click" this.clearUserDefaultNodePools}}
           />
         {{/if}}
       </Hds::Form::HelperText>

--- a/ui/app/templates/settings/user-settings.hbs
+++ b/ui/app/templates/settings/user-settings.hbs
@@ -30,6 +30,49 @@
           <F.HelperText>When enabled, new or removed jobs will pop into and out of view on your jobs page. When disabled, you will be notified that changes are pending.</F.HelperText>
         </G.ToggleField>
       </Hds::Form::Toggle::Group>
+
+    <Hds::Separator/>
+    <Hds::Form::Label @controlId="control-ID">
+      Default Namespace
+    </Hds::Form::Label>
+    <Hds::Dropdown @height="300px" @listPosition="bottom-left" as |dd|>
+      <dd.ToggleButton
+        @text={{or this.defaultNamespace "No default set"}}
+        @color="secondary"
+      />
+      <dd.Header @hasDivider={{true}}>
+        <Hds::Form::TextInput::Base
+          @type="search"
+          placeholder="Filter namespaces"
+          @value={{this.namespaceFilter}}
+          {{autofocus}}
+          {{on "input" (action (mut this.namespaceFilter) value="target.value") }}
+          data-test-namespace-filter-searchbox
+        />
+      </dd.Header>
+      {{#each this.filteredNamespaces as |option|}}
+        <dd.Radio
+          {{on "change" (fn this.setDefaultNamespace option.id)}}
+          @value={{option.id}}
+          checked={{eq option.id this.defaultNamespace}}
+          data-test-dropdown-option={{option.id}}
+        >
+          {{option.id}}
+        </dd.Radio>
+      {{else}}
+        <dd.Generic data-test-dropdown-empty>
+          No namespaces match {{this.namespaceFilter}}
+        </dd.Generic>
+      {{/each}}
+
+      <dd.Footer>
+        {{#if this.defaultNamespace}}
+          <Hds::Button @text="Unset default namespace" @isFullWidth={{true}} @color="secondary" @size="small" {{on "click" (action this.setDefaultNamespace null)}} />
+        {{/if}}
+      </dd.Footer>
+
+    </Hds::Dropdown>
+
     </A.Generic>
   </Hds::Alert>
 </section>

--- a/ui/app/utils/properties/local-storage.js
+++ b/ui/app/utils/properties/local-storage.js
@@ -17,8 +17,14 @@ export default function localStorageProperty(localStorageKey, defaultValue) {
       return persistedValue ? JSON.parse(persistedValue) : defaultValue;
     },
     set(key, value) {
-      window.localStorage.setItem(localStorageKey, JSON.stringify(value));
-      return value;
+      if (value === null || value === undefined) {
+        // not just !value because 0 or false could be valid localStorage settings
+        window.localStorage.removeItem(localStorageKey);
+        return defaultValue;
+      } else {
+        window.localStorage.setItem(localStorageKey, JSON.stringify(value));
+        return value;
+      }
     },
   });
 }

--- a/ui/app/utils/properties/local-storage.js
+++ b/ui/app/utils/properties/local-storage.js
@@ -14,6 +14,13 @@ export default function localStorageProperty(localStorageKey, defaultValue) {
   return computed({
     get() {
       const persistedValue = window.localStorage.getItem(localStorageKey);
+      console.log(
+        'persval',
+        localStorageKey,
+        persistedValue,
+        typeof persistedValue
+      );
+      console.log('and so', JSON.parse(persistedValue));
       return persistedValue ? JSON.parse(persistedValue) : defaultValue;
     },
     set(key, value) {

--- a/ui/app/utils/properties/local-storage.js
+++ b/ui/app/utils/properties/local-storage.js
@@ -14,13 +14,6 @@ export default function localStorageProperty(localStorageKey, defaultValue) {
   return computed({
     get() {
       const persistedValue = window.localStorage.getItem(localStorageKey);
-      console.log(
-        'persval',
-        localStorageKey,
-        persistedValue,
-        typeof persistedValue
-      );
-      console.log('and so', JSON.parse(persistedValue));
       return persistedValue ? JSON.parse(persistedValue) : defaultValue;
     },
     set(key, value) {

--- a/ui/tests/acceptance/regions-test.js
+++ b/ui/tests/acceptance/regions-test.js
@@ -119,7 +119,7 @@ module('Acceptance | regions (many)', function (hooks) {
     assert.equal(currentURL(), '/jobs', 'No region query param');
     assert.equal(
       window.localStorage.nomadActiveRegion,
-      'global',
+      '"global"',
       'Region in localStorage'
     );
   });
@@ -137,7 +137,7 @@ module('Acceptance | regions (many)', function (hooks) {
     );
     assert.equal(
       window.localStorage.nomadActiveRegion,
-      newRegion,
+      `"${newRegion}"`,
       'New region in localStorage'
     );
   });
@@ -156,7 +156,7 @@ module('Acceptance | regions (many)', function (hooks) {
     );
     assert.equal(
       window.localStorage.nomadActiveRegion,
-      defaultRegion,
+      `"${defaultRegion}"`,
       'New region in localStorage'
     );
   });
@@ -173,7 +173,7 @@ module('Acceptance | regions (many)', function (hooks) {
     );
     assert.equal(
       window.localStorage.nomadActiveRegion,
-      region,
+      `"${region}"`,
       'Region is also set in localStorage from a detail page'
     );
   });

--- a/ui/tests/unit/adapters/deployment-test.js
+++ b/ui/tests/unit/adapters/deployment-test.js
@@ -20,7 +20,7 @@ module('Unit | Adapter | Deployment', function (hooks) {
     this.server = startMirage();
 
     this.initialize = async ({ region } = {}) => {
-      if (region) window.localStorage.nomadActiveRegion = region;
+      if (region) window.localStorage.nomadActiveRegion = `"${region}"`;
 
       this.server.create('region', { id: 'region-1' });
       this.server.create('region', { id: 'region-2' });
@@ -87,6 +87,7 @@ module('Unit | Adapter | Deployment', function (hooks) {
 
       const request = this.server.pretender.handledRequests[0];
 
+      console.log('req', request);
       assert.equal(
         `${request.method} ${request.url}`,
         testCase.fail(deployment.id)


### PR DESCRIPTION
TODO: Add Nomad Variables as one of the ways that user preferences can get read.

Order should be:
1. config from the user agent's ui.defaults block
2. defaults from a nomad variable at `nomad/ui/defaults/token_ID` or something similar
3. defaults from localStorage, set from a form in the UI
4. manually editing the page in question (filtering by namespace on the jobs page for example, which doesn't re-set your defaults but does override them for that session)


resolves https://github.com/hashicorp/nomad/issues/11970