### PR TITLE
fix: documentation of idempotency_token in API

### DIFF
--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -1764,7 +1764,7 @@ The table below shows this endpoint's support for
 - `:job_id` `(string: <required>)` - Specifies the ID of the job. This is
   specified as part of the path.
 
-- `IdempotencyToken` `(string: "")` - Optional identifier used to prevent more
+- `idempotency_token` `(string: "")` - Optional identifier used to prevent more
   than one instance of the job from being dispatched. This is specified as a
   URL query parameter.
 


### PR DESCRIPTION
The parsing of the idempotency_token requires snake case, as it is a URL query parameter and not part of the JSON request body. 

See also: https://github.com/hashicorp/nomad/blob/2df473c5612cd46000bad755221de49e994256ba/command/agent/http.go#L951