### PR TITLE
cni: network.cni job updates should replace allocs

### DIFF
--- a/.changelog/23764.txt
+++ b/.changelog/23764.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cni: network.cni jobspec updates now replace allocs to apply the new network config
+```

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -544,6 +544,10 @@ func networkUpdated(netA, netB []*structs.NetworkResource) comparison {
 			return difference("network dns", an.DNS, bn.DNS)
 		}
 
+		if !an.CNI.Equal(bn.CNI) {
+			return difference("network cni", an.CNI, bn.CNI)
+		}
+
 		aPorts, bPorts := networkPortMap(an), networkPortMap(bn)
 		if !aPorts.Equal(bPorts) {
 			return difference("network port map", aPorts, bPorts)


### PR DESCRIPTION
We missed this tiny bit in #23538

A change to the [`network{cni{}}` block](https://developer.hashicorp.com/nomad/docs/job-specification/network#cni-parameters) means that the user wants the network config to change, and that only happens during initial alloc setup, so we need to replace the alloc(s) to get fresh network(s) to reconfigure from scratch.

e.g. a job plan diff like this

```
+/- Task Group: "g" (1 in-place update)
  + Network {
    + CNIConfig {
      + a: "ayy"
      }
```

should instead be

```
+/- Task Group: "g" (1 create/destroy update)
  + Network {
    + CNIConfig {
      + a: "ayy"
      }
```