### PR TITLE
client: fixed a bug where AMD CPUs were not correctly fingerprinting base speed

### DIFF
--- a/.changelog/24415.txt
+++ b/.changelog/24415.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: fixed a bug where AMD CPUs were not correctly fingerprinting base speed
+```

--- a/client/lib/numalib/detect_linux_test.go
+++ b/client/lib/numalib/detect_linux_test.go
@@ -68,6 +68,37 @@ func goodSysData(path string) ([]byte, error) {
 	}[path], nil
 }
 
+func goodSysDataAMD(path string) ([]byte, error) {
+	return map[string][]byte{
+		"/sys/devices/system/node/online":                            []byte("0-1"),
+		"/sys/devices/system/cpu/online":                             []byte("0-3"),
+		"/sys/devices/system/node/node0/distance":                    []byte("10"),
+		"/sys/devices/system/node/node0/cpulist":                     []byte("0-3"),
+		"/sys/devices/system/node/node1/distance":                    []byte("10"),
+		"/sys/devices/system/node/node1/cpulist":                     []byte("0-3"),
+		"/sys/devices/system/cpu/cpu0/acpi_cppc/nominal_freq":        []byte("2450"),
+		"/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu0/cpufreq/scaling_driver":        []byte("acpi-cpufreq"),
+		"/sys/devices/system/cpu/cpu0/topology/physical_package_id":  []byte("0"),
+		"/sys/devices/system/cpu/cpu0/topology/thread_siblings_list": []byte("0,2"),
+		"/sys/devices/system/cpu/cpu1/acpi_cppc/nominal_freq":        []byte("2450"),
+		"/sys/devices/system/cpu/cpu1/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu1/cpufreq/scaling_driver":        []byte("acpi-cpufreq"),
+		"/sys/devices/system/cpu/cpu1/topology/physical_package_id":  []byte("0"),
+		"/sys/devices/system/cpu/cpu1/topology/thread_siblings_list": []byte("1,3"),
+		"/sys/devices/system/cpu/cpu2/acpi_cppc/nominal_freq":        []byte("2450"),
+		"/sys/devices/system/cpu/cpu2/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu2/cpufreq/scaling_driver":        []byte("acpi-cpufreq"),
+		"/sys/devices/system/cpu/cpu2/topology/physical_package_id":  []byte("0"),
+		"/sys/devices/system/cpu/cpu2/topology/thread_siblings_list": []byte("0,2"),
+		"/sys/devices/system/cpu/cpu3/acpi_cppc/nominal_freq":        []byte("2450"),
+		"/sys/devices/system/cpu/cpu3/cpufreq/cpuinfo_max_freq":      []byte("3500000"),
+		"/sys/devices/system/cpu/cpu3/cpufreq/scaling_driver":        []byte("acpi-cpufreq"),
+		"/sys/devices/system/cpu/cpu3/topology/physical_package_id":  []byte("0"),
+		"/sys/devices/system/cpu/cpu3/topology/thread_siblings_list": []byte("1,3"),
+	}[path], nil
+}
+
 func TestSysfs_discoverOnline(t *testing.T) {
 	st := MockTopology(&idset.Set[hw.NodeID]{}, SLIT{}, []Core{})
 	goodIDSet := idset.From[hw.NodeID]([]uint8{0, 1})
@@ -191,6 +222,44 @@ func TestSysfs_discoverCores(t *testing.T) {
 					ID:        3,
 					Grade:     Performance,
 					BaseSpeed: 2100,
+					MaxSpeed:  3500,
+				},
+			},
+		}},
+		{"two nodes and good sys AMD data", twoNodes, goodSysDataAMD, &Topology{
+			nodeIDs: twoNodes,
+			Nodes:   twoNodes.Slice(),
+			Cores: []Core{
+				{
+					SocketID:  1,
+					NodeID:    0,
+					ID:        0,
+					Grade:     Performance,
+					BaseSpeed: 2450,
+					MaxSpeed:  3500,
+				},
+				{
+					SocketID:  1,
+					NodeID:    0,
+					ID:        1,
+					Grade:     Performance,
+					BaseSpeed: 2450,
+					MaxSpeed:  3500,
+				},
+				{
+					SocketID:  1,
+					NodeID:    0,
+					ID:        2,
+					Grade:     Performance,
+					BaseSpeed: 2450,
+					MaxSpeed:  3500,
+				},
+				{
+					SocketID:  1,
+					NodeID:    0,
+					ID:        3,
+					Grade:     Performance,
+					BaseSpeed: 2450,
 					MaxSpeed:  3500,
 				},
 			},

--- a/client/lib/numalib/hw/speeds.go
+++ b/client/lib/numalib/hw/speeds.go
@@ -16,6 +16,10 @@ func (khz KHz) MHz() MHz {
 	return MHz(khz / 1000)
 }
 
+func (mhz MHz) KHz() KHz {
+	return KHz(mhz * 1000)
+}
+
 func (khz KHz) String() string {
 	return strconv.FormatUint(uint64(khz.MHz()), 10)
 }


### PR DESCRIPTION
Relates to: #19468

### Description
Within one of our production sites we are running on a mixed server fleet, where some are running baremetal Nomad and others are part of the virtualised fleet. We noticed a big difference in the reported CPU . On the baremetal systems they were using the boost clock at 3.5 GHz whereas on the virtualised load they were using the QEMU default for dmidecode at 2GHz
```
nomad version
Nomad v1.8.2
BuildDate 2024-07-16T08:50:09Z
Revision 7f0822c1e4f25907d9f60e2d595411950dd1bd28
```

### Testing & Reproduction steps
![image](https://github.com/user-attachments/assets/02c7d901-1257-4cfc-855f-624d59ba3e8d)
![image](https://github.com/user-attachments/assets/47e88715-4faf-4d41-b485-7d64ceb73430)

```
grep -H . /sys/devices/system/cpu/cpu0/cpufreq/*
/sys/devices/system/cpu/cpu0/cpufreq/affected_cpus:0
/sys/devices/system/cpu/cpu0/cpufreq/bios_limit:2450000
/sys/devices/system/cpu/cpu0/cpufreq/cpb:1
/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_cur_freq:2450000
/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq:3529052
/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_min_freq:1500000
/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_transition_latency:0
/sys/devices/system/cpu/cpu0/cpufreq/freqdomain_cpus:0 128
/sys/devices/system/cpu/cpu0/cpufreq/related_cpus:0
/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_frequencies:2450000 2000000 1500000
/sys/devices/system/cpu/cpu0/cpufreq/scaling_available_governors:conservative ondemand userspace powersave performance schedutil
/sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq:3241647
/sys/devices/system/cpu/cpu0/cpufreq/scaling_driver:acpi-cpufreq
/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor:performance
/sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq:3529052
/sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq:1500000
/sys/devices/system/cpu/cpu0/cpufreq/scaling_setspeed:<unsupported>
```
```
grep -H . /sys/devices/system/cpu/cpu0/acpi_cppc/*
/sys/devices/system/cpu/cpu0/acpi_cppc/feedback_ctrs:ref:4782881970238275 del:6173496996912339
/sys/devices/system/cpu/cpu0/acpi_cppc/highest_perf:255
/sys/devices/system/cpu/cpu0/acpi_cppc/lowest_freq:400
/sys/devices/system/cpu/cpu0/acpi_cppc/lowest_nonlinear_perf:109
/sys/devices/system/cpu/cpu0/acpi_cppc/lowest_perf:29
/sys/devices/system/cpu/cpu0/acpi_cppc/nominal_freq:2451
/sys/devices/system/cpu/cpu0/acpi_cppc/nominal_perf:177
/sys/devices/system/cpu/cpu0/acpi_cppc/reference_perf:177
/sys/devices/system/cpu/cpu0/acpi_cppc/wraparound_time:18446744073709551615
```
Quick search through our inventory : 
```
AMD EPYC 7313 16-Core Processor
/sys/devices/system/cpu/cpu0/acpi_cppc/nominal_freq:3001

AMD EPYC 7713 64-Core Processor
/sys/devices/system/cpu/cpu0/acpi_cppc/nominal_freq:2000

AMD EPYC 7742 64-Core Processor
/sys/devices/system/cpu/cpu0/acpi_cppc/nominal_freq:2251

AMD EPYC 7763 64-Core Processor
/sys/devices/system/cpu/cpu0/acpi_cppc/nominal_freq:2451
```

### Links
- https://docs.kernel.org/admin-guide/pm/intel_pstate.html#interpretation-of-policy-attributes
- https://docs.kernel.org/admin-guide/acpi/cppc_sysfs.html


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
