### PR TITLE
docs: explain schedule state values

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -547,7 +547,10 @@ type AllocPauseRequest struct {
 }
 
 type AllocGetPauseResponse struct {
-	// ScheduleState will be one of "pause", "run", "scheduled".
+	// ScheduleState will be one of "" (run), "force_run", "scheduled_pause",
+	// "force_pause", or "schedule_resume".
+	//
+	// See nomad/structs/task_sched.go for details.
 	ScheduleState string
 }
 

--- a/website/content/api-docs/allocations.mdx
+++ b/website/content/api-docs/allocations.mdx
@@ -1018,12 +1018,12 @@ The table below shows this endpoint's support for
 
 ### Parameters
 
-- `:alloc_id` `(string: <required>)`- Specifies the UUID of the allocation. This
-  must be the full UUID, not the short 8-character one. This is specified as
-  part of the path.
+- `:alloc_id` `(string: <required>)` - Specifies the UUID of the allocation.
+  This must be the full UUID, not the short 8-character one. This is
+  specified as part of the path.
 
-- `task` - Specifies the task from which to retrieve the time based task
-  execution state.
+- `task` `(string: <required>)` - Specifies the name of the task from which to
+  retrieve the time based task execution state.
 
 ### Sample Request
 
@@ -1038,6 +1038,23 @@ $ nomad operator api /v1/client/allocation/23f520cc-629a-46ff-395f-0661e7aa939e/
   "ScheduleState": "scheduled_pause"
 }
 ```
+
+#### Field Reference
+
+- `ScheduledState` `(string)`: The task's current paused state. It can can have
+  one of the following values:
+
+  - `""` - The task is running. The only state returned for tasks with no
+    schedule.
+
+  - `force_run` - The task's scheduled has been overridden to run.
+
+  - `scheduled_pause` - The task is paused according to its schedule.
+
+  - `schedule_resume` - A schedule override is being removed. Subsequent calls
+    should return running (`""`) or paused (`scheduled_pause`) states. This
+    state is rarely possible to observe since it transitions immediately to
+    another state.
 
 [`shutdown_delay`]: /nomad/docs/job-specification/group#shutdown_delay
 [schedule]: /nomad/docs/job-specification/schedule

--- a/website/content/api-docs/allocations.mdx
+++ b/website/content/api-docs/allocations.mdx
@@ -983,6 +983,19 @@ The table below shows this endpoint's support for
   must be the full UUID, not the short 8-character one. This is specified as
   part of the path.
 
+- `Task` `(string: <required>)` - Specifies the name of the task who schedule
+  should be overridden.
+
+- `ScheduleState` `(string: <required>)` - Specifies the pause state to force
+  the task into. One of:
+
+    - `"pause"` - Forces the task to pause.
+
+    - `"run"` - Forces the task to run.
+
+    - `"scheduled"` - Removes any overrides and forces the task to adhere to
+      its schedule.
+
 ### Sample Request
 
 ```shell-session
@@ -1041,13 +1054,15 @@ $ nomad operator api /v1/client/allocation/23f520cc-629a-46ff-395f-0661e7aa939e/
 
 #### Field Reference
 
-- `ScheduledState` `(string)`: The task's current paused state. It can can have
+- `ScheduleState` `(string)`: The task's current paused state. It can can have
   one of the following values:
 
   - `""` - The task is running. The only state returned for tasks with no
     schedule.
 
-  - `force_run` - The task's scheduled has been overridden to run.
+  - `force_run` - The task's schedule has been overridden to run.
+
+  - `force_pause` - The task's schedule has been overridden to pause.
 
   - `scheduled_pause` - The task is paused according to its schedule.
 

--- a/website/content/api-docs/allocations.mdx
+++ b/website/content/api-docs/allocations.mdx
@@ -983,7 +983,7 @@ The table below shows this endpoint's support for
   must be the full UUID, not the short 8-character one. This is specified as
   part of the path.
 
-- `Task` `(string: <required>)` - Specifies the name of the task who schedule
+- `Task` `(string: <required>)` - Specifies the name of the task whose schedule
   should be overridden.
 
 - `ScheduleState` `(string: <required>)` - Specifies the pause state to force
@@ -1036,7 +1036,7 @@ The table below shows this endpoint's support for
   specified as part of the path.
 
 - `task` `(string: <required>)` - Specifies the name of the task from which to
-  retrieve the time based task execution state.
+  retrieve the time-based task execution state.
 
 ### Sample Request
 


### PR DESCRIPTION
GET /v1/client/allocation/:alloc_id/pause?task=:task_name is a tiny but critical API for observability of tasks with a schedule. This PR explains each of the values which might be returned.

Preview: https://nomad-csj1dlx3r-hashicorp.vercel.app/nomad/api-docs/allocations#override-pause-schedule-state

Internal: NET-11261
