### PR TITLE
update changelog 1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,20 @@ BUG FIXES:
 * ui: Show the namespace in the web UI exec command hint [[GH-20218](https://github.com/hashicorp/nomad/issues/20218)]
 * windows: Fixed a regression where scanning task processes was inefficient [[GH-20619](https://github.com/hashicorp/nomad/issues/20619)]
 
+## 1.7.12 Enterprise (September 17, 2024)
+
+BREAKING CHANGES:
+
+* docker: The default infra_image for pause containers is now registry.k8s.io/pause [[GH-23927](https://github.com/hashicorp/nomad/issues/23927)]
+
+IMPROVEMENTS:
+
+* build: update to go1.22.6 [[GH-23805](https://github.com/hashicorp/nomad/issues/23805)]
+
+BUG FIXES:
+
+* node: Fixed bug where sysbatch allocations were started prematurely [[GH-23858](https://github.com/hashicorp/nomad/issues/23858)]
+
 ## 1.7.11 Enterprise (August 13, 2024)
 
 SECURITY:
@@ -546,6 +560,21 @@ BUG FIXES:
 * variables: Fixed a bug where poststop tasks were not allowed access to Variables [[GH-18754](https://github.com/hashicorp/nomad/issues/18754)]
 * vault: Fixed a bug where poststop tasks would not get a Vault token [[GH-19268](https://github.com/hashicorp/nomad/issues/19268)]
 * vault: Fixed an issue that could cause Nomad to attempt to renew a Vault token that is already expired [[GH-18985](https://github.com/hashicorp/nomad/issues/18985)]
+
+## 1.6.15 Enterprise (September 17, 2024)
+
+BREAKING CHANGES:
+
+* docker: The default infra_image for pause containers is now registry.k8s.io/pause [[GH-23927](https://github.com/hashicorp/nomad/issues/23927)]
+
+IMPROVEMENTS:
+
+* build: update to go1.22.6 [[GH-23805](https://github.com/hashicorp/nomad/issues/23805)]
+* cli: Increase default log level and duration when capturing logs with `operator debug` [[GH-23850](https://github.com/hashicorp/nomad/issues/23850)]
+
+BUG FIXES:
+
+* node: Fixed bug where sysbatch allocations were started prematurely [[GH-23858](https://github.com/hashicorp/nomad/issues/23858)]
 
 ## 1.6.14 Enterprise (August 13, 2024)
 


### PR DESCRIPTION
I botched the CE changelog bits of the checklist (my fault), adding the backport notes
to the CE changelog now.
