### PR TITLE
docker: use streaming stats collection to correct CPU stats

### DIFF
--- a/.changelog/24229.txt
+++ b/.changelog/24229.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fixed a bug where task CPU stats were reported incorrectly
+```


### PR DESCRIPTION
In #23966 we switched to the official Docker SDK for the `docker` driver. In the process we refactored code around stats collection to use the "one shot" version of stats. Unfortunately this "one shot" stats collection does not include the `PreCPU` stats, which are the stats from the previous read. This breaks the calculation we use to determine CPU ticks, because now we're subtracting 0 from the current value to get the delta.

Switch back to using the streaming stats collection. Add a test that fully exercises the `TaskStats` API.

Fixes: https://github.com/hashicorp/nomad/issues/24224
Ref: https://hashicorp.atlassian.net/browse/NET-11348

---

In addition to new tests here, I've tested manually with the setup described here https://github.com/hashicorp/nomad/issues/24224#issuecomment-2417222664 and we get the expected results now.