### PR TITLE
drivers: fix capabilities on non-linux systems

### DIFF
--- a/drivers/shared/capabilities/defaults.go
+++ b/drivers/shared/capabilities/defaults.go
@@ -6,6 +6,7 @@ package capabilities
 import (
 	"fmt"
 	"regexp"
+	"runtime"
 
 	"github.com/moby/sys/capability"
 )
@@ -41,6 +42,13 @@ func Supported() *Set {
 	s := New(nil)
 
 	list, _ := capability.ListSupported()
+
+	// capability.ListSupported() will always return an empty list on non-linux
+	// systems
+	if runtime.GOOS != "linux" {
+		list = capability.ListKnown()
+	}
+
 	// accumulate every capability supported by this system
 	for _, c := range list {
 		s.Add(c.String())

--- a/drivers/shared/capabilities/defaults.go
+++ b/drivers/shared/capabilities/defaults.go
@@ -41,11 +41,14 @@ func NomadDefaults() *Set {
 func Supported() *Set {
 	s := New(nil)
 
-	list, _ := capability.ListSupported()
+	var list []capability.Cap
 
-	// capability.ListSupported() will always return an empty list on non-linux
-	// systems
-	if runtime.GOOS != "linux" {
+	switch runtime.GOOS {
+	case "linux":
+		list, _ = capability.ListSupported()
+	default:
+		// capability.ListSupported() will always return an empty list on
+		// non-linux systems
 		list = capability.ListKnown()
 	}
 


### PR DESCRIPTION
In #24093 we moved from github.com/syndtr/gocapability to github.com/moby/sys/capability due to the former package no longer being maintainer. The new package's capability function works differently: the known/supported functionality is split now, and the `.ListSupported()` call will always return an empty list on non-linux systems. This means Nomad agents won't start on darwin or windows. 