### PR TITLE
Docs: Golden Versions updates

### DIFF
--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -2702,6 +2702,8 @@ WebSocket Request: /v1/job/actions-demo/action?action=weather&allocID=8614ed07-4
 
 This endpoint creates a tag for a job version.
 
+@include 'version/tag-reason.mdx'
+
 | Method | Path              | Produces           |
 | ------ | ----------------- | ------------------ |
 | `POST`  | `/v1/job/:job_id/versions/:tag_name/tag` | `application/json` |
@@ -2711,7 +2713,7 @@ This endpoint creates a tag for a job version.
 - `:job_id` `(string: <required>)` - The ID of the job. Specify `job_id` as part
   of the path.
 - `:tag_name` `(string: <required>)` - The new tag name for the
-  version specified in the payload. Specify `tag_name` as part of the path.
+  version specified in the payload. Must be unique per job. Specify `tag_name` as part of the path.
 - `Version`: `(int: <optional>)` - The job version number. If not
   specified, Nomad tags the latest version. Specify `Version` in the payload.
 - `Description`: `(string: <optional>)` - The tag description. Specify `Description` in the payload.

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -635,8 +635,7 @@ The table below shows this endpoint's support for
   containing the structured diff between the current and last job version. This
   is specified as a query string parameter.
 
-- `diff_version` `(int: <optional>)`: When `diffs=true`, this is the version
-  to compare the other versions to. This is specified as a query string parameter.
+- `diff_version` `(int: <optional>)`: Specifies the version to to compare against the current version when you create the structured diff for a job with `diffs=true`. This is specified as a query string parameter.
 
 - `:job_id` `(string: <required>)` - Specifies the ID of the job. This is
   specified as part of the path.
@@ -1835,11 +1834,11 @@ The table below shows this endpoint's support for
 - `JobID` `(string: <required>)` - Specifies the ID of the job. This is
   specified as part of the path.
 
-- `JobVersion` `(integer: 0)` - Specifies the job version to revert to. Use this
-  or `TaggedVersion`.
+- `JobVersion` `(integer: 0)` - Specifies the job version to revert to. Use either 
+  this parameter or `TaggedVersion`, but do not use both.
 
 - `TaggedVersion` `(string: "")` - Specifies the tag name of the job version you
-  want to revert to. Use this or `JobVersion`.
+  want to revert to. Use either this parameter or `JobVersion`, but do not use both.
 
 - `EnforcePriorVersion` `(integer: nil)` - Optional value specifying the current
   job's version. This is checked and acts as a check-and-set value before

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -1831,7 +1831,11 @@ The table below shows this endpoint's support for
 - `JobID` `(string: <required>)` - Specifies the ID of the job. This is
   specified as part of the path.
 
-- `JobVersion` `(integer: 0)` - Specifies the job version to revert to.
+- `JobVersion` `(integer: 0)` - Specifies the job version to revert to. Use this
+  or `TaggedVersion`.
+
+- `TaggedVersion` `(string: "")` - Specifies the tag name of the job version you
+  want to revert to. Use this or `JobVersion`.
 
 - `EnforcePriorVersion` `(integer: nil)` - Optional value specifying the current
   job's version. This is checked and acts as a check-and-set value before
@@ -1849,10 +1853,21 @@ access. This is specified as a query string parameter.
 
 ### Sample Payload
 
+This example specifies the version.
+
 ```json
 {
   "JobID": "my-job",
   "JobVersion": 2
+}
+```
+
+This example specifies the tagged version.
+
+```json
+{
+  "JobID": "my-job",
+  "TaggedVersion": "golden-version"
 }
 ```
 
@@ -2705,21 +2720,21 @@ This endpoint creates a tag for a job version.
 
 ```json
 {
-  "Version": 2,
+  "Version": 0,
   "Description": "The version we can roll back to."
 }
 ```
 
 ### Sample Request
 
