### PR TITLE
consul: add support for service weight

### DIFF
--- a/.changelog/24186.txt
+++ b/.changelog/24186.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+consul: add support for service weight
+```

--- a/api/services.go
+++ b/api/services.go
@@ -246,6 +246,7 @@ type Service struct {
 	TaskName          string            `mapstructure:"task" hcl:"task,optional"`
 	OnUpdate          string            `mapstructure:"on_update" hcl:"on_update,optional"`
 	Identity          *WorkloadIdentity `hcl:"identity,block"`
+	Weights           *ServiceWeights   `mapstructure:"weights" hcl:"weights,block"`
 
 	// Provider defines which backend system provides the service registration,
 	// either "consul" (default) or "nomad".
@@ -307,6 +308,7 @@ func (s *Service) Canonicalize(t *Task, tg *TaskGroup, job *Job) {
 	}
 
 	s.Connect.Canonicalize()
+	s.Weights.Canonicalize()
 
 	// Canonicalize CheckRestart on Checks and merge Service.CheckRestart
 	// into each check.
@@ -330,5 +332,25 @@ func (s *Service) Canonicalize(t *Task, tg *TaskGroup, job *Job) {
 		if s.Checks[i].OnUpdate == "" {
 			s.Checks[i].OnUpdate = s.OnUpdate
 		}
+	}
+}
+
+// ServiceWeights is the jobspec block which configures how a service instance
+// is weighted in a DNS SRV request based on the service's health status.
+type ServiceWeights struct {
+	Passing int `hcl:"passing,optional"`
+	Warning int `hcl:"warning,optional"`
+}
+
+func (weights *ServiceWeights) Canonicalize() {
+	if weights == nil {
+		return
+	}
+
+	if weights.Passing <= 0 {
+		weights.Passing = 1
+	}
+	if weights.Warning <= 0 {
+		weights.Warning = 1
 	}
 }

--- a/command/agent/consul/service_client_test.go
+++ b/command/agent/consul/service_client_test.go
@@ -125,6 +125,15 @@ func TestSyncLogic_maybeTweakTaggedAddresses(t *testing.T) {
 	}
 }
 
+func TestSyncLogic_weightsDifferent(t *testing.T) {
+	ci.Parallel(t)
+
+	must.False(t, weightsDifferent(nil, api.AgentWeights{Passing: 1, Warning: 1}))
+	must.True(t, weightsDifferent(nil, api.AgentWeights{Passing: 5, Warning: 1}))
+	must.False(t, weightsDifferent(&api.AgentWeights{Passing: 5, Warning: 1}, api.AgentWeights{Passing: 5, Warning: 1}))
+	must.True(t, weightsDifferent(&api.AgentWeights{Passing: 5, Warning: 1}, api.AgentWeights{Passing: 1, Warning: 5}))
+}
+
 func TestSyncLogic_agentServiceUpdateRequired(t *testing.T) {
 	ci.Parallel(t)
 
@@ -172,6 +181,10 @@ func TestSyncLogic_agentServiceUpdateRequired(t *testing.T) {
 		Meta:              map[string]string{"foo": "1"},
 		TaggedAddresses: map[string]api.ServiceAddress{
 			"public_wan": {Address: "1.2.3.4", Port: 8080},
+		},
+		Weights: api.AgentWeights{
+			Passing: 1,
+			Warning: 1,
 		},
 	}
 
@@ -259,6 +272,16 @@ func TestSyncLogic_agentServiceUpdateRequired(t *testing.T) {
 	t.Run("different meta", func(t *testing.T) {
 		try(t, true, syncNewOps, func(w asr) *asr {
 			w.Meta = map[string]string{"foo": "2"}
+			return &w
+		})
+	})
+
+	t.Run("different passing weight", func(t *testing.T) {
+		try(t, true, syncNewOps, func(w asr) *asr {
+			w.Weights = &api.AgentWeights{
+				Passing: 5,
+				Warning: 1,
+			}
 			return &w
 		})
 	})

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1750,6 +1750,8 @@ func ApiServicesToStructs(in []*api.Service, group bool) []*structs.Service {
 			out[i].Identity = apiWorkloadIdentityToStructs(s.Identity)
 		}
 
+		out[i].Weights = apiWorkloadWeightsToStructs(s.Weights)
+
 	}
 
 	return out
@@ -1769,6 +1771,16 @@ func apiWorkloadIdentityToStructs(in *api.WorkloadIdentity) *structs.WorkloadIde
 		Filepath:     in.Filepath,
 		ServiceName:  in.ServiceName,
 		TTL:          in.TTL,
+	}
+}
+
+func apiWorkloadWeightsToStructs(in *api.ServiceWeights) *structs.ServiceWeights {
+	if in == nil {
+		return nil
+	}
+	return &structs.ServiceWeights{
+		Passing: in.Passing,
+		Warning: in.Warning,
 	}
 }
 

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -2708,6 +2708,10 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						TaggedAddresses: map[string]string{
 							"wan": "1.2.3.4",
 						},
+						Weights: &api.ServiceWeights{
+							Passing: 5,
+							Warning: 1,
+						},
 						CheckRestart: &api.CheckRestart{
 							Limit: 4,
 							Grace: pointer.Of(11 * time.Second),
@@ -2819,6 +2823,10 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								Address:           "task.example.com",
 								Meta: map[string]string{
 									"servicemeta": "foobar",
+								},
+								Weights: &api.ServiceWeights{
+									Passing: 7,
+									Warning: 2,
 								},
 								CheckRestart: &api.CheckRestart{
 									Limit: 4,
@@ -3148,6 +3156,10 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 						TaggedAddresses: map[string]string{
 							"wan": "1.2.3.4",
 						},
+						Weights: &structs.ServiceWeights{
+							Passing: 5,
+							Warning: 1,
+						},
 						OnUpdate: structs.OnUpdateRequireHealthy,
 						Checks: []*structs.ServiceCheck{
 							{
@@ -3263,6 +3275,10 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								Address:           "task.example.com",
 								Meta: map[string]string{
 									"servicemeta": "foobar",
+								},
+								Weights: &structs.ServiceWeights{
+									Passing: 7,
+									Warning: 2,
 								},
 								OnUpdate: structs.OnUpdateRequireHealthy,
 								Checks: []*structs.ServiceCheck{

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -847,6 +847,11 @@ func serviceDiff(old, new *Service, contextual bool) *ObjectDiff {
 		diff.Objects = append(diff.Objects, wiDiffs)
 	}
 
+	// Weights diffs
+	if weightsDiffs := weightsDiff(old.Weights, new.Weights, contextual); weightsDiffs != nil {
+		diff.Objects = append(diff.Objects, weightsDiffs)
+	}
+
 	return diff
 }
 
@@ -2984,6 +2989,42 @@ func idSliceDiffs(old, new []*WorkloadIdentity, contextual bool) []*ObjectDiff {
 	}
 	sort.Sort(ObjectDiffs(diffs))
 	return diffs
+}
+
+func weightsDiff(oldWeights *ServiceWeights, newWeights *ServiceWeights, contextual bool) *ObjectDiff {
+	if reflect.DeepEqual(oldWeights, newWeights) {
+		return nil
+	}
+
+	flatten := func(weights *ServiceWeights) map[string]string {
+		m := map[string]string{}
+		if weights.Passing > 0 {
+			m["Passing"] = strconv.Itoa(weights.Passing)
+		}
+		if weights.Warning > 0 {
+			m["Warning"] = strconv.Itoa(weights.Warning)
+		}
+		return m
+	}
+
+	diff := &ObjectDiff{Type: DiffTypeNone, Name: "Weights"}
+	var oldPrimitiveFlat, newPrimitiveFlat map[string]string
+	if oldWeights == nil {
+		diff.Type = DiffTypeAdded
+		newPrimitiveFlat = flatten(newWeights)
+	} else if newWeights == nil {
+		diff.Type = DiffTypeDeleted
+		oldPrimitiveFlat = flatten(oldWeights)
+	} else {
+		diff.Type = DiffTypeEdited
+		oldPrimitiveFlat = flatten(oldWeights)
+		newPrimitiveFlat = flatten(newWeights)
+	}
+
+	// Diff the primitive fields.
+	diff.Fields = fieldDiffs(oldPrimitiveFlat, newPrimitiveFlat, contextual)
+
+	return diff
 }
 
 // idDiff returns the diff of two identity objects. If contextual diff is

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -9924,6 +9924,10 @@ func TestServicesDiff(t *testing.T) {
 					EnableTagOverride: true,
 					Tags:              []string{"prod"},
 					CanaryTags:        []string{"canary"},
+					Weights: &ServiceWeights{
+						Passing: 1,
+						Warning: 1,
+					},
 				},
 			},
 			New: []*Service{
@@ -9935,6 +9939,10 @@ func TestServicesDiff(t *testing.T) {
 					EnableTagOverride: false,
 					Tags:              []string{"prod", "dev"},
 					CanaryTags:        []string{"qa"},
+					Weights: &ServiceWeights{
+						Passing: 5,
+						Warning: 1,
+					},
 				},
 			},
 			Expected: []*ObjectDiff{
@@ -10026,6 +10034,24 @@ func TestServicesDiff(t *testing.T) {
 									Name: "Tags",
 									Old:  "prod",
 									New:  "prod",
+								},
+							},
+						},
+						{
+							Type: DiffTypeEdited,
+							Name: "Weights",
+							Fields: []*FieldDiff{
+								{
+									Type: DiffTypeEdited,
+									Name: "Passing",
+									Old:  "1",
+									New:  "5",
+								},
+								{
+									Type: DiffTypeNone,
+									Name: "Warning",
+									Old:  "1",
+									New:  "1",
 								},
 							},
 						},

--- a/website/content/docs/job-specification/service.mdx
+++ b/website/content/docs/job-specification/service.mdx
@@ -32,6 +32,11 @@ job "docs" {
 
         provider = "consul"
 
+        weights {
+          passing = 5
+          warning = 1
+        }
+
         meta {
           meta = "for your service"
         }
@@ -92,6 +97,13 @@ Service Mesh][connect] integration.
   define multiple checks for the service. At this time, a check using the Nomad
   provider supports `tcp` and `http` checks. The Consul integration supports
   the `grpc`, `http`, `script`<sup><small>1</small></sup>, and `tcp` checks.
+
+- `weights` <code>(Weights: nil)</code> - Specifies how a service instance is
+  weighted in a DNS SRV request based on the service's health status, as
+  described in the Consul [weights][] documentation. Only available where
+  `provider = "consul"` The `weight` block supports the following fields:
+  - `passing` <code>int: 1</code> - The weight of services in passing state.
+  - `warning` <code>int: 1</code> - The weight of services in warning state.
 
 - `connect` - Configures the [Consul Connect][connect] integration. Only
   available on group services and where `provider = "consul"`.
@@ -536,3 +548,4 @@ advertise and check directly since Nomad isn't managing any port assignments.
 [`consul.name`]: /nomad/docs/configuration/consul#name
 [`consul.service_identity`]: /nomad/docs/configuration/consul#service_identity
 [identity_block]: /nomad/docs/job-specification/identity
+[weights]: /consul/docs/services/configuration/services-configuration-reference#weights


### PR DESCRIPTION
## Manual verification
```
No `weights`
```
```
$ curl -s http://127.0.0.1:8500/v1/agent/services  | jq '.[] | select(.Service=="global-redis-check") | .Weights'
{
  "Passing": 1,
  "Warning": 1
}

