### PR TITLE
deps: update go-plugin to 1.6.2

### DIFF
--- a/.changelog/24265.txt
+++ b/.changelog/24265.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+deps: Fixed a bug where restarting Nomad could cause an unrelated process with the same PID as a failed executor to be killed
+```

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/hashicorp/go-msgpack/v2 v2.1.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-netaddrs v0.1.0
-	github.com/hashicorp/go-plugin v1.6.1
+	github.com/hashicorp/go-plugin v1.6.2
 	github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.9
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/go-set/v3 v3.0.0-alpha.1

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-netaddrs v0.1.0 h1:TnlYvODD4C/wO+j7cX1z69kV5gOzI87u3OcUinANaW8=
 github.com/hashicorp/go-netaddrs v0.1.0/go.mod h1:33+a/emi5R5dqRspOuZKO0E+Tuz5WV1F84eRWALkedA=
-github.com/hashicorp/go-plugin v1.6.1 h1:P7MR2UP6gNKGPp+y7EZw2kOiq4IR9WiqLvp0XOsVdwI=
-github.com/hashicorp/go-plugin v1.6.1/go.mod h1:XPHFku2tFo3o3QKFgSYo+cghcUhw1NA1hZyMK0PWAw0=
+github.com/hashicorp/go-plugin v1.6.2 h1:zdGAEd0V1lCaU0u+MxWQhtSDQmahpkwOun8U8EiRVog=
+github.com/hashicorp/go-plugin v1.6.2/go.mod h1:CkgLQ5CZqNmdL9U9JzM532t8ZiYQ35+pj3b1FD37R0Q=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-retryablehttp v0.6.6/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-retryablehttp v0.7.7 h1:C8hUCYzor8PIfXHa4UrZkU4VvK8o9ISHxT2Q8+VepXU=

--- a/plugins/drivers/testutils/testing.go
+++ b/plugins/drivers/testutils/testing.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"testing"
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
@@ -25,7 +26,6 @@ import (
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/drivers/fsisolation"
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
-	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/shoenig/test/must"
 )
 
@@ -33,7 +33,7 @@ type DriverHarness struct {
 	drivers.DriverPlugin
 	client *plugin.GRPCClient
 	server *plugin.GRPCServer
-	t      testing.T
+	t      *testing.T
 	logger hclog.Logger
 	impl   drivers.DriverPlugin
 	cgroup string
@@ -42,7 +42,7 @@ type DriverHarness struct {
 func (h *DriverHarness) Impl() drivers.DriverPlugin {
 	return h.impl
 }
-func NewDriverHarness(t testing.T, d drivers.DriverPlugin) *DriverHarness {
+func NewDriverHarness(t *testing.T, d drivers.DriverPlugin) *DriverHarness {
 	logger := testlog.HCLogger(t).Named("driver_harness")
 	pd := drivers.NewDriverPlugin(d, logger)
 


### PR DESCRIPTION
During allocation recovery, the go-plugin reattachment workflow checks to see if the PID we stored in client state is still running. If so, we try to connect to that process. If that fails, we kill the process under the presumption it's not working. But during reattachment we don't know that the PID we have is still valid. Which means that the process we're trying to attach to may have exited and a different process has spawned with the same PID. This results in some unrelated process getting silently killed.

Update go-plugin to 1.6.2, which includes a bug fix so we do not kill the process.

Fixes: https://github.com/hashicorp/nomad/issues/23969
Ref: https://hashicorp.atlassian.net/browse/NET-11233