### PR TITLE
template: allow change_mode script to run after client restart

### DIFF
--- a/.changelog/23663.txt
+++ b/.changelog/23663.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+template: Fixed a bug where change_mode = "script" would not execute after a client restart
+```

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -126,6 +126,7 @@ func (tr *TaskRunner) initHooks() {
 			consulNamespace:     consulNamespace,
 			nomadNamespace:      tr.alloc.Job.Namespace,
 			renderOnTaskRestart: task.RestartPolicy.RenderTemplates,
+			driverHandle:        tr.handle,
 		}))
 	}
 

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -585,7 +585,7 @@ func (tm *TaskTemplateManager) processScript(script *structs.ChangeScript, wg *s
 
 	if tm.handle == nil {
 		failureMsg := fmt.Sprintf(
-			"Template failed to run script %v with arguments %v because task driver doesn't support the exec operation",
+			"Template failed to run script %v with arguments %v because task driver handle is not available",
 			script.Command,
 			script.Args,
 		)


### PR DESCRIPTION
For templates with `change_mode = "script"`, we set a driver handle in the poststart method, so the template runner can execute the script inside the task. But when the client is restarted and the template contents change during that window, we trigger a change_mode in the prestart method. In that case, the hook will not have the handle and so returns an errror trying to run the change mode.

We restore the driver handle before we call any prestart hooks, so we can pass that handle in the constructor whenever it's available. In the normal task start case the handle will be empty but also won't be called.

The error messages are also misleading, as there's no capabilities check happening here. Update the error messages to match.

Fixes: https://github.com/hashicorp/nomad/issues/15851
Ref: https://hashicorp.atlassian.net/browse/NET-9338