### PR TITLE
docs: minimal Consul policy for Nomad agents needs node:write

### DIFF
--- a/website/content/docs/integrations/consul/acl.mdx
+++ b/website/content/docs/integrations/consul/acl.mdx
@@ -33,7 +33,7 @@ agent_prefix "" {
 }
 
 node_prefix "" {
-  policy = "read"
+  policy = "write"
 }
 
 service_prefix "" {
@@ -53,7 +53,7 @@ agent_prefix "" {
 }
 
 node_prefix "" {
-  policy = "read"
+  policy = "write"
 }
 
 service_prefix "" {


### PR DESCRIPTION
Since Consul 1.15 (https://github.com/hashicorp/consul/pull/16097) Consul client agent only uses the agent token to perform [anti-entropy](https://developer.hashicorp.com/consul/docs/architecture/anti-entropy) after you deregister a service via the Agent API. so the Consul client agent must have its own agent token.

Internal ref: https://hashicorp.atlassian.net/browse/NET-10360