### PR TITLE
add changelog entry for workload identity filename feature

### DIFF
--- a/.changelog/24038.txt
+++ b/.changelog/24038.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+identity: Added filepath parameter to identity block for persisting workload identities
+```


### PR DESCRIPTION
Adds missing changelog entry for previous [PR](https://github.com/hashicorp/nomad/pull/24038) regarding the new filename parameter in the job spec.