### PR TITLE
scheduler: fixed a bug where resource calculation did not account correctly for poststart tasks

### DIFF
--- a/.changelog/24297.txt
+++ b/.changelog/24297.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: fixed a bug where resource calculation did not account correctly for poststart tasks
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3859,6 +3859,7 @@ func (a *AllocatedResources) Comparable() *ComparableResources {
 	prestartSidecarTasks := &AllocatedTaskResources{}
 	prestartEphemeralTasks := &AllocatedTaskResources{}
 	main := &AllocatedTaskResources{}
+	poststartTasks := &AllocatedTaskResources{}
 	poststopTasks := &AllocatedTaskResources{}
 
 	for taskName, r := range a.Tasks {
@@ -3871,12 +3872,15 @@ func (a *AllocatedResources) Comparable() *ComparableResources {
 			} else {
 				prestartEphemeralTasks.Add(r)
 			}
+		} else if lc.Hook == TaskLifecycleHookPoststart {
+			poststartTasks.Add(r)
 		} else if lc.Hook == TaskLifecycleHookPoststop {
 			poststopTasks.Add(r)
 		}
 	}
 
 	// update this loop to account for lifecycle hook
+	main.Add(poststartTasks)
 	prestartEphemeralTasks.Max(main)
 	prestartEphemeralTasks.Max(poststopTasks)
 	prestartSidecarTasks.Add(prestartEphemeralTasks)


### PR DESCRIPTION
Fixes a bug in the AllocatedResources.Comparable method, which resulted in
reporting less required resources than actually expected. This could result in
overscheduling of allocations on a single node  and overlapping cgroup cpusets.


Split to #24304

---

```
job "redis2nd" {
  type = "service"
  group "cache" {
    count = 1

    task "redis-prestart" {
      lifecycle {
        hook    = "prestart"
        sidecar = false
      }
      driver = "docker"
      config {
        image = "hello-world:latest"
      }
      resources {
        cpu = 1000
      }
    }

    task "redis" {
      driver = "docker"
      config {
        image = "redis:3.2"
      }
      resources {
        cpu = 1000
      }
    }

    task "redis-start-side" {
      lifecycle {
        hook    = "poststart"
        sidecar = true
      }
      driver = "docker"
      config {
        image = "redis:3.2"
      }
      resources {
        cpu = 1000
      }
    }

    task "redis-poststop" {
      lifecycle {
        hook    = "poststop"
        sidecar = false
      }
      driver = "docker"
      config {
        image = "hello-world:latest"
      }
      resources {
        cpu = 1000
      }
    }
  }
}
```


![image](https://github.com/user-attachments/assets/61ee7616-475b-42f6-ab13-a95a22e48209)


**Before**
```
[sandbox@nomad-dev nomad]$ curl -s http://localhost:4646/v1/metrics | jq '.Gauges[] | select(.Name | contains("allocated.cpu")) | .Name, .Value'
"nomad.client.allocated.cpu"
1000.0
"nomad.client.unallocated.cpu"
277380.0
```

**After**
```
[sandbox@nomad-dev nomad]$ curl -s http://localhost:4646/v1/metrics | jq '.Gauges[] | select(.Name | contains("allocated.cpu")) | .Name, .Value'
"nomad.client.allocated.cpu"
2000.0
"nomad.client.unallocated.cpu"
276380.0
```