### PR TITLE
[ui] Fix an issue where variables index dropdown would appear underneath table headers

### DIFF
--- a/.changelog/24162.txt
+++ b/.changelog/24162.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix an issue where a dropdown on the variables page would appear underneath table headers
+```

--- a/ui/app/styles/components/variables.scss
+++ b/ui/app/styles/components/variables.scss
@@ -12,6 +12,8 @@ $hdsInputHeight: 35px;
 
 .variable-title {
   margin-bottom: 2rem;
+  z-index: $z-base;
+
   .hds-page-header__main {
     flex-direction: unset;
   }


### PR DESCRIPTION
Resolves #24151 

(To test: check out the variables page in firefox/safari. Appears to have been working fine in chrome etc.)