### PR TITLE
fix cpucompat_default_test

### DIFF
--- a/nomad/structs/cpucompat_default_test.go
+++ b/nomad/structs/cpucompat_default_test.go
@@ -27,7 +27,6 @@ func TestNUMA_topologyFromLegacy_plain(t *testing.T) {
 	result := topologyFromLegacy(old)
 
 	exp := &numalib.Topology{
-		NodeIDs:   idset.From[hw.NodeID]([]hw.NodeID{0}),
 		Distances: numalib.SLIT{{10}},
 		Cores: []numalib.Core{
 			makeLegacyCore(0),
@@ -38,12 +37,12 @@ func TestNUMA_topologyFromLegacy_plain(t *testing.T) {
 		OverrideTotalCompute:   12800,
 		OverrideWitholdCompute: 0,
 	}
-
+	exp.SetNodes(idset.From[hw.NodeID]([]hw.NodeID{0}))
 	// only compares compute total
 	must.Equal(t, exp, result)
 
 	// check underlying fields
-	must.Eq(t, exp.NodeIDs, result.NodeIDs)
+	must.Eq(t, exp.GetNodes(), result.GetNodes())
 	must.Eq(t, exp.Distances, result.Distances)
 	must.Eq(t, exp.Cores, result.Cores)
 	must.Eq(t, exp.OverrideTotalCompute, result.OverrideTotalCompute)


### PR DESCRIPTION
I think this was missed because of the `!linux` build tag.
This [previous commit](https://github.com/hashicorp/nomad/commit/7d73065066e61c19e96a555749a51be83d14926f#diff-5c2cb0736f6332a8e02ab7b266defcdc423a2caaf16f14fb69e5e0215cc053c1R60) changed NodeIDs to a private attribute.