### PR TITLE
command/debug: capture more logs by default

### DIFF
--- a/.changelog/23850.txt
+++ b/.changelog/23850.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Increase default log level and duration when capturing logs with `operator debug`
+```

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -157,7 +157,7 @@ Debug Options:
 
   -duration=<duration>
     Set the duration of the debug capture. Logs will be captured from specified servers and
-    nodes at "log-level". Defaults to 2m.
+    nodes at "log-level". Defaults to 5m.
 
   -event-index=<index>
     Specifies the index to start streaming events from. If the requested index is
@@ -177,7 +177,7 @@ Debug Options:
     duration to capture a single snapshot. Defaults to 30s.
 
   -log-level=<level>
-    The log level to monitor. Defaults to DEBUG.
+    The log level to monitor. Defaults to TRACE.
 
   -log-include-location
     Include file and line information in each log line monitored. The default
@@ -359,11 +359,11 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	var nodeIDs, serverIDs string
 	var allowStale bool
 
-	flags.StringVar(&duration, "duration", "2m", "")
+	flags.StringVar(&duration, "duration", "5m", "")
 	flags.Int64Var(&eventIndex, "event-index", 0, "")
 	flags.StringVar(&eventTopic, "event-topic", "none", "")
 	flags.StringVar(&interval, "interval", "30s", "")
-	flags.StringVar(&c.logLevel, "log-level", "DEBUG", "")
+	flags.StringVar(&c.logLevel, "log-level", "TRACE", "")
 	flags.BoolVar(&c.logIncludeLocation, "log-include-location", true, "")
 	flags.IntVar(&c.maxNodes, "max-nodes", 10, "")
 	flags.StringVar(&c.nodeClass, "node-class", "", "")

--- a/website/content/docs/commands/operator/debug.mdx
+++ b/website/content/docs/commands/operator/debug.mdx
@@ -47,13 +47,13 @@ true.
 
 ## Debug Options
 
-- `-duration=2m`: Set the duration of the debug capture. Logs will be captured from
-  specified servers and nodes at `log-level`. Defaults to `2m`.
+- `-duration=5m`: Set the duration of the debug capture. Logs will be captured from
+  specified servers and nodes at `log-level`. Defaults to `5m`.
 
 - `-interval=30s`: The interval between snapshots of the Nomad state.
   If unspecified, only one snapshot is captured. Defaults to `30s`.
 
-- `-log-level=DEBUG`: The log level to monitor. Defaults to `DEBUG`.
+- `-log-level=TRACE`: The log level to monitor. Defaults to `TRACE`.
 
 - `-log-include-location`: Include file and line information in each log line
   monitored. The default is `true`.


### PR DESCRIPTION
This PR changes `nomad operator debug`'s default behavior to include more logs. Specifically:

1. Increase the default duration to 5 minutes.
2. Capture the logs at TRACE level by default.

Jira: [NET-10281](https://hashicorp.atlassian.net/browse/NET-10281)

[NET-10281]: https://hashicorp.atlassian.net/browse/NET-10281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