### PR TITLE
fix: handle template re-renders on client restart

### DIFF
--- a/.changelog/24399.txt
+++ b/.changelog/24399.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fix: handles consul template re-renders on client restart
+```

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -317,7 +317,10 @@ WAIT:
 				if event.LastWouldRender.IsZero() {
 					continue WAIT
 				}
-				// If the template _actually_ rendered to disk, mark it dirty
+				// If the template _actually_ rendered to disk, mark it
+				// dirty. We track events here so that onTemplateRendered
+				// doesn't go back to the runner's RenderedEvents and process
+				// new events that don't make us dirty.				
 				if !event.LastDidRender.IsZero() {
 					dirtyEvents[event.Template.ID()] = event
 				}

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -277,6 +277,10 @@ func (tm *TaskTemplateManager) handleFirstRender() {
 		<-eventTimer.C
 	}
 
+	// dirtyEvents are events that actually rendered to disk and need to trigger
+	// their respective change_mode operation
+	dirtyEvents := map[string]*manager.RenderEvent{}
+
 	// outstandingEvent tracks whether there is an outstanding event that should
 	// be fired.
 	outstandingEvent := false
@@ -308,22 +312,22 @@ WAIT:
 				continue
 			}
 
-			dirty := false
 			for _, event := range events {
 				// This template hasn't been rendered
 				if event.LastWouldRender.IsZero() {
 					continue WAIT
 				}
-				if event.WouldRender && event.DidRender {
-					dirty = true
+				// If the template _actually_ rendered to disk, mark it dirty
+				if !event.LastDidRender.IsZero() {
+					dirtyEvents[event.Template.ID()] = event
 				}
 			}
 
 			// if there's a driver handle then the task is already running and
 			// that changes how we want to behave on first render
-			if dirty && tm.config.Lifecycle.IsRunning() {
+			if len(dirtyEvents) > 0 && tm.config.Lifecycle.IsRunning() {
 				handledRenders := make(map[string]time.Time, len(tm.config.Templates))
-				tm.onTemplateRendered(handledRenders, time.Time{})
+				tm.onTemplateRendered(handledRenders, time.Time{}, dirtyEvents)
 			}
 
 			break WAIT
@@ -417,12 +421,13 @@ func (tm *TaskTemplateManager) handleTemplateRerenders(allRenderedTime time.Time
 					SetFailsTask().
 					SetDisplayMessage(fmt.Sprintf("Template failed: %v", err)))
 		case <-tm.runner.TemplateRenderedCh():
-			tm.onTemplateRendered(handledRenders, allRenderedTime)
+			events := tm.runner.RenderEvents()
+			tm.onTemplateRendered(handledRenders, allRenderedTime, events)
 		}
 	}
 }
 
-func (tm *TaskTemplateManager) onTemplateRendered(handledRenders map[string]time.Time, allRenderedTime time.Time) {
+func (tm *TaskTemplateManager) onTemplateRendered(handledRenders map[string]time.Time, allRenderedTime time.Time, events map[string]*manager.RenderEvent) {
 
 	var handling []string
 	signals := make(map[string]struct{})
@@ -430,7 +435,6 @@ func (tm *TaskTemplateManager) onTemplateRendered(handledRenders map[string]time
 	restart := false
 	var splay time.Duration
 
-	events := tm.runner.RenderEvents()
 	for id, event := range events {
 
 		// First time through

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -320,7 +320,7 @@ WAIT:
 				// If the template _actually_ rendered to disk, mark it
 				// dirty. We track events here so that onTemplateRendered
 				// doesn't go back to the runner's RenderedEvents and process
-				// new events that don't make us dirty.				
+				// events that don't make us dirty.
 				if !event.LastDidRender.IsZero() {
 					dirtyEvents[event.Template.ID()] = event
 				}

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -807,8 +807,8 @@ OUTER:
 }
 
 // Tests an edge case where a task has multiple templates and the client is restarted.
-// In this case, vault may re-render and overwrite some fields in the first render event
-// but we still want to make sure it causes a restart.
+// In this case, consul-template may re-render and overwrite some fields in the first
+// render event but we still want to make sure it causes a restart.
 // We cannot control the order in which these templates are rendered, so this test will
 // exhibit flakiness if this edge case is not properly handled.
 func TestTaskTemplateManager_FirstRender_MultiSecret(t *testing.T) {


### PR DESCRIPTION
When multiple templates with api functions are included in a task, it's possible for consul-template to re-render templates as it creates watchers, overwriting render event data. This change uses event fields that do not get overwritten, and only executes the change mode for templates that were actually written to disk.

Fixes: [#24140](https://github.com/hashicorp/nomad/issues/24140)