### PR TITLE
api: handle newlines in JobSubmission vars correctly

### DIFF
--- a/.changelog/23560.txt
+++ b/.changelog/23560.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fixed bug where newlines in JobSubmission vars weren't encoded correctly
+```

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/cronexpr"
@@ -996,6 +997,15 @@ func (js *JobSubmission) Canonicalize() {
 
 	if len(js.VariableFlags) == 0 {
 		js.VariableFlags = nil
+	}
+
+	// if there are multiline variables, make sure we escape the newline
+	// characters to preserve them. This way, when the job gets stopped and
+	// restarted in the UI, variable values will be parsed correctly.
+	for k, v := range js.VariableFlags {
+		if strings.Contains(v, "\n") {
+			js.VariableFlags[k] = strings.ReplaceAll(v, "\n", "\\n")
+		}
 	}
 }
 

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1496,6 +1496,15 @@ func TestJobs_JobSubmission_Canonicalize(t *testing.T) {
 		js.Canonicalize()
 		must.Nil(t, js.VariableFlags)
 	})
+
+	t.Run("multiline var values", func(t *testing.T) {
+		js := &JobSubmission{
+			Source:        "abc123",
+			VariableFlags: map[string]string{"test": "foo\nbar"},
+		}
+		js.Canonicalize()
+		must.Eq(t, js.VariableFlags["test"], "foo\\nbar")
+	})
 }
 
 func TestJobs_JobSubmission_Copy(t *testing.T) {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -908,6 +908,8 @@ func apiJobSubmissionToStructs(submission *api.JobSubmission) *structs.JobSubmis
 	if submission == nil {
 		return nil
 	}
+
+	submission.Canonicalize()
 	return &structs.JobSubmission{
 		Source:        submission.Source,
 		Format:        submission.Format,


### PR DESCRIPTION
Fixes a bug where variable values in job submissions that contained newlines weren't encoded correctly, and thus jobs that contained them couldn't be resumed once stopped via the UI. 

Internal ref: https://hashicorp.atlassian.net/browse/NET-9966