### PR TITLE
Docs: Add IPv6 support page

### DIFF
--- a/website/content/docs/operations/ipv6-support.mdx
+++ b/website/content/docs/operations/ipv6-support.mdx
@@ -1,0 +1,67 @@
+---
+layout: docs
+page_title: Support for IPv6
+description: |-
+  Nomad support for IPv6
+---
+
+All of this depends on the host machine(s) supporting IPv6 in the first place.
+
+* AWS VPC needs some special config to set EC2 up for success
+* The OS inside the instance needs to support it
+  * Fedora cloud by default does not (iirc), but ubuntu does, and amazon linux (fedora based) does, etc etc etc
+* For on-prem (like my linux laptop), the DHCP server (my wifi router) needs to supply IPv6
+
+# ✅ Nomad \<-\> Nomad
+
+Connections between one Nomad agent and another (intra-cluster RPC calls).
+
+* Server \<-\> Server
+  * Server agent config: `server{ server_join{ retry_join = [“ip:v6:add:rs”] }}`
+* Server \<-\> Client
+  * Client agent config: `client{ servers = [“ip:v6:add:rs”] }`
+* Client \<-\> Client ?
+  * I did not test our best-effort [ephemeral\_disk.migrate](https://developer.hashicorp.com/nomad/docs/job-specification/ephemeral_disk#migrate) feature
+* [Advertise](https://developer.hashicorp.com/nomad/docs/configuration#advertise) addresses determine how server/clients will register with the cluster:
+
+`advertise {`
+  `# https://pkg.go.dev/github.com/hashicorp/go-sockaddr/template`
+  `http = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" | limit 1 | attr \"address\" }}"`
+  `rpc  = ^ ditto`
+  `serf = ^ ditto`
+`}`
+(there may be better ways to accomplish that, but it works.)
+
+# ✅ Nomad \<-\> Other
+
+Connections between Nomad and some other system (HTTP calls).
+
+* Nomad CLI and web UI
+  * `NOMAD_ADDR=’http://[ip:v6:ad:dr]:4646’`
+* Service integration
+  * Nomad can reach Consul to register services
+  * Nomad can reach Vault to fetch secrets
+* Workload identity
+  * Consul can reach Nomad at `‘[ip:v6:ad:dr]:4646/.well-known/jwks.json’`
+    `nomad setup consul -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"`
+  * Ditto Vault
+    `nomad setup consul -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"`
+  * And presumably other 3rd parties, as the listener on the Nomad side is identical.
+
+# ✅ Workloads
+
+Connections to and from tasks run by Nomad (arbitrary network calls).
+
+* Anything on the host network can use its IPv6 connectivity directly
+* Services can be registered with an IPv6 address
+  * With either Nomad service discovery, or Consul
+    `service{ provider = “nomad|consul” }` (consul is the default)
+  * Using the [preferred\_address\_family](https://developer.hashicorp.com/nomad/docs/configuration/client#preferred_address_family) client config
+* Nomad’s [“bridge” network mode](https://developer.hashicorp.com/nomad/docs/job-specification/network#network-modes) can be configured for IPv6
+  * Using the [bridge\_network\_subnet\_ipv6](https://github.com/hashicorp/nomad/pull/23882/files#diff-e8490f68e1cda7aaf7a59848e979b52d693d508da7f42967bfd7971b104dac88R181) client config (coming in Nomad 1.9)
+* The [docker driver](https://developer.hashicorp.com/nomad/docs/drivers/docker) has some ipv6 options ([see also](https://developer.hashicorp.com/nomad/docs/job-specification/service#ipv6-docker-containers))
+  * If docker itself is ipv6-enabled
+
+## ❓ Consul Connect
+
+I have not tested this.

--- a/website/content/docs/operations/ipv6-support.mdx
+++ b/website/content/docs/operations/ipv6-support.mdx
@@ -79,30 +79,33 @@ server {
 
 Most connections between Nomad and other external systems occur via HTTP.
 
-For example, when you use this `NOMAD_ADDR` environment variable:
+For example, when you set this `NOMAD_ADDR` environment variable:
 
 ```
 export NOMAD_ADDR='http://[2001:db8::1]:4646'
 ```
 
-- You can use the Nomad CLI, which makes Nomad API calls.
-- You can open the Nomad web UI in a browser with the command `nomad ui`.
-- You can use [Workload identity][workload-identity]
+You can do the following:
+
+- Use the Nomad CLI, which makes Nomad API calls.
+- Open the Nomad web UI in a browser with the command `nomad ui`.
+- Use [Workload identity][workload-identity].
   - Nomad can reach Consul and Vault at IPv6 addresses, if they are listening,
     to register services or fetch secrets.
-  - You can configure Consul with the [`nomad setup consul` command][setup-consul].
+  - Configure Consul with the [`nomad setup consul` command][setup-consul].
 
     ```
     nomad setup consul -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"
 
-  - You can configure Vault with the [`nomad setup vault` command][setup-vault].
+  - Configure Vault with the [`nomad setup vault` command][setup-vault].
 
     ```
     nomad setup vault -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"
     ```
 
-  - Various other third-party services that support OIDC connections should
-    also be able to reach Nomad at an IPv6 address, so long as the third-party services support IPv6.
+Various other third-party services that support OIDC connections should also be
+able to reach Nomad at an IPv6 address, so long as the third-party services
+support IPv6.
 
 ## Workloads
 

--- a/website/content/docs/operations/ipv6-support.mdx
+++ b/website/content/docs/operations/ipv6-support.mdx
@@ -10,23 +10,26 @@ description: |-
 Nomad supports IPv6 as long as the underlying networks, host machines,
 and operating systems running it support IPv6.
 
-You'll need different configuration settings for different connection contexts,
-outlined below.
+This guide illustrates the different configuration settings you need for different connection contexts.
 
 ## Advertise
 
-[Advertise][advertise] addresses for Nomad servers and clients specify what
+[Advertise][advertise] Nomad server and client addresses to specify what
 address other servers, clients, or external systems should use to make
 connections back to the agent.
 
 You can use [go-sockaddr][] templating to dynamically select a public IPv6
-address, for example:
+address. In this example, for each protocol, fetch one IPv6 address from public
+interfaces and assign it as the protocol's address.
 
 ```hcl
 advertise {
-  http = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" | limit 1 | attr \"address\" }}"
-  rpc  = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" | limit 1 | attr \"address\" }}"
-  serf = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" | limit 1 | attr \"address\" }}"
+  http = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" \
+         | limit 1 | attr \"address\" }}"
+  rpc  = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" \
+         | limit 1 | attr \"address\" }}"
+  serf = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" \
+         | limit 1 | attr \"address\" }}"
 }
 ```
 
@@ -34,13 +37,13 @@ advertise {
 
 Nomad agent processes connect to one another to make RPC calls for cluster operations.
 
-The simplest way to use IPv6 on Nomad is with DNS that resolves to IPv6,
-or using cloud auto-join, but here are some examples that use IPv6 addresses
-explicitly.
+We recommend using IPv6 on Nomad with DNS that resolves to IPv6 or by
+using cloud auto-join. The following server-to-server and client-to-server
+examples use IPv6 addresses explicitly.
 
 ### Server to server
 
-Servers join together based on the [`server_join`][server_join] block.
+Use the [`server_join`][server_join] block to link servers together.
 
 ```hcl
 server {
@@ -53,8 +56,8 @@ server {
 
 ### Client to server
 
-Clients can join a cluster with `server_join` like servers can, or with the
-[`servers`][client.servers] parameter.
+Use the [`servers`][client.servers] parameter or the `server_join` parameter to
+link clients.
 
 ```hcl
 client {
@@ -63,11 +66,20 @@ client {
 }
 ```
 
+```hcl
+server {
+  enabled = true
+  server_join {
+    retry_join = ["[2001:db8::1]", "[2001:db8::2]", "[2001:db8::3]"]
+  }
+}
+```
+
 ## Nomad to external systems
 
-Most connections between Nomad and other external systems occurs via HTTP.
+Most connections between Nomad and other external systems occur via HTTP.
 
-Using this `NOMAD_ADDR` environment variable as an example:
+For example, when you use this `NOMAD_ADDR` environment variable:
 
 ```
 export NOMAD_ADDR='http://[2001:db8::1]:4646'
@@ -78,34 +90,40 @@ export NOMAD_ADDR='http://[2001:db8::1]:4646'
 - You can use [Workload identity][workload-identity]
   - Nomad can reach Consul and Vault at IPv6 addresses, if they are listening,
     to register services or fetch secrets.
-  - You can configure Consul with the [`nomad setup consul` command][setup-consul]:
+  - You can configure Consul with the [`nomad setup consul` command][setup-consul].
+
     ```
     nomad setup consul -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"
-    ```
-  - You can configure Vault with the [`nomad setup vault` command][setup-vault]:
+
+  - You can configure Vault with the [`nomad setup vault` command][setup-vault].
+
     ```
     nomad setup vault -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"
     ```
+
   - Various other third-party services that support OIDC connections should
-    also be able to reach Nomad at an IPv6 address, so long as they support it.
+    also be able to reach Nomad at an IPv6 address, so long as the third-party services support IPv6.
 
 ## Workloads
 
 Nomad supports arbitrary IPv6 network calls to and from tasks on client nodes.
 
-- With host networking, tasks use the same network as the host machine.
+With host networking, tasks use the same network as the host machine.
+
 - Use these options to register services with an IPv6 address:
   - Set the [`preferred_address_family`][preferred_address_family-config]
-    client config to `"ipv6"`
+    client config to `"ipv6"`.
   - Include a [`service`][service-block] block in your job specification with
     either the "nomad" or "consul" provider as usual.
 - Use [`bridge_network_subnet_ipv6`][bridge-network-subnet-ipv6] to configure
   Nomad's [bridge network mode][bridge-network-mode] for IPv6.
-- [CNI][cni] plugins can work with IPv6 as well (Nomad's bridge network does this).
-- Some task drivers have their own IPv6 configuration options
-  - If you have enabled IPv6 support in the [Docker driver][docker-driver],
-    you can configure IPv6 in your job specification. Refer to
-    [IPv6 Docker containers][ipv6-docker-containers] for details.
+
+[CNI][cni] plugins can work with IPv6 as well. Nomad's bridge network does this.
+
+Some task drivers have their own IPv6 configuration options. If you have enabled
+IPv6 support in the [Docker driver][docker-driver], you can configure IPv6 in
+your job specification. Refer to [IPv6 Docker
+containers][ipv6-docker-containers] for details.
 
 
 [server_join]: /nomad/docs/configuration/server_join

--- a/website/content/docs/operations/ipv6-support.mdx
+++ b/website/content/docs/operations/ipv6-support.mdx
@@ -5,63 +5,88 @@ description: |-
   Nomad support for IPv6
 ---
 
-All of this depends on the host machine(s) supporting IPv6 in the first place.
+# IPv6 support in Nomad
 
-* AWS VPC needs some special config to set EC2 up for success
-* The OS inside the instance needs to support it
-  * Fedora cloud by default does not (iirc), but ubuntu does, and amazon linux (fedora based) does, etc etc etc
-* For on-prem (like my linux laptop), the DHCP server (my wifi router) needs to supply IPv6
+Nomad supports IPv6 as long as the underlying host machines and networks support IPv6.
 
-# ✅ Nomad \<-\> Nomad
+- If you use AWS, you need to configure AWS VPC to support IPv6 on EC2. Refer to
+  these AWS docs for more information:
+  - [IPv6 support for your VPC][aws-vpc-ipv6]
+  - [Manage the IPv6 addresses for your EC2 instances][aws-ec2-ipv6]
+- The OS running on the host must support IPv6.
+- For on-prem installations, your network infrastructure must support IPv6.
+
+## Nomad to Nomad
 
 Connections between one Nomad agent and another (intra-cluster RPC calls).
 
-* Server \<-\> Server
-  * Server agent config: `server{ server_join{ retry_join = [“ip:v6:add:rs”] }}`
-* Server \<-\> Client
-  * Client agent config: `client{ servers = [“ip:v6:add:rs”] }`
-* Client \<-\> Client ?
-  * I did not test our best-effort [ephemeral\_disk.migrate](https://developer.hashicorp.com/nomad/docs/job-specification/ephemeral_disk#migrate) feature
-* [Advertise](https://developer.hashicorp.com/nomad/docs/configuration#advertise) addresses determine how server/clients will register with the cluster:
+- Server to server
+  - Server agent config: `server{ server_join{ retry_join = [“ip:v6:add:rs”] }}`
+- Server to client
+  - Client agent config: `client{ servers = [“ip:v6:add:rs”] }`
 
-`advertise {`
-  `# https://pkg.go.dev/github.com/hashicorp/go-sockaddr/template`
-  `http = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" | limit 1 | attr \"address\" }}"`
-  `rpc  = ^ ditto`
-  `serf = ^ ditto`
-`}`
-(there may be better ways to accomplish that, but it works.)
 
-# ✅ Nomad \<-\> Other
+[Advertise][advertise-config] addresses determine how server and clients register with the cluster.
 
-Connections between Nomad and some other system (HTTP calls).
+```
+advertise {
+  # https://pkg.go.dev/github.com/hashicorp/go-sockaddr/template
+  http = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" | limit 1 | attr \"address\" }}"
+  rpc  = ^ ditto
+  serf = ^ ditto
+}
+```
 
-* Nomad CLI and web UI
-  * `NOMAD_ADDR=’http://[ip:v6:ad:dr]:4646’`
-* Service integration
-  * Nomad can reach Consul to register services
-  * Nomad can reach Vault to fetch secrets
-* Workload identity
-  * Consul can reach Nomad at `‘[ip:v6:ad:dr]:4646/.well-known/jwks.json’`
-    `nomad setup consul -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"`
-  * Ditto Vault
-    `nomad setup consul -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"`
-  * And presumably other 3rd parties, as the listener on the Nomad side is identical.
 
-# ✅ Workloads
+## Nomad to external system
 
-Connections to and from tasks run by Nomad (arbitrary network calls).
+The following HTTP connections between Nomad, Consul, and Vault support IPv6:
 
-* Anything on the host network can use its IPv6 connectivity directly
-* Services can be registered with an IPv6 address
-  * With either Nomad service discovery, or Consul
-    `service{ provider = “nomad|consul” }` (consul is the default)
-  * Using the [preferred\_address\_family](https://developer.hashicorp.com/nomad/docs/configuration/client#preferred_address_family) client config
-* Nomad’s [“bridge” network mode](https://developer.hashicorp.com/nomad/docs/job-specification/network#network-modes) can be configured for IPv6
-  * Using the [bridge\_network\_subnet\_ipv6](https://github.com/hashicorp/nomad/pull/23882/files#diff-e8490f68e1cda7aaf7a59848e979b52d693d508da7f42967bfd7971b104dac88R181) client config (coming in Nomad 1.9)
-* The [docker driver](https://developer.hashicorp.com/nomad/docs/drivers/docker) has some ipv6 options ([see also](https://developer.hashicorp.com/nomad/docs/job-specification/service#ipv6-docker-containers))
-  * If docker itself is ipv6-enabled
+- Nomad CLI and web UI
+  - `NOMAD_ADDR=’http://[ip:v6:ad:dr]:4646’`
+- Service integration
+  - Nomad can reach Consul to register services.
+  - Nomad can reach Vault to fetch secrets.
+- Workload identity
+  - Consul can reach Nomad at `‘[ip:v6:ad:dr]:4646/.well-known/jwks.json’`.
+    Configure this using the [`nomad setup consul` command][setup-consul].
 
-## ❓ Consul Connect
+      `nomad setup consul -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"`.
 
-I have not tested this.
+  -  Vault can reach Nomad at `‘[ip:v6:ad:dr]:4646/.well-known/jwks.json’`.
+     Configure this using the [`nomad setup vault` command][setup-vault].
+
+      `nomad setup vault -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"`.
+
+Other third-party connections should work, as the listener on the Nomad side is identical.
+
+## Workloads
+
+Nomad supports IPv6 in arbitrary network calls to and from tasks. Anything
+running on the host network can use the host network's IPv6 connectivity directly.
+
+
+- Use one of the these options to register services with an IPv6 address:
+  - Nomad service discovery.
+  - Consul `service { provider = “nomad|consul” }`. This is Nomad's default behavior.
+  - The [`preferred_address_family`][preferred_address_family-config]
+    client config.
+- Use [`bridge_network_subnet_ipv6`][bridge-network-subnet-ipv6] to configure
+  Nomad’s [bridge network mode][bridge-network-mode] for IPv6.
+- If you have enabled IPv6 support in the [Docker driver][docker-driver], you
+  can configure IPv6 in your job spec. Refer to [IPv6 Docker
+  containers][ipv6-docker-containers] for details.
+
+
+[aws-vpc-ipv6]:
+    https://docs.aws.amazon.com/vpc/latest/userguide/vpc-migrate-ipv6.html
+[aws-ec2-ipv6]:
+    https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/working-with-ipv6-addresses.html
+[advertise-config]: /nomad/docs/configuration#advertise
+[preferred_address_family-config]: /nomad/docs/configuration/client#preferred_address_family
+[bridge-network-mode]: /nomad/docs/job-specification/network#network-modes
+[bridge-network-subnet-ipv6]: /nomad/docs/configuration/client#bridge_network_subnet_ipv6
+[docker-driver]: /nomad/docs/drivers/docker
+[ipv6-docker-containers]: /nomad/docs/job-specification/service#ipv6-docker-containers
+[setup-consul]: /nomad/docs/commands/setup/consul
+[setup-vault]: /nomad/docs/commands/setup/vault

--- a/website/content/docs/operations/ipv6-support.mdx
+++ b/website/content/docs/operations/ipv6-support.mdx
@@ -7,85 +7,117 @@ description: |-
 
 # IPv6 support in Nomad
 
-Nomad supports IPv6 as long as the underlying host machines and networks support IPv6.
+Nomad supports IPv6 as long as the underlying networks, host machines,
+and operating systems running it support IPv6.
 
-- If you use AWS, you need to configure AWS VPC to support IPv6 on EC2. Refer to
-  these AWS docs for more information:
-  - [IPv6 support for your VPC][aws-vpc-ipv6]
-  - [Manage the IPv6 addresses for your EC2 instances][aws-ec2-ipv6]
-- The OS running on the host must support IPv6.
-- For on-prem installations, your network infrastructure must support IPv6.
+You'll need different configuration settings for different connection contexts,
+outlined below.
 
-## Nomad to Nomad
+## Advertise
 
-Connections between one Nomad agent and another (intra-cluster RPC calls).
+[Advertise][advertise] addresses for Nomad servers and clients specify what
+address other servers, clients, or external systems should use to make
+connections back to the agent.
 
-- Server to server
-  - Server agent config: `server{ server_join{ retry_join = [“ip:v6:add:rs”] }}`
-- Server to client
-  - Client agent config: `client{ servers = [“ip:v6:add:rs”] }`
+You can use [go-sockaddr][] templating to dynamically select a public IPv6
+address, for example:
 
-
-[Advertise][advertise-config] addresses determine how server and clients register with the cluster.
-
-```
+```hcl
 advertise {
-  # https://pkg.go.dev/github.com/hashicorp/go-sockaddr/template
   http = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" | limit 1 | attr \"address\" }}"
-  rpc  = ^ ditto
-  serf = ^ ditto
+  rpc  = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" | limit 1 | attr \"address\" }}"
+  serf = "{{ GetPublicInterfaces | include \"type\" \"IPv6\" | limit 1 | attr \"address\" }}"
 }
 ```
 
+## Nomad to Nomad
 
-## Nomad to external system
+Nomad agent processes connect to one another to make RPC calls for cluster operations.
 
-The following HTTP connections between Nomad, Consul, and Vault support IPv6:
+The simplest way to use IPv6 on Nomad is with DNS that resolves to IPv6,
+or using cloud auto-join, but here are some examples that use IPv6 addresses
+explicitly.
 
-- Nomad CLI and web UI
-  - `NOMAD_ADDR=’http://[ip:v6:ad:dr]:4646’`
-- Service integration
-  - Nomad can reach Consul to register services.
-  - Nomad can reach Vault to fetch secrets.
-- Workload identity
-  - Consul can reach Nomad at `‘[ip:v6:ad:dr]:4646/.well-known/jwks.json’`.
-    Configure this using the [`nomad setup consul` command][setup-consul].
+### Server to server
 
-      `nomad setup consul -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"`.
+Servers join together based on the [`server_join`][server_join] block.
 
-  -  Vault can reach Nomad at `‘[ip:v6:ad:dr]:4646/.well-known/jwks.json’`.
-     Configure this using the [`nomad setup vault` command][setup-vault].
+```hcl
+server {
+  enabled = true
+  server_join {
+    retry_join = ["[2001:db8::1]", "[2001:db8::2]"]
+  }
+}
+```
 
-      `nomad setup vault -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"`.
+### Client to server
 
-Other third-party connections should work, as the listener on the Nomad side is identical.
+Clients can join a cluster with `server_join` like servers can, or with the
+[`servers`][client.servers] parameter.
+
+```hcl
+client {
+  enabled = true
+  servers = ["[2001:db8::1]", "[2001:db8::2]", "[2001:db8::3]"]
+}
+```
+
+## Nomad to external systems
+
+Most connections between Nomad and other external systems occurs via HTTP.
+
+Using this `NOMAD_ADDR` environment variable as an example:
+
+```
+export NOMAD_ADDR='http://[2001:db8::1]:4646'
+```
+
+- You can use the Nomad CLI, which makes Nomad API calls.
+- You can open the Nomad web UI in a browser with the command `nomad ui`.
+- You can use [Workload identity][workload-identity]
+  - Nomad can reach Consul and Vault at IPv6 addresses, if they are listening,
+    to register services or fetch secrets.
+  - You can configure Consul with the [`nomad setup consul` command][setup-consul]:
+    ```
+    nomad setup consul -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"
+    ```
+  - You can configure Vault with the [`nomad setup vault` command][setup-vault]:
+    ```
+    nomad setup vault -y -jwks-url="$NOMAD_ADDR/.well-known/jwks.json"
+    ```
+  - Various other third-party services that support OIDC connections should
+    also be able to reach Nomad at an IPv6 address, so long as they support it.
 
 ## Workloads
 
-Nomad supports IPv6 in arbitrary network calls to and from tasks. Anything
-running on the host network can use the host network's IPv6 connectivity directly.
+Nomad supports arbitrary IPv6 network calls to and from tasks on client nodes.
 
-
-- Use one of the these options to register services with an IPv6 address:
-  - Nomad service discovery.
-  - Consul `service { provider = “nomad|consul” }`. This is Nomad's default behavior.
-  - The [`preferred_address_family`][preferred_address_family-config]
-    client config.
+- With host networking, tasks use the same network as the host machine.
+- Use these options to register services with an IPv6 address:
+  - Set the [`preferred_address_family`][preferred_address_family-config]
+    client config to `"ipv6"`
+  - Include a [`service`][service-block] block in your job specification with
+    either the "nomad" or "consul" provider as usual.
 - Use [`bridge_network_subnet_ipv6`][bridge-network-subnet-ipv6] to configure
-  Nomad’s [bridge network mode][bridge-network-mode] for IPv6.
-- If you have enabled IPv6 support in the [Docker driver][docker-driver], you
-  can configure IPv6 in your job spec. Refer to [IPv6 Docker
-  containers][ipv6-docker-containers] for details.
+  Nomad's [bridge network mode][bridge-network-mode] for IPv6.
+- [CNI][cni] plugins can work with IPv6 as well (Nomad's bridge network does this).
+- Some task drivers have their own IPv6 configuration options
+  - If you have enabled IPv6 support in the [Docker driver][docker-driver],
+    you can configure IPv6 in your job specification. Refer to
+    [IPv6 Docker containers][ipv6-docker-containers] for details.
 
 
-[aws-vpc-ipv6]:
-    https://docs.aws.amazon.com/vpc/latest/userguide/vpc-migrate-ipv6.html
-[aws-ec2-ipv6]:
-    https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/working-with-ipv6-addresses.html
-[advertise-config]: /nomad/docs/configuration#advertise
+[server_join]: /nomad/docs/configuration/server_join
+[client.servers]: /nomad/docs/configuration/client#servers
+[go-sockaddr]: https://pkg.go.dev/github.com/hashicorp/go-sockaddr/template
+[advertise]: /nomad/docs/configuration#advertise
+[workload-identity]: /nomad/docs/concepts/workload-identity
+[service-block]: /nomad/docs/job-specification/service
 [preferred_address_family-config]: /nomad/docs/configuration/client#preferred_address_family
 [bridge-network-mode]: /nomad/docs/job-specification/network#network-modes
 [bridge-network-subnet-ipv6]: /nomad/docs/configuration/client#bridge_network_subnet_ipv6
+[cni]: /nomad/docs/networking/cni
 [docker-driver]: /nomad/docs/drivers/docker
 [ipv6-docker-containers]: /nomad/docs/job-specification/service#ipv6-docker-containers
 [setup-consul]: /nomad/docs/commands/setup/consul

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -2363,6 +2363,10 @@
       {
         "title": "Federate AWS Access with Workload Identity",
         "path": "operations/aws-oidc-provider"
+      },
+      {
+        "title": "IPv6 Support",
+        "path": "operations/ipv6-support"
       }
     ]
   },


### PR DESCRIPTION
Add IPv6 support page to operations section.

Fixes: [CE-718]

Deploy preview https://nomad-git-ce718-hashicorp.vercel.app/nomad/docs/operations/ipv6-support

[CE-718]: https://hashicorp.atlassian.net/browse/CE-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