### PR TITLE
Validate that Connect Native services define a port

### DIFF
--- a/.changelog/24329.txt
+++ b/.changelog/24329.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+connect: add validation to ensure that connect native services specify a port
+```

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -846,7 +846,7 @@ func (s *Service) validateCheckPort(c *ServiceCheck) error {
 func (s *Service) validateConsulService(mErr *multierror.Error) {
 	// check checks
 	for _, c := range s.Checks {
-		// validat ethe check port
+		// validate the check port
 		if err := s.validateCheckPort(c); err != nil {
 			mErr.Errors = append(mErr.Errors, err)
 			continue
@@ -876,6 +876,11 @@ func (s *Service) validateConsulService(mErr *multierror.Error) {
 		// happen implicitly in a job mutation if there is only one task)
 		if s.Connect.IsNative() && len(s.TaskName) == 0 {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Service %s is Connect Native and requires setting the task", s.Name))
+		}
+
+		// if service is connect native a port must be set on the service or consul will reject it
+		if s.Connect.IsNative() && s.PortLabel == "" {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("Service %s is Connect Native and requires setting the port", s.Name))
 		}
 	}
 }

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -1889,7 +1889,8 @@ func TestService_Validate(t *testing.T) {
 		{
 			name: "Native Connect without task name",
 			input: &Service{
-				Name: "testservice",
+				Name:      "testservice",
+				PortLabel: "8080",
 				Connect: &ConsulConnect{
 					Native: true,
 				},
@@ -1899,8 +1900,33 @@ func TestService_Validate(t *testing.T) {
 		{
 			name: "Native Connect with task name",
 			input: &Service{
+				Name:      "testservice",
+				PortLabel: "8080",
+				TaskName:  "testtask",
+				Connect: &ConsulConnect{
+					Native: true,
+				},
+			},
+			expErr: false,
+		},
+		{
+			name: "Native Connect without port",
+			input: &Service{
 				Name:     "testservice",
 				TaskName: "testtask",
+				Connect: &ConsulConnect{
+					Native: true,
+				},
+			},
+			expErr:    true,
+			expErrStr: "Service testservice is Connect Native and requires setting the port",
+		},
+		{
+			name: "Native Connect with port",
+			input: &Service{
+				Name:      "testservice",
+				TaskName:  "testtask",
+				PortLabel: "8080",
 				Connect: &ConsulConnect{
 					Native: true,
 				},
@@ -1996,8 +2022,8 @@ func TestService_Validate(t *testing.T) {
 		{
 			name: "provider consul with notes too long",
 			input: &Service{
-				Name:     "testservice",
-				Provider: "consul",
+				Name:      "testservice",
+				Provider:  "consul",
 				PortLabel: "port",
 				Checks: []*ServiceCheck{
 					{
@@ -2006,7 +2032,7 @@ func TestService_Validate(t *testing.T) {
 						Path:     "/",
 						Interval: 1 * time.Second,
 						Timeout:  3 * time.Second,
-						Notes: strings.Repeat("A", 256),
+						Notes:    strings.Repeat("A", 256),
 					},
 				},
 			},


### PR DESCRIPTION
This PR adds a validation check for PortLabels on Connect Native enabled services. This is a [requirement](https://github.com/hashicorp/consul/blob/6351a821aa171fddfab01776cce199d62aa6d5e2/agent/structs/structs.go#L1692-L1695) in Consul and if missing from the job spec will continually error.

```
"service": "nomad",
"message": "failed to update services in Consul",
"attributes": {
    "hostname": "<snip>",
    "@level": "warn",
    "@timestamp": "2024-10-29T15:16:34.148322Z",
    "service": "nomad",
    "@module": "consul.sync",
    "error": "Unexpected response code: 400 (Validation failed: 1 error occurred:\n\t* Port or SocketPath must be set for a Connect native service.)",
    "status": "info",
}
```

I can't get all of the tests to pass locally but `TestService_Validate` looked good.

```
=== RUN   TestService_Validate
=== PAUSE TestService_Validate
=== CONT  TestService_Validate
=== RUN   TestService_Validate/base_service
=== RUN   TestService_Validate/Native_Connect_without_task_name
=== RUN   TestService_Validate/Native_Connect_with_task_name
=== RUN   TestService_Validate/Native_Connect_without_port
=== RUN   TestService_Validate/Native_Connect_with_port
=== RUN   TestService_Validate/Native_Connect_with_Sidecar
=== RUN   TestService_Validate/provider_nomad_with_checks
=== RUN   TestService_Validate/provider_nomad_with_invalid_check_type
=== RUN   TestService_Validate/provider_nomad_with_tls_skip_verify
=== RUN   TestService_Validate/provider_nomad_with_connect
=== RUN   TestService_Validate/provider_nomad_valid
=== RUN   TestService_Validate/provider_consul_with_notes_too_long
--- PASS: TestService_Validate (0.00s)
    --- PASS: TestService_Validate/base_service (0.00s)
    --- PASS: TestService_Validate/Native_Connect_without_task_name (0.00s)
    --- PASS: TestService_Validate/Native_Connect_with_task_name (0.00s)
    --- PASS: TestService_Validate/Native_Connect_without_port (0.00s)
    --- PASS: TestService_Validate/Native_Connect_with_port (0.00s)
    --- PASS: TestService_Validate/Native_Connect_with_Sidecar (0.00s)
    --- PASS: TestService_Validate/provider_nomad_with_checks (0.00s)
    --- PASS: TestService_Validate/provider_nomad_with_invalid_check_type (0.00s)
    --- PASS: TestService_Validate/provider_nomad_with_tls_skip_verify (0.00s)
    --- PASS: TestService_Validate/provider_nomad_with_connect (0.00s)
    --- PASS: TestService_Validate/provider_nomad_valid (0.00s)
    --- PASS: TestService_Validate/provider_consul_with_notes_too_long (0.00s)
PASS
```