### PR TITLE
workload identity: add support for extra claims config for Vault

### DIFF
--- a/e2e/vaultcompat/cluster_setup_test.go
+++ b/e2e/vaultcompat/cluster_setup_test.go
@@ -36,7 +36,7 @@ func roleWID(policies []string) map[string]any {
 	return map[string]any{
 		"role_type":               "jwt",
 		"bound_audiences":         "vault.io",
-		"user_claim":              "/nomad_job_id",
+		"user_claim":              "/extra_claims/nomad_workload_id",
 		"user_claim_json_pointer": true,
 		"claim_mappings": map[string]any{
 			"nomad_namespace": "nomad_namespace",

--- a/e2e/vaultcompat/input/restricted_jwt.hcl
+++ b/e2e/vaultcompat/input/restricted_jwt.hcl
@@ -1,0 +1,38 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+job "restricted_jwt" {
+  type = "batch"
+
+  // Tasks in this group are expected to succeed and run to completion.
+  group "success" {
+    vault {}
+
+    count = 2
+
+    // Task default_identity uses the default workload identity injected by the
+    // server and the inherits the Vault configuration from the group.
+    task "authorized" {
+      driver = "raw_exec"
+
+      config {
+        command = "cat"
+        args    = ["${NOMAD_SECRETS_DIR}/secret.txt"]
+      }
+
+      // Vault has an alias that maps this job's nomad_workload_id to an entity
+      // with a policy that allows access to these secrets
+      template {
+        data        = <<EOF
+{{with secret "secret/data/restricted"}}{{.Data.data.secret}}{{end}}
+EOF
+        destination = "${NOMAD_SECRETS_DIR}/secret.txt"
+      }
+
+      restart {
+        attempts = 0
+        mode     = "fail"
+      }
+    }
+  }
+}

--- a/e2e/vaultcompat/run_ce_test.go
+++ b/e2e/vaultcompat/run_ce_test.go
@@ -63,4 +63,5 @@ func testVaultJWT(t *testing.T, b build) {
 
 	// Run test job.
 	runJob(t, nc, "input/cat_jwt.hcl", "default", validateJWTAllocs)
+	runJob(t, nc, "input/restricted_jwt.hcl", "default", validateJWTAllocs)
 }

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"slices"
+	"strings"
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
@@ -501,6 +502,21 @@ func (c *Config) VaultIdentityConfig(cluster string) *structs.WorkloadIdentity {
 	}
 
 	return workloadIdentityFromConfig(conf.DefaultIdentity)
+}
+
+// GetVaultForIdentity reverses VaultIdentityConfig and finds the Vault
+// configuration that goes with a particular workload identity intended for
+// Vault
+func (c *Config) GetVaultForIdentity(wi *structs.WorkloadIdentity) *config.VaultConfig {
+	if !wi.IsVault() {
+		return nil
+	}
+	cluster := strings.TrimPrefix(wi.Name, structs.WorkloadIdentityVaultPrefix)
+	if cluster == "" {
+		return nil
+	}
+	conf := c.VaultConfigs[cluster]
+	return conf
 }
 
 func (c *Config) GetDefaultConsul() *config.ConsulConfig {

--- a/nomad/structs/workload_id.go
+++ b/nomad/structs/workload_id.go
@@ -76,6 +76,8 @@ type IdentityClaims struct {
 	VaultNamespace  string `json:"vault_namespace,omitempty"`
 	VaultRole       string `json:"vault_role,omitempty"`
 
+	// ExtraClaims are added based on this identity's
+	// WorkloadIdentityConfiguration, controlled by server configuration
 	ExtraClaims map[string]string `json:"extra_claims,omitempty"`
 
 	jwt.Claims
@@ -227,7 +229,9 @@ func strAttrGet[T any](x *T, fn func(x *T) string) string {
 }
 
 func (b *IdentityClaimsBuilder) interpolate() {
-
+	if len(b.extras) == 0 {
+		return
+	}
 	r := strings.NewReplacer(
 		// attributes that always exist
 		"${job.region}", b.job.Region,
@@ -310,7 +314,8 @@ type WorkloadIdentity struct {
 	TTL time.Duration
 
 	// Note: ExtraClaims is available on config/WorkloadIdentity but not
-	// available here on jobspecs
+	// available here on jobspecs because that might allow a job author to
+	// escalate their privileges if they know what claim mappings to expect.
 }
 
 // IsConsul returns true if the identity name starts with the standard prefix

--- a/nomad/structs/workload_id_test.go
+++ b/nomad/structs/workload_id_test.go
@@ -184,6 +184,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:group:group-service:consul-service_group-service-http",
 				Audience: jwt.Audience{"group-service.consul.io"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		// group: no consul.
 		// task:  no consul, no vault.
@@ -195,6 +196,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:group:task:default-identity",
 				Audience: jwt.Audience{"example.com"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		"job/group/task/alt-identity": {
 			Namespace: "default",
@@ -204,6 +206,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:group:task:alt-identity",
 				Audience: jwt.Audience{"alt.example.com"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		// No ConsulNamespace because there is no consul block at either task
 		// or group level.
@@ -216,6 +219,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:group:task:consul_default",
 				Audience: jwt.Audience{"consul.io"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		// No VaultNamespace because there is no vault block at either task
 		// or group level.
@@ -229,6 +233,9 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:group:task:vault_default",
 				Audience: jwt.Audience{"vault.io"},
 			},
+			ExtraClaims: map[string]string{
+				"nomad_workload_id": "global:default:job",
+			},
 		},
 		"job/group/task/services/task-service": {
 			Namespace:   "default",
@@ -238,6 +245,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:group:task-service:consul-service_task-task-service-http",
 				Audience: jwt.Audience{"task-service.consul.io"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		// group: no consul.
 		// task:  with consul, with vault.
@@ -249,6 +257,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:group:consul-vault-task:default-identity",
 				Audience: jwt.Audience{"example.com"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		// Use task-level Consul namespace.
 		"job/group/consul-vault-task/consul_default": {
@@ -260,6 +269,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:group:consul-vault-task:consul_default",
 				Audience: jwt.Audience{"consul.io"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		// Use task-level Vault namespace.
 		"job/group/consul-vault-task/vault_default": {
@@ -272,6 +282,9 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:group:consul-vault-task:vault_default",
 				Audience: jwt.Audience{"vault.io"},
 			},
+			ExtraClaims: map[string]string{
+				"nomad_workload_id": "global:default:job",
+			},
 		},
 		// Use task-level Consul namespace for task services.
 		"job/group/consul-vault-task/services/consul-vault-task-service": {
@@ -283,6 +296,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:group:consul-vault-task-service:consul-service_consul-vault-task-service-http",
 				Audience: jwt.Audience{"consul.io"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		// group: with consul.
 		// Use group-level Consul namespace for group services.
@@ -295,6 +309,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:consul-group:group-service:consul-service_group-service-http",
 				Audience: jwt.Audience{"group-service.consul.io"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		// group: with consul.
 		// task:  no consul, no vault.
@@ -306,6 +321,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:consul-group:task:default-identity",
 				Audience: jwt.Audience{"example.com"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		"job/consul-group/task/alt-identity": {
 			Namespace: "default",
@@ -315,6 +331,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:consul-group:task:alt-identity",
 				Audience: jwt.Audience{"alt.example.com"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		// Use group-level Consul namespace because task doesn't have a consul
 		// block.
@@ -327,6 +344,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:consul-group:task:consul_default",
 				Audience: jwt.Audience{"consul.io"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		"job/consul-group/task/vault_default": {
 			Namespace: "default",
@@ -336,6 +354,9 @@ func TestNewIdentityClaims(t *testing.T) {
 			Claims: jwt.Claims{
 				Subject:  "global:default:job:consul-group:task:vault_default",
 				Audience: jwt.Audience{"vault.io"},
+			},
+			ExtraClaims: map[string]string{
+				"nomad_workload_id": "global:default:job",
 			},
 		},
 		// Use group-level Consul namespace for task service because task
@@ -349,6 +370,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:consul-group:task-service:consul-service_task-task-service-http",
 				Audience: jwt.Audience{"task-service.consul.io"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		// group: no consul.
 		// task:  with consul, with vault.
@@ -360,6 +382,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:consul-group:consul-vault-task:default-identity",
 				Audience: jwt.Audience{"example.com"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		// Use task-level Consul namespace.
 		"job/consul-group/consul-vault-task/consul_default": {
@@ -371,6 +394,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:consul-group:consul-vault-task:consul_default",
 				Audience: jwt.Audience{"consul.io"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 		"job/consul-group/consul-vault-task/vault_default": {
 			VaultNamespace: "vault-namespace",
@@ -381,6 +405,9 @@ func TestNewIdentityClaims(t *testing.T) {
 			Claims: jwt.Claims{
 				Subject:  "global:default:job:consul-group:consul-vault-task:vault_default",
 				Audience: jwt.Audience{"vault.io"},
+			},
+			ExtraClaims: map[string]string{
+				"nomad_workload_id": "global:default:job",
 			},
 		},
 		// Use task-level Consul namespace for task services.
@@ -393,6 +420,7 @@ func TestNewIdentityClaims(t *testing.T) {
 				Subject:  "global:default:job:consul-group:consul-task-service:consul-service_consul-vault-task-consul-task-service-http",
 				Audience: jwt.Audience{"consul.io"},
 			},
+			ExtraClaims: map[string]string{},
 		},
 	}
 
@@ -492,7 +520,9 @@ func TestNewIdentityClaims(t *testing.T) {
 				WithTask(tc.task).
 				WithService(tc.svc).
 				WithConsul().
-				WithVault().
+				WithVault(map[string]string{
+					"nomad_workload_id": "${job.region}:${job.namespace}:${job.id}",
+				}).
 				Build(now)
 
 			must.Eq(t, tc.expectedClaims, got, must.Cmp(cmpopts.IgnoreFields(

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -64,10 +64,11 @@ type Consul struct {
 
 // WorkloadIdentityConfig is the configuration for default workload identities.
 type WorkloadIdentityConfig struct {
-	Audience []string `json:"aud"`
-	Env      bool     `json:"env"`
-	File     bool     `json:"file"`
-	TTL      string   `json:"ttl"`
+	Audience    []string          `json:"aud"`
+	Env         bool              `json:"env"`
+	File        bool              `json:"file"`
+	TTL         string            `json:"ttl"`
+	ExtraClaims map[string]string `json:"extra_claims,omitempty"`
 }
 
 // Advertise is used to configure the addresses to advertise

--- a/website/content/docs/configuration/vault.mdx
+++ b/website/content/docs/configuration/vault.mdx
@@ -32,6 +32,10 @@ vault {
   default_identity {
     aud = ["vault.io"]
     ttl = "1h"
+
+    extra_claims {
+      unique_id = "${job.region}:${job.namespace}:${job.id}"
+    }
   }
 }
 ```
@@ -185,6 +189,28 @@ will be removed in a future release.
 
 - `ttl` `(string: "")` - Specifies for how long the workload identity should be
   considered as valid before expiring.
+
+- `extra_claims` `(map[string]string: optional)` - A set of key-value pairs that
+  will be provided as extra identity claims for workloads. You can use the keys
+  as user claims in Vault role configurations. The values are interpolated. For
+  example, if you include the extra claim `unique_id =
+  "${job.region}:${job.namespace}:${job.id}"`, you could set the user claim
+  field to `/extra_claims/unique_id` to map that identifier to an entity
+  alias. The available attributes for interpolation are:
+
+  - `${job.region}` - The region where the job is running.
+  - `${job.namespace}` - The job's namespace.
+  - `${job.id}` - The job's ID.
+  - `${job.node_pool}` - The node pool where the allocation is running.
+  - `${group.name}` - The task group name of the task using Vault.
+  - `${task.name}` - The name of the task using Vault.
+  - `${node.id}` - The ID of the node where the allocation is running.
+  - `${node.datacenter}` - The datacenter of the node where the allocation is running.
+  - `${node.pool}` - The node pool of the node where the allocation is running.
+  - `${node.class` - The class of the node where the allocation is running.
+  - `${vault.cluster}` - The Vault cluster name.
+  - `${vault.namespace}` - The Vault namespace.
+  - `${vault.role}` - The Vault role.
 
 ### Token-based Authentication
 

--- a/website/content/docs/configuration/vault.mdx
+++ b/website/content/docs/configuration/vault.mdx
@@ -192,11 +192,11 @@ will be removed in a future release.
 
 - `extra_claims` `(map[string]string: optional)` - A set of key-value pairs that
   will be provided as extra identity claims for workloads. You can use the keys
-  as user claims in Vault role configurations. The values are interpolated. For
-  example, if you include the extra claim `unique_id =
-  "${job.region}:${job.namespace}:${job.id}"`, you could set the user claim
-  field to `/extra_claims/unique_id` to map that identifier to an entity
-  alias. The available attributes for interpolation are:
+  as [user claims in Vault role configurations][vault-jwt-user-claim]. The
+  values are interpolated. For example, if you include the extra claim
+  `unique_id = "${job.region}:${job.namespace}:${job.id}"`, you could set the
+  user claim field to `/extra_claims/unique_id` to map that identifier to an
+  entity alias. The available attributes for interpolation are:
 
   - `${job.region}` - The region where the job is running.
   - `${job.namespace}` - The job's namespace.
@@ -342,3 +342,4 @@ can be accomplished by sending the process a `SIGHUP` signal.
 [vault_bound_aud]: /vault/api-docs/auth/jwt#bound_audiences
 [vault_auth_enable_path]: /vault/docs/commands/auth/enable#path
 [workload_id]: /nomad/docs/concepts/workload-identity
+[vault-jwt-user-claim]: /vault/api-docs/auth/jwt#user_claim


### PR DESCRIPTION
Although we encourage users to use Vault roles, sometimes they're going to want to assign policies based on entity and pre-create entities and aliases based on claims. This allows them to use single default role (or at least small number of them) that has a templated policy, but have an escape hatch from that.

When defining Vault entities the `user_claim` must be unique. When writing Vault binding rules for use with Nomad workload identities the binding rule won't be able to create a 1:1 mapping because the selector language allows accessing only a single field. The `nomad_job_id` claim isn't sufficient to uniquely identify a job because of namespaces. It's possible to create a JWT auth role with `bound_claims` to avoid this becoming a security problem, but this doesn't allow for correct accounting of user claims.

 Add support for an `extra_claims` block on the server's `default_identity` blocks for Vault. This allows a cluster administrator to add a custom claim on all allocations. The values for these claims are interpolatable with a limited subset of fields, similar to how we interpolate the task environment.

Fixes: https://github.com/hashicorp/nomad/issues/23510
Ref: https://hashicorp.atlassian.net/browse/NET-10372
Ref: https://hashicorp.atlassian.net/browse/NET-10387

Note to reviewers: this PR targets the branch of https://github.com/hashicorp/nomad/pull/23708 so that it includes all those changes, but I expect the refactoring PR will merge first and then this PR will target `main` again.
