### PR TITLE
keyring in raft

### DIFF
--- a/.changelog/23977.txt
+++ b/.changelog/23977.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+keyring: Stored wrapped data encryption keys in Raft
+```

--- a/go.mod
+++ b/go.mod
@@ -128,6 +128,7 @@ require (
 	go.etcd.io/bbolt v1.3.9
 	go.uber.org/goleak v1.2.1
 	golang.org/x/crypto v0.27.0
+	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
 	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.25.0
 	golang.org/x/time v0.3.0
@@ -291,7 +292,6 @@ require (
 	github.com/vmware/govmomi v0.18.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8 // indirect
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,6 @@ require (
 	go.etcd.io/bbolt v1.3.9
 	go.uber.org/goleak v1.2.1
 	golang.org/x/crypto v0.27.0
-	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8
 	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.25.0
 	golang.org/x/time v0.3.0
@@ -292,6 +291,7 @@ require (
 	github.com/vmware/govmomi v0.18.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
+	golang.org/x/exp v0.0.0-20240613232115-7f521ea00fb8 // indirect
 	golang.org/x/mod v0.18.0 // indirect
 	golang.org/x/net v0.26.0 // indirect
 	golang.org/x/oauth2 v0.18.0 // indirect

--- a/helper/raftutil/msgtypes.go
+++ b/helper/raftutil/msgtypes.go
@@ -55,8 +55,7 @@ var msgTypeNames = map[structs.MessageType]string{
 	structs.ServiceRegistrationDeleteByIDRequestType:     "ServiceRegistrationDeleteByIDRequestType",
 	structs.ServiceRegistrationDeleteByNodeIDRequestType: "ServiceRegistrationDeleteByNodeIDRequestType",
 	structs.VarApplyStateRequestType:                     "VarApplyStateRequestType",
-	structs.RootKeyMetaUpsertRequestType:                 "RootKeyMetaUpsertRequestType",
-	structs.RootKeyMetaDeleteRequestType:                 "RootKeyMetaDeleteRequestType",
+	structs.WrappedRootKeysDeleteRequestType:             "WrappedRootKeysDeleteRequestType",
 	structs.ACLRolesUpsertRequestType:                    "ACLRolesUpsertRequestType",
 	structs.ACLRolesDeleteByIDRequestType:                "ACLRolesDeleteByIDRequestType",
 	structs.ACLAuthMethodsUpsertRequestType:              "ACLAuthMethodsUpsertRequestType",
@@ -65,6 +64,8 @@ var msgTypeNames = map[structs.MessageType]string{
 	structs.ACLBindingRulesDeleteRequestType:             "ACLBindingRulesDeleteRequestType",
 	structs.NodePoolUpsertRequestType:                    "NodePoolUpsertRequestType",
 	structs.NodePoolDeleteRequestType:                    "NodePoolDeleteRequestType",
+	structs.JobVersionTagRequestType:                     "JobVersionTagRequestType",
+	structs.WrappedRootKeysUpsertRequestType:             "WrappedRootKeysUpsertRequestType",
 	structs.NamespaceUpsertRequestType:                   "NamespaceUpsertRequestType",
 	structs.NamespaceDeleteRequestType:                   "NamespaceDeleteRequestType",
 }

--- a/nomad/acl_test.go
+++ b/nomad/acl_test.go
@@ -63,8 +63,8 @@ func TestAuthenticate_mTLS(t *testing.T) {
 	testutil.WaitForLeader(t, leader.RPC)
 
 	testutil.Wait(t, func() (bool, error) {
-		keyset, err := follower.encrypter.activeKeySet()
-		return keyset != nil, err
+		cs, err := follower.encrypter.activeCipherSet()
+		return cs != nil, err
 	})
 
 	rootToken := uuid.Generate()

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -1690,7 +1690,7 @@ func TestAlloc_SignIdentities_Bad(t *testing.T) {
 	s1, cleanupS1 := TestServer(t, nil)
 	t.Cleanup(cleanupS1)
 	codec := rpcClient(t, s1)
-	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForKeyring(t, s1.RPC, s1.Region())
 
 	node := mock.Node()
 	must.NoError(t, s1.fsm.State().UpsertNode(structs.MsgTypeTestSetup, 100, node))

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -928,7 +928,7 @@ func (c *CoreScheduler) rootKeyRotateOrGC(eval *structs.Evaluation) error {
 func (c *CoreScheduler) rootKeyGC(eval *structs.Evaluation, now time.Time) error {
 
 	ws := memdb.NewWatchSet()
-	iter, err := c.snap.WrappedRootKeys(ws)
+	iter, err := c.snap.RootKeys(ws)
 	if err != nil {
 		return err
 	}
@@ -944,7 +944,7 @@ func (c *CoreScheduler) rootKeyGC(eval *structs.Evaluation, now time.Time) error
 		if raw == nil {
 			break
 		}
-		keyMeta := raw.(*structs.WrappedRootKeys)
+		keyMeta := raw.(*structs.RootKey)
 		if !keyMeta.IsInactive() {
 			continue // never GC keys we're still using
 		}
@@ -996,13 +996,13 @@ func (c *CoreScheduler) rootKeyMigrate(eval *structs.Evaluation) (bool, error) {
 	}
 
 	ws := memdb.NewWatchSet()
-	iter, err := c.snap.WrappedRootKeys(ws)
+	iter, err := c.snap.RootKeys(ws)
 	if err != nil {
 		return false, err
 	}
 	wasMigrated := false
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		wrappedKeys := raw.(*structs.WrappedRootKeys)
+		wrappedKeys := raw.(*structs.RootKey)
 		if len(wrappedKeys.WrappedKeys) > 0 {
 			continue // already migrated
 		}
@@ -1035,17 +1035,17 @@ func (c *CoreScheduler) rootKeyMigrate(eval *structs.Evaluation) (bool, error) {
 // key to active once the rotation threshold has expired
 func (c *CoreScheduler) rootKeyRotate(eval *structs.Evaluation, now time.Time) (bool, error) {
 	var (
-		activeKey       *structs.WrappedRootKeys
-		prepublishedKey *structs.WrappedRootKeys
+		activeKey       *structs.RootKey
+		prepublishedKey *structs.RootKey
 	)
 
 	ws := memdb.NewWatchSet()
-	iter, err := c.snap.WrappedRootKeys(ws)
+	iter, err := c.snap.RootKeys(ws)
 	if err != nil {
 		return false, err
 	}
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		key := raw.(*structs.WrappedRootKeys)
+		key := raw.(*structs.RootKey)
 		switch key.State {
 		case structs.RootKeyStateActive:
 			activeKey = key
@@ -1141,7 +1141,7 @@ func (c *CoreScheduler) rootKeyRotate(eval *structs.Evaluation, now time.Time) (
 func (c *CoreScheduler) variablesRekey(eval *structs.Evaluation) error {
 
 	ws := memdb.NewWatchSet()
-	iter, err := c.snap.WrappedRootKeys(ws)
+	iter, err := c.snap.RootKeys(ws)
 	if err != nil {
 		return err
 	}
@@ -1151,7 +1151,7 @@ func (c *CoreScheduler) variablesRekey(eval *structs.Evaluation) error {
 		if raw == nil {
 			break
 		}
-		wrappedKeys := raw.(*structs.WrappedRootKeys)
+		wrappedKeys := raw.(*structs.RootKey)
 		if !wrappedKeys.IsRekeying() {
 			continue
 		}

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -944,21 +944,21 @@ func (c *CoreScheduler) rootKeyGC(eval *structs.Evaluation, now time.Time) error
 		if raw == nil {
 			break
 		}
-		keyMeta := raw.(*structs.RootKey)
-		if !keyMeta.IsInactive() {
+		rootKey := raw.(*structs.RootKey)
+		if !rootKey.IsInactive() {
 			continue // never GC keys we're still using
 		}
 
 		c.logger.Trace("checking inactive key eligibility for gc",
-			"create_time", keyMeta.CreateTime, "threshold", rotationThreshold.UnixNano())
+			"create_time", rootKey.CreateTime, "threshold", rotationThreshold.UnixNano())
 
-		if keyMeta.CreateTime > rotationThreshold.UnixNano() {
+		if rootKey.CreateTime > rotationThreshold.UnixNano() {
 			continue // don't GC keys with potentially live Workload Identities
 		}
 
 		// don't GC keys used to encrypt Variables or sign legacy non-expiring
 		// Workload Identities
-		inUse, err := c.snap.IsRootKeyInUse(keyMeta.KeyID)
+		inUse, err := c.snap.IsRootKeyInUse(rootKey.KeyID)
 		if err != nil {
 			return err
 		}
@@ -967,7 +967,7 @@ func (c *CoreScheduler) rootKeyGC(eval *structs.Evaluation, now time.Time) error
 		}
 
 		req := &structs.KeyringDeleteRootKeyRequest{
-			KeyID: keyMeta.KeyID,
+			KeyID: rootKey.KeyID,
 			WriteRequest: structs.WriteRequest{
 				Region:    c.srv.config.Region,
 				AuthToken: eval.LeaderACL,

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -984,7 +984,9 @@ func (c *CoreScheduler) rootKeyGC(eval *structs.Evaluation, now time.Time) error
 }
 
 // rootKeyMigrate checks if the cluster is fully upgraded and migrates all the
-// legacy root meta keys to the new wrapped key format
+// legacy root key material to the new wrapped key format. It returns true if
+// any of the keys were migrated, because the caller should now treat the
+// snapshot as invalid.
 //
 // COMPAT(1.12.0): remove this function in 1.12.0 LTS
 func (c *CoreScheduler) rootKeyMigrate(eval *structs.Evaluation) (bool, error) {

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2648,11 +2648,11 @@ func TestCoreScheduler_RootKeyRotate(t *testing.T) {
 	must.NoError(t, err)
 	must.True(t, rotated, must.Sprint("key should rotate"))
 
-	var key1 *structs.WrappedRootKeys
-	iter, err := store.WrappedRootKeys(nil)
+	var key1 *structs.RootKey
+	iter, err := store.RootKeys(nil)
 	must.NoError(t, err)
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		k := raw.(*structs.WrappedRootKeys)
+		k := raw.(*structs.RootKey)
 		if k.KeyID == key0.KeyID {
 			must.True(t, k.IsActive(), must.Sprint("expected original key to be active"))
 		} else {
@@ -2675,10 +2675,10 @@ func TestCoreScheduler_RootKeyRotate(t *testing.T) {
 	c.snap, _ = store.Snapshot()
 	rotated, err = c.rootKeyRotate(eval, now)
 
-	iter, err = store.WrappedRootKeys(nil)
+	iter, err = store.RootKeys(nil)
 	must.NoError(t, err)
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		k := raw.(*structs.WrappedRootKeys)
+		k := raw.(*structs.RootKey)
 		switch k.KeyID {
 		case key0.KeyID:
 			must.True(t, k.IsActive(), must.Sprint("original key should still be active"))
@@ -2694,10 +2694,10 @@ func TestCoreScheduler_RootKeyRotate(t *testing.T) {
 	now = time.Unix(0, key1.PublishTime+(time.Minute*10).Nanoseconds())
 	rotated, err = c.rootKeyRotate(eval, now)
 
-	iter, err = store.WrappedRootKeys(nil)
+	iter, err = store.RootKeys(nil)
 	must.NoError(t, err)
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		k := raw.(*structs.WrappedRootKeys)
+		k := raw.(*structs.RootKey)
 		switch k.KeyID {
 		case key0.KeyID:
 			must.True(t, k.IsInactive(), must.Sprint("original key should be inactive"))
@@ -2733,14 +2733,14 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 	yesterday := now - (24 * time.Hour).Nanoseconds()
 
 	// insert an "old" inactive key
-	key1 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakeInactive()
+	key1 := structs.NewRootKey(structs.NewRootKeyMeta()).MakeInactive()
 	key1.CreateTime = yesterday
-	must.NoError(t, store.UpsertWrappedRootKeys(600, key1, false))
+	must.NoError(t, store.UpsertRootKey(600, key1, false))
 
 	// insert an "old" and inactive key with a variable that's using it
-	key2 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakeInactive()
+	key2 := structs.NewRootKey(structs.NewRootKeyMeta()).MakeInactive()
 	key2.CreateTime = yesterday
-	must.NoError(t, store.UpsertWrappedRootKeys(700, key2, false))
+	must.NoError(t, store.UpsertRootKey(700, key2, false))
 
 	variable := mock.VariableEncrypted()
 	variable.KeyID = key2.KeyID
@@ -2752,9 +2752,9 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 	must.NoError(t, setResp.Error)
 
 	// insert an "old" key that's inactive but being used by an alloc
-	key3 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakeInactive()
+	key3 := structs.NewRootKey(structs.NewRootKeyMeta()).MakeInactive()
 	key3.CreateTime = yesterday
-	must.NoError(t, store.UpsertWrappedRootKeys(800, key3, false))
+	must.NoError(t, store.UpsertRootKey(800, key3, false))
 
 	// insert the allocation using key3
 	alloc := mock.Alloc()
@@ -2764,9 +2764,9 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 		structs.MsgTypeTestSetup, 850, []*structs.Allocation{alloc}))
 
 	// insert an "old" key that's inactive but being used by an alloc
-	key4 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakeInactive()
+	key4 := structs.NewRootKey(structs.NewRootKeyMeta()).MakeInactive()
 	key4.CreateTime = yesterday
-	must.NoError(t, store.UpsertWrappedRootKeys(900, key4, false))
+	must.NoError(t, store.UpsertRootKey(900, key4, false))
 
 	// insert the dead allocation using key4
 	alloc2 := mock.Alloc()
@@ -2777,14 +2777,14 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 		structs.MsgTypeTestSetup, 950, []*structs.Allocation{alloc2}))
 
 	// insert an inactive key older than RootKeyGCThreshold but not RootKeyRotationThreshold
-	key5 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakeInactive()
+	key5 := structs.NewRootKey(structs.NewRootKeyMeta()).MakeInactive()
 	key5.CreateTime = now - (15 * time.Minute).Nanoseconds()
-	must.NoError(t, store.UpsertWrappedRootKeys(1500, key5, false))
+	must.NoError(t, store.UpsertRootKey(1500, key5, false))
 
 	// prepublishing key should never be GC'd no matter how old
-	key6 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakePrepublished(yesterday)
+	key6 := structs.NewRootKey(structs.NewRootKeyMeta()).MakePrepublished(yesterday)
 	key6.CreateTime = yesterday
-	must.NoError(t, store.UpsertWrappedRootKeys(1600, key6, false))
+	must.NoError(t, store.UpsertRootKey(1600, key6, false))
 
 	// run the core job
 	snap, err := store.Snapshot()
@@ -2795,31 +2795,31 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 	must.NoError(t, c.rootKeyGC(eval, time.Now()))
 
 	ws := memdb.NewWatchSet()
-	key, err := store.WrappedRootKeysByID(ws, key0.KeyID)
+	key, err := store.RootKeyByID(ws, key0.KeyID)
 	must.NoError(t, err)
 	must.NotNil(t, key, must.Sprint("active key should not have been GCd"))
 
-	key, err = store.WrappedRootKeysByID(ws, key1.KeyID)
+	key, err = store.RootKeyByID(ws, key1.KeyID)
 	must.NoError(t, err)
 	must.Nil(t, key, must.Sprint("old and unused inactive key should have been GCd"))
 
-	key, err = store.WrappedRootKeysByID(ws, key2.KeyID)
+	key, err = store.RootKeyByID(ws, key2.KeyID)
 	must.NoError(t, err)
 	must.NotNil(t, key, must.Sprint("old key should not have been GCd if still in use"))
 
-	key, err = store.WrappedRootKeysByID(ws, key3.KeyID)
+	key, err = store.RootKeyByID(ws, key3.KeyID)
 	must.NoError(t, err)
 	must.NotNil(t, key, must.Sprint("old key used to sign a live alloc should not have been GCd"))
 
-	key, err = store.WrappedRootKeysByID(ws, key4.KeyID)
+	key, err = store.RootKeyByID(ws, key4.KeyID)
 	must.NoError(t, err)
 	must.Nil(t, key, must.Sprint("old key used to sign a terminal alloc should have been GCd"))
 
-	key, err = store.WrappedRootKeysByID(ws, key5.KeyID)
+	key, err = store.RootKeyByID(ws, key5.KeyID)
 	must.NoError(t, err)
 	must.NotNil(t, key, must.Sprint("key newer than GC+rotation threshold should not have been GCd"))
 
-	key, err = store.WrappedRootKeysByID(ws, key6.KeyID)
+	key, err = store.RootKeyByID(ws, key6.KeyID)
 	must.NoError(t, err)
 	must.NotNil(t, key, must.Sprint("prepublishing key should not have been GCd"))
 }
@@ -2883,7 +2883,7 @@ func TestCoreScheduler_VariablesRekey(t *testing.T) {
 				}
 			}
 
-			originalKey, _ := store.WrappedRootKeysByID(nil, key0.KeyID)
+			originalKey, _ := store.RootKeyByID(nil, key0.KeyID)
 			return originalKey.IsInactive()
 		}),
 	), must.Sprint("variable rekey should be complete"))

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -2623,7 +2623,7 @@ func TestCoreScheduler_RootKeyRotate(t *testing.T) {
 
 	// active key, will never be GC'd
 	store := srv.fsm.State()
-	key0, err := store.GetActiveRootKeyMeta(nil)
+	key0, err := store.GetActiveRootKey(nil)
 	must.NotNil(t, key0, must.Sprint("expected keyring to be bootstapped"))
 	must.NoError(t, err)
 
@@ -2648,11 +2648,11 @@ func TestCoreScheduler_RootKeyRotate(t *testing.T) {
 	must.NoError(t, err)
 	must.True(t, rotated, must.Sprint("key should rotate"))
 
-	var key1 *structs.RootKeyMeta
-	iter, err := store.RootKeyMetas(nil)
+	var key1 *structs.WrappedRootKeys
+	iter, err := store.WrappedRootKeys(nil)
 	must.NoError(t, err)
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		k := raw.(*structs.RootKeyMeta)
+		k := raw.(*structs.WrappedRootKeys)
 		if k.KeyID == key0.KeyID {
 			must.True(t, k.IsActive(), must.Sprint("expected original key to be active"))
 		} else {
@@ -2675,10 +2675,10 @@ func TestCoreScheduler_RootKeyRotate(t *testing.T) {
 	c.snap, _ = store.Snapshot()
 	rotated, err = c.rootKeyRotate(eval, now)
 
-	iter, err = store.RootKeyMetas(nil)
+	iter, err = store.WrappedRootKeys(nil)
 	must.NoError(t, err)
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		k := raw.(*structs.RootKeyMeta)
+		k := raw.(*structs.WrappedRootKeys)
 		switch k.KeyID {
 		case key0.KeyID:
 			must.True(t, k.IsActive(), must.Sprint("original key should still be active"))
@@ -2694,10 +2694,10 @@ func TestCoreScheduler_RootKeyRotate(t *testing.T) {
 	now = time.Unix(0, key1.PublishTime+(time.Minute*10).Nanoseconds())
 	rotated, err = c.rootKeyRotate(eval, now)
 
-	iter, err = store.RootKeyMetas(nil)
+	iter, err = store.WrappedRootKeys(nil)
 	must.NoError(t, err)
 	for raw := iter.Next(); raw != nil; raw = iter.Next() {
-		k := raw.(*structs.RootKeyMeta)
+		k := raw.(*structs.WrappedRootKeys)
 		switch k.KeyID {
 		case key0.KeyID:
 			must.True(t, k.IsInactive(), must.Sprint("original key should be inactive"))
@@ -2725,7 +2725,7 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 
 	// active key, will never be GC'd
 	store := srv.fsm.State()
-	key0, err := store.GetActiveRootKeyMeta(nil)
+	key0, err := store.GetActiveRootKey(nil)
 	must.NotNil(t, key0, must.Sprint("expected keyring to be bootstapped"))
 	must.NoError(t, err)
 
@@ -2733,14 +2733,14 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 	yesterday := now - (24 * time.Hour).Nanoseconds()
 
 	// insert an "old" inactive key
-	key1 := structs.NewRootKeyMeta().MakeInactive()
+	key1 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakeInactive()
 	key1.CreateTime = yesterday
-	must.NoError(t, store.UpsertRootKeyMeta(600, key1, false))
+	must.NoError(t, store.UpsertWrappedRootKeys(600, key1, false))
 
 	// insert an "old" and inactive key with a variable that's using it
-	key2 := structs.NewRootKeyMeta().MakeInactive()
+	key2 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakeInactive()
 	key2.CreateTime = yesterday
-	must.NoError(t, store.UpsertRootKeyMeta(700, key2, false))
+	must.NoError(t, store.UpsertWrappedRootKeys(700, key2, false))
 
 	variable := mock.VariableEncrypted()
 	variable.KeyID = key2.KeyID
@@ -2752,9 +2752,9 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 	must.NoError(t, setResp.Error)
 
 	// insert an "old" key that's inactive but being used by an alloc
-	key3 := structs.NewRootKeyMeta().MakeInactive()
+	key3 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakeInactive()
 	key3.CreateTime = yesterday
-	must.NoError(t, store.UpsertRootKeyMeta(800, key3, false))
+	must.NoError(t, store.UpsertWrappedRootKeys(800, key3, false))
 
 	// insert the allocation using key3
 	alloc := mock.Alloc()
@@ -2764,9 +2764,9 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 		structs.MsgTypeTestSetup, 850, []*structs.Allocation{alloc}))
 
 	// insert an "old" key that's inactive but being used by an alloc
-	key4 := structs.NewRootKeyMeta().MakeInactive()
+	key4 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakeInactive()
 	key4.CreateTime = yesterday
-	must.NoError(t, store.UpsertRootKeyMeta(900, key4, false))
+	must.NoError(t, store.UpsertWrappedRootKeys(900, key4, false))
 
 	// insert the dead allocation using key4
 	alloc2 := mock.Alloc()
@@ -2777,14 +2777,14 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 		structs.MsgTypeTestSetup, 950, []*structs.Allocation{alloc2}))
 
 	// insert an inactive key older than RootKeyGCThreshold but not RootKeyRotationThreshold
-	key5 := structs.NewRootKeyMeta().MakeInactive()
+	key5 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakeInactive()
 	key5.CreateTime = now - (15 * time.Minute).Nanoseconds()
-	must.NoError(t, store.UpsertRootKeyMeta(1500, key5, false))
+	must.NoError(t, store.UpsertWrappedRootKeys(1500, key5, false))
 
 	// prepublishing key should never be GC'd no matter how old
-	key6 := structs.NewRootKeyMeta().MakePrepublished(yesterday)
+	key6 := structs.NewWrappedRootKeys(structs.NewRootKeyMeta()).MakePrepublished(yesterday)
 	key6.CreateTime = yesterday
-	must.NoError(t, store.UpsertRootKeyMeta(1600, key6, false))
+	must.NoError(t, store.UpsertWrappedRootKeys(1600, key6, false))
 
 	// run the core job
 	snap, err := store.Snapshot()
@@ -2795,31 +2795,31 @@ func TestCoreScheduler_RootKeyGC(t *testing.T) {
 	must.NoError(t, c.rootKeyGC(eval, time.Now()))
 
 	ws := memdb.NewWatchSet()
-	key, err := store.RootKeyMetaByID(ws, key0.KeyID)
+	key, err := store.WrappedRootKeysByID(ws, key0.KeyID)
 	must.NoError(t, err)
 	must.NotNil(t, key, must.Sprint("active key should not have been GCd"))
 
-	key, err = store.RootKeyMetaByID(ws, key1.KeyID)
+	key, err = store.WrappedRootKeysByID(ws, key1.KeyID)
 	must.NoError(t, err)
 	must.Nil(t, key, must.Sprint("old and unused inactive key should have been GCd"))
 
-	key, err = store.RootKeyMetaByID(ws, key2.KeyID)
+	key, err = store.WrappedRootKeysByID(ws, key2.KeyID)
 	must.NoError(t, err)
 	must.NotNil(t, key, must.Sprint("old key should not have been GCd if still in use"))
 
-	key, err = store.RootKeyMetaByID(ws, key3.KeyID)
+	key, err = store.WrappedRootKeysByID(ws, key3.KeyID)
 	must.NoError(t, err)
 	must.NotNil(t, key, must.Sprint("old key used to sign a live alloc should not have been GCd"))
 
-	key, err = store.RootKeyMetaByID(ws, key4.KeyID)
+	key, err = store.WrappedRootKeysByID(ws, key4.KeyID)
 	must.NoError(t, err)
 	must.Nil(t, key, must.Sprint("old key used to sign a terminal alloc should have been GCd"))
 
-	key, err = store.RootKeyMetaByID(ws, key5.KeyID)
+	key, err = store.WrappedRootKeysByID(ws, key5.KeyID)
 	must.NoError(t, err)
 	must.NotNil(t, key, must.Sprint("key newer than GC+rotation threshold should not have been GCd"))
 
-	key, err = store.RootKeyMetaByID(ws, key6.KeyID)
+	key, err = store.WrappedRootKeysByID(ws, key6.KeyID)
 	must.NoError(t, err)
 	must.NotNil(t, key, must.Sprint("prepublishing key should not have been GCd"))
 }
@@ -2835,7 +2835,7 @@ func TestCoreScheduler_VariablesRekey(t *testing.T) {
 	testutil.WaitForKeyring(t, srv.RPC, "global")
 
 	store := srv.fsm.State()
-	key0, err := store.GetActiveRootKeyMeta(nil)
+	key0, err := store.GetActiveRootKey(nil)
 	must.NotNil(t, key0, must.Sprint("expected keyring to be bootstapped"))
 	must.NoError(t, err)
 
@@ -2883,7 +2883,7 @@ func TestCoreScheduler_VariablesRekey(t *testing.T) {
 				}
 			}
 
-			originalKey, _ := store.RootKeyMetaByID(nil, key0.KeyID)
+			originalKey, _ := store.WrappedRootKeysByID(nil, key0.KeyID)
 			return originalKey.IsInactive()
 		}),
 	), must.Sprint("variable rekey should be complete"))

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"net/rpc"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,11 +18,6 @@ import (
 
 	"github.com/go-jose/go-jose/v3/jwt"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc/v2"
-	"github.com/shoenig/test"
-	"github.com/shoenig/test/must"
-	"github.com/shoenig/test/wait"
-	"github.com/stretchr/testify/require"
-
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -30,6 +26,10 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test"
+	"github.com/shoenig/test/must"
+	"github.com/shoenig/test/wait"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -73,7 +73,9 @@ func TestEncrypter_LoadSave(t *testing.T) {
 			key, err := structs.NewRootKey(algo)
 			must.Greater(t, 0, len(key.RSAKey))
 			must.NoError(t, err)
-			must.NoError(t, encrypter.saveKeyToStore(key))
+
+			_, err = encrypter.wrapRootKey(key, false)
+			must.NoError(t, err)
 
 			// startup code path
 			gotKey, err := encrypter.loadKeyFromStore(
@@ -81,7 +83,8 @@ func TestEncrypter_LoadSave(t *testing.T) {
 			must.NoError(t, err)
 			must.NoError(t, encrypter.addCipher(gotKey))
 			must.Greater(t, 0, len(gotKey.RSAKey))
-			must.NoError(t, encrypter.saveKeyToStore(key))
+			_, err = encrypter.wrapRootKey(key, false)
+			must.NoError(t, err)
 
 			active, err := encrypter.keysetByIDLocked(key.Meta.KeyID)
 			must.NoError(t, err)
@@ -94,15 +97,15 @@ func TestEncrypter_LoadSave(t *testing.T) {
 		must.NoError(t, err)
 
 		// create a wrapper file identical to those before we had external KMS
-		kekWrapper, err := encrypter.encryptDEK(key, &structs.KEKProviderConfig{})
-		kekWrapper.Provider = ""
-		kekWrapper.ProviderID = ""
-		kekWrapper.EncryptedDataEncryptionKey = kekWrapper.WrappedDataEncryptionKey.Ciphertext
-		kekWrapper.EncryptedRSAKey = kekWrapper.WrappedRSAKey.Ciphertext
-		kekWrapper.WrappedDataEncryptionKey = nil
-		kekWrapper.WrappedRSAKey = nil
+		wrappedKey, err := encrypter.encryptDEK(key, &structs.KEKProviderConfig{})
+		diskWrapper := &structs.KeyEncryptionKeyWrapper{
+			Meta:                       key.Meta,
+			KeyEncryptionKey:           wrappedKey.KeyEncryptionKey,
+			EncryptedDataEncryptionKey: wrappedKey.WrappedDataEncryptionKey.Ciphertext,
+			EncryptedRSAKey:            wrappedKey.WrappedRSAKey.Ciphertext,
+		}
 
-		buf, err := json.Marshal(kekWrapper)
+		buf, err := json.Marshal(diskWrapper)
 		must.NoError(t, err)
 
 		path := filepath.Join(tmpDir, key.Meta.KeyID+".nks.json")
@@ -223,8 +226,9 @@ func TestEncrypter_Restore(t *testing.T) {
 	}
 }
 
-// TestEncrypter_KeyringReplication exercises key replication between servers
-func TestEncrypter_KeyringReplication(t *testing.T) {
+// TestEncrypter_KeyringBootstrapping exercises key decryption tasks as new
+// servers come online and leaders are elected.
+func TestEncrypter_KeyringBootstrapping(t *testing.T) {
 
 	ci.Parallel(t)
 
@@ -283,20 +287,35 @@ func TestEncrypter_KeyringReplication(t *testing.T) {
 
 	keyID1 := listResp.Keys[0].KeyID
 
-	keyPath := filepath.Join(leader.GetConfig().DataDir, "keystore",
-		keyID1+".aead.nks.json")
-	_, err := os.Stat(keyPath)
-	must.NoError(t, err, must.Sprint("expected key to be found in leader keystore"))
+	// Helper function for checking that a specific key is in the keyring for a
+	// specific server
+	checkPublicKeyFn := func(codec rpc.ClientCodec, keyID string) bool {
+		listPublicReq := &structs.GenericRequest{
+			QueryOptions: structs.QueryOptions{
+				Region:     "global",
+				AllowStale: true,
+			},
+		}
+		var listPublicResp structs.KeyringListPublicResponse
+		msgpackrpc.CallWithCodec(codec, "Keyring.ListPublic", listPublicReq, &listPublicResp)
+		for _, key := range listPublicResp.PublicKeys {
+			if key.KeyID == keyID && len(key.PublicKey) > 0 {
+				return true
+			}
+		}
+		return false
+	}
+
+	// leader's key should already be available by the time its elected the
+	// leader
+	must.True(t, checkPublicKeyFn(codec, keyID1))
 
 	// Helper function for checking that a specific key has been
-	// replicated to followers
-
+	// replicated to all followers
 	checkReplicationFn := func(keyID string) func() bool {
 		return func() bool {
 			for _, srv := range servers {
-				keyPath := filepath.Join(srv.GetConfig().DataDir, "keystore",
-					keyID+".aead.nks.json")
-				if _, err := os.Stat(keyPath); err != nil {
+				if !checkPublicKeyFn(rpcClient(t, srv), keyID) {
 					return false
 				}
 			}
@@ -317,7 +336,7 @@ func TestEncrypter_KeyringReplication(t *testing.T) {
 		},
 	}
 	var rotateResp structs.KeyringRotateRootKeyResponse
-	err = msgpackrpc.CallWithCodec(codec, "Keyring.Rotate", rotateReq, &rotateResp)
+	err := msgpackrpc.CallWithCodec(codec, "Keyring.Rotate", rotateReq, &rotateResp)
 	must.NoError(t, err)
 	keyID2 := rotateResp.Key.KeyID
 
@@ -332,10 +351,8 @@ func TestEncrypter_KeyringReplication(t *testing.T) {
 	must.NoError(t, err)
 	must.NotNil(t, getResp.Key, must.Sprint("expected key to be found on leader"))
 
-	keyPath = filepath.Join(leader.GetConfig().DataDir, "keystore",
-		keyID2+".aead.nks.json")
-	_, err = os.Stat(keyPath)
-	must.NoError(t, err, must.Sprint("expected key to be found in leader keystore"))
+	must.True(t, checkPublicKeyFn(codec, keyID1),
+		must.Sprint("expected key to be found in leader keystore"))
 
 	must.Wait(t, wait.InitialSuccess(
 		wait.BoolFunc(checkReplicationFn(keyID2)),
@@ -576,6 +593,23 @@ func TestEncrypter_Upgrade17(t *testing.T) {
 	testutil.WaitForKeyring(t, srv.RPC, "global")
 	codec := rpcClient(t, srv)
 
+	initKey, err := srv.State().GetActiveRootKey(nil)
+	must.NoError(t, err)
+
+	wr := structs.WriteRequest{
+		Namespace: "default",
+		Region:    "global",
+	}
+
+	// Delete the initialization key because it's a newer WrappedRootKey from
+	// 1.9, which isn't under test here.
+	_, _, err = srv.raftApply(
+		structs.WrappedRootKeysDeleteRequestType, structs.KeyringDeleteRootKeyRequest{
+			KeyID:        initKey.KeyID,
+			WriteRequest: wr,
+		})
+	must.NoError(t, err)
+
 	// Fake life as a 1.6 server by writing only ed25519 keys
 	oldRootKey, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
 	must.NoError(t, err)
@@ -586,13 +620,10 @@ func TestEncrypter_Upgrade17(t *testing.T) {
 	oldRootKey.RSAKey = nil
 
 	// Add to keyring
-	must.NoError(t, srv.encrypter.AddKey(oldRootKey))
+	_, err = srv.encrypter.AddUnwrappedKey(oldRootKey, false)
+	must.NoError(t, err)
 
-	// Write metadata to Raft
-	wr := structs.WriteRequest{
-		Namespace: "default",
-		Region:    "global",
-	}
+	// Write a legacy key metadata to Raft
 	req := structs.KeyringUpdateRootKeyMetaRequest{
 		RootKeyMeta:  oldRootKey.Meta,
 		WriteRequest: wr,

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -70,7 +70,7 @@ func TestEncrypter_LoadSave(t *testing.T) {
 
 	for _, algo := range algos {
 		t.Run(string(algo), func(t *testing.T) {
-			key, err := structs.NewRootKey(algo)
+			key, err := structs.NewUnwrappedRootKey(algo)
 			must.Greater(t, 0, len(key.RSAKey))
 			must.NoError(t, err)
 
@@ -86,14 +86,14 @@ func TestEncrypter_LoadSave(t *testing.T) {
 			_, err = encrypter.wrapRootKey(key, false)
 			must.NoError(t, err)
 
-			active, err := encrypter.keysetByIDLocked(key.Meta.KeyID)
+			active, err := encrypter.cipherSetByIDLocked(key.Meta.KeyID)
 			must.NoError(t, err)
 			must.Greater(t, 0, len(active.rootKey.RSAKey))
 		})
 	}
 
 	t.Run("legacy aead wrapper", func(t *testing.T) {
-		key, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
+		key, err := structs.NewUnwrappedRootKey(structs.EncryptionAlgorithmAES256GCM)
 		must.NoError(t, err)
 
 		// create a wrapper file identical to those before we had external KMS
@@ -543,7 +543,7 @@ func TestEncrypter_SignVerify_AlgNone(t *testing.T) {
 
 	e := srv.encrypter
 
-	keyset, err := e.activeKeySet()
+	keyset, err := e.activeCipherSet()
 	must.NoError(t, err)
 	keyID := keyset.rootKey.Meta.KeyID
 
@@ -611,7 +611,7 @@ func TestEncrypter_Upgrade17(t *testing.T) {
 	must.NoError(t, err)
 
 	// Fake life as a 1.6 server by writing only ed25519 keys
-	oldRootKey, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
+	oldRootKey, err := structs.NewUnwrappedRootKey(structs.EncryptionAlgorithmAES256GCM)
 	must.NoError(t, err)
 
 	oldRootKey = oldRootKey.MakeActive()

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1837,9 +1837,12 @@ func (n *nomadFSM) restoreImpl(old io.ReadCloser, filter *FSMFilter) error {
 				return err
 			}
 
-			if err := restore.RootKeyMetaRestore(keyMeta); err != nil {
+			wrappedKeys := structs.NewWrappedRootKeys(keyMeta)
+			if err := restore.WrappedRootKeysRestore(wrappedKeys); err != nil {
 				return err
 			}
+
+			go n.encrypter.AddWrappedKey(n.encrypter.srv.shutdownCtx, wrappedKeys)
 
 		case WrappedRootKeysSnapshot:
 			wrappedKeys := new(structs.WrappedRootKeys)
@@ -1850,6 +1853,8 @@ func (n *nomadFSM) restoreImpl(old io.ReadCloser, filter *FSMFilter) error {
 			if err := restore.WrappedRootKeysRestore(wrappedKeys); err != nil {
 				return err
 			}
+
+			go n.encrypter.AddWrappedKey(n.encrypter.srv.shutdownCtx, wrappedKeys)
 
 		case ACLRoleSnapshot:
 

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -66,6 +66,7 @@ const (
 	ACLBindingRuleSnapshot               SnapshotType = 27
 	NodePoolSnapshot                     SnapshotType = 28
 	JobSubmissionSnapshot                SnapshotType = 29
+	WrappedRootKeysSnapshot              SnapshotType = 30
 
 	// Namespace appliers were moved from enterprise and therefore start at 64
 	NamespaceSnapshot SnapshotType = 64
@@ -102,6 +103,7 @@ var snapshotTypeStrings = map[SnapshotType]string{
 	ACLBindingRuleSnapshot:               "ACLBindingRule",
 	NodePoolSnapshot:                     "NodePool",
 	JobSubmissionSnapshot:                "JobSubmission",
+	WrappedRootKeysSnapshot:              "WrappedRootKeys",
 	NamespaceSnapshot:                    "Namespace",
 }
 
@@ -126,6 +128,7 @@ type nomadFSM struct {
 	evalBroker         *EvalBroker
 	blockedEvals       *BlockedEvals
 	periodicDispatcher *PeriodicDispatch
+	encrypter          *Encrypter
 	logger             hclog.Logger
 	state              *state.StateStore
 	timetable          *TimeTable
@@ -171,6 +174,9 @@ type FSMConfig struct {
 	// be added to.
 	Blocked *BlockedEvals
 
+	// Encrypter is the encrypter where new WrappedRootKeys should be added
+	Encrypter *Encrypter
+
 	// Logger is the logger used by the FSM
 	Logger hclog.Logger
 
@@ -207,6 +213,7 @@ func NewFSM(config *FSMConfig) (*nomadFSM, error) {
 		evalBroker:          config.EvalBroker,
 		periodicDispatcher:  config.Periodic,
 		blockedEvals:        config.Blocked,
+		encrypter:           config.Encrypter,
 		logger:              config.Logger.Named("fsm"),
 		config:              config,
 		state:               state,
@@ -371,8 +378,8 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		return n.applyVariableOperation(msgType, buf[1:], log.Index)
 	case structs.RootKeyMetaUpsertRequestType:
 		return n.applyRootKeyMetaUpsert(msgType, buf[1:], log.Index)
-	case structs.RootKeyMetaDeleteRequestType:
-		return n.applyRootKeyMetaDelete(msgType, buf[1:], log.Index)
+	case structs.WrappedRootKeysDeleteRequestType:
+		return n.applyWrappedRootKeysDelete(msgType, buf[1:], log.Index)
 	case structs.ACLRolesUpsertRequestType:
 		return n.applyACLRolesUpsert(msgType, buf[1:], log.Index)
 	case structs.ACLRolesDeleteByIDRequestType:
@@ -385,6 +392,9 @@ func (n *nomadFSM) Apply(log *raft.Log) interface{} {
 		return n.applyACLBindingRulesUpsert(buf[1:], log.Index)
 	case structs.ACLBindingRulesDeleteRequestType:
 		return n.applyACLBindingRulesDelete(buf[1:], log.Index)
+	case structs.WrappedRootKeysUpsertRequestType:
+		return n.applyWrappedRootKeysUpsert(msgType, buf[1:], log.Index)
+
 	}
 
 	// Check enterprise only message types.
@@ -1830,6 +1840,17 @@ func (n *nomadFSM) restoreImpl(old io.ReadCloser, filter *FSMFilter) error {
 			if err := restore.RootKeyMetaRestore(keyMeta); err != nil {
 				return err
 			}
+
+		case WrappedRootKeysSnapshot:
+			wrappedKeys := new(structs.WrappedRootKeys)
+			if err := dec.Decode(wrappedKeys); err != nil {
+				return err
+			}
+
+			if err := restore.WrappedRootKeysRestore(wrappedKeys); err != nil {
+				return err
+			}
+
 		case ACLRoleSnapshot:
 
 			// Create a new ACLRole object, so we can decode the message into
@@ -2303,27 +2324,52 @@ func (n *nomadFSM) applyRootKeyMetaUpsert(msgType structs.MessageType, buf []byt
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	if err := n.state.UpsertRootKeyMeta(index, req.RootKeyMeta, req.Rekey); err != nil {
-		n.logger.Error("UpsertRootKeyMeta failed", "error", err)
+	wrappedRootKeys := structs.NewWrappedRootKeys(req.RootKeyMeta)
+
+	if err := n.state.UpsertWrappedRootKeys(index, wrappedRootKeys, req.Rekey); err != nil {
+		n.logger.Error("UpsertWrappedRootKeys failed", "error", err)
 		return err
 	}
+
+	// start a task to decrypt the key material
+	go n.encrypter.AddWrappedKey(n.encrypter.srv.shutdownCtx, wrappedRootKeys)
 
 	return nil
 }
 
-func (n *nomadFSM) applyRootKeyMetaDelete(msgType structs.MessageType, buf []byte, index uint64) interface{} {
-	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_root_key_meta_delete"}, time.Now())
+func (n *nomadFSM) applyWrappedRootKeysUpsert(msgType structs.MessageType, buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_wrapped_root_key_upsert"}, time.Now())
+
+	var req structs.KeyringUpsertWrappedRootKeyRequest
+	if err := structs.Decode(buf, &req); err != nil {
+		panic(fmt.Errorf("failed to decode request: %v", err))
+	}
+
+	if err := n.state.UpsertWrappedRootKeys(index, req.WrappedRootKeys, req.Rekey); err != nil {
+		n.logger.Error("UpsertWrappedRootKeys failed", "error", err)
+		return err
+	}
+
+	// start a task to decrypt the key material
+	go n.encrypter.AddWrappedKey(n.encrypter.srv.shutdownCtx, req.WrappedRootKeys)
+
+	return nil
+}
+
+func (n *nomadFSM) applyWrappedRootKeysDelete(msgType structs.MessageType, buf []byte, index uint64) interface{} {
+	defer metrics.MeasureSince([]string{"nomad", "fsm", "apply_wrapped_root_key_delete"}, time.Now())
 
 	var req structs.KeyringDeleteRootKeyRequest
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	if err := n.state.DeleteRootKeyMeta(index, req.KeyID); err != nil {
-		n.logger.Error("DeleteRootKeyMeta failed", "error", err)
+	if err := n.state.DeleteWrappedRootKeys(index, req.KeyID); err != nil {
+		n.logger.Error("DeleteWrappedRootKeys failed", "error", err)
 		return err
 	}
 
+	n.encrypter.RemoveKey(req.KeyID)
 	return nil
 }
 
@@ -2447,7 +2493,7 @@ func (s *nomadSnapshot) Persist(sink raft.SnapshotSink) error {
 		sink.Cancel()
 		return err
 	}
-	if err := s.persistRootKeyMeta(sink, encoder); err != nil {
+	if err := s.persistWrappedRootKeys(sink, encoder); err != nil {
 		sink.Cancel()
 		return err
 	}
@@ -3092,11 +3138,11 @@ func (s *nomadSnapshot) persistVariablesQuotas(sink raft.SnapshotSink,
 	return nil
 }
 
-func (s *nomadSnapshot) persistRootKeyMeta(sink raft.SnapshotSink,
+func (s *nomadSnapshot) persistWrappedRootKeys(sink raft.SnapshotSink,
 	encoder *codec.Encoder) error {
 
 	ws := memdb.NewWatchSet()
-	keys, err := s.snap.RootKeyMetas(ws)
+	keys, err := s.snap.WrappedRootKeys(ws)
 	if err != nil {
 		return err
 	}
@@ -3106,8 +3152,8 @@ func (s *nomadSnapshot) persistRootKeyMeta(sink raft.SnapshotSink,
 		if raw == nil {
 			break
 		}
-		key := raw.(*structs.RootKeyMeta)
-		sink.Write([]byte{byte(RootKeyMetaSnapshot)})
+		key := raw.(*structs.WrappedRootKeys)
+		sink.Write([]byte{byte(WrappedRootKeysSnapshot)})
 		if err := encoder.Encode(key); err != nil {
 			return err
 		}

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1842,7 +1842,11 @@ func (n *nomadFSM) restoreImpl(old io.ReadCloser, filter *FSMFilter) error {
 				return err
 			}
 
-			go n.encrypter.AddWrappedKey(n.encrypter.srv.shutdownCtx, wrappedKeys)
+			if n.encrypter != nil {
+				// only decrypt the key if we're running in a real server and
+				// not the 'operator snapshot' command context
+				go n.encrypter.AddWrappedKey(n.encrypter.srv.shutdownCtx, wrappedKeys)
+			}
 
 		case RootKeySnapshot:
 			wrappedKeys := new(structs.RootKey)
@@ -1854,7 +1858,11 @@ func (n *nomadFSM) restoreImpl(old io.ReadCloser, filter *FSMFilter) error {
 				return err
 			}
 
-			go n.encrypter.AddWrappedKey(n.encrypter.srv.shutdownCtx, wrappedKeys)
+			if n.encrypter != nil {
+				// only decrypt the key if we're running in a real server and
+				// not the 'operator snapshot' command context
+				go n.encrypter.AddWrappedKey(n.encrypter.srv.shutdownCtx, wrappedKeys)
+			}
 
 		case ACLRoleSnapshot:
 

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -60,29 +60,42 @@ func (k *Keyring) Rotate(args *structs.KeyringRotateRootKeyRequest, reply *struc
 	}
 
 	if args.PublishTime != 0 {
-		rootKey.Meta = rootKey.Meta.MakePrepublished(args.PublishTime)
+		rootKey.Meta.State = structs.RootKeyStatePrepublished
+		rootKey.Meta.PublishTime = args.PublishTime
 	} else {
-		rootKey.Meta = rootKey.Meta.MakeActive()
+		rootKey.Meta.State = structs.RootKeyStateActive
 	}
 
-	// make sure it's been added to the local keystore before we write
-	// it to raft, so that followers don't try to Get a key that
-	// hasn't yet been written to disk
-	err = k.encrypter.AddKey(rootKey)
+	isClusterUpgraded := ServersMeetMinimumVersion(
+		k.srv.serf.Members(), k.srv.Region(), minVersionKeyringInRaft, true)
+
+	// wrap/encrypt the key before we write it to Raft
+	wrappedKeys, err := k.encrypter.AddUnwrappedKey(rootKey, isClusterUpgraded)
 	if err != nil {
 		return err
 	}
 
-	// Update metadata via Raft so followers can retrieve this key
-	req := structs.KeyringUpdateRootKeyMetaRequest{
-		RootKeyMeta:  rootKey.Meta,
-		Rekey:        args.Full,
-		WriteRequest: args.WriteRequest,
+	var index uint64
+	if isClusterUpgraded {
+		_, index, err = k.srv.raftApply(structs.WrappedRootKeysUpsertRequestType,
+			structs.KeyringUpsertWrappedRootKeyRequest{
+				WrappedRootKeys: wrappedKeys,
+				Rekey:           args.Full,
+				WriteRequest:    args.WriteRequest,
+			})
+	} else {
+		// COMPAT(1.12.0): remove the version check and this code path
+		_, index, err = k.srv.raftApply(structs.RootKeyMetaUpsertRequestType,
+			structs.KeyringUpdateRootKeyMetaRequest{
+				RootKeyMeta:  rootKey.Meta,
+				Rekey:        args.Full,
+				WriteRequest: args.WriteRequest,
+			})
 	}
-	_, index, err := k.srv.raftApply(structs.RootKeyMetaUpsertRequestType, req)
 	if err != nil {
 		return err
 	}
+
 	reply.Key = rootKey.Meta
 	reply.Index = index
 
@@ -129,29 +142,23 @@ func (k *Keyring) List(args *structs.KeyringListRootKeyMetaRequest, reply *struc
 	opts := blockingOptions{
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
-		run: func(ws memdb.WatchSet, s *state.StateStore) error {
-
-			// retrieve all the key metadata
-			snap, err := k.srv.fsm.State().Snapshot()
+		run: func(ws memdb.WatchSet, store *state.StateStore) error {
+			iter, err := store.WrappedRootKeys(ws)
 			if err != nil {
 				return err
 			}
-			iter, err := snap.RootKeyMetas(ws)
-			if err != nil {
-				return err
-			}
-
 			keys := []*structs.RootKeyMeta{}
 			for {
 				raw := iter.Next()
 				if raw == nil {
 					break
 				}
-				keyMeta := raw.(*structs.RootKeyMeta)
-				keys = append(keys, keyMeta)
+				wrappedKey := raw.(*structs.WrappedRootKeys)
+				keys = append(keys, wrappedKey.Meta())
 			}
+
 			reply.Keys = keys
-			return k.srv.replySetIndex(state.TableRootKeyMeta, &reply.QueryMeta)
+			return k.srv.replySetIndex(state.TableWrappedRootKeys, &reply.QueryMeta)
 		},
 	}
 	return k.srv.blockingRPC(&opts)
@@ -183,22 +190,35 @@ func (k *Keyring) Update(args *structs.KeyringUpdateRootKeyRequest, reply *struc
 		return err
 	}
 
+	isClusterUpgraded := ServersMeetMinimumVersion(
+		k.srv.serf.Members(), k.srv.Region(), minVersionKeyringInRaft, true)
+
 	// make sure it's been added to the local keystore before we write
 	// it to raft, so that followers don't try to Get a key that
 	// hasn't yet been written to disk
-	err = k.encrypter.AddKey(args.RootKey)
+	wrappedKeys, err := k.encrypter.AddUnwrappedKey(args.RootKey, isClusterUpgraded)
 	if err != nil {
 		return err
 	}
 
-	// unwrap the request to turn it into a meta update only
-	metaReq := &structs.KeyringUpdateRootKeyMetaRequest{
-		RootKeyMeta:  args.RootKey.Meta,
-		WriteRequest: args.WriteRequest,
-	}
+	var index uint64
+	if isClusterUpgraded {
+		_, index, err = k.srv.raftApply(structs.WrappedRootKeysUpsertRequestType,
+			structs.KeyringUpsertWrappedRootKeyRequest{
+				WrappedRootKeys: wrappedKeys,
+				WriteRequest:    args.WriteRequest,
+			})
+	} else {
+		// COMPAT(1.12.0): remove the version check and this code path
+		// unwrap the request to turn it into a meta update only
+		metaReq := &structs.KeyringUpdateRootKeyMetaRequest{
+			RootKeyMeta:  args.RootKey.Meta,
+			WriteRequest: args.WriteRequest,
+		}
 
-	// update the metadata via Raft
-	_, index, err := k.srv.raftApply(structs.RootKeyMetaUpsertRequestType, metaReq)
+		// update the metadata via Raft
+		_, index, err = k.srv.raftApply(structs.RootKeyMetaUpsertRequestType, metaReq)
+	}
 	if err != nil {
 		return err
 	}
@@ -225,11 +245,11 @@ func (k *Keyring) validateUpdate(args *structs.KeyringUpdateRootKeyRequest) erro
 		return err
 	}
 	ws := memdb.NewWatchSet()
-	keyMeta, err := snap.RootKeyMetaByID(ws, args.RootKey.Meta.KeyID)
+	wrappedKeys, err := snap.WrappedRootKeysByID(ws, args.RootKey.Meta.KeyID)
 	if err != nil {
 		return err
 	}
-	if keyMeta != nil && keyMeta.Algorithm != args.RootKey.Meta.Algorithm {
+	if wrappedKeys != nil && wrappedKeys.Algorithm != args.RootKey.Meta.Algorithm {
 		return fmt.Errorf("root key algorithm cannot be changed after a key is created")
 	}
 
@@ -261,39 +281,29 @@ func (k *Keyring) Get(args *structs.KeyringGetRootKeyRequest, reply *structs.Key
 		queryMeta: &reply.QueryMeta,
 		run: func(ws memdb.WatchSet, s *state.StateStore) error {
 
-			// retrieve the key metadata
 			snap, err := k.srv.fsm.State().Snapshot()
 			if err != nil {
 				return err
 			}
-			keyMeta, err := snap.RootKeyMetaByID(ws, args.KeyID)
+			wrappedKeys, err := snap.WrappedRootKeysByID(ws, args.KeyID)
 			if err != nil {
 				return err
 			}
-			if keyMeta == nil {
-				return k.srv.replySetIndex(state.TableRootKeyMeta, &reply.QueryMeta)
+			if wrappedKeys == nil {
+				return k.srv.replySetIndex(state.TableWrappedRootKeys, &reply.QueryMeta)
 			}
 
 			// retrieve the key material from the keyring
-			rootKey, err := k.encrypter.GetKey(keyMeta.KeyID)
+			rootKey, err := k.encrypter.GetKey(wrappedKeys.KeyID)
 			if err != nil {
 				return err
 			}
 			reply.Key = rootKey
-
-			// Use the last index that affected the policy table
-			index, err := s.Index(state.TableRootKeyMeta)
+			err = k.srv.replySetIndex(state.TableWrappedRootKeys, &reply.QueryMeta)
 			if err != nil {
 				return err
 			}
 
-			// Ensure we never set the index to zero, otherwise a blocking query
-			// cannot be used.  We floor the index at one, since realistically
-			// the first write must have a higher index.
-			if index == 0 {
-				index = 1
-			}
-			reply.Index = index
 			return nil
 		},
 	}
@@ -324,24 +334,21 @@ func (k *Keyring) Delete(args *structs.KeyringDeleteRootKeyRequest, reply *struc
 	}
 
 	// lookup any existing key and validate the delete
+	var index uint64
 	snap, err := k.srv.fsm.State().Snapshot()
 	if err != nil {
 		return err
 	}
 	ws := memdb.NewWatchSet()
-	keyMeta, err := snap.RootKeyMetaByID(ws, args.KeyID)
+	wrappedKey, err := snap.WrappedRootKeysByID(ws, args.KeyID)
 	if err != nil {
 		return err
 	}
-	if keyMeta == nil {
-		return nil // safe to bail out early
-	}
-	if keyMeta.IsActive() {
+	if wrappedKey != nil && wrappedKey.IsActive() {
 		return fmt.Errorf("active root key cannot be deleted - call rotate first")
 	}
 
-	// update via Raft
-	_, index, err := k.srv.raftApply(structs.RootKeyMetaDeleteRequestType, args)
+	_, index, err = k.srv.raftApply(structs.WrappedRootKeysDeleteRequestType, args)
 	if err != nil {
 		return err
 	}
@@ -377,40 +384,33 @@ func (k *Keyring) ListPublic(args *structs.GenericRequest, reply *structs.Keyrin
 	opts := blockingOptions{
 		queryOpts: &args.QueryOptions,
 		queryMeta: &reply.QueryMeta,
-		run: func(ws memdb.WatchSet, s *state.StateStore) error {
-
-			// retrieve all the key metadata
-			snap, err := k.srv.fsm.State().Snapshot()
+		run: func(ws memdb.WatchSet, store *state.StateStore) error {
+			iter, err := store.WrappedRootKeys(ws)
 			if err != nil {
 				return err
 			}
-			iter, err := snap.RootKeyMetas(ws)
-			if err != nil {
-				return err
-			}
-
 			pubKeys := []*structs.KeyringPublicKey{}
 			for {
 				raw := iter.Next()
 				if raw == nil {
 					break
 				}
-
-				keyMeta := raw.(*structs.RootKeyMeta)
-				if keyMeta.State == structs.RootKeyStateDeprecated {
+				wrappedKeys := raw.(*structs.WrappedRootKeys)
+				if wrappedKeys.State == structs.RootKeyStateDeprecated {
 					// Only include valid keys
 					continue
 				}
 
-				pubKey, err := k.encrypter.GetPublicKey(keyMeta.KeyID)
+				pubKey, err := k.encrypter.GetPublicKey(wrappedKeys.KeyID)
 				if err != nil {
 					return err
 				}
 
 				pubKeys = append(pubKeys, pubKey)
+
 			}
 			reply.PublicKeys = pubKeys
-			return k.srv.replySetIndex(state.TableRootKeyMeta, &reply.QueryMeta)
+			return k.srv.replySetIndex(state.TableWrappedRootKeys, &reply.QueryMeta)
 		},
 	}
 	return k.srv.blockingRPC(&opts)

--- a/nomad/keyring_endpoint_test.go
+++ b/nomad/keyring_endpoint_test.go
@@ -29,7 +29,7 @@ func TestKeyringEndpoint_CRUD(t *testing.T) {
 
 	// Upsert a new key
 
-	key, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
+	key, err := structs.NewUnwrappedRootKey(structs.EncryptionAlgorithmAES256GCM)
 	require.NoError(t, err)
 	id := key.Meta.KeyID
 	key = key.MakeActive()
@@ -139,7 +139,7 @@ func TestKeyringEndpoint_InvalidUpdates(t *testing.T) {
 	codec := rpcClient(t, srv)
 
 	// Setup an existing key
-	key, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
+	key, err := structs.NewUnwrappedRootKey(structs.EncryptionAlgorithmAES256GCM)
 	require.NoError(t, err)
 	id := key.Meta.KeyID
 	key = key.MakeActive()
@@ -156,30 +156,30 @@ func TestKeyringEndpoint_InvalidUpdates(t *testing.T) {
 	require.NoError(t, err)
 
 	testCases := []struct {
-		key            *structs.RootKey
+		key            *structs.UnwrappedRootKey
 		expectedErrMsg string
 	}{
 		{
-			key:            &structs.RootKey{},
+			key:            &structs.UnwrappedRootKey{},
 			expectedErrMsg: "root key metadata is required",
 		},
 		{
-			key:            &structs.RootKey{Meta: &structs.RootKeyMeta{}},
+			key:            &structs.UnwrappedRootKey{Meta: &structs.RootKeyMeta{}},
 			expectedErrMsg: "root key UUID is required",
 		},
 		{
-			key:            &structs.RootKey{Meta: &structs.RootKeyMeta{KeyID: "invalid"}},
+			key:            &structs.UnwrappedRootKey{Meta: &structs.RootKeyMeta{KeyID: "invalid"}},
 			expectedErrMsg: "root key UUID is required",
 		},
 		{
-			key: &structs.RootKey{Meta: &structs.RootKeyMeta{
+			key: &structs.UnwrappedRootKey{Meta: &structs.RootKeyMeta{
 				KeyID:     id,
 				Algorithm: structs.EncryptionAlgorithmAES256GCM,
 			}},
 			expectedErrMsg: "root key state \"\" is invalid",
 		},
 		{
-			key: &structs.RootKey{Meta: &structs.RootKeyMeta{
+			key: &structs.UnwrappedRootKey{Meta: &structs.RootKeyMeta{
 				KeyID:     id,
 				Algorithm: structs.EncryptionAlgorithmAES256GCM,
 				State:     structs.RootKeyStateActive,
@@ -188,7 +188,7 @@ func TestKeyringEndpoint_InvalidUpdates(t *testing.T) {
 		},
 
 		{
-			key: &structs.RootKey{
+			key: &structs.UnwrappedRootKey{
 				Key: []byte{0x01},
 				Meta: &structs.RootKeyMeta{
 					KeyID:     id,
@@ -233,7 +233,7 @@ func TestKeyringEndpoint_Rotate(t *testing.T) {
 	must.NoError(t, err)
 
 	// Setup an existing key
-	key, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
+	key, err := structs.NewUnwrappedRootKey(structs.EncryptionAlgorithmAES256GCM)
 	must.NoError(t, err)
 	key1 := key.Meta
 

--- a/nomad/keyring_endpoint_test.go
+++ b/nomad/keyring_endpoint_test.go
@@ -106,7 +106,7 @@ func TestKeyringEndpoint_CRUD(t *testing.T) {
 	require.EqualError(t, err, "active root key cannot be deleted - call rotate first")
 
 	// set inactive
-	updateReq.RootKey.Meta = updateReq.RootKey.Meta.MakeInactive()
+	updateReq.RootKey = updateReq.RootKey.MakeInactive()
 	err = msgpackrpc.CallWithCodec(codec, "Keyring.Update", updateReq, &updateResp)
 	require.NoError(t, err)
 
@@ -229,7 +229,7 @@ func TestKeyringEndpoint_Rotate(t *testing.T) {
 	codec := rpcClient(t, srv)
 
 	store := srv.fsm.State()
-	key0, err := store.GetActiveRootKeyMeta(nil)
+	key0, err := store.GetActiveRootKey(nil)
 	must.NoError(t, err)
 
 	// Setup an existing key

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -2721,6 +2721,7 @@ func (s *Server) getOrCreateSchedulerConfig() *structs.SchedulerConfiguration {
 }
 
 var minVersionKeyring = version.Must(version.NewVersion("1.4.0"))
+var minVersionKeyringInRaft = version.Must(version.NewVersion("1.8.4-dev"))
 
 // initializeKeyring creates the first root key if the leader doesn't
 // already have one. The metadata will be replicated via raft and then
@@ -2731,12 +2732,12 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) {
 	logger := s.logger.Named("keyring")
 
 	store := s.fsm.State()
-	keyMeta, err := store.GetActiveRootKeyMeta(nil)
+	key, err := store.GetActiveRootKey(nil)
 	if err != nil {
 		logger.Error("failed to get active key: %v", err)
 		return
 	}
-	if keyMeta != nil {
+	if key != nil {
 		return
 	}
 
@@ -2766,18 +2767,32 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) {
 		return
 	}
 
-	err = s.encrypter.AddKey(rootKey)
+	isClusterUpgraded := ServersMeetMinimumVersion(
+		s.serf.Members(), s.Region(), minVersionKeyringInRaft, true)
+
+	wrappedKeys, err := s.encrypter.AddUnwrappedKey(rootKey, isClusterUpgraded)
 	if err != nil {
 		logger.Error("could not add initial key to keyring", "error", err)
 		return
 	}
-
-	if _, _, err = s.raftApply(structs.RootKeyMetaUpsertRequestType,
-		structs.KeyringUpdateRootKeyMetaRequest{
-			RootKeyMeta: rootKey.Meta,
-		}); err != nil {
-		logger.Error("could not initialize keyring", "error", err)
-		return
+	if isClusterUpgraded {
+		logger.Warn("cluster is upgraded to 1.9.0: initializing keyring")
+		if _, _, err = s.raftApply(structs.WrappedRootKeysUpsertRequestType,
+			structs.KeyringUpsertWrappedRootKeyRequest{
+				WrappedRootKeys: wrappedKeys,
+			}); err != nil {
+			logger.Error("could not initialize keyring", "error", err)
+			return
+		}
+	} else {
+		logger.Warn("cluster is not upgraded to 1.9.0: initializing legacy keyring")
+		if _, _, err = s.raftApply(structs.RootKeyMetaUpsertRequestType,
+			structs.KeyringUpdateRootKeyMetaRequest{
+				RootKeyMeta: rootKey.Meta,
+			}); err != nil {
+			logger.Error("could not initialize keyring", "error", err)
+			return
+		}
 	}
 
 	logger.Info("initialized keyring", "id", rootKey.Meta.KeyID)

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -2721,7 +2721,7 @@ func (s *Server) getOrCreateSchedulerConfig() *structs.SchedulerConfiguration {
 }
 
 var minVersionKeyring = version.Must(version.NewVersion("1.4.0"))
-var minVersionKeyringInRaft = version.Must(version.NewVersion("1.8.4-dev"))
+var minVersionKeyringInRaft = version.Must(version.NewVersion("1.9.0-dev"))
 
 // initializeKeyring creates the first root key if the leader doesn't
 // already have one. The metadata will be replicated via raft and then

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -2760,7 +2760,7 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) {
 
 	logger.Trace("initializing keyring")
 
-	rootKey, err := structs.NewRootKey(structs.EncryptionAlgorithmAES256GCM)
+	rootKey, err := structs.NewUnwrappedRootKey(structs.EncryptionAlgorithmAES256GCM)
 	rootKey = rootKey.MakeActive()
 	if err != nil {
 		logger.Error("could not initialize keyring: %v", err)

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -2776,7 +2776,6 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) {
 		return
 	}
 	if isClusterUpgraded {
-		logger.Warn("cluster is upgraded to 1.9.0: initializing keyring")
 		if _, _, err = s.raftApply(structs.WrappedRootKeysUpsertRequestType,
 			structs.KeyringUpsertWrappedRootKeyRequest{
 				WrappedRootKeys: wrappedKeys,
@@ -2785,7 +2784,8 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) {
 			return
 		}
 	} else {
-		logger.Warn("cluster is not upgraded to 1.9.0: initializing legacy keyring")
+		logger.Warn(fmt.Sprintf("not all servers are >=%q; initializing legacy keyring",
+			minVersionKeyringInRaft))
 		if _, _, err = s.raftApply(structs.RootKeyMetaUpsertRequestType,
 			structs.KeyringUpdateRootKeyMetaRequest{
 				RootKeyMeta: rootKey.Meta,

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -467,6 +467,54 @@ func TestPlanApply_signAllocIdentities(t *testing.T) {
 	}
 }
 
+// TestPlanApply_KeyringNotReady asserts we safely fail to apply a plan if the
+// leader's keyring is not ready
+func TestPlanApply_KeyringNotReady(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, cleanup := TestServer(t, func(c *Config) {
+		c.KEKProviderConfigs = []*structs.KEKProviderConfig{{
+			Provider: "no-such-provider",
+			Active:   true,
+		}}
+	})
+	defer cleanup()
+	testutil.WaitForLeader(t, srv.RPC)
+
+	node := mock.Node()
+	alloc := mock.Alloc()
+	deploy := mock.Deployment()
+	dupdates := []*structs.DeploymentStatusUpdate{
+		{
+			DeploymentID:      uuid.Generate(),
+			Status:            "foo",
+			StatusDescription: "bar",
+		},
+	}
+	plan := &structs.Plan{
+		Job: alloc.Job,
+		NodeAllocation: map[string][]*structs.Allocation{
+			node.ID: {alloc},
+		},
+		Deployment:        deploy,
+		DeploymentUpdates: dupdates,
+	}
+
+	planRes := &structs.PlanResult{
+		NodeAllocation: map[string][]*structs.Allocation{
+			node.ID: {alloc},
+		},
+		NodeUpdate:        map[string][]*structs.Allocation{},
+		NodePreemptions:   map[string][]*structs.Allocation{},
+		Deployment:        deploy,
+		DeploymentUpdates: dupdates,
+	}
+	snap, _ := srv.State().Snapshot()
+
+	_, err := srv.applyPlan(plan, planRes, snap)
+	must.EqError(t, err, "keyring has not been initialized yet")
+}
+
 func TestPlanApply_EvalPlan_Simple(t *testing.T) {
 	ci.Parallel(t)
 	state := testStateStore(t)

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -75,7 +75,7 @@ func TestPlanApply_applyPlan(t *testing.T) {
 
 	s1, cleanupS1 := TestServer(t, nil)
 	defer cleanupS1()
-	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForKeyring(t, s1.RPC, s1.Region())
 
 	// Register node
 	node := mock.Node()

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -251,7 +251,7 @@ func TestPlanApply_applyPlanWithNormalizedAllocs(t *testing.T) {
 		c.Build = "1.4.0"
 	})
 	defer cleanupS1()
-	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForKeyring(t, s1.RPC, s1.Region())
 
 	// Register node
 	node := mock.Node()
@@ -479,7 +479,7 @@ func TestPlanApply_KeyringNotReady(t *testing.T) {
 		}}
 	})
 	defer cleanup()
-	testutil.WaitForLeader(t, srv.RPC)
+	testutil.WaitForLeader(t, srv.RPC) // don't WaitForKeyring
 
 	node := mock.Node()
 	alloc := mock.Alloc()

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -553,6 +553,9 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigFunc
 	// exist before it can start.
 	s.keyringReplicator = NewKeyringReplicator(s, encrypter)
 
+	// Block until keys are decrypted
+	s.encrypter.IsReady(s.shutdownCtx)
+
 	// Done
 	return s, nil
 }
@@ -1378,6 +1381,7 @@ func (s *Server) setupRaft() error {
 		EvalBroker:         s.evalBroker,
 		Periodic:           s.periodicDispatcher,
 		Blocked:            s.blockedEvals,
+		Encrypter:          s.encrypter,
 		Logger:             s.logger,
 		Region:             s.Region(),
 		EnableEventBroker:  s.config.EnableEventBroker,

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -20,7 +20,7 @@ const (
 	TableServiceRegistrations = "service_registrations"
 	TableVariables            = "variables"
 	TableVariablesQuotas      = "variables_quota"
-	TableRootKeyMeta          = "root_key_meta"
+	TableWrappedRootKeys      = "wrapped_root_keys"
 	TableACLRoles             = "acl_roles"
 	TableACLAuthMethods       = "acl_auth_methods"
 	TableACLBindingRules      = "acl_binding_rules"
@@ -93,7 +93,7 @@ func init() {
 		serviceRegistrationsTableSchema,
 		variablesTableSchema,
 		variablesQuotasTableSchema,
-		variablesRootKeyMetaSchema,
+		wrappedRootKeySchema,
 		aclRolesTableSchema,
 		aclAuthMethodsTableSchema,
 		bindingRulesTableSchema,
@@ -1557,10 +1557,10 @@ func variablesQuotasTableSchema() *memdb.TableSchema {
 	}
 }
 
-// variablesRootKeyMetaSchema returns the MemDB schema for Nomad root keys
-func variablesRootKeyMetaSchema() *memdb.TableSchema {
+// wrappedRootKeySchema returns the MemDB schema for wrapped Nomad root keys
+func wrappedRootKeySchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: TableRootKeyMeta,
+		Name: TableWrappedRootKeys,
 		Indexes: map[string]*memdb.IndexSchema{
 			indexID: {
 				Name:         indexID,

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -20,7 +20,7 @@ const (
 	TableServiceRegistrations = "service_registrations"
 	TableVariables            = "variables"
 	TableVariablesQuotas      = "variables_quota"
-	TableWrappedRootKeys      = "wrapped_root_keys"
+	TableRootKeys             = "root_keys"
 	TableACLRoles             = "acl_roles"
 	TableACLAuthMethods       = "acl_auth_methods"
 	TableACLBindingRules      = "acl_binding_rules"
@@ -1560,7 +1560,7 @@ func variablesQuotasTableSchema() *memdb.TableSchema {
 // wrappedRootKeySchema returns the MemDB schema for wrapped Nomad root keys
 func wrappedRootKeySchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: TableWrappedRootKeys,
+		Name: TableRootKeys,
 		Indexes: map[string]*memdb.IndexSchema{
 			indexID: {
 				Name:         indexID,

--- a/nomad/state/state_store_keyring_test.go
+++ b/nomad/state/state_store_keyring_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/shoenig/test/must"
 )
 
-func TestStateStore_RootKeyMetaData_CRUD(t *testing.T) {
+func TestStateStore_WrappedRootKey_CRUD(t *testing.T) {
 	ci.Parallel(t)
 	store := testStateStore(t)
 	index, err := store.LatestIndex()
@@ -23,34 +24,36 @@ func TestStateStore_RootKeyMetaData_CRUD(t *testing.T) {
 		key := structs.NewRootKeyMeta()
 		keyIDs = append(keyIDs, key.KeyID)
 		if i == 0 {
-			key = key.MakeActive()
+			key.State = structs.RootKeyStateActive
 		}
 		index++
-		must.NoError(t, store.UpsertRootKeyMeta(index, key, false))
+		wrappedKeys := structs.NewWrappedRootKeys(key)
+		must.NoError(t, store.UpsertWrappedRootKeys(index, wrappedKeys, false))
 	}
 
 	// retrieve the active key
-	activeKey, err := store.GetActiveRootKeyMeta(nil)
+	activeKey, err := store.GetActiveRootKey(nil)
 	must.NoError(t, err)
 	must.NotNil(t, activeKey)
 
 	// update an inactive key to active and verify the rotation
-	inactiveKey, err := store.RootKeyMetaByID(nil, keyIDs[1])
+	inactiveKey, err := store.WrappedRootKeysByID(nil, keyIDs[1])
 	must.NoError(t, err)
 	must.NotNil(t, inactiveKey)
 	oldCreateIndex := inactiveKey.CreateIndex
-	newlyActiveKey := inactiveKey.MakeActive()
+	newlyActiveKey := inactiveKey.Copy()
+	newlyActiveKey = inactiveKey.MakeActive()
 	index++
-	must.NoError(t, store.UpsertRootKeyMeta(index, newlyActiveKey, false))
+	must.NoError(t, store.UpsertWrappedRootKeys(index, newlyActiveKey, false))
 
-	iter, err := store.RootKeyMetas(nil)
+	iter, err := store.WrappedRootKeys(nil)
 	must.NoError(t, err)
 	for {
 		raw := iter.Next()
 		if raw == nil {
 			break
 		}
-		key := raw.(*structs.RootKeyMeta)
+		key := raw.(*structs.WrappedRootKeys)
 		if key.KeyID == newlyActiveKey.KeyID {
 			must.True(t, key.IsActive(), must.Sprint("expected updated key to be active"))
 			must.Eq(t, oldCreateIndex, key.CreateIndex)
@@ -61,9 +64,9 @@ func TestStateStore_RootKeyMetaData_CRUD(t *testing.T) {
 
 	// delete the active key and verify it's been deleted
 	index++
-	must.NoError(t, store.DeleteRootKeyMeta(index, keyIDs[1]))
+	must.NoError(t, store.DeleteWrappedRootKeys(index, keyIDs[1]))
 
-	iter, err = store.RootKeyMetas(nil)
+	iter, err = store.WrappedRootKeys(nil)
 	must.NoError(t, err)
 	var found int
 	for {
@@ -71,10 +74,13 @@ func TestStateStore_RootKeyMetaData_CRUD(t *testing.T) {
 		if raw == nil {
 			break
 		}
-		key := raw.(*structs.RootKeyMeta)
+		key := raw.(*structs.WrappedRootKeys)
 		must.NotEq(t, keyIDs[1], key.KeyID)
 		must.False(t, key.IsActive(), must.Sprint("expected remaining keys to be inactive"))
 		found++
 	}
 	must.Eq(t, 2, found, must.Sprint("expected only 2 keys remaining"))
+
+	// deleting non-existent keys is safe
+	must.NoError(t, store.DeleteWrappedRootKeys(index, uuid.Generate()))
 }

--- a/nomad/state/state_store_restore.go
+++ b/nomad/state/state_store_restore.go
@@ -243,14 +243,14 @@ func (r *StateRestore) VariablesQuotaRestore(quota *structs.VariablesQuota) erro
 // RootKeyMetaRestore is used to restore a legacy root key meta entry into the
 // wrapped_root_keys table.
 func (r *StateRestore) RootKeyMetaRestore(meta *structs.RootKeyMeta) error {
-	wrappedRootKeys := structs.NewWrappedRootKeys(meta)
-	return r.WrappedRootKeysRestore(wrappedRootKeys)
+	wrappedRootKeys := structs.NewRootKey(meta)
+	return r.RootKeyRestore(wrappedRootKeys)
 }
 
-// WrappedRootKeysRestore is used to restore a single wrapped root key into the
+// RootKeyRestore is used to restore a single wrapped root key into the
 // wrapped_root_keys table.
-func (r *StateRestore) WrappedRootKeysRestore(wrappedKeys *structs.WrappedRootKeys) error {
-	if err := r.txn.Insert(TableWrappedRootKeys, wrappedKeys); err != nil {
+func (r *StateRestore) RootKeyRestore(wrappedKeys *structs.RootKey) error {
+	if err := r.txn.Insert(TableRootKeys, wrappedKeys); err != nil {
 		return fmt.Errorf("wrapped root keys insert failed: %v", err)
 	}
 	return nil

--- a/nomad/state/state_store_restore.go
+++ b/nomad/state/state_store_restore.go
@@ -240,11 +240,18 @@ func (r *StateRestore) VariablesQuotaRestore(quota *structs.VariablesQuota) erro
 	return nil
 }
 
-// RootKeyMetaQuotaRestore is used to restore a single root key meta into the
-// root_key_meta table.
-func (r *StateRestore) RootKeyMetaRestore(quota *structs.RootKeyMeta) error {
-	if err := r.txn.Insert(TableRootKeyMeta, quota); err != nil {
-		return fmt.Errorf("root key meta insert failed: %v", err)
+// RootKeyMetaRestore is used to restore a legacy root key meta entry into the
+// wrapped_root_keys table.
+func (r *StateRestore) RootKeyMetaRestore(meta *structs.RootKeyMeta) error {
+	wrappedRootKeys := structs.NewWrappedRootKeys(meta)
+	return r.WrappedRootKeysRestore(wrappedRootKeys)
+}
+
+// WrappedRootKeysRestore is used to restore a single wrapped root key into the
+// wrapped_root_keys table.
+func (r *StateRestore) WrappedRootKeysRestore(wrappedKeys *structs.WrappedRootKeys) error {
+	if err := r.txn.Insert(TableWrappedRootKeys, wrappedKeys); err != nil {
+		return fmt.Errorf("wrapped root keys insert failed: %v", err)
 	}
 	return nil
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -117,8 +117,8 @@ const (
 	ServiceRegistrationDeleteByIDRequestType     MessageType = 48
 	ServiceRegistrationDeleteByNodeIDRequestType MessageType = 49
 	VarApplyStateRequestType                     MessageType = 50
-	RootKeyMetaUpsertRequestType                 MessageType = 51
-	RootKeyMetaDeleteRequestType                 MessageType = 52
+	RootKeyMetaUpsertRequestType                 MessageType = 51 // DEPRECATED
+	WrappedRootKeysDeleteRequestType             MessageType = 52
 	ACLRolesUpsertRequestType                    MessageType = 53
 	ACLRolesDeleteByIDRequestType                MessageType = 54
 	ACLAuthMethodsUpsertRequestType              MessageType = 55
@@ -127,10 +127,13 @@ const (
 	ACLBindingRulesDeleteRequestType             MessageType = 58
 	NodePoolUpsertRequestType                    MessageType = 59
 	NodePoolDeleteRequestType                    MessageType = 60
+	JobVersionTagRequestType                     MessageType = 61
+	WrappedRootKeysUpsertRequestType             MessageType = 62
+	NamespaceUpsertRequestType                   MessageType = 64
+	NamespaceDeleteRequestType                   MessageType = 65
 
-	// Namespace types were moved from enterprise and therefore start at 64
-	NamespaceUpsertRequestType MessageType = 64
-	NamespaceDeleteRequestType MessageType = 65
+	// NOTE: MessageTypes are shared between CE and ENT. If you need to add a
+	// new type, check that ENT is not already using that value.
 )
 
 const (


### PR DESCRIPTION
In Nomad 1.4, we implemented a root keyring to support encrypting Variables and signing Workload Identities. The keyring was originally stored with the AEAD-wrapped DEKs and the KEK together in a JSON keystore file on disk. We recently added support for using an external KMS for the KEK to improve the security model for the keyring. But we've encountered multiple instances of the keystore files not getting backed up separately from the Raft snapshot, resulting in failure to restore clusters from backup.

Move Nomad's root keyring into Raft (encrypted with a KMS/Vault where available) in order to eliminate operational problems with the separate on-disk keystore.

Fixes: https://github.com/hashicorp/nomad/issues/23665
Ref: https://hashicorp.atlassian.net/browse/NET-10523
Ref: https://go.hashi.co/rfc/nmd-203

---

Notes for reviewers:
* I wanted to split this out into a couple of PRs but because we're replacing the existing state store table rather than having it side-by-side, there wasn't a reasonable subset that actually compiled doing it that way.
* Documentation updates will be in a separate PR
* Tooling updates for redacting key material will be in a separate PR