### PR TITLE
docker: always use API version negotiation when initializing clients

### DIFF
--- a/.changelog/24237.txt
+++ b/.changelog/24237.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Always negotiate API version when initializing clients
+```

--- a/drivers/docker/docklog/docker_logger.go
+++ b/drivers/docker/docklog/docker_logger.go
@@ -225,13 +225,18 @@ func (d *dockerLogger) getDockerClient(opts *StartOpts) (*client.Client, error) 
 			d.logger.Debug("using TLS client connection to docker", "endpoint", opts.Endpoint)
 			newClient, err = client.NewClientWithOpts(
 				client.WithHost(opts.Endpoint),
-				client.WithTLSClientConfig(opts.TLSCA, opts.TLSCert, opts.TLSKey))
+				client.WithTLSClientConfig(opts.TLSCA, opts.TLSCert, opts.TLSKey),
+				client.WithAPIVersionNegotiation(),
+			)
 			if err != nil {
 				merr.Errors = append(merr.Errors, err)
 			}
 		} else {
 			d.logger.Debug("using plaintext client connection to docker", "endpoint", opts.Endpoint)
-			newClient, err = client.NewClientWithOpts(client.WithHost(opts.Endpoint))
+			newClient, err = client.NewClientWithOpts(
+				client.WithHost(opts.Endpoint),
+				client.WithAPIVersionNegotiation(),
+			)
 			if err != nil {
 				merr.Errors = append(merr.Errors, err)
 			}

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1927,13 +1927,17 @@ func (d *Driver) newDockerClient(timeout time.Duration) (*client.Client, error) 
 			newClient, err = client.NewClientWithOpts(
 				client.WithHost(dockerEndpoint),
 				client.WithTLSClientConfig(ca, cert, key),
+				client.WithAPIVersionNegotiation(),
 			)
 			if err != nil {
 				merr.Errors = append(merr.Errors, err)
 			}
 		} else {
 			d.logger.Debug("using standard client connection", "endpoint", dockerEndpoint)
-			newClient, err = client.NewClientWithOpts(client.WithHost(dockerEndpoint))
+			newClient, err = client.NewClientWithOpts(
+				client.WithHost(dockerEndpoint),
+				client.WithAPIVersionNegotiation(),
+			)
 			if err != nil {
 				merr.Errors = append(merr.Errors, err)
 			}


### PR DESCRIPTION
During a refactoring of the docker driver in https://github.com/hashicorp/nomad/pull/23966 we introduced a bug: API version negotiation option was not passed to every new client call. 

Fixes https://github.com/hashicorp/nomad/issues/24212
internal ref: https://hashicorp.atlassian.net/browse/NET-11337