### PR TITLE
gc: be consistent with setting create/modify timestamp tz

### DIFF
--- a/nomad/blocked_evals.go
+++ b/nomad/blocked_evals.go
@@ -411,7 +411,7 @@ func (b *BlockedEvals) Unblock(computedClass string, index uint64) {
 	// Store the index in which the unblock happened. We use this on subsequent
 	// block calls in case the evaluation was in the scheduler when a trigger
 	// occurred.
-	b.unblockIndexes[computedClass] = unblockEvent{index, time.Now()}
+	b.unblockIndexes[computedClass] = unblockEvent{index, time.Now().UTC()}
 
 	// Capture chan in lock as Flush overwrites it
 	ch := b.capacityChangeCh
@@ -446,7 +446,7 @@ func (b *BlockedEvals) UnblockQuota(quota string, index uint64) {
 	// Store the index in which the unblock happened. We use this on subsequent
 	// block calls in case the evaluation was in the scheduler when a trigger
 	// occurred.
-	b.unblockIndexes[quota] = unblockEvent{index, time.Now()}
+	b.unblockIndexes[quota] = unblockEvent{index, time.Now().UTC()}
 	ch := b.capacityChangeCh
 	done := b.stopCh
 	b.l.Unlock()
@@ -475,7 +475,7 @@ func (b *BlockedEvals) UnblockClassAndQuota(class, quota string, index uint64) {
 	// Store the index in which the unblock happened. We use this on subsequent
 	// block calls in case the evaluation was in the scheduler when a trigger
 	// occurred.
-	now := time.Now()
+	now := time.Now().UTC()
 	if quota != "" {
 		b.unblockIndexes[quota] = unblockEvent{index, now}
 	}

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -375,7 +375,7 @@ func (c *CoreScheduler) gcEval(eval *structs.Evaluation, cutoffTime time.Time, a
 	gcEval := true
 	var gcAllocIDs []string
 	for _, alloc := range allocs {
-		if !allocGCEligible(alloc, job, time.Now(), cutoffTime) {
+		if !allocGCEligible(alloc, job, time.Now().UTC(), cutoffTime) {
 			// Can't GC the evaluation since not all of the allocations are
 			// terminal
 			gcEval = false

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -34,8 +34,8 @@ func TestCoreScheduler_EvalGC(t *testing.T) {
 	// Insert "dead" eval
 	store := s1.fsm.State()
 	eval := mock.Eval()
-	eval.CreateTime = time.Now().Add(-6 * time.Hour).UnixNano() // make sure objects we insert are older than GC thresholds
-	eval.ModifyTime = time.Now().Add(-5 * time.Hour).UnixNano()
+	eval.CreateTime = time.Now().UTC().Add(-6 * time.Hour).UnixNano() // make sure objects we insert are older than GC thresholds
+	eval.ModifyTime = time.Now().UTC().Add(-5 * time.Hour).UnixNano()
 	eval.Status = structs.EvalStatusFailed
 	must.NoError(t, store.UpsertJobSummary(999, mock.JobSummary(eval.JobID)))
 	must.NoError(t, store.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval}))
@@ -120,8 +120,8 @@ func TestCoreScheduler_EvalGC_ReschedulingAllocs(t *testing.T) {
 	// Insert "dead" eval
 	store := s1.fsm.State()
 	eval := mock.Eval()
-	eval.CreateTime = time.Now().Add(-6 * time.Hour).UnixNano() // make sure objects we insert are older than GC thresholds
-	eval.ModifyTime = time.Now().Add(-5 * time.Hour).UnixNano()
+	eval.CreateTime = time.Now().UTC().Add(-6 * time.Hour).UnixNano() // make sure objects we insert are older than GC thresholds
+	eval.ModifyTime = time.Now().UTC().Add(-5 * time.Hour).UnixNano()
 	eval.Status = structs.EvalStatusFailed
 	must.NoError(t, store.UpsertJobSummary(999, mock.JobSummary(eval.JobID)))
 	must.NoError(t, store.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval}))
@@ -129,8 +129,8 @@ func TestCoreScheduler_EvalGC_ReschedulingAllocs(t *testing.T) {
 	// Insert "pending" eval for same job
 	eval2 := mock.Eval()
 	eval2.JobID = eval.JobID
-	eval2.CreateTime = time.Now().Add(-6 * time.Hour).UnixNano() // make sure objects we insert are older than GC thresholds
-	eval2.ModifyTime = time.Now().Add(-5 * time.Hour).UnixNano()
+	eval2.CreateTime = time.Now().UTC().Add(-6 * time.Hour).UnixNano() // make sure objects we insert are older than GC thresholds
+	eval2.ModifyTime = time.Now().UTC().Add(-5 * time.Hour).UnixNano()
 	must.NoError(t, store.UpsertJobSummary(999, mock.JobSummary(eval2.JobID)))
 	must.NoError(t, store.UpsertEvals(structs.MsgTypeTestSetup, 1003, []*structs.Evaluation{eval2}))
 
@@ -215,8 +215,8 @@ func TestCoreScheduler_EvalGC_StoppedJob_Reschedulable(t *testing.T) {
 	store := s1.fsm.State()
 	eval := mock.Eval()
 	eval.Status = structs.EvalStatusFailed
-	eval.CreateTime = time.Now().Add(-6 * time.Hour).UnixNano() // make sure objects we insert are older than GC thresholds
-	eval.ModifyTime = time.Now().Add(-5 * time.Hour).UnixNano()
+	eval.CreateTime = time.Now().UTC().Add(-6 * time.Hour).UnixNano() // make sure objects we insert are older than GC thresholds
+	eval.ModifyTime = time.Now().UTC().Add(-5 * time.Hour).UnixNano()
 	must.NoError(t, store.UpsertJobSummary(999, mock.JobSummary(eval.JobID)))
 	must.NoError(t, store.UpsertEvals(structs.MsgTypeTestSetup, 1000, []*structs.Evaluation{eval}))
 

--- a/nomad/mock/csi.go
+++ b/nomad/mock/csi.go
@@ -51,8 +51,8 @@ func CSIVolume(plugin *structs.CSIPlugin) *structs.CSIVolume {
 		ControllersExpected: len(plugin.Controllers),
 		NodesHealthy:        plugin.NodesHealthy,
 		NodesExpected:       len(plugin.Nodes),
-		CreateTime:          time.Now().Add(-6 * time.Hour).UnixNano(),
-		ModifyTime:          time.Now().Add(-5 * time.Hour).UnixNano(),
+		CreateTime:          time.Now().UTC().Add(-6 * time.Hour).UnixNano(),
+		ModifyTime:          time.Now().UTC().Add(-5 * time.Hour).UnixNano(),
 	}
 }
 

--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -144,7 +144,7 @@ func Job() *structs.Job {
 		CreateIndex:    42,
 		ModifyIndex:    99,
 		JobModifyIndex: 99,
-		SubmitTime:     time.Now().Add(-6 * time.Hour).UnixNano(),
+		SubmitTime:     time.Now().UTC().Add(-6 * time.Hour).UnixNano(),
 	}
 	job.Canonicalize()
 	return job

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -376,7 +376,7 @@ type CSIVolListStub struct {
 
 // NewCSIVolume creates the volume struct. No side-effects
 func NewCSIVolume(volumeID string, index uint64) *CSIVolume {
-	now := time.Now().UnixNano()
+	now := time.Now().UTC().UnixNano()
 	out := &CSIVolume{
 		ID:          volumeID,
 		CreateIndex: index,
@@ -1121,7 +1121,7 @@ type CSIPlugin struct {
 
 // NewCSIPlugin creates the plugin struct. No side-effects
 func NewCSIPlugin(id string, index uint64) *CSIPlugin {
-	now := time.Now().UnixNano()
+	now := time.Now().UTC().UnixNano()
 	out := &CSIPlugin{
 		ID:          id,
 		CreateIndex: index,

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -376,7 +376,7 @@ type CSIVolListStub struct {
 
 // NewCSIVolume creates the volume struct. No side-effects
 func NewCSIVolume(volumeID string, index uint64) *CSIVolume {
-	now := time.Now().UTC().UnixNano()
+	now := time.Now().UnixNano()
 	out := &CSIVolume{
 		ID:          volumeID,
 		CreateIndex: index,
@@ -1121,7 +1121,7 @@ type CSIPlugin struct {
 
 // NewCSIPlugin creates the plugin struct. No side-effects
 func NewCSIPlugin(id string, index uint64) *CSIPlugin {
-	now := time.Now().UTC().UnixNano()
+	now := time.Now().UnixNano()
 	out := &CSIPlugin{
 		ID:          id,
 		CreateIndex: index,

--- a/scheduler/reconcile.go
+++ b/scheduler/reconcile.go
@@ -216,7 +216,7 @@ func NewAllocReconciler(logger log.Logger, allocUpdateFn allocUpdateType, batch 
 		evalID:                      evalID,
 		evalPriority:                evalPriority,
 		supportsDisconnectedClients: supportsDisconnectedClients,
-		now:                         time.Now(),
+		now:                         time.Now().UTC(),
 		result: &reconcileResults{
 			attributeUpdates:          make(map[string]*structs.Allocation),
 			disconnectUpdates:         make(map[string]*structs.Allocation),


### PR DESCRIPTION
Whenever setting objects creation/modify time, we should always use UTC. https://github.com/hashicorp/nomad/pull/24112 introduced some inconsistencies in this area, and this PR fixes it.