### PR TITLE
docs: add note about removing support for older clients in 1.9

### DIFF
--- a/website/content/docs/release-notes/nomad/upcoming.mdx
+++ b/website/content/docs/release-notes/nomad/upcoming.mdx
@@ -28,6 +28,10 @@ unless there's a required change due to a security vulnerability.
 * Nomad will remove support for HCL1 job specifications and the `-hcl1` flag on
   the `nomad job run` and other commands. Refer to [GH-20195][] for more details.
 * Nomad will remove the [`tls_prefer_server_cipher_suites`][] agent configuration.
+* Nomad will remove support for Nomad client agents older than 1.6.0. Older
+  nodes will fail heartbeats. Nomad servers will mark the workloads on those
+  nodes as lost and reschedule them normally according to the job's `reschedule`
+  block.
 
 ## Nomad 1.10.0 LTS
 

--- a/website/content/docs/release-notes/nomad/upcoming.mdx
+++ b/website/content/docs/release-notes/nomad/upcoming.mdx
@@ -30,8 +30,8 @@ unless there's a required change due to a security vulnerability.
 * Nomad will remove the [`tls_prefer_server_cipher_suites`][] agent configuration.
 * Nomad will remove support for Nomad client agents older than 1.6.0. Older
   nodes will fail heartbeats. Nomad servers will mark the workloads on those
-  nodes as lost and reschedule them normally according to the job's `reschedule`
-  block.
+  nodes as lost and reschedule them normally according to the job's
+  [`reschedule`][] block.
 
 ## Nomad 1.10.0 LTS
 
@@ -67,3 +67,4 @@ Nomad 1.10.0 is a Long-Term Support release for Enterprise customers.
 [vault-integration]: /nomad/docs/integrations/vault/acl
 [GH-18529]: https://github.com/hashicorp/nomad/issues/18529
 [`disconnect`]: /nomad/docs/job-specification/disconnect
+[`reschedule`]: /nomad/docs/job-specification/reschedule


### PR DESCRIPTION
In Nomad 1.6.0 we started sending the node secret with RPCs that previously did not include it. We planned to deprecate the older auth workflow but didn't set a release. Removing the legacy support means that nodes running <1.6.0 will fail to heartbeat.

Ref: https://hashicorp.atlassian.net/browse/NET-10009