### PR TITLE
Remove wrong `VariableFlags` parameter from parse job endpoint

### DIFF
--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -243,9 +243,6 @@ The table below shows this endpoint's support for
 - `Variables` `(string: "")` - Specifies HCL2 variables to use during parsing of
   the job in the var file format.
 
-- `VariableFlags` `(map[string]string: nil)` - Specifies HCL2 variables to use
-  during parsing of the job in key = value format.
-
 - `HCLv1` `(bool: false)` - Use the legacy v1 HCL parser.
 
 ### Sample Payload


### PR DESCRIPTION
Currently the documentation for the parse job endpoint mentions the parameter `VariableFlags` which is not actually supported by the code, this PR removes it from the website.