### PR TITLE
docker: adjust capabilities on Windows

### DIFF
--- a/.changelog/23599.txt
+++ b/.changelog/23599.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+windows: Fix bug with containers capabilities on Docker CE
+```

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1115,14 +1115,11 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 	if err != nil {
 		return c, err
 	}
-	info, err := client.Info()
-	if err != nil {
-		return c, err
-	}
+	ver, _ := client.Version()
 
 	// set add/drop capabilities
 	if hostConfig.CapAdd, hostConfig.CapDrop, err = capabilities.Delta(
-		capabilities.DockerDefaults(info), d.config.AllowCaps, driverConfig.CapAdd, driverConfig.CapDrop,
+		capabilities.DockerDefaults(ver), d.config.AllowCaps, driverConfig.CapAdd, driverConfig.CapDrop,
 	); err != nil {
 		return c, err
 	}

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1115,7 +1115,10 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 	if err != nil {
 		return c, err
 	}
-	ver, _ := client.Version()
+	ver, err := client.Version()
+	if err != nil {
+		return c, err
+	}
 
 	// set add/drop capabilities
 	if hostConfig.CapAdd, hostConfig.CapDrop, err = capabilities.Delta(

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1109,9 +1109,20 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 	}
 	hostConfig.Privileged = driverConfig.Privileged
 
+	// get docker client info (we need to know the runtime to adjust
+	// OS-specific capabilities)
+	client, err := d.getDockerClient()
+	if err != nil {
+		return c, err
+	}
+	info, err := client.Info()
+	if err != nil {
+		return c, err
+	}
+
 	// set add/drop capabilities
 	if hostConfig.CapAdd, hostConfig.CapDrop, err = capabilities.Delta(
-		capabilities.DockerDefaults(), d.config.AllowCaps, driverConfig.CapAdd, driverConfig.CapDrop,
+		capabilities.DockerDefaults(info), d.config.AllowCaps, driverConfig.CapAdd, driverConfig.CapDrop,
 	); err != nil {
 		return c, err
 	}

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/nomad/client/lib/numalib"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/client/testutil"
-	"github.com/hashicorp/nomad/drivers/shared/capabilities"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclspecutils"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
@@ -195,13 +194,6 @@ func dockerDriverHarness(t *testing.T, cfg map[string]interface{}) *dtestutil.Dr
 				"image_delay": "1s",
 			},
 		}
-	}
-
-	// If on windows, "allow" (don't attempt to drop) linux capabilities.
-	// https://github.com/hashicorp/nomad/issues/15181
-	// TODO: this should instead get fixed properly in capabilities package.
-	if _, ok := cfg["allow_caps"]; !ok && runtime.GOOS == "windows" {
-		cfg["allow_caps"] = capabilities.DockerDefaults().Slice(false)
 	}
 
 	plugLoader, err := loader.NewPluginLoader(&loader.PluginLoaderConfig{

--- a/drivers/docker/driver_windows.go
+++ b/drivers/docker/driver_windows.go
@@ -16,10 +16,6 @@ func getPortBinding(ip string, port string) docker.PortBinding {
 	return docker.PortBinding{HostIP: "", HostPort: port}
 }
 
-func tweakCapabilities(basics, adds, drops []string) ([]string, error) {
-	return nil, nil
-}
-
 var containerAdminErrMsg = "running container as ContainerAdmin is unsafe; change the container user, set task configuration to privileged or enable windows_allow_insecure_container_admin to disable this check"
 
 func validateImageUser(user, taskUser string, taskDriverConfig *TaskConfig, driverConfig *DriverConfig) error {

--- a/drivers/shared/capabilities/defaults.go
+++ b/drivers/shared/capabilities/defaults.go
@@ -6,6 +6,7 @@ package capabilities
 import (
 	"fmt"
 	"regexp"
+	"runtime"
 
 	"github.com/syndtr/gocapability/capability"
 )
@@ -64,6 +65,11 @@ func Supported() *Set {
 			continue
 		}
 		s.Add(c.String())
+	}
+
+	// workaround for Windows that doesn't support NET_RAW
+	if runtime.GOOS == "windows" {
+		s.Remove([]string{"NET_RAW"})
 	}
 
 	return s

--- a/drivers/shared/capabilities/defaults.go
+++ b/drivers/shared/capabilities/defaults.go
@@ -6,7 +6,6 @@ package capabilities
 import (
 	"fmt"
 	"regexp"
-	"runtime"
 
 	"github.com/syndtr/gocapability/capability"
 )
@@ -28,17 +27,6 @@ var (
 // This set is use in the as HCL configuration default, described by HCLSpecLiteral.
 func NomadDefaults() *Set {
 	return New(extractLiteral.FindAllString(HCLSpecLiteral, -1))
-}
-
-// DockerDefaults is a list of Linux capabilities enabled by Docker by default
-// and is used to compute the set of capabilities to add/drop given docker driver
-// configuration.
-//
-// https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
-func DockerDefaults() *Set {
-	defaults := NomadDefaults()
-	defaults.Add("NET_RAW")
-	return defaults
 }
 
 // Supported returns the set of capabilities supported by the operating system.
@@ -65,11 +53,6 @@ func Supported() *Set {
 			continue
 		}
 		s.Add(c.String())
-	}
-
-	// workaround for Windows that doesn't support NET_RAW
-	if runtime.GOOS == "windows" {
-		s.Remove([]string{"NET_RAW"})
 	}
 
 	return s

--- a/drivers/shared/capabilities/defaults_default.go
+++ b/drivers/shared/capabilities/defaults_default.go
@@ -12,7 +12,7 @@ import docker "github.com/fsouza/go-dockerclient"
 // configuration.
 //
 // https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
-func DockerDefaults(info *docker.DockerInfo) *Set {
+func DockerDefaults(info *docker.Env) *Set {
 	defaults := NomadDefaults()
 	defaults.Add("NET_RAW")
 	return defaults

--- a/drivers/shared/capabilities/defaults_default.go
+++ b/drivers/shared/capabilities/defaults_default.go
@@ -1,0 +1,17 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build !windows
+
+package capabilities
+
+// DockerDefaults is a list of Linux capabilities enabled by Docker by default
+// and is used to compute the set of capabilities to add/drop given docker driver
+// configuration.
+//
+// https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
+func DockerDefaults() *Set {
+	defaults := NomadDefaults()
+	defaults.Add("NET_RAW")
+	return defaults
+}

--- a/drivers/shared/capabilities/defaults_default.go
+++ b/drivers/shared/capabilities/defaults_default.go
@@ -5,12 +5,14 @@
 
 package capabilities
 
+import docker "github.com/fsouza/go-dockerclient"
+
 // DockerDefaults is a list of Linux capabilities enabled by Docker by default
 // and is used to compute the set of capabilities to add/drop given docker driver
 // configuration.
 //
 // https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities
-func DockerDefaults() *Set {
+func DockerDefaults(info *docker.DockerInfo) *Set {
 	defaults := NomadDefaults()
 	defaults.Add("NET_RAW")
 	return defaults

--- a/drivers/shared/capabilities/defaults_test.go
+++ b/drivers/shared/capabilities/defaults_test.go
@@ -26,7 +26,7 @@ func TestSet_NomadDefaults(t *testing.T) {
 func TestSet_DockerDefaults(t *testing.T) {
 	ci.Parallel(t)
 
-	result := DockerDefaults()
+	result := DockerDefaults(nil)
 	require.Len(t, result.Slice(false), 14)
 	require.Contains(t, result.String(), "net_raw")
 }
@@ -280,7 +280,7 @@ func TestCaps_Delta(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			add, drop, err := Delta(DockerDefaults(), tc.allowCaps, tc.capAdd, tc.capDrop)
+			add, drop, err := Delta(DockerDefaults(nil), tc.allowCaps, tc.capAdd, tc.capDrop)
 			if !tc.skip {
 				require.Equal(t, tc.err, err)
 				require.Equal(t, tc.expAdd, add)

--- a/drivers/shared/capabilities/defaults_windows.go
+++ b/drivers/shared/capabilities/defaults_windows.go
@@ -1,0 +1,14 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build windows
+
+package capabilities
+
+// DockerDefaults is a list of Windows capabilities enabled by Docker by default
+// and is used to compute the set of capabilities to add/drop given docker driver
+// configuration.
+func DockerDefaults() *Set {
+	defaults := NomadDefaults()
+	return defaults
+}

--- a/drivers/shared/capabilities/defaults_windows.go
+++ b/drivers/shared/capabilities/defaults_windows.go
@@ -5,10 +5,25 @@
 
 package capabilities
 
+import (
+	"strings"
+
+	docker "github.com/fsouza/go-dockerclient"
+)
+
 // DockerDefaults is a list of Windows capabilities enabled by Docker by default
 // and is used to compute the set of capabilities to add/drop given docker driver
 // configuration.
-func DockerDefaults() *Set {
+//
+// Doing this on windows is somewhat tricky, because capabilities differ by
+// runtime, so we have to perform some extra checks.
+func DockerDefaults(info *docker.DockerInfo) *Set {
 	defaults := NomadDefaults()
+
+	// Docker CE doesn't support NET_RAW on Windows, Mirantis (aka Docker EE) does
+	if info != nil && !strings.Contains(info.ServerVersion, "-ce") {
+		defaults.Add("NET_RAW")
+	}
+
 	return defaults
 }

--- a/drivers/shared/capabilities/defaults_windows.go
+++ b/drivers/shared/capabilities/defaults_windows.go
@@ -17,11 +17,15 @@ import (
 //
 // Doing this on windows is somewhat tricky, because capabilities differ by
 // runtime, so we have to perform some extra checks.
-func DockerDefaults(info *docker.DockerInfo) *Set {
+func DockerDefaults(ver *docker.Env) *Set {
 	defaults := NomadDefaults()
 
 	// Docker CE doesn't support NET_RAW on Windows, Mirantis (aka Docker EE) does
-	if info != nil && !strings.Contains(info.ServerVersion, "-ce") {
+	var platform string
+	if ver != nil {
+		platform = ver.Get("Platform")
+	}
+	if strings.Contains(platform, "Mirantis") {
 		defaults.Add("NET_RAW")
 	}
 


### PR DESCRIPTION
Adjusts Docker capabilities per OS, and checks for runtime on Windows. 

Fixes #15181 
Internal ref: https://hashicorp.atlassian.net/browse/NET-9506