### PR TITLE
docker: fix script check execution

### DIFF
--- a/e2e/consul/input/on_update_check_restart.nomad
+++ b/e2e/consul/input/on_update_check_restart.nomad
@@ -48,7 +48,6 @@ job "test" {
         on_update = "ignore_warnings"
 
         args = [
-          "-c",
           "/local/ready.sh"
         ]
 
@@ -95,4 +94,3 @@ EOT
     }
   }
 }
-


### PR DESCRIPTION
In #24095 we made a fix for non-streaming exec into Docker tasks for script checks and `change_mode = "script"`, but didn't complete E2E testing. We need to use `ContainerExecAttach` in the new API in order to get stdout/stderr from tasklets, but the previous `ContainerExecStart` call will prevent this from running successfully with an error that the exec has already run.

* Ref: [NET-11202 (comment)](https://hashicorp.atlassian.net/browse/NET-11202?focusedCommentId=551618)
* This has shipped in Nomad 1.9.0-beta.1 but not production yet.
* This should fix the remaining issues in nightly E2E for Docker.

---

Note for reviewers: at this point the `(*taskHandle).Exec` and `(*driver).ExecTaskStreaming` are similar enough that I suspect we could at least partially merge them, but I'm trying to avoid adding more churn to this code during the beta window. I'd also like to fix this more universally for other driver authors when we tackle [NET-11219](https://hashicorp.atlassian.net/browse/NET-11219)

E2E run of the currently-failing tests:

```
$ NOMAD_E2E=1 go test -v -count=1 . -run 'TestE2E/Consul/\*consul\.OnUpdateChecksTest'
=== RUN   TestE2E
=== RUN   TestE2E/Consul
=== RUN   TestE2E/Consul/*consul.OnUpdateChecksTest
=== RUN   TestE2E/Consul/*consul.OnUpdateChecksTest/TestOnUpdateCheck_IgnoreWarning_IgnoreErrors
=== RUN   TestE2E/Consul/*consul.OnUpdateChecksTest/TestOnUpdate_CheckRestart
=== RUN   TestE2E/ConsulNamespaces
--- PASS: TestE2E (105.32s)
    --- PASS: TestE2E/Consul (105.32s)
        --- PASS: TestE2E/Consul/*consul.OnUpdateChecksTest (105.32s)
            --- PASS: TestE2E/Consul/*consul.OnUpdateChecksTest/TestOnUpdateCheck_IgnoreWarning_IgnoreErrors (67.02s)
            --- PASS: TestE2E/Consul/*consul.OnUpdateChecksTest/TestOnUpdate_CheckRestart (38.17s)
    --- PASS: TestE2E/ConsulNamespaces (0.00s)
PASS
ok      github.com/hashicorp/nomad/e2e  105.335s
```

[NET-11219]: https://hashicorp.atlassian.net/browse/NET-11219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