### PR TITLE
client: log an error message if total detected cpu is zero

### DIFF
--- a/client/fingerprint/cpu.go
+++ b/client/fingerprint/cpu.go
@@ -164,6 +164,10 @@ func (f *CPUFingerprint) setTotalCompute(response *FingerprintResponse) {
 	totalCompute := f.top.TotalCompute()
 	usableCompute := f.top.UsableCompute()
 
+	if totalCompute == 0 {
+		f.logger.Error("cpu.totalcompute is zero, CPU fingerprinting likely failed", "cpu.totalcompute", totalCompute)
+	}
+
 	response.AddAttribute("cpu.totalcompute", f.frequency(totalCompute))
 	response.AddAttribute("cpu.usablecompute", f.frequency(usableCompute))
 }


### PR DESCRIPTION
It would be useful to surface CPU fingerprinting issue with an `ERROR` level log message, vide suggestion in https://github.com/hashicorp/nomad/issues/23811