### PR TITLE
Stop referring non existent vault.file attribute

### DIFF
--- a/website/content/docs/job-specification/vault.mdx
+++ b/website/content/docs/job-specification/vault.mdx
@@ -46,7 +46,7 @@ to the secret directory at `secrets/vault_token` and by injecting a `VAULT_TOKEN
 environment variable. If the Nomad cluster is [configured](/nomad/docs/configuration/vault#namespace)
 to use [Vault Namespaces](/vault/docs/enterprise/namespaces),
 a `VAULT_NAMESPACE` environment variable will be injected whenever `VAULT_TOKEN` is set.
-This behavior can be altered using the `env` and `file` parameters.
+This behavior can be altered using the `env` and `disable_file` parameters.
 
 If Nomad is unable to renew the Vault token (perhaps due to a Vault outage or
 network error), the client will attempt to retrieve a new Vault token. If successful, the
@@ -162,10 +162,10 @@ the task itself:
 
 ```hcl
 vault {
-  role        = "prod"
-  change_mode = "noop"
-  env         = false
-  file        = false
+  role         = "prod"
+  change_mode  = "noop"
+  env          = false
+  disable_file = true
 }
 
 template {


### PR DESCRIPTION
The documentation is referring to a `file` attribute that does not exist on the `vault` block.

This PR changes those references to mention the `disable_file` attribute instead.