### PR TITLE
[ui] Adds an ellipsis and max width to profile nav token name

### DIFF
--- a/.changelog/24240.txt
+++ b/.changelog/24240.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Put a max-width on token name so it doesn't collide with the search box in the top nav
+```

--- a/ui/app/styles/core/navbar.scss
+++ b/ui/app/styles/core/navbar.scss
@@ -177,6 +177,14 @@ $secondaryNavbarHeight: 4.5rem;
     }
   }
 
+  .profile-dropdown .hds-dropdown-toggle-button__text {
+    max-width: 150px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    direction: rtl;
+  }
+
   .custom-label {
     border-radius: 1rem;
     padding: 0.25rem 1rem;


### PR DESCRIPTION
Maxes out the width of the profile dropdown for token name so that it isn't as likely to bump into the searchbox etc.

<img width="1473" alt="image" src="https://github.com/user-attachments/assets/4664b1d4-44e0-4753-ba4d-930c2c226f09">


(Note: a better, and eventual, solution to this is to use css grid or flexbox, but today is not that day)