### PR TITLE
docker: fix bug in waiting for container to exit

### DIFF
--- a/drivers/docker/handle.go
+++ b/drivers/docker/handle.go
@@ -292,12 +292,12 @@ func (h *taskHandle) run() {
 
 	h.startCpusetFixer()
 
-	ctx, cancel := context.WithTimeout(context.Background(), dockerTimeout)
-	defer cancel()
-
 	var werr error
 	var exitCode containerapi.WaitResponse
-	exitCodeC, errC := h.infinityClient.ContainerWait(ctx, h.containerID, containerapi.WaitConditionNotRunning)
+	// this needs to use the background context because the container can
+	// outlive Nomad itself
+	exitCodeC, errC := h.infinityClient.ContainerWait(
+		context.Background(), h.containerID, containerapi.WaitConditionNotRunning)
 
 	select {
 	case exitCode = <-exitCodeC:
@@ -307,6 +307,9 @@ func (h *taskHandle) run() {
 	case werr = <-errC:
 		h.logger.Error("failed to wait for container; already terminated")
 	}
+
+	ctx, inspectCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer inspectCancel()
 
 	container, ierr := h.dockerClient.ContainerInspect(ctx, h.containerID)
 	oom := false
@@ -331,7 +334,10 @@ func (h *taskHandle) run() {
 	close(h.doneCh)
 
 	// Stop the container just incase the docker daemon's wait returned
-	// incorrectly.
+	// incorrectly. Container should have exited by now so kill_timeout can be
+	// ignored.
+	ctx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer stopCancel()
 	if err := h.dockerClient.ContainerStop(ctx, h.containerID, containerapi.StopOptions{
 		Timeout: pointer.Of(0),
 	}); err != nil {


### PR DESCRIPTION
In ##23966 when we switched to using the official Docker SDK client, we had more contexts to add because most of the library methods take one. But for some APIs like waiting for a container to exit after we've started it, we never want to close this context, because the container can outlive the Nomad agent itself. If we close this context, the waiter fails and then we stop the container (after only running 5min).

* Ref: [NET-11202 (comment)](https://hashicorp.atlassian.net/browse/NET-11202?focusedCommentId=550009)
* This has shipped in Nomad 1.9.0-beta.1 but not production yet.