-This example creates a tag named "golden-version" for version two of the
-"ecommerce-site" job.
+This example creates a tag named `golden-version` for version zero of the
+`hello-world` job.
 
 ```shell-session
-curl -X POST \
- localhost:4646/v1/job/ecommerce-site/versions/golden-version/tag \
+$ curl -X POST \
+ localhost:4646/v1/job/hello-world/versions/golden-version/tag \
  -H "Content-Type: application/json" -d \
- '{"Version": 2, "Description": "The version we can roll back to."}'
+ '{"Version": 0, "Description": "The version we can roll back to."}'
 ```
 
 ### Sample Response
@@ -2750,10 +2765,10 @@ This endpoint deletes a job version tag.
 
 ### Sample Request
 
-This example deletes the tag named "golden-version" from the job "ecommerce-site".
+This example deletes the `golden-version` tag from the `hello-world` job.
 
 ```shell-session
-curl -X DELETE localhost:4646/v1/job/ecommerce-site/versions/golden-version/tag -H "Content-Type: application/json"
+$ curl -X DELETE localhost:4646/v1/job/hello-world/versions/golden-version/tag -H "Content-Type: application/json"
 ```
 
 ### Sample Response

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -2682,3 +2682,93 @@ WebSocket Request: /v1/job/actions-demo/action?action=weather&allocID=8614ed07-4
 # Toronto: ⛅️  -1°C
 {"stdout":{"data":"VG9yb250bzog4puF77iPICAtMcKwQw0K"}}
 ```
+
+## Create Job Version Tag
+
+This endpoint creates a tag for a job version.
+
+| Method | Path              | Produces           |
+| ------ | ----------------- | ------------------ |
+| `POST`  | `/v1/job/:job_id/versions/:tag_name/tag` | `application/json` |
+
+### Parameters
+
+- `:job_id` `(string: <required>)` - The ID of the job. Specify `job_id` as part
+  of the path.
+- `:tag_name` `(string: <required>)` - The new tag name for the
+  version specified in the payload. Specify `tag_name` as part of the path.
+- `Version`: `(int: <optional>)` - The job version number. If not
+  specified, Nomad tags the latest version. Specify `Version` in the payload.
+- `Description`: `(string: <optional>)` - The tag description. Specify `Description` in the payload.
+
+### Sample Payload
+
+```json
+{
+  "Version": 2,
+  "Description": "The version we can roll back to."
+}
+```
+
+### Sample Request
+
+This example creates a tag named "golden-version" for version two of the
+"ecommerce-site" job.
+
+```shell-session
+curl -X POST \
+ localhost:4646/v1/job/ecommerce-site/versions/golden-version/tag \
+ -H "Content-Type: application/json" -d \
+ '{"Version": 2, "Description": "The version we can roll back to."}'
+```
+
+### Sample Response
+
+```json
+{
+  "Name":"golden-version",
+  "Description":"The version we can roll back to.",
+  "TaggedTime":1728325495829793000,
+  "Index":361,
+  "LastContact":0,
+  "KnownLeader":false,
+  "NextToken":""}
+```
+
+## Delete Job Version Tag
+
+This endpoint deletes a job version tag.
+
+| Method | Path              | Produces           |
+| ------ | ----------------- | ------------------ |
+| `DELETE`  | `/v1/job/:job_id/versions/:tag_name/tag` | `application/json` |
+
+### Parameters
+
+- `:job_id` `(string: <required>)` - The ID of the job. Specify `job_id` as part of the path.
+- `:tag_name` `(string: <required>)` - The tag name. Specify `tag_name` as part of the path.
+
+### Sample Request
+
+This example deletes the tag named "golden-version" from the job "ecommerce-site".
+
+```shell-session
+curl -X DELETE localhost:4646/v1/job/ecommerce-site/versions/golden-version/tag -H "Content-Type: application/json"
+```
+
+### Sample Response
+
+```json
+{
+  "EvalID":"",
+  "EvalCreateIndex":0,
+  "JobModifyIndex":0,
+  "VolumeEvalID":"",
+  "VolumeEvalIndex":0,
+  "Index":0,
+  "LastContact":0,
+  "KnownLeader":false,
+  "NextToken":""
+}
+```
+

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -632,7 +632,11 @@ The table below shows this endpoint's support for
 ### Parameters
 
 - `diffs` `(bool: false)` - Specifies if the Diffs field should be populated,
-  containing the structured diff between the current and last job version.
+  containing the structured diff between the current and last job version. This
+  is specified as a query string parameter.
+
+- `diff_version` `(int: <optional>)`: When `diffs=true`, this is the version
+  to compare the other versions to. This is specified as a query string parameter.
 
 - `:job_id` `(string: <required>)` - Specifies the ID of the job. This is
   specified as part of the path.

--- a/website/content/docs/commands/job/revert.mdx
+++ b/website/content/docs/commands/job/revert.mdx
@@ -31,10 +31,10 @@ authentication.
 nomad job revert [options] <job> <version|tag>
 ```
 
