### PR TITLE
Consul Connect over IPv6 (except tproxy)

### DIFF
--- a/command/agent/consul/connect.go
+++ b/command/agent/consul/connect.go
@@ -154,7 +154,7 @@ func connectSidecarProxy(info structs.AllocInfo, proxy *structs.ConsulProxy, cPo
 		Mode:                mode,
 		LocalServiceAddress: proxy.LocalServiceAddress,
 		LocalServicePort:    proxy.LocalServicePort,
-		Config:              connectProxyConfig(proxy.Config, cPort, info),
+		Config:              connectProxyConfig(proxy.Config, cPort, info, networks),
 		Upstreams:           connectUpstreams(proxy.Upstreams),
 		Expose:              expose,
 	}, nil
@@ -243,12 +243,12 @@ func connectMeshGateway(in structs.ConsulMeshGateway) api.MeshGatewayConfig {
 	return gw
 }
 
-func connectProxyConfig(cfg map[string]interface{}, port int, info structs.AllocInfo) map[string]interface{} {
+func connectProxyConfig(cfg map[string]interface{}, port int, info structs.AllocInfo, networks structs.Networks) map[string]interface{} {
 	if cfg == nil {
 		cfg = make(map[string]interface{})
 	}
 	if _, ok := cfg["bind_address"]; !ok {
-		cfg["bind_address"] = "0.0.0.0"
+		cfg["bind_address"] = connectProxyBindAddress(networks)
 	}
 	cfg["bind_port"] = port
 
@@ -260,6 +260,15 @@ func connectProxyConfig(cfg map[string]interface{}, port int, info structs.Alloc
 	}
 	injectNomadInfo(cfg, tags)
 	return cfg
+}
+
+func connectProxyBindAddress(networks structs.Networks) string {
+	for _, n := range networks {
+		if n.Mode == "bridge" && n.IsIPv6() {
+			return "::"
+		}
+	}
+	return "0.0.0.0"
 }
 
 // injectNomadInfo merges nomad information into cfg=>envoy_stats_tags

--- a/command/agent/consul/connect.go
+++ b/command/agent/consul/connect.go
@@ -247,7 +247,9 @@ func connectProxyConfig(cfg map[string]interface{}, port int, info structs.Alloc
 	if cfg == nil {
 		cfg = make(map[string]interface{})
 	}
-	cfg["bind_address"] = "0.0.0.0"
+	if _, ok := cfg["bind_address"]; !ok {
+		cfg["bind_address"] = "0.0.0.0"
+	}
 	cfg["bind_port"] = port
 
 	tags := map[string]string{

--- a/command/agent/consul/connect_test.go
+++ b/command/agent/consul/connect_test.go
@@ -426,6 +426,16 @@ func TestConnect_connectProxyConfig(t *testing.T) {
 			"foo": "bar",
 		}, 42, structs.AllocInfo{AllocID: "test_alloc2"}))
 	})
