### PR TITLE
csi: remove redundant namespace field from volume status output

### DIFF
--- a/.changelog/24432.txt
+++ b/.changelog/24432.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Removed redundant namespace output from volume status command
+```

--- a/command/volume_status_csi.go
+++ b/command/volume_status_csi.go
@@ -205,11 +205,9 @@ func (c *VolumeStatusCommand) formatBasic(vol *api.CSIVolume) (string, error) {
 		fmt.Sprintf("Controllers Expected|%d", vol.ControllersExpected),
 		fmt.Sprintf("Nodes Healthy|%d", vol.NodesHealthy),
 		fmt.Sprintf("Nodes Expected|%d", vol.NodesExpected),
-
 		fmt.Sprintf("Access Mode|%s", vol.AccessMode),
 		fmt.Sprintf("Attachment Mode|%s", vol.AttachmentMode),
 		fmt.Sprintf("Mount Options|%s", csiVolMountOption(vol.MountOptions, nil)),
-		fmt.Sprintf("Namespace|%s", vol.Namespace),
 	}
 
 	// Exit early


### PR DESCRIPTION
The `volume status :id` command outputs the namespace for a CSI volume twice. Drop the second output.

Ref: https://github.com/hashicorp/nomad/pull/24382#discussion_r1837097250