### PR TITLE
docs: add Quota specification page

### DIFF
--- a/website/content/docs/commands/quota/apply.mdx
+++ b/website/content/docs/commands/quota/apply.mdx
@@ -7,7 +7,7 @@ description: |
 
 # Command: quota apply
 
-The `quota apply` command is used to create or update quota specifications.
+The `quota apply` command is used to create or update [quota specifications][].
 
 ~> Quota commands are only available with Nomad Enterprise.
 
@@ -39,3 +39,5 @@ Create a new quota specification:
 $ nomad quota apply my-quota.hcl
 Successfully applied quota specification "my-quota"!
 ```
+
+[quota specifications]: /nomad/docs/other-specifications/quota

--- a/website/content/docs/commands/quota/init.mdx
+++ b/website/content/docs/commands/quota/init.mdx
@@ -7,8 +7,8 @@ description: |
 
 # Command: quota init
 
-The `quota init` command is used to create an example quota specification file
-that can be used as a starting point to customize further.
+The `quota init` command is used to create an example [quota specification][]
+file that can be used as a starting point to customize further.
 
 ~> Quota commands are only available with Nomad Enterprise.
 
@@ -30,3 +30,5 @@ Create an example quota specification:
 $ nomad quota init
 Example quota specification written to spec.hcl
 ```
+
+[quota specification]: /nomad/docs/other-specifications/quota

--- a/website/content/docs/enterprise/index.mdx
+++ b/website/content/docs/enterprise/index.mdx
@@ -154,9 +154,10 @@ thorough overview.
 
 Resource Quotas enable an operator to limit resource consumption across teams
 or projects to reduce waste and align budgets. In Nomad Enterprise, operators
-can define quota specifications and apply them to namespaces. When a quota is
-attached to a namespace, the jobs within the namespace may not consume more
-resources than the quota specification allows.
+can define [quota specifications](/nomad/docs/other-specifications/quota)
+and apply them to namespaces. When a quota is attached to a namespace,
+the jobs within the namespace may not consume more resources than the quota
+specification allows.
 
 This allows operators to partition a shared cluster and ensure that no single
 actor can consume the whole resources of the cluster.

--- a/website/content/docs/job-specification/resources.mdx
+++ b/website/content/docs/job-specification/resources.mdx
@@ -133,7 +133,7 @@ oversubscription support.
 
 Memory oversubscription is opt-in. Nomad operators can enable [Memory
 Oversubscription in the scheduler configuration][api_sched_config]. Enterprise
-customers can use [Resource Quotas][tutorial_quota] to limit the memory
+customers can use [Resource Quotas][quota_spec] to limit the memory
 oversubscription and enable or disable memory oversubscription per [node
 pool][np_sched_config].
 
@@ -157,6 +157,6 @@ resource utilization and considering the following suggestions:
 [docker_cpu]: /nomad/docs/drivers/docker#cpu
 [exec_cpu]: /nomad/docs/drivers/exec#cpu
 [np_sched_config]: /nomad/docs/other-specifications/node-pool#memory_oversubscription_enabled
-[tutorial_quota]: /nomad/tutorials/governance-and-policy/quotas
+[quota_spec]: /nomad/docs/other-specifications/quota
 [numa]: /nomad/docs/job-specification/numa 'Nomad NUMA Job Specification'
 [`secrets/`]: /nomad/docs/runtime/environment#secrets

--- a/website/content/docs/other-specifications/index.mdx
+++ b/website/content/docs/other-specifications/index.mdx
@@ -6,12 +6,13 @@ description: Learn about other specifications used in Nomad.
 
 # Other Specifications
 
-In addition to [jobs][job_spec] there are other objects that can be specified
-in Nomad.
+In addition to
+[Jobs](/nomad/docs/job-specification),
+there are other objects that can be specified in Nomad:
 
-- [ACL Policy][acl_policy_spec]
-- [Volume][volume_spec]
-
-[job_spec]: /nomad/docs/job-specification
-[acl_policy_spec]: /nomad/docs/other-specifications/acl-policy
-[volume_spec]: /nomad/docs/other-specifications/volume
+- [ACL Policy](/nomad/docs/other-specifications/acl-policy)
+- [Namespace](/nomad/docs/other-specifications/namespace)
+- [Node Pool](/nomad/docs/other-specifications/node-pool)
+- [Quota](/nomad/docs/other-specifications/quota)
+- [Variable](/nomad/docs/other-specifications/variables)
+- [Volume](/nomad/docs/other-specifications/volume)

