### PR TITLE
api: only set url field in config if previously unset

### DIFF
--- a/.changelog/23785.txt
+++ b/.changelog/23785.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fixed a bug where an `api.Config` targeting a unix domain socket could not be reused between clients
+```

--- a/api/api.go
+++ b/api/api.go
@@ -509,9 +509,13 @@ func NewClient(config *Config) (*Client, error) {
 	}
 
 	// we have to test the address that comes from DefaultConfig, because it
-	// could be the value of NOMAD_ADDR which is applied without testing
-	if config.url, err = url.Parse(config.Address); err != nil {
-		return nil, fmt.Errorf("invalid address '%s': %v", config.Address, err)
+	// could be the value of NOMAD_ADDR which is applied without testing. But
+	// only on the first use of this Config, otherwise we'll have mutated the
+	// address
+	if config.url == nil {
+		if config.url, err = url.Parse(config.Address); err != nil {
+			return nil, fmt.Errorf("invalid address '%s': %v", config.Address, err)
+		}
 	}
 
 	httpClient := config.HttpClient


### PR DESCRIPTION
In #16872 we added support for configuring the API client with a unix domain socket. In order to set the host correctly, we parse the address before mutating the Address field in the configuration. But this prevents the configuration from being reused across multiple clients, as the next time we parse the address it will no longer be pointing to the socket. This breaks consumers like the autoscaler, which reuse the API config between plugins.

Update the `NewClient` constructor to only override the `url` field if it hasn't already been parsed. Include a test demonstrating safe reuse with a unix domain socket.

Ref: https://github.com/hashicorp/nomad-autoscaler/issues/944
Ref: https://github.com/hashicorp/nomad-autoscaler/pull/945

---

Note for reviewers: in some hypothetical "v2" of the API I'd like to have some kind of options or builder pattern for the client config where we can "consume" the config. But for the moment getting the `Config` to be safely reusable seems like the best approach to avoid further backwards-incompatibility.