### PR TITLE
client/allocdir: chown directories as _daemon_ user if available

### DIFF
--- a/client/allocdir/fs_unix.go
+++ b/client/allocdir/fs_unix.go
@@ -48,6 +48,14 @@ func dropDirPermissions(path string, desired os.FileMode) error {
 		return fmt.Errorf("Unable to find nobody user: %w", err)
 	}
 
+	// Within a snap we can't chown to `nobody`, so we use `_daemon_` instead
+	// requires snap configured to use `system-usernames`
+	// https://snapcraft.io/docs/system-usernames
+	snapu, err := users.Lookup("_daemon_")
+	if err == nil {
+		u = snapu
+	}
+
 	uid, err := getUid(u)
 	if err != nil {
 		return err


### PR DESCRIPTION
running within a snap (https://snapcraft.io/) means code is unable to chown to nobody user unfortunately

chown to _daemon_ user instead if available https://snapcraft.io/docs/system-usernames

ref #23619

```sh
me@mydevice:~$ sudo snap run --shell my-snap.nomad
root@mydevice:/home/me# cd
root@mydevice:~# pwd
/root/snap/my-snap/x5
root@mydevice:~# touch foo
root@mydevice:~# chown _daemon_ foo
root@mydevice:~# touch bar
root@mydevice:~# chown nobody bar
chown: changing ownership of 'bar': Operation not permitted
```