-The `job revert` command requires two inputs, the job ID and the version or tag
-of that job to revert to.  When you specify a version number, Nomad reverts the
-job to the exact version number. Alternately, when you specify a version tag,
-Nomad reverts to the version with that tag.
+The `job revert` command requires two inputs, the job ID and the version number
+or tag of that job to revert to.  When you specify a version number, Nomad
+reverts the job to the exact version number. Alternately, when you specify a
+version tag, Nomad reverts to the version with that tag.
 
 When ACLs are enabled, this command requires a token with the `submit-job`
 capability for the job's namespace. The `list-jobs` capability is required to

--- a/website/content/docs/commands/job/revert.mdx
+++ b/website/content/docs/commands/job/revert.mdx
@@ -27,13 +27,14 @@ authentication.
 
 ## Usage
 
-```plaintext
+```shell-session
 nomad job revert [options] <job> <version|tag>
 ```
 
 The `job revert` command requires two inputs, the job ID and the version or tag
-of that job to revert to.  If you specify the version number,  Nomad reverts the
-job to the exact version number. If you specify a version tag, Nomad reverts the job to the version with the given tag.
+of that job to revert to.  When you specify a version number, Nomad reverts the
+job to the exact version number. Alternately, when you specify a version tag,
+Nomad reverts to the version with that tag.
 
 When ACLs are enabled, this command requires a token with the `submit-job`
 capability for the job's namespace. The `list-jobs` capability is required to

--- a/website/content/docs/commands/job/revert.mdx
+++ b/website/content/docs/commands/job/revert.mdx
@@ -28,11 +28,12 @@ authentication.
 ## Usage
 
 ```plaintext
-nomad job revert [options] <job> <version>
+nomad job revert [options] <job> <version|tag>
 ```
 
-The `job revert` command requires two inputs, the job ID and the version of that
-job to revert to.
+The `job revert` command requires two inputs, the job ID and the version or tag
+of that job to revert to.  If you specify the version number,  Nomad reverts the
+job to the exact version number. If you specify a version tag, Nomad reverts the job to the version with the given tag.
 
 When ACLs are enabled, this command requires a token with the `submit-job`
 capability for the job's namespace. The `list-jobs` capability is required to

--- a/website/content/docs/commands/job/revert.mdx
+++ b/website/content/docs/commands/job/revert.mdx
@@ -31,10 +31,11 @@ authentication.
 nomad job revert [options] <job> <version|tag>
 ```
 
-The `job revert` command requires two inputs, the job ID and the version number
-or tag of that job to revert to.  When you specify a version number, Nomad
+The `job revert` command requires two inputs: the job ID, and the version number
+or tag of the job to revert to.  When you specify a version number, Nomad
 reverts the job to the exact version number. Alternately, when you specify a
-version tag, Nomad reverts to the version with that tag.
+custom tag name as a string, Nomad reverts to the version tagged with that
+name.
 
 When ACLs are enabled, this command requires a token with the `submit-job`
 capability for the job's namespace. The `list-jobs` capability is required to

