### PR TITLE
docker: fix delimiter for selinux label for read-only volumes

### DIFF
--- a/.changelog/23750.txt
+++ b/.changelog/23750.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fixed a bug where plugin SELinux labels would conflict with read-only `volume` options
+```

--- a/client/testutil/driver_compatible.go
+++ b/client/testutil/driver_compatible.go
@@ -63,9 +63,17 @@ func RequireLinux(t *testing.T) {
 }
 
 // RequireNotWindows skips tests whenever:
-// - running on Window
+// - running on Windows
 func RequireNotWindows(t *testing.T) {
 	if runtime.GOOS == "windows" {
+		t.Skip("Test requires non-Windows")
+	}
+}
+
+// RequireWindows skips tests whenever:
+// - not running on Windows
+func RequireWindows(t *testing.T) {
+	if runtime.GOOS != "windows" {
 		t.Skip("Test requires non-Windows")
 	}
 }


### PR DESCRIPTION
The Docker driver's `volume` field to specify bind-mounts takes a list of strings that consist of three `:`-delimited fields: source, destination, and options. We append the SELinux label from the plugin configuration as the third field. But when the user has already specified the volume is read-only with `:ro`, we're incorrectly appending the SELinux label with another `:` instead of the required `,`.

Combine the options into a single field value before appending them to the bind mounts configuration. Updated the tests to split out Windows behavior (which has a different volume specification format) and to ensure the test task has the expected environment for bind mounts.

Fixes: https://github.com/hashicorp/nomad/issues/23690