### PR TITLE
DOCS: CE-659 chroot limitations for isolated fork/exec driver

### DIFF
--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -214,9 +214,8 @@ client {
 
 ### `chroot_env` Parameters
 
-Drivers based on [isolated fork/exec](/nomad/docs/drivers/exec) implement file
-system isolation using chroot on Linux. The `chroot_env` map allows the chroot
-environment to be configured using source paths on the host operating system.
+On Linux, drivers based on [isolated fork/exec](/nomad/docs/drivers/exec) implement file system isolation using chroot. The `chroot_env` map lets you configure the chroot environment using source paths on the host operating system.
+
 The mapping format is:
 
 ```text
@@ -240,13 +239,13 @@ client {
 }
 ```
 
-When `chroot_env` is unspecified, the `exec` driver will use a default chroot
-environment with the most commonly used parts of the operating system. Please
-see the [Nomad `exec` driver documentation](/nomad/docs/drivers/exec#chroot) for
+@include 'chroot-limitations.mdx'
+
+When `chroot_env` is unspecified, the `exec` driver uses a default chroot
+environment with the most commonly used parts of the operating system. Refer to the [Nomad `exec` driver documentation](/nomad/docs/drivers/exec#chroot) for
 the full list.
 
-Nomad will never attempt to embed the `alloc_dir` in the
-chroot as doing so would cause infinite recursion.
+Nomad never attempts to embed the `alloc_dir` in the chroot as doing so would cause infinite recursion.
 
 ### `options` Parameters
 

--- a/website/content/docs/drivers/exec.mdx
+++ b/website/content/docs/drivers/exec.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: 'Drivers: Exec'
-description: The Exec task driver is used to run binaries using OS isolation primitives.
+description: The Exec task driver runs binaries using OS isolation primitives.
 ---
 
 # Isolated Fork/Exec Driver
@@ -229,8 +229,9 @@ on [cgroup controller requirements][] for more details.
 
 ### Chroot
 
-The chroot is populated with data in the following directories from the host
-machine:
+Chroot changes the root directory of the current process and all its child processes. Nomad uses a chroot environment to implement file system isolation.
+
+Nomad populates the chroot environment with data in the following host machine directories:
 
 ```
 [
@@ -245,13 +246,13 @@ machine:
 ]
 ```
 
-The task's chroot is populated by linking or copying the data from the host into
-the chroot. Note that this can take considerable disk space. Since Nomad v0.5.3,
-the client manages garbage collection locally which mitigates any issue this may
-create.
+Nomad populates the task's chroot environment by linking or copying the data from the host into the chroot. Note that this can take considerable disk space.
+The client manages garbage collection locally, which mitigates any issue this may create.
 
-This list is configurable through the agent client
-[configuration file](/nomad/docs/configuration/client#chroot_env).
+@include 'chroot-limitations.mdx'
+
+Configure the chroot environment list through the agent client's
+[`chroot_env` attribute](/nomad/docs/configuration/client#chroot_env).
 
 ### CPU
 

--- a/website/content/partials/chroot-limitations.mdx
+++ b/website/content/partials/chroot-limitations.mdx
@@ -1,0 +1,3 @@
+!> **Warning:** chroot doesn't copy or recreate directories and files that systemd uses. Specifically on Ubuntu, `/etc/resolv.conf` is a symlink to `/run/systemd/resolve/stub-resolv.conf`, so chroot doesn't copy or link to `resolv.conf`.
+
+In these cases, configure your job's [network block](/nomad/docs/job-specification/network) for each chroot task.

--- a/website/content/partials/chroot-limitations.mdx
+++ b/website/content/partials/chroot-limitations.mdx
@@ -1,3 +1,3 @@
-!> **Warning:** chroot doesn't copy or recreate directories and files that systemd uses. Specifically on Ubuntu, `/etc/resolv.conf` is a symlink to `/run/systemd/resolve/stub-resolv.conf`, so chroot doesn't copy or link to `resolv.conf`.
+!> **Warning chroot limitations:** Nomad by default doesn't copy the ephemeral runtime files in the `/run` directory. For exampe, on Ubuntu, `/etc/resolv.conf` is a symlink to `/run/systemd/resolve/stub-resolv.conf`, so Nomad doesn't copy `resolv.conf` to the chroot environment.
 
 In these cases, configure your job's [network block](/nomad/docs/job-specification/network) for each chroot task.


### PR DESCRIPTION
[Jira issue](https://hashicorp.atlassian.net/browse/CE-659). 

Based on my research, this looks like a chroot limitation and not necessarily a Nomad issue (I could be completely wrong), so I added a new partial with a warning.


Deploy previews:
- [Fork/isolated chroot section](https://nomad-git-docs-ce659-hashicorp.vercel.app/nomad/docs/drivers/exec#chroot)
- [Client config chroot section](https://nomad-git-docs-ce659-hashicorp.vercel.app/nomad/docs/configuration/client#chroot_env-parameters)