--- a/website/content/docs/commands/job/tag.mdx
+++ b/website/content/docs/commands/job/tag.mdx
@@ -33,8 +33,8 @@ job versions. You can [diff] and [revert] saved versions.
 
 ### Apply usage
 
-```shell
-nomad job tag apply [options] <job_name>
+```shell-session
+nomad job tag apply [options] <job_id>
 ```
 
 ### Apply options
@@ -45,20 +45,20 @@ nomad job tag apply [options] <job_name>
 
 ### Apply examples
 
-This example tags the latest version of the job named "job_store_site".
+This example tags the latest version of the job "ecommerce-site".
 
-```shell
-nomad job tag apply -name "My Golden Version" \
-		-description "The version we can roll back to if needed" \
-    job_store_site
+```shell-session
+nomad job tag apply -name "golden-version" \
+		-description "The version we can roll back to." \
+    ecommerce-site
 ```
 
-This example tags version 3 of the job named "job_store_site".
+This example tags version 3 of the job "ecommerce-site".
 
-```shell
+```shell-session
 nomad job tag apply -version 3 \
-      -name "My Golden Version" \
-      job_store_site
+      -name "golden-version" \
+      ecommerce-site
 ```
 
 ## Unset
@@ -67,8 +67,8 @@ Use `nomad job tag unset` to remove a tag from a job version. This command requi
 
 ### Unset usage
 
-```shell
-nomad job tag unset [options] <job_name> -name <tag>
+```shell-session
+nomad job tag unset [options] <job_id> -name <tag>
 ```
 
 ### Unset options
@@ -77,10 +77,10 @@ nomad job tag unset [options] <job_name> -name <tag>
 
 ### Examples
 
-This example removes the "My Golden Versions" tag from the "my_store_site" job.
+This example removes the "golden-version" tag from the "ecommerce-site" job.
 
-```shell
-nomad job tag unset my_store_site -name "My Golden Version"
+```shell-session
+nomad job tag unset ecommerce-site -name "golden-version"
 ```
 
 [diff]: /nomad/docs/commands/job/history/

--- a/website/content/docs/commands/job/tag.mdx
+++ b/website/content/docs/commands/job/tag.mdx
@@ -8,6 +8,8 @@ description: |
 
 # Command: job tag
 
+@include 'version/tag-reason.mdx'
+
 Use the `job tag` command to manage tags for job versions. `job tag` has the
 following subcommands:
 
@@ -38,7 +40,7 @@ nomad job tag apply [options] <job_id>
 
 ### Apply options
 
-- `name`: Specifies the name of the tag.
+- `name`: Specifies the name of the tag. Must be unique per job.
 - `description`: If set, specifies a description for the tag.
 - `version`: If set, specifies the version of the job to tag. If not provided, Nomad tags the latest version of the job.
 

--- a/website/content/docs/commands/job/tag.mdx
+++ b/website/content/docs/commands/job/tag.mdx
@@ -1,0 +1,88 @@
+---
+layout: docs
+page_title: 'Commands: job tag'
+description: |
+  Use the job tag commands to manage versions. The job tag apply command saves a job version tag, and the job tag unset command removes a job version tag.
+---
+
+
+# Command: job tag
+
+Use the `job tag` command to manage tags for job versions. `job tag` has the
+following subcommands:
+
+- [`job tag apply`](#apply): Save a job version tag.
+- [`job tag unset`](#unset): Remove a tag from a job version.
+
+## Usage
+
+```shell
+nomad job tag <subcommand> [options] [args]
+```
+
+## General options
+
+Use these optional general options with the subcommands.
+
+@include 'general_options.mdx'
+
+## Apply
+
+Use `job tag apply` to save a job version. Nomad does not garbage collect saved
+job versions. You can [diff] and [revert] saved versions.
+
+### Apply usage
+
+```shell
+nomad job tag apply [options] <job_name>
+```
+
+### Apply options
+
+- `name`: Specifies the name of the tag.
+- `description`: If set, specifies a description for the tag.
+- `version`: If set, specifies the version of the job to tag. If not provided, Nomad tags the latest version of the job.
+
+### Apply examples
+
+This example tags the latest version of the job named "job_store_site".
+
+```shell
+nomad job tag apply -name "My Golden Version" \
+		-description "The version we can roll back to if needed" \
+    job_store_site
+```
+
+This example tags version 3 of the job named "job_store_site".
+
+```shell
+nomad job tag apply -version 3 \
+      -name "My Golden Version" \
+      job_store_site
+```
+
+## Unset
+
+Use `nomad job tag unset` to remove a tag from a job version. This command requires a job name and a tag name.
+
+### Unset usage
+
+```shell
+nomad job tag unset [options] <job_name> -name <tag>
+```
+
+### Unset options
+
+- `name`: Specifies the name of the tag to remove from the job version.
+
+### Examples
+
+This example removes the "My Golden Versions" tag from the "my_store_site" job.
+
+```shell
+nomad job tag unset my_store_site -name "My Golden Version"
+```
+
+[diff]: /nomad/docs/commands/job/history/
+[revert]: /nomad/docs/commands/job/revert/
+

--- a/website/content/docs/commands/job/tag.mdx
+++ b/website/content/docs/commands/job/tag.mdx
@@ -28,8 +28,7 @@ Use these optional general options with the subcommands.
 
 ## Apply
 
-Use `job tag apply` to save a job version. Nomad does not garbage collect saved
-job versions. You can [diff] and [revert] saved versions.
+Use `job tag apply` to create or modify a version tag.
 
 ### Apply usage
 
@@ -45,25 +44,25 @@ nomad job tag apply [options] <job_id>
 
 ### Apply examples
 
-This example tags the latest version of the job "ecommerce-site".
+This example tags the latest version of the job `hello-world`.
 
 ```shell-session
