### PR TITLE
[ui] Fix: upload jobspec button

### DIFF
--- a/.changelog/23548.txt
+++ b/.changelog/23548.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix the Upload Jobspec button on the Run Job page
+```

--- a/ui/app/modifiers/code-mirror.js
+++ b/ui/app/modifiers/code-mirror.js
@@ -31,6 +31,8 @@ export default class CodeMirrorModifier extends Modifier {
       this.element = element;
       this.args = { positional, named };
       this._setup();
+    } else {
+      this.didUpdateArguments();
     }
   }
 

--- a/ui/app/templates/components/job-editor.hbs
+++ b/ui/app/templates/components/job-editor.hbs
@@ -15,28 +15,26 @@
         <p>
           Paste or author HCL or JSON to submit to your cluster, or select from a list of templates. A plan will be requested before the job is submitted. You can also attach a job spec by uploading a job file or dragging &amp; dropping a file to the editor.
         </p>
-
-        {{#if (can "read variable" path="nomad/job-templates/*" namespace="*")}}
-          <Hds::ButtonSet>
-            <label
-              class="job-spec-upload hds-button hds-button--color-secondary hds-button--size-medium"
-            >
-              <div class="hds-button__text">Upload file</div>
-              <input
-              type="file"
-                onchange={{action this.uploadJobSpec}}
-                accept=".hcl,.json,.nomad"
-              />
-            </label>
+        <Hds::ButtonSet>
+          <label
+            class="job-spec-upload hds-button hds-button--color-secondary hds-button--size-medium"
+          >
+            <div class="hds-button__text">Upload file</div>
+            <input
+            type="file"
+              onchange={{action this.fns.onUpload}}
+              accept=".hcl,.json,.nomad"
+            />
+          </label>
+          {{#if (can "read variable" path="nomad/job-templates/*" namespace="*")}}
             <Hds::Button
               @text="Choose from template"
               @color="secondary"
               @route="jobs.run.templates"
               data-test-choose-template
             />
-          </Hds::ButtonSet>
-        {{/if}}
-
+          {{/if}}
+        </Hds::ButtonSet>
       </header>
     {{/if}}
     {{did-update this.setDefinitionOnModel this.definition}}


### PR DESCRIPTION
At some point recently, the upload jobspec button (on the Job Run page) stopped working and I've yet to find a good reason why.

The job editor component uses what's called a [render modifier](https://blog.emberjs.com/coming-soon-in-ember-octane-part-4/) in Ember. It uses [a library](https://github.com/ember-modifier/ember-modifier/tree/main) to help add syntactical sugar to do this.

(Modifier TLDR: it "modifies" an existing HTML element, like a `<div>` in this case, instead of creating a new one in an Ember context. This is useful for codemirror, our text editor, because it needs to exist outside of an Ember context for lifecycle reasons)

There's a lifecycle hook in modifiers written this way called `modify()`, and there were previously ones called `didUpdateArguments()` and `didUpdateArguments()`. Previously, we'd set this up to use `didUpdateArguments` to let the `code-mirror` modifier, but per the library's [migrations guide](https://github.com/ember-modifier/ember-modifier/blob/main/MIGRATIONS.md#didupdatearguments), this is/was being deprecated.

Problem is, `modify()` is a lifecycle hook that happens both on initial load and on content update and on external-attribute (like the "should word-wrap" property, etc.) and bundling everything into `modify()` over-compounds this pattern a bit.

This PR makes it so that we still use `didUpdateArguments()`, but as a conditional method call from `modify()`.

### To test:
Head to the jobs index page, click "Run Job", click "Upload", and you should now see the text of your .hcl upload appear in the text editor. In previous (1.8.x anyway) versions this should not work.

![image](https://github.com/hashicorp/nomad/assets/713991/fe395794-965b-479a-ba0c-c88577b534b7)
