### PR TITLE
docs: warn about Consul auth method locality

### DIFF
--- a/website/content/docs/integrations/consul/acl.mdx
+++ b/website/content/docs/integrations/consul/acl.mdx
@@ -109,10 +109,10 @@ Nomad uses to sign workload identities. With these keys, Consul is able to
 validate their origin and confirm that they were actually created by Nomad.
 
 Nomad cannot recreate Consul tokens that have been deleted. The auth method
-configuration should never set the `MaxTokenTTL` field. Consul tokens will be
+configuration should never set the `MaxTokenTTL` field. Consul tokens are
 local to the Consul datacenter unless you set `TokenLocality: "global"` in the
-auth method. We recommend using local tokens (the default) because global tokens
-require the primary Consul datacenter is available when allocations start.
+auth method. We recommend using local tokens, which is the default. Global tokens
+require that the primary Consul datacenter is available when allocations start.
 
 <CodeBlockConfig highlight="2" filename="auth-method.json">
 

--- a/website/content/docs/integrations/consul/acl.mdx
+++ b/website/content/docs/integrations/consul/acl.mdx
@@ -109,7 +109,10 @@ Nomad uses to sign workload identities. With these keys, Consul is able to
 validate their origin and confirm that they were actually created by Nomad.
 
 Nomad cannot recreate Consul tokens that have been deleted. The auth method
-configuration should never set the `MaxTokenTTL` field.
+configuration should never set the `MaxTokenTTL` field. Consul tokens will be
+local to the Consul datacenter unless you set `TokenLocality: "global"` in the
+auth method. We recommend using local tokens (the default) because global tokens
+require the primary Consul datacenter is available when allocations start.
 
 <CodeBlockConfig highlight="2" filename="auth-method.json">
 


### PR DESCRIPTION
The locality of Consul tokens we mint via Workload Identity is governed by the Consul auth method configuration. By default tokens are local to the Consul datacenter, which typically maps 1:1 with a Nomad region. Cluster administrators who need cross-datacenter tokens can get them by setting the locality to global, at the risk of placement problems if the primary DC isn't available.

Ref: https://github.com/hashicorp/consul/issues/21863
Fixes: https://github.com/hashicorp/nomad/issues/23505