$ dig @127.0.0.1 -p 8600 global-redis-check.service.consul SRV +short
1 1 27982 7f000001.addr.dc1.consul.
```
---
```
weights {}
```
```
$ ./bin/nomad job plan ./job.hcl
+/- Job: "redis"
+/- Task Group: "cache" (1 in-place update)
  +/- Task: "redis" (forces in-place update)
    +/- Service {
        Address:           ""
        ...
      + Weights {
        + Passing: "1"
        + Warning: "1"
        }
        }
```
```
$ curl -s http://127.0.0.1:8500/v1/agent/services  | jq '.[] | select(.Service=="global-redis-check") | .Weights'
{
  "Passing": 1,
  "Warning": 1
}	
```
---
```
weights {
  passing = 5
}
```
```
$ ./bin/nomad job plan ./job.hcl
+/- Job: "redis"
+/- Task Group: "cache" (1 in-place update)
  +/- Task: "redis" (forces in-place update)
    +/- Service {
          Address:           ""
          ...
      +/- Weights {
        +/- Passing: "1" => "5"
            Warning: "1"
          }
        }
```
```
$ curl -s http://127.0.0.1:8500/v1/agent/services  | jq '.[] | select(.Service=="global-redis-check") | .Weights'
{
  "Passing": 5,
  "Warning": 1
}

$ dig @127.0.0.1 -p 8600 global-redis-check.service.consul SRV +short
1 5 30957 7f000001.addr.dc1.consul.
```