-nomad job tag apply -name "golden-version" \
+$ nomad job tag apply -name "golden-version" \
 		-description "The version we can roll back to." \
-    ecommerce-site
+    hello-world
 ```
 
-This example tags version 3 of the job "ecommerce-site".
+This example tags version zero of the job `hello-world`.
 
 ```shell-session
-nomad job tag apply -version 3 \
+$ nomad job tag apply -version 0 \
       -name "golden-version" \
-      ecommerce-site
+      hello-world
 ```
 
 ## Unset
 
-Use `nomad job tag unset` to remove a tag from a job version. This command requires a job name and a tag name.
+Use `nomad job tag unset` to delete a tag from a version. This command requires a job name and a tag name.
 
 ### Unset usage
 
@@ -77,10 +76,10 @@ nomad job tag unset [options] <job_id> -name <tag>
 
 ### Examples
 
-This example removes the "golden-version" tag from the "ecommerce-site" job.
+This example removes the `golden-version` tag from the `hello-world` job.
 
 ```shell-session
-nomad job tag unset ecommerce-site -name "golden-version"
+$ nomad job tag unset hello-world -name "golden-version"
 ```
 
 [diff]: /nomad/docs/commands/job/history/

--- a/website/content/docs/concepts/job.mdx
+++ b/website/content/docs/concepts/job.mdx
@@ -96,6 +96,34 @@ zero. Nomad's garbage collector has not yet removed or purged the job.
 The `Stopped` status indicates that a user has manually stopped the job.
 Nomad's garbage collector has not yet removed or purged the job.
 
+## Job versions
+
+@TODO - still working on this section!!
+
+Describe, pin, prevent garbage collection
+
+Nomad does not garbage collect saved
+job versions. You can [diff] and [revert] saved versions.
+
+version name is unique per job
+
+Nomad jobs have a version history that is stored in state. Over time, Nomad
+garbage collects terminal versions. You can run commands like `nomad job
+history` to see differences between past versions of jobs and their immediate
+predecessors. Additionally, you can run `nomad job plan` to see the hypothetical
+difference of an update against the current job version.
+
+These “diff” views are useful tools in the “measure twice, cut once” vein of configuration management, as they help users get a granular view of not just what’s about to change in the job spec they’ve modified, but also the rendered differences after environment variables, etc. are applied. These tools help users make better decisions about updating jobs and are critical parts of several Nomad workflows (for example: running a job through the Web UI requires going through a plan phase so the user sees a job diff before they’re able to submit the update).
+
+Jobs can have an unlimited number of versions. Sometimes these versions are slow-moving (for example, an operator changes the image tag of their docker-run application when there is a major version update), and other times they are very fast (for example, a user writes their own auto-scaler that makes template configuration changes based on external factors).
+
+
+When you update and resubmit a job, Nomad increases the version number.
+
+Jobs can have an unlimited number of versions.
+
+Tag names must be unique per job.
+
 ## Related resources
 
 Refer to the following Nomad documentation pages for more information about

--- a/website/content/docs/concepts/job.mdx
+++ b/website/content/docs/concepts/job.mdx
@@ -109,9 +109,6 @@ tag with a unique name and optional description. Nomad does not garbage collect
 tagged versions even when the tagged version is dead. This lets you revert to
 a previous version regardless of how old the tagged version is.
 
-You can create, modify, and remove tags using the CLI, API, and web UI. Refer to
-the [Job versions guide][job-versions-guide] for examples.
-
 ### Compare versions
 
 You can compare the current job version to all previous versions or to a
@@ -122,16 +119,10 @@ of jobs and their immediate predecessors. Additionally, you can run `nomad job
 plan` to review the hypothetical difference of an update against the current job
 version.
 
-Refer to the [Compare versions section][compare-versions-section] of the Job
-versions guide for examples.
-
 ### Revert to a previous version
 
 You can revert the current running job to a previous version. Nomad stops the
 running job and deploys the chosen version.
-
-Refer to the [Revert to a version section][revert-version-section] of
-the Job versions guide for examples using the CLI, API, and web UI.
 
 ## Related resources
 
@@ -161,6 +152,3 @@ configure them:
 [Schedulers]: /nomad/docs/schedulers
 [task-groups]: /nomad/docs/glossary#task-group
 [tasks]: /nomad/docs/glossary#task
-[job-versions-guide]: /nomad/tutorials/manage-jobs/jobs-version
-[compare-versions-section]: /nomad/tutorials/manage-jobs/jobs-version.mdx#compare-versions
-[revert-version-section]: /nomad/tutorials/manage-jobs/jobs-version.mdx#revert-to-a-version

--- a/website/content/docs/concepts/job.mdx
+++ b/website/content/docs/concepts/job.mdx
@@ -117,9 +117,9 @@ the [Job versions guide][job-versions-guide] for examples.
 You can compare the current job version to all previous versions or to a
 specific version. Additionally, you can compare two specific versions.
 
-Run commands like `nomad job history` to see differences between past versions
+Run commands like `nomad job history` to review differences between past versions
 of jobs and their immediate predecessors. Additionally, you can run `nomad job
