### PR TITLE
connect: fix ipv6 bind_address test

### DIFF
--- a/command/agent/consul/connect_test.go
+++ b/command/agent/consul/connect_test.go
@@ -442,11 +442,9 @@ func TestConnect_connectProxyConfig(t *testing.T) {
 			"bind_address":     "::",
 			"bind_port":        42,
 			"envoy_stats_tags": []string{"nomad.alloc_id=ipv6_alloc"},
-		}, connectProxyConfig(map[string]any{
-			"bind_address": "::",
-		}, 42, structs.AllocInfo{AllocID: "ipv6_alloc"}, []*structs.NetworkResource{
-			{Mode: "bridge", IP: "fd00:a110:c8::1"},
-		}))
+		}, connectProxyConfig(nil, 42, structs.AllocInfo{AllocID: "ipv6_alloc"},
+			[]*structs.NetworkResource{{Mode: "bridge", IP: "fd00:a110:c8::1"}},
+		))
 	})
 }
 


### PR DESCRIPTION
I realized this test I wrote in #24203 didn't actually test the IPv6-detection logic, because `"bind_address": "::"` was being passed in as config, effectively bypassing the important bit here:

https://github.com/hashicorp/nomad/blob/eb8d240aeefa4edf4b632cc6a9d39984103a6848/command/agent/consul/connect.go#L250-L252