### PR TITLE
networking: set alloc NetworkStatus.AddressIPv6

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -435,6 +435,7 @@ type AllocDeploymentStatus struct {
 type AllocNetworkStatus struct {
 	InterfaceName string
 	Address       string
+	AddressIPv6   string
 	DNS           *DNSConfig
 }
 

--- a/client/allocrunner/networking_cni.go
+++ b/client/allocrunner/networking_cni.go
@@ -393,36 +393,51 @@ func (c *cniNetworkConfigurator) cniToAllocNet(res *cni.Result) (*structs.AllocN
 	}
 	sort.Strings(names)
 
-	// Use the first sandbox interface with an IP address
-	for _, name := range names {
-		iface := res.Interfaces[name]
-		if iface == nil {
+	// setStatus sets netStatus.Address and netStatus.InterfaceName
+	// if it finds a suitable interface that has IP address(es)
+	// (at least IPv4, possibly also IPv6)
+	setStatus := func(requireSandbox bool) {
+		for _, name := range names {
+			iface := res.Interfaces[name]
 			// this should never happen but this value is coming from external
 			// plugins so we should guard against it
-			delete(res.Interfaces, name)
-			continue
-		}
+			if iface == nil {
+				continue
+			}
 
-		if iface.Sandbox != "" && len(iface.IPConfigs) > 0 {
-			netStatus.Address = iface.IPConfigs[0].IP.String()
-			netStatus.InterfaceName = name
-			break
+			if requireSandbox && iface.Sandbox == "" {
+				continue
+			}
+
+			for _, ipConfig := range iface.IPConfigs {
+				isIP4 := ipConfig.IP.To4() != nil
+				if netStatus.Address == "" && isIP4 {
+					netStatus.Address = ipConfig.IP.String()
+				}
+				if netStatus.AddressIPv6 == "" && !isIP4 {
+					netStatus.AddressIPv6 = ipConfig.IP.String()
+				}
+			}
+
+			// found a good interface, so we're done
+			if netStatus.Address != "" {
+				netStatus.InterfaceName = name
+				return
+			}
 		}
 	}
+
+	// Use the first sandbox interface with an IP address
+	setStatus(true)
 
 	// If no IP address was found, use the first interface with an address
 	// found as a fallback
 	if netStatus.Address == "" {
-		for _, name := range names {
-			iface := res.Interfaces[name]
-			if len(iface.IPConfigs) > 0 {
-				ip := iface.IPConfigs[0].IP.String()
-				c.logger.Debug("no sandbox interface with an address found CNI result, using first available", "interface", name, "ip", ip)
-				netStatus.Address = ip
-				netStatus.InterfaceName = name
-				break
-			}
-		}
+		setStatus(false)
+		c.logger.Debug("no sandbox interface with an address found CNI result, using first available",
+			"interface", netStatus.InterfaceName,
+			"ip", netStatus.Address,
+		)
 	}
 
 	// If no IP address could be found, return an error

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -12101,6 +12101,7 @@ func (s *NodeScoreMeta) Data() interface{} {
 type AllocNetworkStatus struct {
 	InterfaceName string
 	Address       string
+	AddressIPv6   string
 	DNS           *DNSConfig
 }
 
@@ -12111,6 +12112,7 @@ func (a *AllocNetworkStatus) Copy() *AllocNetworkStatus {
 	return &AllocNetworkStatus{
 		InterfaceName: a.InterfaceName,
 		Address:       a.Address,
+		AddressIPv6:   a.AddressIPv6,
 		DNS:           a.DNS.Copy(),
 	}
 }
@@ -12130,6 +12132,8 @@ func (a *AllocNetworkStatus) Equal(o *AllocNetworkStatus) bool {
 	case a.InterfaceName != o.InterfaceName:
 		return false
 	case a.Address != o.Address:
+		return false
+	case a.AddressIPv6 != o.AddressIPv6:
 		return false
 	case !a.DNS.Equal(o.DNS):
 		return false


### PR DESCRIPTION
#23882 added an IPv6 option for the Nomad `bridge` network mode, but an IPv6 addr created by it was not stored anywhere (aside from ip6tables on the node).

This puts it alongside the IPv4 address in an alloc's NetworkStatus, so it can be found with an API call if needed.

e.g.:

```
$ nomad alloc status -json 3dca | jq '.NetworkStatus'
{
  "Address": "172.26.64.14",
  "AddressIPv6": "fd00:a110:c8::b",
  "DNS": null,
  "InterfaceName": "eth0"
}
```