### PR TITLE
tests: fixup copywrite in test file

### DIFF
--- a/command/agent/testdata/template.hcl
+++ b/command/agent/testdata/template.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 client {
   template {
     function_denylist    = ["plugin"]


### PR DESCRIPTION
In #24007 we merged new HCL files but they were missing copywrite headers because the scan didn't run on this PR for some reason. I've already backported this to the Enterprise branches.