### PR TITLE
identity: adds ability to specify custom filepath for saving workload…

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1246,6 +1246,7 @@ type WorkloadIdentity struct {
 	ChangeSignal string        `mapstructure:"change_signal" hcl:"change_signal,optional"`
 	Env          bool          `hcl:"env,optional"`
 	File         bool          `hcl:"file,optional"`
+	Filepath     string        `hcl:"filepath,optional"`
 	ServiceName  string        `hcl:"service_name,optional"`
 	TTL          time.Duration `mapstructure:"ttl" hcl:"ttl,optional"`
 }

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1681,6 +1681,7 @@ func apiWorkloadIdentityToStructs(in *api.WorkloadIdentity) *structs.WorkloadIde
 		ChangeSignal: in.ChangeSignal,
 		Env:          in.Env,
 		File:         in.File,
+		Filepath:     in.Filepath,
 		ServiceName:  in.ServiceName,
 		TTL:          in.TTL,
 	}

--- a/e2e/workload_id/input/identity.nomad
+++ b/e2e/workload_id/input/identity.nomad
@@ -90,6 +90,27 @@ job "identity" {
       }
     }
 
+    task "filepath" {
+
+      identity {
+        file     = true
+        filepath = "local/nomad_token"
+      }
+
+      driver = "docker"
+      config {
+        image = "bash:5"
+
+        #HACK without the ending `sleep 2` we seem to sometimes miss logs :(
+        args = ["-c", "wc -c < local/nomad_token; env | grep NOMAD_TOKEN; echo done; sleep 2"]
+      }
+      resources {
+        cpu    = 16
+        memory = 32
+        disk   = 64
+      }
+    }
+
     # falsey task should be the same as no identity block
     task "falsey" {
 

--- a/e2e/workload_id/workload_id_test.go
+++ b/e2e/workload_id/workload_id_test.go
@@ -71,6 +71,11 @@ func testIdentity(t *testing.T) {
 			file: true,
 		},
 		{
+			task: "filepath",
+			env:  false,
+			file: true,
+		},
+		{
 			task: "falsey",
 			env:  false,
 			file: false,
@@ -94,6 +99,10 @@ func testIdentity(t *testing.T) {
 		must.StrHasSuffix(t, "done\n", logs, ps)
 
 		lines := strings.Split(logs, "\n")
+
+		// Whether filepath is set or not, the log length assertion should
+		// be the same, assuming the token was read from the correct location.
+		// So we don't need special switch cases for filepath.
 		switch {
 		case tc.env && tc.file:
 			must.Len(t, 4, lines, ps)

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -545,6 +545,9 @@ func workloadIdentityFromConfig(widConfig *config.WorkloadIdentityConfig) *struc
 	if widConfig.File != nil {
 		wid.File = *widConfig.File
 	}
+	if widConfig.Filepath != "" {
+		wid.Filepath = widConfig.Filepath
+	}
 	if widConfig.TTL != nil {
 		wid.TTL = *widConfig.TTL
 	}

--- a/nomad/structs/config/workload_id.go
+++ b/nomad/structs/config/workload_id.go
@@ -31,8 +31,12 @@ type WorkloadIdentityConfig struct {
 	Env *bool `mapstructure:"env"`
 
 	// File writes the Workload Identity into the Task's secrets directory
-	// if set.
+	// or specified filepath if set.
 	File *bool `mapstructure:"file"`
+
+	// Filepath write the Workload Identity to a specified directory in the
+	// Task's filesystem
+	Filepath string `mapstructure:"filepath"`
 
 	// TTL is used to determine the expiration of the credentials created for
 	// this identity (eg the JWT "exp" claim).
@@ -83,6 +87,9 @@ func (wi *WorkloadIdentityConfig) Equal(other *WorkloadIdentityConfig) bool {
 	if !pointer.Eq(wi.File, other.File) {
 		return false
 	}
+	if wi.Filepath != other.Filepath {
+		return false
+	}
 	if !pointer.Eq(wi.TTL, other.TTL) {
 		return false
 	}
@@ -119,6 +126,9 @@ func (wi *WorkloadIdentityConfig) Merge(other *WorkloadIdentityConfig) *Workload
 	result.Env = pointer.Merge(result.Env, other.Env)
 	result.File = pointer.Merge(result.File, other.File)
 	result.TTL = pointer.Merge(result.TTL, other.TTL)
+	if other.Filepath != "" {
+		result.Filepath = other.Filepath
+	}
 	if other.TTLHCL != "" {
 		result.TTLHCL = other.TTLHCL
 	}

--- a/nomad/structs/config/workload_id_test.go
+++ b/nomad/structs/config/workload_id_test.go
@@ -20,6 +20,7 @@ func TestWorkloadIdentityConfig_Copy(t *testing.T) {
 		Audience: []string{"aud"},
 		Env:      pointer.Of(true),
 		File:     pointer.Of(false),
+		Filepath: "foo",
 		TTL:      pointer.Of(time.Hour),
 	}
 
@@ -36,12 +37,14 @@ func TestWorkloadIdentityConfig_Copy(t *testing.T) {
 	clone.Audience[0] = "changed"
 	*clone.Env = false
 	*clone.File = true
+	clone.Filepath = "changed"
 	*clone.TTL = time.Second
 
 	must.NotEq(t, original, clone)
 	must.NotEqOp(t, original, clone)
 	must.NotEqOp(t, original.Env, clone.Env)
 	must.NotEqOp(t, original.File, clone.File)
+	must.NotEqOp(t, original.Filepath, clone.Filepath)
 	must.NotEqOp(t, original.TTL, clone.TTL)
 }
 
@@ -61,6 +64,7 @@ func TestWorkloadIdentityConfig_Equal(t *testing.T) {
 				Audience: []string{"aud"},
 				Env:      pointer.Of(true),
 				File:     pointer.Of(false),
+				Filepath: "foo",
 				TTL:      pointer.Of(time.Hour),
 			},
 			b: &WorkloadIdentityConfig{
@@ -68,6 +72,7 @@ func TestWorkloadIdentityConfig_Equal(t *testing.T) {
 				Audience: []string{"aud"},
 				Env:      pointer.Of(true),
 				File:     pointer.Of(false),
+				Filepath: "foo",
 				TTL:      pointer.Of(time.Hour),
 			},
 			expectEq: true,
@@ -123,6 +128,16 @@ func TestWorkloadIdentityConfig_Equal(t *testing.T) {
 			expectEq: false,
 		},
 		{
+			name: "different filepath",
+			a: &WorkloadIdentityConfig{
+				Filepath: "a",
+			},
+			b: &WorkloadIdentityConfig{
+				Filepath: "b",
+			},
+			expectEq: false,
+		},
+		{
 			name: "different file nil",
 			a: &WorkloadIdentityConfig{
 				File: pointer.Of(true),
@@ -173,6 +188,7 @@ func TestWorkloadIdentityConfig_Merge(t *testing.T) {
 				Audience: []string{"aud"},
 				Env:      pointer.Of(true),
 				File:     pointer.Of(false),
+				Filepath: "test",
 				TTL:      pointer.Of(time.Hour),
 			},
 		},
@@ -186,6 +202,7 @@ func TestWorkloadIdentityConfig_Merge(t *testing.T) {
 				Audience: []string{"aud", "other"},
 				Env:      pointer.Of(true),
 				File:     pointer.Of(false),
+				Filepath: "test",
 				TTL:      pointer.Of(time.Hour),
 			},
 		},
@@ -199,6 +216,7 @@ func TestWorkloadIdentityConfig_Merge(t *testing.T) {
 				Audience: []string{"aud"},
 				Env:      pointer.Of(false),
 				File:     pointer.Of(false),
+				Filepath: "test",
 				TTL:      pointer.Of(time.Hour),
 			},
 		},
@@ -212,6 +230,21 @@ func TestWorkloadIdentityConfig_Merge(t *testing.T) {
 				Audience: []string{"aud"},
 				Env:      pointer.Of(true),
 				File:     pointer.Of(true),
+				Filepath: "test",
+				TTL:      pointer.Of(time.Hour),
+			},
+		},
+		{
+			name: "merge filepath",
+			other: &WorkloadIdentityConfig{
+				Filepath: "other",
+			},
+			expected: &WorkloadIdentityConfig{
+				Name:     "test",
+				Audience: []string{"aud"},
+				Env:      pointer.Of(true),
+				File:     pointer.Of(false),
+				Filepath: "other",
 				TTL:      pointer.Of(time.Hour),
 			},
 		},
@@ -225,6 +258,7 @@ func TestWorkloadIdentityConfig_Merge(t *testing.T) {
 				Audience: []string{"aud"},
 				Env:      pointer.Of(true),
 				File:     pointer.Of(false),
+				Filepath: "test",
 				TTL:      pointer.Of(time.Second),
 			},
 		},
@@ -237,6 +271,7 @@ func TestWorkloadIdentityConfig_Merge(t *testing.T) {
 				Audience: []string{"aud"},
 				Env:      pointer.Of(true),
 				File:     pointer.Of(false),
+				Filepath: "test",
 				TTL:      pointer.Of(time.Hour),
 			}
 			got := original.Merge(tc.other)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8340,7 +8340,14 @@ func (t *Task) Validate(jobType string, tg *TaskGroup) error {
 		// TODO: Investigate validation of the PluginMountDir. Not much we can do apart from check IsAbs until after we understand its execution environment though :(
 	}
 
-	// Validate Identity/Identities
+	// Validate default Identity
+	if t.Identity != nil {
+		if err := t.Identity.Validate(); err != nil {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("Identity %q is invalid: %w", t.Identity.Name, err))
+		}
+	}
+
+	// Validate Identities
 	for _, wid := range t.Identities {
 		// Task.Canonicalize should move the default identity out of the Identities
 		// slice, so if one is found that means it is a duplicate.

--- a/nomad/structs/workload_id.go
+++ b/nomad/structs/workload_id.go
@@ -304,8 +304,12 @@ type WorkloadIdentity struct {
 	Env bool
 
 	// File writes the Workload Identity into the Task's secrets directory
-	// if set.
+	// or path specified by Filepath if set.
 	File bool
+
+	// Filepath is used to specify a custom path for the Task's Workload
+	// Identity JWT.
+	Filepath string
 
 	// ServiceName is used to bind the identity to a correct Consul service.
 	ServiceName string
@@ -356,6 +360,7 @@ func (wi *WorkloadIdentity) Copy() *WorkloadIdentity {
 		ChangeSignal: wi.ChangeSignal,
 		Env:          wi.Env,
 		File:         wi.File,
+		Filepath:     wi.Filepath,
 		ServiceName:  wi.ServiceName,
 		TTL:          wi.TTL,
 	}
@@ -387,6 +392,10 @@ func (wi *WorkloadIdentity) Equal(other *WorkloadIdentity) bool {
 	}
 
 	if wi.File != other.File {
+		return false
+	}
+
+	if wi.Filepath != other.Filepath {
 		return false
 	}
 
@@ -460,6 +469,10 @@ func (wi *WorkloadIdentity) Validate() error {
 
 	if wi.TTL < 0 {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("ttl must be >= 0"))
+	}
+
+	if wi.Filepath != "" && !wi.File {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("file parameter must be true in order to specify filepath"))
 	}
 
 	return mErr.ErrorOrNil()

--- a/nomad/structs/workload_id_test.go
+++ b/nomad/structs/workload_id_test.go
@@ -575,6 +575,12 @@ func TestWorkloadIdentity_Equal(t *testing.T) {
 	newWI.File = false
 	must.Equal(t, orig, newWI)
 
+	newWI.Filepath = "foo"
+	must.NotEqual(t, orig, newWI)
+
+	newWI.Filepath = ""
+	must.Equal(t, orig, newWI)
+
 	newWI.Name = "foo"
 	must.NotEqual(t, orig, newWI)
 
@@ -768,6 +774,14 @@ func TestWorkloadIdentity_Validate(t *testing.T) {
 				Audience: []string{"foo"},
 			},
 			Warn: "identities without an expiration are insecure",
+		},
+		{
+			Desc: "Filepath set without file",
+			In: WorkloadIdentity{
+				Name:     "foo",
+				Filepath: "foo",
+			},
+			Err: "file parameter must be true in order to specify filepath",
 		},
 	}
 

--- a/website/content/docs/job-specification/identity.mdx
+++ b/website/content/docs/job-specification/identity.mdx
@@ -34,6 +34,7 @@ job "docs" {
       identity {
         env         = true
         file        = true
+        filepath    = "local/example.jwt"
 
         # Restart on token renewal to get the new env var
         change_mode = "restart"
@@ -81,6 +82,9 @@ job "docs" {
   [`task.user`][taskuser] parameter is set, the token file will only be
   readable by that user. Otherwise the file is readable by everyone but is
   protected by parent directory permissions.
+- `filepath` `(string: "")` - If not empty and file is `true`, the workload
+  identity will be available at the specified location relative to the 
+  [task working directory][] instead of the `NOMAD_SECRETS_DIR`.
 - `ttl` `(string: "")` - The lifetime of the identity before it expires. The
   client will renew the identity at roughly half the TTL. This is specified
   using a label suffix like "30s" or "1h". You may not set a TTL on the default
@@ -355,3 +359,4 @@ EOF
 [taskapi]: /nomad/api-docs/task-api
 [taskuser]: /nomad/docs/job-specification/task#user "Nomad task Block"
 [windows]: https://devblogs.microsoft.com/commandline/af_unix-comes-to-windows/
+[task working directory]: /nomad/docs/runtime/environment#task-directories 'Task Directories'


### PR DESCRIPTION
Adds a parameter to identities spec that allows users to specify a custom filepath for persisting workload identities.