### PR TITLE
api: new dispatch endpoint sends body as Payload

### DIFF
--- a/.changelog/24312.txt
+++ b/.changelog/24312.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: new parameterized dispatch endpoint sends raw HTTP request body as Payload
+```

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -1813,6 +1813,55 @@ $ curl \
 }
 ```
 
+## Dispatch Job with raw Payload body
+
+This endpoint dispatches a new instance of a parameterized job using the full
+request body as the `Payload` as described in [Dispatch Job](#dispatch-job).
+
+| Method | Path                               | Produces           |
+| ------ | ---------------------------------- | ------------------ |
+| `POST` | `/v1/job/:job_id/dispatch/payload` | `application/json` |
+
+The table below shows this endpoint's support for
+[blocking queries](/nomad/api-docs#blocking-queries) and
+[required ACLs](/nomad/api-docs#acls).
+
+| Blocking Queries | ACL Required             |
+| ---------------- | ------------------------ |
+| `NO`             | `namespace:dispatch-job` |
+
+### Parameters
+
+- `:job_id` `(string: <required>)` - Specifies the ID of the job. This is
+specified as part of the path.
+
+### Sample Payload
+
+```
+any HTTP request body, JSON or otherwise, becomes the dispatch Payload
+```
+
+### Sample Request
+
+```shell-session
+$ curl \
+    --request POST \
+    --data 'anything at all' \
+    https://localhost:4646/v1/job/my-job/dispatch
+```
+
+### Sample Response
+
+```json
+{
+  "DispatchedJobID": "param/dispatch-1730920906-81821d1f",
+  "EvalCreateIndex": 179,
+  "EvalID": "5e973383-8d59-3f33-4496-72112a882605",
+  "Index": 179,
+  "JobCreateIndex": 178
+}
+```
+
 ## Revert to older Job Version
 
 This endpoint reverts the job to an older version.


### PR DESCRIPTION
This opens up dispatching parameterized jobs by systems that do not allow modifying what http request body they send (like webhooks).

e.g. these two requests are equal:

```shell
# existing endpoint
POST '{"Payload": "'"$(base64 <<< "hello")"'"}' /v1/job/my-job/dispatch
# new in this PR
POST 'hello' /v1/job/my-job/dispatch/payload
```

Closes #24312