### PR TITLE
e2e: skip missing windows ami if windows clients=0

### DIFF
--- a/e2e/terraform/.gitignore
+++ b/e2e/terraform/.gitignore
@@ -1,2 +1,3 @@
 *.zip
 uploads/
+custom.tfvars

--- a/e2e/terraform/Makefile
+++ b/e2e/terraform/Makefile
@@ -1,32 +1,29 @@
-PKG_PATH = $(shell pwd)/../../pkg/linux_amd64/nomad
+PKG_PATH ?= $(shell pwd)/../../pkg/linux_amd64/nomad
 NOMAD_LICENSE_PATH ?=
 CONSUL_LICENSE_PATH ?=
 
 # deploy for quick local development testing
 
-plan:
-	terraform plan \
-		-var="nomad_local_binary=$(PKG_PATH)" \
-		-var="volumes=false" \
-		-var="client_count_ubuntu_jammy_amd64=3" \
-		-var="client_count_windows_2016_amd64=0" \
-		-var="consul_license=$(shell cat $(CONSUL_LICENSE_PATH))"
+custom.tfvars:
+	echo 'nomad_local_binary = "$(PKG_PATH)"' > custom.tfvars
+	echo 'volumes = false' >> custom.tfvars
+	echo 'client_count_ubuntu_jammy_amd64 = 3' >> custom.tfvars
+	echo 'client_count_windows_2016_amd64 = 0' >> custom.tfvars
+	echo 'consul_license = "$(shell cat $(CONSUL_LICENSE_PATH))"' >> custom.tfvars
+	echo 'nomad_license = "$(shell cat $(NOMAD_LICENSE_PATH))"' >> custom.tfvars
 
-apply:
-	terraform apply -auto-approve \
-		-var="nomad_local_binary=$(PKG_PATH)" \
-		-var="volumes=false" \
-		-var="client_count_ubuntu_jammy_amd64=3" \
-		-var="client_count_windows_2016_amd64=0" \
-		-var="consul_license=$(shell cat $(CONSUL_LICENSE_PATH))"
+.PHONY: plan apply clean destroy plan_full apply_full clean_full destroy_full tidy
+
+plan: custom.tfvars
+	terraform plan -var-file=custom.tfvars
+
+apply: custom.tfvars
+	terraform apply -var-file=custom.tfvars -auto-approve
+
+destroy: custom.tfvars
+	terraform destroy -var-file=custom.tfvars -auto-approve
 
 clean: destroy tidy
-
-destroy:
-	terraform destroy -auto-approve \
-		-var="nomad_local_binary=$(PKG_PATH)" \
-		-var="client_count_ubuntu_jammy_amd64=3" \
-		-var="client_count_windows_2016_amd64=0"
 
 # deploy what's in E2E nightly
 
@@ -35,6 +32,7 @@ plan_full:
 
 apply_full:
 	@terraform apply -auto-approve \
+		-var="consul_license=$(shell cat $(CONSUL_LICENSE_PATH))" \
 		-var="nomad_license=$(shell cat $(NOMAD_LICENSE_PATH))"
 
 clean_full: destroy_full tidy
@@ -53,3 +51,4 @@ tidy:
 	rm -rf uploads/*
 	git checkout uploads/README.md
 	rm -f terraform.tfstate.*.backup
+	rm custom.tfvars

--- a/e2e/terraform/compute.tf
+++ b/e2e/terraform/compute.tf
@@ -40,7 +40,7 @@ resource "aws_instance" "client_ubuntu_jammy_amd64" {
 }
 
 resource "aws_instance" "client_windows_2016_amd64" {
-  ami                    = data.aws_ami.windows_2016_amd64.image_id
+  ami                    = data.aws_ami.windows_2016_amd64[0].image_id
   instance_type          = var.instance_type
   key_name               = module.keys.key_name
   vpc_security_group_ids = [aws_security_group.clients.id]
@@ -105,6 +105,8 @@ data "aws_ami" "ubuntu_jammy_amd64" {
 }
 
 data "aws_ami" "windows_2016_amd64" {
+  count = var.client_count_windows_2016_amd64 > 0 ? 1 : 0
+
   most_recent = true
   owners      = ["self"]
 


### PR DESCRIPTION
and tweak Makefile to generate a `custom.tfvars` instead of specifying vars separately via CLI.
hoping this makes it a little more obvious if there is no consul/nomad license.

I often packer build only linux if I'm testing something in linux (which is most of the time),
and as a result, there's no windows image with my git sha, so tf plan fails looking for the AMI,
even though I set windows clients to 0.

the change to `compute.tf` allows me to avoid futzing with any .tf files when testing such things.