### PR TITLE
tools: filter Nomad Enterprise tags in pre-push hook

### DIFF
--- a/dev/hooks/pre-push
+++ b/dev/hooks/pre-push
@@ -31,6 +31,7 @@ if [ -f version/version_ent.go ]; then
 fi
 
 # do not push directly to main, stable-*, release/*
+# do not push Enterprise tags
 # ====================
 while read local_ref local_sha remote_ref remote_sha
 do
@@ -45,5 +46,13 @@ do
     if echo "$remote_ref"|grep -q 'refs/heads/release/.*'; then
         fail "refusing to push directly to a branch prefixed \`release/\`"
     fi
-done
 
+    if echo "$remote_ref" | grep -q 'refs/tags/v.*\+ent'; then
+        fail "refusing to push Nomad Enterprise tag"
+    fi
+
+    if echo "$remote_ref" | grep -q 'refs/tags/v.*\+pro'; then
+        fail "refusing to push Nomad Enterprise (pro) tag"
+    fi
+
+done


### PR DESCRIPTION
Our git pre-push hook already prevents Nomad Enterprise code from getting pushed anywhere but its own repo. But this hook only works for files on the current worktree (checkout). Were you to fetch an Enterprise tag into your local Community Edition repo but not have it checked out, and then `git push --tags`, you'd push that tag and the associated commit history.

Add tag filtering to the pre-push hook to prevent Enterprise tags (and the older `+pro` SKU) tags from getting pushed to the Community Edition repo.

To test from any CE checkout:

```
$ git tag v1.20.0+ent
$ git push --tags
```

(and then cleanup via `git tag -d v1.20.0+ent`)