### PR TITLE
fingerprint gce: collect preemptibility

### DIFF
--- a/.changelog/24169.txt
+++ b/.changelog/24169.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+fingerprint gce: fingerprint preemptibility
+```

--- a/client/fingerprint/env_gce.go
+++ b/client/fingerprint/env_gce.go
@@ -160,6 +160,7 @@ func (f *EnvGCEFingerprint) Fingerprint(req *FingerprintRequest, resp *Fingerpri
 		"cpu-platform":                   false,
 		"scheduling/automatic-restart":   false,
 		"scheduling/on-host-maintenance": false,
+		"scheduling/preemptible":         false,
 	}
 
 	for k, unique := range keys {

--- a/client/fingerprint/env_gce_test.go
+++ b/client/fingerprint/env_gce_test.go
@@ -148,6 +148,7 @@ func testFingerprint_GCE(t *testing.T, withExternalIp bool) {
 
 	assertNodeAttributeEquals(t, response.Attributes, "platform.gce.scheduling.automatic-restart", "TRUE")
 	assertNodeAttributeEquals(t, response.Attributes, "platform.gce.scheduling.on-host-maintenance", "MIGRATE")
+	assertNodeAttributeEquals(t, response.Attributes, "platform.gce.scheduling.preemptible", "FALSE")
 	assertNodeAttributeEquals(t, response.Attributes, "platform.gce.cpu-platform", "Intel Ivy Bridge")
 	assertNodeAttributeEquals(t, response.Attributes, "platform.gce.tag.abc", "true")
 	assertNodeAttributeEquals(t, response.Attributes, "platform.gce.tag.def", "true")
@@ -199,6 +200,11 @@ const GCE_routes = `
       "uri": "/computeMetadata/v1/instance/scheduling/on-host-maintenance",
       "content-type": "text/plain",
       "body": "MIGRATE"
+    },
+    {
+      "uri": "/computeMetadata/v1/instance/scheduling/preemptible",
+      "content-type": "text/plain",
+      "body": "FALSE"
     },
     {
       "uri": "/computeMetadata/v1/instance/cpu-platform",


### PR DESCRIPTION
As documented in https://cloud.google.com/compute/docs/metadata/predefined-metadata-keys

This PR fingerprints one more piece of information on Google Cloud instances: whether the instances are preemptible or not. 