### PR TITLE
template: fix panic in change_mode=script on client restart

### DIFF
--- a/.changelog/24057.txt
+++ b/.changelog/24057.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+template: Fixed a panic on client restart when using change_mode=script
+```

--- a/client/allocrunner/interfaces/task_lifecycle.go
+++ b/client/allocrunner/interfaces/task_lifecycle.go
@@ -129,6 +129,7 @@ type TaskPoststartRequest struct {
 	// Stats collector
 	DriverStats DriverStats
 }
+
 type TaskPoststartResponse struct{}
 
 type TaskPoststartHook interface {

--- a/client/allocrunner/taskrunner/driver_handle.go
+++ b/client/allocrunner/taskrunner/driver_handle.go
@@ -66,6 +66,9 @@ func (h *DriverHandle) Signal(s string) error {
 
 // Exec is the handled used by client endpoint handler to invoke the appropriate task driver exec.
 func (h *DriverHandle) Exec(timeout time.Duration, cmd string, args []string) ([]byte, int, error) {
+	if h == nil {
+		return nil, 0, ErrTaskNotRunning
+	}
 	command := append([]string{cmd}, args...)
 	res, err := h.driver.ExecTask(h.taskID, command, timeout)
 	if err != nil {
@@ -80,6 +83,9 @@ func (h *DriverHandle) ExecStreaming(ctx context.Context,
 	command []string,
 	tty bool,
 	stream drivers.ExecTaskStream) error {
+	if h == nil {
+		return ErrTaskNotRunning
+	}
 
 	if impl, ok := h.driver.(drivers.ExecTaskStreamingRawDriver); ok {
 		return impl.ExecTaskStreamingRaw(ctx, h.taskID, command, tty, stream)

--- a/client/allocrunner/taskrunner/interfaces/lifecycle.go
+++ b/client/allocrunner/taskrunner/interfaces/lifecycle.go
@@ -5,6 +5,7 @@ package interfaces
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -19,6 +20,9 @@ type TaskLifecycle interface {
 
 	// Kill a task permanently.
 	Kill(ctx context.Context, event *structs.TaskEvent) error
+
+	// Exec into a running task.
+	Exec(timeout time.Duration, cmd string, args []string) ([]byte, int, error)
 
 	// IsRunning returns true if the task runner has a handle to the task
 	// driver, which is useful for distinguishing restored tasks during

--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -5,6 +5,7 @@ package taskrunner
 
 import (
 	"context"
+	"time"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -124,6 +125,18 @@ func (tr *TaskRunner) restartImpl(ctx context.Context, event *structs.TaskEvent,
 	case <-ctx.Done():
 	}
 	return nil
+}
+
+func (tr *TaskRunner) Exec(timeout time.Duration, cmd string, args []string) ([]byte, int, error) {
+	tr.logger.Trace("Exec requested")
+
+	handle := tr.getDriverHandle()
+	if handle == nil {
+		return nil, 0, ErrTaskNotRunning
+	}
+
+	out, code, err := handle.Exec(timeout, cmd, args)
+	return out, code, err
 }
 
 func (tr *TaskRunner) Signal(event *structs.TaskEvent, s string) error {

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -126,7 +126,6 @@ func (tr *TaskRunner) initHooks() {
 			consulNamespace:     consulNamespace,
 			nomadNamespace:      tr.alloc.Job.Namespace,
 			renderOnTaskRestart: task.RestartPolicy.RenderTemplates,
-			driverHandle:        tr.handle,
 		}))
 	}
 

--- a/client/allocrunner/taskrunner/template_hook_test.go
+++ b/client/allocrunner/taskrunner/template_hook_test.go
@@ -121,10 +121,9 @@ func Test_templateHook_Prestart_ConsulWI(t *testing.T) {
 				hookResources: tt.hr,
 			}
 			h := &templateHook{
-				config:       conf,
-				logger:       logger,
-				managerLock:  sync.Mutex{},
-				driverHandle: nil,
+				config:      conf,
+				logger:      logger,
+				managerLock: sync.Mutex{},
 			}
 			req := &interfaces.TaskPrestartRequest{
 				Alloc:   a,
@@ -289,14 +288,10 @@ func TestTemplateHook_RestoreChangeModeScript(t *testing.T) {
 	envBuilder := taskenv.NewBuilder(mock.Node(), alloc, task, clientConfig.Region)
 
 	lifecycle := trtesting.NewMockTaskHooks()
+	lifecycle.SetupExecTest(117, fmt.Errorf("oh no"))
 	lifecycle.HasHandle = true
 
 	events := &trtesting.MockEmitter{}
-
-	executor := &simpleExec{
-		code: 117,
-		err:  fmt.Errorf("oh no"),
-	}
 
 	hook := newTemplateHook(&templateHookConfig{
 		alloc:     alloc,
@@ -315,7 +310,6 @@ func TestTemplateHook_RestoreChangeModeScript(t *testing.T) {
 		clientConfig:  clientConfig,
 		envBuilder:    envBuilder,
 		hookResources: &cstructs.AllocHookResources{},
-		driverHandle:  executor,
 	})
 	req := &interfaces.TaskPrestartRequest{
 		Alloc:   alloc,
@@ -334,7 +328,7 @@ func TestTemplateHook_RestoreChangeModeScript(t *testing.T) {
 	gotEvents := events.Events()
 	must.Len(t, 1, gotEvents)
 	must.Eq(t, structs.TaskHookFailed, gotEvents[0].Type)
-	must.Eq(t, "Template failed to run script echo with arguments [foo] on change: oh no Exit code: 117",
+	must.Eq(t, "Template failed to run script echo with arguments [foo] on change: oh no. Exit code: 117",
 		gotEvents[0].DisplayMessage)
 
 }


### PR DESCRIPTION
When we introduced `change_mode=script` to templates, we passed the driver handle down into the template manager so we could call its `Exec` method directly. But the lifecycle of the driver handle is managed by the taskrunner and isn't available when the template manager is first created. This has led to a series of patches trying to fixup the behavior (#15915, #15192, #23663, #23917). Part of the challenge in getting this right is using an interface to avoid the circular import of the driver handle.

But the taskrunner already has a way to deal with this problem using a "lazy handle". The other template change modes already use this indirectly through the `Lifecycle` interface. Change the driver handle `Exec` call in the template manager to a new `Lifecycle.Exec` call that reuses the existing behavior. This eliminates the need for the template manager to know anything at all about the handle state.

Fixes: https://github.com/hashicorp/nomad/issues/24051