-plan` to see the hypothetical difference of an update against the current job
+plan` to review the hypothetical difference of an update against the current job
 version.
 
 Refer to the [Compare versions section][compare-versions-section] of the Job

--- a/website/content/docs/concepts/job.mdx
+++ b/website/content/docs/concepts/job.mdx
@@ -98,31 +98,40 @@ Nomad's garbage collector has not yet removed or purged the job.
 
 ## Job versions
 
-@TODO - still working on this section!!
+Nomad creates a new version for your job each time you run your job. A job can
+have an unlimited number of versions, and version history is stored in state.
+Over time, Nomad garbage collects dead versions that do not have a version tag.
 
-Describe, pin, prevent garbage collection
+### Tag a version
 
-Nomad does not garbage collect saved
-job versions. You can [diff] and [revert] saved versions.
+When you want to save or pin a specific version, you need to create a version
+tag with a unique name and optional description. Nomad does not garbage collect
+tagged versions even when the tagged version is dead. This lets you revert to
+a previous version regardless of how old the tagged version is.
 
-version name is unique per job
+You can create, modify, and remove tags using the CLI, API, and web UI. Refer to
+the [Job versions guide][job-versions-guide] for examples.
 
-Nomad jobs have a version history that is stored in state. Over time, Nomad
-garbage collects terminal versions. You can run commands like `nomad job
-history` to see differences between past versions of jobs and their immediate
-predecessors. Additionally, you can run `nomad job plan` to see the hypothetical
-difference of an update against the current job version.
+### Compare versions
 
