### PR TITLE
client/allocdir: ignore mount permission errors if root

### DIFF
--- a/client/allocdir/fs_linux.go
+++ b/client/allocdir/fs_linux.go
@@ -78,6 +78,13 @@ func createSecretDir(dir string) error {
 		flags := uintptr(syscall.MS_NOEXEC)
 		options := fmt.Sprintf("size=%dm", secretDirTmpfsSize)
 		if err := syscall.Mount("tmpfs", dir, "tmpfs", flags, options); err != nil {
+			if err == syscall.EPERM {
+				// If we don't have permission to mount tmpfs as root,
+				// just settle for MkdirAll() and continue.
+				// This might be blocked if it in undesirable to create
+				// a mount point in a separate namespace to dockerd
+				return nil
+			}
 			return os.NewSyscallError("mount", err)
 		}
 


### PR DESCRIPTION
ref: #23619

On some systems (eg snaps) nomad and docker run in their own mount namespaces which means that dockerd can't see mount points created by nomad.

By a server admin denying the permission for nomad to mount tmpfs they can make the decision to keep nomad working.

There should be no other reason for root to fail to do so due to a permission error.