### PR TITLE
build: update versions file for backports

### DIFF
--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -6,14 +6,14 @@
 
 schema = 1
 active_versions {
+  version "1.9.x" {
+    ce_active = true
+  }
   version "1.8.x" {
     ce_active = true
     lts       = true
   }
   version "1.7.x" {
-    ce_active = true
-  }
-  version "1.6.x" {
     ce_active = true
   }
 }


### PR DESCRIPTION
We can't backport to 1.9.x release branches without this change.