### PR TITLE
Docs: Update CLI job tag unset

### DIFF
--- a/website/content/docs/commands/job/tag.mdx
+++ b/website/content/docs/commands/job/tag.mdx
@@ -22,12 +22,6 @@ following subcommands:
 nomad job tag <subcommand> [options] [args]
 ```
 
-## General options
-
-Use these optional general options with the subcommands.
-
-@include 'general_options.mdx'
-
 ## Apply
 
 Use `job tag apply` to create or modify a version tag.
@@ -37,6 +31,15 @@ Use `job tag apply` to create or modify a version tag.
 ```shell-session
 nomad job tag apply [options] <job_id>
 ```
+
+### General options
+
+<details>
+<summary>Expand to see general options</summary>
+
+@include 'general_options.mdx'
+
+</details>
 
 ### Apply options
 
@@ -69,8 +72,17 @@ Use `nomad job tag unset` to delete a tag from a version. This command requires 
 ### Unset usage
 
 ```shell-session
-nomad job tag unset [options]  -name <tag> <job_id>
+nomad job tag unset [options] <job_id>
 ```
+
+### General options
+
+<details>
+<summary>Expand to see general options</summary>
+
+@include 'general_options.mdx'
+
+</details>
 
 ### Unset options
 

--- a/website/content/docs/commands/job/tag.mdx
+++ b/website/content/docs/commands/job/tag.mdx
@@ -35,7 +35,7 @@ nomad job tag apply [options] <job_id>
 ### General options
 
 <details>
-<summary>Expand to see general options</summary>
+<summary>Expand for general options</summary>
 
 @include 'general_options.mdx'
 
@@ -78,7 +78,7 @@ nomad job tag unset [options] <job_id>
 ### General options
 
 <details>
-<summary>Expand to see general options</summary>
+<summary>Expand for general options</summary>
 
 @include 'general_options.mdx'
 

--- a/website/content/docs/commands/job/tag.mdx
+++ b/website/content/docs/commands/job/tag.mdx
@@ -69,7 +69,7 @@ Use `nomad job tag unset` to delete a tag from a version. This command requires 
 ### Unset usage
 
 ```shell-session
-nomad job tag unset [options] <job_id> -name <tag>
+nomad job tag unset [options]  -name <tag> <job_id>
 ```
 
 ### Unset options
@@ -81,7 +81,7 @@ nomad job tag unset [options] <job_id> -name <tag>
 This example removes the `golden-version` tag from the `hello-world` job.
 
 ```shell-session
-$ nomad job tag unset hello-world -name "golden-version"
+$ nomad job tag unset -name "golden-version" hello-world
 ```
 
 [diff]: /nomad/docs/commands/job/history/


### PR DESCRIPTION
CLI help order was wrong, so updating the CLI command.
I updated the usage to use `[options]`, moved general options into each subcommand but put that list in  `<details>` so the long general options list doesn't take up space. I didn't add the details tags to the included general_options file because that would affect several pages, but not all since use of that include is not consistent throughout the CLI command pages.

Fixes: [CE-739]
Relates to: [#24272] [#24266]

https://nomad-git-ce739-hashicorp.vercel.app/nomad/docs/commands/job/tag

[CE-739]: https://hashicorp.atlassian.net/browse/CE-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