### PR TITLE
deps: update to go-set/v3 and refactor to use custom iterators

### DIFF
--- a/client/acl.go
+++ b/client/acl.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/nomad/structs"
 )

--- a/client/allocdir/task_dir.go
+++ b/client/allocdir/task_dir.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/helper/users/dynamic"
 	"github.com/hashicorp/nomad/plugins/drivers/fsisolation"
 )

--- a/client/allocrunner/consul_grpc_sock_hook.go
+++ b/client/allocrunner/consul_grpc_sock_hook.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -72,8 +72,7 @@ func newConsulGRPCSocketHook(
 	}
 	proxies := map[string]*grpcSocketProxy{}
 
-	clusterNames.ForEach(func(clusterName string) bool {
-
+	for clusterName := range clusterNames.Items() {
 		// Attempt to find the gRPC port via the node attributes, otherwise use
 		// the default fallback.
 		attrName := "consul.grpc"
@@ -91,8 +90,7 @@ func newConsulGRPCSocketHook(
 			configs[clusterName],
 			consulGRPCPort,
 		)
-		return true
-	})
+	}
 
 	return &consulGRPCSocketHook{
 		alloc:   alloc,

--- a/client/allocrunner/consul_http_sock_hook.go
+++ b/client/allocrunner/consul_http_sock_hook.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -59,14 +59,13 @@ func newConsulHTTPSocketHook(
 	}
 	proxies := map[string]*httpSocketProxy{}
 
-	clusterNames.ForEach(func(clusterName string) bool {
+	for clusterName := range clusterNames.Items() {
 		proxies[clusterName] = newHTTPSocketProxy(
 			logger,
 			allocDir,
 			configs[clusterName],
 		)
-		return true
-	})
+	}
 
 	return &consulHTTPSockHook{
 		alloc:   alloc,

--- a/client/allocrunner/networking_cni.go
+++ b/client/allocrunner/networking_cni.go
@@ -27,7 +27,7 @@ import (
 	cnilibrary "github.com/containernetworking/cni/libcni"
 	consulIPTables "github.com/hashicorp/consul/sdk/iptables"
 	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/envoy"
 	"github.com/hashicorp/nomad/nomad/structs"

--- a/client/lib/cgroupslib/editor.go
+++ b/client/lib/cgroupslib/editor.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"golang.org/x/sys/unix"
 )
 
@@ -176,10 +176,9 @@ func (l *lifeCG1) Kill() error {
 	}
 
 	signal := unix.SignalNum("SIGKILL")
-	pids.ForEach(func(pid int) bool {
+	for pid := range pids.Items() {
 		_ = unix.Kill(pid, signal)
-		return true
-	})
+	}
 
 	return l.thaw()
 }

--- a/client/lib/cgroupslib/mount.go
+++ b/client/lib/cgroupslib/mount.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 )
 
 // detect tries to detect which cgroups version we have by looking at the mount

