### PR TITLE
docker: close hijacked write connection when exec ends

### DIFF
--- a/.changelog/24244.txt
+++ b/.changelog/24244.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fixed a bug where alloc exec could leak a goroutine
+```

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1836,7 +1836,11 @@ func (d *Driver) ExecTaskStreaming(ctx context.Context, taskID string, opts *dri
 	if err != nil {
 		return nil, fmt.Errorf("failed to attach to exec: %v", err)
 	}
-	defer resp.Close()
+	defer func() {
+		opts.Stdin.Close() // close stdin
+		resp.CloseWrite()  // close hijacked write connection
+		resp.Close()       // close read connection
+	}()
 
 	go func() {
 		if !opts.Tty {


### PR DESCRIPTION
Close the `stdin` and hijacked write connection handles upon exiting the exec function. Otherwise the goroutine reading from `stdin` will leak and hang forever.

Fixes #24242