### PR TITLE
test: fix rawexec driver unix test imports

### DIFF
--- a/drivers/rawexec/driver_unix_test.go
+++ b/drivers/rawexec/driver_unix_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/nomad/plugins/drivers"
 	dtestutil "github.com/hashicorp/nomad/plugins/drivers/testutils"
 	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )


### PR DESCRIPTION
The `must` package import was missing from the `drivers/rawexec/driver_unix_test.go` file.  This PR adds the import so these tests can build and run.