### PR TITLE
networking: refactor some iptables for testability

### DIFF
--- a/client/allocrunner/networking_iptables.go
+++ b/client/allocrunner/networking_iptables.go
@@ -1,0 +1,102 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build linux
+
+package allocrunner
+
+import (
+	"fmt"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+const (
+	// cniAdminChainName is the name of the admin iptables chain used to allow
+	// forwarding traffic to allocations
+	cniAdminChainName = "NOMAD-ADMIN"
+)
+
+// newIPTables provides an *iptables.IPTables for the requested address family
+// "ipv6" or "ipv4"
+func newIPTables(family structs.NodeNetworkAF) (IPTables, error) {
+	if family == structs.NodeNetworkAF_IPv6 {
+		return iptables.New(iptables.IPFamily(iptables.ProtocolIPv6), iptables.Timeout(5))
+	}
+	return iptables.New()
+}
+func newIPTablesCleanup(family structs.NodeNetworkAF) (IPTablesCleanup, error) {
+	return newIPTables(family)
+}
+func newIPTablesChain(family structs.NodeNetworkAF) (IPTablesChain, error) {
+	return newIPTables(family)
+}
+
+// IPTables is a subset of iptables.IPTables
+type IPTables interface {
+	IPTablesCleanup
+	IPTablesChain
+}
+type IPTablesCleanup interface {
+	List(table, chain string) ([]string, error)
+	Delete(table, chain string, rule ...string) error
+	ClearAndDeleteChain(table, chain string) error
+}
+type IPTablesChain interface {
+	ListChains(table string) ([]string, error)
+	NewChain(table string, chain string) error
+	Exists(table string, chain string, rulespec ...string) (bool, error)
+	Append(table string, chain string, rulespec ...string) error
+}
+
+// ensureChainRule ensures our admin chain exists and contains a rule to accept
+// traffic to the bridge network
+func ensureChainRule(ipt IPTablesChain, bridgeName, subnet string) error {
+	if err := ensureChain(ipt, "filter", cniAdminChainName); err != nil {
+		return err
+	}
+	rule := generateAdminChainRule(bridgeName, subnet)
+	if err := appendChainRule(ipt, cniAdminChainName, rule); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ensureChain ensures that the given chain exists, creating it if missing
+func ensureChain(ipt IPTablesChain, table, chain string) error {
+	chains, err := ipt.ListChains(table)
+	if err != nil {
+		return fmt.Errorf("failed to list iptables chains: %v", err)
+	}
+	for _, ch := range chains {
+		if ch == chain {
+			return nil
+		}
+	}
+
+	err = ipt.NewChain(table, chain)
+
+	// if err is for chain already existing return as it is possible another
+	// goroutine created it first
+	if e, ok := err.(*iptables.Error); ok && e.ExitStatus() == 1 {
+		return nil
+	}
+
+	return err
+}
+
+// appendChainRule adds the given rule to the chain
+func appendChainRule(ipt IPTablesChain, chain string, rule []string) error {
+	exists, err := ipt.Exists("filter", chain, rule...)
+	if !exists && err == nil {
+		err = ipt.Append("filter", chain, rule...)
+	}
+	return err
+}
+
+// generateAdminChainRule builds the iptables rule that is inserted into the
+// CNI admin chain to ensure traffic forwarding to the bridge network
+func generateAdminChainRule(bridgeName, subnet string) []string {
+	return []string{"-o", bridgeName, "-d", subnet, "-j", "ACCEPT"}
+}

--- a/client/allocrunner/networking_iptables_test.go
+++ b/client/allocrunner/networking_iptables_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package allocrunner
+
+import (
+	"errors"
+	"slices"
+	"testing"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+func TestNewIPTables(t *testing.T) {
+	for family, expect := range map[structs.NodeNetworkAF]iptables.Protocol{
+		structs.NodeNetworkAF_IPv6: iptables.ProtocolIPv6,
+		structs.NodeNetworkAF_IPv4: iptables.ProtocolIPv4,
+		"other":                    iptables.ProtocolIPv4,
+	} {
+		t.Run(string(family), func(t *testing.T) {
+			mgr, err := newIPTables(family)
+			must.NoError(t, err)
+			cast := mgr.(*iptables.IPTables)
+			must.Eq(t, expect, cast.Proto(), must.Sprint("unexpected ip family"))
+
+			cleanup, err := newIPTablesCleanup(family)
+			must.NoError(t, err)
+			cast = cleanup.(*iptables.IPTables)
+			must.Eq(t, expect, cast.Proto(), must.Sprint("unexpected ip family"))
+
+			chain, err := newIPTablesChain(family)
+			must.NoError(t, err)
+			cast = chain.(*iptables.IPTables)
+			must.Eq(t, expect, cast.Proto(), must.Sprint("unexpected ip family"))
+		})
+	}
+}
+
+func TestIPTables_ensureChainRule(t *testing.T) {
+	ipt := &mockIPTablesChain{}
+	err := ensureChainRule(ipt, "test-bridge", "1.1.1.1/1")
+	must.NoError(t, err)
+	must.Eq(t, ipt.chain, cniAdminChainName)
+	must.Eq(t, ipt.table, "filter")
+	must.Eq(t, ipt.rules, []string{"-o", "test-bridge", "-d", "1.1.1.1/1", "-j", "ACCEPT"})
+}
+
+type mockIPTablesCleanup struct {
+	listCall  [2]string
+	listRules []string
+	listErr   error
+
+	deleteCall [2]string
+	deleteErr  error
+
+	clearCall [2]string
+	clearErr  error
+}
+
+func (ipt *mockIPTablesCleanup) List(table, chain string) ([]string, error) {
+	ipt.listCall[0], ipt.listCall[1] = table, chain
+	return ipt.listRules, ipt.listErr
+}
+
+func (ipt *mockIPTablesCleanup) Delete(table, chain string, rule ...string) error {
+	ipt.deleteCall[0], ipt.deleteCall[1] = table, chain
+	return ipt.deleteErr
+}
+
+func (ipt *mockIPTablesCleanup) ClearAndDeleteChain(table, chain string) error {
+	ipt.clearCall[0], ipt.clearCall[1] = table, chain
+	return ipt.clearErr
+}
+
+type mockIPTablesChain struct {
+	// we're not keeping a complete database of iptables hierarchy,
+	// just the one table-chain-rules combo we expect to create.
+	table string
+	chain string
+	rules []string
+
+	// we'll error if NewChain or Append are called more than once
+	newChainCalled bool
+	appendCalled   bool
+
+	listChainsErr error
+	newChainErr   error
+	existsErr     error
+	appendErr     error
+}
+
+func (ipt *mockIPTablesChain) ListChains(table string) ([]string, error) {
+	return []string{ipt.chain}, ipt.listChainsErr
+}
+
+func (ipt *mockIPTablesChain) NewChain(table string, chain string) error {
+	if ipt.newChainCalled {
+		return errors.New("ipt.NewChain should only be called once")
+	}
+	ipt.newChainCalled = true
+	if ipt.newChainErr != nil {
+		return ipt.newChainErr
+	}
+	ipt.table = table
+	ipt.chain = chain
+	return nil
+}
+
+func (ipt *mockIPTablesChain) Exists(table string, chain string, rulespec ...string) (bool, error) {
+	return ipt.table == table &&
+		ipt.chain == chain &&
+		slices.Equal(rulespec, ipt.rules), ipt.existsErr
+}
+
+func (ipt *mockIPTablesChain) Append(table string, chain string, rulespec ...string) error {
+	if ipt.appendCalled {
+		return errors.New("ipt.Append should only be called once")
+	}
+	ipt.appendCalled = true
+	if ipt.table != table || ipt.chain != chain {
+		return errors.New("should only be Append-ing to the one chain")
+	}
+	ipt.rules = rulespec
+	return ipt.appendErr
+}


### PR DESCRIPTION
When adding support for ipv6 to the Nomad bridge network, I found that iptables admin chain logic was untested, so this refactor is in pursuit of that.  I also creeped a little bit to move the iptables cleanup mock to live next to the chain mock, so this iptables stuff is more centralized in one spot.

The coming-soon bridge+ipv6 PR will do more actual testing -- this is a separate no-op PR to allow easier backporting for potential future bugfixes and such.