### PR TITLE
Allow static ports duplication on network host with multiple matches

### DIFF
--- a/.changelog/23693.txt
+++ b/.changelog/23693.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+networking: Fixed a bug where if a client have two IP on the same network host, only one can provide the same static port
+```

--- a/.changelog/23693.txt
+++ b/.changelog/23693.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-networking: Fixed a bug where if a client have two IP on the same network host, only one can provide the same static port
+networking: The same static port can now be used more than once on host networks with multiple IPs
 ```

--- a/nomad/structs/network.go
+++ b/nomad/structs/network.go
@@ -526,7 +526,8 @@ func (idx *NetworkIndex) AssignPorts(ask *NetworkResource) (AllocatedPorts, erro
 
 			// Check if in use
 			if used != nil && used.Check(uint(port.Value)) {
-				return nil, fmt.Errorf("reserved port collision %s=%d", port.Label, port.Value)
+				addrErr = fmt.Errorf("reserved port collision %s=%d", port.Label, port.Value)
+				continue
 			}
 
 			allocPort = &AllocatedPortMapping{


### PR DESCRIPTION
When a client add two IP matching the same network host, it should be able to used both for static ports
The primary used case is when an application with not configurable port is deployed on a big bare metal host. It would be wasteful to not allow multiple time the same host to be used.

Fixes: #23693 