### PR TITLE
docs: add note to reschedule block for update progress deadline.

### DIFF
--- a/website/content/docs/job-specification/reschedule.mdx
+++ b/website/content/docs/job-specification/reschedule.mdx
@@ -78,8 +78,10 @@ they run on every node.
 - `max_delay` `(string: <varies>)` - is an upper bound on the delay beyond which it will not increase. This parameter
   is used when `delay_function` is `exponential` or `fibonacci`, and is ignored when `constant` delay is used.
 
-- `unlimited` `(boolean:<varies>)` - `unlimited` enables unlimited reschedule attempts. If this is set to true
-  the `attempts` and `interval` fields are not used.
+- `unlimited` `(boolean:<varies>)` - `unlimited` enables unlimited reschedule attempts. If this is
+  set to `true` the `attempts` and `interval` fields are not used. The [`progress_deadline`][]
+  parameter within the update block is still adhered to when this is set to `true`, meaning no more
+  reschedule attempts will be triggered once the [`progress_deadline`][] is reached.
 
 Information about reschedule attempts are displayed in the CLI and API for
 allocations. Rescheduling is enabled by default for service and batch jobs
@@ -127,3 +129,5 @@ job "docs" {
   }
 }
 ```
+
+[`progress_deadline`]: /nomad/docs/job-specification/update#progress_deadline


### PR DESCRIPTION
Even when set to unlimited, reschedules will stop once the updates progess deadline is reached.