-These “diff” views are useful tools in the “measure twice, cut once” vein of configuration management, as they help users get a granular view of not just what’s about to change in the job spec they’ve modified, but also the rendered differences after environment variables, etc. are applied. These tools help users make better decisions about updating jobs and are critical parts of several Nomad workflows (for example: running a job through the Web UI requires going through a plan phase so the user sees a job diff before they’re able to submit the update).
+You can compare the current job version to all previous versions or to a
+specific version. Additionally, you can compare two specific versions.
 
-Jobs can have an unlimited number of versions. Sometimes these versions are slow-moving (for example, an operator changes the image tag of their docker-run application when there is a major version update), and other times they are very fast (for example, a user writes their own auto-scaler that makes template configuration changes based on external factors).
+Run commands like `nomad job history` to see differences between past versions
+of jobs and their immediate predecessors. Additionally, you can run `nomad job
+plan` to see the hypothetical difference of an update against the current job
+version.
 
+Refer to the [Compare versions section][compare-versions-section] of the Job
+versions guide for examples.
 
-When you update and resubmit a job, Nomad increases the version number.
+### Revert to a previous version
 
-Jobs can have an unlimited number of versions.
+You can revert the current running job to a previous version. Nomad stops the
+running job and deploys the chosen version.
 
-Tag names must be unique per job.
+Refer to the [Revert to a version section][revert-version-section] of
+the Job versions guide for examples using the CLI, API, and web UI.
 
 ## Related resources
 
@@ -152,3 +161,6 @@ configure them:
 [Schedulers]: /nomad/docs/schedulers
 [task-groups]: /nomad/docs/glossary#task-group
 [tasks]: /nomad/docs/glossary#task
+[job-versions-guide]: /nomad/tutorials/manage-jobs/jobs-version
+[compare-versions-section]: /nomad/tutorials/manage-jobs/jobs-version.mdx#compare-versions
+[revert-version-section]: /nomad/tutorials/manage-jobs/jobs-version.mdx#revert-to-a-version

--- a/website/content/partials/version/tag-reason.mdx
+++ b/website/content/partials/version/tag-reason.mdx
@@ -1,0 +1,4 @@
+Applying a tag to a version prevents Nomad from garbage collecting that version.
+You can compare versions by tag name as well as version number.
+
+Tag names must be unique per job.

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -664,6 +664,10 @@
             "path": "commands/job/stop"
           },
           {
+            "title": "tag",
+            "path": "commands/job/tag"
+          },
+          {
             "title": "validate",
             "path": "commands/job/validate"
           }


### PR DESCRIPTION
Add job version content to Job page. https://nomad-git-ce714-hashicorp.vercel.app/nomad/docs/concepts/job/

Update CLI:
- revert https://nomad-git-ce714-hashicorp.vercel.app/nomad/docs/commands/job/revert
- new page for tag  https://nomad-git-ce714-hashicorp.vercel.app/nomad/docs/commands/job/tag

Update API:
- jobs.mdx https://nomad-git-ce714-hashicorp.vercel.app/nomad/api-docs/jobs#create-job-version-tag

**There are broken links to the Jobs version tutorial since that PR hasn't been merged**

Partial: [CE-714]

Relates to: https://github.com/hashicorp/tutorials/pull/2294  which is the version tags how-to guide. It's in tutorials because all the other Job-related how-to guides are there. Eventually that how-to content will be moved to docs.

[CE-714]: https://hashicorp.atlassian.net/browse/CE-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