### PR TITLE
Prevent pruning and reaping of TaggedVersion jobs

### DIFF
--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -127,8 +127,8 @@ OUTER:
 	for i := iter.Next(); i != nil; i = iter.Next() {
 		job := i.(*structs.Job)
 
-		// Ignore new jobs.
-		if job.CreateIndex > oldThreshold {
+		// Ignore new jobs and jobs with TaggedVersion
+		if job.CreateIndex > oldThreshold || job.TaggedVersion != nil {
 			continue
 		}
 
@@ -156,7 +156,21 @@ OUTER:
 
 		// Job is eligible for garbage collection
 		if allEvalsGC {
-			gcJob = append(gcJob, job)
+			safeToDelete := true
+			versions, err := c.snap.JobVersionsByID(ws, job.Namespace, job.ID)
+			if err != nil {
+				c.logger.Error("job GC failed to get versions for job", "job", job.ID, "error", err)
+				continue
+			}
+			for _, version := range versions {
+				if version.TaggedVersion != nil {
+					safeToDelete = false
+					break
+				}
+			}
+			if safeToDelete {
+				gcJob = append(gcJob, job)
+			}
 			gcAlloc = append(gcAlloc, jobAlloc...)
 			gcEval = append(gcEval, jobEval...)
 		}
@@ -182,8 +196,16 @@ OUTER:
 
 // jobReap contacts the leader and issues a reap on the passed jobs
 func (c *CoreScheduler) jobReap(jobs []*structs.Job, leaderACL string) error {
+	// Filter out jobs with TaggedVersion
+	jobsToReap := make([]*structs.Job, 0, len(jobs))
+	for _, job := range jobs {
+		if job.TaggedVersion == nil {
+			jobsToReap = append(jobsToReap, job)
+		}
+	}
+
 	// Call to the leader to issue the reap
-	for _, req := range c.partitionJobReap(jobs, leaderACL, structs.MaxUUIDsPerWriteRequest) {
+	for _, req := range c.partitionJobReap(jobsToReap, leaderACL, structs.MaxUUIDsPerWriteRequest) {
 		var resp structs.JobBatchDeregisterResponse
 		if err := c.srv.RPC(structs.JobBatchDeregisterRPCMethod, req, &resp); err != nil {
 			c.logger.Error("batch job reap failed", "error", err)
@@ -214,6 +236,7 @@ func (c *CoreScheduler) partitionJobReap(jobs []*structs.Job, leaderACL string, 
 
 		if remaining := len(jobs) - submittedJobs; remaining > 0 {
 			if remaining <= available {
+				// TODO: do I need to check for TaggedVersion here as well?
 				for _, job := range jobs[submittedJobs:] {
 					jns := structs.NamespacedID{ID: job.ID, Namespace: job.Namespace}
 					req.Jobs[jns] = option

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -611,7 +611,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 }
 
 // A job that has any of its versions tagged should not be GC-able.
-func TestCoreScheduler_EvalGC_JobVersionTags(t *testing.T) {
+func TestCoreScheduler_EvalGC_JobTaggedVersion(t *testing.T) {
 	ci.Parallel(t)
 
 	s1, cleanupS1 := TestServer(t, nil)
@@ -622,15 +622,18 @@ func TestCoreScheduler_EvalGC_JobVersionTags(t *testing.T) {
 	job := mock.MinJob()
 	job.Stop = true // to be GC-able
 
+	// to be GC-able, the job needs an associated eval with a terminal Status,
+	// so that the job gets considered "dead" and not "pending"
+	// NOTE: this needs to come before UpsertJob for some Mystery Reason
+	//       (otherwise job Status ends up as "pending" later)
+	eval := mock.Eval()
+	eval.JobID = job.ID
+	eval.Status = structs.EvalStatusComplete
+	must.NoError(t, store.UpsertEvals(structs.MsgTypeTestSetup, 999, []*structs.Evaluation{eval}))
 	// upsert a couple versions of the job, so the "jobs" table has one
 	// and the "job_version" table has two.
 	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job.Copy()))
 	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, 1001, nil, job.Copy()))
-	// to be GC-able, also need an associated eval with a terminal Status
-	eval := mock.Eval()
-	eval.JobID = job.ID
-	eval.Status = structs.EvalStatusComplete
-	must.NoError(t, store.UpsertEvals(structs.MsgTypeTestSetup, 1002, []*structs.Evaluation{eval}))
 
 	jobExists := func(t *testing.T) bool {
 		t.Helper()
@@ -652,22 +655,45 @@ func TestCoreScheduler_EvalGC_JobVersionTags(t *testing.T) {
 		must.NoError(t, core.Process(gc))
 	}
 
+	applyTag := func(t *testing.T, idx, version uint64, name, desc string) {
+		t.Helper()
+		must.NoError(t, store.UpdateJobVersionTag(idx, job.Namespace,
+			&structs.JobApplyTagRequest{
+				JobID: job.ID,
+				Name:  name,
+				Tag: &structs.JobTaggedVersion{
+					Name:        name,
+					Description: desc,
+				},
+				Version: version,
+			}))
+	}
+	unsetTag := func(t *testing.T, idx uint64, name string) {
+		t.Helper()
+		must.NoError(t, store.UpdateJobVersionTag(idx, job.Namespace,
+			&structs.JobApplyTagRequest{
+				JobID: job.ID,
+				Name:  name,
+				Tag:   nil, // this triggers the deletion
+			}))
+	}
+
 	// tagging the latest version (latest of the 2 jobs, 0 and 1, is 1)
 	// will tag the job in the "jobs" table, which should protect from GC
-	must.NoError(t, store.UpdateJobVersionTag(2000, job.Namespace, job.ID, 1, "v1", "version 1"))
+	applyTag(t, 2000, 1, "v1", "version 1")
 	forceGC(t)
 	must.True(t, jobExists(t), must.Sprint("latest job version being tagged should protect from GC"))
 
-	// untagging latest and tagging the oldest, which is only in "job_version"
-	// table should also protect from GC
-	must.NoError(t, store.UnsetJobVersionTag(3000, job.Namespace, job.ID, "v1"))
-	must.NoError(t, store.UpdateJobVersionTag(3001, job.Namespace, job.ID, 0, "v0", "version 0"))
+	// untagging latest and tagging the oldest (only one in "job_version" table)
+	// should also protect from GC
+	unsetTag(t, 3000, "v1")
+	applyTag(t, 3001, 0, "v0", "version 0")
 	forceGC(t)
 	must.True(t, jobExists(t), must.Sprint("old job version being tagged should protect from GC"))
 
-	// untagging v0 should leave no tags left, so GC should delete the job
-	// and all its versions
-	must.NoError(t, store.UnsetJobVersionTag(4000, job.Namespace, job.ID, "v0"))
+	//untagging v0 should leave no tags left, so GC should delete the job
+	//and all its versions
+	unsetTag(t, 4000, "v0")
 	forceGC(t)
 	must.False(t, jobExists(t), must.Sprint("all tags being removed should enable GC"))
 }

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -372,6 +372,11 @@ func jobIsGCable(obj interface{}) (bool, error) {
 		return false, fmt.Errorf("Unexpected type: %v", obj)
 	}
 
+	// job versions that are tagged should be kept
+	if j.TaggedVersion != nil {
+		return false, nil
+	}
+
 	// If the job is periodic or parameterized it is only garbage collectable if
 	// it is stopped.
 	periodic := j.Periodic != nil && j.Periodic.Enabled

--- a/nomad/state/schema_test.go
+++ b/nomad/state/schema_test.go
@@ -242,6 +242,14 @@ func Test_jobIsGCable(t *testing.T) {
 			expectedOutput:      true,
 			expectedOutputError: nil,
 		},
+		{
+			name: "tagged",
+			inputObj: &structs.Job{
+				TaggedVersion: &structs.JobTaggedVersion{Name: "any"},
+			},
+			expectedOutput:      false,
+			expectedOutputError: nil,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2171,7 +2171,7 @@ func (s *StateStore) upsertJobVersion(index uint64, job *structs.Job, txn *txn) 
 		return nil
 	}
 
-	// We have to delete a historic job to make room.
+	// We have to delete historic jobs to make room.
 	// Find index of the highest versioned stable job
 	stableIdx := -1
 	for i, j := range all {
@@ -2188,10 +2188,21 @@ func (s *StateStore) upsertJobVersion(index uint64, job *structs.Job, txn *txn) 
 		all[max-1], all[max] = all[max], all[max-1]
 	}
 
-	// Delete the job outside of the set that are being kept.
-	d := all[max]
-	if err := txn.Delete("job_version", d); err != nil {
-		return fmt.Errorf("failed to delete job %v (%d) from job_version", d.ID, d.Version)
+	// Find the oldest non-tagged version to delete
+	deleteIdx := -1
+	for i := len(all) - 1; i >= max; i-- {
+		if all[i].TaggedVersion == nil {
+			deleteIdx = i
+			break
+		}
+	}
+
+	// If we found a non-tagged version to delete, delete it
+	if deleteIdx != -1 {
+		d := all[deleteIdx]
+		if err := txn.Delete("job_version", d); err != nil {
+			return fmt.Errorf("failed to delete job %v (%d) from job_version", d.ID, d.Version)
+		}
 	}
 
 	return nil

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2171,7 +2171,7 @@ func (s *StateStore) upsertJobVersion(index uint64, job *structs.Job, txn *txn) 
 		return nil
 	}
 
-	// We have to delete historic jobs to make room.
+	// We have to delete a historic job to make room.
 	// Find index of the highest versioned stable job
 	stableIdx := -1
 	for i, j := range all {


### PR DESCRIPTION
Hi this is totally Phil and not Daniel (ok it is Daniel)

This protects tagged versions of jobs from being bumped off as new versions are created, and prevents jobs that have any tagged versions from being GC'd.