### PR TITLE
CSI: fix namespace ACL bypass on create/register APIs

### DIFF
--- a/.changelog/24396.txt
+++ b/.changelog/24396.txt
@@ -1,0 +1,3 @@
+```release-note:security
+csi: Fixed a bug where a user with csi-write-volume permissions to one namespace can create volumes in another namespace (CVE-2024-10975)
+```


### PR DESCRIPTION
When creating or registering a CSI volume, the RPC handler uses the volume specification's namespace instead of the request namespace. This works as intended, but the ACL check is only on the request namespace.

This allows a cross-namespace ACL bypass for authenticated users who have `csi-write-volume` capabilities in one namespace but not another namespace. Such a user can set the volume specification to a forbidden namespace while setting the `-namespace` flag in the CLI or API. The ACL check happens against the namespace they do have permission to, but the volume is created in the forbidden namespace.

This changeset fixes the bug by moving the namespace check into the loop over the volumes being written by the RPCs. It also updates the tests to better cover ACL checking in these two RPCs.

Ref: CVE-2024-10975
Ref: https://hashicorp.atlassian.net/browse/SECVULN-15463
Fixes: https://github.com/hashicorp/nomad/issues/24397