### PR TITLE
windows: set job object for executor and children

### DIFF
--- a/.changelog/24214.txt
+++ b/.changelog/24214.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+windows: Fixed a bug where a crashed executor would orphan task processes
+```

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -87,6 +87,8 @@ jobs:
           gotestsum --format=short-verbose \
             --junitfile results.xml \
             github.com/hashicorp/nomad/drivers/docker \
+            github.com/hashicorp/nomad/drivers/rawexec \
+            github.com/hashicorp/nomad/drivers/shared/executor \
             github.com/hashicorp/nomad/client/lib/fifo \
             github.com/hashicorp/nomad/client/logmon \
             github.com/hashicorp/nomad/client/allocrunner/taskrunner/template \

--- a/drivers/rawexec/driver_test.go
+++ b/drivers/rawexec/driver_test.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strconv"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -235,103 +234,6 @@ func TestRawExecDriver_StartWait(t *testing.T) {
 	require.False(result.OOMKilled)
 	require.NoError(result.Err)
 	require.NoError(harness.DestroyTask(task.ID, true))
-}
-
-func TestRawExecDriver_StartWaitRecoverWaitStop(t *testing.T) {
-	ci.Parallel(t)
-	require := require.New(t)
-
-	d := newEnabledRawExecDriver(t)
-	harness := dtestutil.NewDriverHarness(t, d)
-	defer harness.Kill()
-
-	config := &Config{Enabled: true}
-	var data []byte
-	require.NoError(basePlug.MsgPackEncode(&data, config))
-	bconfig := &basePlug.Config{
-		PluginConfig: data,
-		AgentConfig: &base.AgentConfig{
-			Driver: &base.ClientDriverConfig{
-				Topology: d.nomadConfig.Topology,
-			},
-		},
-	}
-	require.NoError(harness.SetConfig(bconfig))
-
-	allocID := uuid.Generate()
-	taskName := "sleep"
-	task := &drivers.TaskConfig{
-		AllocID:   allocID,
-		ID:        uuid.Generate(),
-		Name:      taskName,
-		Env:       defaultEnv(),
-		Resources: testResources(allocID, taskName),
-	}
-	tc := &TaskConfig{
-		Command: testtask.Path(),
-		Args:    []string{"sleep", "100s"},
-	}
-	require.NoError(task.EncodeConcreteDriverConfig(&tc))
-
-	testtask.SetTaskConfigEnv(task)
-
-	cleanup := harness.MkAllocDir(task, false)
-	defer cleanup()
-
-	harness.MakeTaskCgroup(allocID, taskName)
-
-	handle, _, err := harness.StartTask(task)
-	require.NoError(err)
-
-	ch, err := harness.WaitTask(context.Background(), task.ID)
-	require.NoError(err)
-
-	var waitDone bool
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		result := <-ch
-		require.Error(result.Err)
-		waitDone = true
-	}()
-
-	originalStatus, err := d.InspectTask(task.ID)
-	require.NoError(err)
-
-	d.tasks.Delete(task.ID)
-
-	wg.Wait()
-	require.True(waitDone)
-	_, err = d.InspectTask(task.ID)
-	require.Equal(drivers.ErrTaskNotFound, err)
-
-	err = d.RecoverTask(handle)
-	require.NoError(err)
-
-	status, err := d.InspectTask(task.ID)
-	require.NoError(err)
-	require.Exactly(originalStatus, status)
-
-	ch, err = harness.WaitTask(context.Background(), task.ID)
-	require.NoError(err)
-
-	wg.Add(1)
-	waitDone = false
-	go func() {
-		defer wg.Done()
-		result := <-ch
-		require.NoError(result.Err)
-		require.NotZero(result.ExitCode)
-		require.Equal(9, result.Signal)
-		waitDone = true
-	}()
-
-	time.Sleep(300 * time.Millisecond)
-	require.NoError(d.StopTask(task.ID, 0, "SIGKILL"))
-	wg.Wait()
-	require.NoError(d.DestroyTask(task.ID, false))
-	require.True(waitDone)
 }
 
 func TestRawExecDriver_Start_Wait_AllocDir(t *testing.T) {

--- a/drivers/rawexec/driver_unix_test.go
+++ b/drivers/rawexec/driver_unix_test.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 	"github.com/hashicorp/nomad/helper/testtask"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/plugins/base"
+	basePlug "github.com/hashicorp/nomad/plugins/base"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	dtestutil "github.com/hashicorp/nomad/plugins/drivers/testutils"
 	"github.com/hashicorp/nomad/testutil"
@@ -442,4 +444,101 @@ func TestRawExec_ExecTaskStreaming_User(t *testing.T) {
 	require.Zero(t, code)
 	require.Empty(t, stderr)
 	require.Contains(t, stdout, "nobody")
+}
+
+func TestRawExecDriver_StartWaitRecoverWaitStop(t *testing.T) {
+	ci.Parallel(t)
+	require := require.New(t)
+
+	d := newEnabledRawExecDriver(t)
+	harness := dtestutil.NewDriverHarness(t, d)
+	defer harness.Kill()
+
+	config := &Config{Enabled: true}
+	var data []byte
+	require.NoError(basePlug.MsgPackEncode(&data, config))
+	bconfig := &basePlug.Config{
+		PluginConfig: data,
+		AgentConfig: &base.AgentConfig{
+			Driver: &base.ClientDriverConfig{
+				Topology: d.nomadConfig.Topology,
+			},
+		},
+	}
+	require.NoError(harness.SetConfig(bconfig))
+
+	allocID := uuid.Generate()
+	taskName := "sleep"
+	task := &drivers.TaskConfig{
+		AllocID:   allocID,
+		ID:        uuid.Generate(),
+		Name:      taskName,
+		Env:       defaultEnv(),
+		Resources: testResources(allocID, taskName),
+	}
+	tc := &TaskConfig{
+		Command: testtask.Path(),
+		Args:    []string{"sleep", "100s"},
+	}
+	require.NoError(task.EncodeConcreteDriverConfig(&tc))
+
+	testtask.SetTaskConfigEnv(task)
+
+	cleanup := harness.MkAllocDir(task, false)
+	defer cleanup()
+
+	harness.MakeTaskCgroup(allocID, taskName)
+
+	handle, _, err := harness.StartTask(task)
+	require.NoError(err)
+
+	ch, err := harness.WaitTask(context.Background(), task.ID)
+	require.NoError(err)
+
+	var waitDone bool
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		result := <-ch
+		require.Error(result.Err)
+		waitDone = true
+	}()
+
+	originalStatus, err := d.InspectTask(task.ID)
+	require.NoError(err)
+
+	d.tasks.Delete(task.ID)
+
+	wg.Wait()
+	require.True(waitDone)
+	_, err = d.InspectTask(task.ID)
+	require.Equal(drivers.ErrTaskNotFound, err)
+
+	err = d.RecoverTask(handle)
+	require.NoError(err)
+
+	status, err := d.InspectTask(task.ID)
+	require.NoError(err)
+	require.Exactly(originalStatus, status)
+
+	ch, err = harness.WaitTask(context.Background(), task.ID)
+	require.NoError(err)
+
+	wg.Add(1)
+	waitDone = false
+	go func() {
+		defer wg.Done()
+		result := <-ch
+		require.NoError(result.Err)
+		require.NotZero(result.ExitCode)
+		require.Equal(9, result.Signal)
+		waitDone = true
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	require.NoError(d.StopTask(task.ID, 0, "SIGKILL"))
+	wg.Wait()
+	require.NoError(d.DestroyTask(task.ID, false))
+	require.True(waitDone)
 }

--- a/drivers/rawexec/driver_windows_test.go
+++ b/drivers/rawexec/driver_windows_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+
+package rawexec
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/plugins/base"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	dtestutil "github.com/hashicorp/nomad/plugins/drivers/testutils"
+	"github.com/shoenig/test/must"
+)
+
+// TestRawExecDriver_ExecutorKill verifies that killing the executor will stop
+// its child processes
+func TestRawExecDriver_ExecutorKill(t *testing.T) {
+	ci.Parallel(t)
+
+	d := newEnabledRawExecDriver(t)
+	harness := dtestutil.NewDriverHarness(t, d)
+	t.Cleanup(harness.Kill)
+
+	config := &Config{Enabled: true}
+	var data []byte
+	must.NoError(t, base.MsgPackEncode(&data, config))
+	bconfig := &base.Config{
+		PluginConfig: data,
+		AgentConfig: &base.AgentConfig{
+			Driver: &base.ClientDriverConfig{
+				Topology: d.nomadConfig.Topology,
+			},
+		},
+	}
+	must.NoError(t, harness.SetConfig(bconfig))
+
+	allocID := uuid.Generate()
+	taskName := "test"
+	task := &drivers.TaskConfig{
+		AllocID:   allocID,
+		ID:        uuid.Generate(),
+		Name:      taskName,
+		Resources: testResources(allocID, taskName),
+	}
+
+	taskConfig := map[string]interface{}{}
+	taskConfig["command"] = "Powershell.exe"
+	taskConfig["args"] = []string{"sleep", "100s"}
+
+	must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
+
+	cleanup := harness.MkAllocDir(task, false)
+	t.Cleanup(cleanup)
+
+	handle, _, err := harness.StartTask(task)
+	must.NoError(t, err)
+
+	var taskState TaskState
+	must.NoError(t, handle.GetDriverState(&taskState))
+	must.NoError(t, harness.WaitUntilStarted(task.ID, 1*time.Second))
+
+	// forcibly kill the executor, not the workload
+	must.NotEq(t, taskState.ReattachConfig.Pid, taskState.Pid)
+	proc, err := os.FindProcess(taskState.ReattachConfig.Pid)
+	must.NoError(t, err)
+
+	taskProc, err := os.FindProcess(taskState.Pid)
+	must.NoError(t, err)
+
+	must.NoError(t, proc.Kill())
+	t.Logf("killed %d, waiting on %d to stop", taskState.ReattachConfig.Pid, taskState.Pid)
+
+	t.Cleanup(func() {
+		if taskProc != nil {
+			taskProc.Kill()
+		}
+	})
+
+	done := make(chan struct{})
+	go func() {
+		taskProc.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected child process to exit")
+	case <-done:
+	}
+}

--- a/drivers/shared/executor/executor_windows_test.go
+++ b/drivers/shared/executor/executor_windows_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build windows
+
+package executor
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/lib/numalib"
+	"github.com/hashicorp/nomad/client/taskenv"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/nomad/plugins/drivers/fsisolation"
+	"github.com/shoenig/test/must"
+)
+
+// testExecutorCommand sets up a test task environment.
+func testExecutorCommand(t *testing.T) *testExecCmd {
+	alloc := mock.Alloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	taskEnv := taskenv.NewBuilder(mock.Node(), alloc, task, "global").Build()
+
+	allocDir := allocdir.NewAllocDir(testlog.HCLogger(t), t.TempDir(), t.TempDir(), alloc.ID)
+	must.NoError(t, allocDir.Build())
+	t.Cleanup(func() { allocDir.Destroy() })
+
+	must.NoError(t, allocDir.NewTaskDir(task).Build(fsisolation.None, nil, task.User))
+	td := allocDir.TaskDirs[task.Name]
+	cmd := &ExecCommand{
+		Env:     taskEnv.List(),
+		TaskDir: td.Dir,
+		Resources: &drivers.Resources{
+			NomadResources: &structs.AllocatedTaskResources{
+				Cpu: structs.AllocatedCpuResources{
+					CpuShares: 500,
+				},
+				Memory: structs.AllocatedMemoryResources{
+					MemoryMB: 256,
+				},
+			},
+		},
+	}
+
+	testCmd := &testExecCmd{
+		command:  cmd,
+		allocDir: allocDir,
+	}
+	configureTLogging(t, testCmd)
+	return testCmd
+}
+
+func TestExecutor_ProcessExit(t *testing.T) {
+	ci.Parallel(t)
+
+	topology := numalib.Scan(numalib.PlatformScanners())
+	compute := topology.Compute()
+
+	cmd := testExecutorCommand(t)
+	cmd.command.Cmd = "Powershell.exe"
+	cmd.command.Args = []string{"sleep", "30"}
+	executor := NewExecutor(testlog.HCLogger(t), compute)
+
+	t.Cleanup(func() { executor.Shutdown("SIGKILL", 0) })
+
+	childPs, err := executor.Launch(cmd.command)
+	must.NoError(t, err)
+	must.NonZero(t, childPs.Pid)
+
+	proc, err := os.FindProcess(childPs.Pid)
+	must.NoError(t, err)
+	must.NoError(t, proc.Kill())
+
+	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Second)
+	t.Cleanup(cancel)
+	waitPs, err := executor.Wait(ctx)
+	must.NoError(t, err)
+	must.Eq(t, 1, waitPs.ExitCode)
+	must.Eq(t, childPs.Pid, waitPs.Pid)
+}

--- a/drivers/shared/executor/utils_test.go
+++ b/drivers/shared/executor/utils_test.go
@@ -4,8 +4,13 @@
 package executor
 
 import (
+	"bytes"
+	"io"
+	"os"
+	"sync"
 	"testing"
 
+	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,4 +33,46 @@ func TestUtils_IsolationMode(t *testing.T) {
 		result := IsolationMode(tc.plugin, tc.task)
 		require.Equal(t, tc.exp, result)
 	}
+}
+
+type testExecCmd struct {
+	command  *ExecCommand
+	allocDir *allocdir.AllocDir
+
+	stdout         *bytes.Buffer
+	stderr         *bytes.Buffer
+	outputCopyDone *sync.WaitGroup
+}
+
+// configureTLogging configures a test command executor with buffer as
+// Std{out|err} but using os.Pipe so it mimics non-test case where cmd is set
+// with files as Std{out|err} the buffers can be used to read command output
+func configureTLogging(t *testing.T, testcmd *testExecCmd) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	var copyDone sync.WaitGroup
+
+	stdoutPr, stdoutPw, err := os.Pipe()
+	require.NoError(t, err)
+
+	stderrPr, stderrPw, err := os.Pipe()
+	require.NoError(t, err)
+
+	copyDone.Add(2)
+	go func() {
+		defer copyDone.Done()
+		io.Copy(&stdout, stdoutPr)
+	}()
+	go func() {
+		defer copyDone.Done()
+		io.Copy(&stderr, stderrPr)
+	}()
+
+	testcmd.stdout = &stdout
+	testcmd.stderr = &stderr
+	testcmd.outputCopyDone = &copyDone
+
+	testcmd.command.stdout = stdoutPw
+	testcmd.command.stderr = stderrPw
+	return
 }


### PR DESCRIPTION
On Windows, if the `raw_exec` driver's executor exits, the child processes are not also killed. Create a Windows "job object" (not to be confused with a Nomad job) and add the executor to it. Child processes of the executor will inherit the job automatically. When the handle to the job object is freed (on executor exit), the job itself is destroyed and this causes all processes in that job to exit.

Fixes: https://github.com/hashicorp/nomad/issues/23668
Ref: https://learn.microsoft.com/en-us/windows/win32/procthread/job-objects

~Note: automated testing for this will need to be end-to-end but we're not running Windows on nightly anymore.~ I've verified the behavior works as expected using Process Explorer. Killing the executor kills all child processes as expected. Killing the root child process causes the executor to exit (as usual) and that in turn kills any child processes that didn't exit already.

_Edit: added tests, which requires changing what runs in CI as well_