### PR TITLE
testing: RPC-only test client helper

### DIFF
--- a/client/testing.go
+++ b/client/testing.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/nomad/helper/pool"
 	"github.com/hashicorp/nomad/helper/testlog"
 	testing "github.com/mitchellh/go-testing-interface"
+	"github.com/shoenig/test/must"
 )
 
 // TestClient creates an in-memory client for testing purposes and returns a
@@ -92,8 +93,8 @@ func TestClientWithRPCs(t testing.T, cb func(c *config.Config), rpcs map[string]
 // with the server and then returns mock RPC responses for those interfaces
 // passed in the `rpcs` parameter. Useful for testing client RPCs from the
 // server. Returns the Client, a shutdown function, and any error.
-func TestRPCOnlyClient(t testing.T, cb func(c *config.Config), srvAddr net.Addr, rpcs map[string]any) (*Client, func() error, error) {
-	var err error
+func TestRPCOnlyClient(t testing.T, cb func(c *config.Config), srvAddr net.Addr, rpcs map[string]any) (*Client, func()) {
+	t.Helper()
 	conf, cleanup := config.TestClientConfig(t)
 	conf.StateDBFactory = state.GetStateDBFactory(true)
 	if cb != nil {
@@ -112,7 +113,7 @@ func TestRPCOnlyClient(t testing.T, cb func(c *config.Config), srvAddr net.Addr,
 	client.connPool = pool.NewPool(testlog.HCLogger(t), 10*time.Second, 10, nil)
 	client.init()
 
-	cancelFunc := func() error {
+	cancelFunc := func() {
 		ch := make(chan error)
 
 		go func() {
@@ -125,19 +126,19 @@ func TestRPCOnlyClient(t testing.T, cb func(c *config.Config), srvAddr net.Addr,
 
 		select {
 		case <-ch:
-			return nil
+			return
 		case <-time.After(5 * time.Second):
-			return fmt.Errorf("timed out while shutting down client")
+			t.Error("timed out while shutting down client")
+			return
 		}
 	}
 
 	go client.rpcConnListener()
 
-	_, err = client.SetServers([]string{srvAddr.String()})
-	if err != nil {
-		return nil, cancelFunc, fmt.Errorf("could not set servers: %v", err)
-	}
+	_, err := client.SetServers([]string{srvAddr.String()})
+	must.NoError(t, err, must.Sprintf("could not set servers: %v", err))
+
 	client.shutdownGroup.Go(client.registerAndHeartbeat)
 
-	return client, cancelFunc, nil
+	return client, cancelFunc
 }

--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -117,8 +117,7 @@ func (c *MockClientCSI) NodeExpandVolume(req *cstructs.ClientCSINodeExpandVolume
 
 func TestClientCSIController_AttachVolume_Local(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupLocal(t)
-	defer cleanup()
+	codec := setupLocal(t)
 
 	req := &cstructs.ClientCSIControllerAttachVolumeRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -131,8 +130,7 @@ func TestClientCSIController_AttachVolume_Local(t *testing.T) {
 
 func TestClientCSIController_AttachVolume_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupForward(t)
-	defer cleanup()
+	codec := setupForward(t)
 
 	req := &cstructs.ClientCSIControllerAttachVolumeRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -145,8 +143,7 @@ func TestClientCSIController_AttachVolume_Forwarded(t *testing.T) {
 
 func TestClientCSIController_DetachVolume_Local(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupLocal(t)
-	defer cleanup()
+	codec := setupLocal(t)
 
 	req := &cstructs.ClientCSIControllerDetachVolumeRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -159,8 +156,7 @@ func TestClientCSIController_DetachVolume_Local(t *testing.T) {
 
 func TestClientCSIController_DetachVolume_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupForward(t)
-	defer cleanup()
+	codec := setupForward(t)
 
 	req := &cstructs.ClientCSIControllerDetachVolumeRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -173,8 +169,7 @@ func TestClientCSIController_DetachVolume_Forwarded(t *testing.T) {
 
 func TestClientCSIController_ValidateVolume_Local(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupLocal(t)
-	defer cleanup()
+	codec := setupLocal(t)
 
 	req := &cstructs.ClientCSIControllerValidateVolumeRequest{
 		VolumeID:           "test",
@@ -188,8 +183,7 @@ func TestClientCSIController_ValidateVolume_Local(t *testing.T) {
 
 func TestClientCSIController_ValidateVolume_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupForward(t)
-	defer cleanup()
+	codec := setupForward(t)
 
 	req := &cstructs.ClientCSIControllerValidateVolumeRequest{
 		VolumeID:           "test",
@@ -203,8 +197,7 @@ func TestClientCSIController_ValidateVolume_Forwarded(t *testing.T) {
 
 func TestClientCSIController_CreateVolume_Local(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupLocal(t)
-	defer cleanup()
+	codec := setupLocal(t)
 
 	req := &cstructs.ClientCSIControllerCreateVolumeRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -217,8 +210,7 @@ func TestClientCSIController_CreateVolume_Local(t *testing.T) {
 
 func TestClientCSIController_CreateVolume_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupForward(t)
-	defer cleanup()
+	codec := setupForward(t)
 
 	req := &cstructs.ClientCSIControllerCreateVolumeRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -231,8 +223,7 @@ func TestClientCSIController_CreateVolume_Forwarded(t *testing.T) {
 
 func TestClientCSIController_DeleteVolume_Local(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupLocal(t)
-	defer cleanup()
+	codec := setupLocal(t)
 
 	req := &cstructs.ClientCSIControllerDeleteVolumeRequest{
 		ExternalVolumeID:   "test",
@@ -246,8 +237,7 @@ func TestClientCSIController_DeleteVolume_Local(t *testing.T) {
 
 func TestClientCSIController_DeleteVolume_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupForward(t)
-	defer cleanup()
+	codec := setupForward(t)
 
 	req := &cstructs.ClientCSIControllerDeleteVolumeRequest{
 		ExternalVolumeID:   "test",
@@ -261,8 +251,7 @@ func TestClientCSIController_DeleteVolume_Forwarded(t *testing.T) {
 
 func TestClientCSIController_ListVolumes_Local(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupLocal(t)
-	defer cleanup()
+	codec := setupLocal(t)
 
 	req := &cstructs.ClientCSIControllerListVolumesRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -275,8 +264,7 @@ func TestClientCSIController_ListVolumes_Local(t *testing.T) {
 
 func TestClientCSIController_ListVolumes_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupForward(t)
-	defer cleanup()
+	codec := setupForward(t)
 
 	req := &cstructs.ClientCSIControllerListVolumesRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -289,8 +277,7 @@ func TestClientCSIController_ListVolumes_Forwarded(t *testing.T) {
 
 func TestClientCSIController_CreateSnapshot_Local(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupLocal(t)
-	defer cleanup()
+	codec := setupLocal(t)
 
 	req := &cstructs.ClientCSIControllerCreateSnapshotRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -303,8 +290,7 @@ func TestClientCSIController_CreateSnapshot_Local(t *testing.T) {
 
 func TestClientCSIController_CreateSnapshot_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupForward(t)
-	defer cleanup()
+	codec := setupForward(t)
 
 	req := &cstructs.ClientCSIControllerCreateSnapshotRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -317,8 +303,7 @@ func TestClientCSIController_CreateSnapshot_Forwarded(t *testing.T) {
 
 func TestClientCSIController_DeleteSnapshot_Local(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupLocal(t)
-	defer cleanup()
+	codec := setupLocal(t)
 
 	req := &cstructs.ClientCSIControllerDeleteSnapshotRequest{
 		ID:                 "test",
@@ -332,8 +317,7 @@ func TestClientCSIController_DeleteSnapshot_Local(t *testing.T) {
 
 func TestClientCSIController_DeleteSnapshot_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupForward(t)
-	defer cleanup()
+	codec := setupForward(t)
 
 	req := &cstructs.ClientCSIControllerDeleteSnapshotRequest{
 		ID:                 "test",
@@ -347,8 +331,7 @@ func TestClientCSIController_DeleteSnapshot_Forwarded(t *testing.T) {
 
 func TestClientCSIController_ListSnapshots_Local(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupLocal(t)
-	defer cleanup()
+	codec := setupLocal(t)
 
 	req := &cstructs.ClientCSIControllerListSnapshotsRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -361,8 +344,7 @@ func TestClientCSIController_ListSnapshots_Local(t *testing.T) {
 
 func TestClientCSIController_ListSnapshots_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	codec, cleanup := setupForward(t)
-	defer cleanup()
+	codec := setupForward(t)
 
 	req := &cstructs.ClientCSIControllerListSnapshotsRequest{
 		CSIControllerQuery: cstructs.CSIControllerQuery{PluginID: "minnie"},
@@ -420,10 +402,12 @@ func TestClientCSI_NodeForControllerPlugin(t *testing.T) {
 
 // sets up a pair of servers, each with one client, and registers a plugin to the clients.
 // returns a RPC client to the leader and a cleanup function.
-func setupForward(t *testing.T) (rpc.ClientCodec, func()) {
+func setupForward(t *testing.T) rpc.ClientCodec {
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) { c.BootstrapExpect = 2 })
 	s2, cleanupS2 := TestServer(t, func(c *Config) { c.BootstrapExpect = 2 })
+	t.Cleanup(cleanupS1)
+	t.Cleanup(cleanupS2)
 	TestJoin(t, s1, s2)
 
 	testutil.WaitForLeader(t, s1.RPC)
@@ -433,27 +417,22 @@ func setupForward(t *testing.T) (rpc.ClientCodec, func()) {
 	c1, cleanupC1 := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s1.config.RPCAddr.String()}
 	})
+	t.Cleanup(func() { cleanupC1() })
 
 	// Wait for client initialization
 	select {
 	case <-c1.Ready():
 	case <-time.After(10 * time.Second):
-		cleanupC1()
-		cleanupS1()
-		cleanupS2()
 		t.Fatal("client timedout on initialize")
 	}
 
 	c2, cleanupC2 := client.TestClient(t, func(c *config.Config) {
 		c.Servers = []string{s2.config.RPCAddr.String()}
 	})
+	t.Cleanup(func() { cleanupC2() })
 	select {
 	case <-c2.Ready():
 	case <-time.After(10 * time.Second):
-		cleanupC1()
-		cleanupC2()
-		cleanupS1()
-		cleanupS2()
 		t.Fatal("client timedout on initialize")
 	}
 
@@ -483,20 +462,14 @@ func setupForward(t *testing.T) (rpc.ClientCodec, func()) {
 
 	s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1)
 
-	cleanup := func() {
-		cleanupC1()
-		cleanupC2()
-		cleanupS2()
-		cleanupS1()
-	}
-
-	return codec, cleanup
+	return codec
 }
 
 // sets up a single server with a client, and registers a plugin to the client.
-func setupLocal(t *testing.T) (rpc.ClientCodec, func()) {
+func setupLocal(t *testing.T) rpc.ClientCodec {
 	var err error
 	s1, cleanupS1 := TestServer(t, func(c *Config) { c.BootstrapExpect = 1 })
+	t.Cleanup(cleanupS1)
 
 	testutil.WaitForLeader(t, s1.RPC)
 	codec := rpcClient(t, s1)
@@ -512,15 +485,10 @@ func setupLocal(t *testing.T) (rpc.ClientCodec, func()) {
 	mockCSI.NextDeleteSnapshotError = fmt.Errorf("no plugins registered for type")
 	mockCSI.NextListExternalSnapshotsError = fmt.Errorf("no plugins registered for type")
 
-	c1, cleanupC1, err := client.TestRPCOnlyClient(t, nil, s1.config.RPCAddr,
+	c1, cleanupC1 := client.TestRPCOnlyClient(t, nil, s1.config.RPCAddr,
 		map[string]interface{}{"CSI": mockCSI},
 	)
-
-	if err != nil {
-		cleanupC1()
-		cleanupS1()
-		must.NoError(t, err, must.Sprint("could not setup test client"))
-	}
+	t.Cleanup(cleanupC1)
 
 	node1 := c1.UpdateConfig(func(c *config.Config) {
 		c.Node.Attributes["nomad.version"] = "0.11.0" // client RPCs not supported on early versions
@@ -532,11 +500,7 @@ func setupLocal(t *testing.T) (rpc.ClientCodec, func()) {
 	}
 	var resp structs.NodeUpdateResponse
 	err = c1.RPC("Node.Register", req, &resp)
-	if err != nil {
-		cleanupC1()
-		cleanupS1()
-		must.NoError(t, err, must.Sprint("could not register client node"))
-	}
+	must.NoError(t, err, must.Sprint("could not register client node"))
 
 	waitForNodes(t, s1, 1, 1)
 
@@ -555,12 +519,7 @@ func setupLocal(t *testing.T) (rpc.ClientCodec, func()) {
 	}).Node
 	s1.fsm.state.UpsertNode(structs.MsgTypeTestSetup, 1000, node1)
 
-	cleanup := func() {
-		cleanupC1()
-		cleanupS1()
-	}
-
-	return codec, cleanup
+	return codec
 }
 
 // waitForNodes waits until the server is connected to connectedNodes

--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 // MockClientCSI is a mock for the nomad.ClientCSI RPC server (see
@@ -117,7 +117,6 @@ func (c *MockClientCSI) NodeExpandVolume(req *cstructs.ClientCSINodeExpandVolume
 
 func TestClientCSIController_AttachVolume_Local(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupLocal(t)
 	defer cleanup()
 
@@ -127,13 +126,11 @@ func TestClientCSIController_AttachVolume_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerAttachVolume", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_AttachVolume_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupForward(t)
 	defer cleanup()
 
@@ -143,13 +140,11 @@ func TestClientCSIController_AttachVolume_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerAttachVolume", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_DetachVolume_Local(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupLocal(t)
 	defer cleanup()
 
@@ -159,13 +154,11 @@ func TestClientCSIController_DetachVolume_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerDetachVolume", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_DetachVolume_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupForward(t)
 	defer cleanup()
 
@@ -175,13 +168,11 @@ func TestClientCSIController_DetachVolume_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerDetachVolume", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_ValidateVolume_Local(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupLocal(t)
 	defer cleanup()
 
@@ -192,13 +183,11 @@ func TestClientCSIController_ValidateVolume_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerValidateVolume", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_ValidateVolume_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupForward(t)
 	defer cleanup()
 
@@ -209,13 +198,11 @@ func TestClientCSIController_ValidateVolume_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerValidateVolume", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_CreateVolume_Local(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupLocal(t)
 	defer cleanup()
 
@@ -225,13 +212,11 @@ func TestClientCSIController_CreateVolume_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerCreateVolume", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_CreateVolume_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupForward(t)
 	defer cleanup()
 
@@ -241,13 +226,11 @@ func TestClientCSIController_CreateVolume_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerCreateVolume", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_DeleteVolume_Local(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupLocal(t)
 	defer cleanup()
 
@@ -258,13 +241,11 @@ func TestClientCSIController_DeleteVolume_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerDeleteVolume", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_DeleteVolume_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupForward(t)
 	defer cleanup()
 
@@ -275,13 +256,11 @@ func TestClientCSIController_DeleteVolume_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerDeleteVolume", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_ListVolumes_Local(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupLocal(t)
 	defer cleanup()
 
@@ -291,13 +270,11 @@ func TestClientCSIController_ListVolumes_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerListVolumes", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_ListVolumes_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupForward(t)
 	defer cleanup()
 
@@ -307,13 +284,11 @@ func TestClientCSIController_ListVolumes_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerListVolumes", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_CreateSnapshot_Local(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupLocal(t)
 	defer cleanup()
 
@@ -323,13 +298,11 @@ func TestClientCSIController_CreateSnapshot_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerCreateSnapshot", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_CreateSnapshot_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupForward(t)
 	defer cleanup()
 
@@ -339,13 +312,11 @@ func TestClientCSIController_CreateSnapshot_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerCreateSnapshot", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_DeleteSnapshot_Local(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupLocal(t)
 	defer cleanup()
 
@@ -356,13 +327,11 @@ func TestClientCSIController_DeleteSnapshot_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerDeleteSnapshot", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_DeleteSnapshot_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupForward(t)
 	defer cleanup()
 
@@ -373,13 +342,11 @@ func TestClientCSIController_DeleteSnapshot_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerDeleteSnapshot", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_ListSnapshots_Local(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupLocal(t)
 	defer cleanup()
 
@@ -389,13 +356,11 @@ func TestClientCSIController_ListSnapshots_Local(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerListSnapshots", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSIController_ListSnapshots_Forwarded(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 	codec, cleanup := setupForward(t)
 	defer cleanup()
 
@@ -405,8 +370,7 @@ func TestClientCSIController_ListSnapshots_Forwarded(t *testing.T) {
 
 	var resp structs.GenericResponse
 	err := msgpackrpc.CallWithCodec(codec, "ClientCSI.ControllerListSnapshots", req, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "no plugins registered for type")
+	must.ErrorContains(t, err, "no plugins registered for type")
 }
 
 func TestClientCSI_NodeForControllerPlugin(t *testing.T) {
@@ -435,23 +399,23 @@ func TestClientCSI_NodeForControllerPlugin(t *testing.T) {
 	node3.ID = uuid.Generate()
 
 	err := state.UpsertNode(structs.MsgTypeTestSetup, 1002, node1)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	err = state.UpsertNode(structs.MsgTypeTestSetup, 1003, node2)
-	require.NoError(t, err)
+	must.NoError(t, err)
 	err = state.UpsertNode(structs.MsgTypeTestSetup, 1004, node3)
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	ws := memdb.NewWatchSet()
 
 	plugin, err := state.CSIPluginByID(ws, "minnie")
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	clientCSI := NewClientCSIEndpoint(srv, nil)
 	nodeIDs, err := clientCSI.clientIDsForController(plugin.ID)
-	require.NoError(t, err)
-	require.Equal(t, 1, len(nodeIDs))
+	must.NoError(t, err)
+	must.Len(t, 1, nodeIDs)
 	// only node1 has both the controller and a recent Nomad version
-	require.Equal(t, nodeIDs[0], node1.ID)
+	must.Eq(t, nodeIDs[0], node1.ID)
 }
 
 // sets up a pair of servers, each with one client, and registers a plugin to the clients.
@@ -548,17 +512,14 @@ func setupLocal(t *testing.T) (rpc.ClientCodec, func()) {
 	mockCSI.NextDeleteSnapshotError = fmt.Errorf("no plugins registered for type")
 	mockCSI.NextListExternalSnapshotsError = fmt.Errorf("no plugins registered for type")
 
-	c1, cleanupC1 := client.TestClientWithRPCs(t,
-		func(c *config.Config) {
-			c.Servers = []string{s1.config.RPCAddr.String()}
-		},
+	c1, cleanupC1, err := client.TestRPCOnlyClient(t, nil, s1.config.RPCAddr,
 		map[string]interface{}{"CSI": mockCSI},
 	)
 
 	if err != nil {
 		cleanupC1()
 		cleanupS1()
-		require.NoError(t, err, "could not setup test client")
+		must.NoError(t, err, must.Sprint("could not setup test client"))
 	}
 
 	node1 := c1.UpdateConfig(func(c *config.Config) {
@@ -574,7 +535,7 @@ func setupLocal(t *testing.T) (rpc.ClientCodec, func()) {
 	if err != nil {
 		cleanupC1()
 		cleanupS1()
-		require.NoError(t, err, "could not register client node")
+		must.NoError(t, err, must.Sprint("could not register client node"))
 	}
 
 	waitForNodes(t, s1, 1, 1)
@@ -630,6 +591,6 @@ func waitForNodes(t *testing.T, s *Server, connectedNodes, totalNodes int) {
 		}
 		return true, nil
 	}, func(err error) {
-		require.NoError(t, err)
+		must.NoError(t, err)
 	})
 }


### PR DESCRIPTION
In #10193 we introduced a testing helper that spins up a client RPC server without the rest of the client operations so that we can make server-side client RPC tests lighter. But this wasn't actually ever wired up to the intended target. While working on Dynamic Host Volumes I noticed that this would be useful for RPC tests.

This changeset fixes some bugs in the helper that arose from client code drift, and makes it used by the client RPC tests for CSI. This will also get used for the DHV RPC tests.

Ref: https://github.com/hashicorp/nomad/pull/10193