### PR TITLE
command line tools for redacting keyring from snapshots

### DIFF
--- a/.changelog/24023.txt
+++ b/.changelog/24023.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added redaction options to operator snapshot commands
+```

--- a/command/commands.go
+++ b/command/commands.go
@@ -849,6 +849,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"operator snapshot redact": func() (cli.Command, error) {
+			return &OperatorSnapshotRedactCommand{
+				Meta: meta,
+			}, nil
+		},
 
 		"plan": func() (cli.Command, error) {
 			return &JobPlanCommand{

--- a/command/operator_snapshot_redact.go
+++ b/command/operator_snapshot_redact.go
@@ -1,0 +1,95 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/hashicorp/nomad/helper/raftutil"
+	"github.com/posener/complete"
+)
+
+type OperatorSnapshotRedactCommand struct {
+	Meta
+}
+
+func (c *OperatorSnapshotRedactCommand) Help() string {
+	helpText := `
+Usage: nomad operator snapshot redact [options] <file>
+
+  Removes key material from an existing snapshot file created by the operator
+  snapshot save command, when using the AEAD keyring provider. When using a KMS
+  keyring provider, no cleartext key material is stored in snapshots and this
+  command is not necessary. Note that this command requires loading the entire
+  snapshot into memory locally and overwrites the existing snapshot.
+
+  This is useful for situations where you need to transmit a snapshot without
+  exposing key material.
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
+
+	return strings.TrimSpace(helpText)
+}
+
+func (c *OperatorSnapshotRedactCommand) AutocompleteFlags() complete.Flags {
+	return complete.Flags{}
+}
+
+func (c *OperatorSnapshotRedactCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFiles("*")
+}
+
+func (c *OperatorSnapshotRedactCommand) Synopsis() string {
+	return "Redacts an existing snapshot of Nomad server state"
+}
+
+func (c *OperatorSnapshotRedactCommand) Name() string { return "operator snapshot redact" }
+
+func (c *OperatorSnapshotRedactCommand) Run(args []string) int {
+	if len(args) != 1 {
+		c.Ui.Error("This command takes one argument: <file>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	path := args[0]
+	f, err := os.Open(path)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error opening snapshot file: %s", err))
+		return 1
+	}
+	defer f.Close()
+
+	tmpFile, err := os.Create(path + ".tmp")
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to create temporary file: %v", err))
+		return 1
+	}
+
+	_, err = io.Copy(tmpFile, f)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to copy snapshot to temporary file: %v", err))
+		return 1
+	}
+
+	err = raftutil.RedactSnapshot(tmpFile)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to redact snapshot: %v", err))
+		return 1
+	}
+
+	err = os.Rename(tmpFile.Name(), path)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to finalize snapshot file: %v", err))
+		return 1
+	}
+
+	c.Ui.Output("Snapshot redacted")
+	return 0
+}

--- a/command/operator_snapshot_state.go
+++ b/command/operator_snapshot_state.go
@@ -85,7 +85,7 @@ func (c *OperatorSnapshotStateCommand) Run(args []string) int {
 	}
 	defer f.Close()
 
-	state, meta, err := raftutil.RestoreFromArchive(f, filter)
+	_, state, meta, err := raftutil.RestoreFromArchive(f, filter)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to read archive file: %s", err))
 		return 1

--- a/helper/raftutil/snapshot.go
+++ b/helper/raftutil/snapshot.go
@@ -103,5 +103,6 @@ func RedactSnapshot(srcFile *os.File) error {
 	if err != nil {
 		return fmt.Errorf("Failed to copy snapshot to temporary file: %v", err)
 	}
-	return nil
+
+	return srcFile.Sync()
 }

--- a/helper/raftutil/snapshot.go
+++ b/helper/raftutil/snapshot.go
@@ -6,21 +6,22 @@ package raftutil
 import (
 	"fmt"
 	"io"
+	"os"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/raft"
-
 	"github.com/hashicorp/nomad/helper/snapshot"
 	"github.com/hashicorp/nomad/nomad"
 	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/raft"
 )
 
-func RestoreFromArchive(archive io.Reader, filter *nomad.FSMFilter) (*state.StateStore, *raft.SnapshotMeta, error) {
+func RestoreFromArchive(archive io.Reader, filter *nomad.FSMFilter) (raft.FSM, *state.StateStore, *raft.SnapshotMeta, error) {
 	logger := hclog.L()
 
 	fsm, err := dummyFSM(logger)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create FSM: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to create FSM: %w", err)
 	}
 
 	// r is closed by RestoreFiltered, w is closed by CopySnapshot
@@ -40,13 +41,67 @@ func RestoreFromArchive(archive io.Reader, filter *nomad.FSMFilter) (*state.Stat
 
 	err = fsm.RestoreWithFilter(r, filter)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to restore from snapshot: %w", err)
+		return nil, nil, nil, fmt.Errorf("failed to restore from snapshot: %w", err)
 	}
 
 	select {
 	case err := <-errCh:
-		return nil, nil, err
+		return nil, nil, nil, err
 	case meta := <-metaCh:
-		return fsm.State(), meta, nil
+		return fsm, fsm.State(), meta, nil
 	}
+}
+
+func RedactSnapshot(srcFile *os.File) error {
+	srcFile.Seek(0, 0)
+	fsm, store, meta, err := RestoreFromArchive(srcFile, nil)
+	if err != nil {
+		return fmt.Errorf("Failed to load snapshot from archive: %w", err)
+	}
+
+	iter, err := store.RootKeys(nil)
+	if err != nil {
+		return fmt.Errorf("Failed to query for root keys: %v", err)
+	}
+
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		rootKey := raw.(*structs.RootKey)
+		if rootKey == nil {
+			break
+		}
+		if len(rootKey.WrappedKeys) > 0 {
+			rootKey.KeyID = rootKey.KeyID + " [REDACTED]"
+			rootKey.WrappedKeys = nil
+		}
+		msg, err := structs.Encode(structs.WrappedRootKeysUpsertRequestType,
+			&structs.KeyringUpsertWrappedRootKeyRequest{
+				WrappedRootKeys: rootKey,
+			})
+		if err != nil {
+			return fmt.Errorf("Could not re-encode redacted key: %v", err)
+		}
+
+		fsm.Apply(&raft.Log{
+			Type: raft.LogCommand,
+			Data: msg,
+		})
+	}
+
+	snap, err := snapshot.NewFromFSM(hclog.Default(), fsm, meta)
+	if err != nil {
+		return fmt.Errorf("Failed to create redacted snapshot: %v", err)
+	}
+
+	srcFile.Truncate(0)
+	srcFile.Seek(0, 0)
+
+	_, err = io.Copy(srcFile, snap)
+	if err != nil {
+		return fmt.Errorf("Failed to copy snapshot to temporary file: %v", err)
+	}
+	return nil
 }

