### PR TITLE
build: remove inactive CE versions from being backport eligible

### DIFF
--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -11,9 +11,9 @@ active_versions {
     lts       = true
   }
   version "1.7.x" {
-    ce_active = true
+    ce_active = false
   }
   version "1.6.x" {
-    ce_active = true
+    ce_active = false
   }
 }


### PR DESCRIPTION
As of Nomad 1.8.0 LTS we're no longer backporting changes to Nomad CE versions 1.7.x and 1.6.x. We never got around to removing the flags in the file the backport assistant uses to control automated backports.