### PR TITLE
consul: allow non-root Nomad to rewrite token

### DIFF
--- a/.changelog/24410.txt
+++ b/.changelog/24410.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul: Fixed a bug where non-root Nomad agents could not recreate a task's Consul token on task restart
+```

--- a/client/allocrunner/taskrunner/consul_hook.go
+++ b/client/allocrunner/taskrunner/consul_hook.go
@@ -25,7 +25,7 @@ const (
 
 	// consulTokenFilePerms is the level of file permissions granted on the file in
 	// the secrets directory for the task
-	consulTokenFilePerms = 0440
+	consulTokenFilePerms = 0640
 )
 
 type consulHook struct {


### PR DESCRIPTION
When a task restarts, the Nomad client may need to rewrite the Consul token, but it's created with permissions that prevent a non-root agent from writing to it. While Nomad clients should be run as root (currently), it's harmless to allow whatever user the Nomad agent is running as to be able to write to it, and that's one less barrier to rootless Nomad.

(Note that the Vault token already has `u+rw` permissions.)

Ref: https://github.com/hashicorp/nomad/issues/23859#issuecomment-2465757392