### PR TITLE
keyring: Fix a panic when decrypting aead with empty RSA block.

### DIFF
--- a/.changelog/24442.txt
+++ b/.changelog/24442.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+keyring: Fixed a bug when decrypting aead with an empty RSA block on state upserts
+```

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -477,7 +477,7 @@ func (e *Encrypter) decryptWrappedKeyTask(ctx context.Context, cancel context.Ca
 		// Decrypt RSAKey for Workload Identity JWT signing if one exists. Prior to
 		// 1.7 an ed25519 key derived from the root key was used instead of an RSA
 		// key.
-		if wrappedKey.WrappedRSAKey != nil {
+		if wrappedKey.WrappedRSAKey != nil && len(wrappedKey.WrappedRSAKey.Ciphertext) > 0 {
 			rsaKey, err = wrapper.Decrypt(e.srv.shutdownCtx, wrappedKey.WrappedRSAKey)
 			if err != nil {
 				err := fmt.Errorf("%w (rsa key): %w", ErrDecryptFailed, err)


### PR DESCRIPTION
### Description
Clusters that have gone through several upgrades have be found to include keyring material which has an empty RSA block.

In more recent versions of Nomad, an empty RSA block is omitted from being written to disk. This results in the panic not being present. Older versions, however, did not have this struct tag meaning we wrote an empty JSON block which is not accounted for in the current version.

Spot check for this locally in the code:
```
ag "WrappedRSAKey != nil {"
```
```
ag "WrappedRSAKey != nil && "
nomad/encrypter.go
480:		if wrappedKey.WrappedRSAKey != nil && len(wrappedKey.WrappedRSAKey.Ciphertext) > 0 {
808:	if kekWrapper.WrappedRSAKey != nil && len(kekWrapper.WrappedRSAKey.Ciphertext) > 0 {
```

### Links
closes #24441 
related https://github.com/hashicorp/nomad/pull/24383

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
