### PR TITLE
quota: parse device block

### DIFF
--- a/api/util_test.go
+++ b/api/util_test.go
@@ -120,7 +120,7 @@ func testQuotaSpec() *QuotaSpec {
 					CPU:      pointerOf(2000),
 					MemoryMB: pointerOf(2000),
 					Devices: []*RequestedDevice{{
-						Name:  "gpu/nvidia/1080ti",
+						Name:  "nvidia/gpu/1080ti",
 						Count: pointerOf(uint64(2)),
 					}},
 				},

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -119,6 +119,10 @@ func testQuotaSpec() *QuotaSpec {
 				RegionLimit: &Resources{
 					CPU:      pointerOf(2000),
 					MemoryMB: pointerOf(2000),
+					Devices: []*RequestedDevice{{
+						Name:  "gpu/nvidia/1080ti",
+						Count: pointerOf(uint64(2)),
+					}},
 				},
 			},
 		},

--- a/command/quota_apply.go
+++ b/command/quota_apply.go
@@ -270,6 +270,7 @@ func parseQuotaResource(result *api.Resources, list *ast.ObjectList) error {
 		"cpu",
 		"memory",
 		"memory_max",
+		"device",
 	}
 	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 		return multierror.Prefix(err, "resources ->")
@@ -280,9 +281,46 @@ func parseQuotaResource(result *api.Resources, list *ast.ObjectList) error {
 		return err
 	}
 
+	// Manually parse
+	delete(m, "device")
+
 	if err := mapstructure.WeakDecode(m, result); err != nil {
 		return err
 	}
 
+	// Parse devices
+	if o := listVal.Filter("device"); len(o.Items) > 0 {
+		result.Devices = make([]*api.RequestedDevice, 0)
+		if err := parseDeviceResource(&result.Devices, o); err != nil {
+			return multierror.Prefix(err, "devices ->")
+		}
+	}
+
+	return nil
+}
+
+func parseDeviceResource(result *[]*api.RequestedDevice, list *ast.ObjectList) error {
+	for _, o := range list.Elem().Items {
+		// Check for invalid keys
+		valid := []string{
+			"name",
+			"count",
+		}
+		if err := helper.CheckHCLKeys(o.Val, valid); err != nil {
+			return err
+		}
+
+		var m map[string]interface{}
+		if err := hcl.DecodeObject(&m, o.Val); err != nil {
+			return err
+		}
+
+		var device api.RequestedDevice
+		if err := mapstructure.WeakDecode(m, &device); err != nil {
+			return err
+		}
+
+		*result = append(*result, &device)
+	}
 	return nil
 }

--- a/command/quota_apply.go
+++ b/command/quota_apply.go
@@ -270,7 +270,7 @@ func parseQuotaResource(result *api.Resources, list *ast.ObjectList) error {
 		"cpu",
 		"memory",
 		"memory_max",
-		"device",
+		"devices",
 	}
 	if err := helper.CheckHCLKeys(listVal, valid); err != nil {
 		return multierror.Prefix(err, "resources ->")
@@ -282,7 +282,7 @@ func parseQuotaResource(result *api.Resources, list *ast.ObjectList) error {
 	}
 
 	// Manually parse
-	delete(m, "device")
+	delete(m, "devices")
 
 	if err := mapstructure.WeakDecode(m, result); err != nil {
 		return err


### PR DESCRIPTION
related to: https://github.com/hashicorp/nomad/issues/9917
internal ref: https://hashicorp.atlassian.net/browse/NET-9858

~note to reviewers: This CE PR doesn't require an ENT counterpart, because for parsing quota spec ce and ent share the code. Follow-up PRs with updated `quota init` command and the actual logic of enforcing quotas will follow.~

Sorry for going back and forth on this,  I'm still confused about the ce/ent split in quotas. Of course we need an ent PR to handle ent structs: https://github.com/hashicorp/nomad-enterprise/pull/1787