+
+	t.Run("bind_address override", func(t *testing.T) {
+		require.Equal(t, map[string]interface{}{
+			"bind_address":     "::",
+			"bind_port":        42,
+			"envoy_stats_tags": []string{"nomad.alloc_id=test_alloc1b"},
+		}, connectProxyConfig(map[string]interface{}{
+			"bind_address": "::",
+		}, 42, structs.AllocInfo{AllocID: "test_alloc1b"}))
+	})
 }
 
 func TestConnect_getConnectPort(t *testing.T) {

--- a/command/agent/consul/connect_test.go
+++ b/command/agent/consul/connect_test.go
@@ -409,7 +409,7 @@ func TestConnect_connectProxyConfig(t *testing.T) {
 	ci.Parallel(t)
 
 	t.Run("nil map", func(t *testing.T) {
-		require.Equal(t, map[string]interface{}{
+		must.Eq(t, map[string]any{
 			"bind_address":     "0.0.0.0",
 			"bind_port":        42,
 			"envoy_stats_tags": []string{"nomad.alloc_id=test_alloc1"},
@@ -417,34 +417,34 @@ func TestConnect_connectProxyConfig(t *testing.T) {
 	})
 
 	t.Run("pre-existing map", func(t *testing.T) {
-		require.Equal(t, map[string]interface{}{
+		must.Eq(t, map[string]any{
 			"bind_address":     "0.0.0.0",
 			"bind_port":        42,
 			"foo":              "bar",
 			"envoy_stats_tags": []string{"nomad.alloc_id=test_alloc2"},
-		}, connectProxyConfig(map[string]interface{}{
+		}, connectProxyConfig(map[string]any{
 			"foo": "bar",
 		}, 42, structs.AllocInfo{AllocID: "test_alloc2"}, nil))
 	})
 
 	t.Run("bind_address override", func(t *testing.T) {
-		require.Equal(t, map[string]interface{}{
+		must.Eq(t, map[string]any{
 			"bind_address":     "anything",
 			"bind_port":        42,
-			"envoy_stats_tags": []string{"nomad.alloc_id=test_alloc1b"},
-		}, connectProxyConfig(map[string]interface{}{
+			"envoy_stats_tags": []string{"nomad.alloc_id=custom_bind_alloc"},
+		}, connectProxyConfig(map[string]any{
 			"bind_address": "anything",
-		}, 42, structs.AllocInfo{AllocID: "test_alloc1b"}, nil))
+		}, 42, structs.AllocInfo{AllocID: "custom_bind_alloc"}, nil))
 	})
 
 	t.Run("bind_address ipv6", func(t *testing.T) {
-		require.Equal(t, map[string]interface{}{
+		must.Eq(t, map[string]any{
 			"bind_address":     "::",
 			"bind_port":        42,
-			"envoy_stats_tags": []string{"nomad.alloc_id=test_alloc1b"},
-		}, connectProxyConfig(map[string]interface{}{
+			"envoy_stats_tags": []string{"nomad.alloc_id=ipv6_alloc"},
+		}, connectProxyConfig(map[string]any{
 			"bind_address": "::",
-		}, 42, structs.AllocInfo{AllocID: "test_alloc1b"}, []*structs.NetworkResource{
+		}, 42, structs.AllocInfo{AllocID: "ipv6_alloc"}, []*structs.NetworkResource{
 			{Mode: "bridge", IP: "fd00:a110:c8::1"},
 		}))
 	})

--- a/command/agent/consul/connect_test.go
+++ b/command/agent/consul/connect_test.go
@@ -413,7 +413,7 @@ func TestConnect_connectProxyConfig(t *testing.T) {
 			"bind_address":     "0.0.0.0",
 			"bind_port":        42,
 			"envoy_stats_tags": []string{"nomad.alloc_id=test_alloc1"},
-		}, connectProxyConfig(nil, 42, structs.AllocInfo{AllocID: "test_alloc1"}))
+		}, connectProxyConfig(nil, 42, structs.AllocInfo{AllocID: "test_alloc1"}, nil))
 	})
 
 	t.Run("pre-existing map", func(t *testing.T) {
@@ -424,17 +424,29 @@ func TestConnect_connectProxyConfig(t *testing.T) {
 			"envoy_stats_tags": []string{"nomad.alloc_id=test_alloc2"},
 		}, connectProxyConfig(map[string]interface{}{
 			"foo": "bar",
-		}, 42, structs.AllocInfo{AllocID: "test_alloc2"}))
+		}, 42, structs.AllocInfo{AllocID: "test_alloc2"}, nil))
 	})
 
 	t.Run("bind_address override", func(t *testing.T) {
+		require.Equal(t, map[string]interface{}{
+			"bind_address":     "anything",
+			"bind_port":        42,
+			"envoy_stats_tags": []string{"nomad.alloc_id=test_alloc1b"},
+		}, connectProxyConfig(map[string]interface{}{
+			"bind_address": "anything",
+		}, 42, structs.AllocInfo{AllocID: "test_alloc1b"}, nil))
+	})
+
+	t.Run("bind_address ipv6", func(t *testing.T) {
 		require.Equal(t, map[string]interface{}{
 			"bind_address":     "::",
 			"bind_port":        42,
 			"envoy_stats_tags": []string{"nomad.alloc_id=test_alloc1b"},
 		}, connectProxyConfig(map[string]interface{}{
 			"bind_address": "::",
-		}, 42, structs.AllocInfo{AllocID: "test_alloc1b"}))
+		}, 42, structs.AllocInfo{AllocID: "test_alloc1b"}, []*structs.NetworkResource{
+			{Mode: "bridge", IP: "fd00:a110:c8::1"},
+		}))
 	})
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3037,6 +3037,11 @@ func (n *NetworkResource) PortLabels() map[string]int {
 	return labelValues
 }
 
+func (n *NetworkResource) IsIPv6() bool {
+	ip := net.ParseIP(n.IP)
+	return ip != nil && ip.To4() == nil
+}
+
 // Networks defined for a task on the Resources struct.
 type Networks []*NetworkResource
 


### PR DESCRIPTION
Mostly resolves #7905 -- #23882 introduced IPv6 support to Nomad's "bridge" network mode, and this extends that to Consul Connect (which also requires "bridge" mode).  I say "mostly" because Transparent Proxy still does not work (the Consul CNI plugin does not do any `ip6tables` at the moment for its extra functionality).

Along the way, I found that since we were always setting Connect/Envoy's `bind_address` to `"0.0.0.0"`, the user couldn't pick anything else (like I had tried `"::"`).  In particular, even with this PR auto-detecting IPv6, I imagine a user might like to set it to `""` (empty), so that Consul [`proxy-defaults` config](https://developer.hashicorp.com/consul/docs/connect/config-entries/proxy-defaults#examples) can come into play.  I did not add a config option for the client along these lines, but an individual job could set it like so:

```hcl
connect {
  sidecar_service {
    proxy {
      config {
        bind_address = "" # let consul proxy-defaults handle it
      }
```

Or set it to whatever they may like.

---

My preferred way to replicate the behavior is (on a host/network with ipv6 support), enable ipv6 on the Nomad bridge and prefer ipv6 for services on a client (per #23388):

```hcl
client {
  enabled = true

  bridge_network_subnet_ipv6 = "fd00:a110:c8::/120"
  preferred_address_family   = "ipv6"
}
```

Consul can run in dev mode. `consul agent -dev`

Then use the basic countdash example:

```shell-session
$ nomad job init -connect -short
Example job file written to example.nomad.hcl
```

<details><summary><code>example.nomad.hcl</code></summary>

```hcl
job "countdash" {

  group "api" {
    network {
      mode = "bridge"
    }

    service {
      name = "count-api"
      port = "9001"

      connect {
        sidecar_service {}
      }
    }

    task "web" {
      driver = "docker"

      config {
        image          = "hashicorpdev/counter-api:v3"
        auth_soft_fail = true
      }
    }
  }

  group "dashboard" {
    network {
      mode = "bridge"

      port "http" {
        static = 9002
        to     = 9002
      }
    }

    service {
      name = "count-dashboard"
      port = "9002"

      connect {
        sidecar_service {
          proxy {
            upstreams {
              destination_name = "count-api"
              local_bind_port  = 8080
            }
          }
        }
      }
    }

    task "dashboard" {
      driver = "docker"

      env {
        COUNTING_SERVICE_URL = "http://${NOMAD_UPSTREAM_ADDR_count_api}"
      }

      config {
        image          = "hashicorpdev/counter-dashboard:v3"
        auth_soft_fail = true
      }
    }
  }
}
```

</details>

The alloc and service addresses will be ipv6, health checks pass, and the counter counts.