### PR TITLE
ci: try less hard to cache go modules

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   checks:
     # largest available self-hosted disk for extra iops because linting is io-intensive
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "disk_gb=255", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-22.04' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "disk_gb=255", "type=m7a.2xlarge;m6a.2xlarge"]') || 'custom-linux-xl-nomad-22.04' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -34,7 +34,11 @@ jobs:
       - name: Git config token
         if: endsWith(github.repository, '-enterprise')
         run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
-      - uses: hashicorp/setup-golang@v3
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          cache: true
+          go-version-file: .go-version
+          cache-dependency-path: '**/go.sum'
       - name: Run make check
         run: |
           make missing

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -37,7 +37,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: hashicorp/setup-golang@36878950ae8f21c1bc25accaf67a4df88c29b01d # v3
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          cache: ${{ contains(runner.name, 'Github Actions') }}
+          go-version-file: .go-version
+          cache-dependency-path: '**/go.sum'
 
       - name: Clone Security Scanner repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -47,49 +47,38 @@ env:
   NOMAD_TEST_LOG_LEVEL: OFF
 
 jobs:
-  # this caches dependencies for subsequent jobs, including private deps in enterprise
-  mods:
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-22.04' }}
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: ./.github/actions/vault-secrets
-        with:
-          paths: |-
-            kv/data/github/hashicorp/nomad-enterprise/gha ELEVATED_GITHUB_TOKEN ;
-      - name: Git config token
-        if: endsWith(github.repository, '-enterprise')
-        run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
-      - uses: hashicorp/setup-golang@v3
-      - name: Get Go modules
-        run: |
-          make bootstrap
-          make tidy
   checks:
     uses: ./.github/workflows/checks.yaml
-    needs: [mods]
   compile:
-    needs: [mods, checks]
+    needs: [checks]
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-2019]
+        os: [ubuntu-24.04, macos-14, windows-2019]
     runs-on: ${{matrix.os}}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: hashicorp/setup-golang@v3
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          cache: ${{ contains(runner.name, 'Github Actions') }}
+          go-version-file: .go-version
+          cache-dependency-path: '**/go.sum'
       - name: Run make dev
         run: |
           make bootstrap
           make dev
   tests-api:
-    needs: [mods]
+    needs: [checks]
     runs-on: custom-linux-xl-nomad-22.04
     timeout-minutes: 8
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: hashicorp/setup-golang@v3
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          cache: true
+          go-version-file: .go-version
+          cache-dependency-path: '**/go.sum'
       - name: Run API tests
         env:
           GOTEST_MOD: api
@@ -99,7 +88,7 @@ jobs:
           sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
           sudo -E env "PATH=$PATH" make test-nomad-module
   tests-groups:
-    needs: [mods]
+    needs: [checks]
     runs-on: ubuntu-22.04
     timeout-minutes: 30
     strategy:
@@ -113,12 +102,14 @@ jobs:
           - quick
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      - uses: hashicorp/setup-golang@v3
-
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          cache: ${{ contains(runner.name, 'Github Actions') }}
+          go-version-file: .go-version
+          cache-dependency-path: '**/go.sum'
       - name: Install optional dependencies
         if: ${{ matrix.groups == 'drivers' }}
         run: sudo apt update && sudo apt install qemu-system
-
       - name: Run Matrix Tests
         env:
           GOTEST_GROUP: ${{matrix.groups}}
@@ -126,8 +117,8 @@ jobs:
           make bootstrap
           make generate-all
           make dev
-          hc-install install -version ${{env.VAULT_VERSION}} -path ${{env.GOBIN}} vault
-          hc-install install -version ${{env.CONSUL_VERSION}} -path ${{env.GOBIN}} consul
+          sudo -E env "PATH=$PATH" hc-install install -version ${{env.VAULT_VERSION}} -path '${{env.GOPATH}}/bin' vault
+          sudo -E env "PATH=$PATH" hc-install install -version ${{env.CONSUL_VERSION}} -path '${{env.GOPATH}}/bin' consul
           sudo sed -i 's!Defaults!#Defaults!g' /etc/sudoers
           sudo -E env "PATH=$PATH" make test-nomad
 permissions:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -46,7 +46,11 @@ jobs:
       - name: Git config token
         if: endsWith(github.repository, '-enterprise')
         run: git config --global url.'https://${{ env.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
-      - uses: hashicorp/setup-golang@v3
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          cache: ${{ contains(runner.name, 'Github Actions') }}
+          go-version-file: .go-version
+          cache-dependency-path: '**/go.sum'
       - run: make deps
       - name: Vault Compatability
         run: make integration-test
@@ -59,7 +63,11 @@ jobs:
       - name: Git config token
         if: endsWith(github.repository, '-enterprise')
         run: git config --global url.'https://${{ secrets.ELEVATED_GITHUB_TOKEN }}@github.com'.insteadOf 'https://github.com'
-      - uses: hashicorp/setup-golang@v3
+      - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          cache: ${{ contains(runner.name, 'Github Actions') }}
+          go-version-file: .go-version
+          cache-dependency-path: '**/go.sum'
       - name: Consul Compatability
         run: |
           make deps


### PR DESCRIPTION
This PR drops the `mods` workflow as well as the use of the `hashicorp/setup-go` action. These were added in the past to try and speed up downstream workflows by having go modules already cached. Since then, the `actions/setup-go` action added support for caching which we can now just make use of. But also we've been required to split some workflows into running on self-hosted runners (in ENT). On these runners the caching mechanism implies a slow rsync between the underlying Azure infrastructure and the runner on AWS. Empirically I've found it's much faster to just download the Go modules from the Go module cache hosted by Google. So, disable caching on self hosted runners.