### PR TITLE
fix: fix slice init length

### DIFF
--- a/command/node_status.go
+++ b/command/node_status.go
@@ -794,7 +794,7 @@ func formatEventDetails(details map[string]string) string {
 
 func (c *NodeStatusCommand) formatAttributes(node *api.Node) {
 	// Print the attributes
-	keys := make([]string, len(node.Attributes))
+	keys := make([]string, 0, len(node.Attributes))
 	for k := range node.Attributes {
 		keys = append(keys, k)
 	}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(node.Attributes)  rather than initializing the length of this slice.