### PR TITLE
scheduler: support for device - aware numa scheduling (#1760)

### DIFF
--- a/api/resources.go
+++ b/api/resources.go
@@ -4,6 +4,7 @@
 package api
 
 import (
+	"slices"
 	"strconv"
 )
 
@@ -115,6 +116,10 @@ func (r *Resources) Merge(other *Resources) {
 type NUMAResource struct {
 	// Affinity must be one of "none", "prefer", "require".
 	Affinity string `hcl:"affinity,optional"`
+
+	// Devices is the subset of devices requested by the task that must share
+	// the same numa node, along with the tasks reserved cpu cores.
+	Devices []string `hcl:"devices,optional"`
 }
 
 func (n *NUMAResource) Copy() *NUMAResource {
@@ -123,6 +128,7 @@ func (n *NUMAResource) Copy() *NUMAResource {
 	}
 	return &NUMAResource{
 		Affinity: n.Affinity,
+		Devices:  slices.Clone(n.Devices),
 	}
 }
 
@@ -132,6 +138,9 @@ func (n *NUMAResource) Canonicalize() {
 	}
 	if n.Affinity == "" {
 		n.Affinity = "none"
+	}
+	if len(n.Devices) == 0 {
+		n.Devices = nil
 	}
 }
 

--- a/api/resources_test.go
+++ b/api/resources_test.go
@@ -94,8 +94,11 @@ func TestNUMAResource_Copy(t *testing.T) {
 	r1 := &NUMAResource{Affinity: "none"}
 	r2 := r1.Copy()
 	r1.Affinity = "require"
+	r1.Devices = []string{"nvidia/gpu"}
 	must.Eq(t, "require", r1.Affinity)
 	must.Eq(t, "none", r2.Affinity)
+	must.Eq(t, []string{"nvidia/gpu"}, r1.Devices)
+	must.SliceEmpty(t, r2.Devices)
 }
 
 func TestNUMAResource_Canonicalize(t *testing.T) {
@@ -108,4 +111,8 @@ func TestNUMAResource_Canonicalize(t *testing.T) {
 	var n2 = &NUMAResource{Affinity: ""}
 	n2.Canonicalize()
 	must.Eq(t, &NUMAResource{Affinity: "none"}, n2)
+
+	var n3 = &NUMAResource{Affinity: "require", Devices: []string{}}
+	n3.Canonicalize()
+	must.Eq(t, &NUMAResource{Affinity: "require", Devices: nil}, n3)
 }

--- a/client/lib/idset/idset.go
+++ b/client/lib/idset/idset.go
@@ -106,9 +106,16 @@ func From[T, U ID](slice []U) *Set[T] {
 	return result
 }
 
+// Difference returns the set of elements in s but not in other.
 func (s *Set[T]) Difference(other *Set[T]) *Set[T] {
 	diff := s.items.Difference(other.items)
 	return &Set[T]{items: diff.(*set.Set[T])}
+}
+
+// Intersect returns the set of elements that are in both s and other.
+func (s *Set[T]) Intersect(other *Set[T]) *Set[T] {
+	intersection := s.items.Intersect(other.items)
+	return &Set[T]{items: intersection.(*set.Set[T])}
 }
 
 // Contains returns whether the Set contains item.

--- a/client/lib/numalib/detect_linux_test.go
+++ b/client/lib/numalib/detect_linux_test.go
@@ -69,7 +69,7 @@ func goodSysData(path string) ([]byte, error) {
 }
 
 func TestSysfs_discoverOnline(t *testing.T) {
-	st := NewTopology(&idset.Set[hw.NodeID]{}, SLIT{}, []Core{})
+	st := MockTopology(&idset.Set[hw.NodeID]{}, SLIT{}, []Core{})
 	goodIDSet := idset.From[hw.NodeID]([]uint8{0, 1})
 	oneNode := idset.From[hw.NodeID]([]uint8{0})
 
@@ -91,7 +91,7 @@ func TestSysfs_discoverOnline(t *testing.T) {
 }
 
 func TestSysfs_discoverCosts(t *testing.T) {
-	st := NewTopology(idset.Empty[hw.NodeID](), SLIT{}, []Core{})
+	st := MockTopology(idset.Empty[hw.NodeID](), SLIT{}, []Core{})
 	twoNodes := idset.From[hw.NodeID]([]uint8{1, 3})
 
 	tests := []struct {
@@ -121,7 +121,7 @@ func TestSysfs_discoverCosts(t *testing.T) {
 }
 
 func TestSysfs_discoverCores(t *testing.T) {
-	st := NewTopology(idset.Empty[hw.NodeID](), SLIT{}, []Core{})
+	st := MockTopology(idset.Empty[hw.NodeID](), SLIT{}, []Core{})
 	oneNode := idset.From[hw.NodeID]([]uint8{0})
 	twoNodes := idset.From[hw.NodeID]([]uint8{1, 3})
 

--- a/client/lib/numalib/testing.go
+++ b/client/lib/numalib/testing.go
@@ -1,0 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package numalib
+
+import (
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
+)
+
+// MockTopology is a constructor for the Topology object, only used in tests for
+// mocking.
+func MockTopology(nodeIDs *idset.Set[hw.NodeID], distances SLIT, cores []Core) *Topology {
+	t := &Topology{
+		nodeIDs:   nodeIDs,
+		Distances: distances, Cores: cores}
+	t.SetNodes(nodeIDs)
+	return t
+}

--- a/client/lib/numalib/topology.go
+++ b/client/lib/numalib/topology.go
@@ -63,19 +63,28 @@ type Topology struct {
 	Distances SLIT
 	Cores     []Core
 
+	// BusAssociativity maps the specific bus each PCI device is plugged into
+	// with its hardware associated numa node
+	//
+	// e.g. "0000:03:00.0" -> 1
+	//
+	// Note that the key may not exactly match the Locality.PciBusID from the
+	// fingerprint of the device with regard to the domain value.
+	//
+	//
+	// 0000:03:00.0
+	// ^    ^  ^  ^
+	// |    |  |  |-- function (identifies functionality of device)
+	// |    |  |-- device (identifies the device number on the bus)
+	// |    |
+	// |    |-- bus (identifies which bus segment the device is connected to)
+	// |
+	// |-- domain (basically always 0, may be 0000 or 00000000)
+	BusAssociativity map[string]hw.NodeID
+
 	// explicit overrides from client configuration
 	OverrideTotalCompute   hw.MHz
 	OverrideWitholdCompute hw.MHz
-}
-
-// NewTopology is a constructor for the Topology object, only used in tests for
-// mocking.
-func NewTopology(nodeIDs *idset.Set[hw.NodeID], distances SLIT, cores []Core) *Topology {
-	t := &Topology{
-		nodeIDs:   nodeIDs,
-		Distances: distances, Cores: cores}
-	t.SetNodes(nodeIDs)
-	return t
 }
 
 func (t *Topology) SetNodes(nodes *idset.Set[hw.NodeID]) {

--- a/nomad/mock/node.go
+++ b/nomad/mock/node.go
@@ -130,6 +130,7 @@ func DrainNode() *structs.Node {
 // NvidiaNode returns a node with two instances of an Nvidia GPU
 func NvidiaNode() *structs.Node {
 	n := Node()
+	n.NodeResources.Processors.Topology = structs.MockWorkstationTopology()
 	n.NodeResources.Devices = []*structs.NodeDeviceResource{
 		{
 			Type:   "gpu",
@@ -145,10 +146,16 @@ func NvidiaNode() *structs.Node {
 				{
 					ID:      uuid.Generate(),
 					Healthy: true,
+					Locality: &structs.NodeDeviceLocality{
+						PciBusID: "0000:02:00.1", // node 0
+					},
 				},
 				{
 					ID:      uuid.Generate(),
 					Healthy: true,
+					Locality: &structs.NodeDeviceLocality{
+						PciBusID: "0000:02:01.1", // node 0
+					},
 				},
 			},
 		},

--- a/nomad/structs/devices.go
+++ b/nomad/structs/devices.go
@@ -3,6 +3,8 @@
 
 package structs
 
+import "maps"
+
 // DeviceAccounter is used to account for device usage on a node. It can detect
 // when a node is oversubscribed and can be used for deciding what devices are
 // free
@@ -20,6 +22,25 @@ type DeviceAccounterInstance struct {
 	// Instances is a mapping of the device IDs to their usage.
 	// Only a value of 0 indicates that the instance is unused.
 	Instances map[string]int
+}
+
+// Locality returns the NodeDeviceLocality of the instance of the specific deviceID.
+//
+// If no instance matching the deviceID is found, nil is returned.
+func (dai *DeviceAccounterInstance) GetLocality(instanceID string) *NodeDeviceLocality {
+	for _, instance := range dai.Device.Instances {
+		if instance.ID == instanceID {
+			return instance.Locality.Copy()
+		}
+	}
+	return nil
+}
+
+func (dai *DeviceAccounterInstance) Copy() *DeviceAccounterInstance {
+	return &DeviceAccounterInstance{
+		Device:    dai.Device.Copy(),
+		Instances: maps.Clone(dai.Instances),
+	}
 }
 
 // NewDeviceAccounter returns a new device accounter. The node is used to
@@ -56,6 +77,14 @@ func NewDeviceAccounter(n *Node) *DeviceAccounter {
 	}
 
 	return d
+}
+
+func (d *DeviceAccounter) Copy() *DeviceAccounter {
+	devices := make(map[DeviceIdTuple]*DeviceAccounterInstance, len(d.Devices))
+	for k, v := range d.Devices {
+		devices[k] = v.Copy()
+	}
+	return &DeviceAccounter{Devices: devices}
 }
 
 // AddAllocs takes a set of allocations and internally marks which devices are

--- a/nomad/structs/numa_test.go
+++ b/nomad/structs/numa_test.go
@@ -21,9 +21,13 @@ func TestNUMA_Equal(t *testing.T) {
 
 	must.StructEqual(t, &NUMA{
 		Affinity: "none",
+		Devices:  []string{"nvidia/gpu"},
 	}, []must.Tweak[*NUMA]{{
 		Field: "Affinity",
 		Apply: func(n *NUMA) { n.Affinity = "require" },
+	}, {
+		Field: "Devices",
+		Apply: func(n *NUMA) { n.Devices = []string{"a/b", "c/d"} },
 	}})
 }
 
@@ -67,7 +71,8 @@ func TestNUMA_Validate(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			numa := &NUMA{
-				tc.affinity,
+				Affinity: tc.affinity,
+				Devices:  nil,
 			}
 			result := numa.Validate()
 			must.Eq(t, tc.exp, result)

--- a/nomad/structs/testing.go
+++ b/nomad/structs/testing.go
@@ -43,6 +43,7 @@ func NodeResourcesToAllocatedResources(n *NodeResources) *AllocatedResources {
 // - 1 socket, 1 NUMA node
 // - 4 cores @ 3500 MHz (14,000 MHz total)
 // - no client config overrides
+// - no devices
 func MockBasicTopology() *numalib.Topology {
 	cores := make([]numalib.Core, 4)
 	for i := 0; i < 4; i++ {
@@ -60,6 +61,7 @@ func MockBasicTopology() *numalib.Topology {
 		Cores:                  cores,
 		OverrideTotalCompute:   0,
 		OverrideWitholdCompute: 0,
+		BusAssociativity:       nil,
 	}
 	t.SetNodes(idset.From[hw.NodeID]([]hw.NodeID{0}))
 	return t
@@ -67,10 +69,17 @@ func MockBasicTopology() *numalib.Topology {
 
 // MockWorkstationTopology returns a numalib.Topology that looks like a typical
 // workstation;
-// - 2 socket, 2 NUMA node (200% penalty)
-// - 16 cores / 32 threads @ 3000 MHz (96,000 MHz total)
-// - node0: odd cores, node1: even cores
-// - no client config overrides
+//   - 2 socket, 2 NUMA node (200% penalty)
+//   - 16 cores / 32 threads @ 3000 MHz (96,000 MHz total)
+//   - node0: odd cores, node1: even cores
+//   - no client config overrides
+//   - node0 devices:
+//     nvidia/gpu/t1000 - 0000:02:00.1
+//     nvidia/gpu/t1000 - 0000:02:01.1
+//     net/type1        - 0000:03:00.2
+//   - node1 devices:
+//     nvidia/gpu/r600  - 0000:08:00.1
+//     fpga/kv0         - 0000:09:01.0
 func MockWorkstationTopology() *numalib.Topology {
 	cores := make([]numalib.Core, 32)
 	for i := 0; i < 32; i++ {
@@ -86,6 +95,13 @@ func MockWorkstationTopology() *numalib.Topology {
 	t := &numalib.Topology{
 		Distances: numalib.SLIT{[]numalib.Cost{10, 20}, {20, 10}},
 		Cores:     cores,
+		BusAssociativity: map[string]hw.NodeID{
+			"0000:02:00.1": 0,
+			"0000:02:01.1": 0,
+			"0000:03:00.2": 0,
+			"0000:08:00.1": 1,
+			"0000:09:01.0": 1,
+		},
 	}
 	t.SetNodes(idset.From[hw.NodeID]([]hw.NodeID{0, 1}))
 	return t

--- a/scheduler/device.go
+++ b/scheduler/device.go
@@ -5,9 +5,12 @@ package scheduler
 
 import (
 	"fmt"
+	"strings"
 
 	"math"
 
+	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/nomad/client/lib/numalib"
 	"github.com/hashicorp/nomad/nomad/structs"
 	psstructs "github.com/hashicorp/nomad/plugins/shared/structs"
 )
@@ -30,10 +33,77 @@ func newDeviceAllocator(ctx Context, n *structs.Node) *deviceAllocator {
 	}
 }
 
-// AssignDevice takes a device request and returns an assignment as well as a
-// score for the assignment. If no assignment could be made, an error is
+func (da *deviceAllocator) Copy() *deviceAllocator {
+	accounter := da.DeviceAccounter.Copy()
+	allocator := &deviceAllocator{accounter, da.ctx}
+	return allocator
+}
+
+type memoryNodeMatcher struct {
+	memoryNode int               // the target memory node (-1 indicates don't care)
+	topology   *numalib.Topology // the topology of the candidate node
+	devices    *set.Set[string]  // the set of devices requiring numa associativity
+}
+
+// equalBusID will compare the instance specific device bus id values in a way
+// that handles non-uniform domain strings (e.g. "0000" vs "00000000").
+//
+// e.g. 0000:03:00.1 is equal to 00000000:03.00.1
+func equalBusID(a, b string) bool {
+	if a == b {
+		return true
+	}
+	noDomainA := strings.TrimLeft(a, "0")
+	noDomainB := strings.TrimLeft(b, "0")
+	return noDomainA == noDomainB
+}
+
+// Matches returns whether the given device instance is on a PCI bus that is
+// on the same NUMA node as the memory node of the matcher.
+//
+// instanceID is something like "GPU-6b5fa173-5fa6-2d38-54fe-d64c1fe4fe10"
+//
+// device is the grouping of device instance this instance belongs to and is
+// how we find the pci bus locality.
+func (m *memoryNodeMatcher) Matches(instanceID string, device *structs.NodeDeviceResource) bool {
+	// -1 is the sentinel value for not caring about the associated memory
+	// node, in which case we simply treat the device as a match
+	if m.memoryNode == -1 {
+		return true
+	}
+
+	// if the device is not listed in the numa block of the task resources then
+	// we do not care about what node is is on
+	if !m.devices.Contains(device.ID().String()) {
+		return true
+	}
+
+	// check if the hardware locality of the device matches the nume node of this
+	// memoryNodeMatcher instance. we do so by finding the specific device of
+	// the given instance id, looking at its locality, and comparing the locality
+	// using equalBusID because direct == equality does not work, due to
+	// differences in pci bus domain representations
+	for _, instance := range device.Instances {
+		if instance.ID == instanceID {
+			if instance.Locality != nil {
+				instanceBusID := instance.Locality.PciBusID
+				for busID, node := range m.topology.BusAssociativity {
+					if equalBusID(busID, instanceBusID) {
+						result := int(node) == m.memoryNode
+						return result
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}
+
+// createOffer takes a device request and returns an assignment as well as a
+// score for the assignment. If no assignment is possible, an error is
 // returned explaining why.
-func (d *deviceAllocator) AssignDevice(ask *structs.RequestedDevice) (out *structs.AllocatedDeviceResource, score float64, err error) {
+func (d *deviceAllocator) createOffer(mem *memoryNodeMatcher, ask *structs.RequestedDevice) (out *structs.AllocatedDeviceResource, score float64, err error) {
 	// Try to hot path
 	if len(d.Devices) == 0 {
 		return nil, 0.0, fmt.Errorf("no devices available")
@@ -52,10 +122,14 @@ func (d *deviceAllocator) AssignDevice(ask *structs.RequestedDevice) (out *struc
 	for id, devInst := range d.Devices {
 		// Check if we have enough unused instances to use this
 		assignable := uint64(0)
-		for _, v := range devInst.Instances {
-			if v == 0 {
-				assignable++
+		for instanceID, v := range devInst.Instances {
+			if v != 0 {
+				continue
 			}
+			if !mem.Matches(instanceID, devInst.Device) {
+				continue
+			}
+			assignable++
 		}
 
 		// This device doesn't have enough instances

--- a/scheduler/device_test.go
+++ b/scheduler/device_test.go
@@ -6,7 +6,9 @@ package scheduler
 import (
 	"testing"
 
+	"github.com/hashicorp/go-set/v2"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/client/lib/numalib"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -14,6 +16,12 @@ import (
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
+
+func anyMemoryNodeMatcher() *memoryNodeMatcher {
+	return &memoryNodeMatcher{
+		memoryNode: -1,
+	}
+}
 
 // deviceRequest takes the name, count and potential constraints and affinities
 // and returns a device request.
@@ -104,7 +112,8 @@ func TestDeviceAllocator_Allocate_GenericRequest(t *testing.T) {
 	// Build the request
 	ask := deviceRequest("gpu", 1, nil, nil)
 
-	out, score, err := d.AssignDevice(ask)
+	mem := anyMemoryNodeMatcher()
+	out, score, err := d.createOffer(mem, ask)
 	require.NotNil(out)
 	require.Zero(score)
 	require.NoError(err)
@@ -127,7 +136,8 @@ func TestDeviceAllocator_Allocate_FullyQualifiedRequest(t *testing.T) {
 	// Build the request
 	ask := deviceRequest("intel/fpga/F100", 1, nil, nil)
 
-	out, score, err := d.AssignDevice(ask)
+	mem := anyMemoryNodeMatcher()
+	out, score, err := d.createOffer(mem, ask)
 	require.NotNil(out)
 	require.Zero(score)
 	require.NoError(err)
@@ -150,10 +160,63 @@ func TestDeviceAllocator_Allocate_NotEnoughInstances(t *testing.T) {
 	// Build the request
 	ask := deviceRequest("gpu", 4, nil, nil)
 
-	out, _, err := d.AssignDevice(ask)
+	mem := anyMemoryNodeMatcher()
+	out, _, err := d.createOffer(mem, ask)
 	require.Nil(out)
 	require.Error(err)
 	require.Contains(err.Error(), "no devices match request")
+}
+
+func TestDeviceAllocator_Allocate_NUMA_available(t *testing.T) {
+	ci.Parallel(t)
+
+	_, ctx := testContext(t)
+	n := devNode()
+	d := newDeviceAllocator(ctx, n)
+
+	ask := deviceRequest("nvidia/gpu/1080ti", 2, nil, nil)
+
+	mem := &memoryNodeMatcher{
+		memoryNode: 0,
+		topology:   structs.MockWorkstationTopology(),
+		devices:    set.From([]string{"nvidia/gpu/1080ti"}),
+	}
+	out, _, err := d.createOffer(mem, ask)
+	must.NoError(t, err)
+	must.SliceLen(t, 2, out.DeviceIDs) // DeviceIDs are actually instance ids
+}
+
+func TestDeviceAllocator_Allocate_NUMA_node1(t *testing.T) {
+	ci.Parallel(t)
+
+	_, ctx := testContext(t)
+	n := devNode()
+	n.NodeResources.Devices = append(n.NodeResources.Devices, &structs.NodeDeviceResource{
+		Type:   "fpga",
+		Vendor: "xilinx",
+		Name:   "7XA",
+		Instances: []*structs.NodeDevice{
+			{
+				ID:      uuid.Generate(),
+				Healthy: true,
+				Locality: &structs.NodeDeviceLocality{
+					PciBusID: "00000000:09:01.0",
+				},
+			},
+		},
+	})
+	d := newDeviceAllocator(ctx, n)
+
+	ask := deviceRequest("xilinx/fpga/7XA", 1, nil, nil)
+
+	mem := &memoryNodeMatcher{
+		memoryNode: 1,
+		topology:   structs.MockWorkstationTopology(),
+		devices:    set.From([]string{"xilinx/fpga/7XA"}),
+	}
+	out, _, err := d.createOffer(mem, ask)
+	must.NoError(t, err)
+	must.SliceLen(t, 1, out.DeviceIDs)
 }
 
 // Test that asking for a device with constraints works
@@ -272,7 +335,8 @@ func TestDeviceAllocator_Allocate_Constraints(t *testing.T) {
 			// Build the request
 			ask := deviceRequest(c.Name, 1, c.Constraints, nil)
 
-			out, score, err := d.AssignDevice(ask)
+			mem := anyMemoryNodeMatcher()
+			out, score, err := d.createOffer(mem, ask)
 			if c.NoPlacement {
 				require.Nil(t, out)
 			} else {
@@ -378,7 +442,8 @@ func TestDeviceAllocator_Allocate_Affinities(t *testing.T) {
 			// Build the request
 			ask := deviceRequest(c.Name, 1, nil, c.Affinities)
 
-			out, score, err := d.AssignDevice(ask)
+			mem := anyMemoryNodeMatcher()
+			out, score, err := d.createOffer(mem, ask)
 			require.NotNil(out)
 			require.NoError(err)
 			if c.ZeroScore {
@@ -390,6 +455,121 @@ func TestDeviceAllocator_Allocate_Affinities(t *testing.T) {
 			// Check that we got the nvidia device
 			require.Len(out.DeviceIDs, 1)
 			require.Contains(collectInstanceIDs(c.ExpectedDevice), out.DeviceIDs[0])
+		})
+	}
+}
+
+func Test_equalBusID(t *testing.T) {
+	must.True(t, equalBusID("0000:03:00.1", "00000000:03:00.1"))
+	must.False(t, equalBusID("0000:03:00.1", "0000:03:00.0"))
+}
+
+func Test_memoryNodeMatcher(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name            string
+		memoryNode      int                         // memory node in consideration
+		topology        *numalib.Topology           // cpu cores and device bus associativity
+		taskNumaDevices *set.Set[string]            // devices that require numa associativity
+		instance        string                      // asking if this particular instance (id) satisfies the request
+		device          *structs.NodeDeviceResource // device group that contains specifics about instance(s)
+		exp             bool
+	}{
+		{
+			name:            "ws: single gpu match on node 0",
+			memoryNode:      0,
+			topology:        structs.MockWorkstationTopology(),
+			taskNumaDevices: set.From([]string{"nvidia/gpu/t1000"}),
+			instance:        "GPU-T1000-01",
+			device: &structs.NodeDeviceResource{
+				Vendor: "nvidia",
+				Type:   "gpu",
+				Name:   "t1000",
+				Instances: []*structs.NodeDevice{
+					{
+						ID: "GPU-T1000-01",
+						Locality: &structs.NodeDeviceLocality{
+							PciBusID: "0000:02:00.1",
+						},
+					},
+				},
+			},
+			exp: true,
+		},
+		{
+			name:            "ws: single gpu no match on node 1",
+			memoryNode:      1,
+			topology:        structs.MockWorkstationTopology(),
+			taskNumaDevices: set.From([]string{"nvidia/gpu/t1000"}),
+			instance:        "GPU-T1000-01",
+			device: &structs.NodeDeviceResource{
+				Vendor: "nvidia",
+				Type:   "gpu",
+				Name:   "t1000",
+				Instances: []*structs.NodeDevice{
+					{
+						ID: "GPU-T1000-01",
+						Locality: &structs.NodeDeviceLocality{
+							PciBusID: "0000:02:00.1",
+						},
+					},
+				},
+			},
+			exp: false,
+		},
+		{
+			name:            "ws: net card match on node 0",
+			memoryNode:      0,
+			topology:        structs.MockWorkstationTopology(),
+			taskNumaDevices: set.From([]string{"nvidia/gpu/t1000", "net/type1"}),
+			instance:        "NET-T1-01",
+			device: &structs.NodeDeviceResource{
+				Type: "net",
+				Name: "nic100",
+				Instances: []*structs.NodeDevice{
+					{
+						ID: "NET-T1-01",
+						Locality: &structs.NodeDeviceLocality{
+							PciBusID: "0000:03:00.2",
+						},
+					},
+				},
+			},
+			exp: true,
+		},
+		{
+			name:       "ws: any memory node",
+			memoryNode: -1,
+			exp:        true,
+		},
+		{
+			name:            "ws: device is not requested to be numa aware",
+			memoryNode:      0,
+			taskNumaDevices: set.From([]string{"amd/gpu/t1000"}),
+			instance:        "NET-T2-01",
+			device: &structs.NodeDeviceResource{
+				Type: "net",
+				Name: "nic200",
+				Instances: []*structs.NodeDevice{
+					{
+						ID: "NET-T2-01",
+					},
+				},
+			},
+			exp: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &memoryNodeMatcher{
+				memoryNode: tc.memoryNode,
+				topology:   tc.topology,
+				devices:    tc.taskNumaDevices,
+			}
+			result := m.Matches(tc.instance, tc.device)
+			must.Eq(t, tc.exp, result)
 		})
 	}
 }

--- a/scheduler/numa_ce.go
+++ b/scheduler/numa_ce.go
@@ -16,9 +16,10 @@ import (
 )
 
 type coreSelector struct {
-	topology       *numalib.Topology
-	availableCores *idset.Set[hw.CoreID]
-	shuffle        func([]numalib.Core)
+	topology         *numalib.Topology
+	availableCores   *idset.Set[hw.CoreID]
+	shuffle          func([]numalib.Core)
+	deviceMemoryNode int
 }
 
 // Select returns a set of CoreIDs that satisfy the requested core reservations,
@@ -40,4 +41,11 @@ func randomizeCores(cores []numalib.Core) {
 	rand.Shuffle(len(cores), func(x, y int) {
 		cores[x], cores[y] = cores[y], cores[x]
 	})
+}
+
+// candidateMemoryNodes return -1 on CE, indicating any memory node is acceptable
+//
+// (NUMA aware scheduling is an enterprise feature)
+func (cs *coreSelector) candidateMemoryNodes(ask *structs.Resources) []int {
+	return []int{-1}
 }

--- a/scheduler/preemption.go
+++ b/scheduler/preemption.go
@@ -4,9 +4,11 @@
 package scheduler
 
 import (
+	"maps"
 	"math"
 	"sort"
 
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -23,6 +25,13 @@ type groupedAllocs struct {
 type allocInfo struct {
 	maxParallel int
 	resources   *structs.ComparableResources
+}
+
+func (ai *allocInfo) Copy() *allocInfo {
+	return &allocInfo{
+		maxParallel: ai.maxParallel,
+		resources:   ai.resources.Copy(),
+	}
 }
 
 // PreemptionResource interface is implemented by different
@@ -131,6 +140,23 @@ func NewPreemptor(jobPriority int, ctx Context, jobID *structs.NamespacedID) *Pr
 		jobID:              jobID,
 		allocDetails:       make(map[string]*allocInfo),
 		ctx:                ctx,
+	}
+}
+
+func (p *Preemptor) Copy() *Preemptor {
+	currentPreemptions := make(map[structs.NamespacedID]map[string]int)
+	for k, v := range p.currentPreemptions {
+		currentPreemptions[k] = maps.Clone(v)
+	}
+
+	return &Preemptor{
+		currentPreemptions:     currentPreemptions,
+		allocDetails:           helper.DeepCopyMap(p.allocDetails),
+		jobPriority:            p.jobPriority,
+		jobID:                  p.jobID,
+		nodeRemainingResources: p.nodeRemainingResources.Copy(),
+		currentAllocs:          helper.CopySlice(p.currentAllocs),
+		ctx:                    p.ctx,
 	}
 }
 
@@ -473,12 +499,12 @@ func newAllocDeviceGroup() *deviceGroupAllocs {
 // PreemptForDevice tries to find allocations to preempt to meet devices needed
 // This is called once per device request when assigning devices to the task
 func (p *Preemptor) PreemptForDevice(ask *structs.RequestedDevice, devAlloc *deviceAllocator) []*structs.Allocation {
-
 	// Group allocations by device, tracking the number of
 	// instances used in each device by alloc id
 	deviceToAllocs := make(map[structs.DeviceIdTuple]*deviceGroupAllocs)
 	for _, alloc := range p.currentAllocs {
 		for _, tr := range alloc.AllocatedResources.Tasks {
+
 			// Ignore allocs that don't use devices
 			if len(tr.Devices) == 0 {
 				continue


### PR DESCRIPTION
(CE backport of ENT 59433d56c7215c0b8bf33764f41b57d9bd30160f (without ent files))

original in https://github.com/hashicorp/nomad-enterprise/pull/1760