### PR TITLE
node endpoints: do not create evals for sysbatch jobs

### DIFF
--- a/.changelog/23858.txt
+++ b/.changelog/23858.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+node: Fixed bug where sysbatch allocations were started prematurely
+```

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1695,6 +1695,12 @@ func (n *Node) createNodeEvals(node *structs.Node, nodeIndex uint64) ([]string, 
 		}
 		jobIDs[alloc.JobNamespacedID()] = struct{}{}
 
+		// If it's a sysbatch job, skip it. Sysbatch job evals should only
+		// ever be created by structs.EvalTriggerPeriodicJob
+		if alloc.Job.Type == structs.JobTypeSysBatch {
+			continue
+		}
+
 		// Create a new eval
 		eval := &structs.Evaluation{
 			ID:              uuid.Generate(),

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1695,8 +1695,11 @@ func (n *Node) createNodeEvals(node *structs.Node, nodeIndex uint64) ([]string, 
 		}
 		jobIDs[alloc.JobNamespacedID()] = struct{}{}
 
-		// If it's a sysbatch job, skip it. Sysbatch job evals should only
-		// ever be created by structs.EvalTriggerPeriodicJob
+		// If it's a sysbatch job, skip it. Sysbatch job evals should only ever
+		// be created by periodic-job if they are periodic, and job-register or
+		// job-scaling if they are not. Calling the system scheduler by
+		// node-update trigger can cause unnecessary or premature allocations
+		// to be created.
 		if alloc.Job.Type == structs.JobTypeSysBatch {
 			continue
 		}


### PR DESCRIPTION
`node-update` triggers should never trigger sysbatch allocations, these should only ever be create by `periodic-job` or `job-register`.

An example scenario is: an allocation spawned by a sysbatch periodic job is running on a node, the allocation gets stopped, GC runs, the node becomes ineligible and eligible again, all within the parent sysbatch job period window. If this happens, `node-update` will trigger the system scheduler and prematurely start an allocation. This is not a desired behavior, and in fact a bug. 

Ref: https://hashicorp.atlassian.net/browse/NET-9323