### PR TITLE
version: bump base to 1.9.0

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -19,7 +19,7 @@ var (
 	GitDescribe string
 
 	// The main version number that is being run at the moment.
-	Version = "1.8.4"
+	Version = "1.9.0"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
We're releasing the beta for Nomad 1.9.0 shortly. Bumping the base version now will make it easier to test out new features that require a version check. Builds from `main` will show as `1.9.0-dev`.