### PR TITLE
release: fix typo in the LAST_RELEASE sed regex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
           # LAST_RELEASE is used to generate the new CHANGELOG entries, so it's
           # only updated for final releases.
           if [ -z "$(semver get prerel ${{ github.event.inputs.version }})" ]; then
-            sed -i.bak -re "s|^(LAST_RELEASE\s+\?=\s+v).*$|\1${{ github.event.inputs.version }}|g" GNUmakefile
+            sed -i.bak -re "s|^(LAST_RELEASE\s+\?=\s).*$|\1${{ github.event.inputs.version }}|g" GNUmakefile
             rm -fr GNUmakefile.bak
             git diff --color=always GNUmakefile
           else

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -46,7 +46,7 @@ PROTO_COMPARE_TAG ?= v1.0.3$(if $(findstring ent,$(GO_TAGS)),+ent,)
 # or backport version, without the leading "v". main should have the latest
 # published release here, and release branches should point to the latest
 # published release in their X.Y release line.
-LAST_RELEASE ?= 1.8.4
+LAST_RELEASE ?= 1.9.2
 
 default: help
 


### PR DESCRIPTION
In the past the `make changelog` command expected `v`-prefixed `LAST_VERSION`, but now it doesn't. The regular expression we had in the release workflow did not account for this and thus the changelog update didn't work correctly. 