--- a/scheduler/benchmarks/helpers_test.go
+++ b/scheduler/benchmarks/helpers_test.go
@@ -73,7 +73,7 @@ func NewHarnessFromSnapshot(t testing.TB, snapshotPath string) (*scheduler.Harne
 	}
 	defer f.Close()
 
-	state, _, err := raftutil.RestoreFromArchive(f, nil)
+	_, state, _, err := raftutil.RestoreFromArchive(f, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/website/content/docs/commands/operator/snapshot/redact.mdx
+++ b/website/content/docs/commands/operator/snapshot/redact.mdx
@@ -1,0 +1,36 @@
+---
+layout: docs
+page_title: 'Commands: operator snapshot redact'
+description: |
+  Redacts snapshot of Nomad server state
+---
+
+# Command: operator snapshot redact
+
+
+The `operator snapshot redact` command removes key material from an existing
+snapshot file created by the `operator snapshot save` command, when using the
+AEAD keyring provider.
+
+This is useful for situations where you need to transmit a snapshot without
+exposing key material.
+
+<Warning>
+
+When using a [KMS keyring provider][], no cleartext key material is stored in
+snapshots and this command is not necessary. Note that this command requires
+loading the entire snapshot into memory locally and overwrites the existing
+snapshot.
+
+Snapshots made before Nomad 1.9.0 will not include the keyrings.
+
+</Warning>
+
+## Usage
+
+```plaintext
+nomad operator snapshot redact <file>
+```
+
+
+[KMS keyring provider]: /nomad/docs/configuration/keyring

--- a/website/content/docs/commands/operator/snapshot/save.mdx
+++ b/website/content/docs/commands/operator/snapshot/save.mdx
@@ -16,12 +16,14 @@ snapshot operations.
 
 <Warning>
 
-This command only saves a Raft snapshot. This snapshot does not include
-keyrings. You must back up keyrings separately.
+This command includes Nomad's keyring in the snapshot. If you are not using a
+[KMS provider][] to secure the keyring, you should use the `-redact` flag to
+remove key material before transmitting the snapshot to HashiCorp Support.
 
-If you use this snapshot to recover a cluster, you also need to restore the
-keyring onto at least one server. Refer to the Key Management's [Restoring the
-Keyring from Backup][restore the keyring] section for instructions.
+Snapshots made before Nomad 1.9.0 will not include the keyrings. If you use
+older snapshots to recover a cluster, you also need to restore the keyring onto
+at least one server. Refer to the Key Management's [Restoring the Keyring from
+Backup][restore the keyring] section for instructions.
 
 </Warning>
 
@@ -54,10 +56,16 @@ nomad operator snapshot save [options] <file>
 
 ## Snapshot Save Options
 
-- `-stale`: The stale argument defaults to `false`, which means the leader
+- `-redact`: The redact option will locally edit the snapshot to remove any
+  cleartext key material from the root keyring. Only the AEAD keyring provider
+  has cleartext key material in Raft. Note that this operation requires loading
+  the snapshot into memory locally.
+
+- `-stale`: The stale option defaults to `false`, which means the leader
   provides the result. If the cluster is in an outage state without a leader,
   you may need to set `-stale` to `true` to get the configuration from a
   non-leader server.
 
 [outage recovery]: /nomad/tutorials/manage-clusters/outage-recovery
 [restore the keyring]: /nomad/docs/operations/key-management#restoring-the-keyring-from-backup
+[KMS provider]: /nomad/docs/configuration/keyring

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -938,6 +938,10 @@
                 "path": "commands/operator/snapshot/inspect"
               },
               {
+                "title": "redact",
+                "path": "commands/operator/snapshot/redact"
+              },
+              {
                 "title": "restore",
                 "path": "commands/operator/snapshot/restore"
               },


### PR DESCRIPTION
In #23977 we moved the keyring into Raft, which can expose key material in Raft snapshots when using the less-secure AEAD keyring instead of KMS. This changeset adds tools for redacting this material from snapshots:

* The `operator snapshot state` command gains the ability to display key metadata (only), which respects the `-filter` option.
* The `operator snapshot save` command gains a `-redact` option that removes key material from the snapshot after it's downloaded.
* A new `operator snapshot redact` command allows removing key material from an existing snapshot.

Full documentation on the new keyring work coming in a separate PR