### PR TITLE
Backport of: docs: refactor CNI plugin content to 1.7.x (#23707)

### DIFF
--- a/website/content/docs/concepts/plugins/cni.mdx
+++ b/website/content/docs/concepts/plugins/cni.mdx
@@ -61,4 +61,4 @@ Nomad Networking documentation](/nomad/docs/networking/cni).
 [cni_spec]: https://www.cni.dev/docs/spec/
 [cni_spec_net_config]: https://github.com/containernetworking/cni/blob/main/SPEC.md#configuration-format
 [cni_spec_plugin_config]: https://github.com/containernetworking/cni/blob/main/SPEC.md#plugin-configuration-objects
-[nomad_install]: /nomad/tutorials/get-started/get-started-install#post-installation-steps
+[nomad_install]: /nomad/tutorials/get-started/get-started-install#linux-post-installation-steps

--- a/website/content/docs/install/index.mdx
+++ b/website/content/docs/install/index.mdx
@@ -1,78 +1,23 @@
 ---
 layout: docs
-page_title: Installing Nomad
-description: Learn how to install Nomad.
+page_title: Install Nomad
+description: Learn how to install Nomad on Linux, Mac, and Windows.
 ---
 
-# Installing Nomad
+# Install Nomad
 
 Nomad is available as a pre-compiled binary or as a package for several
 operating systems. You can also [build Nomad from source](#from-source).
 
--> If you are interested in trialing Nomad without installing it locally, see the
-[Quickstart](/nomad/docs/install/quickstart) for options to get started with Nomad.
+-> If you are interested in trialing Nomad without installing it locally, see
+the [Quickstart](/nomad/docs/install/quickstart) for options to get started with
+Nomad.
 
 <Tabs>
-<Tab heading="Manual installation" group="manual">
-
-You can download a [precompiled binary](/nomad/downloads) and
-run it on your machine locally. You can also verify the binary using the
-available SHA-256 sums. After downloading Nomad, unzip the package. Make sure
-that the `nomad` binary is available on your `PATH` before continuing with the
-other guides.
-
-</Tab>
-<Tab heading="Homebrew on macOS" group="homebrew">
-
-[Homebrew](https://brew.sh) is a free and open source package management system
-for Mac OS X. Install the official [Nomad
-formula](https://github.com/hashicorp/homebrew-tap) from the terminal.
-
-First, install the HashiCorp tap, a repository of all of the HashiCorp Homebrew
-packages.
-
-```shell-session
-$ brew tap hashicorp/tap
-```
-
-Now, install Nomad with `hashicorp/tap/nomad`.
-
-```shell-session
-$ brew install hashicorp/tap/nomad
-```
-
-~> **NOTE:** This installs a signed binary and is automatically updated with
-every new official release.
-
-To update to the latest, run
-
-```shell-session
-$ brew upgrade hashicorp/tap/nomad
-```
-
-</Tab>
-<Tab heading="Chocolatey on Windows" group="chocolatey">
-
-[Chocolatey](https://chocolatey.org/) is a free and open-source package
-management system for Windows. Install the [Nomad
-package](https://chocolatey.org/packages/nomad) from the command-line.
-
-```shell-session
-$ choco install nomad
-```
-
-~> **NOTE:** Chocolatey and the Nomad package are **NOT** directly maintained
-by HashiCorp. The latest version of Nomad is always available by manual
-installation.
-
-</Tab>
-<Tab heading="Linux Packages" group="linux">
-
-HashiCorp officially maintains and signs packages for the following Linux
-distributions.
+<Tab heading="Linux" group="linux">
 
 <Tabs>
-<Tab heading="Ubuntu/Debian">
+<Tab heading="Ubuntu/Debian" group="ubuntu">
 
 Install the required packages.
 
@@ -84,13 +29,15 @@ $ sudo apt-get update && \
 Add the HashiCorp [GPG key][gpg-key].
 
 ```shell-session
-$ wget -O- https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+$ wget -O- https://apt.releases.hashicorp.com/gpg | \
+  sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
 ```
 
 Add the official HashiCorp Linux repository.
 
 ```shell-session
-$ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+$ echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
+| sudo tee /etc/apt/sources.list.d/hashicorp.list
 ```
 
 Update and install.
@@ -100,7 +47,7 @@ $ sudo apt-get update && sudo apt-get install nomad
 ```
 
 </Tab>
-<Tab heading="CentOS/RHEL">
+<Tab heading="RHEL/CentOS" group="rhel">
 
 Install `yum-config-manager` to manage your repositories.
 
@@ -121,7 +68,7 @@ $ sudo yum -y install nomad
 ```
 
 </Tab>
-<Tab heading="Fedora">
+<Tab heading="Fedora" group="fedora">
 
 Install `dnf config-manager` to manage your repositories.
 
@@ -132,7 +79,8 @@ $ sudo dnf install -y dnf-plugins-core
 Use `dnf config-manager` to add the official HashiCorp Linux repository.
 
 ```shell-session
-$ sudo dnf config-manager --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo
+$ sudo dnf config-manager \
+  --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo
 ```
 
 Install.
@@ -142,7 +90,7 @@ $ sudo dnf -y install nomad
 ```
 
 </Tab>
-<Tab heading="Amazon Linux">
+<Tab heading="Amazon Linux" group="amazonlinux">
 
 Install `yum-config-manager` to manage your repositories.
 
@@ -153,7 +101,8 @@ $ sudo yum install -y yum-utils
 Use `yum-config-manager` to add the official HashiCorp Linux repository.
 
 ```shell-session
-$ sudo yum-config-manager --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo
+$ sudo yum-config-manager \
+  --add-repo https://rpm.releases.hashicorp.com/AmazonLinux/hashicorp.repo
 ```
 
 Install.
@@ -163,182 +112,107 @@ $ sudo yum -y install nomad
 ```
 
 </Tab>
-</Tabs>
+<Tab heading="Manual" group="linux-manual">
 
--> **TIP:** Now that you have added the HashiCorp repository, you can install
-[Consul](/consul/tutorials) and
-[Vault](/vault/tutorials) with the same command.
+@include 'install/manual-install.mdx'
 
 </Tab>
 </Tabs>
 
-## Post-installation steps
+</Tab>
 
-These steps are considered optional but can be helpful for running Nomad and to
+<Tab heading="Mac" group="mac">
+
+<Tabs>
+<Tab heading="Homebrew" group="mac-homebrew">
+
+[Homebrew](https://brew.sh) is a free and open source package management system
+for Mac OS X. Install the official [Nomad
+formula](https://github.com/hashicorp/homebrew-tap) from the terminal.
+
+First, install the HashiCorp tap, a repository of all of the HashiCorp Homebrew
+packages.
+
+```shell-session
+$ brew tap hashicorp/tap
+```
+
+Now, install Nomad with `hashicorp/tap/nomad`.
+
+```shell-session
+$ brew install hashicorp/tap/nomad
+```
+
+-> This installs a signed binary and is automatically updated with
+every new official release.
+
+To update to the latest, run
+
+```shell-session
+$ brew upgrade hashicorp/tap/nomad
+```
+</Tab>
+<Tab heading="Manual" group="mac-manual">
+
+@include 'install/manual-install.mdx'
+
+</Tab>
+</Tabs>
+
+</Tab>
+
+<Tab heading="Windows" group="windows">
+
+<Tabs>
+<Tab heading="Chocolatey" group="windows-chocolatey">
+
+[Chocolatey](https://chocolatey.org/) is a free and open-source package
+management system for Windows. Install the [Nomad
+package](https://chocolatey.org/packages/nomad) from the command-line.
+
+```shell-session
+$ choco install nomad
+```
+
+-> Chocolatey and the Nomad package are **NOT** directly maintained
+by HashiCorp. The latest version of Nomad is always available by manual
+installation.
+
+</Tab>
+<Tab heading="Manual" group="windows-manual">
+
+@include 'install/manual-install.mdx'
+
+</Tab>
+</Tabs>
+
+</Tab>
+
+</Tabs>
+
+
+## Linux post-installation steps
+
+These steps are optional but can be helpful for running Nomad and to
 take advantage of additional Nomad functionalities.
 
-<Tabs>
-<Tab heading="Manual installation" group="manual">
+-> You need to run client agents as root (or with `sudo`) so that cpuset accounting and network namespaces work correctly.
 
-<Tabs>
-<Tab heading="Linux Packages">
-<h3>Add the Nomad binary to your system path</h3>
+### Install CNI reference plugins
 
-Permanently add a new location to your path by editing your shell's settings
-file (usually called something like `~/.bashrc`, where the part of the filename
-after the `.` and before `rc` is the name of your shell). In that file you
-should see a line that starts with `export PATH=`, followed by a
-colon-separated list of locations. Add the location of the Nomad binary to that
-list and save the file. Then reload your shell's configuration with the command
-`source ~/.bashrc`, replacing `bash` with the name of your shell.
+@include 'install/install-cni-plugins.mdx'
 
-<h3>Install CNI plugins</h3>
+### Install consul-cni plugin
 
-Nomad uses CNI plugins to configure network namespaces when using the `bridge`
-network mode. All Linux Nomad client nodes using network namespaces must have
-CNI plugins installed.
+@include 'install/install-consul-cni-plugin.mdx'
 
-The following commands install the CNI reference plugins.
+### Configure bridge network to route traffic through iptables
 
-```shell-session
-$ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/v1.0.0/cni-plugins-linux-$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)"-v1.0.0.tgz && \
-  sudo mkdir -p /opt/cni/bin && \
-  sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
-```
+@include 'install/bridge-iptables.mdx'
 
-Ensure your Linux operating system distribution has been configured to allow
-container traffic through the bridge network to be routed via iptables. These
-tunables can be set as follows.
+### Verify cgroup controllers
 
-```shell-session
-$ echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-arptables && \
-  echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-ip6tables && \
-  echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
-```
-
-To preserve these settings on startup of a client node, add a file including the
-following to `/etc/sysctl.d/` or remove the file your Linux distribution puts in
-that directory.
-
-<CodeBlockConfig filename="/etc/sysctl.d/bridge.conf">
-
-```ini
-net.bridge.bridge-nf-call-arptables = 1
-net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-```
-
-</CodeBlockConfig>
-
-<h3>Verify cgroup controllers</h3>
-
-On Linux, Nomad uses cgroups to control resource usage of tasks. If one or more
-required cgroups are unavailable, Nomad will disable resource controls that
-require cgroups entirely. With cgroups v2, you can verify that you have all
-required controllers as follows:
-
-```shell-session
-$ cat /sys/fs/cgroup/cgroup.controllers
-cpuset cpu io memory pids
-```
-
-See the documentation on [cgroup controller requirements][] for more details.
-
-</Tab>
-
-<Tab heading="macOS">
-<h3>Add the Nomad binary to your system path</h3>
-
-Permanently add a new location to your path by editing your shell's settings
-file (usually called something like `~/.bashrc`, where the part of the filename
-after the `.` and before `rc` is the name of your shell). In that file you
-should see a line that starts with `export PATH=`, followed by a
-colon-separated list of locations. Add the location of the Nomad binary to that
-list and save the file. Then reload your shell's configuration with the command
-`source ~/.bashrc`, replacing `bash` with the name of your shell.
-</Tab>
-
-<Tab heading="Windows">
-
-<h3>Add the Nomad binary to your system path</h3>
-
-Add a location to your path via the GUI by navigating to `Environment
-Variables` in your system settings, and looking for the variable called `PATH`.
-You should see a semicolon-separated list of locations. Add the Nomad binary's
-location to that list and then launch a new console window.
-</Tab>
-</Tabs>
-</Tab>
-
-<Tab heading="Homebrew on macOS" group="homebrew">
-No additional steps necessary after installing Nomad using Homebrew.
-</Tab>
-
-<Tab heading="Chocolatey on Windows" group="chocolatey">
-No additional steps necessary after installing Nomad using Chocolatey.
-</Tab>
-
-<Tab heading="Linux" group="linux">
-
-Note that if you are running Nomad on Linux, you'll need to run client agents as
-root (or with `sudo`) so that cpuset accounting and network namespaces work
-correctly.
-
-<h3>Install CNI plugins</h3>
-
-Nomad uses CNI plugins to configure network namespaces when using the `bridge`
-network mode. All Linux Nomad client nodes using network namespaces must have
-CNI plugins installed.
-
-The following commands install the CNI reference plugins.
-
-```shell-session
-$ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/v1.0.0/cni-plugins-linux-$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)"-v1.0.0.tgz && \
-  sudo mkdir -p /opt/cni/bin && \
-  sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
-```
-
-Ensure your Linux operating system distribution has been configured to allow
-container traffic through the bridge network to be routed via iptables. These
-tunables can be set as follows.
-
-```shell-session
-$ echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-arptables && \
-  echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-ip6tables && \
-  echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables
-```
-
-To preserve these settings on startup of a client node, add a file including the
-following to `/etc/sysctl.d/` or remove the file your Linux distribution puts in
-that directory.
-
-<CodeBlockConfig filename="/etc/sysctl.d/bridge.conf">
-
-```ini
-net.bridge.bridge-nf-call-arptables = 1
-net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-```
-
-</CodeBlockConfig>
-
-<h3>Verify cgroup controllers</h3>
-
-On Linux, Nomad uses cgroups to control resource usage of tasks. If one or more
-required cgroups are unavailable, Nomad will disable resource controls that
-require cgroups entirely. With cgroups v2, you can verify that you have all
-required controllers as follows:
-
-```shell-session
-$ cat /sys/fs/cgroup/cgroup.controllers
-cpuset cpu io memory pids
-```
-
-See the documentation on [cgroup controller requirements][] for more details.
-
-</Tab>
-</Tabs>
-
+@include 'install/cgroup-controllers.mdx'
 
 ## Verify the Installation
 
@@ -434,4 +308,4 @@ and ensuring `GOPATH/bin` is within your `PATH`. A copy of
 
 [gpg-key]: https://apt.releases.hashicorp.com/gpg "HashiCorp GPG key"
 [go-version]: https://github.com/hashicorp/nomad/blob/main/.go-version
-[cgroup controller requirements]: /nomad/docs/install/production/requirements#hardening-nomad
+

--- a/website/content/docs/install/production/requirements.mdx
+++ b/website/content/docs/install/production/requirements.mdx
@@ -103,52 +103,11 @@ $ echo "49152 65535" > /proc/sys/net/ipv4/ip_local_port_range
 
 ## Bridge Networking and `iptables`
 
-Nomad's task group networks and Consul Connect integration use bridge networking and iptables to send traffic between containers. The Linux kernel bridge module has three "tunables" that control whether traffic crossing the bridge are processed by iptables. Some operating systems (RedHat, CentOS, and Fedora in particular) configure these tunables to optimize for VM workloads where iptables rules might not be correctly configured for guest traffic.
-
-These tunables can be set to allow iptables processing for the bridge network as follows:
-
-```shell-session
-$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
-$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
-$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
-```
-
-To preserve these settings on startup of a client node, add a file including the following to `/etc/sysctl.d/` or remove the file your Linux distribution puts in that directory.
-
-```text
-net.bridge.bridge-nf-call-arptables = 1
-net.bridge.bridge-nf-call-ip6tables = 1
-net.bridge.bridge-nf-call-iptables = 1
-```
+@include 'install/bridge-iptables.mdx'
 
 ## Cgroup Controllers
 
-On Linux, Nomad uses cgroups to control access to resources like CPU and
-memory. Nomad can support both [cgroups v2][] and the legacy [cgroups
-v1][]. When Nomad clients start, they will determine the available cgroup
-controllers and include the attribute `os.cgroups.version` in their
-fingerprint.
-
-Nomad can only use cgroups to control resources if all the required controllers
-are available. If one or more required cgroups are unavailable, Nomad will
-disable resource controls that require cgroups entirely. You will most often see
-missing controllers on platforms used outside of datacenters, such as Raspberry
-Pi or similar hobbyist computers.
-
-On cgroups v2, you can verify that you have all required controllers as follows:
-
-```shell-session
-$ cat /sys/fs/cgroup/cgroup.controllers
-cpuset cpu io memory pids
-```
-
-On legacy cgroups v1, you can look for this same list of required controllers as
-directories under the directory `/sys/fs/cgroup`.
-
-To enable missing cgroups, add the appropriate boot command line arguments. For
-example, to enable the `cpuset` cgroup, you'll need to add `cgroup_cpuset=1
-cgroup_enable=cpuset`. These arguments should be added wherever specified by
-your bootloader.
+@include 'install/cgroup-controllers.mdx'
 
 ## Hardening Nomad
 
@@ -260,5 +219,3 @@ in automated pipelines for [CLI operations][docs_cli], such as
 [`nomad fmt`]: /nomad/docs/commands/fmt
 [mTLS]: /nomad/tutorials/transport-security/security-enable-tls
 [ephemeral disk migration]: /nomad/docs/job-specification/ephemeral_disk#migrat
-[cgroups v1]: https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/cgroups.html
-[cgroups v2]: https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html

--- a/website/content/docs/integrations/consul/service-mesh.mdx
+++ b/website/content/docs/integrations/consul/service-mesh.mdx
@@ -150,6 +150,9 @@ Nomad uses CNI reference plugins to configure the network namespace used to secu
 Consul service mesh sidecar proxy. All Nomad client nodes using network namespaces
 must have these CNI plugins [installed][cni_install].
 
+To use [`transparent_proxy`][] mode, Nomad client nodes will also need the
+[`consul-cni`][] plugin installed. See the Linux post-installation [steps](/nomad/docs/install#linux-post-installation-steps) for more detail on how to install CNI plugins.
+
 ## Run the Service Mesh-enabled Services
 
 Once Nomad and Consul are running, submit the following service mesh-enabled services
@@ -376,4 +379,15 @@ filesystem.
 [anon_token]: /consul/docs/security/acl/acl-tokens#special-purpose-tokens
 [consul_ports]: /consul/docs/agent/config/config-files#ports
 [consul_grpc_tls]: /consul/docs/upgrading/upgrade-specific#changes-to-grpc-tls-configuration
-[cni_install]: /nomad/docs/install#post-installation-steps
+[cni_install]: /nomad/docs/install#linux-post-installation-steps
+[transparent proxy]: /consul/docs/k8s/connect/transparent-proxy
+[go-sockaddr/template]: https://pkg.go.dev/github.com/hashicorp/go-sockaddr/template
+[`recursors`]: /consul/docs/agent/config/config-files#recursors
+[`transparent_proxy`]: /nomad/docs/job-specification/transparent_proxy
+[tproxy_no_dns]: /nomad/docs/job-specification/transparent_proxy#no_dns
+[`consul-cni`]: https://releases.hashicorp.com/consul-cni
+[virtual IP]: /consul/docs/services/discovery/dns-static-lookups#service-virtual-ip-lookups
+[cni_plugins]: /nomad/docs/networking/cni#cni-reference-plugins
+[consul_dns_port]: /consul/docs/agent/config/config-files#dns_port
+[`network.dns`]: /nomad/docs/job-specification/network#dns-parameters
+[`client.meta`]: /nomad/docs/configuration/client#meta

--- a/website/content/docs/networking/cni.mdx
+++ b/website/content/docs/networking/cni.mdx
@@ -1,90 +1,97 @@
 ---
 layout: docs
-page_title: CNI
+page_title: CNI plugins and bridge networking
 description: |-
-  Learn about Nomad's runtime environment variables, interpolation, caveats,
-  and more.
+  Learn how to install Container Network Interface (CNI) reference plugins, configure Nomad's bridge networking, and how to use CNI networks with Nomad jobs.
 ---
 
 # Container Network Interface (CNI)
 
-Nomad has built-in support for scheduling compute resources such as
-CPU, memory, and networking. Nomad's network plugin support extends
-this to allow scheduling tasks with purpose-created or specialty network
-configurations. Network plugins are third-party plugins that conform to the
-[Container Network Interface (CNI)][cni_spec] specification.
+This page show you how to install the [CNI reference plugins][cni-plugin-docs]
+on your Linux distribution and configure bridge networking on your Nomad
+clients. You can apply this guide's workflow to installing any plugin that
+complies with the [Container Network Interface (CNI) Specification][cni-spec],
+but you should verify plugin compatibility with Nomad before deploying in
+production.
 
-Network plugins need to be installed and configured on each client. The [Nomad
-installation instructions][nomad_install] recommend installing the [CNI
-reference plugins][cni_ref] because certain Nomad networking features, like
-`bridge` network mode and Consul service mesh, leverage them to provide an
-operating-system agnostic interface to configure workload networking.
-
-Custom networking in Nomad is accomplished with a combination of CNI plugin
-binaries and CNI configuration files.
-
-## CNI reference plugins
-
-The CNCF maintains a set of reference CNI plugins for basic network operations.
-These plugins are required for Nomad's `bridge` networking mode and for integrating
-with Consul service mesh.
-
-See the Linux [post-install steps][cni_install] for installing CNI reference plugins.
-
-## CNI plugins
-
-Spec-compliant plugins should work with Nomad, however, it's possible a plugin
-vendor has implemented their plugin to make non-standard API calls, or it is
-otherwise non-compliant with the CNI specification. In those situations the
-plugin may not function correctly in a Nomad environment. You should verify
-plugin compatibility with Nomad before deploying in production.
-
-CNI plugins are installed and configured on a per-client basis. Nomad consults
-the path given in the client's [`cni_path`][] to find CNI plugin executables.
-
-## CNI configuration files
+## Introduction
 
 The CNI specification defines a network configuration format for administrators.
-It contains directives for both the orchestrator and the plugins to consume.
-At plugin execution time, this configuration format is interpreted by Nomad
-and transformed into arguments for the plugins.
+The configuration contains directives for both the orchestrator and the plugins
+to consume. Nomad implements custom networking through a combination of CNI
+reference plugin binaries and CNI configuration files. Networking features, like
+bridge network mode and Consul service mesh, leverage the CNI reference plugins
+to provide an operating-system agnostic interface to configure workload
+networking.
 
-Nomad reads the following extensions from the [`cni_config_dir`][]—
-`/opt/cni/config` by default:
+## Requirements
 
-* `.conflist` files are loaded as [network
-  configurations][cni_spec_net_config] that contain a list of plugin
-  configurations.
+- You are familiar with [CNI reference plugins][cni-plugin-docs].
+- You are familiar with [how Nomad uses Container Network Interface (CNI) plugins for bridge networking](/nomad/docs/networking#bridge-networking).
+- You are running Nomad on Linux.
 
-* `.conf` and `.json` files are loaded as individual [plugin
-  configurations][cni_spec_plugin_config] for a specific network.
+## CNI plugins and bridge networking workflow
 
-## Using CNI networks with Nomad jobs
+Perform the following on each Nomad client:
 
-To specify that a job should use a CNI network, set the task group's
-network [`mode`][] attribute to the value `cni/<your_cni_config_name>`.
-Nomad will then schedule the workload on client nodes that have fingerprinted a
-CNI configuration with the given name. For example, to use the configuration
-named `mynet`, you should set the task group's network mode to `cni/mynet`.
-Nodes that have a network configuration defining a network named `mynet` in
-their [`cni_config_dir`][] will be eligible to run the workload.
+1. [Install CNI reference plugins](#install-cni-reference-plugins).
+1. [Configure bridge module to route traffic through iptables](#configure-bridge-module-to-route-traffic-through-iptables).
+1. [Create a bridge mode configuration](#create-a-cni-bridge-mode-configuration).
+1. [Configure Nomad clients](#configure-nomad-clients).
 
-## Nomad's `bridge` configuration
+After you configure and restart your Nomad clients, [use a CNI network with a
+job](#use-a-cni-network-with-a-job).
+
+### Install CNI reference plugins
+
+@include 'install/install-cni-plugins.mdx'
+
+### Configure bridge module to route traffic through iptables
+
+@include 'install/bridge-iptables.mdx'
+
+## Create a CNI bridge mode configuration
 
 Nomad itself uses CNI plugins and configuration as the underlying implementation
-for the `bridge` network mode, using the [loopback][], [bridge][], [firewall][],
-and [portmap][] CNI plugins configured together to create Nomad's bridge
+for the `bridge` network mode, using the loopback, [bridge][], [firewall][], and
+[portmap][] CNI reference plugins configured together to create Nomad's bridge
 network.
 
-The following is the configuration template Nomad uses when setting up these
-networks with the template placeholders replaced with the default configuration
-values for [`bridge_network_name`][], [`bridge_network_subnet`][], and an
-internal constant that provides the value for `iptablesAdminChainName`. This is
-a convenient jumping off point to discuss a worked example.
+[comment-source-image]:
+    https://www.figma.com/file/Ne2qaPUlBTmTYer9biCfK9/Networking?node-id=0%3A1&t=BepgOoQ0kb76GwIr-1
+
+[![Visual example of Nomad bridge
+network](/img/nomad-bridge-network.png)](/img/nomad-bridge-network.png)
+
+When setting up a bridge network, Nomad uses a configuration template based on
+the CNI Specification's [example
+configuration](https://www.cni.dev/docs/spec/#example-configuration). Refer to
+the external [configuration
+format](https://www.cni.dev/docs/spec/#example-configuration) for a complete
+explanation of the fields.
+
+You can use this template as a basis for your own CNI-based bridge network
+configuration in cases where you need access to an unsupported option in the
+default configuration, like hairpin mode.
+
+This example uses two default values from Nomad client configuration.
+
+- The default value for
+  [`bridge_network_name`](/nomad/docs/configuration/client#bridge_network_name)
+  is the value for the bridge plugin name.
+- The default value for bridge subnet [`bridge_network_subnet`](
+  /nomad/docs/configuration/client#bridge_network_subnet) is the bridge plugin
+  subnet.
+
+The `NOMAD-ADMIN` internal constant provides the value for
+`iptablesAdminChainName`. In your own configuration, ensure that you change the
+`iptablesAdminChainName` to a unique value.
+
+<CodeBlockConfig highlight="10,20,32">
 
 ```json
 {
-  "cniVersion": "0.4.0",
+  "cniVersion": "1.0.0",
   "name": "nomad",
   "plugins": [
     {
@@ -125,103 +132,129 @@ a convenient jumping off point to discuss a worked example.
 }
 ```
 
-<!-- Source: https://www.figma.com/file/Ne2qaPUlBTmTYer9biCfK9/Networking?node-id=0%3A1&t=BepgOoQ0kb76GwIr-1 -->
-[![Visual example of Nomad bridge network](/img/nomad-bridge-network.png)](/img/nomad-bridge-network.png)
+</CodeBlockConfig>
 
-For a more thorough understanding of this configuration, consider each CNI
-plugin's configuration in turn.
+This configuration uses the following CNI reference plugins:
 
-### loopback
+- loopback: The loopback plugin sets the default local interface, lo0, created
+  inside the bridge network's network namespace to UP. This allows workload
+  running inside the namespace to bind to a namespace-specific loopback
+  interface.
+- bridge: The [bridge][] plugin creates a bridge (virtual switch) named `nomad`
+  that resides in the host network namespace. Because Nomad intends this bridge
+  to provide network connectivity to allocations, we configured it to be a
+  gateway by setting `isGateway` to `true`. This tells the plugin to assign an
+  IP address to the bridge interface.
 
-The `loopback` plugin sets the default local interface, `lo0`, created inside
-the bridge network's network namespace to **UP**. This allows workload running
-inside the namespace to bind to a namespace-specific loopback interface.
+   The bridge plugin connects allocations on the same host into a virtual switch
+   bridge that resides in the host network namespace. By default, Nomad creates
+   a single bridge for each client.
 
-### bridge
+   Since Nomad's bridge network is designed to provide network connectivity to
+   the allocations, Nomad configures the bridge interface to be a gateway for
+   outgoing traffic by providing it with an address using an `ipam`
+   configuration. The default configuration creates a host-local address for the
+   host side of the bridge in the `172.26.64.0/20` subnet at `172.26.64.1`.
 
-The `bridge` plugin creates a bridge (virtual switch) named `nomad` that resides
-in the host network namespace. Because this bridge is intended to provide
-network connectivity to allocations, it's configured to be a gateway by setting
-`isGateway` to `true`. This tells the plugin to assign an IP address to the
-bridge interface
+   When associating allocations to the bridge, Nomad creates addresses for the
+   allocations from that same subnet using the host-local plugin. The
+   configuration also specifies a default route for the allocations of the
+   host-side bridge address.
+- firewall: The [firewall][] plugin creates firewall rules to allow traffic to
+  and from the allocation's IP address via the host network. Nomad uses the
+  iptables backend for the firewall plugin.
 
-The bridge plugin connects allocations (on the same host) into a bridge (virtual
-switch) that resides in the host network namespace. By default Nomad creates a
-single bridge for each client. Since Nomad's bridge network is designed to
-provide network connectivity to the allocations, it configures the bridge
-interface to be a gateway for outgoing traffic by providing it with an address
-using an `ipam` configuration. The default configuration creates a host-local
-address for the host side of the bridge in the `172.26.64.0/20` subnet at
-`172.26.64.1`. When associating allocations to the bridge, it creates addresses
-for the allocations from that same subnet using the host-local plugin. The
-configuration also specifies a default route for the allocations of the
-host-side bridge address.
+   This configuration creates two new iptables chains, `CNI-FORWARD` and
+   `NOMAD-ADMIN`, in the filter table and adds rules that allow the given
+   interface to send and receive traffic.
 
-### firewall
+   The firewall creates an admin chain using the `iptablesAdminChainName` value,
+   which is `NOMAD-ADMIN` in this example. The admin chain is a user-controlled
+   chain for custom rules that run before rules managed by the firewall plugin.
+   The firewall plugin does not add, delete, or modify rules in the admin chain.
 
-The firewall plugin creates firewall rules to allow traffic to/from the
-allocation's IP address via the host network. Nomad uses the iptables backend
-for the firewall plugin. This configuration creates two new iptables chains,
-`CNI-FORWARD` and `NOMAD-ADMIN`, in the filter table and add rules that allow
-the given interface to send/receive traffic.
+   Nomad adds a new chain called `CNI-FORWARD` to to the `FORWARD` chain.
+   `CNI-FORWARD` is the chain where Nomad adds rules when it creates allocations
+   and removes the rules when those allocations stop. The `CNI-FORWARD` chain
+   first sends all traffic to the `NOMAD-ADMIN` chain.
 
-The firewall creates an admin chain using the name provided in the
-`iptablesAdminChainName` attribute. For this case, it's called `NOMAD-ADMIN`.
-The admin chain is a user-controlled chain for custom rules that run before
-rules managed by the firewall plugin. The firewall plugin does not add, delete,
-or modify rules in the admin chain.
+   Use the `iptables` command to list the iptables rules present in each chain.
 
-A new chain, `CNI-FORWARD` is added to the `FORWARD` chain. `CNI-FORWARD` is
-the chain where rules will be added when allocations are created and from where
-rules will be removed when those allocations stop. The `CNI-FORWARD` chain
-first sends all traffic to `NOMAD-ADMIN` chain.
+   ```shell-session
+   $ sudo iptables -L
+   ```
 
-You can use the following command to list the iptables rules present in each
-chain.
+- portmap: Nomad needs to be able to map specific ports from the host to tasks
+  running in the allocation namespace. The [portmap][] plugin forwards traffic
+  from one or more ports on the host to the allocation using network address
+  translation (NAT) rules.
 
-```shell-session
-$ sudo iptables -L
+   The plugin sets up two sequences of chains and rules:
+
+   - One primary destination NAT (DNAT) sequence to rewrite the destination.
+   - One source NAT (SNAT) sequence to masquerade traffic as needed.
+
+   Use the `iptables` command to list the iptables rules in the NAT table.
+
+   ```shell-session
+   $ sudo iptables -t nat -L
+   ```
+
+Save your bridge network configuration file to a Nomad-accessible directory. By
+default, Nomad loads configuration files from the `/opt/cni/config` directory.
+However, you may configure a different location using the
+[`cni_config_dir`](/nomad/docs/configuration/client#cni_config_dir) parameter.
+Refer to the [Configure Nomad clients](#configure-nomad-clients) section for an
+example.
+
+## Configure Nomad clients
+
+At plugin execution time, Nomad interprets your CNI network configuration and
+transforms it into arguments for the plugins.
+
+Nomad reads the following files from the
+[`cni_config_dir`](/nomad/docs/configuration/client#cni_config_dir) parameter —
+`/opt/cni/config` by default:
+
+- `.conflist`: Nomad loads these files as [network
+  configurations](https://www.cni.dev/docs/spec/#configuration-format) that
+  contain a list of plugin configurations.
+
+- `.conf` and `.json`: Nomad loads these files as individual [plugin
+  configurations](https://www.cni.dev/docs/spec/#plugin-configuration-objects)
+  for a specific network.
+
+Add the [`cni_path`](/nomad/docs/configuration/client#cni_path) and
+[`cni_config_dir`](/nomad/docs/configuration/client#cni_config_dir) attributes
+to each client's `client.hcl` file.
+
+This example uses the default values for both attributes.
+
+<CodeBlockConfig filename="/etc/nomad.d/client.hcl">
+
+```hcl
+client {
+  enabled = true
+  cni_path = "opt/cni/bin"
+  cni_config_dir = "opt/cni/config"
+}
 ```
 
-### portmap
+</CodeBlockConfig>
 
-Nomad needs to be able to map specific ports from the host to tasks running in
-the allocation namespace. The `portmap` plugin forwards traffic from one or more
-ports on the host to the allocation using network address translation (NAT)
-rules.
+## Use a CNI network with a job
 
-The plugin sets up two sequences of chains and rules:
+To specify that a job should use a CNI network, set the task group's network
+[`mode`](/nomad/docs/job-specification/network#mode) attribute to the value
+`cni/<your_cni_config_name>`. Nomad then schedules the workload on client nodes
+that have fingerprinted a CNI configuration with the given name. For example, to
+use the configuration named `mynet`, you should set the task group's network
+mode to `cni/mynet`. Nodes that have a network configuration defining a network
+named `mynet` in their `cni_config_dir` are eligible to run the workload.
 
-- One “primary” `DNAT` (destination NAT) sequence to rewrite the destination.
-- One `SNAT` (source NAT) sequence that will masquerade traffic as needed.
 
-You can use the following command to list the iptables rules in the NAT table.
-
-```shell-session
-$ sudo iptables -t nat -L
-```
-
-## Create your own
-
-You can use this template as a basis for your own CNI-based bridge network
-configuration in cases where you need access to an unsupported option in the
-default configuration, like hairpin mode. When making your own bridge network
-based on this template, ensure that you change the `iptablesAdminChainName` to
-a unique value for your configuration.
-
-[3rd_party_cni]: https://www.cni.dev/docs/#3rd-party-plugins
-[`bridge_network_name`]: /nomad/docs/configuration/client#bridge_network_name
-[`bridge_network_subnet`]: /nomad/docs/configuration/client#bridge_network_subnet
-[`cni_config_dir`]: /nomad/docs/configuration/client#cni_config_dir
-[`cni_path`]: /nomad/docs/configuration/client#cni_path
-[`mode`]: /nomad/docs/job-specification/network#mode
+[cni-spec]: https://www.cni.dev/docs/spec/
+[cni-plugin-docs]: https://www.cni.dev/plugins/current/
 [bridge]: https://www.cni.dev/plugins/current/main/bridge/
-[cni_install]: /nomad/docs/install#post-installation-steps
-[cni_ref]: https://github.com/containernetworking/plugins
-[cni_spec]: https://www.cni.dev/docs/spec/
-[cni_spec_net_config]: https://github.com/containernetworking/cni/blob/main/SPEC.md#configuration-format
-[cni_spec_plugin_config]: https://github.com/containernetworking/cni/blob/main/SPEC.md#plugin-configuration-objects
 [firewall]: https://www.cni.dev/plugins/current/meta/firewall/
-[loopback]: https://github.com/containernetworking/plugins#main-interface-creating
-[nomad_install]: /nomad/tutorials/get-started/get-started-install#post-installation-steps
 [portmap]: https://www.cni.dev/plugins/current/meta/portmap/

--- a/website/content/docs/networking/index.mdx
+++ b/website/content/docs/networking/index.mdx
@@ -8,26 +8,28 @@ description: |-
 
 # Networking
 
-Nomad is a workload orchestrator and so it focuses on the scheduling aspects of
-a deployment, touching areas such as networking as little as possible.
+Nomad is a workload orchestrator and focuses on the scheduling aspects of a
+deployment, touching areas such as networking as little as possible.
 
-**Networking in Nomad is usually done via _configuration_ instead of
-_infrastructure_**. This means that Nomad provides ways for you to access the
+Networking in Nomad is usually done via _configuration_ instead of
+_infrastructure_. This means that Nomad provides ways for you to access the
 information you need to connect your workloads instead of running additional
 components behind the scenes, such as DNS servers and load balancers.
 
-This can be confusing at first since it is quite different from what you may
-be used to from other tools. This section explains how networking works in
-Nomad, some of the different patterns and configurations you are likely to find
-and use, and how Nomad differs from other tools in this aspect.
+Nomad networking is quite different from what you may familiar with from other
+tools. This section explains how networking works in Nomad, some of the
+different patterns and configurations you are likely to find and use, and how
+Nomad differs from other tools in this aspect.
 
 ## Allocation networking
 
-The base unit of scheduling in Nomad is an [allocation][], which means that all
+The base unit of scheduling in Nomad is an
+[allocation](/nomad/docs/concepts/architecture#allocation), which means that all
 tasks in the same allocation run in the same client and share common resources,
 such as disk and networking. Allocations can request access to network
-resources, such as ports, using the [`network`][jobspec_network] block. At its
-simplest configuration, a `network` block can be defined as:
+resources, such as ports, using the
+[`network`](/nomad/docs/job-specification/network) block. You can define a basic
+`network` block as the following:
 
 ```hcl
 job "..." {
@@ -41,20 +43,27 @@ job "..." {
 }
 ```
 
-Nomad reserves a random port in the client between [`min_dynamic_port`][] and
-[`max_dynamic_port`][] that has not been allocated yet and creates a port
-mapping from the host network interface to the allocation.
+Nomad reserves a random port in the client between
+[`min_dynamic_port`](/nomad/docs/configuration/client#min_dynamic_port) and
+[`max_dynamic_port`](/nomad/docs/configuration/client#max_dynamic_port) that has
+not been allocated yet. Nomad then creates a port mapping from the host network
+interface to the allocation.
 
-<!-- Source: https://drive.google.com/file/d/1q4a2ab0TyLEPdWiO2DIianAPWuPqLqZ4/view?usp=share_link -->
-[![Nomad Port Mapping](/img/networking/port_mapping.png)](/img/networking/port_mapping.png)
+[comment-image-source]:
+    https://drive.google.com/file/d/1q4a2ab0TyLEPdWiO2DIianAPWuPqLqZ4/view?usp=share_link
 
-The selected port number can be accessed by tasks using the
-[`NOMAD_PORT_<label>`][runtime_environment] environment variable to bind and
-expose the workload at the client's IP address and the given port.
+[![Nomad Port
+Mapping](/img/networking/port_mapping.png)](/img/networking/port_mapping.png)
 
-The specific configuration process depends on what you are running, but it is
-usually done using a configuration file rendered from a [`template`][] or
-passed directly via command line arguments:
+Tasks can access the selected port number using the
+[`NOMAD_PORT_<label>`](/nomad/docs/runtime/environment#network-related-variables)
+environment variable to bind and expose the workload at the client's IP address
+and the given port.
+
+The specific configuration process depends on what you are running. However,
+usually you use a
+[`template`](/nomad/docs/job-specification/template#template-examples) to create
+a configuration file such as the following:
 
 ```hcl
 job "..." {
@@ -76,14 +85,18 @@ job "..." {
 }
 ```
 
-It is also possible to request a specific port number, instead of a random one,
-by setting a [`static`][] value for the `port`. **This should only be used by
-specialized workloads**, such as load balancers and system jobs, since it can
-be hard to manage them manually to avoid scheduling collisions.
+You may also pass configuration via command line arguments.
 
-With the task listening at one of the client's ports, other processes can
-access it directly using the client's IP and port, but first they need to find
-these values. This process is called [service discovery][].
+It is also possible to request a specific port number instead of a random one by
+setting a [`static`](/nomad/docs/job-specification/network#static) value for the
+`port`. This should only be used by specialized workloads, such as load
+balancers and system jobs, since it can be hard to manage them manually to avoid
+scheduling collisions.
+
+With the task listening at one of the client's ports, other processes can access
+the task directly using the client's IP and port, but first the processes need
+to find these values. This process is called [service
+discovery](/nomad/docs/networking/service-discovery).
 
 When using IP and port to connect allocations it is important to make sure your
 network topology and routing configuration allow the Nomad clients to
@@ -91,26 +104,44 @@ communicate with each other.
 
 ## Bridge networking
 
-Linux clients support a network [`mode`][network_mode] called [`bridge`][]. A
-bridge network acts like a virtual network switch allowing processes connected
-to the bridge to reach each other while isolating them from others.
+Linux clients support a network
+[`mode`](/nomad/docs/job-specification/network#mode) called
+[`bridge`](/nomad/docs/job-specification/network#bridge). A bridge network acts
+like a virtual network switch, allowing processes connected to the bridge to
+reach each other while isolating them from others.
+
+### Container Network Interface (CNI) reference plugins
+
+Nomad's bridge network leverages [CNI reference
+plugins](https://github.com/containernetworking/plugins) to provide an
+operating-system agnostic interface to configure workload networking. Nomad's
+network plugin support extends Nomad's built-in compute resource scheduling to
+allow scheduling tasks with specialty network configurations, which Nomad
+implements with a combination of CNI reference plugins and CNI configuration
+files.
+
+### How bridge networking works
 
 When an allocation uses bridge networking, the Nomad agent creates a bridge
-called `nomad` (or the value set in [`bridge_network_name`][]) using the
-[`bridge` CNI plugin][cni_bridge] if one doesn't exist yet. Before using this
-mode you must first [install the CNI plugins][cni_install] into your clients.
-By default a single bridge is created in each Nomad client.
+called `nomad` (or the value set in
+[`bridge_network_name`](/nomad/docs/configuration/client#bridge_network_name))
+using the [`bridge` CNI plugin](
+https://www.cni.dev/plugins/current/main/bridge/) if one doesn't exist yet.
+Before using this mode you must first [install the CNI
+plugins](/nomad/docs/networking/cni/) into your clients. By default, Nomad
+creates a single bridge in each Nomad client.
 
-<!-- Source: https://drive.google.com/file/d/1q4a2ab0TyLEPdWiO2DIianAPWuPqLqZ4/view?usp=share_link -->
+[comment-image-source]:
+    https://drive.google.com/file/d/1q4a2ab0TyLEPdWiO2DIianAPWuPqLqZ4/view?usp=share_link
+
 [![Nomad Bridge](/img/networking/bridge.png)](/img/networking/bridge.png)
 
 Allocations that use the `bridge` network mode run in an isolated network
-namespace and are connected to the bridge. This allows Nomad to map random
-ports from the host to specific port numbers inside the allocation that are
-expected by the tasks.
+namespace and are connected to the bridge. This allows Nomad to map random ports
+from the host to specific port numbers inside the allocation that tasks expect.
 
-For example, an HTTP server that listens on port `3000` by default can be
-configured with the following `network` block:
+For example, you can configure an HTTP server that listens on port `3000` by
+default with the following `network` block:
 
 ```hcl
 job "..." {
@@ -142,33 +173,29 @@ bridge. This results in three different network access scopes:
   with `port` forwarding are accessible from external sources.
 
 ~> **Warning:** To prevent any type of external access when using `bridge`
-   network mode make sure to bind your workloads to the loopback interface
-   only.
+network mode make sure to bind your workloads to the loopback interface only.
 
-Bridge networking is at the core of [service mesh][] and a requirement when
-using [Consul Service Mesh][consul_service_mesh].
+Bridge networking is at the core of [service
+mesh](/nomad/docs/networking/service-mesh) and a requirement when using [Consul
+Service Mesh](/nomad/docs/integrations/consul-connect).
 
 ### Bridge networking with Docker
 
 The Docker daemon manages its own network configuration and creates its own
-[bridge network][docker_bridge], network namespaces, and [`iptable`
-rules][docker_iptables]. Tasks using the `docker` task driver connect to the
-Docker bridge instead of using the one created by Nomad and, by default, each
-container runs in its own Docker managed network namespace.
+[bridge network](https://docs.docker.com/network/bridge/), network namespaces,
+and [`iptable` rules](https://docs.docker.com/network/iptables/). Tasks using
+the `docker` task driver connect to the Docker bridge instead of using the one
+created by Nomad and, by default, each container runs in its own Docker managed
+network namespace.
 
 When using `bridge` network mode, Nomad creates a placeholder container using
-the image defined in [`infra_image`][] to initialize a Docker network namespace
-that is shared by all tasks in the allocation to allow them to communicate with
-each other.
+the image defined in [`infra_image`](/nomad/docs/drivers/docker#infra_image) to
+initialize a Docker network namespace that is shared by all tasks in the
+allocation to allow them to communicate with each other.
 
 The Docker task driver has its own task-level
-[`network_mode`][docker_network_mode] configuration. Its default value depends
-on the group-level [`network.mode`][network_mode] configuration.
-
-~> **Warning:** The task-level `network_mode` may conflict with the group-level
-   `network.mode` configuration and generate unexpected results. If you set the
-   group `network.mode = "bridge"` you should not set the Docker config
-   `network_mode`.
+[`network_mode`](/nomad/docs/drivers/docker#network_mode) configuration. Its
+default value depends on the group-level `network.mode` configuration.
 
 ```hcl
 group "..." {
@@ -189,30 +216,40 @@ group "..." {
 }
 ```
 
-The diagram below illustrates what happens when a Docker task is configured
+~> **Warning:** The task-level `network_mode` may conflict with the group-level
+`network.mode` configuration and generate unexpected results. If you set the
+group `network.mode = "bridge"` you should not set the Docker config
+`network_mode`.
+
+This diagram illustrates what happens when a Docker task is configured
 incorrectly.
 
-<!-- Source: https://drive.google.com/file/d/1q4a2ab0TyLEPdWiO2DIianAPWuPqLqZ4/view?usp=share_link -->
-[![Nomad Bridge](/img/networking/docker_bridge.png)](/img/networking/docker_bridge.png)
+[comment-image-source]:
+    https://drive.google.com/file/d/1q4a2ab0TyLEPdWiO2DIianAPWuPqLqZ4/view?usp=share_link
+
+[![Nomad
+Bridge](/img/networking/docker_bridge.png)](/img/networking/docker_bridge.png)
 
 The tasks in the rightmost allocation are not able to communicate with each
 other using their loopback interface because they were placed in different
 network namespaces.
 
-Since the group `network.mode` is `bridge`, Nomad creates the pause container
-to establish a shared network namespace for all tasks, but setting the
-task-level `network_mode` to `bridge` places the task in a different namespace.
-This prevents, for example, a task from communicating with its sidecar proxy in
-a [service mesh][] deployment.
+Since the group `network.mode` is `bridge`, Nomad creates the pause container to
+establish a shared network namespace for all tasks, but setting the task-level
+`network_mode` to `bridge` places the task in a different namespace. This
+prevents, for example, a task from communicating with its sidecar proxy in a
+service mesh deployment.
 
-Refer to the [`network_mode`][docker_network_mode] documentation and the
-[Networking][docker_networking] section for more information.
+Refer to the [`network_mode`](/nomad/docs/drivers/docker#network_mode)
+documentation and the [Networking](/nomad/docs/drivers/docker#networking)
+section for more information.
 
 -> **Note:** Docker Desktop in non-Linux environments runs a local virtual
    machine, adding an extra layer of indirection. Refer to the
-   [FAQ][faq_docker] for more details.
+   [FAQ](/nomad/docs/faq#q-how-to-connect-to-my-host-network-when-using-docker-desktop-windows-and-macos)
+   for more details.
 
-## Comparing with other tools
+## Comparison with other tools
 
 ### Kubernetes and Docker Compose
 
@@ -240,13 +277,15 @@ services:
 
 To access a service from another container you can reference the service name
 directly, for example using `postgres://db:5432`. In order to enable this
-pattern, Docker Compose includes an [internal DNS services][docker_dns] and a
-load balancer that is transparent to user. When running in Swarm mode, Docker
-Compose also requires an overlay network to route requests across hosts.
+pattern, Docker Compose includes an [internal DNS
+services](https://docs.docker.com/config/containers/container-networking/#dns-services)
+and a load balancer that is transparent to the user. When running in Swarm mode,
+Docker Compose also requires an overlay network to route requests across hosts.
 
 
-Kubernetes provides the [`Service`][k8s_service] abstraction that can be used
-to declare how a set of Pods are accessed.
+Kubernetes provides the
+[`Service`](https://kubernetes.io/docs/concepts/services-networking/service/)
+abstraction that can be used to declare how a set of Pods are accessed.
 
 ```yaml
 apiVersion: v1
@@ -264,68 +303,38 @@ spec:
 
 To access the Service you use a FQDN such as
 `my-service.prod.svc.cluster.local`. This name is resolved by the [DNS
-service][k8s_dns] which is an add-on that runs in all nodes. Along with this
-service, each node also runs a [`kube-proxy`][k8s_kubeproxy] instance to
-distribute requests to all Pods matched by the Service.
+service](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/)
+which is an add-on that runs in all nodes. Along with this service, each node
+also runs a
+[`kube-proxy`](https://kubernetes.io/docs/concepts/overview/components/#kube-proxy)
+instance to distribute requests to all Pods matched by the Service.
 
 You can use the same FQDN networking style with Nomad using [Consul's DNS
-interface][consul_dns] and configuring your clients with [DNS
-forwarding][consul_dns_forwarding], and deploying a [load
-balancer][nomad_load_balancer].
+interface](/consul/docs/services/discovery/dns-overview) and configuring your
+clients with [DNS forwarding](/consul/tutorials/networking/dns-forwarding), and
+deploying a [load balancer](/nomad/tutorials/load-balancing).
 
 Another key difference from Nomad is that in Kubernetes and Docker Compose each
-container has its own IP address, requiring a virtual network to map physical
-IP addresses to virtual ones. In case of Docker Compose in Swarm mode an
-[`overlay`][docker_overlay] is also required to enable traffic across multiple
-hosts. This allows multiple containers running the same service to listen on
-the same port number.
+container has its own IP address, requiring a virtual network to map physical IP
+addresses to virtual ones. In the case of Docker Compose in Swarm mode, an
+[`overlay`](https://docs.docker.com/network/overlay/) is also required to enable
+traffic across multiple hosts. This allows multiple containers running the same
+service to listen on the same port number.
 
-In Nomad, allocations use the IP address of the client they are running and are
-assigned random port numbers and so Nomad service discovery with DNS uses
-[`SRV` records][dns_srv] instead of `A` or `AAAA` records.
+In Nomad, allocations use the IP address of the client in which they are running
+and are assigned random port numbers. Nomad service discovery with DNS uses
+[`SRV` records]( https://en.wikipedia.org/wiki/SRV_record) instead of `A` or
+`AAAA` records.
 
 ## Next topics
 
-- [Service Discovery][service discovery]
-- [Service Mesh][service mesh]
-- [Container Network Interface][cni]
+- [Service Discovery](/nomad/docs/networking/service-discovery)
+- [Service Mesh](/nomad/docs/networking/service-mesh)
+- [Container Network Interface](/nomad/docs/networking/cni) plugins guide
 
 ## Additional resources
 
-- [Understanding Networking in Nomad - Karan Sharma](https://mrkaran.dev/posts/nomad-networking-explained/)
-- [Understanding Nomad Networking Patterns - Luiz Aoqui, HashiTalks: Canada 2021](https://www.youtube.com/watch?v=wTA5HxB_uuk)
-
-[`bridge_network_name`]: /nomad/docs/configuration/client#bridge_network_name
-[`bridge`]: /nomad/docs/job-specification/network#bridge
-[`infra_image`]: /nomad/docs/drivers/docker#infra_image
-[`max_dynamic_port`]: /nomad/docs/configuration/client#max_dynamic_port
-[`min_dynamic_port`]: /nomad/docs/configuration/client#min_dynamic_port
-[`static`]: /nomad/docs/job-specification/network#static
-[`template`]: /nomad/docs/job-specification/template#template-examples
-[allocation]: /nomad/docs/concepts/architecture#allocation
-[cni]: /nomad/docs/networking/cni
-[cni_bridge]: https://www.cni.dev/plugins/current/main/bridge/
-[cni_install]: /nomad/docs/install#post-installation-steps
-[consul_dns]: /consul/docs/services/discovery/dns-overview
-[consul_dns_forwarding]: /consul/tutorials/networking/dns-forwarding
-[consul_service_mesh]: /nomad/docs/integrations/consul-connect
-[dns_srv]: https://en.wikipedia.org/wiki/SRV_record
-[docker_bridge]: https://docs.docker.com/network/bridge/
-[docker_compose]: https://docs.docker.com/compose/
-[docker_dns]: https://docs.docker.com/config/containers/container-networking/#dns-services
-[docker_iptables]: https://docs.docker.com/network/iptables/
-[docker_network_mode]: /nomad/docs/drivers/docker#network_mode
-[docker_networking]: /nomad/docs/drivers/docker#networking
-[docker_overlay]: https://docs.docker.com/network/overlay/
-[docker_swarm]: https://docs.docker.com/engine/swarm/
-[faq_docker]: /nomad/docs/faq#q-how-to-connect-to-my-host-network-when-using-docker-desktop-windows-and-macos
-[jobspec_network]: /nomad/docs/job-specification/network
-[k8s_dns]: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/
-[k8s_ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
-[k8s_kubeproxy]: https://kubernetes.io/docs/concepts/overview/components/#kube-proxy
-[k8s_service]: https://kubernetes.io/docs/concepts/services-networking/service/
-[network_mode]: /nomad/docs/job-specification/network#mode
-[nomad_load_balancer]: /nomad/tutorials/load-balancing
-[runtime_environment]: /nomad/docs/runtime/environment#network-related-variables
-[service discovery]: /nomad/docs/networking/service-discovery
-[service mesh]: /nomad/docs/networking/service-mesh
+- [Understanding Networking in Nomad - Karan
+  Sharma](https://mrkaran.dev/posts/nomad-networking-explained/)
+- [Understanding Nomad Networking Patterns - Luiz Aoqui, HashiTalks: Canada
+  2021](https://www.youtube.com/watch?v=wTA5HxB_uuk)

--- a/website/content/partials/install/bridge-iptables.mdx
+++ b/website/content/partials/install/bridge-iptables.mdx
@@ -1,0 +1,38 @@
+Nomad's task group networks integrate with Consul's service mesh using bridge
+networking and iptables to send traffic between containers.
+
+~> **Warning:** New Linux versions, such as Ubuntu 24.04, may not enable bridge
+networking by default. Use `sudo modprobe bridge` to load the bridge module if
+it is missing.
+
+The Linux kernel bridge module has three tunable parameters that control whether
+iptables processes traffic crossing the bridge. Some operating systems,
+including RedHat, CentOS, and Fedora, might have iptables rules that are not
+correctly configured for guest traffic because these tunable parameters are
+optimized for VM workloads.
+
+Ensure your Linux operating system distribution is configured to allow iptables
+to route container traffic through the bridge network. Run the following
+commands to set the tunable parameters to allow iptables processing for the
+bridge network.
+
+```shell-session
+$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-arptables
+$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-ip6tables
+$ echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables
+```
+
+To preserve these settings on startup of a client node, add a file to
+`/etc/sysctl.d/` or remove the file your Linux distribution puts in that
+directory. The following example configures the tunable parameters for a client
+node.
+
+<CodeBlockConfig filename="/etc/sysctl.d/bridge.conf">
+
+```ini
+net.bridge.bridge-nf-call-arptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.bridge.bridge-nf-call-iptables = 1
+```
+
+</CodeBlockConfig>

--- a/website/content/partials/install/cgroup-controllers.mdx
+++ b/website/content/partials/install/cgroup-controllers.mdx
@@ -1,0 +1,22 @@
+On Linux, Nomad uses cgroups to control access to resources like CPU and memory.
+Nomad supports both [cgroups
+v2](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html) and the
+legacy [cgroups
+v1](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/cgroups.html).
+When Nomad clients start, they determine the available cgroup controllers and
+include the attribute `os.cgroups.version` in their fingerprint.
+
+On cgroups v2, you can run the following command to verify that you have all
+required controllers.
+
+```shell-session
+$ cat /sys/fs/cgroup/cgroup.controllers
+cpuset cpu io memory pids
+```
+
+On legacy cgroups v1, this same list of required controllers appears as a series
+of sub-directories under the directory `/sys/fs/cgroup`.
+
+Refer to the [cgroup controller
+requirements](/nomad/docs/install/production/requirements#cgroup-controllers)
+for more details and to enable missing cgroups.

--- a/website/content/partials/install/install-cni-plugins.mdx
+++ b/website/content/partials/install/install-cni-plugins.mdx
@@ -1,0 +1,23 @@
+Nomad uses CNI plugins to configure network namespaces when using the `bridge`
+network mode. You must install the CNI plugins on all Linux Nomad client nodes
+that use network namespaces. Refer to the [CNI Plugins external
+guide](https://www.cni.dev/plugins/current/) for details on individual plugins.
+
+The following series of commands determines your operating system architecture,
+downloads the [CNI 1.5.1
+release](https://github.com/containernetworking/plugins/releases/tag/v1.5.1),
+and then extracts the CNI plugin binaries into the `/opt/cni/bin` directory.
+Update the `CNI_PLUGIN_VERSION` value to use a different release version.
+
+```shell-session
+$ export ARCH_CNI=$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)
+$ export CNI_PLUGIN_VERSION=v1.5.1
+$ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-linux-${ARCH_CNI}-${CNI_PLUGIN_VERSION}".tgz && \
+  sudo mkdir -p /opt/cni/bin && \
+  sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz
+```
+
+Nomad looks for CNI plugin binaries by default in the `/opt/cni/bin` directory.
+However, you may install in the binaries in a different directory and then
+configure using the [`cni_path`](/nomad/docs/configuration/client#cni_path)
+attribute.

--- a/website/content/partials/install/install-consul-cni-plugin.mdx
+++ b/website/content/partials/install/install-consul-cni-plugin.mdx
@@ -1,0 +1,53 @@
+When you use the [`transparent_proxy`
+block](/nomad/docs/job-specification/transparent_proxy) for Consul service mesh,
+you must also install the [`consul-cni`
+plugin](https://releases.hashicorp.com/consul-cni) on each client node for
+Consul to properly redirect inbound and outbound traffic for services to the
+Envoy proxy. For more information, refer to [Enable the Consul CNI
+plugin](/consul/docs/k8s/connect/transparent-proxy/enable-transparent-proxy#enable-the-consul-cni-plugin)
+in the Consul documentation.
+
+You must install the CNI plugins before you install the Consul CNI plugin. The
+following commands assume that you already installed the CNI plugins.
+
+Install the `consul-cni` plugin on each client node.
+
+<Tabs>
+<Tab heading="Ubuntu/Debian" group="ubuntu">
+
+```shell-session
+$ sudo apt-get install -y consul-cni
+```
+
+</Tab>
+<Tab heading="RHEL/CentOS" group="rhel">
+
+```shell-session
+$ sudo yum -y install consul-cni
+```
+
+</Tab>
+<Tab heading="Fedora" group="fedora">
+
+```shell-session
+$ sudo dnf -y install consul-cni
+```
+
+</Tab>
+<Tab heading="Amazon Linux" group="amazonlinux">
+
+```shell-session
+$ sudo yum -y install consul-cni
+```
+
+</Tab>
+<Tab heading="Manual" group="linux-manual">
+
+```shell-session
+$ export ARCH_CNI=$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)
+$ curl -L -o consul-cni.zip "https://releases.hashicorp.com/consul-cni/1.5.1/consul-cni_1.5.1_linux_${ARCH_CNI}".zip && \
+  sudo unzip consul-cni.zip -d /opt/cni/bin -x LICENSE.txt
+```
+
+</Tab>
+</Tabs>

--- a/website/content/partials/install/manual-install.mdx
+++ b/website/content/partials/install/manual-install.mdx
@@ -1,0 +1,4 @@
+Download a [precompiled binary](https://releases.hashicorp.com/nomad/), verify
+the binary using the available SHA-256 sums, and unzip the package to a location
+on your machine. Make sure that the location of the `nomad` binary is available
+on your `PATH` before continuing with the other guides.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1,6 +1,6 @@
 [
   {
-    "title": "Installing Nomad",
+    "title": "Install Nomad",
     "routes": [
       {
         "title": "Overview",


### PR DESCRIPTION
- Pulled common content from multiple pages into new partials
- Refactored install/index to be OS-based so I could add linux-distro-based instructions to install-consul-cni-plugins.mdx partial. The tab groups on the install/index page do match and change focus as expected.
- Moved CNI overview-type content to networking/index
- Refactored networking/cni to include install CNI plugins and configuration content (from install/index).
- Moved CNI plugins explanation in bridge mode configuration section into bullet points. They had been #### headings, which aren't rendered in the R page TOC. I tried to simplify and format the bullet point content to be easier to scan.

Ref: https://hashicorp.atlassian.net/browse/CE-661
Fixes: https://github.com/hashicorp/nomad/issues/23229
Fixes: https://github.com/hashicorp/nomad/issues/23583