### PR TITLE
build: update hc-install to current

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -137,7 +137,7 @@ deps:  ## Install build and development dependencies
 	go install github.com/bufbuild/buf/cmd/buf@v0.36.0
 	go install github.com/hashicorp/go-changelog/cmd/changelog-build@latest
 	go install golang.org/x/tools/cmd/stringer@v0.18.0
-	go install github.com/hashicorp/hc-install/cmd/hc-install@v0.6.1
+	go install github.com/hashicorp/hc-install/cmd/hc-install@v0.9.0
 	go install github.com/shoenig/go-modtool@v0.2.0
 
 .PHONY: lint-deps

--- a/e2e/consulcompat/shared_download_test.go
+++ b/e2e/consulcompat/shared_download_test.go
@@ -40,8 +40,15 @@ func downloadConsulBuild(t *testing.T, b build, baseDir string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "hc-install", "install", "-version", b.Version, "-path", path, "consul")
+	cmd := exec.CommandContext(ctx, "hc-install", "install",
+		"-version", b.Version, "-path", path, "consul")
 	bs, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("download: failed to download %s, retrying once: %v", b.Version, err)
+		cmd = exec.CommandContext(ctx, "hc-install", "install",
+			"-version", b.Version, "-path", path, "consul")
+		bs, err = cmd.CombinedOutput()
+	}
 	must.NoError(t, err, must.Sprintf("failed to download consul %s: %s", b.Version, string(bs)))
 }
 

--- a/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
@@ -33,7 +33,7 @@ sudo apt-get install -y \
      apt-transport-https ca-certificates gnupg2 stress
 
 # Install hc-install
-curl -o /tmp/hc-install.zip https://releases.hashicorp.com/hc-install/0.5.2/hc-install_0.5.2_linux_amd64.zip
+curl -o /tmp/hc-install.zip https://releases.hashicorp.com/hc-install/0.9.0/hc-install_0.9.0_linux_amd64.zip
 sudo unzip -d /usr/local/bin /tmp/hc-install.zip
 
 # Install sockaddr

--- a/e2e/vaultcompat/vaultcompat_test.go
+++ b/e2e/vaultcompat/vaultcompat_test.go
@@ -329,6 +329,12 @@ func downloadVaultBuild(t *testing.T, b build) {
 
 	cmd := exec.CommandContext(ctx, "hc-install", "install", "-version", b.Version, "-path", path, "vault")
 	bs, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("download: failed to download %s, retrying once: %v", b.Version, err)
+		cmd = exec.CommandContext(ctx, "hc-install", "install",
+			"-version", b.Version, "-path", path, "vault")
+		bs, err = cmd.CombinedOutput()
+	}
 	must.NoError(t, err, must.Sprintf("failed to download vault %s: %s", b.Version, string(bs)))
 }
 


### PR DESCRIPTION
Installing Vault and Consul from releases.hashicorp.com via `hc-install` has been failing intermittently. Update the `hc-install` binaries to be current and add one retry to downloads for our compat tests so that we can get builds more reliably green while the underlying issue is being debugged.