### PR TITLE
scheduler: fix reconnecting allocations getting rescheduled

### DIFF
--- a/.changelog/24165.txt
+++ b/.changelog/24165.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: fixes reconnecting allocations not getting picked correctly when replacements failed
+```


### PR DESCRIPTION
In scenarios where a disconnected client reconnects with failed replacement allocs, the reconcile strategy for picking the correct allocation was not working.  These changes allow evaluation of multiple replacement allocs, and the stopping of allocs that are in a client terminal status.