### PR TITLE
release: explicitly set Linux service file user and group param.

### DIFF
--- a/.release/linux/package/usr/lib/systemd/system/nomad.service
+++ b/.release/linux/package/usr/lib/systemd/system/nomad.service
@@ -26,6 +26,12 @@ After=network-online.target
 # StartLimitInterval = 10s
 
 [Service]
+
+# Nomad clients need to be run as "root" whereas Nomad servers should be run as
+# the "nomad" user. Please change this if needed.
+User=root
+Group=root
+
 Type=notify
 EnvironmentFile=-/etc/nomad.d/nomad.env
 ExecReload=/bin/kill -HUP $MAINPID


### PR DESCRIPTION
The default root:root is used as this provides permissions to run both server and client agents. The comment details what changes can be made to operators if needed.

When running the service file prior to this change, root:root would be the default.

closes #23685 