### PR TITLE
e2e: ui: update playwright to 1.48.0

### DIFF
--- a/e2e/ui/package-lock.json
+++ b/e2e/ui/package-lock.json
@@ -5,17 +5,17 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@playwright/test": "^1.47.0"
+        "@playwright/test": "^1.48.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0.tgz",
-      "integrity": "sha512-SgAdlSwYVpToI4e/IH19IHHWvoijAYH5hu2MWSXptRypLSnzj51PcGD+rsOXFayde4P9ZLi+loXVwArg6IUkCA==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
+      "integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.47.0"
+        "playwright": "1.48.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -40,13 +40,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz",
-      "integrity": "sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
+      "integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.47.0"
+        "playwright-core": "1.48.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
-      "integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
+      "integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -74,12 +74,12 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0.tgz",
-      "integrity": "sha512-SgAdlSwYVpToI4e/IH19IHHWvoijAYH5hu2MWSXptRypLSnzj51PcGD+rsOXFayde4P9ZLi+loXVwArg6IUkCA==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
+      "integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
       "dev": true,
       "requires": {
-        "playwright": "1.47.0"
+        "playwright": "1.48.0"
       }
     },
     "fsevents": {
@@ -90,19 +90,19 @@
       "optional": true
     },
     "playwright": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz",
-      "integrity": "sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
+      "integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.47.0"
+        "playwright-core": "1.48.0"
       }
     },
     "playwright-core": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
-      "integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
+      "integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
       "dev": true
     }
   }

--- a/e2e/ui/package.json
+++ b/e2e/ui/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "@playwright/test": "^1.47.0"
+    "@playwright/test": "^1.48.0"
   }
 }

--- a/e2e/ui/run.sh
+++ b/e2e/ui/run.sh
@@ -33,7 +33,7 @@ EOF
 }
 
 
-IMAGE="mcr.microsoft.com/playwright:v1.47.0-noble"
+IMAGE="mcr.microsoft.com/playwright:v1.48.0-noble"
 pushd $(dirname "${BASH_SOURCE[0]}") > /dev/null
 
 run_tests() {


### PR DESCRIPTION
fix for e2e failure

```
Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium-1140/chrome-linux/chrome
╔══════════════════════════════════════════════════════════════════════╗
║ Looks like Playwright Test or Playwright was just updated to 1.48.0. ║
║ Please update docker image as well.                                  ║
║ -  current: mcr.microsoft.com/playwright:v1.47.0-jammy               ║
║ - required: mcr.microsoft.com/playwright:v1.48.0-jammy               ║
║                                                                      ║
║ <3 Playwright Team                                                   ║
╚══════════════════════════════════════════════════════════════════════╝
```

steps to update:
 * edit run.sh IMAGE variable manually
 * run ./run.sh test