### PR TITLE
security: fix write symlink escape on the same allocdir path

### DIFF
--- a/.changelog/23738.txt
+++ b/.changelog/23738.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-security: Fix write symlink escape during unarchive by removing existing paths within the same allocdir.
+security: Fix symlink escape during unarchiving by removing existing paths within the same allocdir. Compromising the Nomad client agent at the source allocation first is a prerequisite for leveraging this issue.
 ```

--- a/.changelog/23738.txt
+++ b/.changelog/23738.txt
@@ -1,0 +1,3 @@
+```release-note:security
+security: Fix write symlink escape during unarchive by removing existing paths within the same allocdir.
+```

--- a/client/allocwatcher/alloc_watcher.go
+++ b/client/allocwatcher/alloc_watcher.go
@@ -636,7 +636,13 @@ func (p *remotePrevAlloc) streamAllocDir(ctx context.Context, resp io.ReadCloser
 		}
 		// If the header is a file, we write to a file
 		if hdr.Typeflag == tar.TypeReg {
-			f, err := os.Create(filepath.Join(dest, hdr.Name))
+			fPath := filepath.Join(dest, hdr.Name)
+			if _, err := os.Lstat(fPath); err == nil {
+				if err := os.Remove(fPath); err != nil {
+					return fmt.Errorf("error removing existing file: %w", err)
+				}
+			}
+			f, err := os.Create(fPath)
 			if err != nil {
 				return fmt.Errorf("error creating file: %w", err)
 			}

--- a/client/allocwatcher/alloc_watcher_unix_test.go
+++ b/client/allocwatcher/alloc_watcher_unix_test.go
@@ -145,6 +145,8 @@ func TestPrevAlloc_StreamAllocDir_SyminkWriteAttack(t *testing.T) {
 	content := "HelloWorld from outside"
 
 	// Create a tar archive with a symlink that attempts to escape the allocation directory
+	// by including a header that writes to the same path and follows the symlink target
+	// outside of the sandboxed environment.
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 	t.Cleanup(func() { tw.Close() })


### PR DESCRIPTION
Resolves symlink escape when unarchiving by removing existing paths within the same allocation directory which can occur by writing a header that points to a symlink that lives outside of the sandbox environment. This exploit requires first compromising the Nomad client agent at the source allocation.

Ref: [NET-10607](https://hashicorp.atlassian.net/browse/NET-10607) & https://github.com/hashicorp/nomad-enterprise/pull/1725

[NET-10607]: https://hashicorp.atlassian.net/browse/NET-10607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