### PR TITLE
docs: remove references to serf.io site

### DIFF
--- a/nomad/server.go
+++ b/nomad/server.go
@@ -1644,9 +1644,10 @@ func (s *Server) setupSerf(conf *serf.Config, ch chan serf.Event, path string) (
 			return nil, err
 		}
 	}
-	// LeavePropagateDelay is used to make sure broadcasted leave intents propagate
-	// This value was tuned using https://www.serf.io/docs/internals/simulator.html to
-	// allow for convergence in 99.9% of nodes in a 10 node cluster
+	// LeavePropagateDelay is used to make sure broadcasted leave intents
+	// propagate This value was tuned using
+	// https://github.com/hashicorp/serf/blob/master/docs/internals/simulator.html.erb
+	// to allow for convergence in 99.9% of nodes in a 10 node cluster
 	conf.LeavePropagateDelay = 1 * time.Second
 	conf.Merge = &serfMergeDelegate{}
 

--- a/website/content/docs/concepts/gossip.mdx
+++ b/website/content/docs/concepts/gossip.mdx
@@ -8,11 +8,11 @@ description: |-
 
 # Gossip Protocol
 
-Nomad uses a [gossip protocol](https://en.wikipedia.org/wiki/Gossip_protocol)
-to manage membership. This is provided through the use of the [Serf library](https://www.serf.io/).
-The gossip protocol used by Serf is based on
-["SWIM: Scalable Weakly-consistent Infection-style Process Group Membership Protocol"](https://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf),
-with a few minor adaptations. There are more details about [Serf's protocol here](https://www.serf.io/docs/concepts/gossip.html).
+Nomad uses the [Serf library][serf] to provide a [gossip
+protocol](https://en.wikipedia.org/wiki/Gossip_protocol) to manage membership.
+The gossip protocol used by Serf is based on ["SWIM: Scalable Weakly-consistent
+Infection-style Process Group Membership Protocol"][swim], with a few minor
+adaptations. There are more details about [Serf's protocol here][gossip].
 
 ~> **Advanced Topic!** This page covers technical details of
 the internals of Nomad. You do not need to know these details to effectively
@@ -21,14 +21,20 @@ to learn about them without having to go spelunking through the source code.
 
 ## Gossip in Nomad
 
-Nomad makes use of a single global WAN gossip pool that all servers participate in.
-Membership information provided by the gossip pool allows servers to perform cross region
-requests. The integrated failure detection allows Nomad to gracefully handle an entire region
-losing connectivity, or just a single server in a remote region. The gossip protocol
-is also used to detect servers in the same region to perform automatic clustering
-via the [consensus protocol](/nomad/docs/concepts/consensus).
+Nomad makes use of a single global WAN gossip pool that all servers participate
+in. Membership information provided by the gossip pool allows servers to perform
+cross region requests. The integrated failure detection allows Nomad to
+gracefully handle an entire region losing connectivity, or just a single server
+in a remote region. Nomad also uses the gossip protocol to detect servers in the
+same region to perform automatic clustering via the [consensus
+protocol](/nomad/docs/concepts/consensus).
 
-All of these features are provided by leveraging [Serf](https://www.serf.io/). It
-is used as an embedded library to provide these features. From a user perspective,
-this is not important, since the abstraction should be masked by Nomad. It can be useful
-however as a developer to understand how this library is leveraged.
+To provide all these features, Nomad uses [Serf][serf] as an embedded
+library. From a user perspective, this is not important, since Nomad masks the
+abstraction. However, developers may find it useful to understand how Nomad
+leverages the Serf library.
+
+
+[serf]: https://github.com/hashicorp/serf
+[gossip]: https://github.com/hashicorp/serf/blob/master/docs/internals/gossip.html.markdown
+[swim]: https://www.cs.cornell.edu/projects/Quicksilver/public_pdfs/SWIM.pdf

--- a/website/content/docs/concepts/security.mdx
+++ b/website/content/docs/concepts/security.mdx
@@ -333,14 +333,15 @@ There are two main components to consider to for external threats in a Nomad clu
 
 ### Network Ports
 
-| **Port / Protocol**  | Agents  | Description                                                                                                                                                                         |
-| -------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Port / Protocol**  | Agents  | Description                                                                                                                                                           |
+|----------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **4646** / TCP       | All     | [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol) to provide [UI](/nomad/tutorials/web-ui/web-ui-access) and [API](/nomad/api-docs) access to agents. |
-| **4647** / TCP       | All     | [RPC](https://en.wikipedia.org/wiki/Remote_procedure_call) protocol used by agents.                                                                                                 |
-| **4648** / TCP + UDP | Servers | [gossip](/nomad/docs/concepts/gossip) protocol to manage server membership using [Serf](https://www.serf.io/).                                                                           |
+| **4647** / TCP       | All     | [RPC](https://en.wikipedia.org/wiki/Remote_procedure_call) protocol used by agents.                                                                                   |
+| **4648** / TCP + UDP | Servers | [gossip](/nomad/docs/concepts/gossip) protocol to manage server membership using [Serf][serf].                                                                        |
 
 
 [api_metrics]: /nomad/api-docs/metrics
 [api_status_peers]: /nomad/api-docs/status#list-peers
 [Variables]: /nomad/docs/concepts/variables
 [verify_https_client]: /nomad/docs/configuration/tls#verify_https_client
+[serf]: https://github.com/hashicorp/serf


### PR DESCRIPTION
The serf.io site is being taken down, so change all our links to point to the repo docs instead.

Ref: https://github.com/hashicorp/serf/pull/743