### PR TITLE
cli: update nomad job init full examples

### DIFF
--- a/.changelog/24232.txt
+++ b/.changelog/24232.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Updated example job specifications in nomad job init
+```

--- a/command/asset/connect.nomad.hcl
+++ b/command/asset/connect.nomad.hcl
@@ -123,9 +123,11 @@ job "countdash" {
       }
 
       # The "resources" block describes the requirements a task needs to
-      # execute. Resource requirements include attributes such as memory, cpu, cores, and devices.
+      # execute. Resource requirements include attributes such as memory, cpu,
+      # cores, and devices.
       #
-      # For a complete list of supported resources and examples on the "resources" block, refer to:
+      # For a complete list of supported resources and examples on the
+      # "resources" block, refer to:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/resources
       #

--- a/command/asset/connect.nomad.hcl
+++ b/command/asset/connect.nomad.hcl
@@ -6,7 +6,7 @@
 # should run. Jobs have a globally unique name, one or many task groups, which
 # are themselves collections of one or many tasks.
 #
-# For more information and examples on the "job" block, please see:
+# For more information and examples on the "job" block, refer to
 #
 #     https://developer.hashicorp.com/nomad/docs/job-specification/job
 #
@@ -15,7 +15,7 @@ job "countdash" {
   # The "ui" block provides options to modify the presentation of the Job index
   # page in Nomad's Web UI.
   #
-  # For more information on the "ui" block, please see:
+  # For more information on the "ui" block, refer to:
   #
   #   https://developer.hashicorp.com/nomad/docs/job-specification/ui
   #
@@ -32,9 +32,9 @@ job "countdash" {
   }
 
   # The "group" block defines tasks that should be co-located on the same Nomad
-  # client. Any task within a group will be placed on the same client.
+  # client. Nomad places any task within a group onto the same client.
   #
-  # For more information and examples on the "group" block, please see:
+  # For more information and examples on the "group" block, refer to:
   #
   #     https://developer.hashicorp.com/nomad/docs/job-specification/group
   #
@@ -100,7 +100,7 @@ job "countdash" {
     # The "task" block creates an individual unit of work, such as a Docker
     # container, web application, or batch processing.
     #
-    # For more information and examples on the "task" block, please see:
+    # For more information and examples on the "task" block, refer to:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/task
     #
@@ -123,9 +123,9 @@ job "countdash" {
       }
 
       # The "resources" block describes the requirements a task needs to
-      # execute. Resource requirements include memory, cpu, and more.
+      # execute. Resource requirements include attributes such as memory, cpu, cores, and devices.
       #
-      # For more information and examples on the "resources" block, please see:
+      # For a complete list of supported resources and examples on the "resources" block, refer to:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/resources
       #

--- a/command/asset/connect.nomad.hcl
+++ b/command/asset/connect.nomad.hcl
@@ -6,239 +6,39 @@
 # should run. Jobs have a globally unique name, one or many task groups, which
 # are themselves collections of one or many tasks.
 #
-# For more information and examples on the "job" block, please see
-# the online documentation at:
+# For more information and examples on the "job" block, please see:
 #
-#     https://developer.hashicorp.com/nomad/docs/job-specification/job.html
+#     https://developer.hashicorp.com/nomad/docs/job-specification/job
 #
 job "countdash" {
-  # The "region" parameter specifies the region in which to execute the job. If
-  # omitted, this inherits the default region name of "global".
-  # region = "global"
-  #
-  # The "datacenters" parameter specifies the list of datacenters which should
-  # be considered when placing this task. This accepts wildcards and defaults
-  # allowing placement on all datacenters.
-  datacenters = ["*"]
 
-  # The "type" parameter controls the type of job, which impacts the scheduler's
-  # decision on placement. This configuration is optional and defaults to
-  # "service". For a full list of job types and their differences, please see
-  # the online documentation.
+  # The "ui" block provides options to modify the presentation of the Job index
+  # page in Nomad's Web UI.
   #
-  # For more information, please see the online documentation at:
+  # For more information on the "ui" block, please see:
   #
-  #     https://developer.hashicorp.com/nomad/docs/jobspec/schedulers.html
+  #   https://developer.hashicorp.com/nomad/docs/job-specification/ui
   #
-  type = "service"
-
-  # The "constraint" block defines additional constraints for placing this job,
-  # in addition to any resource or driver constraints. This block may be placed
-  # at the "job", "group", or "task" level, and supports variable interpolation.
-  #
-  # For more information and examples on the "constraint" block, please see
-  # the online documentation at:
-  #
-  #     https://developer.hashicorp.com/nomad/docs/job-specification/constraint.html
-  #
-  # constraint {
-  #   attribute = "${attr.kernel.name}"
-  #   value     = "linux"
-  # }
-
-  # The "update" block specifies the update strategy of task groups. The update
-  # strategy is used to control things like rolling upgrades, canaries, and
-  # blue/green deployments. If omitted, no update strategy is enforced. The
-  # "update" block may be placed at the job or task group. When placed at the
-  # job, it applies to all groups within the job. When placed at both the job and
-  # group level, the blocks are merged with the group's taking precedence.
-  #
-  # For more information and examples on the "update" block, please see
-  # the online documentation at:
-  #
-  #     https://developer.hashicorp.com/nomad/docs/job-specification/update.html
-  #
-  update {
-    # The "max_parallel" parameter specifies the maximum number of updates to
-    # perform in parallel. In this case, this specifies to update a single task
-    # at a time.
-    max_parallel = 1
-
-    # The "min_healthy_time" parameter specifies the minimum time the allocation
-    # must be in the healthy state before it is marked as healthy and unblocks
-    # further allocations from being updated.
-    min_healthy_time = "10s"
-
-    # The "healthy_deadline" parameter specifies the deadline in which the
-    # allocation must be marked as healthy after which the allocation is
-    # automatically transitioned to unhealthy. Transitioning to unhealthy will
-    # fail the deployment and potentially roll back the job if "auto_revert" is
-    # set to true.
-    healthy_deadline = "3m"
-
-    # The "progress_deadline" parameter specifies the deadline in which an
-    # allocation must be marked as healthy. The deadline begins when the first
-    # allocation for the deployment is created and is reset whenever an allocation
-    # as part of the deployment transitions to a healthy state. If no allocation
-    # transitions to the healthy state before the progress deadline, the
-    # deployment is marked as failed.
-    progress_deadline = "10m"
-
-    # The "auto_revert" parameter specifies if the job should auto-revert to the
-    # last stable job on deployment failure. A job is marked as stable if all the
-    # allocations as part of its deployment were marked healthy.
-    auto_revert = false
-
-    # The "canary" parameter specifies that changes to the job that would result
-    # in destructive updates should create the specified number of canaries
-    # without stopping any previous allocations. Once the operator determines the
-    # canaries are healthy, they can be promoted which unblocks a rolling update
-    # of the remaining allocations at a rate of "max_parallel".
-    #
-    # Further, setting "canary" equal to the count of the task group allows
-    # blue/green deployments. When the job is updated, a full set of the new
-    # version is deployed and upon promotion the old version is stopped.
-    canary = 0
+  ui {
+    description = "Sample Consul Service Mesh Job"
+    link {
+      label = "Learn more about Nomad"
+      url   = "https://developer.hashicorp.com/nomad"
+    }
+    link {
+      label = "Learn more about Consul"
+      url   = "https://developer.hashicorp.com/consul"
+    }
   }
-  # The migrate block specifies the group's strategy for migrating off of
-  # draining nodes. If omitted, a default migration strategy is applied.
-  #
-  # For more information on the "migrate" block, please see
-  # the online documentation at:
-  #
-  #     https://developer.hashicorp.com/nomad/docs/job-specification/migrate.html
-  #
-  migrate {
-    # Specifies the number of task groups that can be migrated at the same
-    # time. This number must be less than the total count for the group as
-    # (count - max_parallel) will be left running during migrations.
-    max_parallel = 1
 
-    # Specifies the mechanism in which allocations health is determined. The
-    # potential values are "checks" or "task_states".
-    health_check = "checks"
-
-    # Specifies the minimum time the allocation must be in the healthy state
-    # before it is marked as healthy and unblocks further allocations from being
-    # migrated. This is specified using a label suffix like "30s" or "15m".
-    min_healthy_time = "10s"
-
-    # Specifies the deadline in which the allocation must be marked as healthy
-    # after which the allocation is automatically transitioned to unhealthy. This
-    # is specified using a label suffix like "2m" or "1h".
-    healthy_deadline = "5m"
-  }
-  # The "group" block defines a series of tasks that should be co-located on
-  # the same Nomad client. Any task within a group will be placed on the same
-  # client.
+  # The "group" block defines tasks that should be co-located on the same Nomad
+  # client. Any task within a group will be placed on the same client.
   #
-  # For more information and examples on the "group" block, please see
-  # the online documentation at:
+  # For more information and examples on the "group" block, please see:
   #
-  #     https://developer.hashicorp.com/nomad/docs/job-specification/group.html
+  #     https://developer.hashicorp.com/nomad/docs/job-specification/group
   #
   group "api" {
-    # The "count" parameter specifies the number of the task groups that should
-    # be running under this group. This value must be non-negative and defaults
-    # to 1.
-    count = 1
-
-    # The "restart" block configures a group's behavior on task failure. If
-    # left unspecified, a default restart policy is used based on the job type.
-    #
-    # For more information and examples on the "restart" block, please see
-    # the online documentation at:
-    #
-    #     https://developer.hashicorp.com/nomad/docs/job-specification/restart.html
-    #
-    restart {
-      # The number of attempts to run the job within the specified interval.
-      attempts = 2
-      interval = "30m"
-
-      # The "delay" parameter specifies the duration to wait before restarting
-      # a task after it has failed.
-      delay = "15s"
-
-      # The "mode" parameter controls what happens when a task has restarted
-      # "attempts" times within the interval. "delay" mode delays the next
-      # restart until the next interval. "fail" mode does not restart the task
-      # if "attempts" has been hit within the interval.
-      mode = "fail"
-    }
-
-    # The "ephemeral_disk" block instructs Nomad to utilize an ephemeral disk
-    # instead of a hard disk requirement. Clients using this block should
-    # not specify disk requirements in the resources block of the task. All
-    # tasks in this group will share the same ephemeral disk.
-    #
-    # For more information and examples on the "ephemeral_disk" block, please
-    # see the online documentation at:
-    #
-    #     https://developer.hashicorp.com/nomad/docs/job-specification/ephemeral_disk.html
-    #
-    ephemeral_disk {
-      # When sticky is true and the task group is updated, the scheduler
-      # will prefer to place the updated allocation on the same node and
-      # will migrate the data. This is useful for tasks that store data
-      # that should persist across allocation updates.
-      # sticky = true
-      #
-      # Setting migrate to true results in the allocation directory of a
-      # sticky allocation directory to be migrated.
-      # migrate = true
-      #
-      # The "size" parameter specifies the size in MB of shared ephemeral disk
-      # between tasks in the group.
-      size = 300
-    }
-
-    # The "affinity" block enables operators to express placement preferences
-    # based on node attributes or metadata.
-    #
-    # For more information and examples on the "affinity" block, please
-    # see the online documentation at:
-    #
-    #     https://developer.hashicorp.com/nomad/docs/job-specification/affinity.html
-    #
-    # affinity {
-    #   # attribute specifies the name of a node attribute or metadata
-    #   attribute = "${node.datacenter}"
-    #
-    #   # value specifies the desired attribute value. In this example Nomad
-    #   # will prefer placement in the "us-west1" datacenter.
-    #   value = "us-west1"
-    #
-    #   # weight can be used to indicate relative preference
-    #   # when the job has more than one affinity. It defaults to 50 if not set.
-    #   weight = 100
-    # }
-
-
-    # The "spread" block allows operators to increase the failure tolerance of
-    # their applications by specifying a node attribute that allocations
-    # should be spread over.
-    #
-    # For more information and examples on the "spread" block, please
-    # see the online documentation at:
-    #
-    #     https://developer.hashicorp.com/nomad/docs/job-specification/spread.html
-    #
-    # spread {
-    #   # attribute specifies the name of a node attribute or metadata
-    #   attribute = "${node.datacenter}"
-    # }
-
-    # targets can be used to define desired percentages of allocations
-    # for each targeted attribute value.
-    #
-    #   target "us-east1" {
-    #     percent = 60
-    #   }
-    #   target "us-west1" {
-    #     percent = 40
-    #   }
-    #  }
 
     # The "network" block for a group creates a network namespace shared
     # by all tasks within the group.
@@ -296,13 +96,13 @@ job "countdash" {
         sidecar_service {}
       }
     }
+
     # The "task" block creates an individual unit of work, such as a Docker
     # container, web application, or batch processing.
     #
-    # For more information and examples on the "task" block, please see
-    # the online documentation at:
+    # For more information and examples on the "task" block, please see:
     #
-    #     https://developer.hashicorp.com/nomad/docs/job-specification/task.html
+    #     https://developer.hashicorp.com/nomad/docs/job-specification/task
     #
     task "web" {
       # The "driver" parameter specifies the task driver that should be used to
@@ -322,57 +122,12 @@ job "countdash" {
         auth_soft_fail = true
       }
 
-      # The "artifact" block instructs Nomad to download an artifact from a
-      # remote source prior to starting the task. This provides a convenient
-      # mechanism for downloading configuration files or data needed to run the
-      # task. It is possible to specify the "artifact" block multiple times to
-      # download multiple artifacts.
-      #
-      # For more information and examples on the "artifact" block, please see
-      # the online documentation at:
-      #
-      #     https://developer.hashicorp.com/nomad/docs/job-specification/artifact.html
-      #
-      # artifact {
-      #   source = "http://foo.com/artifact.tar.gz"
-      #   options {
-      #     checksum = "md5:c4aa853ad2215426eb7d70a21922e794"
-      #   }
-      # }
-
-
-      # The "logs" block instructs the Nomad client on how many log files and
-      # the maximum size of those logs files to retain. Logging is enabled by
-      # default, but the "logs" block allows for finer-grained control over
-      # the log rotation and storage configuration.
-      #
-      # For more information and examples on the "logs" block, please see
-      # the online documentation at:
-      #
-      #     https://developer.hashicorp.com/nomad/docs/job-specification/logs.html
-      #
-      # logs {
-      #   max_files     = 10
-      #   max_file_size = 15
-      # }
-
-      # The "identity" block instructs Nomad to expose the task's workload
-      # identity token as an environment variable and in the file
-      # secrets/nomad_token.
-      # identity {
-      #   env  = true
-      #   file = true
-      # }
-
       # The "resources" block describes the requirements a task needs to
-      # execute. Resource requirements include memory, network, cpu, and more.
-      # This ensures the task will execute on a machine that contains enough
-      # resource capacity.
+      # execute. Resource requirements include memory, cpu, and more.
       #
-      # For more information and examples on the "resources" block, please see
-      # the online documentation at:
+      # For more information and examples on the "resources" block, please see:
       #
-      #     https://developer.hashicorp.com/nomad/docs/job-specification/resources.html
+      #     https://developer.hashicorp.com/nomad/docs/job-specification/resources
       #
       resources {
         cpu    = 500 # 500 MHz
@@ -415,10 +170,11 @@ job "countdash" {
     #   }
     # }
   }
+
   # This job has a second "group" block to define tasks that might be placed
   # on a separate Nomad client from the group above.
-  #
   group "dashboard" {
+
     network {
       mode = "bridge"
 

--- a/command/asset/example.nomad.hcl
+++ b/command/asset/example.nomad.hcl
@@ -345,9 +345,11 @@ job "example" {
       }
 
       # The "resources" block describes the requirements a task needs to
-      # execute. Resource requirements include attributes such as memory, cpu, cores, and devices.
+      # execute. Resource requirements include attributes such as memory, cpu,
+      # cores, and devices.
       #
-      # For a complete list of attributes and examples on the "resources" block, refer to:
+      # For a complete list of attributes and examples on the "resources"
+      # block, refer to:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/resources
       #

--- a/command/asset/example.nomad.hcl
+++ b/command/asset/example.nomad.hcl
@@ -6,8 +6,7 @@
 # should run. Jobs have a globally unique name, one or many task groups, which
 # are themselves collections of one or many tasks.
 #
-# For more information and examples on the "job" block, please see
-# the online documentation at:
+# For more information and examples on the "job" block, please see:
 #
 #     https://developer.hashicorp.com/nomad/docs/job-specification/job
 #
@@ -23,10 +22,9 @@ job "example" {
 
   # The "type" parameter controls the type of job, which impacts the scheduler's
   # decision on placement. This configuration is optional and defaults to
-  # "service". For a full list of job types and their differences, please see
-  # the online documentation.
+  # "service". For a full list of job types and their differences, please see:
   #
-  # For more information, please see the online documentation at:
+  # For more information, please see:
   #
   #     https://developer.hashicorp.com/nomad/docs/schedulers
   #
@@ -36,8 +34,7 @@ job "example" {
   # in addition to any resource or driver constraints. This block may be placed
   # at the "job", "group", or "task" level, and supports variable interpolation.
   #
-  # For more information and examples on the "constraint" block, please see
-  # the online documentation at:
+  # For more information and examples on the "constraint" block, please see:
   #
   #     https://developer.hashicorp.com/nomad/docs/job-specification/constraint
   #
@@ -53,8 +50,7 @@ job "example" {
   # job, it applies to all groups within the job. When placed at both the job and
   # group level, the blocks are merged with the group's taking precedence.
   #
-  # For more information and examples on the "update" block, please see
-  # the online documentation at:
+  # For more information and examples on the "update" block, please see:
   #
   #     https://developer.hashicorp.com/nomad/docs/job-specification/update
   #
@@ -100,11 +96,11 @@ job "example" {
     # version is deployed and upon promotion the old version is stopped.
     canary = 0
   }
+
   # The migrate block specifies the group's strategy for migrating off of
   # draining nodes. If omitted, a default migration strategy is applied.
   #
-  # For more information on the "migrate" block, please see
-  # the online documentation at:
+  # For more information on the "migrate" block, please see:
   #
   #     https://developer.hashicorp.com/nomad/docs/job-specification/migrate
   #
@@ -128,26 +124,38 @@ job "example" {
     # is specified using a label suffix like "2m" or "1h".
     healthy_deadline = "5m"
   }
-  # The "group" block defines a series of tasks that should be co-located on
-  # the same Nomad client. Any task within a group will be placed on the same
-  # client.
+
+  # The "ui" block provides options to modify the presentation of the Job index
+  # page in Nomad's Web UI.
   #
-  # For more information and examples on the "group" block, please see
-  # the online documentation at:
+  # For more information on the "ui" block, please see:
+  #
+  #   https://developer.hashicorp.com/nomad/docs/job-specification/ui
+  #
+  ui {
+    description = "Nomad **Example** Job"
+    link {
+      label = "Learn more about Nomad"
+      url   = "https://developer.hashicorp.com/nomad"
+    }
+  }
+
+  # The "group" block defines tasks that should be co-located on the same Nomad
+  # client. Any task within a group will be placed on the same client.
+  #
+  # For more information and examples on the "group" block, please see:
   #
   #     https://developer.hashicorp.com/nomad/docs/job-specification/group
   #
   group "cache" {
-    # The "count" parameter specifies the number of the task groups that should
-    # be running under this group. This value must be non-negative and defaults
-    # to 1.
+    # The "count" parameter specifies the number of this task group. This value
+    # must be non-negative and defaults to 1.
     count = 1
 
-    # The "network" block specifies the network configuration for the allocation
-    # including requesting port bindings.
+    # The "network" block specifies the network configuration for the task
+    # group including requesting port bindings.
     #
-    # For more information and examples on the "network" block, please see
-    # the online documentation at:
+    # For more information and examples on the "network" block, please see:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/network
     #
@@ -162,8 +170,7 @@ job "example" {
     # will make the service discoverable after Nomad has placed it on a host and
     # port.
     #
-    # For more information and examples on the "service" block, please see
-    # the online documentation at:
+    # For more information and examples on the "service" block, please see:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/service
     #
@@ -173,10 +180,12 @@ job "example" {
       port     = "db"
       provider = "nomad"
 
-      # The "check" block instructs Nomad to create a Consul health check for
-      # this service. A sample check is provided here for your convenience;
-      # uncomment it to enable it. The "check" block is documented in the
-      # "service" block documentation.
+      # The "check" block instructs Nomad to create a health check for
+      # this service. Uncomment the sample check below to enable it.
+      #
+      # For more information and examples on the "check" block, please see:
+      #
+      #   https://developer.hashicorp.com/nomad/docs/job-specification/check
 
       # check {
       #   name     = "alive"
@@ -190,13 +199,12 @@ job "example" {
     # The "restart" block configures a group's behavior on task failure. If
     # left unspecified, a default restart policy is used based on the job type.
     #
-    # For more information and examples on the "restart" block, please see
-    # the online documentation at:
+    # For more information and examples on the "restart" block:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/restart
     #
     restart {
-      # The number of attempts to run the job within the specified interval.
+      # The number of attempts to run within the specified interval.
       attempts = 2
       interval = "30m"
 
@@ -211,27 +219,25 @@ job "example" {
       mode = "fail"
     }
 
-    # The "ephemeral_disk" block instructs Nomad to utilize an ephemeral disk
-    # instead of a hard disk requirement. Clients using this block should
-    # not specify disk requirements in the resources block of the task. All
-    # tasks in this group will share the same ephemeral disk.
+    # The "ephemeral_disk" block describes the ephemeral disk requirements of
+    # the group. All tasks in this group will share the same ephemeral disk.
     #
     # For more information and examples on the "ephemeral_disk" block, please
-    # see the online documentation at:
+    # see:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/ephemeral_disk
     #
     ephemeral_disk {
-      # When sticky is true and the task group is updated, the scheduler
-      # will prefer to place the updated allocation on the same node and
-      # will migrate the data. This is useful for tasks that store data
-      # that should persist across allocation updates.
+      # When sticky is true and the task group is updated, the scheduler will
+      # prefer to place the updated allocation on the same node and migrate the
+      # data. This is useful for tasks that store data that should persist
+      # across updates.
       # sticky = true
-      #
-      # Setting migrate to true results in the allocation directory of a
-      # sticky allocation directory to be migrated.
+
+      # Setting migrate to true results in the allocation directory being
+      # copied to the new allocation on update.
       # migrate = true
-      #
+
       # The "size" parameter specifies the size in MB of shared ephemeral disk
       # between tasks in the group.
       size = 300
@@ -240,44 +246,26 @@ job "example" {
     # The "affinity" block enables operators to express placement preferences
     # based on node attributes or metadata.
     #
-    # For more information and examples on the "affinity" block, please
-    # see the online documentation at:
+    # For more information and examples on the "affinity" block, please see:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/affinity
     #
     # affinity {
-    # attribute specifies the name of a node attribute or metadata
-    # attribute = "${node.datacenter}"
-
-
-    # value specifies the desired attribute value. In this example Nomad
-    # will prefer placement in the "us-west1" datacenter.
-    # value  = "us-west1"
-
-
-    # weight can be used to indicate relative preference
-    # when the job has more than one affinity. It defaults to 50 if not set.
-    # weight = 100
-    #  }
-
+    #   attribute = "${node.datacenter}"
+    #   value     = "us-west1"
+    #   weight    = 100
+    # }
 
     # The "spread" block allows operators to increase the failure tolerance of
     # their applications by specifying a node attribute that allocations
     # should be spread over.
     #
-    # For more information and examples on the "spread" block, please
-    # see the online documentation at:
+    # For more information and examples on the "spread" block, please see:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/spread
     #
     # spread {
-    # attribute specifies the name of a node attribute or metadata
-    # attribute = "${node.datacenter}"
-
-
-    # targets can be used to define desired percentages of allocations
-    # for each targeted attribute value.
-    #
+    #   attribute = "${node.datacenter}"
     #   target "us-east1" {
     #     percent = 60
     #   }
@@ -287,10 +275,9 @@ job "example" {
     #  }
 
     # The "task" block creates an individual unit of work, such as a Docker
-    # container, web application, or batch processing.
+    # container, virtual machine, or process.
     #
-    # For more information and examples on the "task" block, please see
-    # the online documentation at:
+    # For more information and examples on the "task" block, please see:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/task
     #
@@ -316,11 +303,10 @@ job "example" {
       # The "artifact" block instructs Nomad to download an artifact from a
       # remote source prior to starting the task. This provides a convenient
       # mechanism for downloading configuration files or data needed to run the
-      # task. It is possible to specify the "artifact" block multiple times to
-      # download multiple artifacts.
+      # task. The "artifact" block can be specified multiple times to download
+      # multiple artifacts.
       #
-      # For more information and examples on the "artifact" block, please see
-      # the online documentation at:
+      # For more information and examples on the "artifact" block, please see:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/artifact
       #
@@ -336,8 +322,7 @@ job "example" {
       # default, but the "logs" block allows for finer-grained control over
       # the log rotation and storage configuration.
       #
-      # For more information and examples on the "logs" block, please see
-      # the online documentation at:
+      # For more information and examples on the "logs" block, please see:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/logs
       #
@@ -349,6 +334,11 @@ job "example" {
       # The "identity" block instructs Nomad to expose the task's workload
       # identity token as an environment variable and in the file
       # secrets/nomad_token.
+      #
+      # For more information and examples on the "identity" block, please see:
+      #
+      #     https://developer.hashicorp.com/nomad/docs/job-specification/identity
+      #
       identity {
         env  = true
         file = true
@@ -356,11 +346,8 @@ job "example" {
 
       # The "resources" block describes the requirements a task needs to
       # execute. Resource requirements include memory, cpu, and more.
-      # This ensures the task will execute on a machine that contains enough
-      # resource capacity.
       #
-      # For more information and examples on the "resources" block, please see
-      # the online documentation at:
+      # For more information and examples on the "resources" block, please see:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/resources
       #
@@ -369,13 +356,11 @@ job "example" {
         memory = 256 # 256MB
       }
 
-
-      # The "template" block instructs Nomad to manage a template, such as
-      # a configuration file or script. This template can optionally pull data
-      # from Consul or Vault to populate runtime configuration data.
+      # The "template" block instructs Nomad to manage a template, such as a
+      # configuration file or script. This template can optionally pull data
+      # from Nomad, Consul, or Vault to populate runtime configuration data.
       #
-      # For more information and examples on the "template" block, please see
-      # the online documentation at:
+      # For more information and examples on the "template" block, please see:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/template
       #
@@ -396,15 +381,14 @@ job "example" {
       #   env         = true
       # }
 
-      # The "vault" block instructs the Nomad client to acquire a token from
-      # a HashiCorp Vault server. The Nomad servers must be configured and
-      # authorized to communicate with Vault. By default, Nomad will inject
-      # The token into the job via an environment variable and make the token
-      # available to the "template" block. The Nomad client handles the renewal
-      # and revocation of the Vault token.
+      # The "vault" block instructs the Nomad client to acquire a token from a
+      # HashiCorp Vault server. Nomad must be configured to communicate with
+      # Vault. By default, Nomad will inject the token into the task via an
+      # environment variable and make the token available to the "template"
+      # block. The Nomad client handles the renewal and revocation of the Vault
+      # token.
       #
-      # For more information and examples on the "vault" block, please see
-      # the online documentation at:
+      # For more information and examples on the "vault" block, please see:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/vault
       #

--- a/command/asset/example.nomad.hcl
+++ b/command/asset/example.nomad.hcl
@@ -6,7 +6,7 @@
 # should run. Jobs have a globally unique name, one or many task groups, which
 # are themselves collections of one or many tasks.
 #
-# For more information and examples on the "job" block, please see:
+# For more information and examples on the "job" block, refer to:
 #
 #     https://developer.hashicorp.com/nomad/docs/job-specification/job
 #
@@ -22,19 +22,19 @@ job "example" {
 
   # The "type" parameter controls the type of job, which impacts the scheduler's
   # decision on placement. This configuration is optional and defaults to
-  # "service". For a full list of job types and their differences, please see:
+  # "service".
   #
-  # For more information, please see:
+  # For a full list of job types and their differences, refer to:
   #
   #     https://developer.hashicorp.com/nomad/docs/schedulers
   #
   type = "service"
 
   # The "constraint" block defines additional constraints for placing this job,
-  # in addition to any resource or driver constraints. This block may be placed
-  # at the "job", "group", or "task" level, and supports variable interpolation.
+  # in addition to any resource or driver constraints. You may place this block
+  # at the "job", "group", or "task" level, and it supports variable interpolation.
   #
-  # For more information and examples on the "constraint" block, please see:
+  # For more information and examples on the "constraint" block, refer to:
   #
   #     https://developer.hashicorp.com/nomad/docs/job-specification/constraint
   #
@@ -48,9 +48,9 @@ job "example" {
   # blue/green deployments. If omitted, no update strategy is enforced. The
   # "update" block may be placed at the job or task group. When placed at the
   # job, it applies to all groups within the job. When placed at both the job and
-  # group level, the blocks are merged with the group's taking precedence.
+  # group level, the blocks are merged with the groups taking precedence.
   #
-  # For more information and examples on the "update" block, please see:
+  # For more information and examples on the "update" block, refer to:
   #
   #     https://developer.hashicorp.com/nomad/docs/job-specification/update
   #
@@ -98,9 +98,9 @@ job "example" {
   }
 
   # The migrate block specifies the group's strategy for migrating off of
-  # draining nodes. If omitted, a default migration strategy is applied.
+  # draining nodes. If omitted, Nomad applies a default migration strategy.
   #
-  # For more information on the "migrate" block, please see:
+  # For more information on the "migrate" block, refer to:
   #
   #     https://developer.hashicorp.com/nomad/docs/job-specification/migrate
   #
@@ -128,7 +128,7 @@ job "example" {
   # The "ui" block provides options to modify the presentation of the Job index
   # page in Nomad's Web UI.
   #
-  # For more information on the "ui" block, please see:
+  # For more information on the "ui" block, refer to:
   #
   #   https://developer.hashicorp.com/nomad/docs/job-specification/ui
   #
@@ -141,9 +141,9 @@ job "example" {
   }
 
   # The "group" block defines tasks that should be co-located on the same Nomad
-  # client. Any task within a group will be placed on the same client.
+  # client. Nomad places any task within a group onto the same client.
   #
-  # For more information and examples on the "group" block, please see:
+  # For more information and examples on the "group" block, refer to:
   #
   #     https://developer.hashicorp.com/nomad/docs/job-specification/group
   #
@@ -155,7 +155,7 @@ job "example" {
     # The "network" block specifies the network configuration for the task
     # group including requesting port bindings.
     #
-    # For more information and examples on the "network" block, please see:
+    # For more information and examples on the "network" block, refer to:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/network
     #
@@ -170,7 +170,7 @@ job "example" {
     # will make the service discoverable after Nomad has placed it on a host and
     # port.
     #
-    # For more information and examples on the "service" block, please see:
+    # For more information and examples on the "service" block, refer to:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/service
     #
@@ -183,7 +183,7 @@ job "example" {
       # The "check" block instructs Nomad to create a health check for
       # this service. Uncomment the sample check below to enable it.
       #
-      # For more information and examples on the "check" block, please see:
+      # For more information and examples on the "check" block, refer to:
       #
       #   https://developer.hashicorp.com/nomad/docs/job-specification/check
 
@@ -197,9 +197,9 @@ job "example" {
     }
 
     # The "restart" block configures a group's behavior on task failure. If
-    # left unspecified, a default restart policy is used based on the job type.
+    # left unspecified, Nomad uses a default restart policy based on the job type.
     #
-    # For more information and examples on the "restart" block:
+    # For more information and examples on the "restart" block, refer to:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/restart
     #
@@ -220,22 +220,22 @@ job "example" {
     }
 
     # The "ephemeral_disk" block describes the ephemeral disk requirements of
-    # the group. All tasks in this group will share the same ephemeral disk.
+    # the group. All tasks in this group share the same ephemeral disk.
     #
-    # For more information and examples on the "ephemeral_disk" block, please
-    # see:
+    # For more information and examples on the "ephemeral_disk" block, refer
+    # to:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/ephemeral_disk
     #
     ephemeral_disk {
-      # When sticky is true and the task group is updated, the scheduler will
-      # prefer to place the updated allocation on the same node and migrate the
+      # When sticky is true and the task group is updated, the scheduler
+      # prefers to place the updated allocation on the same node and migrate the
       # data. This is useful for tasks that store data that should persist
       # across updates.
       # sticky = true
 
-      # Setting migrate to true results in the allocation directory being
-      # copied to the new allocation on update.
+      # Setting migrate to true results Nomad copying the allocation directory
+      # to the new allocation on update.
       # migrate = true
 
       # The "size" parameter specifies the size in MB of shared ephemeral disk
@@ -243,10 +243,10 @@ job "example" {
       size = 300
     }
 
-    # The "affinity" block enables operators to express placement preferences
+    # The "affinity" block lets you express placement preferences
     # based on node attributes or metadata.
     #
-    # For more information and examples on the "affinity" block, please see:
+    # For more information and examples on the "affinity" block, refer to:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/affinity
     #
@@ -256,11 +256,11 @@ job "example" {
     #   weight    = 100
     # }
 
-    # The "spread" block allows operators to increase the failure tolerance of
-    # their applications by specifying a node attribute that allocations
+    # The "spread" block let you increase the failure tolerance of
+    # your applications by specifying a node attribute that allocations
     # should be spread over.
     #
-    # For more information and examples on the "spread" block, please see:
+    # For more information and examples on the "spread" block, refer to:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/spread
     #
@@ -277,7 +277,7 @@ job "example" {
     # The "task" block creates an individual unit of work, such as a Docker
     # container, virtual machine, or process.
     #
-    # For more information and examples on the "task" block, please see:
+    # For more information and examples on the "task" block, refer to:
     #
     #     https://developer.hashicorp.com/nomad/docs/job-specification/task
     #
@@ -303,10 +303,10 @@ job "example" {
       # The "artifact" block instructs Nomad to download an artifact from a
       # remote source prior to starting the task. This provides a convenient
       # mechanism for downloading configuration files or data needed to run the
-      # task. The "artifact" block can be specified multiple times to download
+      # task. Specify the "artifact" block multiple times to download
       # multiple artifacts.
       #
-      # For more information and examples on the "artifact" block, please see:
+      # For more information and examples on the "artifact" block, refer to:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/artifact
       #
@@ -322,7 +322,7 @@ job "example" {
       # default, but the "logs" block allows for finer-grained control over
       # the log rotation and storage configuration.
       #
-      # For more information and examples on the "logs" block, please see:
+      # For more information and examples on the "logs" block, refer to:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/logs
       #
@@ -335,7 +335,7 @@ job "example" {
       # identity token as an environment variable and in the file
       # secrets/nomad_token.
       #
-      # For more information and examples on the "identity" block, please see:
+      # For more information and examples on the "identity" block, refer to:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/identity
       #
@@ -345,9 +345,9 @@ job "example" {
       }
 
       # The "resources" block describes the requirements a task needs to
-      # execute. Resource requirements include memory, cpu, and more.
+      # execute. Resource requirements include attributes such as memory, cpu, cores, and devices.
       #
-      # For more information and examples on the "resources" block, please see:
+      # For a complete list of attributes and examples on the "resources" block, refer to:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/resources
       #
@@ -360,7 +360,7 @@ job "example" {
       # configuration file or script. This template can optionally pull data
       # from Nomad, Consul, or Vault to populate runtime configuration data.
       #
-      # For more information and examples on the "template" block, please see:
+      # For more information and examples on the "template" block, refer to:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/template
       #
@@ -383,12 +383,12 @@ job "example" {
 
       # The "vault" block instructs the Nomad client to acquire a token from a
       # HashiCorp Vault server. Nomad must be configured to communicate with
-      # Vault. By default, Nomad will inject the token into the task via an
-      # environment variable and make the token available to the "template"
+      # Vault. By default, Nomad injects the token into the task via an
+      # environment variable and makes the token available to the "template"
       # block. The Nomad client handles the renewal and revocation of the Vault
       # token.
       #
-      # For more information and examples on the "vault" block, please see:
+      # For more information and examples on the "vault" block, refer to:
       #
       #     https://developer.hashicorp.com/nomad/docs/job-specification/vault
       #


### PR DESCRIPTION
The full example jobspecs emitted by [`nomad job init`](https://developer.hashicorp.com/nomad/docs/commands/job/init) and `nomad job init -connect` have not seen any improvement in over a year. I intended to just peek in, add a new [`ui{}` block](https://developer.hashicorp.com/nomad/docs/job-specification/ui) block, and be done. However, something about skimming over the phrase `the online documentation` a dozen times made me stop and do some spring cleaning.

The diff is an absolute nightmare even though I think my changes are fairly minor. Some highlights:

1. Added a `ui` block because I think it should be a widely used feature!
2. Removed tons of non-connect-related blocks from the connect example. I don't think the value of documenting blocks twice in the normal example and in connect is worth it. We could add some templating to keep those blocks in sync, but I just don't think repeating our examples is helpful. When people want a service mesh example, they probably want to see exactly what's relevant to the service mesh, not a bunch of unrelated topics like `affinity{}`.
3. Removed `the online documentation`. It is 2024, not 1999. I think our users know what a URL implies.
4. Cleaned up whitespace in a few places although I did remove some comments to do it. For example I couldn't figure out how best to indent `affinity{}` and all of its field comments, so I just removed the field comments. I think users are much better off visiting _the online documentation_ for those details. The examples should demonstrate Nomad's featureset, not be a comprehensive guide to those features.

Pinging @philrenaud because I've been pestering Phil with `ui{}` things already, and @aimeeu because despite this being a part of the `nomad` binary, I think it's documentation, and I want to make sure my changes fit with the style of similar examples our docs are full of. Let me know if you want to hand it off.