### PR TITLE
e2e: fix module name of an artifact we download

### DIFF
--- a/e2e/artifact/artifact_test.go
+++ b/e2e/artifact/artifact_test.go
@@ -41,7 +41,7 @@ func artifactCheckLogContents(t *testing.T, nomad *api.Client, group, task strin
 	t.Run(task, func(t *testing.T) {
 		logs, err := e2eutil.AllocTaskLogs(allocID, task, e2eutil.LogsStdOut)
 		must.NoError(t, err)
-		must.StrContains(t, logs, "module github.com/hashicorp/go-set/v2")
+		must.StrContains(t, logs, "module github.com/hashicorp/go-set/v3")
 	})
 }
 


### PR DESCRIPTION
Because this will definitely never change again, for sure, trust me.
