### PR TITLE
Fix parsing CNI .conf and .json config formats

### DIFF
--- a/.changelog/23629.txt
+++ b/.changelog/23629.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cni: .conf and .json config files are now parsed properly
+```

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -72,7 +72,11 @@ func newBridgeNetworkConfigurator(log hclog.Logger, alloc *structs.Allocation, b
 		netCfg = buildNomadBridgeNetConfig(*b, false)
 	}
 
-	c, err := newCNINetworkConfiguratorWithConf(log, cniPath, bridgeNetworkAllocIfPrefix, ignorePortMappingHostIP, netCfg, node)
+	parser := &cniConfParser{
+		listBytes: netCfg,
+	}
+
+	c, err := newCNINetworkConfiguratorWithConf(log, cniPath, bridgeNetworkAllocIfPrefix, ignorePortMappingHostIP, parser, node)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Our documentation states that we support `.conf` and `.json` config formats (which are the same, actually), but in reality only `.conflist` works properly.  All of them are fingerprinted correctly, but only conflist works at allocation run time.

Fixes #19816

The first commit is here for a reference, which used a boolean to keep track of whether or not `confIsList`, but in my second pass I made a little struct to make it easier (I think) to hold correctly.

I have some e2e tests set up for this too, but I'll do that in a separate PR since we generally don't backport those.