### PR TITLE
Docs: Update leadership transfer options docs

### DIFF
--- a/command/operator_raft_leadership_transfer.go
+++ b/command/operator_raft_leadership_transfer.go
@@ -35,7 +35,7 @@ General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
-Remove Peer Options:
+Transfer Leadership Options:
 
   -peer-address="IP:port"
     Transfer leadership to the Nomad server with given Raft address.


### PR DESCRIPTION
Before:
```
Remove Peer Options:

  -peer-address="IP:port"
    Transfer leadership to the Nomad server with given Raft address.

  -peer-id="id"
    Transfer leadership to the Nomad server with given Raft ID.
```

After
```
Transfer Leadership Options:

  -peer-address="IP:port"
    Transfer leadership to the Nomad server with given Raft address.

  -peer-id="id"
    Transfer leadership to the Nomad server with given Raft ID.
```