### PR TITLE
docs: warn about UID overlap between workload and Envoy tproxy

### DIFF
--- a/website/content/docs/integrations/consul/service-mesh.mdx
+++ b/website/content/docs/integrations/consul/service-mesh.mdx
@@ -159,6 +159,8 @@ Using transparent proxy has several important requirements:
   `client_addr`).
 * The Consul agent must be configured with [`recursors`][] if you want
   allocations to make DNS queries for applications outside the service mesh.
+* Your workload's task cannot use the same [Unix user ID (UID)][uid] as the
+  Envoy sidecar proxy.
 * You cannot set a [`network.dns`][] block on the allocation (unless you set
   [`no_dns`][tproxy_no_dns], see below).
 
@@ -515,3 +517,4 @@ nomad node meta apply -node-id $nodeID \
 [consul_dns_port]: /consul/docs/agent/config/config-files#dns_port
 [`network.dns`]: /nomad/docs/job-specification/network#dns-parameters
 [`client.meta`]: /nomad/docs/configuration/client#meta
+[uid]: /nomad/docs/job-specification/transparent_proxy#uid

--- a/website/content/docs/job-specification/transparent_proxy.mdx
+++ b/website/content/docs/job-specification/transparent_proxy.mdx
@@ -40,6 +40,8 @@ Using transparent proxy has some important restrictions:
   [`no_dns`](#no_dns), see below).
 * The node where the allocation is placed must be configured as described in
   the Service Mesh integration documentation for [Transparent Proxy][].
+* The workload's task cannot use the same Unix user ID (UID) as the Envoy
+  sidecar proxy.
 
 ## `transparent_proxy` Parameters
 
@@ -78,7 +80,8 @@ Using transparent proxy has some important restrictions:
 * `uid` `(string "101")` - The Unix user ID (UID) used by the Envoy proxy. You
   should only set this value if you have a custom build of the Envoy container
   image which uses a different UID. You can change the default value for a given
-  node via [client metadata](#client-metadata) (see below).
+  node via [client metadata](#client-metadata) (see below). Note that your
+  workload's task cannot use the same UID as the Envoy sidecar proxy.
 
 ## Client Metadata
 


### PR DESCRIPTION
When using transparent proxy mode with the `connect` block, the UID of the workload cannot be the same as the UID of the Envoy sidecar (currently 101 in the default Envoy container image).

Fixes: https://github.com/hashicorp/nomad/issues/23508

~I'll follow-up with a second PR for the tutorial.~ Actually, that doesn't fit in the tutorial format.