### PR TITLE
e2e: test ipv6 connectivity for bridge network

### DIFF
--- a/e2e/networking/inputs/docker_bridged_ipv6.nomad.hcl
+++ b/e2e/networking/inputs/docker_bridged_ipv6.nomad.hcl
@@ -1,0 +1,44 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+job "bridge-ipv6" {
+  group "g" {
+    network {
+      mode = "bridge"
+      port "http" {
+        to = 8000
+        static = 8000
+      }
+
+    }
+    service {
+      name     = "a-web"
+      port     = "http"
+      provider = "nomad"
+      address_mode = "alloc"
+    }
+    task "t" {
+      template {
+        data = <<EOH
+         #!/usr/bin/env bash
+
+         apt update
+         apt install curl -y
+         EOH
+         destination = "local/bridge_ipv6.sh"
+      }
+      template {
+              data = "hellooo-thereee:P"
+              destination = "local/index.html"
+            }
+
+      driver = "docker"
+      config {
+        image   = "python:slim"
+        command = "python3"
+        args    = ["-m", "http.server", "--directory=local", "--bind=::"]
+        ports   = ["http"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds end to end tests for https://github.com/hashicorp/nomad/issues/14101.

This test runs a default bridge job and checks that the allocation (within the bridge network namespace) can curl an IPv6 address. 
