### PR TITLE
docker: fix non-streaming exec attachment

### DIFF
--- a/drivers/docker/handle.go
+++ b/drivers/docker/handle.go
@@ -95,7 +95,7 @@ func (h *taskHandle) Exec(ctx context.Context, cmd string, args []string) (*driv
 	}
 	exec, err := h.dockerClient.ContainerExecCreate(ctx, h.containerID, createExecOpts)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create exec object: %v", err)
 	}
 
 	execResult := &drivers.ExecTaskResult{ExitResult: &drivers.ExitResult{}}
@@ -110,12 +110,12 @@ func (h *taskHandle) Exec(ctx context.Context, cmd string, args []string) (*driv
 	}
 
 	// hijack exec output streams
-	hijacked, err := h.dockerClient.ContainerExecAttach(ctx, h.containerID, containerapi.ExecStartOptions{
+	hijacked, err := h.dockerClient.ContainerExecAttach(ctx, exec.ID, containerapi.ExecStartOptions{
 		Detach: false,
 		Tty:    false,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to attach to exec: %v", err)
 	}
 
 	_, err = stdcopy.StdCopy(stdout, stderr, hijacked.Reader)


### PR DESCRIPTION
In ##23966 when we switched to using the official Docker SDK client, this included new API calls for attaching to the "exec objects" created for running processes inside a running Docker task. When we updated the API for the non-streaming cases (script health checks, and `change_mode = "script"`), we used the container ID and not the exec object ID. These IDs aren't identical because you can have multiple exec objects for a given container. This results in errors like "unable to upgrade to tcp, received 404" because the Docker API can't find the exec object with the container ID.

* Ref: [NET-11202 (comment)](https://hashicorp.atlassian.net/browse/NET-11202?focusedCommentId=551618)
* This has shipped in Nomad 1.9.0-beta.1 but not production yet.
* I found this via hands-on testing but I suspect it's what's causing test failures overnight in E2E as well, but haven't proven that yet.