### PR TITLE
start: allow users to call job start command to start stopped jobs

### DIFF
--- a/.changelog/24150.txt
+++ b/.changelog/24150.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added job start command to allow starting a stopped job from the cli
+```

--- a/command/commands.go
+++ b/command/commands.go
@@ -524,6 +524,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"job start": func() (cli.Command, error) {
+			return &JobStartCommand{
+				Meta: meta,
+			}, nil
+		},
 		"job tag": func() (cli.Command, error) {
 			return &JobTagCommand{
 				Meta: meta,

--- a/command/commands.go
+++ b/command/commands.go
@@ -1104,6 +1104,11 @@ func Commands(metaPtr *Meta, agentUi cli.Ui) map[string]cli.CommandFactory {
 				Meta: meta,
 			}, nil
 		},
+		"start": func() (cli.Command, error) {
+			return &JobStartCommand{
+				Meta: meta,
+			}, nil
+		},
 		"system": func() (cli.Command, error) {
 			return &SystemCommand{
 				Meta: meta,

--- a/command/job_start.go
+++ b/command/job_start.go
@@ -1,0 +1,252 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"fmt"
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/posener/complete"
+	"os"
+	"strings"
+	"sync"
+)
+
+type JobStartCommand struct {
+	Meta
+}
+
+func (c *JobStartCommand) Help() string {
+	helpText := `
+Usage: nomad job start [options] <job>
+Alias: nomad start
+
+  Start an existing stopped job. This command is used to start a previously stopped job's
+  most recent running version up. Upon successful start, an interactive
+  monitor session will start to display log lines as the job starts up its
+  allocations based on its most recent running version. It is safe to exit the monitor
+  early using ctrl+c.
+
+  When ACLs are enabled, this command requires a token with the 'submit-job'
+  and 'read-job' capabilities for the job's namespace. The 'list-jobs'
+  capability is required to run the command with job prefixes instead of exact
+  job IDs.
+
+
+General Options:
+
+  ` + generalOptionsUsage(usageOptsDefault) + `
+
+Start Options:
+
+  -detach
+    Return immediately instead of entering monitor mode. After the
+    job start command is submitted, a new evaluation ID is printed to the
+    screen, which can be used to examine the evaluation using the eval-status
+    command.
+
+  -consul-token
+   The Consul token used to verify that the caller has access to the Service
+   Identity policies associated in the targeted version of the job.
+
+  -vault-token
+   The Vault token used to verify that the caller has access to the Vault
+   policies in the targeted version of the job.
+
+  -verbose
+    Display full information.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *JobStartCommand) Synopsis() string {
+	return "Start a stopped job"
+}
+
+func (c *JobStartCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-detach":  complete.PredictNothing,
+			"-verbose": complete.PredictNothing,
+		})
+}
+
+func (c *JobStartCommand) AutocompleteArgs() complete.Predictor {
+	return complete.PredictFunc(func(a complete.Args) []string {
+		client, err := c.Meta.Client()
+		if err != nil {
+			return nil
+		}
+
+		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
+		if err != nil {
+			return []string{}
+		}
+		return resp.Matches[contexts.Jobs]
+	})
+}
+func (c *JobStartCommand) Name() string { return "job start" }
+
+func (c *JobStartCommand) Run(args []string) int {
+	var detach, verbose bool
+	var consulToken, vaultToken string
+
+	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
+	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.BoolVar(&detach, "detach", false, "")
+	flags.BoolVar(&verbose, "verbose", false, "")
+	flags.StringVar(&consulToken, "consul-token", "", "")
+	flags.StringVar(&vaultToken, "vault-token", "", "")
+
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	// Check that we got at least one job
+	args = flags.Args()
+	if len(args) < 1 {
+		c.Ui.Error("This command takes at least one argument: <job>")
+		c.Ui.Error(commandErrorText(c))
+		return 1
+	}
+
+	var jobIDs []string
+	for _, jobID := range flags.Args() {
+		jobIDs = append(jobIDs, strings.TrimSpace(jobID))
+	}
+
+	// Get the HTTP client
+	client, err := c.Meta.Client()
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
+		return 1
+	}
+
+	statusCh := make(chan int, len(jobIDs))
+	var wg sync.WaitGroup
+
+	for _, jobID := range jobIDs {
+		jobID := jobID
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			// Truncate the id unless full length is requested
+			length := shortId
+			if verbose {
+				length = fullId
+			}
+
+			// Check if the job exists and has been stopped
+			jobId, namespace, err := c.JobIDByPrefix(client, jobID, nil)
+			if err != nil {
+				c.Ui.Error(err.Error())
+				statusCh <- 1
+				return
+			}
+			job, err := c.JobByPrefix(client, jobId, nil)
+			if err != nil {
+				c.Ui.Error(err.Error())
+				statusCh <- 1
+				return
+			}
+			if *job.Status != "dead" {
+				c.Ui.Error(fmt.Sprintf("Job  %v has not been stopped and has following status: %v", *job.Name, *job.Status))
+				statusCh <- 1
+				return
+
+			}
+
+			// Get all versions associated to current job
+			q := &api.QueryOptions{Namespace: namespace}
+
+			versions, _, _, err := client.Jobs().Versions(jobID, true, q)
+			if err != nil {
+				c.Ui.Error(fmt.Sprintf("Error retrieving job versions: %s", err))
+				statusCh <- 1
+			}
+
+			// Find the most recent running version for this job
+			var chosenVersion *api.Job
+			var chosenIndex uint64
+			versionAvailable := false
+			for i := len(versions) - 1; i >= 0; i-- {
+				if *versions[i].Status == "running" {
+					chosenVersion = versions[i]
+					chosenIndex = uint64(i)
+					versionAvailable = true
+				}
+
+			}
+			if !versionAvailable {
+				c.Ui.Error(fmt.Sprintf("No previous running versions of job %v,  %s", chosenVersion, err))
+				statusCh <- 1
+				return
+			}
+
+			// Parse the Consul token
+			if consulToken == "" {
+				// Check the environment variable
+				consulToken = os.Getenv("CONSUL_HTTP_TOKEN")
+			}
+
+			// Parse the Vault token
+			if vaultToken == "" {
+				// Check the environment variable
+				vaultToken = os.Getenv("VAULT_TOKEN")
+			}
+
+			// Revert to most recent running version!
+			m := &api.WriteOptions{Namespace: namespace}
+			resp, _, err := client.Jobs().Revert(jobID, chosenIndex, nil, m, consulToken, vaultToken)
+			if err != nil {
+				c.Ui.Error(fmt.Sprintf("Error retrieving job versions: %s, %v", err, chosenIndex))
+				statusCh <- 1
+				return
+			}
+			if *job.Name == "bridge2" {
+				c.Ui.Output(fmt.Sprintf("HERE"))
+
+			}
+
+			// Nothing to do
+			evalCreated := resp.EvalID != ""
+
+			if !evalCreated {
+				statusCh <- 0
+				return
+			}
+
+			if detach {
+				c.Ui.Output("Evaluation ID: " + resp.EvalID)
+				statusCh <- 0
+				return
+			}
+
+			mon := newMonitor(c.Ui, client, length)
+			statusCh <- mon.monitor(resp.EvalID)
+
+		}()
+	}
+	// users will still see
+	// errors if any while we
+	// wait for the goroutines
+	// to finish processing
+	wg.Wait()
+
+	// close the channel to ensure
+	// the range statement below
+	// doesn't go on indefinitely
+	close(statusCh)
+
+	// return a non-zero exit code
+	// if even a single job start fails
+	for status := range statusCh {
+		if status != 0 {
+			return status
+		}
+	}
+	return 0
+}

