### PR TITLE
deps: upgrade raft from v1.6.1 -> v1.7.1

### DIFF
--- a/.changelog/24029.txt
+++ b/.changelog/24029.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+raft: Bump raft to v1.7.1 which includes pre-vote. This should make servers more stable after network partitions
+```

--- a/go.mod
+++ b/go.mod
@@ -82,7 +82,7 @@ require (
 	github.com/hashicorp/memberlist v0.5.1
 	github.com/hashicorp/net-rpc-msgpackrpc/v2 v2.0.0
 	github.com/hashicorp/nomad/api v0.0.0-20230103221135-ce00d683f9be
-	github.com/hashicorp/raft v1.6.1
+	github.com/hashicorp/raft v1.7.1
 	github.com/hashicorp/raft-autopilot v0.1.6
 	github.com/hashicorp/raft-boltdb/v2 v2.3.0
 	github.com/hashicorp/serf v0.10.2-0.20240320153621-5d32001edfaa

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/hashicorp/memberlist v0.5.1/go.mod h1:zGDXV6AqbDTKTM6yxW0I4+JtFzZAJVo
 github.com/hashicorp/net-rpc-msgpackrpc/v2 v2.0.0 h1:kBpVVl1sl3MaSrs97e0+pDQhSrqJv9gVbSUrPpVfl1w=
 github.com/hashicorp/net-rpc-msgpackrpc/v2 v2.0.0/go.mod h1:6pdNz0vo0mF0GvhwDG56O3N18qBrAz/XRIcfINfTbwo=
 github.com/hashicorp/raft v1.2.0/go.mod h1:vPAJM8Asw6u8LxC3eJCUZmRP/E4QmUGE1R7g7k8sG/8=
-github.com/hashicorp/raft v1.6.1 h1:v/jm5fcYHvVkL0akByAp+IDdDSzCNCGhdO6VdB56HIM=
-github.com/hashicorp/raft v1.6.1/go.mod h1:N1sKh6Vn47mrWvEArQgILTyng8GoDRNYlgKyK7PMjs0=
+github.com/hashicorp/raft v1.7.1 h1:ytxsNx4baHsRZrhUcbt3+79zc4ly8qm7pi0393pSchY=
+github.com/hashicorp/raft v1.7.1/go.mod h1:hUeiEwQQR/Nk2iKDD0dkEhklSsu3jcAcqvPzPoZSAEM=
 github.com/hashicorp/raft-autopilot v0.1.6 h1:C1q3RNF2FfXNZfHWbvVAu0QixaQK8K5pX4O5lh+9z4I=
 github.com/hashicorp/raft-autopilot v0.1.6/go.mod h1:Af4jZBwaNOI+tXfIqIdbcAnh/UyyqIMj/pOISIfhArw=
 github.com/hashicorp/raft-boltdb v0.0.0-20171010151810-6e5ba93211ea/go.mod h1:pNv7Wc3ycL6F5oOWn+tPGo2gWD4a5X+yp/ntwdKLjRk=


### PR DESCRIPTION
The major change between Raft v1.6 -> v1.7 was the introduction of the Prevote feature. Before Prevote, when a partitioned node rejoins a cluster it may cause an election even if the cluster was stable. Prevote can avoid this useless election so reintroducing partitioned servers to an otherwise stable cluster becomes seamless.

Full details: https://github.com/hashicorp/raft/pull/530

In #20335 we discussed whether or not to add a configuration option to disable prevote in case bugs were discovered. While bugs have been found (hence the v1.7.1 version as opposed to v1.7.0), I'm choosing to follow Vault's lead of straightfordwardly bumping the raft dependency: hashicorp/vault#27605 and hashicorp/vault#28218