### PR TITLE
[ui] Signing in with a token explicitly sets the region dropdown activeRegion

### DIFF
--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -23,7 +23,7 @@ export default class Tokens extends Controller {
   @service token;
   @service store;
   @service router;
-
+  @service system;
   queryParams = ['code', 'state', 'jwtAuthMethod'];
 
   @tracked secret = this.token.secret;
@@ -163,6 +163,14 @@ export default class Tokens extends Controller {
 
           // Refetch the token and associated policies
           this.token.get('fetchSelfTokenAndPolicies').perform().catch();
+
+          if (!this.system.activeRegion) {
+            this.system.get('defaultRegion').then((res) => {
+              if (res.region) {
+                this.system.set('activeRegion', res.region);
+              }
+            });
+          }
 
           this.signInStatus = 'success';
           this.token.set('tokenNotFound', false);

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -57,7 +57,7 @@ export default class SystemService extends Service {
     });
   }
 
-  @computed
+  @computed('token.selfToken')
   get defaultRegion() {
     const token = this.token;
     return PromiseObject.create({

--- a/ui/app/templates/components/region-switcher.hbs
+++ b/ui/app/templates/components/region-switcher.hbs
@@ -12,10 +12,13 @@
       @tagName="div"
       @triggerClass={{this.decoration}}
       @options={{this.sortedRegions}}
-      @selected={{this.system.activeRegion}}
+      @selected={{or this.system.activeRegion 'Select a Region'}}
       @searchEnabled={{false}}
       @onChange={{action this.gotoRegion}} as |region|>
-      <span class="ember-power-select-prefix">Region: </span>{{region}}
+      {{#if this.system.activeRegion}}
+        <span class="ember-power-select-prefix">Region: </span>
+      {{/if}}
+      {{region}}
     </PowerSelect>
   </span>
 {{else}}

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -708,7 +708,12 @@ export default function () {
     return this.serialize(volume);
   });
 
-  this.get('/agent/members', function ({ agents, regions }) {
+  this.get('/agent/members', function ({ agents, regions }, req) {
+    const tokenPresent = req.requestHeaders['X-Nomad-Token'];
+    if (!tokenPresent) {
+      return new Response(403, {}, 'Forbidden');
+    }
+
     const firstRegion = regions.first();
     return {
       ServerRegion: firstRegion ? firstRegion.id : null,

--- a/ui/tests/acceptance/regions-test.js
+++ b/ui/tests/acceptance/regions-test.js
@@ -15,6 +15,7 @@ import JobsList from 'nomad-ui/tests/pages/jobs/list';
 import ClientsList from 'nomad-ui/tests/pages/clients/list';
 import Layout from 'nomad-ui/tests/pages/layout';
 import Allocation from 'nomad-ui/tests/pages/allocations/detail';
+import Tokens from 'nomad-ui/tests/pages/settings/tokens';
 
 module('Acceptance | regions (only one)', function (hooks) {
   setupApplicationTest(hooks);
@@ -217,5 +218,27 @@ module('Acceptance | regions (many)', function (hooks) {
         assert.ok(req.url.includes(`region=${region}`), req.url);
       }
     });
+  });
+
+  test('Signing in sets the active region', async function (assert) {
+    window.localStorage.clear();
+    let managementToken = server.create('token');
+    await Tokens.visit();
+    assert.equal(
+      Layout.navbar.regionSwitcher.text,
+      'Select a Region',
+      'Region picker says "Select a Region" before signing in'
+    );
+    await Tokens.secret(managementToken.secretId).submit();
+    assert.equal(
+      window.localStorage.nomadActiveRegion,
+      'global',
+      'Region is set in localStorage after signing in'
+    );
+    assert.equal(
+      Layout.navbar.regionSwitcher.text,
+      'Region: global',
+      'Region picker says "Region: global" after signing in'
+    );
   });
 });

--- a/ui/tests/unit/adapters/job-test.js
+++ b/ui/tests/unit/adapters/job-test.js
@@ -468,6 +468,9 @@ module('Unit | Adapter | Job', function (hooks) {
   });
 
   test('when the region is set to the default region, requests are made without the region query param', async function (assert) {
+    const secret = 'here is the secret';
+    this.subject().set('token.secret', secret);
+
     await this.initializeUI({ region: 'region-1' });
 
     const { pretender } = this.server;


### PR DESCRIPTION
Relates to @shoenig's work in https://github.com/hashicorp/nomad/pull/24320 so branching off of that

As it stands, when you sign in with a token in a multi-region cluster, the `system.regions` array exists, but the `system.activeRegion` doesn't re-compute.

This makes that value recompute automatically during token verification, and refreshes the regions list to trigger that.

(Note: I don't think this is an issue for SSO-based authentication, since there is an explicit page refresh, which would handle region-setting by virtue of initial page load)

Resolves #24337 