--- a/command/job_start.go
+++ b/command/job_start.go
@@ -172,7 +172,7 @@ func (c *JobStartCommand) Run(args []string) int {
 			var chosenIndex uint64
 			versionAvailable := false
 			for i := len(versions) - 1; i >= 0; i-- {
-				if *versions[i].Status == "running" && *versions[i].Stop == true {
+				if *versions[i].Status == "running" && *versions[i].Stop {
 					chosenIndex = uint64(i)
 					versionAvailable = true
 					break

--- a/command/job_start.go
+++ b/command/job_start.go
@@ -206,10 +206,6 @@ func (c *JobStartCommand) Run(args []string) int {
 				statusCh <- 1
 				return
 			}
-			if *job.Name == "bridge2" {
-				c.Ui.Output(fmt.Sprintf("HERE"))
-
-			}
 
 			// Nothing to do
 			evalCreated := resp.EvalID != ""

--- a/command/job_start.go
+++ b/command/job_start.go
@@ -198,7 +198,6 @@ func (c *JobStartCommand) Run(args []string) int {
 				statusCh <- 1
 				return
 			}
-			versions, _, _, err = client.Jobs().Versions(*job.ID, true, q)
 
 			// Nothing to do: periodic or dispatch job
 			evalCreated := resp.EvalID != ""

--- a/command/job_start.go
+++ b/command/job_start.go
@@ -25,9 +25,9 @@ Usage: nomad job start [options] <job>
 Alias: nomad start
 
   Start an existing stopped job. This command is used to start a previously stopped job's
-  most recent running version. Upon successful start, an interactive
+  most recent version. Upon successful start, an interactive
   monitor session will start to display log lines as the job starts its
-  allocations based on its most recent running version. It is safe to exit the monitor
+  allocations based on its most recent version. It is safe to exit the monitor
   early using ctrl+c.
 
   When ACLs are enabled, this command requires a token with the 'submit-job'
@@ -174,8 +174,9 @@ func (c *JobStartCommand) Run(args []string) int {
 
 			}
 			c.versionSelected = chosenVersion
+
 			if !versionAvailable {
-				c.Ui.Error(fmt.Sprintf("No previous running versions of job %v", *job.Name))
+				c.Ui.Error(fmt.Sprintf("No previous available versions of job %v", *job.Name))
 				statusCh <- 1
 				return
 			}

--- a/command/job_start.go
+++ b/command/job_start.go
@@ -16,7 +16,8 @@ import (
 
 type JobStartCommand struct {
 	Meta
-	versionSelected uint64
+	versionCh chan uint64
+	Eval      string
 }
 
 func (c *JobStartCommand) Help() string {
@@ -24,39 +25,48 @@ func (c *JobStartCommand) Help() string {
 Usage: nomad job start [options] <job>
 Alias: nomad start
 
-  Start an existing stopped job. This command is used to start a previously stopped job's
-  most recent version. Upon successful start, an interactive
-  monitor session will start to display log lines as the job starts its
-  allocations based on its most recent version. It is safe to exit the monitor
-  early using ctrl+c.
 
-  When ACLs are enabled, this command requires a token with the 'submit-job'
-  and 'read-job' capabilities for the job's namespace. The 'list-jobs'
-  capability is required to run the command with job prefixes instead of exact
-  job IDs.
+ Start one or multiple stopped jobs. This command is used to start a previously stopped job's
+ most recent version. Upon successful start, an interactive
+ monitor session will start to display log lines as the job starts its
+ allocations based on its most recent version. It is safe to exit the monitor
+ early using ctrl+c.
+
+
+ When ACLs are enabled, this command requires a token with the 'submit-job'
+ and 'read-job' capabilities for the job's namespace. The 'list-jobs'
+ capability is required to run the command with job prefixes instead of exact
+ job IDs.
+
 
 General Options:
 
-  ` + generalOptionsUsage(usageOptsDefault) + `
+
+ ` + generalOptionsUsage(usageOptsDefault) + `
+
 
 Start Options:
 
-  -detach
-    Return immediately instead of entering monitor mode. After the
-    job start command is submitted, a new evaluation ID is printed to the
-    screen, which can be used to examine the evaluation using the eval-status
-    command.
 
-  -consul-token
-   The Consul token used to verify that the caller has access to the Service
-   Identity policies associated in the targeted version of the job.
+ -detach
+   Return immediately instead of entering monitor mode. After the
+   job start command is submitted, a new evaluation ID is printed to the
+   screen, which can be used to examine the evaluation using the eval-status
+   command.
 
-  -vault-token
-   The Vault token used to verify that the caller has access to the Vault
-   policies in the targeted version of the job.
 
-  -verbose
-    Display full information.
+ -consul-token
+  The Consul token used to verify that the caller has access to the Service
+  Identity policies associated in the targeted version of the job.
+
+
+ -vault-token
+  The Vault token used to verify that the caller has access to the Vault
+  policies in the targeted version of the job.
+
+
+ -verbose
+   Display full information.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -123,8 +133,16 @@ func (c *JobStartCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
 		return 1
 	}
+	if consulToken == "" {
+		consulToken = os.Getenv("CONSUL_HTTP_TOKEN")
+	}
+
+	if vaultToken == "" {
+		vaultToken = os.Getenv("VAULT_TOKEN")
+	}
 
 	statusCh := make(chan int, len(jobIDs))
+	c.versionCh = make(chan uint64, len(args))
 	var wg sync.WaitGroup
 
 	for _, jobIDPrefix := range jobIDs {
@@ -152,42 +170,14 @@ func (c *JobStartCommand) Run(args []string) int {
 				return
 
 			}
-
-			// Get all versions associated to current job
-			q := &api.QueryOptions{Namespace: *job.Namespace}
-
-			versions, _, _, err := client.Jobs().Versions(*job.ID, true, q)
+			chosenVersion, err := c.GetSelectedVersion(client, job, *job.Namespace)
 			if err != nil {
-				c.Ui.Error(fmt.Sprintf("Error retrieving job versions: %s", err))
-				statusCh <- 1
-			}
-
-			// Find the most recent version for this job that has not been stopped
-			var chosenVersion uint64
-			versionAvailable := false
-			for i := range versions {
-				if !*versions[i].Stop {
-					chosenVersion = *versions[i].Version
-					versionAvailable = true
-					break
-				}
-
-			}
-			c.versionSelected = chosenVersion
-
-			if !versionAvailable {
-				c.Ui.Error(fmt.Sprintf("No previous available versions of job %v", *job.Name))
+				c.Ui.Error(err.Error())
 				statusCh <- 1
 				return
 			}
 
-			if consulToken == "" {
-				consulToken = os.Getenv("CONSUL_HTTP_TOKEN")
-			}
-
-			if vaultToken == "" {
-				vaultToken = os.Getenv("VAULT_TOKEN")
-			}
+			c.versionCh <- chosenVersion
 
 			// Revert to most recent running version!
 			m := &api.WriteOptions{Namespace: *job.Namespace}
@@ -206,6 +196,7 @@ func (c *JobStartCommand) Run(args []string) int {
 				statusCh <- 0
 				return
 			}
+			c.Eval = resp.EvalID
 
 			if detach {
 				c.Ui.Output("Evaluation ID: " + resp.EvalID)
@@ -227,6 +218,7 @@ func (c *JobStartCommand) Run(args []string) int {
 	// close the channel to ensure
 	// the range statement below
 	// doesn't go on indefinitely
+	close(c.versionCh)
 	close(statusCh)
 
 	// return a non-zero exit code
@@ -237,4 +229,33 @@ func (c *JobStartCommand) Run(args []string) int {
 		}
 	}
 	return 0
+}
+func (c *JobStartCommand) GetSelectedVersion(client *api.Client, job *api.Job, namespace string) (uint64, error) {
+
+	// Get all versions associated to current job
+	q := &api.QueryOptions{Namespace: *job.Namespace}
+
+	versions, _, _, err := client.Jobs().Versions(*job.ID, true, q)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error retrieving job versions: %s", err))
+		return 0, fmt.Errorf("error retrieving job versions: %s", err)
+	}
+
+	// Find the most recent version for this job that has not been stopped
+	var chosenVersion uint64
+	versionAvailable := false
+	for _, version := range versions {
+		if !*version.Stop && *version.Status == "running" {
+			chosenVersion = *version.Version
+			versionAvailable = true
+			break
+		}
+	}
+	if !versionAvailable {
+		c.Ui.Error(fmt.Sprintf("No previous available versions of job %v", *job.Name))
+		return 0, fmt.Errorf("no previous available versions of job %v", *job.Name)
+	}
+
+	return chosenVersion, nil
+
 }

--- a/command/job_start.go
+++ b/command/job_start.go
@@ -5,7 +5,6 @@ package command
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -51,17 +50,6 @@ Start Options:
    screen, which can be used to examine the evaluation using the eval-status
    command.
 
-
- -consul-token
-  The Consul token used to verify that the caller has access to the Service
-  Identity policies associated in the targeted version of the job.
-
-
- -vault-token
-  The Vault token used to verify that the caller has access to the Vault
-  policies in the targeted version of the job.
-
-
  -verbose
    Display full information.
 `
@@ -98,14 +86,11 @@ func (c *JobStartCommand) Name() string { return "job start" }
 
 func (c *JobStartCommand) Run(args []string) int {
 	var detach, verbose bool
-	var consulToken, vaultToken string
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.BoolVar(&detach, "detach", false, "")
 	flags.BoolVar(&verbose, "verbose", false, "")
-	flags.StringVar(&consulToken, "consul-token", "", "")
-	flags.StringVar(&vaultToken, "vault-token", "", "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -126,13 +111,6 @@ func (c *JobStartCommand) Run(args []string) int {
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error initializing client: %s", err))
 		return 1
-	}
-	if consulToken == "" {
-		consulToken = os.Getenv("CONSUL_HTTP_TOKEN")
-	}
-
-	if vaultToken == "" {
-		vaultToken = os.Getenv("VAULT_TOKEN")
 	}
 
 	// Truncate the id unless full length is requested

--- a/command/job_start.go
+++ b/command/job_start.go
@@ -111,7 +111,7 @@ func (c *JobStartCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Check that we got exactly one arguement
+	// Check that we got exactly one argument
 	args = flags.Args()
 	if len(args) != 1 {
 		c.Ui.Error("This command takes one argument: <job>")

--- a/command/job_start.go
+++ b/command/job_start.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"sync"
+	"time"
 
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
@@ -16,8 +16,6 @@ import (
 
 type JobStartCommand struct {
 	Meta
-	versionCh chan uint64
-	Eval      string
 }
 
 func (c *JobStartCommand) Help() string {
@@ -26,11 +24,10 @@ Usage: nomad job start [options] <job>
 Alias: nomad start
 
 
- Start one or multiple stopped jobs. This command is used to start a previously stopped job's
- most recent version. Upon successful start, an interactive
- monitor session will start to display log lines as the job starts its
- allocations based on its most recent version. It is safe to exit the monitor
- early using ctrl+c.
+ Starts a stopped job. The job must be currently registered with Nomad. Upon
+ successful start, an interactive monitor session will start to display log
+ lines as the job starts its allocations based on its most recent version.
+ It is safe to exit the monitor early using ctrl+c.
 
 
  When ACLs are enabled, this command requires a token with the 'submit-job'
@@ -114,18 +111,15 @@ func (c *JobStartCommand) Run(args []string) int {
 		return 1
 	}
 
-	// Check that we got at least one job
+	// Check that we got exactly one arguement
 	args = flags.Args()
-	if len(args) < 1 {
-		c.Ui.Error("This command takes at least one argument: <job>")
+	if len(args) != 1 {
+		c.Ui.Error("This command takes one argument: <job>")
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}
 
-	var jobIDs []string
-	for _, jobID := range flags.Args() {
-		jobIDs = append(jobIDs, strings.TrimSpace(jobID))
-	}
+	jobIDPrefix := strings.TrimSpace(args[0])
 
 	// Get the HTTP client
 	client, err := c.Meta.Client()
@@ -141,121 +135,98 @@ func (c *JobStartCommand) Run(args []string) int {
 		vaultToken = os.Getenv("VAULT_TOKEN")
 	}
 
-	statusCh := make(chan int, len(jobIDs))
-	c.versionCh = make(chan uint64, len(args))
-	var wg sync.WaitGroup
-
-	for _, jobIDPrefix := range jobIDs {
-
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-
-			// Truncate the id unless full length is requested
-			length := shortId
-			if verbose {
-				length = fullId
-			}
-
-			job, err := c.JobByPrefix(client, jobIDPrefix, nil)
-			if err != nil {
-				c.Ui.Error(err.Error())
-				statusCh <- 1
-				return
-			}
-
-			if *job.Status != "dead" {
-				c.Ui.Info(fmt.Sprintf("Job  %v has not been stopped and has the following status: %v", *job.Name, *job.Status))
-				statusCh <- 0
-				return
-
-			}
-			chosenVersion, err := c.GetSelectedVersion(client, job, *job.Namespace)
-			if err != nil {
-				c.Ui.Error(err.Error())
-				statusCh <- 1
-				return
-			}
-
-			c.versionCh <- chosenVersion
-
-			// Revert to most recent running version!
-			m := &api.WriteOptions{Namespace: *job.Namespace}
-
-			resp, _, err := client.Jobs().Revert(*job.ID, chosenVersion, nil, m, consulToken, vaultToken)
-			if err != nil {
-				c.Ui.Error(fmt.Sprintf("Error retrieving job version %v for job %s: %s,", chosenVersion, *job.ID, err))
-				statusCh <- 1
-				return
-			}
-
-			// Nothing to do: periodic or dispatch job
-			evalCreated := resp.EvalID != ""
-
-			if !evalCreated {
-				statusCh <- 0
-				return
-			}
-			c.Eval = resp.EvalID
-
-			if detach {
-				c.Ui.Output("Evaluation ID: " + resp.EvalID)
-				statusCh <- 0
-				return
-			}
-
-			mon := newMonitor(c.Ui, client, length)
-			statusCh <- mon.monitor(resp.EvalID)
-
-		}()
+	// Truncate the id unless full length is requested
+	length := shortId
+	if verbose {
+		length = fullId
 	}
-	// users will still see
-	// errors if any while we
-	// wait for the goroutines
-	// to finish processing
-	wg.Wait()
 
-	// close the channel to ensure
-	// the range statement below
-	// doesn't go on indefinitely
-	close(c.versionCh)
-	close(statusCh)
+	job, err := c.JobByPrefix(client, jobIDPrefix, nil)
+	if err != nil {
+		fmt.Println("error getting job!")
+		c.Ui.Error(err.Error())
+		return 1
+	}
 
-	// return a non-zero exit code
-	// if even a single job start fails
-	for status := range statusCh {
-		if status != 0 {
-			return status
+	var jobID, jobName, namespace string
+
+	if job.ID != nil {
+		jobID = *job.ID
+	}
+	if job.Name != nil {
+		jobName = *job.Name
+	}
+	if job.Namespace != nil {
+		namespace = *job.Namespace
+	}
+
+	if job.Stop != nil && !*job.Stop {
+		c.Ui.Error(fmt.Sprintf("Job '%v' has not been stopped", jobName))
+		return 1
+	}
+
+	chosenVersion, err := c.GetSelectedVersion(client, jobID, namespace)
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	// Revert to most recent non-stopped version!
+	m := &api.WriteOptions{Namespace: namespace}
+	resp, _, err := client.Jobs().Revert(jobID, chosenVersion, nil, m, consulToken, vaultToken)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error retrieving job version %v for job %s: %s,", chosenVersion, jobID, err))
+		return 1
+	}
+
+	// Check if the job is periodic or is a parameterized job
+	periodic := job.IsPeriodic()
+	paramjob := job.IsParameterized()
+	multiregion := job.IsMultiregion()
+	if detach || periodic || paramjob || multiregion {
+		c.Ui.Output("Job start successful")
+		if periodic && !paramjob {
+			loc, err := job.Periodic.GetLocation()
+			if err == nil {
+				now := time.Now().In(loc)
+				next, err := job.Periodic.Next(now)
+				if err != nil {
+					c.Ui.Error(fmt.Sprintf("Error determining next launch time: %v", err))
+				} else {
+					c.Ui.Output(fmt.Sprintf("Approximate next launch time: %s (%s from now)",
+						formatTime(next), formatTimeDifference(now, next, time.Second)))
+				}
+			}
+		} else if !paramjob {
+			c.Ui.Output("Evaluation ID: " + resp.EvalID)
 		}
+
+		return 0
 	}
-	return 0
+
+	mon := newMonitor(c.Ui, client, length)
+	return mon.monitor(resp.EvalID)
 }
-func (c *JobStartCommand) GetSelectedVersion(client *api.Client, job *api.Job, namespace string) (uint64, error) {
+
+func (c *JobStartCommand) GetSelectedVersion(client *api.Client, jobID string, namespace string) (uint64, error) {
 
 	// Get all versions associated to current job
-	q := &api.QueryOptions{Namespace: *job.Namespace}
+	q := &api.QueryOptions{Namespace: namespace}
 
-	versions, _, _, err := client.Jobs().Versions(*job.ID, true, q)
+	// Versions are returned in sorted order
+	versions, _, _, err := client.Jobs().Versions(jobID, true, q)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error retrieving job versions: %s", err))
-		return 0, fmt.Errorf("error retrieving job versions: %s", err)
+		return 0, fmt.Errorf("Error retrieving job versions: %s", err)
 	}
 
 	// Find the most recent version for this job that has not been stopped
-	var chosenVersion uint64
-	versionAvailable := false
 	for _, version := range versions {
-		if !*version.Stop && *version.Status == "running" {
-			chosenVersion = *version.Version
-			versionAvailable = true
-			break
+		if version.Stop == nil {
+			continue
+		}
+		if !*version.Stop {
+			return *version.Version, nil
 		}
 	}
-	if !versionAvailable {
-		c.Ui.Error(fmt.Sprintf("No previous available versions of job %v", *job.Name))
-		return 0, fmt.Errorf("no previous available versions of job %v", *job.Name)
-	}
-
-	return chosenVersion, nil
-
+	return 0, fmt.Errorf("No valid job version available to start")
 }

--- a/command/job_start_test.go
+++ b/command/job_start_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package command
 
 import (

--- a/command/job_start_test.go
+++ b/command/job_start_test.go
@@ -2,19 +2,18 @@ package command
 
 import (
 	"encoding/json"
-	"github.com/hashicorp/nomad/nomad/mock"
-	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/posener/complete"
-	"os"
-	"path/filepath"
-	"testing"
-
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/mitchellh/cli"
+	"github.com/posener/complete"
 	"github.com/shoenig/test/must"
+	"os"
+	"path/filepath"
+	"testing"
 )
 
 var _ cli.Command = (*JobStartCommand)(nil)
@@ -55,7 +54,7 @@ func TestJobStartCommand_Fails(t *testing.T) {
 	out = ui.ErrorWriter.String()
 	must.StrContains(t, out, "Error querying job prefix")
 
-	// Fails on attempting to start a job that's not been stopped
+	// Info on attempting to start a job that's not been stopped
 	jobID := uuid.Generate()
 	jobFilePath := filepath.Join(os.TempDir(), jobID+".nomad")
 
@@ -85,8 +84,8 @@ func TestJobStartCommand_Fails(t *testing.T) {
 	)
 
 	code = cmd.Run([]string{"-address=" + addr, jobID})
-	must.One(t, code)
-	out = ui.ErrorWriter.String()
+	must.Zero(t, code)
+	out = ui.OutputWriter.String()
 	must.StrContains(t, out, "has not been stopped and has following status:")
 
 }
@@ -98,7 +97,6 @@ func TestStartCommand_ManyJobs(t *testing.T) {
 		c.DevMode = true
 	})
 	defer srv.Shutdown()
-
 	// the number of jobs we want to run
 	numJobs := 10
 
@@ -140,11 +138,13 @@ func TestStartCommand_ManyJobs(t *testing.T) {
 		must.NoError(t, err)
 
 		cmd := &JobRunCommand{Meta: Meta{Ui: ui}}
+
 		code := cmd.Run([]string{"-address", addr, "-json", jobFile})
 		must.Zero(t, code,
 			must.Sprintf("job stop stdout: %s", ui.OutputWriter.String()),
 			must.Sprintf("job stop stderr: %s", ui.ErrorWriter.String()),
 		)
+
 	}
 
 	// helper for stopping a list of jobs
@@ -175,7 +175,9 @@ func TestStartCommand_ManyJobs(t *testing.T) {
 		must.Sprintf("job start stdout: %s", stdout),
 		must.Sprintf("job start stderr: %s", stderr),
 	)
+
 }
+
 func TestStartCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
 

--- a/command/job_start_test.go
+++ b/command/job_start_test.go
@@ -1,0 +1,200 @@
+package command
+
+import (
+	"encoding/json"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/posener/complete"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/command/agent"
+	"github.com/hashicorp/nomad/helper/pointer"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/mitchellh/cli"
+	"github.com/shoenig/test/must"
+)
+
+var _ cli.Command = (*JobStartCommand)(nil)
+
+func TestJobStartCommand_Fails(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, _, addr := testServer(t, true, func(c *agent.Config) {
+		c.DevMode = true
+	})
+	defer srv.Shutdown()
+
+	ui := cli.NewMockUi()
+	cmd := &JobStartCommand{Meta: Meta{Ui: ui}}
+
+	// Fails on misuse
+	code := cmd.Run([]string{"-bad", "-flag"})
+	must.One(t, code)
+
+	out := ui.ErrorWriter.String()
+	must.StrContains(t, out, "flag provided but not defined: -bad")
+
+	ui.ErrorWriter.Reset()
+
+	// Fails on nonexistent job ID
+	code = cmd.Run([]string{"-address=" + addr, "non-existent"})
+	must.One(t, code)
+
+	out = ui.ErrorWriter.String()
+	must.StrContains(t, out, "No job(s) with prefix or ID")
+
+	ui.ErrorWriter.Reset()
+
+	// Fails on connection failure
+	code = cmd.Run([]string{"-address=nope", "n"})
+	must.One(t, code)
+
+	out = ui.ErrorWriter.String()
+	must.StrContains(t, out, "Error querying job prefix")
+
+	// Fails on attempting to start a job that's not been stopped
+	jobID := uuid.Generate()
+	jobFilePath := filepath.Join(os.TempDir(), jobID+".nomad")
+
+	t.Cleanup(func() {
+		_ = os.Remove(jobFilePath)
+	})
+	job := testJob(jobID)
+	job.TaskGroups[0].Tasks[0].Resources.MemoryMB = pointer.Of(16)
+	job.TaskGroups[0].Tasks[0].Resources.DiskMB = pointer.Of(32)
+	job.TaskGroups[0].Tasks[0].Resources.CPU = pointer.Of(10)
+	job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+		"run_for": "30s",
+	}
+
+	jobJSON, err := json.MarshalIndent(job, "", " ")
+	must.NoError(t, err)
+
+	jobFile := jobFilePath
+	err = os.WriteFile(jobFile, []byte(jobJSON), 0o644)
+	must.NoError(t, err)
+
+	runCmd := &JobRunCommand{Meta: Meta{Ui: ui}}
+	code = runCmd.Run([]string{"-address", addr, "-json", jobFile})
+	must.Zero(t, code,
+		must.Sprintf("job stop stdout: %s", ui.OutputWriter.String()),
+		must.Sprintf("job stop stderr: %s", ui.ErrorWriter.String()),
+	)
+
+	code = cmd.Run([]string{"-address=" + addr, jobID})
+	must.One(t, code)
+	out = ui.ErrorWriter.String()
+	must.StrContains(t, out, "has not been stopped and has following status:")
+
+}
+
+func TestStartCommand_ManyJobs(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, _, addr := testServer(t, true, func(c *agent.Config) {
+		c.DevMode = true
+	})
+	defer srv.Shutdown()
+
+	// the number of jobs we want to run
+	numJobs := 10
+
+	// create and run a handful of jobs
+	jobIDs := make([]string, 0, numJobs)
+	for i := 0; i < numJobs; i++ {
+		jobID := uuid.Generate()
+		jobIDs = append(jobIDs, jobID)
+	}
+
+	jobFilePath := func(jobID string) string {
+		return filepath.Join(os.TempDir(), jobID+".nomad")
+	}
+
+	// cleanup job files we will create
+	t.Cleanup(func() {
+		for _, jobID := range jobIDs {
+			_ = os.Remove(jobFilePath(jobID))
+		}
+	})
+
+	// record cli output
+	ui := cli.NewMockUi()
+
+	for _, jobID := range jobIDs {
+		job := testJob(jobID)
+		job.TaskGroups[0].Tasks[0].Resources.MemoryMB = pointer.Of(16)
+		job.TaskGroups[0].Tasks[0].Resources.DiskMB = pointer.Of(32)
+		job.TaskGroups[0].Tasks[0].Resources.CPU = pointer.Of(10)
+		job.TaskGroups[0].Tasks[0].Config = map[string]interface{}{
+			"run_for": "30s",
+		}
+
+		jobJSON, err := json.MarshalIndent(job, "", " ")
+		must.NoError(t, err)
+
+		jobFile := jobFilePath(jobID)
+		err = os.WriteFile(jobFile, []byte(jobJSON), 0o644)
+		must.NoError(t, err)
+
+		cmd := &JobRunCommand{Meta: Meta{Ui: ui}}
+		code := cmd.Run([]string{"-address", addr, "-json", jobFile})
+		must.Zero(t, code,
+			must.Sprintf("job stop stdout: %s", ui.OutputWriter.String()),
+			must.Sprintf("job stop stderr: %s", ui.ErrorWriter.String()),
+		)
+	}
+
+	// helper for stopping a list of jobs
+	stop := func(args ...string) (stdout string, stderr string, code int) {
+		cmd := &JobStopCommand{Meta: Meta{Ui: ui}}
+		code = cmd.Run(args)
+		return ui.OutputWriter.String(), ui.ErrorWriter.String(), code
+	}
+	// helper for starting a list of jobs
+	start := func(args ...string) (stdout string, stderr string, code int) {
+		cmd := &JobStartCommand{Meta: Meta{Ui: ui}}
+		code = cmd.Run(args)
+		return ui.OutputWriter.String(), ui.ErrorWriter.String(), code
+	}
+
+	// stop all jobs in one command
+	args := []string{"-address", addr, "-detach"}
+	args = append(args, jobIDs...)
+	stdout, stderr, code := stop(args...)
+	must.Zero(t, code,
+		must.Sprintf("job stop stdout: %s", stdout),
+		must.Sprintf("job stop stderr: %s", stderr),
+	)
+
+	// start all jobs again in one command
+	stdout, stderr, code = start(args...)
+	must.Zero(t, code,
+		must.Sprintf("job start stdout: %s", stdout),
+		must.Sprintf("job start stderr: %s", stderr),
+	)
+}
+func TestStartCommand_AutocompleteArgs(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := cli.NewMockUi()
+	cmd := &JobStartCommand{Meta: Meta{Ui: ui, flagAddress: url}}
+
+	// Create a fake job
+	state := srv.Agent.Server().State()
+	j := mock.Job()
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, j))
+
+	prefix := j.ID[:len(j.ID)-5]
+	args := complete.Args{Last: prefix}
+	predictor := cmd.AutocompleteArgs()
+
+	res := predictor.Predict(args)
+	must.Len(t, 1, res)
+	must.Eq(t, j.ID, res[0])
+}

--- a/command/job_start_test.go
+++ b/command/job_start_test.go
@@ -7,13 +7,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/cli"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/mitchellh/cli"
 	"github.com/posener/complete"
 	"github.com/shoenig/test/must"
 )

--- a/command/job_start_test.go
+++ b/command/job_start_test.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/hashicorp/cli"
@@ -88,12 +87,11 @@ func TestStartCommand_Arguments(t *testing.T) {
 			},
 		}
 
-		if code := cmd.Run([]string{"-address=nope", "foo"}); code != 1 {
-			t.Fatalf("expected exit code 1, got: %d", code)
-		}
-		if out := ui.ErrorWriter.String(); !strings.Contains(out, "Error querying job prefix") {
-			t.Fatalf("expected failed query error, got: %s", out)
-		}
+		code := cmd.Run([]string{"-address=nope", "foo"})
+		must.Eq(t, code, 1)
+
+		out := ui.ErrorWriter.String()
+		must.StrContains(t, out, "Error querying job prefix")
 	})
 	t.Run("fails if given more than 1 argument", func(t *testing.T) {
 		ui := cli.NewMockUi()
@@ -103,12 +101,11 @@ func TestStartCommand_Arguments(t *testing.T) {
 			},
 		}
 
-		if code := cmd.Run([]string{"foo1", "foo2"}); code != 1 {
-			t.Fatalf("expected exit code 1, got: %d", code)
-		}
-		if out := ui.ErrorWriter.String(); !strings.Contains(out, "This command takes one argument: <job>") {
-			t.Fatalf("expected failed query error, got: %s", out)
-		}
+		code := cmd.Run([]string{"foo1", "foo2"})
+		must.Eq(t, code, 1)
+
+		out := ui.ErrorWriter.String()
+		must.StrContains(t, out, "This command takes one argument: <job>")
 	})
 	t.Run("fails if given less than 1 argument", func(t *testing.T) {
 		ui := cli.NewMockUi()
@@ -118,12 +115,11 @@ func TestStartCommand_Arguments(t *testing.T) {
 			},
 		}
 
-		if code := cmd.Run([]string{}); code != 1 {
-			t.Fatalf("expected exit code 1, got: %d", code)
-		}
-		if out := ui.ErrorWriter.String(); !strings.Contains(out, "This command takes one argument: <job>") {
-			t.Fatalf("expected failed query error, got: %s", out)
-		}
+		code := cmd.Run([]string{})
+		must.Eq(t, code, 1)
+
+		out := ui.ErrorWriter.String()
+		must.StrContains(t, out, "This command takes one argument: <job>")
 	})
 }
 

--- a/command/testing_test.go
+++ b/command/testing_test.go
@@ -101,7 +101,30 @@ func testNomadServiceJob(jobID string) *api.Job {
 	}}
 	return j
 }
+func testServiceJob(jobID string) *api.Job {
+	task := api.NewTask("task1", "mock_driver").
+		SetConfig("exit_code", 0).
+		Require(&api.Resources{
+			MemoryMB: pointer.Of(256),
+			CPU:      pointer.Of(100),
+		}).
+		SetLogConfig(&api.LogConfig{
+			MaxFiles:      pointer.Of(1),
+			MaxFileSizeMB: pointer.Of(2),
+		})
 
+	group := api.NewTaskGroup("group1", 1).
+		AddTask(task).
+		RequireDisk(&api.EphemeralDisk{
+			SizeMB: pointer.Of(20),
+		})
+
+	job := api.NewServiceJob(jobID, jobID, "global", 1).
+		AddDatacenter("dc1").
+		AddTaskGroup(group)
+
+	return job
+}
 func testMultiRegionJob(jobID, region, datacenter string) *api.Job {
 	task := api.NewTask("task1", "mock_driver").
 		SetConfig("kill_after", "10s").

--- a/website/content/docs/commands/job/restart.mdx
+++ b/website/content/docs/commands/job/restart.mdx
@@ -8,7 +8,7 @@ description: |
 # `nomad job restart` command reference
 
 The `job restart` command is used to restart or reschedule allocations for a
-particular job.
+particular running job.
 
 Restarting the job calls the [Restart Allocation][api_alloc_restart] API
 endpoint to restart the tasks inside allocations, so the allocations themselves

--- a/website/content/docs/commands/job/start.mdx
+++ b/website/content/docs/commands/job/start.mdx
@@ -2,42 +2,44 @@
 layout: docs
 page_title: 'Commands: job start'
 description: |
-  The start command is used to start a stopped job.
+  The nomad job start command starts the latest version of an existing job
+  with a status of Stopped.
 ---
 
 # Command: job start
 
 The `job start` command is used to start a stopped job.
+Use the `nomad job start` command to start the latest version of an existing job
+with a status of Stopped.
 
-The start command will use a Consul token with the following preference:
-first the `-consul-token` flag, then the `$CONSUL_HTTP_TOKEN` environment variable.
-Because the consul token used to [run] the targeted job version was not
-persisted, it must be provided to start if the targeted job version includes
-Consul Connect enabled services and the Nomad servers were configured to require
-[consul service identity] authentication.
+If your Nomad servers use [consul service identity] authentication and your job
+uses Consul Connect services, you must supply a Consul token. Nomad does not
+persist the Consul token when you [run] a job. Use the `-consul-token` flag to
+pass the token to the `nomad job start` command. Alternately, you may use the
+`$CONSUL_HTTP_TOKEN` environment variable.
 
-The Start command will use a Vault token with the following preference:
-first the `-vault-token` flag, then the `$VAULT_TOKEN` environment variable.
-Because the vault token used to [run] the targeted job version was not
-persisted, it must be provided to start if the targeted job includes
-Vault policies and the Nomad servers were configured to require [vault policy]
-authentication.
+If your Nomad servers require [Vault policy] authentication, you must supply a
+Vault token. Nomad does not persist the Vault token when you [run] a job.
+Use the `-vault-token` flag to pass the token to the `nomad job start` command.
+Alternately, you may use the `$VAULT_TOKEN` environment variable.
 
 ## Usage
 
 ```shell-session
-nomad job start [options] <job>
+nomad job start [options] <job_id>
 ```
 
-The `job start` command requires one input: the job ID. Nomad will start the
-latest version of the job that is not stopped. If the job has not previously
-been stopped, this command will fail.
+The `nomad job start` command requires the job ID. Nomad starts the latest
+version of the job. This command fails if the job does is not currently stopped.
 
-When ACLs are enabled, this command requires a token with the `submit-job`
-capability for the job's namespace. The `list-jobs` capability is required to
-run the command with a job prefix instead of the exact job ID. The `read-job`
-capability is required to monitor the resulting evaluation when `-detach` is
-not used.
+When Nomad uses ACLs, the `nomad job start` command requires a token with one of
+the following capabilities based on the specific scenario:
+
+- The `submit-job`capability for the job's namespace
+- The `list-jobs` capability to run the command with a job prefix instead of the
+  exact job ID
+- The `read-job` capability is required to monitor the resulting evaluation when
+  you do not use the `-detach`option.
 
 ## General Options
 
@@ -45,23 +47,22 @@ not used.
 
 ## Start Options
 
-- `-detach`: Return immediately instead of monitoring. A new evaluation ID
-  will be output, which can be used to examine the evaluation using the
+- `-detach`: Return immediately instead of monitoring. Nomad outputs a new
+  evaluation ID, which you can use to examine the evaluation using the
   [eval status] command.
 
-- `-consul-token`: If set, the passed Consul token is sent along with the Start
-  request to the Nomad servers. This overrides the token found in the
-  `$CONSUL_HTTP_TOKEN` environment variable.
+- `-consul-token`: If set, Nomad sends the Consul token with the
+  request. This overrides the token found in the `$CONSUL_HTTP_TOKEN`
+  environment variable.
 
-- `-vault-token`: If set, the passed Vault token is sent along with the Start
-  request to the Nomad servers. This overrides the token found in the
-  `$VAULT_TOKEN` environment variable.
+- `-vault-token`: If set, Nomad includes the Vault token with the request. This
+  overrides the token found in the `$VAULT_TOKEN` environment variable.
 
 - `-verbose`: Show full information.
 
 ## Examples
 
-Start a previously stopped job:
+Start a previously stopped job.
 
 ```shell-session
 $ nomad job status

--- a/website/content/docs/commands/job/start.mdx
+++ b/website/content/docs/commands/job/start.mdx
@@ -18,7 +18,7 @@ nomad job start [options] <job_id>
 ```
 
 The `nomad job start` command requires the job ID. Nomad creates new version of
-the job based on it's most recent version. This command fails if the job is not
+the job based on its most recent version. This command fails if the job is not
 registered or not currently stopped.
 
 When Nomad uses ACLs, the `nomad job start` command requires a token with one of

--- a/website/content/docs/commands/job/start.mdx
+++ b/website/content/docs/commands/job/start.mdx
@@ -1,0 +1,84 @@
+---
+layout: docs
+page_title: 'Commands: job start'
+description: |
+  The start command is used to start a stopped job.
+---
+
+# Command: job start
+
+The `job start` command is used to start a stopped job.
+
+The start command will use a Consul token with the following preference:
+first the `-consul-token` flag, then the `$CONSUL_HTTP_TOKEN` environment variable.
+Because the consul token used to [run] the targeted job version was not
+persisted, it must be provided to start if the targeted job version includes
+Consul Connect enabled services and the Nomad servers were configured to require
+[consul service identity] authentication.
+
+The Start command will use a Vault token with the following preference:
+first the `-vault-token` flag, then the `$VAULT_TOKEN` environment variable.
+Because the vault token used to [run] the targeted job version was not
+persisted, it must be provided to start if the targeted job includes
+Vault policies and the Nomad servers were configured to require [vault policy]
+authentication.
+
+## Usage
+
+```shell-session
+nomad job start [options] <job>
+```
+
+The `job start` command requires one input: the job ID. Nomad will start the
+latest version of the job that is not stopped. If the job has not previously
+been stopped, this command will fail.
+
+When ACLs are enabled, this command requires a token with the `submit-job`
+capability for the job's namespace. The `list-jobs` capability is required to
+run the command with a job prefix instead of the exact job ID. The `read-job`
+capability is required to monitor the resulting evaluation when `-detach` is
+not used.
+
+## General Options
+
+@include 'general_options.mdx'
+
+## Start Options
+
+- `-detach`: Return immediately instead of monitoring. A new evaluation ID
+  will be output, which can be used to examine the evaluation using the
+  [eval status] command.
+
+- `-consul-token`: If set, the passed Consul token is sent along with the Start
+  request to the Nomad servers. This overrides the token found in the
+  `$CONSUL_HTTP_TOKEN` environment variable.
+
+- `-vault-token`: If set, the passed Vault token is sent along with the Start
+  request to the Nomad servers. This overrides the token found in the
+  `$VAULT_TOKEN` environment variable.
+
+- `-verbose`: Show full information.
+
+## Examples
+
+Start a previously stopped job:
+
+```shell-session
+$ nomad job status
+ID       Type     Priority  Status          Submit Date
+example  service  50        dead (stopped)  2025-02-11T15:33:27-05:00
+
+$ nomad job start example
+==> 2025-02-11T15:34:48-05:00: Monitoring evaluation "8b715538"
+    2025-02-11T15:34:48-05:00: Evaluation triggered by job "example"
+    2025-02-11T15:34:49-05:00: Evaluation within deployment: "866ca498"
+    2025-02-11T15:34:49-05:00: Allocation "4d050576" created: node "8e17fa4d", group "echo"
+    2025-02-11T15:34:49-05:00: Evaluation status changed: "pending" -> "complete"
+==> 2025-02-11T15:34:49-05:00: Evaluation "8b715538" finished with status "complete"
+```
+
+[eval status]: /nomad/docs/commands/eval/status
+[consul service identity]: /nomad/docs/configuration/consul#allow_unauthenticated
+[vault policy]: /nomad/docs/configuration/vault#allow_unauthenticated
+[run]: /nomad/docs/commands/job/run
+

--- a/website/content/docs/commands/job/start.mdx
+++ b/website/content/docs/commands/job/start.mdx
@@ -10,7 +10,7 @@ description: |
 
 The `job start` command is used to start a stopped job.
 Use the `nomad job start` command to start the latest version of an existing job
-with a status of Stopped.
+with a status of Stopped. Refer to [Job statuses] for status explanations.
 
 If your Nomad servers use [consul service identity] authentication and your job
 uses Consul Connect services, you must supply a Consul token. Nomad does not
@@ -82,4 +82,4 @@ $ nomad job start example
 [consul service identity]: /nomad/docs/configuration/consul#allow_unauthenticated
 [vault policy]: /nomad/docs/configuration/vault#allow_unauthenticated
 [run]: /nomad/docs/commands/job/run
-
+[Job statuses]: /nomad/docs/concepts/job#job-statuses

--- a/website/content/docs/commands/job/start.mdx
+++ b/website/content/docs/commands/job/start.mdx
@@ -17,17 +17,14 @@ with a status of Stopped. Refer to [Job statuses] for status explanations.
 nomad job start [options] <job_id>
 ```
 
-The `nomad job start` command requires the job ID. Nomad starts the latest
-version of the job. This command fails if the job does is not currently stopped.
+The `nomad job start` command requires the job ID. Nomad creates new version of
+the job based on it's most recent version. This command fails if the job is not
+registered or not currently stopped.
 
 When Nomad uses ACLs, the `nomad job start` command requires a token with one of
 the following capabilities based on the specific scenario:
 
 - The `submit-job`capability for the job's namespace
-- The `list-jobs` capability to run the command with a job prefix instead of the
-  exact job ID
-- The `read-job` capability is required to monitor the resulting evaluation when
-  you do not use the `-detach`option.
 
 ## General Options
 

--- a/website/content/docs/commands/job/start.mdx
+++ b/website/content/docs/commands/job/start.mdx
@@ -1,27 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: job start'
+page_title: 'nomad job start command reference'
 description: |
   The nomad job start command starts the latest version of an existing job
   with a status of Stopped.
 ---
 
-# Command: job start
+# nomad job start command reference
 
-The `job start` command is used to start a stopped job.
 Use the `nomad job start` command to start the latest version of an existing job
 with a status of Stopped. Refer to [Job statuses] for status explanations.
-
-If your Nomad servers use [consul service identity] authentication and your job
-uses Consul Connect services, you must supply a Consul token. Nomad does not
-persist the Consul token when you [run] a job. Use the `-consul-token` flag to
-pass the token to the `nomad job start` command. Alternately, you may use the
-`$CONSUL_HTTP_TOKEN` environment variable.
-
-If your Nomad servers require [Vault policy] authentication, you must supply a
-Vault token. Nomad does not persist the Vault token when you [run] a job.
-Use the `-vault-token` flag to pass the token to the `nomad job start` command.
-Alternately, you may use the `$VAULT_TOKEN` environment variable.
 
 ## Usage
 
@@ -51,13 +39,6 @@ the following capabilities based on the specific scenario:
   evaluation ID, which you can use to examine the evaluation using the
   [eval status] command.
 
-- `-consul-token`: If set, Nomad sends the Consul token with the
-  request. This overrides the token found in the `$CONSUL_HTTP_TOKEN`
-  environment variable.
-
-- `-vault-token`: If set, Nomad includes the Vault token with the request. This
-  overrides the token found in the `$VAULT_TOKEN` environment variable.
-
 - `-verbose`: Show full information.
 
 ## Examples
@@ -79,7 +60,5 @@ $ nomad job start example
 ```
 
 [eval status]: /nomad/docs/commands/eval/status
-[consul service identity]: /nomad/docs/configuration/consul#allow_unauthenticated
-[vault policy]: /nomad/docs/configuration/vault#allow_unauthenticated
 [run]: /nomad/docs/commands/job/run
 [Job statuses]: /nomad/docs/concepts/job#job-statuses

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -712,6 +712,10 @@
             "path": "commands/job/scaling-events"
           },
           {
+            "title": "start",
+            "path": "commands/job/start"
+          },
+          {
             "title": "status",
             "path": "commands/job/status"
           },


### PR DESCRIPTION
This PR implements the `job start` command, which allows for users to call "job start [options] <job>" with a valid job that has been previously stopped and starts the most recent running and stable version up. 

Fixes: https://github.com/hashicorp/nomad/issues/23852

After more investigation, we found that batch job versions do not get set as running after a stop, rather they are set to pending, and because of this, it is hard to nail down another marker to use in order for us to establish if the version we’d like to revert to is stable , so for now, this feature has been implemented and tested for service jobs only.
