### PR TITLE
[ui] Prevent double-open for cmd+click on jobs index links

### DIFF
--- a/.changelog/23832.txt
+++ b/.changelog/23832.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix an issue where cmd+click or ctrl+click would double-open a job
+```

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -12,6 +12,8 @@ import { tracked } from '@glimmer/tracking';
 import localStorageProperty from 'nomad-ui/utils/properties/local-storage';
 import { restartableTask, timeout } from 'ember-concurrency';
 import Ember from 'ember';
+// eslint-disable-next-line no-unused-vars
+import JobModel from '../../models/job';
 
 const JOB_LIST_THROTTLE = 5000;
 const JOB_DETAILS_THROTTLE = 1000;
@@ -62,8 +64,20 @@ export default class JobsIndexController extends Controller {
   @tracked pendingJobs = null;
   @tracked pendingJobIDs = null;
 
+  /**
+   * Trigger can either be the pointer event itself, or if the keyboard shorcut was used, the html element corresponding to the job.
+   * @param {JobModel} job
+   * @param {PointerEvent|HTMLElement} trigger
+   */
   @action
-  gotoJob(job) {
+  gotoJob(job, trigger) {
+    // Don't navigate if the user clicked on a link; this will happen with modifier keys like cmd/ctrl on the link itself
+    if (
+      trigger instanceof PointerEvent &&
+      /** @type {HTMLElement} */ (trigger.target).tagName === 'A'
+    ) {
+      return;
+    }
     this.router.transitionTo('jobs.job.index', job.idWithNamespace);
   }
 


### PR DESCRIPTION
Previously, cmd+click (or ctrl+click) on the `<a>` tag within job rows on the jobs index page would double-open the page: once in a new tab (as cmd+click does) and another in the same tab (as it would trigger the `{{on "click"}}` Ember event for the job row.

This checks to make sure the clicked element wasn't the anchor tag itself, and if it is, it returns early.

NB: it's a bad practice, generally, to have non-interactive elements like table rows be clickable! However this follows a long-standing convention in the Nomad UI that users may be used to from years of use, and has more than one highly accessible fallback.

Resolves #23544 