### PR TITLE
E2E: remove invalid HCLv1 field on submissions test

### DIFF
--- a/e2e/jobsubmissions/jobsubapi_test.go
+++ b/e2e/jobsubmissions/jobsubapi_test.go
@@ -43,7 +43,6 @@ func testParseAPI(t *testing.T) {
 
 	job, err := nomad.Jobs().ParseHCLOpts(&api.JobsParseRequest{
 		JobHCL:       string(spec),
-		HCLv1:        false,
 		Variables:    "X=\"baz\" \n Y=50 \n Z=true \n",
 		Canonicalize: true,
 	})

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -243,8 +243,6 @@ The table below shows this endpoint's support for
 - `Variables` `(string: "")` - Specifies HCL2 variables to use during parsing of
   the job in the var file format.
 
-- `HCLv1` `(bool: false)` - Use the legacy v1 HCL parser.
-
 ### Sample Payload
 
 ```json


### PR DESCRIPTION
HCLv1 support was removed entirely in #23912, but I missed this one test and documentation reference.