### PR TITLE
fix: add node pool attribute to interpretable values in task env

### DIFF
--- a/.changelog/24052.txt
+++ b/.changelog/24052.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+task: adds node.pool attribute to interpretable values in task env
+```

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -142,6 +142,7 @@ const (
 	nodeRegionKey = "node.region"
 	nodeNameKey   = "node.unique.name"
 	nodeClassKey  = "node.class"
+	nodePoolKey   = "node.pool"
 
 	// Prefixes used for lookups.
 	nodeAttributePrefix = "attr."
@@ -855,6 +856,7 @@ func (b *Builder) setNode(n *structs.Node) *Builder {
 	b.nodeAttrs[nodeNameKey] = n.Name
 	b.nodeAttrs[nodeClassKey] = n.NodeClass
 	b.nodeAttrs[nodeDcKey] = n.Datacenter
+	b.nodeAttrs[nodePoolKey] = n.NodePool
 	b.datacenter = n.Datacenter
 	b.cgroupParent = n.CgroupParent
 

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -31,6 +31,7 @@ const (
 	attrVal   = "amd64"
 	nodeName  = "test node"
 	nodeClass = "test class"
+	nodePool  = "test pool"
 
 	// Environment variable values that tests can rely on
 	envOneKey = "NOMAD_IP"
@@ -56,6 +57,7 @@ func testEnvBuilder() *Builder {
 	}
 	n.Name = nodeName
 	n.NodeClass = nodeClass
+	n.NodePool = nodePool
 
 	task := mock.Job().TaskGroups[0].Tasks[0]
 	task.Env = map[string]string{
@@ -108,8 +110,8 @@ func TestEnvironment_ParseAndReplace_Attr(t *testing.T) {
 func TestEnvironment_ParseAndReplace_Node(t *testing.T) {
 	ci.Parallel(t)
 
-	input := []string{fmt.Sprintf("${%v}", nodeNameKey), fmt.Sprintf("${%v}", nodeClassKey)}
-	exp := []string{nodeName, nodeClass}
+	input := []string{fmt.Sprintf("${%v}", nodeNameKey), fmt.Sprintf("${%v}", nodeClassKey), fmt.Sprintf("${%v}", nodePoolKey)}
+	exp := []string{nodeName, nodeClass, nodePool}
 	env := testEnvBuilder()
 	act := env.Build().ParseAndReplace(input)
 


### PR DESCRIPTION
Added `node.pool` attribute to interpretable node attributes so it could be used as per the [docs](https://developer.hashicorp.com/nomad/docs/runtime/interpolation#node-attributes)