### PR TITLE
build: revert change to active versions

### DIFF
--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -11,9 +11,9 @@ active_versions {
     lts       = true
   }
   version "1.7.x" {
-    ce_active = false
+    ce_active = true
   }
   version "1.6.x" {
-    ce_active = false
+    ce_active = true
   }
 }


### PR DESCRIPTION
In #23720 we removed the 1.7.x and 1.6.x release branches from the "active" versions for backports. But we forgot that we needed these backports to remain active for documentation backports because of versioned docs.