### PR TITLE
ipv6: allow ipv6 connectivity for bridge network

### DIFF
--- a/client/allocrunner/network_manager_linux.go
+++ b/client/allocrunner/network_manager_linux.go
@@ -190,7 +190,7 @@ func newNetworkConfigurator(log hclog.Logger, alloc *structs.Allocation, config 
 
 	switch {
 	case netMode == "bridge":
-		c, err := newBridgeNetworkConfigurator(log, alloc, config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.BridgeNetworkHairpinMode, config.CNIPath, ignorePortMappingHostIP, config.Node)
+		c, err := newBridgeNetworkConfigurator(log, alloc, config.BridgeNetworkName, config.BridgeNetworkAllocSubnet, config.BridgeNetworkAllocSubnetIPv6, config.BridgeNetworkHairpinMode, config.CNIPath, ignorePortMappingHostIP, config.Node)
 		if err != nil {
 			return nil, err
 		}

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -6,6 +6,7 @@ package allocrunner
 import (
 	"context"
 	"fmt"
+
 	"github.com/coreos/go-iptables/iptables"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/nomad/structs"

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -222,6 +222,7 @@ func buildNomadBridgeNetConfig(b bridgeNetworkConfigurator, withConsulCNI bool) 
 		b.allocSubnetIPv4,
 		b.allocSubnetIPv6,
 		cniAdminChainName,
+		cniAdminChainName,
 		consulCNI,
 	))
 }
