### PR TITLE
TaggedVersion information in structs, rather than job_endpoint

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -990,6 +990,24 @@ func (j *JobUILink) Copy() *JobUILink {
 	}
 }
 
+type JobTaggedVersion struct {
+	Name        string
+	Description string
+	TaggedTime  int64
+}
+
+func (j *JobTaggedVersion) Copy() *JobTaggedVersion {
+	if j == nil {
+		return nil
+	}
+
+	return &JobTaggedVersion{
+		Name:        j.Name,
+		Description: j.Description,
+		TaggedTime:  j.TaggedTime,
+	}
+}
+
 func (js *JobSubmission) Canonicalize() {
 	if js == nil {
 		return
@@ -1068,6 +1086,7 @@ type Job struct {
 	CreateIndex              *uint64
 	ModifyIndex              *uint64
 	JobModifyIndex           *uint64
+	TaggedVersion            *JobTaggedVersion
 }
 
 // IsPeriodic returns whether a job is periodic.

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1043,6 +1043,7 @@ func ApiJobToStructJob(job *api.Job) *structs.Job {
 		Constraints:    ApiConstraintsToStructs(job.Constraints),
 		Affinities:     ApiAffinitiesToStructs(job.Affinities),
 		UI:             ApiJobUIConfigToStructs(job.UI),
+		TaggedVersion:  ApiJobTaggedVersionToStructs(job.TaggedVersion),
 	}
 
 	// Update has been pushed into the task groups. stagger and max_parallel are
@@ -2142,6 +2143,18 @@ func ApiJobUIConfigToStructs(jobUI *api.JobUIConfig) *structs.JobUIConfig {
 	return &structs.JobUIConfig{
 		Description: jobUI.Description,
 		Links:       links,
+	}
+}
+
+func ApiJobTaggedVersionToStructs(jobTaggedVersion *api.JobTaggedVersion) *structs.JobTaggedVersion {
+	if jobTaggedVersion == nil {
+		return nil
+	}
+
+	return &structs.JobTaggedVersion{
+		Name:        jobTaggedVersion.Name,
+		Description: jobTaggedVersion.Description,
+		TaggedTime:  jobTaggedVersion.TaggedTime,
 	}
 }
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -4448,3 +4448,35 @@ func TestConversion_ApiJobUIConfigToStructs(t *testing.T) {
 		must.Eq(t, expected, result)
 	})
 }
+
+func TestConversion_ApiJobTaggedVersionToStructs(t *testing.T) {
+	t.Run("nil tagged version", func(t *testing.T) {
+		must.Nil(t, ApiJobTaggedVersionToStructs(nil))
+	})
+
+	t.Run("empty tagged version", func(t *testing.T) {
+		taggedVersion := &api.JobTaggedVersion{}
+		expected := &structs.JobTaggedVersion{
+			Name:        "",
+			Description: "",
+			TaggedTime:  0,
+		}
+		result := ApiJobTaggedVersionToStructs(taggedVersion)
+		must.Eq(t, expected, result)
+	})
+
+	t.Run("tagged version with tag and version", func(t *testing.T) {
+		taggedVersion := &api.JobTaggedVersion{
+			Name:        "low-latency",
+			Description: "Low latency version",
+			TaggedTime:  1234567890,
+		}
+		expected := &structs.JobTaggedVersion{
+			Name:        "low-latency",
+			Description: "Low latency version",
+			TaggedTime:  1234567890,
+		}
+		result := ApiJobTaggedVersionToStructs(taggedVersion)
+		must.Eq(t, expected, result)
+	})
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4668,11 +4668,6 @@ func (j *Job) Canonicalize() {
 	if j.Periodic != nil {
 		j.Periodic.Canonicalize()
 	}
-	// TODO: just for testing
-	// if j.TaggedVersion == nil {
-	// 	j.TaggedVersion = &JobTaggedVersion{}
-	// 	j.TaggedVersion.TaggedTime = time.Now().UnixNano()
-	// }
 }
 
 // Copy returns a deep copy of the Job. It is expected that callers use recover.

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -397,6 +397,18 @@ func TestJob_Validate(t *testing.T) {
 				"Task Group web should have an ephemeral disk object",
 			},
 		},
+		{
+			name: "TaggedVersion Description length",
+			job: &Job{
+				Type: JobTypeService,
+				TaggedVersion: &JobTaggedVersion{
+					Description: strings.Repeat("a", 1001),
+				},
+			},
+			expErr: []string{
+				"Tagged version description must be under 1000 characters",
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Establishes a `TaggedVersion` structure that attaches to Jobs (and therefore JobVersions)

Resolves #23836 