--- a/client/lib/idset/idset.go
+++ b/client/lib/idset/idset.go
@@ -184,7 +184,7 @@ func (s *Set[T]) String() string {
 // ForEach iterates the elements in the set and applies f. Iteration stops
 // if the result of f is a non-nil error.
 func (s *Set[T]) ForEach(f func(id T) error) error {
-	for _, id := range s.items.Slice() {
+	for id := range s.items.Items() {
 		if err := f(id); err != nil {
 			return err
 		}

--- a/client/lib/idset/idset.go
+++ b/client/lib/idset/idset.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 )
 
 // An ID is representative of a non-negative identifier of something like

--- a/client/serviceregistration/watcher.go
+++ b/client/serviceregistration/watcher.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )

--- a/command/acl_token_create.go
+++ b/command/acl_token_create.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/posener/complete"

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -22,7 +22,7 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/serviceregistration"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/envoy"

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1824,8 +1824,7 @@ func (c *ServiceClient) Shutdown() error {
 
 	// Always attempt to deregister Nomad agent Consul entries, even if
 	// deadline was reached
-	for _, id := range c.agentServices.Slice() {
-
+	for id := range c.agentServices.Items() {
 		opts := &api.QueryOptions{
 			Token: c.getServiceToken(id),
 		}
@@ -1860,7 +1859,7 @@ func (c *ServiceClient) Shutdown() error {
 		return false
 	}
 
-	for _, id := range c.agentChecks.Slice() {
+	for id := range c.agentChecks.Items() {
 		// if we couldn't populate remainingChecks it is unlikely that CheckDeregister will work, but try anyway
 		// if we could list the remaining checks, verify that the check we store still exists before removing it.
 		if remainingChecks == nil || checkRemains(id) {
@@ -1932,7 +1931,7 @@ func (c *ServiceClient) setServiceTokens(tokens map[string]string) {
 func (c *ServiceClient) gcDeregisteredServiceTokens() {
 	c.serviceTokensLock.Lock()
 	defer c.serviceTokensLock.Unlock()
-	for _, serviceID := range c.explicitlyDeregisteredServices.Slice() {
+	for serviceID := range c.explicitlyDeregisteredServices.Items() {
 		delete(c.serviceTokens, serviceID)
 	}
 }

--- a/command/job_restart.go
+++ b/command/job_restart.go
@@ -18,7 +18,7 @@ import (
 	humanize "github.com/dustin/go-humanize"
 	"github.com/dustin/go-humanize/english"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"

--- a/command/job_restart.go
+++ b/command/job_restart.go
@@ -674,7 +674,7 @@ func (c *JobRestartCommand) filterAllocs(stubs []AllocationListStubWithJob) []Al
 		// Skip allocations that don't have any of the requested tasks.
 		if c.tasks.Size() > 0 {
 			hasTask := false
-			for _, taskName := range c.tasks.Slice() {
+			for taskName := range c.tasks.Items() {
 				if stub.HasTask(taskName) {
 					hasTask = true
 					break
@@ -910,7 +910,7 @@ func (c *JobRestartCommand) restartAlloc(alloc AllocationListStubWithJob) error 
 
 	// Run restarts concurrently when specific tasks were requested.
 	var restarts multierror.Group
-	for _, task := range c.tasks.Slice() {
+	for task := range c.tasks.Items() {
 		if !alloc.HasTask(task) {
 			continue
 		}

--- a/command/job_restart_test.go
+++ b/command/job_restart_test.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"

--- a/command/node_pool.go
+++ b/command/node_pool.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/mitchellh/cli"

--- a/command/node_pool_delete.go
+++ b/command/node_pool_delete.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/api"
 	"github.com/posener/complete"
 )

--- a/command/node_pool_test.go
+++ b/command/node_pool_test.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/mitchellh/cli"

--- a/command/var_put.go
+++ b/command/var_put.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/hcl/hcl/ast"
 	"github.com/hashicorp/nomad/api"
@@ -588,11 +588,11 @@ func formatInvalidVarKeyChars(invalid []string) string {
 
 	// Sort the characters for output
 	charList := make([]string, 0, chars.Size())
-	chars.ForEach(func(k string) bool {
+
+	for k := range chars.Items() {
 		// Use %s instead of %q to avoid escaping characters.
 		charList = append(charList, fmt.Sprintf(`"%s"`, k))
-		return true
-	})
+	}
 
 	slices.Sort(charList)
 

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -23,7 +23,7 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
 	plugin "github.com/hashicorp/go-plugin"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/cpustats"
 	"github.com/hashicorp/nomad/client/taskenv"

--- a/drivers/docker/reconcile_dangling.go
+++ b/drivers/docker/reconcile_dangling.go
@@ -12,7 +12,7 @@ import (
 
 	docker "github.com/fsouza/go-dockerclient"
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 )
 
 // containerReconciler detects and kills unexpectedly running containers.

--- a/drivers/docker/reconcile_dangling.go
+++ b/drivers/docker/reconcile_dangling.go
@@ -114,7 +114,7 @@ func (r *containerReconciler) removeDanglingContainersIteration() error {
 		return err
 	}
 
-	for _, id := range untracked.Slice() {
+	for id := range untracked.Items() {
 		ctx, cancel := r.dockerAPIQueryContext()
 		err := dockerClient.RemoveContainer(docker.RemoveContainerOptions{
 			Context: ctx,

--- a/drivers/docker/reconcile_dangling_test.go
+++ b/drivers/docker/reconcile_dangling_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
 

--- a/drivers/docker/state.go
+++ b/drivers/docker/state.go
@@ -6,7 +6,7 @@ package docker
 import (
 	"sync"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 )
 
 type taskStore struct {

--- a/drivers/shared/executor/executor_basic.go
+++ b/drivers/shared/executor/executor_basic.go
@@ -9,7 +9,7 @@ import (
 	"os/exec"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/lib/cpustats"
 	"github.com/hashicorp/nomad/drivers/shared/executor/procstats"
 	"github.com/hashicorp/nomad/plugins/drivers"

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -23,7 +23,7 @@ import (
 	"github.com/armon/circbuf"
 	"github.com/hashicorp/consul-template/signals"
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/cpustats"

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/nsutil"
 	"github.com/hashicorp/nomad/drivers/shared/executor/procstats"

--- a/drivers/shared/executor/procstats/getstats.go
+++ b/drivers/shared/executor/procstats/getstats.go
@@ -63,7 +63,7 @@ func (lps *linuxProcStats) scanPIDs() {
 	}
 
 	// insert trackers for new pids not yet present
-	for _, pid := range currentPIDs.Slice() {
+	for pid := range currentPIDs.Items() {
 		if _, exists := lps.latest[pid]; !exists {
 			lps.latest[pid] = &stats{
 				TotalCPU:  cpustats.New(lps.compute),

--- a/drivers/shared/executor/procstats/list_default.go
+++ b/drivers/shared/executor/procstats/list_default.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/lib/lang"
 	"github.com/shirou/gopsutil/v3/process"
 )

--- a/drivers/shared/executor/procstats/list_linux.go
+++ b/drivers/shared/executor/procstats/list_linux.go
@@ -6,7 +6,7 @@
 package procstats
 
 import (
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 )
 

--- a/drivers/shared/executor/procstats/list_windows.go
+++ b/drivers/shared/executor/procstats/list_windows.go
@@ -6,7 +6,7 @@
 package procstats
 
 import (
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/mitchellh/go-ps"
 )
 

--- a/drivers/shared/executor/procstats/procstats.go
+++ b/drivers/shared/executor/procstats/procstats.go
@@ -6,7 +6,7 @@ package procstats
 import (
 	"time"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/lib/cpustats"
 	"github.com/hashicorp/nomad/plugins/drivers"
 )

--- a/e2e/acl/helpers.go
+++ b/e2e/acl/helpers.go
@@ -48,22 +48,22 @@ func NewCleanup() *Cleanup {
 // Any failure will ultimately fail the test, but will not stop the attempts to
 // delete all the resources.
 func (c *Cleanup) Run(t *testing.T, nomadClient *api.Client) {
-	for _, namespace := range c.namespaces.Slice() {
+	for namespace := range c.namespaces.Items() {
 		_, err := nomadClient.Namespaces().Delete(namespace, nil)
 		test.NoError(t, err)
 	}
 
-	for _, policy := range c.aclPolicies.Slice() {
+	for policy := range c.aclPolicies.Items() {
 		_, err := nomadClient.ACLPolicies().Delete(policy, nil)
 		test.NoError(t, err)
 	}
 
-	for _, role := range c.aclRoles.Slice() {
+	for role := range c.aclRoles.Items() {
 		_, err := nomadClient.ACLRoles().Delete(role, nil)
 		test.NoError(t, err)
 	}
 
-	for _, token := range c.aclTokens.Slice() {
+	for token := range c.aclTokens.Items() {
 		_, err := nomadClient.ACLTokens().Delete(token, nil)
 		test.NoError(t, err)
 	}

--- a/e2e/acl/helpers.go
+++ b/e2e/acl/helpers.go
@@ -6,7 +6,7 @@ package acl
 import (
 	"testing"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/api"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"

--- a/e2e/consulcompat/consulcompat_test.go
+++ b/e2e/consulcompat/consulcompat_test.go
@@ -32,12 +32,11 @@ func TestConsulCompat(t *testing.T) {
 		}
 
 		versions := scanConsulVersions(t, getMinimumVersion(t))
-		versions.ForEach(func(b build) bool {
+		for b := range versions.Items() {
 			downloadConsulBuild(t, b, baseDir)
 
 			testConsulBuildLegacy(t, b, baseDir)
 			testConsulBuild(t, b, baseDir)
-			return true
-		})
+		}
 	})
 }

--- a/e2e/consulcompat/shared_download_test.go
+++ b/e2e/consulcompat/shared_download_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/go-version"
 	"github.com/shoenig/test/must"
 )

--- a/e2e/nodedrain/node_drain_test.go
+++ b/e2e/nodedrain/node_drain_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"

--- a/e2e/v3/jobs3/jobs3.go
+++ b/e2e/v3/jobs3/jobs3.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/e2e/v3/util3"
 	"github.com/hashicorp/nomad/helper/pointer"

--- a/e2e/v3/namespaces3/namespaces3.go
+++ b/e2e/v3/namespaces3/namespaces3.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	nomadapi "github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/e2e/v3/util3"
 	"github.com/hashicorp/nomad/helper"

--- a/e2e/v3/namespaces3/namespaces3.go
+++ b/e2e/v3/namespaces3/namespaces3.go
@@ -40,7 +40,7 @@ func (g *Names) cleanup() {
 	namespaceAPI := g.nomadClient.Namespaces()
 
 	// remove any namespaces we created (or updated)
-	for _, namespace := range g.apply.Slice() {
+	for namespace := range g.apply.Items() {
 		name := namespace.Name
 		g.logf("cleanup namespace %q", name)
 		_, err := namespaceAPI.Delete(name, nil)
@@ -75,7 +75,7 @@ func configure(t *testing.T, opts ...Option) Cleanup {
 	g := &Names{
 		t:       t,
 		timeout: 10 * time.Second,
-		apply:   set.NewHashSet[*Namespace, string](3),
+		apply:   set.NewHashSet[*Namespace](3),
 		remove:  set.New[string](3),
 	}
 
@@ -93,14 +93,14 @@ func (g *Names) run() {
 	namespacesAPI := g.nomadClient.Namespaces()
 
 	// do deletions
-	for _, namespace := range g.remove.Slice() {
+	for namespace := range g.remove.Items() {
 		g.logf("delete namespace %q", namespace)
 		_, err := namespacesAPI.Delete(namespace, nil)
 		must.NoError(g.t, err)
 	}
 
 	// do applies
-	for _, namespace := range g.apply.Slice() {
+	for namespace := range g.apply.Items() {
 		g.logf("apply namespace %q", namespace)
 		_, err := namespacesAPI.Register(&nomadapi.Namespace{
 			Name:        namespace.Name,

--- a/e2e/vaultcompat/vaultcompat_test.go
+++ b/e2e/vaultcompat/vaultcompat_test.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/go-version"
 	goversion "github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/api"

--- a/e2e/vaultcompat/vaultcompat_test.go
+++ b/e2e/vaultcompat/vaultcompat_test.go
@@ -54,11 +54,10 @@ func TestVaultCompat(t *testing.T) {
 
 func testVaultVersions(t *testing.T) {
 	versions := scanVaultVersions(t, getMinimumVersion(t))
-	versions.ForEach(func(b build) bool {
+	for b := range versions.Items() {
 		downloadVaultBuild(t, b)
 		testVaultBuild(t, b)
-		return true
-	})
+	}
 }
 
 func testVaultBuild(t *testing.T, b build) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad
 
-go 1.22
+go 1.23
 
 // Pinned dependencies are noted in github.com/hashicorp/nomad/issues/11826.
 replace (
@@ -69,7 +69,7 @@ require (
 	github.com/hashicorp/go-plugin v1.6.0
 	github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.4
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
-	github.com/hashicorp/go-set/v2 v2.1.0
+	github.com/hashicorp/go-set/v3 v3.0.0-alpha.1
 	github.com/hashicorp/go-sockaddr v1.0.6
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.3
@@ -228,6 +228,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.7 // indirect
 	github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1 // indirect
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.2 // indirect
+	github.com/hashicorp/go-set/v2 v2.1.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/mdns v1.0.4 // indirect
 	github.com/hashicorp/vault/api/auth/kubernetes v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -717,6 +717,8 @@ github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.2 h1:phcbL8urUzF/kxA/Oj6awENa
 github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.2/go.mod h1:l8slYwnJA26yBz+ErHpp2IRCLr0vuOMGBORIz4rRiAs=
 github.com/hashicorp/go-set/v2 v2.1.0 h1:iERPCQWks+I+4bTgy0CT2myZsCqNgBg79ZHqwniohXo=
 github.com/hashicorp/go-set/v2 v2.1.0/go.mod h1:6q4nh8UCVZODn2tJ5RbJi8+ki7pjZBsAEYGt6yaGeTo=
+github.com/hashicorp/go-set/v3 v3.0.0-alpha.1 h1:dPUtuqKJGgxtF7YO42oE+NdUONXi5nfLMKH2NpBffIM=
+github.com/hashicorp/go-set/v3 v3.0.0-alpha.1/go.mod h1:7bJRgsF3EL3AtRTzcKXdjAFbYGSef+1gHXhglGGO52k=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
 github.com/hashicorp/go-sockaddr v1.0.6 h1:RSG8rKU28VTUTvEKghe5gIhIQpv8evvNpnDEyqO4u9I=
 github.com/hashicorp/go-sockaddr v1.0.6/go.mod h1:uoUUmtwU7n9Dv3O4SNLeFvg0SxQ3lyjsj6+CCykpaxI=

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/hcl/hcl/ast"
 )
 

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )

--- a/helper/users/dynamic/pool.go
+++ b/helper/users/dynamic/pool.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/helper"
 )
 

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -17,7 +17,7 @@ import (
 	capOIDC "github.com/hashicorp/cap/oidc"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 
 	policy "github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"

--- a/nomad/eval_endpoint_test.go
+++ b/nomad/eval_endpoint_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	memdb "github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc/v2"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/ci"

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"

--- a/nomad/job_endpoint_hook_connect.go
+++ b/nomad/job_endpoint_hook_connect.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/helper/envoy"
 	"github.com/hashicorp/nomad/helper/pointer"

--- a/nomad/job_endpoint_statuses.go
+++ b/nomad/job_endpoint_statuses.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/state/paginator"

--- a/nomad/node_pool_endpoint_test.go
+++ b/nomad/node_pool_endpoint_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc/v2"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper"

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -14,7 +14,7 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/nomad/state"

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2094,7 +2094,7 @@ func (s *StateStore) deleteJobSubmission(job *structs.Job, txn *txn) error {
 	}
 
 	// now delete the submissions we found associated with the job
-	for _, sub := range remove.Slice() {
+	for sub := range remove.Items() {
 		err := txn.Delete("job_submission", sub)
 		if err != nil {
 			return err
@@ -3941,7 +3941,7 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 	}
 
 	// Update the index of when nodes last updated their allocs.
-	for _, nodeID := range nodeIDs.Slice() {
+	for nodeID := range nodeIDs.Items() {
 		if err := s.updateClientAllocUpdateIndex(txn, index, nodeID); err != nil {
 			return fmt.Errorf("node update failed: %v", err)
 		}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/lib/lang"

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/go-bexpr"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"

--- a/nomad/structs/config/workload_id.go
+++ b/nomad/structs/config/workload_id.go
@@ -8,7 +8,7 @@ import (
 	"slices"
 	"time"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/helper/pointer"
 )
 

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/acl"
 	"golang.org/x/crypto/blake2b"
 )

--- a/nomad/structs/job.go
+++ b/nomad/structs/job.go
@@ -4,7 +4,7 @@
 package structs
 
 import (
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 )
 
 const (

--- a/nomad/structs/job_test.go
+++ b/nomad/structs/job_test.go
@@ -6,7 +6,7 @@ package structs
 import (
 	"testing"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/args"
 	"github.com/hashicorp/nomad/helper/pointer"

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -32,7 +32,7 @@ import (
 	"github.com/hashicorp/cronexpr"
 	"github.com/hashicorp/go-msgpack/v2/codec"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/client/lib/idset"

--- a/scheduler/device.go
+++ b/scheduler/device.go
@@ -9,7 +9,7 @@ import (
 
 	"math"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/lib/numalib"
 	"github.com/hashicorp/nomad/nomad/structs"
 	psstructs "github.com/hashicorp/nomad/plugins/shared/structs"

--- a/scheduler/device_test.go
+++ b/scheduler/device_test.go
@@ -6,7 +6,7 @@ package scheduler
 import (
 	"testing"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/lib/numalib"
 	"github.com/hashicorp/nomad/helper/uuid"

--- a/scheduler/propertyset.go
+++ b/scheduler/propertyset.go
@@ -9,7 +9,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -8,7 +8,7 @@ import (
 	"math"
 	"slices"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/lib/idset"
 	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 	"github.com/hashicorp/nomad/helper"

--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/testlog"

--- a/scheduler/spread_test.go
+++ b/scheduler/spread_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -12,7 +12,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,12 +1,10 @@
 module github.com/hashicorp/nomad/tools
 
-go 1.21
-
-toolchain go1.21.0
+go 1.23
 
 require (
-	github.com/hashicorp/go-set/v2 v2.1.0
-	github.com/shoenig/test v0.6.7
+	github.com/hashicorp/go-set/v3 v3.0.0-alpha.1
+	github.com/shoenig/test v1.8.2
 )
 
-require github.com/google/go-cmp v0.5.9 // indirect
+require github.com/google/go-cmp v0.6.0 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -1,6 +1,6 @@
-github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
-github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/hashicorp/go-set/v2 v2.1.0 h1:iERPCQWks+I+4bTgy0CT2myZsCqNgBg79ZHqwniohXo=
-github.com/hashicorp/go-set/v2 v2.1.0/go.mod h1:6q4nh8UCVZODn2tJ5RbJi8+ki7pjZBsAEYGt6yaGeTo=
-github.com/shoenig/test v0.6.7 h1:k92ohN9VyRfZn0ezNfwamtIBT/5byyfLVktRmL/Jmek=
-github.com/shoenig/test v0.6.7/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/hashicorp/go-set/v3 v3.0.0-alpha.1 h1:dPUtuqKJGgxtF7YO42oE+NdUONXi5nfLMKH2NpBffIM=
+github.com/hashicorp/go-set/v3 v3.0.0-alpha.1/go.mod h1:7bJRgsF3EL3AtRTzcKXdjAFbYGSef+1gHXhglGGO52k=
+github.com/shoenig/test v1.8.2 h1:WDlty8UBqJRdmgdJX8lMwvCq97tiN7Um/GZD2vBDuug=
+github.com/shoenig/test v1.8.2/go.mod h1:UxJ6u/x2v/TNs/LoLxBNJRV9DiwBBKYxXSyczsBHFoI=

--- a/tools/missing/main.go
+++ b/tools/missing/main.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,7 +15,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/hashicorp/go-set/v2"
+	"github.com/hashicorp/go-set/v3"
 )
 
 func main() {
@@ -177,7 +178,7 @@ func skip(p string) bool {
 }
 
 func inCode(root string) ([]string, error) {
-	pkgs := set.NewTreeSet[string](set.Compare[string])
+	pkgs := set.NewTreeSet(cmp.Compare[string])
 
 	err := filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
 		if info.IsDir() {


### PR DESCRIPTION
This PR updates `go-set` to `v3` which includes support for [custom iterators](https://pkg.go.dev/iter#hdr-Iterators).

We can use them to replace cases of `.ForEach` which involved creating a clunky closure with a boolean return value for halting iteration. 

```go
s.ForEach(func(item T) bool {
  // do stuff
  return true
})
```

becomes

```go
for item := range s.Items() {
  // do stuff
}
```

We can also use them to replace cases of `Slice()` when used to range over the elements of a set, avoiding creating a full slice worth of garbage.

```go
for _, v := range s.Slice() { // creates a whole N sized slice
}
```

becomes

```go
for v := range s.Items() { // automagically iterates in-place
}
```