### PR TITLE
[ui] Unescape csi/ in plugin GET requests

### DIFF
--- a/.changelog/23625.txt
+++ b/.changelog/23625.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed storage/plugin 404s by unescaping a slash character in the request URL
+```

--- a/ui/app/adapters/plugin.js
+++ b/ui/app/adapters/plugin.js
@@ -11,4 +11,11 @@ export default class PluginAdapter extends Watchable {
   queryParamsToAttrs = {
     type: 'type',
   };
+  // Over in serializers/plugin.js, we prepend csi/ as part of the hash ID for request resolution reasons.
+  // However, this is not part of the actual ID stored in the database and we should treat it like a regular, unescaped
+  // path segment.
+  urlForFindRecord() {
+    let url = super.urlForFindRecord(...arguments);
+    return url.replace('csi%2F', 'csi/');
+  }
 }

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -673,13 +673,8 @@ export default function () {
     return this.serialize(csiPlugins.all());
   });
 
-  this.get('/plugin/:id', function ({ csiPlugins }, { params }) {
-    if (!params.id.startsWith('csi/')) {
-      return new Response(404, {}, null);
-    }
-
-    const id = params.id.replace(/^csi\//, '');
-    const volume = csiPlugins.find(id);
+  this.get('/plugin/csi/:id', function ({ csiPlugins }, { params }) {
+    const volume = csiPlugins.find(params.id);
 
     if (!volume) {
       return new Response(404, {}, null);


### PR DESCRIPTION
This PR unescapes the `/` in the `csi/PLUGIN_NAME` path that Ember Data was escaping due to how/where it was prepended at the adapter layer.

Re: #23615 : This makes it so the plugins UI is usable again, but doesn't solve the underlying no-longer-handles-unescaped-path-slashes problem.