--- a/website/content/docs/other-specifications/quota.mdx
+++ b/website/content/docs/other-specifications/quota.mdx
@@ -1,0 +1,88 @@
+---
+layout: docs
+page_title: Nomad Quota Specification
+description: Learn about Nomad's Resource Quota specification.
+---
+
+# Nomad Quota Specification
+
+<EnterpriseAlert>
+Resource Quotas are only available with Nomad Enterprise.
+</EnterpriseAlert>
+
+[Resource Quotas](/nomad/docs/enterprise#resource-quotas)
+enable an operator to limit resource consumption across teams
+or projects to reduce waste and align budgets.
+
+Quotas can be managed using the Nomad CLI via the
+[`quota`](/nomad/docs/commands/quota)
+subcommands, or with Nomad's
+[HTTP API](/nomad/api-docs/quotas)
+directly.
+
+You may also follow a
+[Quotas tutorial](/nomad/tutorials/governance-and-policy/quotas)
+for more example usage.
+
+## Example Quota Specification
+
+The CLI command `nomad quota init` generates an example `spec.hcl` file:
+
+```hcl
+name        = "default-quota"
+description = "Limit the shared default namespace"
+
+# Create a limit for the global region. Additional limits may
+# be specified in-order to limit other regions.
+limit {
+  region = "global"
+  region_limit {
+    cores      = 0
+    cpu        = 2500
+    memory     = 1000
+    memory_max = 1000
+    device "nvidia/gpu/1080ti" {
+      count = 1
+    }
+  }
+  variables_limit = 1000
+}
+```
+
+## Quota Specification Parameters
+
+- `name` `(string)` - The name of the Quota. This will be used to connect it to a
+[`Namespace`](/nomad/docs/other-specifications/namespace).
+- `description` `(string: <optional>)` - A human-readable description.
+- `limit` <code>([QuotaLimit](#limit-parameters))</code> - The resource limit in a Nomad region.
+
+### `limit` Parameters
+
+- `region` `(string)` - The Nomad `region` that the limit applies to.
+- `region_limit` <code>([RegionLimit](#region_limit-parameters))</code> - Resources to limit.
+- `variables_limit` `(int: 0)` - Maximum total size of all Nomad
+[`variables`](/nomad/docs/concepts/variables)
+in MiB. The default `0` means unlimited, and `-1` means variables are fully disabled.
+
+### `region_limit` Parameters
+
+These are associated with the parameters on a task
+[`resources`](/nomad/docs/job-specification/resources)
+block in a job specification, and the
+[CPU concepts](/nomad/docs/concepts/cpu)
+page has more information regarding CPU resources as well.
+
+- `cores` `(int: <optional>)` - Number of CPU cores
+- `cpu` `(int: <optional>)` - Amount of CPU in MHz
+- `memory` `(int: <optional>)` - Amount of memory in MB
+- `memory_max` `(int: <optional>)` - Max amount of memory in MB
+- `device` <code>([Device](#device-parameters): nil)</code>
+
+### `device` Parameters
+
+The `device` label specifies which device(s) the quota applies to,
+equivalent to the
+[`device`](/nomad/docs/job-specification/device#device-parameters)
+in a job specification.
+
+- `count` `(int)` - How many of this device may be used.

--- a/website/content/docs/other-specifications/quota.mdx
+++ b/website/content/docs/other-specifications/quota.mdx
@@ -62,14 +62,18 @@ variables are fully disabled.
 
 ### `region_limit` parameters
 
-These are associated with the parameters on a task [`resources`][]
-block in a job specification, and the [CPU concepts][] page has more information
-regarding CPU resources as well.
+Region limits define the limits on cumulative task [`resources`][] blocks for
+allocations in the namespace and region the quota is applied to.
 
-- `cores` `(int: <optional>)` - Number of CPU cores
-- `cpu` `(int: <optional>)` - Amount of CPU in MHz
-- `memory` `(int: <optional>)` - Amount of memory in MB
-- `memory_max` `(int: <optional>)` - Max amount of memory in MB
+- `cores` `(int: <optional>)` - The limit on total number of CPU cores from all
+`resources.cores` in the namespace. The [CPU concepts][] documentation
+has more details on CPU resources.
+- `cpu` `(int: <optional>)` - The limit on total amount of CPU from all
+`resources.cpu` in the namespace.
+- `memory` `(int: <optional>)` - The limit on total mount of memory in MB from
+all `resources.memory` in the namespace.
+- `memory_max` `(int: <optional>)` - The limit on total mount of hard memory
+limits in MB from all `resources.memory_max` in the namespace.
 - `device` <code>([Device](#device-parameters): nil)</code>
 
 ### `device` parameters

--- a/website/content/docs/other-specifications/quota.mdx
+++ b/website/content/docs/other-specifications/quota.mdx
@@ -1,20 +1,20 @@
 ---
 layout: docs
-page_title: Nomad Quota Specification
+page_title: Resource Quota Specification
 description: Learn about Nomad's Resource Quota specification.
 ---
 
-# Nomad Quota Specification
+# Resource Quota Specification
 
 <EnterpriseAlert>
 Resource Quotas are only available with Nomad Enterprise.
 </EnterpriseAlert>
 
 [Resource Quotas](/nomad/docs/enterprise#resource-quotas)
-enable an operator to limit resource consumption across teams
+enable you to limit resource consumption across teams
 or projects to reduce waste and align budgets.
 
-Quotas can be managed using the Nomad CLI via the
+You can manage quotas using the Nomad CLI via the
 [`quota`](/nomad/docs/commands/quota)
 subcommands, or with Nomad's
 [HTTP API](/nomad/api-docs/quotas)
@@ -24,9 +24,9 @@ You may also follow a
 [Quotas tutorial](/nomad/tutorials/governance-and-policy/quotas)
 for more example usage.
 
-## Example Quota Specification
+## Example quota specification
 
-The CLI command `nomad quota init` generates an example `spec.hcl` file:
+The CLI command `nomad quota init` generates an example `spec.hcl` file.
 
 ```hcl
 name        = "default-quota"
@@ -49,14 +49,14 @@ limit {
 }
 ```
 
-## Quota Specification Parameters
+## Quota specification parameters
 
-- `name` `(string)` - The name of the Quota. This will be used to connect it to a
+- `name` `(string)` - The name of the quota. Nomad uses `name` to connect the quota to a
 [`Namespace`](/nomad/docs/other-specifications/namespace).
 - `description` `(string: <optional>)` - A human-readable description.
 - `limit` <code>([QuotaLimit](#limit-parameters))</code> - The resource limit in a Nomad region.
 
-### `limit` Parameters
+### `limit` parameters
 
 - `region` `(string)` - The Nomad `region` that the limit applies to.
 - `region_limit` <code>([RegionLimit](#region_limit-parameters))</code> - Resources to limit.
@@ -64,7 +64,7 @@ limit {
 [`variables`](/nomad/docs/concepts/variables)
 in MiB. The default `0` means unlimited, and `-1` means variables are fully disabled.
 
-### `region_limit` Parameters
+### `region_limit` parameters
 
 These are associated with the parameters on a task
 [`resources`](/nomad/docs/job-specification/resources)
@@ -78,7 +78,7 @@ page has more information regarding CPU resources as well.
 - `memory_max` `(int: <optional>)` - Max amount of memory in MB
 - `device` <code>([Device](#device-parameters): nil)</code>
 
-### `device` Parameters
+### `device` parameters
 
 The `device` label specifies which device(s) the quota applies to,
 equivalent to the

--- a/website/content/docs/other-specifications/quota.mdx
+++ b/website/content/docs/other-specifications/quota.mdx
@@ -10,19 +10,13 @@ description: Learn about Nomad's Resource Quota specification.
 Resource Quotas are only available with Nomad Enterprise.
 </EnterpriseAlert>
 
-[Resource Quotas](/nomad/docs/enterprise#resource-quotas)
-enable you to limit resource consumption across teams
-or projects to reduce waste and align budgets.
+[Resource Quotas][] enable you to limit resource consumption across teams or
+projects to reduce waste and align budgets.
 
-You can manage quotas using the Nomad CLI via the
-[`quota`](/nomad/docs/commands/quota)
-subcommands, or with Nomad's
-[HTTP API](/nomad/api-docs/quotas)
-directly.
+You can manage quotas using the Nomad CLI via the [`quota`][] subcommands,
+or with Nomad's [Quota HTTP API][] directly.
 
-You may also follow a
-[Quotas tutorial](/nomad/tutorials/governance-and-policy/quotas)
-for more example usage.
+You may also follow a [Quotas tutorial][] for more example usage.
 
 ## Example quota specification
 
@@ -51,26 +45,26 @@ limit {
 
 ## Quota specification parameters
 
-- `name` `(string)` - The name of the quota. Nomad uses `name` to connect the quota to a
-[`Namespace`](/nomad/docs/other-specifications/namespace).
+- `name` `(string)` - The name of the Quota. Nomad uses `name` to connect the
+quota a [`Namespace`][].
 - `description` `(string: <optional>)` - A human-readable description.
-- `limit` <code>([QuotaLimit](#limit-parameters))</code> - The resource limit in a Nomad region.
+- `limit` <code>([QuotaLimit](#limit-parameters))</code> - The resource limit
+in a Nomad region.
 
 ### `limit` parameters
 
 - `region` `(string)` - The Nomad `region` that the limit applies to.
-- `region_limit` <code>([RegionLimit](#region_limit-parameters))</code> - Resources to limit.
+- `region_limit` <code>([RegionLimit](#region_limit-parameters))</code> -
+Resources to limit.
 - `variables_limit` `(int: 0)` - Maximum total size of all Nomad
-[`variables`](/nomad/docs/concepts/variables)
-in MiB. The default `0` means unlimited, and `-1` means variables are fully disabled.
+[`variables`][] in MiB. The default `0` means unlimited, and `-1` means
+variables are fully disabled.
 
 ### `region_limit` parameters
 
-These are associated with the parameters on a task
-[`resources`](/nomad/docs/job-specification/resources)
-block in a job specification, and the
-[CPU concepts](/nomad/docs/concepts/cpu)
-page has more information regarding CPU resources as well.
+These are associated with the parameters on a task [`resources`][]
+block in a job specification, and the [CPU concepts][] page has more information
+regarding CPU resources as well.
 
 - `cores` `(int: <optional>)` - Number of CPU cores
 - `cpu` `(int: <optional>)` - Amount of CPU in MHz
@@ -81,8 +75,16 @@ page has more information regarding CPU resources as well.
 ### `device` parameters
 
 The `device` label specifies which device(s) the quota applies to,
-equivalent to the
-[`device`](/nomad/docs/job-specification/device#device-parameters)
-in a job specification.
+equivalent to the [`device`][] block in a job specification.
 
 - `count` `(int)` - How many of this device may be used.
+
+[Resource Quotas]: /nomad/docs/enterprise#resource-quotas
+[`quota`]: /nomad/docs/commands/quota
+[Quota HTTP API]: /nomad/api-docs/quotas
+[Quotas tutorial]: /nomad/tutorials/governance-and-policy/quotas
+[`Namespace`]: /nomad/docs/other-specifications/namespace
+[`variables`]: /nomad/docs/concepts/variables
+[`resources`]: /nomad/docs/job-specification/resources
+[CPU concepts]: /nomad/docs/concepts/cpu
+[`device`]: /nomad/docs/job-specification/device#device-parameters

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1916,6 +1916,10 @@
         "path": "other-specifications/node-pool"
       },
       {
+        "title": "Quota",
+        "path": "other-specifications/quota"
+      },
+      {
         "title": "Variables",
         "path": "other-specifications/variables"
       },

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -1916,7 +1916,7 @@
         "path": "other-specifications/node-pool"
       },
       {
-        "title": "Quota",
+        "title": "Resource Quota",
         "path": "other-specifications/quota"
       },
       {


### PR DESCRIPTION
main new page: https://nomad-bmjsdet16-hashicorp.vercel.app/nomad/docs/other-specifications/quota

other affected pages:
* [docs/enterprise](https://nomad-bmjsdet16-hashicorp.vercel.app/nomad/docs/enterprise#resource-quotas)
* [docs/job-specification/resources](https://nomad-bmjsdet16-hashicorp.vercel.app/nomad/docs/job-specification/resources)
* [docs/other-specifications](https://nomad-bmjsdet16-hashicorp.vercel.app/nomad/docs/other-specifications)

---

relates to hashicorp/tutorials#2263

closes #23258