### PR TITLE
Allow scaling system jobs to 0

### DIFF
--- a/.changelog/24363.txt
+++ b/.changelog/24363.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: add the possibility to scale system jobs between 0 and 1
+```

--- a/e2e/scaling/input/namespace_default_system.nomad
+++ b/e2e/scaling/input/namespace_default_system.nomad
@@ -2,23 +2,9 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 job "system_job" {
-  datacenters = ["dc1"]
-
   type = "system"
 
-  constraint {
-    attribute = "${attr.kernel.name}"
-    value     = "linux"
-  }
-
   group "system_job_group" {
-    restart {
-      attempts = 10
-      interval = "1m"
-
-      delay = "2s"
-      mode  = "delay"
-    }
 
     task "system_task" {
       driver = "docker"

--- a/e2e/scaling/input/namespace_default_system.nomad
+++ b/e2e/scaling/input/namespace_default_system.nomad
@@ -1,0 +1,39 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+job "system_job" {
+  datacenters = ["dc1"]
+
+  type = "system"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "system_job_group" {
+    restart {
+      attempts = 10
+      interval = "1m"
+
+      delay = "2s"
+      mode  = "delay"
+    }
+
+    task "system_task" {
+      driver = "docker"
+
+      config {
+        image = "busybox:1"
+
+        command = "/bin/sh"
+        args    = ["-c", "sleep 15000"]
+      }
+
+      env {
+        version = "1"
+      }
+    }
+  }
+}
+

--- a/e2e/scaling/scaling.go
+++ b/e2e/scaling/scaling.go
@@ -225,9 +225,6 @@ func (tc *ScalingE2ETest) TestScalingBasicWithSystemSchedule(f *framework.F) {
 	stopedAllocs, _, err := jobs.Allocations(jobID, false, nil)
 	f.NoError(err)
 
-	stopedAllocs, _, err = jobs.Allocations(jobID, false, nil)
-	f.NoError(err)
-
 	f.Equal(numberOfNodes, len(filterAllocsByDesiredStatus(structs.AllocDesiredStatusStop, stopedAllocs)))
 	f.Equal(numberOfNodes, len(stopedAllocs))
 

--- a/e2e/scaling/scaling.go
+++ b/e2e/scaling/scaling.go
@@ -4,6 +4,7 @@
 package scaling
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/hashicorp/nomad/api"
@@ -182,9 +183,15 @@ func (tc *ScalingE2ETest) TestScalingBasicWithSystemSchedule(f *framework.F) {
 	jobs := nomadClient.Jobs()
 	allocs, _, err := jobs.Allocations(jobID, true, nil)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(allocs))
 
 	allocIDs := e2eutil.AllocIDsFromAllocationListStubs(allocs)
+	require.Equal(t, 1, len(allocIDs))
+
+	fmt.Printf("ids %+v\n job %+v", allocIDs, len(allocs))
+
+	for a := range allocs {
+		fmt.Printf("alloc %+v\n", a)
+	}
 
 	// Wait for allocations to get past initial pending state
 	e2eutil.WaitForAllocsNotPending(t, nomadClient, allocIDs)

--- a/e2e/scaling/scaling.go
+++ b/e2e/scaling/scaling.go
@@ -241,4 +241,10 @@ func (tc *ScalingE2ETest) TestScalingBasicWithSystemSchedule(f *framework.F) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(allocs))
 
+	// Remove the job.
+	_, _, err = tc.Nomad().Jobs().Deregister(jobID, true, nil)
+	f.NoError(err)
+	f.NoError(tc.Nomad().System().GarbageCollect())
+	tc.namespacedJobIDs = [][2]string{}
+
 }

--- a/e2e/scaling/scaling.go
+++ b/e2e/scaling/scaling.go
@@ -207,7 +207,12 @@ func (tc *ScalingE2ETest) TestScalingBasicWithSystemSchedule(f *framework.F) {
 	jobs = nomadClient.Jobs()
 	allocs1, _, err := jobs.Allocations(jobID, true, nil)
 	f.NoError(err)
-	f.EqualValues(initialAllocs, allocs1)
+
+	f.Equal(len(initialAllocs), len(allocs1))
+
+	for i, a := range allocs1 {
+		f.Equal(a.ID, initialAllocs[i].ID)
+	}
 
 	// Scale down to 0
 	testMeta = map[string]interface{}{"scaling-e2e-test": "value"}
@@ -219,10 +224,6 @@ func (tc *ScalingE2ETest) TestScalingBasicWithSystemSchedule(f *framework.F) {
 	// Assert job is still up but no allocs are running
 	stopedAllocs, _, err := jobs.Allocations(jobID, false, nil)
 	f.NoError(err)
-
-	for _, alloc := range stopedAllocs {
-		e2eutil.WaitForAllocStatus(t, nomadClient, alloc.ID, structs.AllocClientStatusComplete)
-	}
 
 	stopedAllocs, _, err = jobs.Allocations(jobID, false, nil)
 	f.NoError(err)

--- a/e2e/scaling/scaling.go
+++ b/e2e/scaling/scaling.go
@@ -187,7 +187,7 @@ func (tc *ScalingE2ETest) TestScalingBasicWithSystemSchedule(f *framework.F) {
 
 	// A system job will spawn an allocation per node, we need to know how many nodes
 	// there are to know how many allocations to expect.
-	numberOfNodes := len(filterNodeByStatus(api.NodeStatusReady, nodeStubList))
+	numberOfNodes := len(nodeStubList)
 
 	f.Equal(numberOfNodes, len(initialAllocs))
 	allocIDs := e2eutil.AllocIDsFromAllocationListStubs(initialAllocs)
@@ -260,18 +260,6 @@ func filterAllocsByDesiredStatus(status string, allocs []*api.AllocationListStub
 	for _, a := range allocs {
 		if a.DesiredStatus == status {
 			res = append(res, a)
-		}
-	}
-
-	return res
-}
-
-func filterNodeByStatus(status string, nodes []*api.NodeListStub) []*api.NodeListStub {
-	res := []*api.NodeListStub{}
-
-	for _, n := range nodes {
-		if n.Status == status {
-			res = append(res, n)
 		}
 	}
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1027,8 +1027,9 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	if job == nil {
 		return structs.NewErrRPCCoded(404, fmt.Sprintf("job %q not found", args.JobID))
 	}
-	if job.Type == structs.JobTypeSystem {
-		return structs.NewErrRPCCoded(http.StatusBadRequest, `cannot scale jobs of type "system"`)
+
+	if job.Type == structs.JobTypeSystem && *args.Count > 1 {
+		return structs.NewErrRPCCoded(http.StatusBadRequest, `jobs of type "system" can only be scaled to 1 or 0`)
 	}
 
 	// Since job is going to be mutated we must copy it since state store methods

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1029,7 +1029,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 	}
 
 	if job.Type == structs.JobTypeSystem && *args.Count > 1 {
-		return structs.NewErrRPCCoded(http.StatusBadRequest, `jobs of type "system" can only be scaled to 1 or 0`)
+		return structs.NewErrRPCCoded(http.StatusBadRequest, `jobs of type "system" can only be scaled between 0 and 1`)
 	}
 
 	// Since job is going to be mutated we must copy it since state store methods

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7055,14 +7055,6 @@ func (tg *TaskGroup) Canonicalize(job *Job) {
 		tg.EphemeralDisk = DefaultEphemeralDisk()
 	}
 
-	if job.Type == JobTypeSystem {
-		if tg.Count > 1 {
-			tg.Count = 1
-		} else if tg.Count < 0 {
-			tg.Count = 0
-		}
-	}
-
 	if tg.Scaling != nil {
 		tg.Scaling.Canonicalize(job, tg, nil)
 	}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7055,8 +7055,12 @@ func (tg *TaskGroup) Canonicalize(job *Job) {
 		tg.EphemeralDisk = DefaultEphemeralDisk()
 	}
 
-	if job.Type == JobTypeSystem && tg.Count == 0 {
-		tg.Count = 1
+	if job.Type == JobTypeSystem {
+		if tg.Count > 1 {
+			tg.Count = 1
+		} else if tg.Count < 0 {
+			tg.Count = 0
+		}
 	}
 
 	if tg.Scaling != nil {


### PR DESCRIPTION
This PR introduces the possibility to temporarily stop a system job by scaling it to 0 and then restart it again by scaling it back up to 1, without having to resubmit it.