@@ -258,14 +259,19 @@ const nomadCNIConfigTemplate = `{
 					]
 				],
 				"routes": [
-					{ "dst": "0.0.0.0/0",
-                      "dst" : "::/0" }
+					{ "dst": "0.0.0.0/0" },
+                    { "dst" : "::/0" }
 				]
 			}
 		},
 		{
 			"type": "firewall",
 			"backend": "iptables",
+			"iptablesAdminChainName": %q
+		},
+		{
+			"type": "firewall",
+			"backend": "ip6tables",
 			"iptablesAdminChainName": %q
 		},
 		{

--- a/client/allocrunner/networking_bridge_linux.go
+++ b/client/allocrunner/networking_bridge_linux.go
@@ -6,8 +6,6 @@ package allocrunner
 import (
 	"context"
 	"fmt"
-	"strings"
-
 	"github.com/coreos/go-iptables/iptables"
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/nomad/structs"

--- a/client/allocrunner/networking_bridge_linux_test.go
+++ b/client/allocrunner/networking_bridge_linux_test.go
@@ -26,26 +26,29 @@ func Test_buildNomadBridgeNetConfig(t *testing.T) {
 		{
 			name: "hairpin",
 			b: &bridgeNetworkConfigurator{
-				bridgeName:  defaultNomadBridgeName,
-				allocSubnet: defaultNomadAllocSubnet,
-				hairpinMode: true,
+				bridgeName:      defaultNomadBridgeName,
+				allocSubnetIPv6: defaultNomadAllocSubnetIPv6,
+				allocSubnetIPv4: defaultNomadAllocSubnet,
+				hairpinMode:     true,
 			},
 		},
 		{
 			name: "bad_input",
 			b: &bridgeNetworkConfigurator{
-				bridgeName:  `bad"`,
-				allocSubnet: defaultNomadAllocSubnet,
-				hairpinMode: true,
+				bridgeName:      `bad"`,
+				allocSubnetIPv6: defaultNomadAllocSubnetIPv6,
+				allocSubnetIPv4: defaultNomadAllocSubnet,
+				hairpinMode:     true,
 			},
 		},
 		{
 			name:          "consul-cni",
 			withConsulCNI: true,
 			b: &bridgeNetworkConfigurator{
-				bridgeName:  defaultNomadBridgeName,
-				allocSubnet: defaultNomadAllocSubnet,
-				hairpinMode: true,
+				bridgeName:      defaultNomadBridgeName,
+				allocSubnetIPv6: defaultNomadAllocSubnetIPv6,
+				allocSubnetIPv4: defaultNomadAllocSubnet,
+				hairpinMode:     true,
 			},
 		},
 	}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -291,8 +291,13 @@ type Config struct {
 
 	// BridgeNetworkAllocSubnet is the IP subnet to use for address allocation
 	// for allocations in bridge networking mode. Subnet must be in CIDR
-	// notation
+	// notation and must be an IPv4 address.
 	BridgeNetworkAllocSubnet string
+
+	// BridgeNetworkAllocSubnetIPv6 is the IP subnet to use for address allocation
+	// for allocations in bridge networking mode. Subnet must be in CIDR
+	// notation and must be an IPv6 address.
+	BridgeNetworkAllocSubnetIPv6 string
 
 	// HostVolumes is a map of the configured host volumes by name.
 	HostVolumes map[string]*structs.ClientHostVolumeConfig

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -890,6 +890,7 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	conf.CNIConfigDir = agentConfig.Client.CNIConfigDir
 	conf.BridgeNetworkName = agentConfig.Client.BridgeNetworkName
 	conf.BridgeNetworkAllocSubnet = agentConfig.Client.BridgeNetworkSubnet
+	conf.BridgeNetworkAllocSubnetIPv6 = agentConfig.Client.BridgeNetworkSubnetIPv6
 	conf.BridgeNetworkHairpinMode = agentConfig.Client.BridgeNetworkHairpinMode
 
 	for _, hn := range agentConfig.Client.HostNetworks {

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -357,10 +357,15 @@ type ClientConfig struct {
 	// bridge network mode
 	BridgeNetworkName string `hcl:"bridge_network_name"`
 
-	// BridgeNetworkSubnet is the subnet to allocate IP addresses from when
+	// BridgeNetworkSubnet is the subnet to allocate IPv4 addresses from when
 	// creating allocations with bridge networking mode. This range is local to
 	// the host
 	BridgeNetworkSubnet string `hcl:"bridge_network_subnet"`
+
+	// BridgeNetworkSubnetIPv6 is the subnet to allocate IPv6 addresses from when
+	// creating allocations with bridge networking mode. This range is local to
+	// the host
+	BridgeNetworkSubnetIPv6 string `hcl:"bridge_network_subnet_ipv6"`
 
 	// BridgeNetworkHairpinMode is whether or not to enable hairpin mode on the
 	// internal bridge network
@@ -2435,7 +2440,9 @@ func (a *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	if b.BridgeNetworkSubnet != "" {
 		result.BridgeNetworkSubnet = b.BridgeNetworkSubnet
 	}
-
+	if b.BridgeNetworkSubnetIPv6 != "" {
+		result.BridgeNetworkSubnetIPv6 = b.BridgeNetworkSubnetIPv6
+	}
 	if b.BridgeNetworkHairpinMode {
 		result.BridgeNetworkHairpinMode = true
 	}

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -92,9 +92,10 @@ var basicConfig = &Config{
 		HostVolumes: []*structs.ClientHostVolumeConfig{
 			{Name: "tmp", Path: "/tmp"},
 		},
-		CNIPath:             "/tmp/cni_path",
-		BridgeNetworkName:   "custom_bridge_name",
-		BridgeNetworkSubnet: "custom_bridge_subnet",
+		CNIPath:                 "/tmp/cni_path",
+		BridgeNetworkName:       "custom_bridge_name",
+		BridgeNetworkSubnet:     "custom_bridge_subnet",
+		BridgeNetworkSubnetIPv6: "custom_bridge_subnet_ipv6",
 	},
 	Server: &ServerConfig{
 		Enabled:                   true,

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -105,6 +105,7 @@ client {
   cni_path              = "/tmp/cni_path"
   bridge_network_name   = "custom_bridge_name"
   bridge_network_subnet = "custom_bridge_subnet"
+  bridge_network_subnet_ipv6 = "custom_bridge_subnet_ipv6"
 }
 
 server {

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -76,6 +76,7 @@
       "alloc_mounts_dir": "/tmp/mounts",
       "bridge_network_name": "custom_bridge_name",
       "bridge_network_subnet": "custom_bridge_subnet",
+      "bridge_network_subnet_ipv6": "custom_bridge_subnet_ipv6",
       "chroot_env": [
         {
           "/opt/myapp/bin": "/bin",


### PR DESCRIPTION
This PR integrates IPv6 connectivity within the bridge network by adding IPv6 range configuration for bridge networking and a default IPv6 subnet IP address if no configuration is specified. 

Resolves https://github.com/hashicorp/nomad/issues/14101.