### PR TITLE
build: apt update before apt install

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Install optional dependencies
         if: ${{ matrix.groups == 'drivers' }}
-        run: sudo apt install qemu-system
+        run: sudo apt update && sudo apt install qemu-system
 
       - name: Run Matrix Tests
         env:


### PR DESCRIPTION
Run `apt update` before `apt install` for `qemu-system` install step. Otherwise the cache may be out of date with Azure's own mirrors.