### PR TITLE
refactor: clean up slice initialization in node status

### DIFF
--- a/command/node_status.go
+++ b/command/node_status.go
@@ -793,18 +793,16 @@ func formatEventDetails(details map[string]string) string {
 }
 
 func (c *NodeStatusCommand) formatAttributes(node *api.Node) {
-	// Print the attributes
-	keys := make([]string, len(node.Attributes))
+	keys := make([]string, 0, len(node.Attributes))
 	for k := range node.Attributes {
 		keys = append(keys, k)
 	}
+
 	sort.Strings(keys)
 
 	var attributes []string
 	for _, k := range keys {
-		if k != "" {
-			attributes = append(attributes, fmt.Sprintf("%s|%s", k, node.Attributes[k]))
-		}
+		attributes = append(attributes, fmt.Sprintf("%s|%s", k, node.Attributes[k]))
 	}
 	c.Ui.Output(c.Colorize().Color("\n[bold]Attributes[reset]"))
 	c.Ui.Output(formatKV(attributes))


### PR DESCRIPTION
We initialize this slice with a zeroed array and then append to it, which means we then have to clean out the empty strings later. Initialize to the correct capacity up front so there are no empty values.

Ref: https://github.com/hashicorp/nomad/pull/24104