### PR TITLE
keyring: reduce locking and replication overhead

### DIFF
--- a/nomad/structs/keyring.go
+++ b/nomad/structs/keyring.go
@@ -196,17 +196,6 @@ func NewRootKeyMeta() *RootKeyMeta {
 	}
 }
 
-// RootKeyMetaStub is for serializing root key metadata to the
-// keystore, not for the List API. It excludes frequently-changing
-// fields such as ModifyIndex so we don't have to sync them to the
-// on-disk keystore when the fields are already in raft.
-type RootKeyMetaStub struct {
-	KeyID      string
-	Algorithm  EncryptionAlgorithm
-	CreateTime int64
-	State      RootKeyState
-}
-
 // IsActive indicates this key is the one currently being used for crypto
 // operations (at most one key can be Active)
 func (rkm *RootKeyMeta) IsActive() bool {
@@ -270,18 +259,6 @@ func (rkm *RootKeyMeta) IsInactive() bool {
 	return rkm.State == RootKeyStateInactive || rkm.State == RootKeyStateDeprecated
 }
 
-func (rkm *RootKeyMeta) Stub() *RootKeyMetaStub {
-	if rkm == nil {
-		return nil
-	}
-	return &RootKeyMetaStub{
-		KeyID:      rkm.KeyID,
-		Algorithm:  rkm.Algorithm,
-		CreateTime: rkm.CreateTime,
-		State:      rkm.State,
-	}
-
-}
 func (rkm *RootKeyMeta) Copy() *RootKeyMeta {
 	if rkm == nil {
 		return nil


### PR DESCRIPTION
While working on #23655 I found there were a few places in the encrypter/keyring where we could make modest improvements to performance and reliability of the existing code.

This changeset allows keyring replication to skip trying to replicate from itself, switches some of the read-only keyring accesses to use the read lock instead of a r/w lock, fixes the logging configuration to drop spurious "extra value" warnings in the logs, drops an unused type, and makes a minor refactoring to eliminate shadowing of the `keyset` type. Pulling this out to its own PR lets us backport these changes to the LTS and reduces the size of the PR that implements #23665.

Ref https://github.com/hashicorp/nomad/issues/23665