### PR TITLE
docker: update infra_image to new registry

### DIFF
--- a/.changelog/23927.txt
+++ b/.changelog/23927.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+docker: The default infra_image for pause containers is now registry.k8s.io/pause
+```

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -275,7 +275,7 @@ var (
 		"infra_image": hclspec.NewDefault(
 			hclspec.NewAttr("infra_image", "string", false),
 			hclspec.NewLiteral(fmt.Sprintf(
-				`"gcr.io/google_containers/pause-%s:3.1"`,
+				`"registry.k8s.io/pause-%s:3.3"`,
 				runtime.GOARCH,
 			)),
 		),

--- a/drivers/docker/driver_unix_test.go
+++ b/drivers/docker/driver_unix_test.go
@@ -712,7 +712,7 @@ func TestDockerDriver_Start_Image_HTTPS(t *testing.T) {
 	testutil.DockerCompatible(t)
 
 	taskCfg := TaskConfig{
-		Image:            "https://gcr.io/google_containers/pause:3.2",
+		Image:            "https://registry.k8s.io/pause:3.3",
 		ImagePullTimeout: "5m",
 	}
 	task := &drivers.TaskConfig{

--- a/drivers/docker/network_test.go
+++ b/drivers/docker/network_test.go
@@ -28,7 +28,7 @@ func TestDriver_createSandboxContainerConfig(t *testing.T) {
 			expectedOutputOpts: &docker.CreateContainerOptions{
 				Name: "nomad_init_768b5e8c-a52e-825c-d564-51100230eb62",
 				Config: &docker.Config{
-					Image: "gcr.io/google_containers/pause-amd64:3.1",
+					Image: "registry.k8s.io/pause-amd64:3.3",
 					Labels: map[string]string{
 						dockerLabelAllocID: "768b5e8c-a52e-825c-d564-51100230eb62",
 					},
@@ -48,7 +48,7 @@ func TestDriver_createSandboxContainerConfig(t *testing.T) {
 			expectedOutputOpts: &docker.CreateContainerOptions{
 				Name: "nomad_init_768b5e8c-a52e-825c-d564-51100230eb62",
 				Config: &docker.Config{
-					Image:    "gcr.io/google_containers/pause-amd64:3.1",
+					Image:    "registry.k8s.io/pause-amd64:3.3",
 					Hostname: "linux",
 					Labels: map[string]string{
 						dockerLabelAllocID: "768b5e8c-a52e-825c-d564-51100230eb62",
@@ -65,7 +65,7 @@ func TestDriver_createSandboxContainerConfig(t *testing.T) {
 
 	d := &Driver{
 		config: &DriverConfig{
-			InfraImage: "gcr.io/google_containers/pause-amd64:3.1",
+			InfraImage: "registry.k8s.io/pause-amd64:3.3",
 		},
 	}
 

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -1014,8 +1014,9 @@ host system.
 
 - `infra_image` - This is the Docker image to use when creating the parent
   container necessary when sharing network namespaces between tasks. Defaults to
-  `gcr.io/google_containers/pause-<goarch>:3.1`. The image will only be pulled from
-  the container registry if its tag is `latest` or the image doesn't yet exist locally.
+  `registry.k8s.io/pause-<goarch>:3.3`. The image will only be pulled from the
+  container registry if its tag is `latest` or the image doesn't yet exist
+  locally.
 
 - `infra_image_pull_timeout` - A time duration that controls how long Nomad will
   wait before cancelling an in-progress pull of the Docker image as specified in

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -21,6 +21,13 @@ Nomad 1.9.0 no longer supports the HCLv1 format for job specifications. Using
 the `-hcl1` option for the `job run`, `job plan`, and `job validate` commands
 will no longer work.
 
+#### Default `infra_image` changed
+
+Due to the deprecation of the third-party `gcr.io` registry, the default Docker
+[`infra_image`][] is now `registry.k8s.io/pause-<arch>:3.3`. If you do not
+override the default, clients using the `docker` driver will make outbound
+requests to the new registry.
+
 #### Dropped support for older clients
 
 Nomad 1.9.0 removes support for Nomad client agents older than 1.6.0. Older
@@ -2180,3 +2187,4 @@ deleted and then Nomad 0.3.0 can be launched.
 [Workload Identity]: /nomad/docs/concepts/workload-identity
 [Process Isolation]: https://learn.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/hyperv-container#process-isolation
 [reschedule]: /nomad/docs/jobs-specification/reschedule
+[`infra_image`]: /nomad/docs/drivers/docker#infra_image

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -21,7 +21,7 @@ Nomad 1.9.0 no longer supports the HCLv1 format for job specifications. Using
 the `-hcl1` option for the `job run`, `job plan`, and `job validate` commands
 will no longer work.
 
-#### Default `infra_image` changed
+#### Default Docker `infra_image` changed
 
 Due to the deprecation of the third-party `gcr.io` registry, the default Docker
 [`infra_image`][] is now `registry.k8s.io/pause-<arch>:3.3`. If you do not


### PR DESCRIPTION
The gcr.io container registry is shutting down in March. Update the default `infra_image` for Docker's "pause" containers to point to the new location hosted by the k8s project.

Fixes: https://github.com/hashicorp/nomad/issues/23911
Ref: https://hashicorp.atlassian.net/browse/NET-10942

---

Question/note for reviewers: I said in #23911 that this is a breaking change so it should go in 1.9.0, but in March when the registry move happens our 1.8 LTS will still be in its support window (as will 1.7 until ~May or so, assuming that's when 1.10 goes out). Anyone on these older versions will have new allocations fail unless they update their pause container. Maybe we should pre-announce backporting this to 1.8 and 1.7 and then do so after 1.9 goes GA to give folks some time to deal with it if they have restrictive firewall environments?