### PR TITLE
acl: disallow leading `/` on variable paths

### DIFF
--- a/.changelog/23757.txt
+++ b/.changelog/23757.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: Submitting a policy with a leading `/` in a variable path will now return an error to prevent improperly working policies.
+```

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -398,7 +398,7 @@ func Parse(rules string) (*Policy, error) {
 				}
 				if strings.HasPrefix(pathPolicy.PathSpec, "/") {
 					return nil, fmt.Errorf(
-						"Invalid variable path '%s' in namespace %s: cannot start with a leading '/'`",
+						"Invalid variable path %q in namespace %s: cannot start with a leading '/'`",
 						pathPolicy.PathSpec, ns.Name)
 				}
 				for _, cap := range pathPolicy.Capabilities {

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
@@ -394,6 +395,11 @@ func Parse(rules string) (*Policy, error) {
 			for _, pathPolicy := range ns.Variables.Paths {
 				if pathPolicy.PathSpec == "" {
 					return nil, fmt.Errorf("Invalid missing variable path in namespace %s", ns.Name)
+				}
+				if strings.HasPrefix(pathPolicy.PathSpec, "/") {
+					return nil, fmt.Errorf(
+						"Invalid variable path '%s' in namespace %s: cannot start with a leading '/'`",
+						pathPolicy.PathSpec, ns.Name)
 				}
 				for _, cap := range pathPolicy.Capabilities {
 					if !isPathCapabilityValid(cap) {

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -497,6 +497,19 @@ func TestParse(t *testing.T) {
 		{
 			`
 			namespace "dev" {
+			  variables {
+                path "/nomad/job" {
+			      capabilities = ["read", "write"]
+                }
+			  }
+			}
+			`,
+			"Invalid variable path '/nomad/job' in namespace dev: cannot start with a leading '/'",
+			nil,
+		},
+		{
+			`
+			namespace "dev" {
 				policy = "read"
 
 				variables {

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -504,7 +504,7 @@ func TestParse(t *testing.T) {
 			  }
 			}
 			`,
-			"Invalid variable path '/nomad/job' in namespace dev: cannot start with a leading '/'",
+			"Invalid variable path \"/nomad/job\" in namespace dev: cannot start with a leading '/'",
 			nil,
 		},
 		{

--- a/website/content/docs/other-specifications/acl-policy.mdx
+++ b/website/content/docs/other-specifications/acl-policy.mdx
@@ -199,7 +199,9 @@ variables block per namespace rule.
 
 A `variables` block includes one or more `path` blocks. Each `path` block is
 labeled with the path it applies to. You may use wildcard globs (`"*"`) in the
-path label, to apply the block to multiple paths in the namespace.
+path label, to apply the block to multiple paths in the namespace. Note that
+variable paths never start with a leading `/`, so Nomad will return an error if
+you submit a policy that has such a path.
 
 Each path has a list of `capabilities`. The available capabilities for Variables
 are as follows:


### PR DESCRIPTION
The path for a Variable never begins with a leading `/`, because it's stripped off in the API before it ever gets to the state store. The CLI and UI allow the leading `/` for convenience, but this can be misleading when it comes to writing ACL policies. An ACL policy with a path starting with a leading `/` will never match.

Update the ACL policy parser so that we prevent an incorrect variable path in the policy.

Fixes: https://github.com/hashicorp/nomad/issues/23730