### PR TITLE
[ui] Fix: Actions should pass job id instead of job name

### DIFF
--- a/.changelog/23553.txt
+++ b/.changelog/23553.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Actions run from jobs with explicit name properties now work from the web UI
+```

--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -192,7 +192,7 @@ export default class JobAdapter extends WatchableNamespaceIDs {
 
     const wsUrl =
       `${protocol}//${prefix}/job/${encodeURIComponent(
-        job.get('name')
+        job.get('plainId')
       )}/action` +
       `?namespace=${job.get('namespace.id')}&action=${
         action.name


### PR DESCRIPTION
This makes it so that jobs with a `name` field that differs from their ID will correctly route an action when run via the web UI.

Resolves #23464 