### PR TITLE
resources: allow job authors to configure size of secrets tmpfs

### DIFF
--- a/.changelog/23696.txt
+++ b/.changelog/23696.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+resources: Added `resources.secrets` field to configure size of secrets directory on Linux
+```

--- a/api/resources.go
+++ b/api/resources.go
@@ -18,6 +18,7 @@ type Resources struct {
 	Networks    []*NetworkResource `hcl:"network,block"`
 	Devices     []*RequestedDevice `hcl:"device,block"`
 	NUMA        *NUMAResource      `hcl:"numa,block"`
+	SecretsMB   *int               `mapstructure:"secrets" hcl:"secrets,optional"`
 
 	// COMPAT(0.10)
 	// XXX Deprecated. Please do not use. The field will be removed in Nomad
@@ -102,6 +103,9 @@ func (r *Resources) Merge(other *Resources) {
 	}
 	if other.NUMA != nil {
 		r.NUMA = other.NUMA.Copy()
+	}
+	if other.SecretsMB != nil {
+		r.SecretsMB = other.SecretsMB
 	}
 }
 

--- a/client/allocdir/alloc_dir_test.go
+++ b/client/allocdir/alloc_dir_test.go
@@ -72,8 +72,8 @@ func TestAllocDir_BuildAlloc(t *testing.T) {
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, tmp, "test")
 	defer d.Destroy()
-	d.NewTaskDir(t1.Name)
-	d.NewTaskDir(t2.Name)
+	d.NewTaskDir(t1)
+	d.NewTaskDir(t2)
 	must.NoError(t, d.Build())
 
 	// Check that the AllocDir and each of the task directories exist.
@@ -118,10 +118,10 @@ func TestAllocDir_MountSharedAlloc(t *testing.T) {
 	must.NoError(t, d.Build())
 
 	// Build 2 task dirs
-	td1 := d.NewTaskDir(t1.Name)
+	td1 := d.NewTaskDir(t1)
 	must.NoError(t, td1.Build(fsisolation.Chroot, nil, "nobody"))
 
-	td2 := d.NewTaskDir(t2.Name)
+	td2 := d.NewTaskDir(t2)
 	must.NoError(t, td2.Build(fsisolation.Chroot, nil, "nobody"))
 
 	// Write a file to the shared dir.
@@ -154,10 +154,10 @@ func TestAllocDir_Snapshot(t *testing.T) {
 	must.NoError(t, d.Build())
 
 	// Build 2 task dirs
-	td1 := d.NewTaskDir(t1.Name)
+	td1 := d.NewTaskDir(t1)
 	must.NoError(t, td1.Build(fsisolation.None, nil, "nobody"))
 
-	td2 := d.NewTaskDir(t2.Name)
+	td2 := d.NewTaskDir(t2)
 	must.NoError(t, td2.Build(fsisolation.None, nil, "nobody"))
 
 	// Write a file to the shared dir.
@@ -218,12 +218,12 @@ func TestAllocDir_Move(t *testing.T) {
 	must.NoError(t, d2.Build())
 	defer d2.Destroy()
 
-	td1 := d1.NewTaskDir(t1.Name)
+	td1 := d1.NewTaskDir(t1)
 	must.NoError(t, td1.Build(fsisolation.None, nil, "nobody"))
 
 	// Create but don't build second task dir to mimic alloc/task runner
 	// behavior (AllocDir.Move() is called pre-TaskDir.Build).
-	d2.NewTaskDir(t1.Name)
+	d2.NewTaskDir(t1)
 
 	dataDir := filepath.Join(d1.SharedDir, SharedDataDir)
 
@@ -295,7 +295,7 @@ func TestAllocDir_ReadAt_SecretDir(t *testing.T) {
 	must.NoError(t, d.Build())
 	defer func() { _ = d.Destroy() }()
 
-	td := d.NewTaskDir(t1.Name)
+	td := d.NewTaskDir(t1)
 	must.NoError(t, td.Build(fsisolation.None, nil, "nobody"))
 
 	// something to write and test reading
@@ -436,7 +436,7 @@ func TestAllocDir_SkipAllocDir(t *testing.T) {
 	}
 
 	allocDir := NewAllocDir(testlog.HCLogger(t), clientAllocDir, mountAllocDir, "test")
-	taskDir := allocDir.NewTaskDir("testtask")
+	taskDir := allocDir.NewTaskDir(t1)
 
 	must.NoError(t, allocDir.Build())
 	defer allocDir.Destroy()
@@ -446,13 +446,13 @@ func TestAllocDir_SkipAllocDir(t *testing.T) {
 	must.NoError(t, err)
 
 	// Assert other directory *was* embedded
-	embeddedOtherDir := filepath.Join(clientAllocDir, "test", "testtask", "etc")
+	embeddedOtherDir := filepath.Join(clientAllocDir, "test", t1.Name, "etc")
 	if _, err := os.Stat(embeddedOtherDir); os.IsNotExist(err) {
 		t.Fatalf("expected other directory to exist at: %q", embeddedOtherDir)
 	}
 
 	// Assert client.alloc_dir was *not* embedded
-	embeddedChroot := filepath.Join(clientAllocDir, "test", "testtask", "nomad")
+	embeddedChroot := filepath.Join(clientAllocDir, "test", t1.Name, "nomad")
 	s, err := os.Stat(embeddedChroot)
 	if s != nil {
 		t.Logf("somehow you managed to embed the chroot without causing infinite recursion!")

--- a/client/allocdir/fs_darwin.go
+++ b/client/allocdir/fs_darwin.go
@@ -19,7 +19,7 @@ func unlinkDir(dir string) error {
 }
 
 // createSecretDir creates the secrets dir folder at the given path
-func createSecretDir(dir string) error {
+func createSecretDir(dir string, _ int) error {
 	return os.MkdirAll(dir, fileMode777)
 }
 

--- a/client/allocdir/fs_freebsd.go
+++ b/client/allocdir/fs_freebsd.go
@@ -19,7 +19,7 @@ func unlinkDir(dir string) error {
 }
 
 // createSecretDir creates the secrets dir folder at the given path
-func createSecretDir(dir string) error {
+func createSecretDir(dir string, _ int) error {
 	return os.MkdirAll(dir, fileMode777)
 }
 

--- a/client/allocdir/fs_linux.go
+++ b/client/allocdir/fs_linux.go
@@ -15,9 +15,6 @@ import (
 )
 
 const (
-	// secretDirTmpfsSize is the size of the tmpfs per task in MBs
-	secretDirTmpfsSize = 1
-
 	// secretMarker is the filename of the marker created so Nomad doesn't
 	// try to mount the secrets tmpfs more than once
 	secretMarker = ".nomad-mount"
@@ -62,7 +59,7 @@ func unlinkDir(dir string) error {
 
 // createSecretDir creates the secrets dir folder at the given path using a
 // tmpfs
-func createSecretDir(dir string) error {
+func createSecretDir(dir string, size int) error {
 	// Only mount the tmpfs if we are root
 	if unix.Geteuid() == 0 {
 		if err := os.MkdirAll(dir, fileMode777); err != nil {
@@ -76,7 +73,7 @@ func createSecretDir(dir string) error {
 		}
 
 		flags := uintptr(syscall.MS_NOEXEC)
-		options := fmt.Sprintf("size=%dm", secretDirTmpfsSize)
+		options := fmt.Sprintf("size=%dm", size)
 		if err := syscall.Mount("tmpfs", dir, "tmpfs", flags, options); err != nil {
 			return os.NewSyscallError("mount", err)
 		}

--- a/client/allocdir/fs_linux_test.go
+++ b/client/allocdir/fs_linux_test.go
@@ -9,19 +9,22 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
 	"golang.org/x/sys/unix"
 )
 
 var notFoundErr = fmt.Errorf("not found")
 
-func isMount(path string) error {
+func isMount(path string) (int, error) {
 	file, err := os.Open("/proc/self/mounts")
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer file.Close()
 	reader := bufio.NewReaderSize(file, 64*1024)
@@ -30,23 +33,31 @@ func isMount(path string) error {
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			if err == io.EOF {
-				return notFoundErr
+				return 0, notFoundErr
 			}
-			return err
+			return 0, err
 		}
 		parts := strings.SplitN(line, " ", 3)
 		if len(parts) != 3 {
-			return fmt.Errorf("unexpected line: %q", line)
+			return 0, fmt.Errorf("unexpected line: %q", line)
 		}
 		if parts[1] == path {
 			// Found it! Make sure it's a tmpfs
 			if parts[0] != "tmpfs" {
-				return fmt.Errorf("unexpected fs: %q", parts[1])
+				return 0, fmt.Errorf("unexpected fs: %q", parts[1])
 			}
-			return nil
+			sizeMatch := regexp.MustCompile(`size=(\d+)k`).FindStringSubmatch(parts[2])
+			if len(sizeMatch) == 0 {
+				return 0, fmt.Errorf("mount entry did not include size: %q", parts[2])
+			}
+			size, err := strconv.ParseInt(sizeMatch[1], 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("could not parse %q as int: %w", sizeMatch[0], err)
+			}
+			return int(size) / 1024, nil
 		}
 	}
-	return fmt.Errorf("exceeded max mount entries (%d)", max)
+	return 0, fmt.Errorf("exceeded max mount entries (%d)", max)
 }
 
 // TestLinuxRootSecretDir asserts secret dir creation and removal are
@@ -69,11 +80,12 @@ func TestLinuxRootSecretDir(t *testing.T) {
 	}
 
 	// creating a secrets dir should work
-	if err := createSecretDir(secretsDir); err != nil {
+	taskSecretsSize := 2
+	if err := createSecretDir(secretsDir, taskSecretsSize); err != nil {
 		t.Fatalf("error creating secrets dir %q: %v", secretsDir, err)
 	}
 	// creating it again should be a noop (NO error)
-	if err := createSecretDir(secretsDir); err != nil {
+	if err := createSecretDir(secretsDir, taskSecretsSize); err != nil {
 		t.Fatalf("error creating secrets dir %q: %v", secretsDir, err)
 	}
 
@@ -85,9 +97,9 @@ func TestLinuxRootSecretDir(t *testing.T) {
 	if !fi.IsDir() {
 		t.Fatalf("secrets dir %q is not a directory and should be", secretsDir)
 	}
-	if err := isMount(secretsDir); err != nil {
-		t.Fatalf("secrets dir %q is not a mount: %v", secretsDir, err)
-	}
+	size, err := isMount(secretsDir)
+	must.NoError(t, err, must.Sprintf("secrets dir %q is not a mount: %v", secretsDir, err))
+	must.Eq(t, taskSecretsSize, size)
 
 	// now remove it
 	if err := removeSecretDir(secretsDir); err != nil {
@@ -95,7 +107,7 @@ func TestLinuxRootSecretDir(t *testing.T) {
 	}
 
 	// make sure it's gone
-	if err := isMount(secretsDir); err != notFoundErr {
+	if _, err := isMount(secretsDir); err != notFoundErr {
 		t.Fatalf("error ensuring secrets dir %q isn't mounted: %v", secretsDir, err)
 	}
 
@@ -125,11 +137,11 @@ func TestLinuxUnprivilegedSecretDir(t *testing.T) {
 	}
 
 	// creating a secrets dir should work
-	if err := createSecretDir(secretsDir); err != nil {
+	if err := createSecretDir(secretsDir, defaultSecretDirTmpfsSize); err != nil {
 		t.Fatalf("error creating secrets dir %q: %v", secretsDir, err)
 	}
 	// creating it again should be a noop (NO error)
-	if err := createSecretDir(secretsDir); err != nil {
+	if err := createSecretDir(secretsDir, defaultSecretDirTmpfsSize); err != nil {
 		t.Fatalf("error creating secrets dir %q: %v", secretsDir, err)
 	}
 
@@ -141,7 +153,7 @@ func TestLinuxUnprivilegedSecretDir(t *testing.T) {
 	if !fi.IsDir() {
 		t.Fatalf("secrets dir %q is not a directory and should be", secretsDir)
 	}
-	if err := isMount(secretsDir); err != notFoundErr {
+	if _, err := isMount(secretsDir); err != notFoundErr {
 		t.Fatalf("error ensuring secrets dir %q isn't mounted: %v", secretsDir, err)
 	}
 

--- a/client/allocdir/fs_netbsd.go
+++ b/client/allocdir/fs_netbsd.go
@@ -19,7 +19,7 @@ func unlinkDir(dir string) error {
 }
 
 // createSecretDir creates the secrets dir folder at the given path
-func createSecretDir(dir string) error {
+func createSecretDir(dir string, _ int) error {
 	return os.MkdirAll(dir, fileMode777)
 }
 

--- a/client/allocdir/fs_solaris.go
+++ b/client/allocdir/fs_solaris.go
@@ -19,7 +19,7 @@ func unlinkDir(dir string) error {
 }
 
 // createSecretDir creates the secrets dir folder at the given path
-func createSecretDir(dir string) error {
+func createSecretDir(dir string, _ int) error {
 	// TODO solaris has support for tmpfs so use that
 	return os.MkdirAll(dir, fileMode777)
 }

--- a/client/allocdir/fs_windows.go
+++ b/client/allocdir/fs_windows.go
@@ -38,7 +38,7 @@ func unlinkDir(dir string) error {
 }
 
 // createSecretDir creates the secrets dir folder at the given path
-func createSecretDir(dir string) error {
+func createSecretDir(dir string, _ int) error {
 	return os.MkdirAll(dir, fileMode777)
 }
 

--- a/client/allocdir/task_dir_test.go
+++ b/client/allocdir/task_dir_test.go
@@ -23,7 +23,7 @@ func TestTaskDir_EmbedNonexistent(t *testing.T) {
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, tmp, "test")
 	defer d.Destroy()
-	td := d.NewTaskDir(t1.Name)
+	td := d.NewTaskDir(t1)
 	must.NoError(t, d.Build())
 
 	fakeDir := "/foobarbaz"
@@ -39,7 +39,7 @@ func TestTaskDir_EmbedDirs(t *testing.T) {
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, tmp, "test")
 	defer d.Destroy()
-	td := d.NewTaskDir(t1.Name)
+	td := d.NewTaskDir(t1)
 	must.NoError(t, d.Build())
 
 	// Create a fake host directory, with a file, and a subfolder that contains
@@ -78,7 +78,7 @@ func TestTaskDir_NonRoot_Image(t *testing.T) {
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, tmp, "test")
 	defer d.Destroy()
-	td := d.NewTaskDir(t1.Name)
+	td := d.NewTaskDir(t1)
 	must.NoError(t, d.Build())
 	must.NoError(t, td.Build(fsisolation.Image, nil, "nobody"))
 }
@@ -93,7 +93,7 @@ func TestTaskDir_NonRoot(t *testing.T) {
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, tmp, "test")
 	defer d.Destroy()
-	td := d.NewTaskDir(t1.Name)
+	td := d.NewTaskDir(t1)
 	must.NoError(t, d.Build())
 	must.NoError(t, td.Build(fsisolation.None, nil, "nobody"))
 
@@ -117,7 +117,7 @@ func TestTaskDir_NonRoot_Unveil(t *testing.T) {
 
 	d := NewAllocDir(testlog.HCLogger(t), tmp, tmp, "test")
 	defer d.Destroy()
-	td := d.NewTaskDir(t1.Name)
+	td := d.NewTaskDir(t1)
 	must.NoError(t, d.Build())
 	must.NoError(t, td.Build(fsisolation.Unveil, nil, u.Username))
 	fi, err := os.Stat(td.MountsTaskDir)
@@ -135,7 +135,7 @@ func TestTaskDir_Root_Unveil(t *testing.T) {
 	// root, can build task dirs for another user
 	d := NewAllocDir(testlog.HCLogger(t), tmp, tmp, "test")
 	defer d.Destroy()
-	td := d.NewTaskDir(t1.Name)
+	td := d.NewTaskDir(t1)
 	must.NoError(t, d.Build())
 	must.NoError(t, td.Build(fsisolation.Unveil, nil, "nobody"))
 	fi, err := os.Stat(td.MountsTaskDir)

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -316,7 +316,7 @@ func (ar *allocRunner) initTaskRunners(tasks []*structs.Task) error {
 			Alloc:               ar.alloc,
 			ClientConfig:        ar.clientConfig,
 			Task:                task,
-			TaskDir:             ar.allocDir.NewTaskDir(task.Name),
+			TaskDir:             ar.allocDir.NewTaskDir(task),
 			Logger:              ar.logger,
 			StateDB:             ar.stateDB,
 			StateUpdater:        ar,

--- a/client/allocrunner/taskrunner/connect_native_hook_test.go
+++ b/client/allocrunner/taskrunner/connect_native_hook_test.go
@@ -279,7 +279,7 @@ func TestTaskRunner_ConnectNativeHook_Noop(t *testing.T) {
 
 	request := &interfaces.TaskPrestartRequest{
 		Task:    task,
-		TaskDir: allocDir.NewTaskDir(task.Name),
+		TaskDir: allocDir.NewTaskDir(task),
 	}
 	require.NoError(t, request.TaskDir.Build(fsisolation.None, nil, task.User))
 
@@ -340,7 +340,7 @@ func TestTaskRunner_ConnectNativeHook_Ok(t *testing.T) {
 	}, logger))
 	request := &interfaces.TaskPrestartRequest{
 		Task:    tg.Tasks[0],
-		TaskDir: allocDir.NewTaskDir(tg.Tasks[0].Name),
+		TaskDir: allocDir.NewTaskDir(tg.Tasks[0]),
 		TaskEnv: taskenv.NewEmptyTaskEnv(),
 	}
 	require.NoError(t, request.TaskDir.Build(fsisolation.None, nil, tg.Tasks[0].User))
@@ -402,7 +402,7 @@ func TestTaskRunner_ConnectNativeHook_with_SI_token(t *testing.T) {
 	}, logger))
 	request := &interfaces.TaskPrestartRequest{
 		Task:    tg.Tasks[0],
-		TaskDir: allocDir.NewTaskDir(tg.Tasks[0].Name),
+		TaskDir: allocDir.NewTaskDir(tg.Tasks[0]),
 		TaskEnv: taskenv.NewEmptyTaskEnv(),
 	}
 	require.NoError(t, request.TaskDir.Build(fsisolation.None, nil, tg.Tasks[0].User))
@@ -485,7 +485,7 @@ func TestTaskRunner_ConnectNativeHook_shareTLS(t *testing.T) {
 		}, logger))
 		request := &interfaces.TaskPrestartRequest{
 			Task:    tg.Tasks[0],
-			TaskDir: allocDir.NewTaskDir(tg.Tasks[0].Name),
+			TaskDir: allocDir.NewTaskDir(tg.Tasks[0]),
 			TaskEnv: taskenv.NewEmptyTaskEnv(), // nothing set in env block
 		}
 		require.NoError(t, request.TaskDir.Build(fsisolation.None, nil, tg.Tasks[0].User))
@@ -612,7 +612,7 @@ func TestTaskRunner_ConnectNativeHook_shareTLS_override(t *testing.T) {
 
 	request := &interfaces.TaskPrestartRequest{
 		Task:    tg.Tasks[0],
-		TaskDir: allocDir.NewTaskDir(tg.Tasks[0].Name),
+		TaskDir: allocDir.NewTaskDir(tg.Tasks[0]),
 		TaskEnv: taskEnv, // env block is configured w/ non-default tls configs
 	}
 	require.NoError(t, request.TaskDir.Build(fsisolation.None, nil, tg.Tasks[0].User))

--- a/client/allocrunner/taskrunner/dispatch_hook_test.go
+++ b/client/allocrunner/taskrunner/dispatch_hook_test.go
@@ -38,7 +38,7 @@ func TestTaskRunner_DispatchHook_NoPayload(t *testing.T) {
 
 	allocDir := allocdir.NewAllocDir(logger, "nomadtest_nopayload", "nomadtest_nopayload", alloc.ID)
 	defer allocDir.Destroy()
-	taskDir := allocDir.NewTaskDir(task.Name)
+	taskDir := allocDir.NewTaskDir(task)
 	require.NoError(taskDir.Build(fsisolation.None, nil, task.User))
 
 	h := newDispatchHook(alloc, logger)
@@ -84,7 +84,7 @@ func TestTaskRunner_DispatchHook_Ok(t *testing.T) {
 
 	allocDir := allocdir.NewAllocDir(logger, "nomadtest_dispatchok", "nomadtest_dispatchok", alloc.ID)
 	defer allocDir.Destroy()
-	taskDir := allocDir.NewTaskDir(task.Name)
+	taskDir := allocDir.NewTaskDir(task)
 	require.NoError(taskDir.Build(fsisolation.None, nil, task.User))
 
 	h := newDispatchHook(alloc, logger)
@@ -129,7 +129,7 @@ func TestTaskRunner_DispatchHook_Error(t *testing.T) {
 
 	allocDir := allocdir.NewAllocDir(logger, "nomadtest_dispatcherr", "nomadtest_dispatcherr", alloc.ID)
 	defer allocDir.Destroy()
-	taskDir := allocDir.NewTaskDir(task.Name)
+	taskDir := allocDir.NewTaskDir(task)
 	require.NoError(taskDir.Build(fsisolation.None, nil, task.User))
 
 	h := newDispatchHook(alloc, logger)

--- a/client/allocrunner/taskrunner/envoy_bootstrap_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_bootstrap_hook_test.go
@@ -359,7 +359,7 @@ func TestEnvoyBootstrapHook_with_SI_token(t *testing.T) {
 	}, consulNamespace, serviceClient, mock.Node(), logger))
 	req := &interfaces.TaskPrestartRequest{
 		Task:    sidecarTask,
-		TaskDir: allocDir.NewTaskDir(sidecarTask.Name),
+		TaskDir: allocDir.NewTaskDir(sidecarTask),
 		TaskEnv: taskenv.NewEmptyTaskEnv(),
 	}
 	require.NoError(t, req.TaskDir.Build(fsisolation.None, nil, sidecarTask.User))
@@ -457,7 +457,7 @@ func TestEnvoyBootstrapHook_sidecar_ok(t *testing.T) {
 	}, consulNamespace, serviceClient, mock.Node(), logger))
 	req := &interfaces.TaskPrestartRequest{
 		Task:    sidecarTask,
-		TaskDir: allocDir.NewTaskDir(sidecarTask.Name),
+		TaskDir: allocDir.NewTaskDir(sidecarTask),
 		TaskEnv: taskenv.NewEmptyTaskEnv(),
 	}
 	require.NoError(t, req.TaskDir.Build(fsisolation.None, nil, sidecarTask.User))
@@ -537,7 +537,7 @@ func TestEnvoyBootstrapHook_gateway_ok(t *testing.T) {
 
 	req := &interfaces.TaskPrestartRequest{
 		Task:    alloc.Job.TaskGroups[0].Tasks[0],
-		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0].Name),
+		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0]),
 		TaskEnv: taskenv.NewEmptyTaskEnv(),
 	}
 	require.NoError(t, req.TaskDir.Build(fsisolation.None, nil, alloc.Job.TaskGroups[0].Tasks[0].User))
@@ -587,7 +587,7 @@ func TestEnvoyBootstrapHook_Noop(t *testing.T) {
 	}, consulNamespace, nil, mock.Node(), logger))
 	req := &interfaces.TaskPrestartRequest{
 		Task:    task,
-		TaskDir: allocDir.NewTaskDir(task.Name),
+		TaskDir: allocDir.NewTaskDir(task),
 	}
 	require.NoError(t, req.TaskDir.Build(fsisolation.None, nil, task.User))
 
@@ -669,7 +669,7 @@ func TestEnvoyBootstrapHook_CommandFailed(t *testing.T) {
 
 	req := &interfaces.TaskPrestartRequest{
 		Task:    sidecarTask,
-		TaskDir: allocDir.NewTaskDir(sidecarTask.Name),
+		TaskDir: allocDir.NewTaskDir(sidecarTask),
 		TaskEnv: taskenv.NewEmptyTaskEnv(),
 	}
 	must.NoError(t, req.TaskDir.Build(fsisolation.None, nil, sidecarTask.User))
@@ -773,7 +773,7 @@ func TestEnvoyBootstrapHook_PreflightFailed(t *testing.T) {
 	// Create the prestart request
 	req := &interfaces.TaskPrestartRequest{
 		Task:    sidecarTask,
-		TaskDir: allocDir.NewTaskDir(sidecarTask.Name),
+		TaskDir: allocDir.NewTaskDir(sidecarTask),
 		TaskEnv: taskenv.NewEmptyTaskEnv(),
 	}
 	must.NoError(t, req.TaskDir.Build(fsisolation.None, nil, sidecarTask.User))

--- a/client/allocrunner/taskrunner/envoy_version_hook_test.go
+++ b/client/allocrunner/taskrunner/envoy_version_hook_test.go
@@ -251,7 +251,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_standard(t *testing.T) {
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{
 		Task:    alloc.Job.TaskGroups[0].Tasks[0],
-		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0].Name),
+		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0]),
 		TaskEnv: taskEnvDefault,
 	}
 	must.NoError(t, request.TaskDir.Build(fsisolation.None, nil, alloc.Job.TaskGroups[0].Tasks[0].User))
@@ -294,7 +294,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_custom(t *testing.T) {
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{
 		Task:    alloc.Job.TaskGroups[0].Tasks[0],
-		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0].Name),
+		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0]),
 		TaskEnv: taskEnvDefault,
 	}
 	must.NoError(t, request.TaskDir.Build(fsisolation.None, nil, alloc.Job.TaskGroups[0].Tasks[0].User))
@@ -339,7 +339,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_skip(t *testing.T) {
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{
 		Task:    alloc.Job.TaskGroups[0].Tasks[0],
-		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0].Name),
+		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0]),
 		TaskEnv: taskEnvDefault,
 	}
 	must.NoError(t, request.TaskDir.Build(fsisolation.None, nil, alloc.Job.TaskGroups[0].Tasks[0].User))
@@ -378,7 +378,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_no_fallback(t *testing.T) {
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{
 		Task:    alloc.Job.TaskGroups[0].Tasks[0],
-		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0].Name),
+		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0]),
 		TaskEnv: taskEnvDefault,
 	}
 	must.NoError(t, request.TaskDir.Build(fsisolation.None, nil, alloc.Job.TaskGroups[0].Tasks[0].User))
@@ -414,7 +414,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_error(t *testing.T) {
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{
 		Task:    alloc.Job.TaskGroups[0].Tasks[0],
-		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0].Name),
+		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0]),
 		TaskEnv: taskEnvDefault,
 	}
 	must.NoError(t, request.TaskDir.Build(fsisolation.None, nil, alloc.Job.TaskGroups[0].Tasks[0].User))
@@ -453,7 +453,7 @@ func TestTaskRunner_EnvoyVersionHook_Prestart_restart(t *testing.T) {
 	// Create a prestart request
 	request := &ifs.TaskPrestartRequest{
 		Task:    alloc.Job.TaskGroups[0].Tasks[0],
-		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0].Name),
+		TaskDir: allocDir.NewTaskDir(alloc.Job.TaskGroups[0].Tasks[0]),
 		TaskEnv: taskEnvDefault,
 	}
 	must.NoError(t, request.TaskDir.Build(fsisolation.None, nil, alloc.Job.TaskGroups[0].Tasks[0].User))

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -443,6 +443,11 @@ func NewTaskRunner(config *Config) (*TaskRunner, error) {
 	if !ok {
 		return nil, fmt.Errorf("no task resources found on allocation")
 	}
+
+	// we had to allocate the tmpfs with the memory to get correct scheduling
+	// and tracking on the node, but now that we're creating the task driver
+	// config we only care about the memory without the secrets.
+	tres.Memory.MemoryMB -= int64(tr.task.Resources.SecretsMB)
 	tr.taskResources = tres
 
 	// Build the restart tracker.

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -106,7 +106,7 @@ func testTaskRunnerConfig(t *testing.T, alloc *structs.Allocation, taskName stri
 		cleanup()
 		t.Fatalf("error building alloc dir: %v", err)
 	}
-	taskDir := allocDir.NewTaskDir(taskName)
+	taskDir := allocDir.NewTaskDir(thisTask)
 
 	// Create cgroup
 	f := cgroupslib.Factory(alloc.ID, taskName, false)

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -1832,7 +1832,7 @@ func TestTaskTemplateManager_Escapes(t *testing.T) {
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	logger := testlog.HCLogger(t)
 	allocDir := allocdir.NewAllocDir(logger, clientConf.AllocDir, clientConf.AllocMountsDir, alloc.ID)
-	taskDir := allocDir.NewTaskDir(task.Name)
+	taskDir := allocDir.NewTaskDir(task)
 
 	containerEnv := func() *taskenv.Builder {
 		// To emulate a Docker or exec tasks we must copy the

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -138,7 +138,7 @@ func TestConsul_Integration(t *testing.T) {
 	t.Cleanup(func() {
 		r.NoError(allocDir.Destroy())
 	})
-	taskDir := allocDir.NewTaskDir(task.Name)
+	taskDir := allocDir.NewTaskDir(task)
 	vclient, err := vaultclient.NewMockVaultClient("default")
 	must.NoError(t, err)
 	consulClient, err := consulapi.NewClient(consulConfig)

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1530,6 +1530,10 @@ func ApiResourcesToStructs(in *api.Resources) *structs.Resources {
 		}
 	}
 
+	if in.SecretsMB != nil {
+		out.SecretsMB = *in.SecretsMB
+	}
+
 	return out
 }
 

--- a/drivers/mock/driver_test.go
+++ b/drivers/mock/driver_test.go
@@ -138,13 +138,14 @@ func mkTestAllocDir(t *testing.T, h *dtestutil.DriverHarness, logger hclog.Logge
 
 	tc.AllocDir = allocDir.AllocDir
 
-	taskDir := allocDir.NewTaskDir(tc.Name)
-	must.NoError(t, taskDir.Build(fsisolation.None, ci.TinyChroot, tc.User))
-
 	task := &structs.Task{
-		Name: tc.Name,
-		Env:  tc.Env,
+		Name:      tc.Name,
+		Env:       tc.Env,
+		Resources: structs.MinResources(),
 	}
+
+	taskDir := allocDir.NewTaskDir(task)
+	must.NoError(t, taskDir.Build(fsisolation.None, ci.TinyChroot, tc.User))
 
 	// no logging
 	tc.StdoutPath = os.DevNull

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -78,7 +78,7 @@ func testExecutorCommandWithChroot(t *testing.T) *testExecCmd {
 	if err := allocDir.Build(); err != nil {
 		t.Fatalf("AllocDir.Build() failed: %v", err)
 	}
-	if err := allocDir.NewTaskDir(task.Name).Build(fsisolation.Chroot, chrootEnv, task.User); err != nil {
+	if err := allocDir.NewTaskDir(task).Build(fsisolation.Chroot, chrootEnv, task.User); err != nil {
 		allocDir.Destroy()
 		t.Fatalf("allocDir.NewTaskDir(%q) failed: %v", task.Name, err)
 	}

--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -80,7 +80,7 @@ func testExecutorCommand(t *testing.T) *testExecCmd {
 	if err := allocDir.Build(); err != nil {
 		t.Fatalf("AllocDir.Build() failed: %v", err)
 	}
-	if err := allocDir.NewTaskDir(task.Name).Build(fsisolation.None, nil, task.User); err != nil {
+	if err := allocDir.NewTaskDir(task).Build(fsisolation.None, nil, task.User); err != nil {
 		allocDir.Destroy()
 		t.Fatalf("allocDir.NewTaskDir(%q) failed: %v", task.Name, err)
 	}
@@ -648,7 +648,7 @@ func TestExecutor_Start_NonExecutableBinaries(t *testing.T) {
 			// need to configure path in chroot with that file if using isolation executor
 			if _, ok := executor.(*UniversalExecutor); !ok {
 				taskName := filepath.Base(testExecCmd.command.TaskDir)
-				err := allocDir.NewTaskDir(taskName).Build(fsisolation.Chroot, map[string]string{
+				err := allocDir.NewTaskDir(&structs.Task{Name: taskName}).Build(fsisolation.Chroot, map[string]string{
 					tmpDir: tmpDir,
 				}, "nobody")
 				require.NoError(err)

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -503,12 +503,3 @@ func Merge[T comparable](a, b T) T {
 	}
 	return a
 }
-
-// AddClamped adds integers but returns maxint if there's overflow
-func AddClamped(a, b int64) int64 {
-	c := a + b
-	if (c > a) == (b > 0) {
-		return c
-	}
-	return math.MaxInt64
-}

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -503,3 +503,12 @@ func Merge[T comparable](a, b T) T {
 	}
 	return a
 }
+
+// AddClamped adds integers but returns maxint if there's overflow
+func AddClamped(a, b int64) int64 {
+	c := a + b
+	if (c > a) == (b > 0) {
+		return c
+	}
+	return math.MaxInt64
+}

--- a/helper/safemath/safemath.go
+++ b/helper/safemath/safemath.go
@@ -1,0 +1,15 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package safemath
+
+import "math"
+
+// Add adds integers but clamps the results to MaxInt64 if there's overflow
+func Add(a, b int64) int64 {
+	c := a + b
+	if (c > a) == (b > 0) {
+		return c
+	}
+	return math.MaxInt64
+}

--- a/helper/safemath/safemath_test.go
+++ b/helper/safemath/safemath_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package safemath
+
+import (
+	"math"
+	"testing"
+
+	"github.com/shoenig/test/must"
+)
+
+// TestAdd_Overflow
+func TestAdd_Overflow(t *testing.T) {
+	must.Eq(t, math.MaxInt64, Add(math.MaxInt64, math.MaxInt64)) // overflow
+	must.Eq(t, math.MaxInt64, Add(1, math.MaxInt64))             // overflow (boundary)
+	must.Eq(t, math.MaxInt64-1, Add(-1, math.MaxInt64))          // no overflow (boundary)
+	must.Eq(t, -1, Add(math.MaxInt64-1, -math.MaxInt64))         // no overflow (subtraction)
+	up := int64(1)
+	must.Eq(t, math.MaxInt64, Add(math.MaxInt64+up, -math.MaxInt64)) // operand overflowed
+}

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -6199,9 +6199,10 @@ func TestTaskDiff(t *testing.T) {
 			},
 			New: &Task{
 				Resources: &Resources{
-					CPU:      200,
-					MemoryMB: 200,
-					DiskMB:   200,
+					CPU:       200,
+					MemoryMB:  200,
+					DiskMB:    200,
+					SecretsMB: 10,
 				},
 			},
 			Expected: &TaskDiff{
@@ -6228,6 +6229,12 @@ func TestTaskDiff(t *testing.T) {
 								Name: "MemoryMB",
 								Old:  "100",
 								New:  "200",
+							},
+							{
+								Type: DiffTypeEdited,
+								Name: "SecretsMB",
+								Old:  "0",
+								New:  "10",
 							},
 						},
 					},
@@ -6291,6 +6298,12 @@ func TestTaskDiff(t *testing.T) {
 							{
 								Type: DiffTypeNone,
 								Name: "MemoryMaxMB",
+								Old:  "0",
+								New:  "0",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "SecretsMB",
 								Old:  "0",
 								New:  "0",
 							},
@@ -6396,6 +6409,12 @@ func TestTaskDiff(t *testing.T) {
 								Name: "MemoryMaxMB",
 								Old:  "200",
 								New:  "300",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "SecretsMB",
+								Old:  "0",
+								New:  "0",
 							},
 						},
 					},
@@ -6743,6 +6762,12 @@ func TestTaskDiff(t *testing.T) {
 							{
 								Type: DiffTypeNone,
 								Name: "MemoryMaxMB",
+								Old:  "0",
+								New:  "0",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "SecretsMB",
 								Old:  "0",
 								New:  "0",
 							},

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2432,6 +2432,7 @@ type Resources struct {
 	Networks    Networks
 	Devices     ResourceDevices
 	NUMA        *NUMA
+	SecretsMB   int
 }
 
 const (
@@ -2502,6 +2503,11 @@ func (r *Resources) Validate() error {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("MemoryMaxMB value (%d) should be larger than MemoryMB value (%d)", r.MemoryMaxMB, r.MemoryMB))
 	}
 
+	if r.SecretsMB > r.MemoryMB {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("SecretsMB value (%d) cannot be larger than MemoryMB value (%d)", r.SecretsMB, r.MemoryMB))
+
+	}
+
 	return mErr.ErrorOrNil()
 }
 
@@ -2529,6 +2535,9 @@ func (r *Resources) Merge(other *Resources) {
 	if len(other.Devices) != 0 {
 		r.Devices = other.Devices
 	}
+	if other.SecretsMB != 0 {
+		r.SecretsMB = other.SecretsMB
+	}
 }
 
 // Equal Resources.
@@ -2548,7 +2557,8 @@ func (r *Resources) Equal(o *Resources) bool {
 		r.DiskMB == o.DiskMB &&
 		r.IOPS == o.IOPS &&
 		r.Networks.Equal(&o.Networks) &&
-		r.Devices.Equal(&o.Devices)
+		r.Devices.Equal(&o.Devices) &&
+		r.SecretsMB == o.SecretsMB
 }
 
 // ResourceDevices are part of Resources.
@@ -2645,6 +2655,7 @@ func (r *Resources) Copy() *Resources {
 		Networks:    r.Networks.Copy(),
 		Devices:     r.Devices.Copy(),
 		NUMA:        r.NUMA.Copy(),
+		SecretsMB:   r.SecretsMB,
 	}
 }
 
@@ -2671,6 +2682,7 @@ func (r *Resources) Add(delta *Resources) {
 		r.MemoryMaxMB += delta.MemoryMB
 	}
 	r.DiskMB += delta.DiskMB
+	r.SecretsMB += delta.SecretsMB
 
 	for _, n := range delta.Networks {
 		// Find the matching interface by IP or CIDR

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2505,7 +2505,9 @@ func (r *Resources) Validate() error {
 
 	if r.SecretsMB > r.MemoryMB {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("SecretsMB value (%d) cannot be larger than MemoryMB value (%d)", r.SecretsMB, r.MemoryMB))
-
+	}
+	if r.SecretsMB < 0 {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("SecretsMB value (%d) cannot be negative", r.SecretsMB))
 	}
 
 	return mErr.ErrorOrNil()

--- a/plugins/drivers/testutils/testing.go
+++ b/plugins/drivers/testutils/testing.go
@@ -92,7 +92,12 @@ func (h *DriverHarness) MkAllocDir(t *drivers.TaskConfig, enableLogs bool) func(
 
 	t.AllocDir = allocDir.AllocDir
 
-	taskDir := allocDir.NewTaskDir(t.Name)
+	task := &structs.Task{
+		Name: t.Name,
+		Env:  t.Env,
+	}
+
+	taskDir := allocDir.NewTaskDir(task)
 
 	caps, err := h.Capabilities()
 	must.NoError(h.t, err)
@@ -100,11 +105,6 @@ func (h *DriverHarness) MkAllocDir(t *drivers.TaskConfig, enableLogs bool) func(
 	fsi := caps.FSIsolation
 	h.logger.Trace("FS isolation", "fsi", fsi)
 	must.NoError(h.t, taskDir.Build(fsi, ci.TinyChroot, t.User))
-
-	task := &structs.Task{
-		Name: t.Name,
-		Env:  t.Env,
-	}
 
 	// Create the mock allocation
 	alloc := mock.Alloc()

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/nomad/client/lib/idset"
 	"github.com/hashicorp/nomad/client/lib/numalib/hw"
-	"github.com/hashicorp/nomad/helper"
+	"github.com/hashicorp/nomad/helper/safemath"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -371,12 +371,12 @@ OUTER:
 					CpuShares: int64(task.Resources.CPU),
 				},
 				Memory: structs.AllocatedMemoryResources{
-					MemoryMB: helper.AddClamped(
+					MemoryMB: safemath.Add(
 						int64(task.Resources.MemoryMB), int64(task.Resources.SecretsMB)),
 				},
 			}
 			if iter.memoryOversubscription {
-				taskResources.Memory.MemoryMaxMB = helper.AddClamped(
+				taskResources.Memory.MemoryMaxMB = safemath.Add(
 					int64(task.Resources.MemoryMaxMB), int64(task.Resources.SecretsMB))
 			}
 

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/nomad/client/lib/idset"
 	"github.com/hashicorp/nomad/client/lib/numalib/hw"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -370,11 +371,13 @@ OUTER:
 					CpuShares: int64(task.Resources.CPU),
 				},
 				Memory: structs.AllocatedMemoryResources{
-					MemoryMB: int64(task.Resources.MemoryMB),
+					MemoryMB: helper.AddClamped(
+						int64(task.Resources.MemoryMB), int64(task.Resources.SecretsMB)),
 				},
 			}
 			if iter.memoryOversubscription {
-				taskResources.Memory.MemoryMaxMB = int64(task.Resources.MemoryMaxMB)
+				taskResources.Memory.MemoryMaxMB = helper.AddClamped(
+					int64(task.Resources.MemoryMaxMB), int64(task.Resources.SecretsMB))
 			}
 
 			// Check if we need a network resource

--- a/scheduler/rank_test.go
+++ b/scheduler/rank_test.go
@@ -1249,8 +1249,9 @@ func TestBinPackIterator_PlannedAlloc(t *testing.T) {
 			{
 				Name: "web",
 				Resources: &structs.Resources{
-					CPU:      1024,
-					MemoryMB: 1024,
+					CPU:       1024,
+					MemoryMB:  1014,
+					SecretsMB: 10,
 				},
 			},
 		},

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -368,6 +368,8 @@ func nonNetworkResourcesUpdated(a, b *structs.Resources) comparison {
 		return difference("task devices", a.Devices, b.Devices)
 	case !a.NUMA.Equal(b.NUMA):
 		return difference("numa", a.NUMA, b.NUMA)
+	case a.SecretsMB != b.SecretsMB:
+		return difference("task secrets", a.SecretsMB, b.SecretsMB)
 	}
 	return same
 }

--- a/website/content/docs/job-specification/resources.mdx
+++ b/website/content/docs/job-specification/resources.mdx
@@ -50,6 +50,17 @@ job "docs" {
 - `device` <code>([Device][]: &lt;optional&gt;)</code> - Specifies the device
   requirements. This may be repeated to request multiple device types.
 
+- `secrets` <code>(`int`: &lt;optional&gt;)</code> - Specifies the size of the
+  [`secrets/`][] directory in MB, on platforms where the directory is a
+  tmpfs. If set, the scheduler adds the `secrets` value to the `memory` value
+  when allocating resources on a client, and this value will be included in the
+  allocated resources shown by the `nomad alloc status` and `nomad node status`
+  commands. If unset, the client will allocate 1 MB of tmpfs space and it will
+  not be counted for scheduling purposes or included in allocated resources. You
+  should not set this value if the workload will be placed on a platform where
+  tmpfs is unsupported, because it will still be counted for scheduling
+  purposes.
+
 ## `resources` Examples
 
 The following examples only show the `resources` blocks. Remember that the
@@ -148,3 +159,4 @@ resource utilization and considering the following suggestions:
 [np_sched_config]: /nomad/docs/other-specifications/node-pool#memory_oversubscription_enabled
 [tutorial_quota]: /nomad/tutorials/governance-and-policy/quotas
 [numa]: /nomad/docs/job-specification/numa 'Nomad NUMA Job Specification'
+[`secrets/`]: /nomad/docs/runtime/environment#secrets


### PR DESCRIPTION
On supported platforms, the secrets directory is a 1MiB tmpfs. But some tasks need larger space for downloading large secrets. This is especially the case for tasks using `templates`, which need extra room to write a temporary file to the secrets directory that gets renamed to the old file atomically.

This changeset allows increasing the size of the tmpfs in the `resources` block. Because this is a memory resource, we need to include it in the memory we allocate for scheduling purposes. The task is already prevented from using more memory in the tmpfs than the `resources.memory` field allows, but can bypass that limit by writing to the tmpfs via `template` or `artifact` blocks.

Therefore, we need to account for the size of the tmpfs in the allocation resources. Simply adding it to the memory needed when we create the allocation allows it to be accounted for in all downstream consumers, and then we'll subtract that amount from the memory resources just before configuring the task driver.

For backwards compatibility, the default value of 1MiB is "free" and ignored by the scheduler. Otherwise we'd be increasing the allocated resources for every existing alloc, which could cause problems across upgrades. If a user explicitly sets `resources.secrets = 1` it will no longer be free.

Fixes: https://github.com/hashicorp/nomad/issues/2481
Ref: https://hashicorp.atlassian.net/browse/NET-10070