### PR TITLE
Docs: Update job version section with tutorial links

### DIFF
--- a/website/content/docs/concepts/job.mdx
+++ b/website/content/docs/concepts/job.mdx
@@ -109,6 +109,9 @@ tag with a unique name and optional description. Nomad does not garbage collect
 tagged versions even when the tagged version is dead. This lets you revert to
 a previous version regardless of how old the tagged version is.
 
+You can create, modify, and remove tags using the CLI, API, and web UI. Refer to
+the [Job versions guide][job-versions-guide] for examples.
+
 ### Compare versions
 
 You can compare the current job version to all previous versions or to a
@@ -119,10 +122,16 @@ of jobs and their immediate predecessors. Additionally, you can run `nomad job
 plan` to review the hypothetical difference of an update against the current job
 version.
 
+Refer to the [Compare versions section][compare-versions-section] of the Job
+versions guide for examples.
+
 ### Revert to a previous version
 
 You can revert the current running job to a previous version. Nomad stops the
 running job and deploys the chosen version.
+
+Refer to the [Revert to a version section][revert-version-section] of
+the Job versions guide for examples using the CLI, API, and web UI.
 
 ## Related resources
 
@@ -152,3 +161,6 @@ configure them:
 [Schedulers]: /nomad/docs/schedulers
 [task-groups]: /nomad/docs/glossary#task-group
 [tasks]: /nomad/docs/glossary#task
+[job-versions-guide]: /nomad/tutorials/manage-jobs/jobs-version
+[compare-versions-section]: /nomad/tutorials/manage-jobs/jobs-version.mdx#compare-versions
+[revert-version-section]: /nomad/tutorials/manage-jobs/jobs-version.mdx#revert-to-a-version

--- a/website/content/docs/concepts/job.mdx
+++ b/website/content/docs/concepts/job.mdx
@@ -162,5 +162,5 @@ configure them:
 [task-groups]: /nomad/docs/glossary#task-group
 [tasks]: /nomad/docs/glossary#task
 [job-versions-guide]: /nomad/tutorials/manage-jobs/jobs-version
-[compare-versions-section]: /nomad/tutorials/manage-jobs/jobs-version.mdx#compare-versions
-[revert-version-section]: /nomad/tutorials/manage-jobs/jobs-version.mdx#revert-to-a-version
+[compare-versions-section]: /nomad/tutorials/manage-jobs/jobs-version#compare-versions
+[revert-version-section]: /nomad/tutorials/manage-jobs/jobs-version#revert-to-a-version


### PR DESCRIPTION
Add tutorial links to Job versions section.
- Tag a version: add link to Job versions guide
- Compare versions: add link to Compare versions section
- Revert: add link to Revert to a version section

Deploy preview: https://nomad-git-ce714a-hashicorp.vercel.app/nomad/docs/concepts/job#job-versions

Relates to: https://github.com/hashicorp/tutorials/pull/2294

Partial: [CE-714]



[CE-714]: https://hashicorp.atlassian.net/browse/CE-714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