### PR TITLE
wip: close the stdin connection

### DIFF
--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1848,6 +1848,7 @@ func (d *Driver) ExecTaskStreaming(ctx context.Context, taskID string, opts *dri
 
 	go func() {
 		_, _ = io.Copy(resp.Conn, opts.Stdin)
+		_ = resp.CloseWrite()
 	}()
 
 	exitCode := 999


### PR DESCRIPTION
This PR closes the hijacked connection used for the `stdin` input to a command being run via `alloc exec`. Without this, a process may remain running waiting for additional input via `stdin` instead of exiting.

Fixes [#24171](https://github.com/hashicorp/nomad/issues/24171)