### PR TITLE
e2e: test cni args

### DIFF
--- a/e2e/cni/cni_test.go
+++ b/e2e/cni/cni_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package cni
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/e2e/v3/cluster3"
+	"github.com/hashicorp/nomad/e2e/v3/jobs3"
+	"github.com/shoenig/test/must"
+)
+
+func TestCNIIntegration(t *testing.T) {
+	cluster3.Establish(t,
+		cluster3.Leader(),
+		cluster3.LinuxClients(1),
+	)
+
+	t.Run("testArgs", testCNIArgs)
+}
+
+func testCNIArgs(t *testing.T) {
+	job, _ := jobs3.Submit(t, "./input/cni_args.nomad.hcl")
+	logs := job.Exec("group", "task", []string{"cat", "local/victory"})
+	t.Logf("FancyMessage: %s", logs.Stdout)
+	// "global" is the Nomad node's region, interpolated in the jobspec,
+	// passed through the CNI plugin, and cat-ed by the task.
+	must.Eq(t, "global\n", logs.Stdout)
+}

--- a/e2e/cni/input/cni_args.nomad.hcl
+++ b/e2e/cni/input/cni_args.nomad.hcl
@@ -1,0 +1,40 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+job "cni_args" {
+  group "group" {
+    network {
+      mode = "cni/cni_args"
+      cni {
+        # feature under test
+        args = {
+          # the message gets placed as a file called "victory"
+          # in the task dir specified here by the cni_args.sh plugin
+          FancyMessage = "${node.region}"
+          FancyTaskDir = "${NOMAD_ALLOC_DIR}/task/local"
+        }
+      }
+    }
+    task "task" {
+      driver = "docker"
+      config {
+        image   = "busybox:1"
+        command = "sh"
+        args    = ["-c", "cat local/victory; sleep 60"]
+      }
+    }
+    # go faster
+    update {
+      min_healthy_time = "0s"
+    }
+    # fail faster (if it does fail)
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+  }
+}

--- a/e2e/terraform/packer/ubuntu-jammy-amd64/cni_args.conflist
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/cni_args.conflist
@@ -1,0 +1,9 @@
+{
+	"cniVersion": "1.0.0",
+	"name": "cni_args",
+	"plugins": [
+		{
+		    "type": "cni_args.sh"
+		}
+	]
+}

--- a/e2e/terraform/packer/ubuntu-jammy-amd64/cni_args.sh
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/cni_args.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+set -euo pipefail
+
+# things are prefixed with "Fancy*" because this is a fancy plugin.
+# CNI_ARGS='IgnoreUnknown=true;FancyTaskDir=/tmp/cni_args;FancyMessage=hiiii;Another=whatever'
+# what we need to do:
+# 1. read CNI_ARGS environment variable
+#    * write to a file named $FancyTaskDir/victory
+# 2. write CNI-spec json to stdout for Nomad to read
+
+# https://github.com/containernetworking/cni/blob/main/SPEC.md#version-success
+function version() {
+  cat <<EOF
+{
+    "cniVersion": "1.0.0",
+    "supportedVersions": [ "0.1.0", "0.2.0", "0.3.0", "0.3.1", "0.4.0", "1.0.0" ]
+}
+EOF
+}
+
+# https://github.com/containernetworking/cni/blob/main/SPEC.md#add-success
+function add() {
+  # get our task dir out of the env var
+  task_dir="$(echo "$CNI_ARGS" | tr ';' '\n' | awk -F= '/^FancyTaskDir=/ {print$2}')"
+  message="$(echo "$CNI_ARGS" | tr ';' '\n' | awk -F= '/^FancyMessage=/ {print$2}')"
+  1>&2 echo "got task dir: $task_dir; message: $message"
+
+  mkdir -p "$task_dir"
+  # and write something to a file we can check in the test.
+  echo "$message" > "$task_dir/victory"
+}
+
+# run the appropriate CNI command
+case "$CNI_COMMAND" in
+  VERSION) version ; exit ;;
+  ADD) add ;;
+esac
+
+# bogus reply so nomad doesn't error
+cat <<EOF
+{
+    "cniVersion" : "1.0.0",
+    "ips": [
+        {
+          "address": "10.1.0.5/16",
+          "gateway": "10.1.0.1",
+          "interface": 1
+        }
+    ],
+    "routes": [
+      {
+        "dst": "0.0.0.0/0"
+      }
+    ],
+    "interfaces": [
+        {
+            "name": "cni0",
+            "mac": "00:11:22:33:44:55"
+        }
+    ],
+    "dns": {
+      "nameservers": [ "10.1.0.1" ]
+    }
+}
+EOF
+

--- a/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
@@ -5,7 +5,7 @@
 # setup script for Ubuntu Linux 22.04. Assumes that Packer has placed
 # build-time config files at /tmp/linux
 
-set -euo pipefail
+set -xeuo pipefail
 
 NOMAD_PLUGIN_DIR=/opt/nomad/plugins/
 
@@ -22,6 +22,7 @@ mkdir_for_root /opt
 mkdir_for_root /opt/bin # for envoy
 mkdir_for_root /srv/data # for host volumes
 mkdir_for_root /opt/cni/bin
+mkdir_for_root /opt/cni/config
 
 # Dependencies
 sudo apt-get update
@@ -116,6 +117,10 @@ echo "Installing CNI plugins"
 wget -q -O - \
      https://github.com/containernetworking/plugins/releases/download/v1.0.0/cni-plugins-linux-amd64-v1.0.0.tgz \
     | sudo tar -C /opt/cni/bin -xz
+
+# Copy cni_args plugin and network configuration files into opt/cni/bin and opt/cni/config
+sudo mv /tmp/linux/cni_args.conflist /opt/cni/config
+sudo mv /tmp/linux/cni_args.sh /opt/cni/bin
 
 # Podman
 echo "Installing Podman"


### PR DESCRIPTION
This PR adds an e2e test for cni args implemented in #23538. 

The test uses a job specification with a custom cni plugin "cni_args.sh" to write a file containing an interpolated variable passed in as a cni arg to the task local folder. Then the test makes sure that this file exists in the correct location and checks that the value was written and interpolated correctly.