### PR TITLE
test: add valid identity name for test task

### DIFF
--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -752,6 +752,7 @@ func testJob() *Job {
 							},
 						},
 						Identity: &WorkloadIdentity{
+							Name: "foo",
 							Env:  true,
 							File: true,
 						},


### PR DESCRIPTION
Validation of the default task was enabled after adding the filename parameter in [#24038](https://github.com/hashicorp/nomad/pull/24038).  This adds a valid identity name to the test tasks so validation tests will pass.