### PR TITLE
e2e: purge the job in the UI stop_proxy() script

### DIFF
--- a/e2e/ui/run.sh
+++ b/e2e/ui/run.sh
@@ -92,7 +92,7 @@ _get_svc_ip() {
 stop_proxy() {
   # make sure addr isn't still pointed at the proxy
   export NOMAD_ADDR="${NOMAD_ADDR/6464/4646}"
-  nomad job stop -namespace=proxy nomad-proxy
+  nomad job stop -purge -namespace=proxy nomad-proxy
   nomad namespace delete proxy
 }
 


### PR DESCRIPTION
otherwise namespace deletion fails due to non-terminal allocations