### PR TITLE
reporting: allow export interval and address to be configurable

### DIFF
--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -179,6 +179,8 @@ func ParseConfigFile(path string) (*Config, error) {
 				c.Client.TemplateConfig.NomadRetry.MaxBackoff = d
 			},
 		},
+		{"reporting.export_interval",
+			&c.Reporting.ExportInterval, &c.Reporting.ExportIntervalHCL, nil},
 	}
 
 	// Parse durations for Consul and Vault config blocks if provided.

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -344,6 +344,9 @@ var basicConfig = &Config{
 		},
 	},
 	Reporting: &config.ReportingConfig{
+		ExportAddress:     "http://localhost:8080",
+		ExportIntervalHCL: "15m",
+		ExportInterval:    time.Minute * 15,
 		License: &config.LicenseReportingConfig{
 			Enabled: pointer.Of(true),
 		},
@@ -427,7 +430,7 @@ var pluginConfig = &Config{
 		},
 	},
 	Reporting: &config.ReportingConfig{
-		&config.LicenseReportingConfig{},
+		License: &config.LicenseReportingConfig{},
 	},
 	Consuls: []*config.ConsulConfig{},
 	Vaults:  []*config.VaultConfig{},
@@ -482,7 +485,7 @@ var nonoptConfig = &Config{
 	HTTPAPIResponseHeaders:    map[string]string{},
 	Sentinel:                  nil,
 	Reporting: &config.ReportingConfig{
-		&config.LicenseReportingConfig{},
+		License: &config.LicenseReportingConfig{},
 	},
 	Consuls: []*config.ConsulConfig{},
 	Vaults:  []*config.VaultConfig{},
@@ -563,7 +566,6 @@ func TestConfig_Parse(t *testing.T) {
 			}
 			actual = oldDefault.Merge(actual)
 
-			must.Eq(t, tc.Result.KEKProviders, actual.KEKProviders)
 			must.Eq(t, tc.Result, removeHelperAttributes(actual))
 		})
 	}
@@ -615,7 +617,7 @@ func (c *Config) addDefaults() {
 	}
 	if c.Reporting == nil {
 		c.Reporting = &config.ReportingConfig{
-			&config.LicenseReportingConfig{
+			License: &config.LicenseReportingConfig{
 				Enabled: pointer.Of(false),
 			},
 		}
@@ -893,7 +895,7 @@ var sample1 = &Config{
 		CleanupDeadServers: pointer.Of(true),
 	},
 	Reporting: &config.ReportingConfig{
-		&config.LicenseReportingConfig{},
+		License: &config.LicenseReportingConfig{},
 	},
 	KEKProviders: []*structs.KEKProviderConfig{
 		{

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -348,6 +348,9 @@ reporting {
   license {
     enabled = true
   }
+
+  address         = "http://localhost:8080"
+  export_interval = "15m"
 }
 
 keyring "awskms" {

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -421,6 +421,8 @@
     }
   ],
   "reporting": {
+    "address": "http://localhost:8080",
+    "export_interval": "15m",
     "license": {
       "enabled": "true"
     }

--- a/nomad/structs/config/reporting.go
+++ b/nomad/structs/config/reporting.go
@@ -3,7 +3,11 @@
 
 package config
 
-import "github.com/hashicorp/nomad/helper/pointer"
+import (
+	"time"
+
+	"github.com/hashicorp/nomad/helper/pointer"
+)
 
 type LicenseReportingConfig struct {
 	Enabled *bool `hcl:"enabled"`
@@ -40,6 +44,15 @@ func (lc *LicenseReportingConfig) Merge(b *LicenseReportingConfig) *LicenseRepor
 
 type ReportingConfig struct {
 	License *LicenseReportingConfig `hcl:"license,block"`
+
+	// ExportAddress overrides the Census license server. This is intended
+	// for testing and should not be configured by end-users.
+	ExportAddress string `hcl:"address" json:"-"`
+
+	// ExportInterval overrides the default export interval. This is intended
+	// for testing and should not be configured by end-users.
+	ExportInterval    time.Duration
+	ExportIntervalHCL string `hcl:"export_interval" json:"-"`
 }
 
 func (r *ReportingConfig) Copy() *ReportingConfig {
@@ -69,12 +82,21 @@ func (r *ReportingConfig) Merge(b *ReportingConfig) *ReportingConfig {
 	} else if b.License != nil {
 		result.License = result.License.Merge(b.License)
 	}
+	if r.ExportAddress == "" {
+		result.ExportAddress = b.ExportAddress
+	}
+	if r.ExportIntervalHCL == "" {
+		result.ExportIntervalHCL = b.ExportIntervalHCL
+	}
+	if r.ExportInterval == 0 {
+		result.ExportInterval = b.ExportInterval
+	}
 
 	return &result
 }
 
 func DefaultReporting() *ReportingConfig {
 	return &ReportingConfig{
-		&LicenseReportingConfig{},
+		License: &LicenseReportingConfig{},
 	}
 }


### PR DESCRIPTION
The internal library for [automated license utilization reporting](https://developer.hashicorp.com/nomad/docs/enterprise/license/utilization-reporting) supports configuration to send metrics to a local development version of the collector. Add "undocumented" configuration options to the `reporting` block allow developers to debug and verify we're sending the data we expect with real Nomad servers and not just unit tests.

Note this behavior does not impact Nomad Community Edition whatsoever, which does not collect telemetry outside of the incidental data from version upgrade checks ([Checkpoint](https://developer.hashicorp.com/nomad/docs/faq#q-what-is-checkpoint-does-nomad-call-home)).

Ref: https://hashicorp.atlassian.net/browse/NET-10057
Ref: https://github.com/hashicorp/nomad-enterprise/pull/1708