### PR TITLE
add missing checks for vault binary in unit tests

### DIFF
--- a/nomad/vault_test.go
+++ b/nomad/vault_test.go
@@ -1169,6 +1169,9 @@ func TestVaultClient_CreateToken_Root_Target_Role(t *testing.T) {
 func TestVaultClient_CreateToken_Denylist_Role(t *testing.T) {
 	ci.Parallel(t)
 
+	v := testutil.NewTestVault(t)
+	defer v.Stop()
+
 	// Need to skip if test is 0.6.4
 	version, err := testutil.VaultVersion()
 	if err != nil {
@@ -1178,9 +1181,6 @@ func TestVaultClient_CreateToken_Denylist_Role(t *testing.T) {
 	if strings.Contains(version, "v0.6.4") {
 		t.Skipf("Vault has a regression in v0.6.4 that this test hits")
 	}
-
-	v := testutil.NewTestVault(t)
-	defer v.Stop()
 
 	// Set the configs token in a new test role
 	v.Config.Token = defaultTestVaultDenylistRoleAndToken(v, t, 5)

--- a/testutil/vault.go
+++ b/testutil/vault.go
@@ -49,7 +49,7 @@ func NewTestVaultFromPath(t testing.T, binary string) *TestVault {
 	t.Helper()
 
 	if _, err := exec.LookPath(binary); err != nil {
-		t.Skipf("Skipping test %s, Vault binary %q not found in path.", t.Name(), binary)
+		t.Skipf("Skipping test, Vault binary %q not found in path.", binary)
 	}
 
 	// Define which log level to use. Default to the same as Nomad but allow a
@@ -140,10 +140,13 @@ func NewTestVault(t testing.T) *TestVault {
 	return NewTestVaultFromPath(t, "vault")
 }
 
-// NewTestVaultDelayed returns a test Vault server that has not been started.
-// Start must be called and it is the callers responsibility to deal with any
-// port conflicts that may occur and retry accordingly.
-func NewTestVaultDelayed(t testing.T) *TestVault {
+func NewTestVaultDelayedFromPath(t testing.T, binary string) *TestVault {
+	t.Helper()
+
+	if _, err := exec.LookPath(binary); err != nil {
+		t.Skipf("Skipping test, Vault binary not %q found in path.", binary)
+	}
+
 	port := ci.PortAllocator.Grab(1)[0]
 	token := uuid.Generate()
 	bind := fmt.Sprintf("-dev-listen-address=127.0.0.1:%d", port)
@@ -182,6 +185,15 @@ func NewTestVaultDelayed(t testing.T) *TestVault {
 	}
 
 	return tv
+}
+
+// NewTestVaultDelayed returns a test Vault server that has not been started.
+// Start must be called and it is the callers responsibility to deal with any
+// port conflicts that may occur and retry accordingly.
+func NewTestVaultDelayed(t testing.T) *TestVault {
+	t.Helper()
+
+	return NewTestVaultDelayedFromPath(t, "vault")
 }
 
 // Start starts the test Vault server and waits for it to respond to its HTTP


### PR DESCRIPTION
Follows the pattern from `NewTestVault` to check for the vault binary, and skips if it does not exist.