### PR TITLE
services: reject node secret for Read/List RPC

### DIFF
--- a/.changelog/23910.txt
+++ b/.changelog/23910.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+services: Clients older than 1.5.0 will fail to read Nomad native services via template blocks
+```

--- a/acl/acl.go
+++ b/acl/acl.go
@@ -906,10 +906,6 @@ func (a *ACL) AllowServiceRegistrationReadList(ns string, isWorkload bool) bool 
 	switch {
 	case a == nil:
 		return false
-	case a.client == PolicyRead,
-		a.client == PolicyWrite:
-		// COMPAT: older clients won't send WI tokens for these requests
-		return true
 	case a.aclsDisabled, a.management:
 		return true
 	}

--- a/nomad/service_registration_endpoint_test.go
+++ b/nomad/service_registration_endpoint_test.go
@@ -848,17 +848,7 @@ func TestServiceRegistration_List(t *testing.T) {
 				var serviceRegResp structs.ServiceRegistrationListResponse
 				err = msgpackrpc.CallWithCodec(
 					codec, structs.ServiceRegistrationListRPCMethod, serviceRegReq, &serviceRegResp)
-				require.NoError(t, err)
-				require.ElementsMatch(t, []*structs.ServiceRegistrationListStub{
-					{
-						Namespace: "platform",
-						Services: []*structs.ServiceRegistrationStub{
-							{
-								ServiceName: "countdash-api",
-								Tags:        []string{"bar"},
-							},
-						}},
-				}, serviceRegResp.Services)
+				must.EqError(t, err, structs.ErrPermissionDenied.Error())
 			},
 			name: "ACLs enabled with node secret token",
 		},
@@ -1139,17 +1129,7 @@ func TestServiceRegistration_GetService(t *testing.T) {
 				var serviceRegResp structs.ServiceRegistrationListResponse
 				err = msgpackrpc.CallWithCodec(
 					codec, structs.ServiceRegistrationListRPCMethod, serviceRegReq, &serviceRegResp)
-				require.NoError(t, err)
-				require.ElementsMatch(t, []*structs.ServiceRegistrationListStub{
-					{
-						Namespace: "platform",
-						Services: []*structs.ServiceRegistrationStub{
-							{
-								ServiceName: "countdash-api",
-								Tags:        []string{"bar"},
-							},
-						}},
-				}, serviceRegResp.Services)
+				must.EqError(t, err, "Permission denied")
 			},
 			name: "ACLs enabled using node secret",
 		},


### PR DESCRIPTION
As of Nomad 1.5.0, Nomad clients never make RPC requests to the ServiceRegistrationList/Read RPC without using a specific Workload Identity rather than the node secret. Nomad servers already have an anti-entropy behavior where terminal allocations / lost nodes get their services cleaned up, so there's no future reason for clients to have this access. Tighten the ACL permissions on these RPCs so that node secrets are no longer valid tokens.

Ref: https://hashicorp.atlassian.net/browse/NET-10009
Ref: https://developer.hashicorp.com/nomad/docs/release-notes/nomad/upcoming#nomad-1-9-0