### PR TITLE
test: wait for keyring in plan submission tests

### DIFF
--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -449,7 +449,7 @@ func TestWorker_SubmitPlan(t *testing.T) {
 		c.EnabledSchedulers = []string{structs.JobTypeService}
 	})
 	defer cleanupS1()
-	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForKeyring(t, s1.RPC, s1.Region())
 
 	// Register node
 	node := mock.Node()


### PR DESCRIPTION
In #23977 we merged a change to how the keyring was stored. Because keyring initialization takes slightly longer now, this uncovered existing timing bugs in some of our tests where tests that require the keyring (ex. plan applier tests) were waiting for the leader but not the keyring initialization. Fix another example we've seen causing test flakes.

Ref: https://github.com/hashicorp/nomad/pull/24021 for an earlier example