### PR TITLE
cni: test Setup method

### DIFF
--- a/client/allocrunner/networking_cni.go
+++ b/client/allocrunner/networking_cni.go
@@ -49,21 +49,6 @@ const (
 	defaultCNIInterfacePrefix = "eth"
 )
 
-type nsOpts struct {
-	args  map[string]string
-	ports []cni.PortMapping
-}
-
-func (o *nsOpts) WithArgs(args map[string]string) cni.NamespaceOpts {
-	o.args = args
-	return cni.WithLabels(args)
-}
-
-func (o *nsOpts) WithCapabilityPortMap(ports []cni.PortMapping) cni.NamespaceOpts {
-	o.ports = ports
-	return cni.WithCapabilityPortMap(ports)
-}
-
 type cniNetworkConfigurator struct {
 	cni                     cni.CNI
 	cniConf                 []byte
@@ -169,8 +154,8 @@ func (c *cniNetworkConfigurator) Setup(ctx context.Context, alloc *structs.Alloc
 	for attempt := 1; ; attempt++ {
 		var err error
 		if res, err = c.cni.Setup(ctx, alloc.ID, spec.Path,
-			c.nsOpts.WithCapabilityPortMap(portMaps.ports),
-			c.nsOpts.WithArgs(cniArgs),
+			c.nsOpts.withCapabilityPortMap(portMaps.ports),
+			c.nsOpts.withArgs(cniArgs),
 		); err != nil {
 			c.logger.Warn("failed to configure network", "error", err, "attempt", attempt)
 			switch attempt {
@@ -605,6 +590,22 @@ func (c *cniNetworkConfigurator) ensureCNIInitialized() error {
 	} else {
 		return err
 	}
+}
+
+// nsOpts keeps track of NamespaceOpts usage, mainly for test assertions.
+type nsOpts struct {
+	args  map[string]string
+	ports []cni.PortMapping
+}
+
+func (o *nsOpts) withArgs(args map[string]string) cni.NamespaceOpts {
+	o.args = args
+	return cni.WithLabels(args)
+}
+
+func (o *nsOpts) withCapabilityPortMap(ports []cni.PortMapping) cni.NamespaceOpts {
+	o.ports = ports
+	return cni.WithCapabilityPortMap(ports)
 }
 
 // portMappings is a wrapper around a slice of cni.PortMapping that lets us

--- a/client/allocrunner/networking_cni_mock_test.go
+++ b/client/allocrunner/networking_cni_mock_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package allocrunner
 
 import (

--- a/client/allocrunner/networking_cni_mock_test.go
+++ b/client/allocrunner/networking_cni_mock_test.go
@@ -1,0 +1,78 @@
+package allocrunner
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/containerd/go-cni"
+	"github.com/containernetworking/cni/pkg/types"
+	"github.com/hashicorp/nomad/testutil"
+)
+
+var _ cni.CNI = &mockCNIPlugin{}
+
+type mockCNIPlugin struct {
+	counter     *testutil.CallCounter
+	setupErrors []string
+}
+
+func newMockCNIPlugin() *mockCNIPlugin {
+
+	callCounts := testutil.NewCallCounter()
+	callCounts.Reset()
+	return &mockCNIPlugin{
+		counter: callCounts,
+	}
+}
+
+func (f *mockCNIPlugin) Setup(ctx context.Context, id, path string, opts ...cni.NamespaceOpts) (*cni.Result, error) {
+	if f.counter != nil {
+		f.counter.Inc("Setup")
+	}
+	numOfCalls := f.counter.Get()["Setup"]
+
+	// tickle caller retries: return an error for this call number
+	if numOfCalls <= len(f.setupErrors) {
+		return nil, fmt.Errorf("uh oh (%d): %s", numOfCalls, f.setupErrors[numOfCalls-1])
+	}
+
+	cniResult := &cni.Result{
+		Interfaces: map[string]*cni.Config{
+			"eth0": {
+				IPConfigs: []*cni.IPConfig{
+					{
+						IP: net.ParseIP("99.99.99.99"),
+					},
+				},
+			},
+		},
+		// cni.Result will return a single empty struct, not an empty slice
+		DNS: []types.DNS{{}},
+	}
+	return cniResult, nil
+}
+
+func (f *mockCNIPlugin) SetupSerially(ctx context.Context, id, path string, opts ...cni.NamespaceOpts) (*cni.Result, error) {
+	return nil, nil
+}
+
+func (f *mockCNIPlugin) Remove(ctx context.Context, id, path string, opts ...cni.NamespaceOpts) error {
+	return nil
+}
+
+func (f *mockCNIPlugin) Check(ctx context.Context, id, path string, opts ...cni.NamespaceOpts) error {
+	return nil
+}
+
+func (f *mockCNIPlugin) Status() error {
+	return nil
+}
+
+func (f *mockCNIPlugin) Load(opts ...cni.Opt) error {
+	return nil
+}
+
+func (f *mockCNIPlugin) GetConfig() *cni.ConfigResult {
+	return nil
+}

--- a/client/allocrunner/networking_cni_test.go
+++ b/client/allocrunner/networking_cni_test.go
@@ -6,6 +6,7 @@
 package allocrunner
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
@@ -18,10 +19,94 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
+
+// FakeCNIPlugin is a fake plugin used for test.
+type FakeCNIPlugin struct {
+	StatusErr error
+	LoadErr   error
+	m         *MockSetupManager
+	name      *cni.Namespace
+}
+
+// NewFakeCNIPlugin create a FakeCNIPlugin.
+func NewFakeCNIPlugin() *FakeCNIPlugin {
+
+	callCounts := testutil.NewCallCounter()
+	callCounts.Reset()
+	return &FakeCNIPlugin{
+		m: &MockSetupManager{
+			CallCounter: callCounts,
+		},
+	}
+}
+
+type MockSetupManager struct {
+	CallCounter *testutil.CallCounter
+}
+
+// Setup setups the network of PodSandbox.
+func (f *FakeCNIPlugin) Setup(ctx context.Context, id, path string, opts ...cni.NamespaceOpts) (*cni.Result, error) {
+
+	if f.m.CallCounter != nil {
+		f.m.CallCounter.Inc("Setup")
+	}
+	var numOfCalls = f.m.CallCounter.Get()["Setup"]
+	if numOfCalls == 1 {
+		return nil, errors.New("first error")
+	} else {
+		cniResult := &cni.Result{
+			Interfaces: map[string]*cni.Config{
+				"cali39179aa3-74": {},
+				"eth0": {
+					IPConfigs: []*cni.IPConfig{
+						{
+							IP: net.IPv4(192, 168, 135, 232),
+						},
+					},
+				},
+			},
+			// cni.Result will return a single empty struct, not an empty slice
+			DNS: []types.DNS{{}},
+		}
+
+		return cniResult, nil
+	}
+}
+
+// SetupSerially sets up the network of PodSandbox without doing the interfaces in parallel.
+func (f *FakeCNIPlugin) SetupSerially(ctx context.Context, id, path string, opts ...cni.NamespaceOpts) (*cni.Result, error) {
+	return nil, nil
+}
+
+// Remove teardown the network of PodSandbox.
+func (f *FakeCNIPlugin) Remove(ctx context.Context, id, path string, opts ...cni.NamespaceOpts) error {
+	return nil
+}
+
+// Check the network of PodSandbox.
+func (f *FakeCNIPlugin) Check(ctx context.Context, id, path string, opts ...cni.NamespaceOpts) error {
+	return nil
+}
+
+// Status get the status of the plugin.
+func (f *FakeCNIPlugin) Status() error {
+	return f.StatusErr
+}
+
+// Load loads the network config.
+func (f *FakeCNIPlugin) Load(opts ...cni.Opt) error {
+	return f.LoadErr
+}
+
+// GetConfig returns a copy of the CNI plugin configurations as parsed by CNI
+func (f *FakeCNIPlugin) GetConfig() *cni.ConfigResult {
+	return nil
+}
 
 type mockIPTables struct {
 	listCall  [2]string
@@ -249,6 +334,168 @@ func TestCNI_addCustomCNIArgs(t *testing.T) {
 			test.Eq(t, tc.expectMap, cniArgs)
 
 		})
+	}
+}
+
+func TestSetup(t *testing.T) {
+	ci.Parallel(t)
+	ctx := context.Background()
+
+	nodeMeta := map[string]string{
+		"connect.transparent_proxy.default_outbound_port": "15001",
+		"connect.transparent_proxy.default_uid":           "101",
+	}
+
+	nodeAttrs := map[string]string{
+		"consul.dns.addr": "192.168.1.117",
+		"consul.dns.port": "8600",
+	}
+
+	allocWithCNIArgs := mock.ConnectAlloc()
+	allocWithoutCNIArgs := mock.ConnectAlloc()
+	allocWithTProxy := mock.ConnectAlloc()
+
+	tg3 := allocWithTProxy.Job.LookupTaskGroup(allocWithTProxy.TaskGroup)
+	tg := allocWithCNIArgs.Job.LookupTaskGroup(allocWithCNIArgs.TaskGroup)
+	tg.Networks = []*structs.NetworkResource{{
+		Mode: "bridge",
+		CNI: &structs.CNIArgs{
+			Args: map[string]string{
+				"first_arg": "example",
+				"new_arg":   "example_2",
+			},
+		},
+	}}
+
+	tg3.Networks = []*structs.NetworkResource{{
+		Mode: "bridge",
+		DNS:  &structs.DNSConfig{},
+		ReservedPorts: []structs.Port{ // non-Connect port
+			{
+				Label:       "http",
+				Value:       9002,
+				To:          9002,
+				HostNetwork: "default",
+			},
+		},
+		DynamicPorts: []structs.Port{ // Connect port
+			{
+				Label:       "connect-proxy-count-dashboard",
+				Value:       0,
+				To:          -1,
+				HostNetwork: "default",
+			},
+			{
+				Label:       "health",
+				Value:       0,
+				To:          9000,
+				HostNetwork: "default",
+			},
+		},
+		CNI: &structs.CNIArgs{
+			Args: map[string]string{
+				"first_arg": "example",
+				"new_arg":   "example_2",
+			},
+		},
+	}}
+	tg3.Services[0].PortLabel = "9002"
+	tg3.Services[0].Connect.SidecarService.Proxy = &structs.ConsulProxy{
+		LocalServiceAddress: "",
+		LocalServicePort:    0,
+		Upstreams:           []structs.ConsulUpstream{},
+		Expose:              &structs.ConsulExposeConfig{},
+		Config:              map[string]interface{}{},
+	}
+	tg3.Services[0].Connect.SidecarService.Proxy.TransparentProxy = &structs.ConsulTransparentProxy{}
+
+	spec := &drivers.NetworkIsolationSpec{
+		Mode:        "group",
+		Path:        "/var/run/docker/netns/a2ece01ea7bc",
+		Labels:      map[string]string{"docker_sandbox_container_id": "4a77cdaad5"},
+		HostsConfig: &drivers.HostsConfig{},
+	}
+
+	src := rand.NewSource(1000)
+	r := rand.New(src)
+
+	testCases := []struct {
+		name         string
+		cluster      string
+		alloc        *structs.Allocation
+		expectAlloc  *structs.AllocNetworkStatus
+		expectErr    string
+		CNI          *FakeCNIPlugin
+		expectedArgs map[string]string
+	}{
+		{
+			name:  "cni args not specified",
+			alloc: allocWithoutCNIArgs,
+			CNI:   NewFakeCNIPlugin(),
+			expectAlloc: &structs.AllocNetworkStatus{
+				InterfaceName: "eth0",
+				Address:       "192.168.135.232",
+			},
+			expectedArgs: map[string]string{
+				"IgnoreUnknown": "true",
+			},
+		},
+		{
+			name:  "cni args specified",
+			alloc: allocWithCNIArgs,
+			CNI:   NewFakeCNIPlugin(),
+			expectAlloc: &structs.AllocNetworkStatus{
+				InterfaceName: "eth0",
+				Address:       "192.168.135.232",
+			},
+			expectedArgs: map[string]string{
+				"IgnoreUnknown": "true",
+				"first_arg":     "example",
+				"new_arg":       "example_2",
+			},
+		},
+		{
+			name:  "iptables / tproxy args and CNI args specified",
+			alloc: allocWithTProxy,
+			CNI:   NewFakeCNIPlugin(),
+			expectAlloc: &structs.AllocNetworkStatus{
+				InterfaceName: "eth0",
+				Address:       "192.168.135.232",
+				DNS: &structs.DNSConfig{
+					Servers: []string{"192.168.1.117"},
+				},
+			},
+			expectedArgs: map[string]string{
+				"IgnoreUnknown":          "true",
+				"first_arg":              "example",
+				"new_arg":                "example_2",
+				"CONSUL_IPTABLES_CONFIG": `{"ConsulDNSIP":"192.168.1.117","ConsulDNSPort":8600,"ProxyUserID":"101","ProxyInboundPort":9999,"ProxyOutboundPort":15001,"ExcludeInboundPorts":["9002"],"ExcludeOutboundPorts":null,"ExcludeOutboundCIDRs":null,"ExcludeUIDs":null,"NetNS":"/var/run/docker/netns/a2ece01ea7bc","IptablesProvider":null}`,
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			c := &cniNetworkConfigurator{
+				nodeAttrs: nodeAttrs,
+				nodeMeta:  nodeMeta,
+				logger:    testlog.HCLogger(t),
+				cni:       tc.CNI,
+				rand:      r,
+				nsOpts:    &nsOpts{},
+			}
+
+			givenAlloc, err := c.Setup(ctx, tc.alloc, spec)
+			if tc.expectErr == "" {
+				must.NoError(t, err)
+				must.Eq(t, tc.expectedArgs, c.nsOpts.args)
+				must.Eq(t, tc.expectAlloc, givenAlloc)
+				must.Eq(t, tc.CNI.m.CallCounter.Get()["Setup"], 2)
+			} else {
+				must.EqError(t, err, tc.expectErr)
+			}
+		})
+
 	}
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7197,7 +7197,7 @@ func (tg *TaskGroup) validateNetworks() error {
 			}
 		}
 		// Validate the cniArgs in each network resource. Make sure there are no duplicate Args in
-		// different network resources or illegal characters (;) in key or value ;)
+		// different network resources or invalid characters (;) in key or value ;)
 		if net.CNI != nil {
 			for k, v := range net.CNI.Args {
 				if cniArgKeys.Contains(k) {
@@ -7206,6 +7206,11 @@ func (tg *TaskGroup) validateNetworks() error {
 				} else {
 					cniArgKeys.Insert(k)
 				}
+				// CNI_ARGS is a ";"-separated string of "key=val", so a ";"
+				// in either key or val would confuse plugins (or libraries)
+				// that parse that string.
+				// Pre-validating this here protects job authors from submitting
+				// a job that will most likely error later on the client anyway.
 				if strings.Contains(k, ";") {
 					err := fmt.Errorf("invalid ';' character in CNI arg key %q", k)
 					mErr.Errors = append(mErr.Errors, err)


### PR DESCRIPTION
This PR adds a test for the `Setup` method, as well as an `nsOpts` field to the `cniNetworkConfigurator` struct. This field is specifically used to keep track of namespace usage for test assertions, and is used in the test written for Setup.