### PR TITLE
[cli] UI URL hints for common CLI commands

### DIFF
--- a/.changelog/24454.txt
+++ b/.changelog/24454.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-cli: Added UI URL hints to the end of common CLI commands and a -ui flag to auto-open them
+cli: Added UI URL hints to the end of common CLI commands and a `-ui` flag to auto-open them
 ```

--- a/.changelog/24454.txt
+++ b/.changelog/24454.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added UI URL hints to the end of common CLI commands and a -ui flag to auto-open them
+```

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -49,6 +49,9 @@ Alloc Status Options:
   -verbose
     Show full information.
 
+  -ui
+    Open the allocation status page in the browser.
+
   -json
     Output the allocation in its JSON format.
 
@@ -70,6 +73,7 @@ func (c *AllocStatusCommand) AutocompleteFlags() complete.Flags {
 			"-verbose": complete.PredictNothing,
 			"-json":    complete.PredictNothing,
 			"-t":       complete.PredictAnything,
+			"-ui":      complete.PredictNothing,
 		})
 }
 
@@ -91,7 +95,7 @@ func (c *AllocStatusCommand) AutocompleteArgs() complete.Predictor {
 func (c *AllocStatusCommand) Name() string { return "alloc status" }
 
 func (c *AllocStatusCommand) Run(args []string) int {
-	var short, displayStats, verbose, json bool
+	var short, displayStats, verbose, json, openURL bool
 	var tmpl string
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
@@ -101,6 +105,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	flags.BoolVar(&displayStats, "stats", false, "")
 	flags.BoolVar(&json, "json", false, "")
 	flags.StringVar(&tmpl, "t", "", "")
+	flags.BoolVar(&openURL, "ui", false, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -242,6 +247,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 		PathParams: map[string]string{
 			"allocID": alloc.ID,
 		},
+		OpenURL: openURL,
 	})
 	if hint != "" {
 		c.Ui.Output(hint)

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -237,6 +237,15 @@ func (c *AllocStatusCommand) Run(args []string) int {
 		c.Ui.Output(formatAllocMetrics(alloc.Metrics, true, "  "))
 	}
 
+	hint, _ := c.Meta.showUIPath(UIHintContext{
+		Command: "alloc status",
+		PathParams: map[string]string{
+			"allocID": alloc.ID,
+		},
+	})
+	if hint != "" {
+		c.Ui.Output(hint)
+	}
 	return 0
 }
 

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -250,7 +250,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 		OpenURL: openURL,
 	})
 	if hint != "" {
-		c.Ui.Output(hint)
+		c.Ui.Warn(hint)
 	}
 	return 0
 }

--- a/command/commands.go
+++ b/command/commands.go
@@ -19,6 +19,9 @@ const (
 
 	// EnvNomadCLIForceColor is an env var that forces colored UI output.
 	EnvNomadCLIForceColor = `NOMAD_CLI_FORCE_COLOR`
+
+	// EnvNomadShowCLIHints is an env var that toggles CLI hints.
+	EnvNomadShowCLIHints = `NOMAD_SHOW_CLI_HINTS`
 )
 
 // DeprecatedCommand is a command that wraps an existing command and prints a

--- a/command/commands.go
+++ b/command/commands.go
@@ -20,8 +20,8 @@ const (
 	// EnvNomadCLIForceColor is an env var that forces colored UI output.
 	EnvNomadCLIForceColor = `NOMAD_CLI_FORCE_COLOR`
 
-	// EnvNomadShowCLIHints is an env var that toggles CLI hints.
-	EnvNomadShowCLIHints = `NOMAD_SHOW_CLI_HINTS`
+	// EnvNomadCLIShowHints is an env var that toggles CLI hints.
+	EnvNomadCLIShowHints = `NOMAD_CLI_SHOW_HINTS`
 )
 
 // DeprecatedCommand is a command that wraps an existing command and prints a

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -187,7 +187,6 @@ func (c *DeploymentStatusCommand) Run(args []string) int {
 			formatTime(time.Now()), limit(deploy.ID, length)))
 		c.monitor(client, deploy.ID, meta.LastIndex, wait, verbose)
 
-		// Hint here
 		hint, _ := c.Meta.showUIPath(UIHintContext{
 			Command: "deployment status",
 			PathParams: map[string]string{

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -197,7 +197,7 @@ func (c *DeploymentStatusCommand) Run(args []string) int {
 		if hint != "" {
 			c.Ui.Output(hint)
 			// Because this is before monitor, newline so we don't scrunch
-			c.Ui.Output("\n")
+			c.Ui.Output("")
 		}
 
 		return 0

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -195,9 +195,9 @@ func (c *DeploymentStatusCommand) Run(args []string) int {
 			OpenURL: openURL,
 		})
 		if hint != "" {
-			c.Ui.Output(hint)
+			c.Ui.Warn(hint)
 			// Because this is before monitor, newline so we don't scrunch
-			c.Ui.Output("")
+			c.Ui.Warn("")
 		}
 
 		return 0
@@ -212,7 +212,7 @@ func (c *DeploymentStatusCommand) Run(args []string) int {
 		OpenURL: openURL,
 	})
 	if hint != "" {
-		c.Ui.Output(hint)
+		c.Ui.Warn(hint)
 	}
 	return 0
 }

--- a/command/eval_list.go
+++ b/command/eval_list.go
@@ -52,6 +52,9 @@ Eval List Options:
 
   -t
     Format and display evaluation using a Go template.
+
+  -ui
+    Open the evaluation in the browser.
 `
 
 	return strings.TrimSpace(helpText)
@@ -72,6 +75,7 @@ func (c *EvalListCommand) AutocompleteFlags() complete.Flags {
 			"-status":     complete.PredictAnything,
 			"-per-page":   complete.PredictAnything,
 			"-page-token": complete.PredictAnything,
+			"-ui":         complete.PredictNothing,
 		})
 }
 
@@ -93,7 +97,7 @@ func (c *EvalListCommand) AutocompleteArgs() complete.Predictor {
 func (c *EvalListCommand) Name() string { return "eval list" }
 
 func (c *EvalListCommand) Run(args []string) int {
-	var monitor, verbose, json bool
+	var monitor, verbose, json, openURL bool
 	var perPage int
 	var tmpl, pageToken, filter, filterJobID, filterStatus string
 
@@ -103,6 +107,7 @@ func (c *EvalListCommand) Run(args []string) int {
 	flags.BoolVar(&verbose, "verbose", false, "")
 	flags.BoolVar(&json, "json", false, "")
 	flags.StringVar(&tmpl, "t", "", "")
+	flags.BoolVar(&openURL, "ui", false, "")
 	flags.IntVar(&perPage, "per-page", 0, "")
 	flags.StringVar(&pageToken, "page-token", "", "")
 	flags.StringVar(&filter, "filter", "", "")
@@ -171,6 +176,14 @@ func (c *EvalListCommand) Run(args []string) int {
 Results have been paginated. To get the next page run:
 
 %s -page-token %s`, argsWithoutPageToken(os.Args), qm.NextToken))
+	}
+
+	hint, _ := c.Meta.showUIPath(UIHintContext{
+		Command: "eval list",
+		OpenURL: openURL,
+	})
+	if hint != "" {
+		c.Ui.Output(hint)
 	}
 
 	return 0

--- a/command/eval_list.go
+++ b/command/eval_list.go
@@ -183,7 +183,7 @@ Results have been paginated. To get the next page run:
 		OpenURL: openURL,
 	})
 	if hint != "" {
-		c.Ui.Output(hint)
+		c.Ui.Warn(hint)
 	}
 
 	return 0

--- a/command/eval_list.go
+++ b/command/eval_list.go
@@ -54,7 +54,7 @@ Eval List Options:
     Format and display evaluation using a Go template.
 
   -ui
-    Open the evaluation in the browser.
+    Open the evaluations page in the browser.
 `
 
 	return strings.TrimSpace(helpText)

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -43,6 +43,9 @@ Eval Status Options:
 
   -t
     Format and display evaluation using a Go template.
+
+  -ui
+    Open the evaluation in the browser.
 `
 
 	return strings.TrimSpace(helpText)
@@ -59,6 +62,7 @@ func (c *EvalStatusCommand) AutocompleteFlags() complete.Flags {
 			"-monitor": complete.PredictNothing,
 			"-t":       complete.PredictAnything,
 			"-verbose": complete.PredictNothing,
+			"-ui":      complete.PredictNothing,
 		})
 }
 
@@ -84,7 +88,7 @@ func (c *EvalStatusCommand) AutocompleteArgs() complete.Predictor {
 func (c *EvalStatusCommand) Name() string { return "eval status" }
 
 func (c *EvalStatusCommand) Run(args []string) int {
-	var monitor, verbose, json bool
+	var monitor, verbose, json, openURL bool
 	var tmpl string
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
@@ -93,7 +97,7 @@ func (c *EvalStatusCommand) Run(args []string) int {
 	flags.BoolVar(&verbose, "verbose", false, "")
 	flags.BoolVar(&json, "json", false, "")
 	flags.StringVar(&tmpl, "t", "", "")
-
+	flags.BoolVar(&openURL, "ui", false, "")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -245,6 +249,17 @@ func (c *EvalStatusCommand) Run(args []string) int {
 			c.Ui.Output(fmt.Sprintf("Evaluation %q waiting for additional capacity to place remainder",
 				limit(eval.BlockedEval, length)))
 		}
+	}
+
+	hint, _ := c.Meta.showUIPath(UIHintContext{
+		Command: "eval status",
+		PathParams: map[string]string{
+			"evalID": eval.ID,
+		},
+		OpenURL: openURL,
+	})
+	if hint != "" {
+		c.Ui.Output(hint)
 	}
 
 	return 0

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -259,7 +259,7 @@ func (c *EvalStatusCommand) Run(args []string) int {
 		OpenURL: openURL,
 	})
 	if hint != "" {
-		c.Ui.Output(hint)
+		c.Ui.Warn(hint)
 	}
 
 	return 0

--- a/command/job_dispatch.go
+++ b/command/job_dispatch.go
@@ -239,9 +239,9 @@ func (c *JobDispatchCommand) Run(args []string) int {
 		OpenURL: openURL,
 	})
 	if hint != "" {
-		c.Ui.Output(hint)
+		c.Ui.Warn(hint)
 		// Because this is before monitor, newline so we don't scrunch
-		c.Ui.Output("")
+		c.Ui.Warn("")
 	}
 	return mon.monitor(resp.EvalID)
 }

--- a/command/job_dispatch.go
+++ b/command/job_dispatch.go
@@ -234,6 +234,7 @@ func (c *JobDispatchCommand) Run(args []string) int {
 		Command: "job dispatch",
 		PathParams: map[string]string{
 			"dispatchID": dispatchID,
+			"namespace":  namespace,
 		},
 		OpenURL: openURL,
 	})

--- a/command/job_dispatch.go
+++ b/command/job_dispatch.go
@@ -241,7 +241,7 @@ func (c *JobDispatchCommand) Run(args []string) int {
 	if hint != "" {
 		c.Ui.Output(hint)
 		// Because this is before monitor, newline so we don't scrunch
-		c.Ui.Output("\n")
+		c.Ui.Output("")
 	}
 	return mon.monitor(resp.EvalID)
 }

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -98,7 +98,7 @@ Run Options:
     the job.
 
   -ui
-    Open the job run page in the browser.
+    Open the job page in the browser.
 
   -policy-override
     Sets the flag to force override any soft mandatory Sentinel policies.

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -260,17 +260,6 @@ func (c *JobRunCommand) Run(args []string) int {
 
 		c.Ui.Output(string(buf))
 
-		hint, _ := c.Meta.showUIPath(UIHintContext{
-			Command: "job run",
-			PathParams: map[string]string{
-				"jobID": *job.ID,
-			},
-			OpenURL: openURL,
-		})
-		if hint != "" {
-			c.Ui.Output(hint)
-		}
-
 		return 0
 	}
 
@@ -319,6 +308,11 @@ func (c *JobRunCommand) Run(args []string) int {
 
 	evalID := resp.EvalID
 
+	jobNamespace := c.Meta.namespace
+	if jobNamespace == "" {
+		jobNamespace = "default"
+	}
+
 	// Check if we should enter monitor mode
 	if detach || periodic || paramjob || multiregion {
 		c.Ui.Output("Job registration successful")
@@ -341,7 +335,8 @@ func (c *JobRunCommand) Run(args []string) int {
 		hint, _ := c.Meta.showUIPath(UIHintContext{
 			Command: "job run",
 			PathParams: map[string]string{
-				"jobID": *job.ID,
+				"jobID":     *job.ID,
+				"namespace": jobNamespace,
 			},
 			OpenURL: openURL,
 		})
@@ -356,7 +351,8 @@ func (c *JobRunCommand) Run(args []string) int {
 	hint, _ := c.Meta.showUIPath(UIHintContext{
 		Command: "job run",
 		PathParams: map[string]string{
-			"jobID": *job.ID,
+			"jobID":     *job.ID,
+			"namespace": jobNamespace,
 		},
 		OpenURL: openURL,
 	})

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -341,7 +341,7 @@ func (c *JobRunCommand) Run(args []string) int {
 			OpenURL: openURL,
 		})
 		if hint != "" {
-			c.Ui.Output(hint)
+			c.Ui.Warn(hint)
 		}
 
 		return 0
@@ -357,9 +357,9 @@ func (c *JobRunCommand) Run(args []string) int {
 		OpenURL: openURL,
 	})
 	if hint != "" {
-		c.Ui.Output(hint)
+		c.Ui.Warn(hint)
 		// Because this is before monitor, newline so we don't scrunch
-		c.Ui.Output("")
+		c.Ui.Warn("")
 	}
 
 	mon := newMonitor(c.Ui, client, length)

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -353,7 +353,6 @@ func (c *JobRunCommand) Run(args []string) int {
 	}
 
 	// Detach was not specified, so start monitoring
-	// Set hint to open the browser
 	hint, _ := c.Meta.showUIPath(UIHintContext{
 		Command: "job run",
 		PathParams: map[string]string{

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -363,6 +363,8 @@ func (c *JobRunCommand) Run(args []string) int {
 	})
 	if hint != "" {
 		c.Ui.Output(hint)
+		// Because this is before monitor, newline so we don't scrunch
+		c.Ui.Output("\n")
 	}
 
 	mon := newMonitor(c.Ui, client, length)

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -359,7 +359,7 @@ func (c *JobRunCommand) Run(args []string) int {
 	if hint != "" {
 		c.Ui.Output(hint)
 		// Because this is before monitor, newline so we don't scrunch
-		c.Ui.Output("\n")
+		c.Ui.Output("")
 	}
 
 	mon := newMonitor(c.Ui, client, length)

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -159,6 +159,12 @@ func (c *JobStatusCommand) Run(args []string) int {
 		if len(jobs) == 0 {
 			// No output if we have no jobs
 			c.Ui.Output("No running jobs")
+			hint, _ := c.Meta.showUIPath(UIHintContext{
+				Command: "job status",
+			})
+			if hint != "" {
+				c.Ui.Output(hint)
+			}
 		} else {
 			if c.json || len(c.tmpl) > 0 {
 				pairs := make([]NamespacedID, len(jobs))
@@ -182,6 +188,12 @@ func (c *JobStatusCommand) Run(args []string) int {
 				c.Ui.Output(out)
 			} else {
 				c.Ui.Output(createStatusListOutput(jobs, allNamespaces))
+				hint, _ := c.Meta.showUIPath(UIHintContext{
+					Command: "job status",
+				})
+				if hint != "" {
+					c.Ui.Output(hint)
+				}
 			}
 		}
 		return 0
@@ -271,6 +283,15 @@ func (c *JobStatusCommand) Run(args []string) int {
 
 	// Exit early
 	if short {
+		hint, _ := c.Meta.showUIPath(UIHintContext{
+			Command: "job status single",
+			PathParams: map[string]string{
+				"jobID": *job.ID,
+			},
+		})
+		if hint != "" {
+			c.Ui.Output(hint)
+		}
 		return 0
 	}
 
@@ -290,6 +311,16 @@ func (c *JobStatusCommand) Run(args []string) int {
 			c.Ui.Error(err.Error())
 			return 1
 		}
+	}
+
+	hint, _ := c.Meta.showUIPath(UIHintContext{
+		Command: "job status single",
+		PathParams: map[string]string{
+			"jobID": *job.ID,
+		},
+	})
+	if hint != "" {
+		c.Ui.Output(hint)
 	}
 
 	return 0

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -28,6 +28,7 @@ type JobStatusCommand struct {
 	verbose   bool
 	json      bool
 	tmpl      string
+	openURL   bool
 }
 
 // NamespacedID is a tuple of an ID and a namespace
@@ -73,6 +74,9 @@ Status Options:
 
   -verbose
     Display full information.
+
+  -ui
+    Open the job status page in the browser.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -88,6 +92,7 @@ func (c *JobStatusCommand) AutocompleteFlags() complete.Flags {
 			"-evals":      complete.PredictNothing,
 			"-short":      complete.PredictNothing,
 			"-verbose":    complete.PredictNothing,
+			"-ui":         complete.PredictNothing,
 		})
 }
 
@@ -119,6 +124,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 	flags.BoolVar(&c.json, "json", false, "")
 	flags.StringVar(&c.tmpl, "t", "", "")
 	flags.BoolVar(&c.verbose, "verbose", false, "")
+	flags.BoolVar(&c.openURL, "ui", false, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -161,6 +167,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 			c.Ui.Output("No running jobs")
 			hint, _ := c.Meta.showUIPath(UIHintContext{
 				Command: "job status",
+				OpenURL: c.openURL,
 			})
 			if hint != "" {
 				c.Ui.Output(hint)
@@ -190,6 +197,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 				c.Ui.Output(createStatusListOutput(jobs, allNamespaces))
 				hint, _ := c.Meta.showUIPath(UIHintContext{
 					Command: "job status",
+					OpenURL: c.openURL,
 				})
 				if hint != "" {
 					c.Ui.Output(hint)
@@ -288,6 +296,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 			PathParams: map[string]string{
 				"jobID": *job.ID,
 			},
+			OpenURL: c.openURL,
 		})
 		if hint != "" {
 			c.Ui.Output(hint)
@@ -318,6 +327,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 		PathParams: map[string]string{
 			"jobID": *job.ID,
 		},
+		OpenURL: c.openURL,
 	})
 	if hint != "" {
 		c.Ui.Output(hint)

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -170,7 +170,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 				OpenURL: c.openURL,
 			})
 			if hint != "" {
-				c.Ui.Output(hint)
+				c.Ui.Warn(hint)
 			}
 		} else {
 			if c.json || len(c.tmpl) > 0 {
@@ -200,7 +200,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 					OpenURL: c.openURL,
 				})
 				if hint != "" {
-					c.Ui.Output(hint)
+					c.Ui.Warn(hint)
 				}
 			}
 		}
@@ -300,7 +300,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 			OpenURL: c.openURL,
 		})
 		if hint != "" {
-			c.Ui.Output(hint)
+			c.Ui.Warn(hint)
 		}
 		return 0
 	}
@@ -332,7 +332,7 @@ func (c *JobStatusCommand) Run(args []string) int {
 		OpenURL: c.openURL,
 	})
 	if hint != "" {
-		c.Ui.Output(hint)
+		c.Ui.Warn(hint)
 	}
 
 	return 0

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -294,7 +294,8 @@ func (c *JobStatusCommand) Run(args []string) int {
 		hint, _ := c.Meta.showUIPath(UIHintContext{
 			Command: "job status single",
 			PathParams: map[string]string{
-				"jobID": *job.ID,
+				"jobID":     *job.ID,
+				"namespace": *job.Namespace,
 			},
 			OpenURL: c.openURL,
 		})
@@ -325,7 +326,8 @@ func (c *JobStatusCommand) Run(args []string) int {
 	hint, _ := c.Meta.showUIPath(UIHintContext{
 		Command: "job status single",
 		PathParams: map[string]string{
-			"jobID": *job.ID,
+			"jobID":     *job.ID,
+			"namespace": *job.Namespace,
 		},
 		OpenURL: c.openURL,
 	})

--- a/command/meta.go
+++ b/command/meta.go
@@ -10,7 +10,11 @@ import (
 	"reflect"
 	"strings"
 
+<<<<<<< HEAD
 	"github.com/hashicorp/cli"
+=======
+	"github.com/hashicorp/cap/util"
+>>>>>>> c48bff6996 (-ui flag for most commands)
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper/pointer"
 	colorable "github.com/mattn/go-colorable"
@@ -460,6 +464,7 @@ type UIRoute struct {
 type UIHintContext struct {
 	Command    string
 	PathParams map[string]string
+	OpenURL    bool
 }
 
 const (
@@ -494,6 +499,10 @@ var CommandUIRoutes = map[string]UIRoute{
 	"job status single": {
 		Path:        "/jobs/:jobID",
 		Description: "View job details and metrics",
+	},
+	"job run": {
+		Path:        "/jobs/:jobID",
+		Description: "View this job in the Web UI",
 	},
 	"alloc status": {
 		Path:        "/allocations/:allocID",
@@ -552,6 +561,12 @@ func (m *Meta) showUIPath(ctx UIHintContext) (string, error) {
 	url, err := m.buildUIPath(route, ctx.PathParams)
 	if err != nil {
 		return "", err
+	}
+
+	if ctx.OpenURL {
+		if err := util.OpenURL(url); err != nil {
+			m.Ui.Warn(fmt.Sprintf("Failed to open browser: %v", err))
+		}
 	}
 
 	return m.formatUIHint(url, route.Description), nil

--- a/command/meta.go
+++ b/command/meta.go
@@ -553,11 +553,6 @@ var CommandUIRoutes = map[string]UIRoute{
 }
 
 func (m *Meta) formatUIHint(url string, description string) string {
-	// Don't show hints for non-terminal output
-	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
-		return ""
-	}
-
 	if description == "" {
 		description = defaultHint
 	}

--- a/command/meta.go
+++ b/command/meta.go
@@ -525,7 +525,7 @@ var CommandUIRoutes = map[string]UIRoute{
 		Description: "View variable details",
 	},
 	"job dispatch": {
-		Path:        "/jobs/:dispatchID",
+		Path:        "/jobs/:dispatchID@:namespace",
 		Description: "View this job",
 	},
 	"eval list": {

--- a/command/meta.go
+++ b/command/meta.go
@@ -597,5 +597,27 @@ func (m *Meta) showUIPath(ctx UIHintContext) (string, error) {
 		}
 	}
 
+	if m.uiHintsDisabled() {
+		return "", nil
+	}
+
 	return m.formatUIHint(url, route.Description), nil
+}
+
+func (m *Meta) uiHintsDisabled() bool {
+	client, err := m.Client()
+	if err != nil {
+		return true
+	}
+	agent, err := client.Agent().Self()
+	if err != nil {
+		return true
+	}
+	agentConfig := agent.Config
+	uiConfig, ok := agentConfig["UI"].(map[string]interface{})
+	if !ok {
+		return true
+	}
+
+	return !uiConfig["CLIURLLinks"].(bool)
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -10,11 +10,8 @@ import (
 	"reflect"
 	"strings"
 
-<<<<<<< HEAD
-	"github.com/hashicorp/cli"
-=======
 	"github.com/hashicorp/cap/util"
->>>>>>> c48bff6996 (-ui flag for most commands)
+	"github.com/hashicorp/cli"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/helper/pointer"
 	colorable "github.com/mattn/go-colorable"
@@ -61,6 +58,8 @@ type Meta struct {
 
 	// token is used for ACLs to access privileged information
 	token string
+
+	showCLIHints *bool
 
 	caCert        string
 	caPath        string
@@ -275,6 +274,14 @@ func (m *Meta) SetupUi(args []string) {
 			InfoColor:  cli.UiColorGreen,
 			Ui:         m.Ui,
 		}
+	}
+
+	// Check to see if the user has disabled hints via env var.
+	showCLIHints := os.Getenv(EnvNomadShowCLIHints)
+	if showCLIHints == "false" {
+		m.showCLIHints = pointer.Of(false)
+	} else if showCLIHints == "true" {
+		m.showCLIHints = pointer.Of(true)
 	}
 }
 
@@ -609,19 +616,43 @@ func (m *Meta) showUIPath(ctx UIHintContext) (string, error) {
 }
 
 func (m *Meta) uiHintsDisabled() bool {
+	// Either the local env var is set to false,
+	// or the agent config is set to false nad the local config isn't set to true
+
+	// First check if the user/env var is set to false. If it is, return early.
+	if m.showCLIHints != nil && !*m.showCLIHints {
+		return true
+	}
+
+	// Next, check if the agent config is set to false. If it is, return early.
 	client, err := m.Client()
 	if err != nil {
 		return true
 	}
+
 	agent, err := client.Agent().Self()
 	if err != nil {
 		return true
 	}
+
 	agentConfig := agent.Config
-	uiConfig, ok := agentConfig["UI"].(map[string]interface{})
+	agentUIConfig, ok := agentConfig["UI"].(map[string]interface{})
 	if !ok {
+		return false
+	}
+
+	agentShowCLIHints, ok := agentUIConfig["ShowCLIHints"].(bool)
+	if !ok {
+		return false
+	}
+
+	if !agentShowCLIHints {
+		// check to see if env var is set to true, overriding the agent setting
+		if m.showCLIHints != nil && *m.showCLIHints {
+			return false
+		}
 		return true
 	}
 
-	return !uiConfig["CLIURLLinks"].(bool)
+	return false
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -509,8 +509,12 @@ var CommandUIRoutes = map[string]UIRoute{
 		Description: "View allocation details",
 	},
 	"var list": {
-		Path:        "/variables/path/:prefix",
+		Path:        "/variables",
 		Description: "View Nomad variables",
+	},
+	"var list prefix": {
+		Path:        "/variables/path/:prefix",
+		Description: "View Nomad variables at this path",
 	},
 	"var get": {
 		Path:        "/variables/var/:path@:namespace",

--- a/command/meta.go
+++ b/command/meta.go
@@ -487,6 +487,18 @@ var CommandUIRoutes = map[string]UIRoute{
 		Path:        "/clients/:nodeID",
 		Description: "View client details and metrics",
 	},
+	"job status": {
+		Path:        "/jobs",
+		Description: "View and manage Nomad jobs",
+	},
+	"job status single": {
+		Path:        "/jobs/:jobID",
+		Description: "View job details and metrics",
+	},
+	"alloc status": {
+		Path:        "/allocations/:allocID",
+		Description: "View allocation details",
+	},
 }
 
 func (m *Meta) formatUIHint(url string, description string) string {
@@ -525,7 +537,7 @@ func (m *Meta) buildUIPath(route UIRoute, params map[string]string) (string, err
 
 	path := route.Path
 	for k, v := range params {
-		path = strings.Replace(path, fmt.Sprintf(":%s", k), v, -1)
+		path = strings.ReplaceAll(path, fmt.Sprintf(":%s", k), v)
 	}
 
 	return fmt.Sprintf("%s/ui%s", client.Address(), path), nil

--- a/command/meta.go
+++ b/command/meta.go
@@ -520,6 +520,22 @@ var CommandUIRoutes = map[string]UIRoute{
 		Path:        "/variables/var/:path@:namespace",
 		Description: "View variable details",
 	},
+	"job dispatch": {
+		Path:        "/jobs/:dispatchID",
+		Description: "View this job",
+	},
+	"eval list": {
+		Path:        "/evaluations",
+		Description: "View evaluations",
+	},
+	"eval status": {
+		Path:        "/evaluations?currentEval=:evalID",
+		Description: "View evaluation details",
+	},
+	"deployment status": {
+		Path:        "/jobs/:jobID/deployments",
+		Description: "View all deployments for this job",
+	},
 }
 
 func (m *Meta) formatUIHint(url string, description string) string {

--- a/command/meta.go
+++ b/command/meta.go
@@ -277,7 +277,7 @@ func (m *Meta) SetupUi(args []string) {
 	}
 
 	// Check to see if the user has disabled hints via env var.
-	showCLIHints := os.Getenv(EnvNomadShowCLIHints)
+	showCLIHints := os.Getenv(EnvNomadCLIShowHints)
 	if showCLIHints == "false" {
 		m.showCLIHints = pointer.Of(false)
 	} else if showCLIHints == "true" {
@@ -636,7 +636,7 @@ func (m *Meta) uiHintsDisabled() bool {
 	}
 
 	agentConfig := agent.Config
-	agentUIConfig, ok := agentConfig["UI"].(map[string]interface{})
+	agentUIConfig, ok := agentConfig["UI"].(map[string]any)
 	if !ok {
 		return false
 	}

--- a/command/meta.go
+++ b/command/meta.go
@@ -497,11 +497,11 @@ var CommandUIRoutes = map[string]UIRoute{
 		Description: "View and manage Nomad jobs",
 	},
 	"job status single": {
-		Path:        "/jobs/:jobID",
+		Path:        "/jobs/:jobID@:namespace",
 		Description: "View job details and metrics",
 	},
 	"job run": {
-		Path:        "/jobs/:jobID",
+		Path:        "/jobs/:jobID@:namespace",
 		Description: "View this job",
 	},
 	"alloc status": {

--- a/command/meta.go
+++ b/command/meta.go
@@ -502,11 +502,23 @@ var CommandUIRoutes = map[string]UIRoute{
 	},
 	"job run": {
 		Path:        "/jobs/:jobID",
-		Description: "View this job in the Web UI",
+		Description: "View this job",
 	},
 	"alloc status": {
 		Path:        "/allocations/:allocID",
 		Description: "View allocation details",
+	},
+	"var list": {
+		Path:        "/variables/path/:prefix",
+		Description: "View Nomad variables",
+	},
+	"var get": {
+		Path:        "/variables/var/:path@:namespace",
+		Description: "View variable details",
+	},
+	"var put": {
+		Path:        "/variables/var/:path@:namespace",
+		Description: "View variable details",
 	},
 }
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -451,3 +451,96 @@ type funcVar func(s string) error
 func (f funcVar) Set(s string) error { return f(s) }
 func (f funcVar) String() string     { return "" }
 func (f funcVar) IsBoolFlag() bool   { return false }
+
+type UIRoute struct {
+	Path        string
+	Description string
+}
+
+type UIHintContext struct {
+	Command    string
+	PathParams map[string]string
+}
+
+const (
+	// Colors and styles
+	resetter = "\033[0m"
+	magenta  = "\033[35m"
+	blue     = "\033[34m"
+	bold     = "\033[1m"
+
+	// Output formatting
+	uiHintDelimiter = "\n\n==> "
+	defaultHint     = "See more in the Web UI:"
+)
+
+var CommandUIRoutes = map[string]UIRoute{
+	"server members": {
+		Path:        "/servers",
+		Description: "View and manage Nomad servers",
+	},
+	"node status": {
+		Path:        "/clients",
+		Description: "View and manage Nomad clients",
+	},
+	"node status single": {
+		Path:        "/clients/:nodeID",
+		Description: "View client details and metrics",
+	},
+}
+
+func (m *Meta) formatUIHint(url string, description string) string {
+	if description == "" {
+		description = defaultHint
+	}
+
+	description = fmt.Sprintf("%s in the Web UI:", description)
+
+	// Basic version without colors
+	hint := fmt.Sprintf("%s%s %s", uiHintDelimiter, description, url)
+
+	// If colors are disabled, return basic version
+	_, coloredUi := m.Ui.(*cli.ColoredUi)
+	if m.noColor || !coloredUi {
+		return hint
+	}
+
+	return fmt.Sprintf("%[1]s%[2]s%[3]s%[4]s%[5]s %[6]s%[7]s%[8]s",
+		bold,
+		magenta,
+		uiHintDelimiter[1:], // "==> "
+		description,
+		resetter,
+		blue,
+		url,
+		resetter,
+	)
+}
+
+func (m *Meta) buildUIPath(route UIRoute, params map[string]string) (string, error) {
+	client, err := m.Client()
+	if err != nil {
+		return "", fmt.Errorf("error getting client config: %v", err)
+	}
+
+	path := route.Path
+	for k, v := range params {
+		path = strings.Replace(path, fmt.Sprintf(":%s", k), v, -1)
+	}
+
+	return fmt.Sprintf("%s/ui%s", client.Address(), path), nil
+}
+
+func (m *Meta) showUIPath(ctx UIHintContext) (string, error) {
+	route, exists := CommandUIRoutes[ctx.Command]
+	if !exists {
+		return "", nil
+	}
+
+	url, err := m.buildUIPath(route, ctx.PathParams)
+	if err != nil {
+		return "", err
+	}
+
+	return m.formatUIHint(url, route.Description), nil
+}

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -441,8 +441,6 @@ func TestMeta_ShowUIPath(t *testing.T) {
 	for _, tc := range cases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			route := CommandUIRoutes[tc.context.Command]
 			expectedHint := fmt.Sprintf("\n\n==> %s in the Web UI: %s", route.Description, tc.expectedURL)
 

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -537,7 +537,7 @@ func TestMeta_ShowUIPath_EnvVarOverride(t *testing.T) {
 
 			// Set environment variable
 			if tc.envValue != "" {
-				t.Setenv("NOMAD_SHOW_CLI_HINTS", tc.envValue)
+				t.Setenv("NOMAD_CLI_SHOW_HINTS", tc.envValue)
 			}
 
 			// Create a test server with UI enabled and CLI hints as per test case

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -497,10 +497,30 @@ func TestMeta_ShowUIPath_CLIURLLinksDisabled(t *testing.T) {
 	must.StrNotContains(t, hint, url+"/ui/jobs")
 }
 
-// TODO: invalid/edge cases
-// - unknown command
-// - missing required params
-// - invalid path params
-// - --output flag on job run
+func TestMeta_ShowUIPath_BrowserOpening(t *testing.T) {
+	ci.Parallel(t)
 
-// TODO: browser opening tests
+	server, client, url := testServer(t, true, func(c *agent.Config) {
+		c.UI.CLIURLLinks = pointer.Of(true)
+	})
+	defer server.Shutdown()
+	waitForNodes(t, client)
+
+	ui := cli.NewMockUi()
+
+	m := &Meta{
+		Ui:          ui,
+		flagAddress: url,
+	}
+
+	hint, err := m.showUIPath(UIHintContext{
+		Command: "job status",
+		OpenURL: true,
+	})
+	must.NoError(t, err)
+	must.StrContains(t, hint, url+"/ui/jobs")
+
+	// Not a perfect test, but it's a start: make sure showUIPath isn't warning about
+	// being unable to open the browser.
+	must.StrNotContains(t, ui.ErrorWriter.String(), "Failed to open browser")
+}

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -43,6 +43,7 @@ type NodeStatusCommand struct {
 	pageToken   string
 	filter      string
 	tmpl        string
+	openURL     bool
 }
 
 func (c *NodeStatusCommand) Help() string {
@@ -92,6 +93,9 @@ Node Status Options:
   -filter
     Specifies an expression used to filter query results.
 
+  -ui
+    Open the node status page in the browser.
+
   -os
     Display operating system name.
 
@@ -126,6 +130,7 @@ func (c *NodeStatusCommand) AutocompleteFlags() complete.Flags {
 			"-os":         complete.PredictAnything,
 			"-quiet":      complete.PredictAnything,
 			"-verbose":    complete.PredictNothing,
+			"-ui":         complete.PredictNothing,
 		})
 }
 
@@ -166,6 +171,7 @@ func (c *NodeStatusCommand) Run(args []string) int {
 	flags.StringVar(&c.filter, "filter", "", "")
 	flags.IntVar(&c.perPage, "per-page", 0, "")
 	flags.StringVar(&c.pageToken, "page-token", "", "")
+	flags.BoolVar(&c.openURL, "ui", false, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -314,6 +320,7 @@ Results have been paginated. To get the next page run:
 
 		hint, _ := c.Meta.showUIPath(UIHintContext{
 			Command: c.Name(),
+			OpenURL: c.openURL,
 		})
 		if hint != "" {
 			c.Ui.Output(hint)
@@ -517,6 +524,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 			PathParams: map[string]string{
 				"nodeID": node.ID,
 			},
+			OpenURL: c.openURL,
 		})
 		if hint != "" {
 			c.Ui.Output(hint)
@@ -614,6 +622,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		PathParams: map[string]string{
 			"nodeID": node.ID,
 		},
+		OpenURL: c.openURL,
 	})
 	if hint != "" {
 		c.Ui.Output(hint)

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -312,6 +312,13 @@ Results have been paginated. To get the next page run:
 %s -page-token %s`, argsWithoutPageToken(os.Args), qm.NextToken))
 		}
 
+		hint, _ := c.Meta.showUIPath(UIHintContext{
+			Command: c.Name(),
+		})
+		if hint != "" {
+			c.Ui.Output(hint)
+		}
+
 		return 0
 	}
 
@@ -369,6 +376,7 @@ Results have been paginated. To get the next page run:
 	}
 
 	return c.formatNode(client, node)
+
 }
 
 func nodeDrivers(n *api.Node) []string {
@@ -504,6 +512,16 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		basic = append(basic, fmt.Sprintf("Drivers|%s", strings.Join(nodeDrivers(node), ",")))
 		c.Ui.Output(c.Colorize().Color(formatKV(basic)))
 
+		hint, _ := c.Meta.showUIPath(UIHintContext{
+			Command: "node status single",
+			PathParams: map[string]string{
+				"nodeID": node.ID,
+			},
+		})
+		if hint != "" {
+			c.Ui.Output(hint)
+		}
+
 		// Output alloc info
 		if err := c.outputAllocInfo(node, nodeAllocs); err != nil {
 			c.Ui.Error(fmt.Sprintf("%s", err))
@@ -589,6 +607,16 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 	if err := c.outputAllocInfo(node, nodeAllocs); err != nil {
 		c.Ui.Error(fmt.Sprintf("%s", err))
 		return 1
+	}
+
+	hint, _ := c.Meta.showUIPath(UIHintContext{
+		Command: "node status single",
+		PathParams: map[string]string{
+			"nodeID": node.ID,
+		},
+	})
+	if hint != "" {
+		c.Ui.Output(hint)
 	}
 
 	return 0

--- a/command/node_status.go
+++ b/command/node_status.go
@@ -323,7 +323,7 @@ Results have been paginated. To get the next page run:
 			OpenURL: c.openURL,
 		})
 		if hint != "" {
-			c.Ui.Output(hint)
+			c.Ui.Warn(hint)
 		}
 
 		return 0
@@ -527,7 +527,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 			OpenURL: c.openURL,
 		})
 		if hint != "" {
-			c.Ui.Output(hint)
+			c.Ui.Warn(hint)
 		}
 
 		// Output alloc info
@@ -625,7 +625,7 @@ func (c *NodeStatusCommand) formatNode(client *api.Client, node *api.Node) int {
 		OpenURL: c.openURL,
 	})
 	if hint != "" {
-		c.Ui.Output(hint)
+		c.Ui.Warn(hint)
 	}
 
 	return 0

--- a/command/plugin_status.go
+++ b/command/plugin_status.go
@@ -146,7 +146,5 @@ func (c *PluginStatusCommand) Run(args []string) int {
 
 	// Extend this section with other plugin implementations
 
-	// TODO: add UI Hints
-
 	return 0
 }

--- a/command/plugin_status.go
+++ b/command/plugin_status.go
@@ -146,5 +146,7 @@ func (c *PluginStatusCommand) Run(args []string) int {
 
 	// Extend this section with other plugin implementations
 
+	// TODO: add UI Hints
+
 	return 0
 }

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -146,6 +146,16 @@ func (c *ServerMembersCommand) Run(args []string) int {
 	// Dump the list
 	c.Ui.Output(columnize.SimpleFormat(out))
 
+	// c.Meta.showUIPath(UIHintContext{
+	// 	Command: "server members",
+	// })
+	hint, _ := c.Meta.showUIPath(UIHintContext{
+		Command: c.Name(),
+	})
+	if hint != "" {
+		c.Ui.Output(hint)
+	}
+
 	// If there were leader errors display a warning
 	if leaderErr != nil {
 		c.Ui.Output("")

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -39,6 +39,9 @@ Server Members Options:
     Show detailed information about each member. This dumps a raw set of tags
     which shows more information than the default output format.
 
+  -ui
+    Open the servers page in the browser.
+
  -json
     Output the latest information about each member in a JSON format.
 
@@ -55,6 +58,7 @@ func (c *ServerMembersCommand) AutocompleteFlags() complete.Flags {
 			"-verbose":  complete.PredictNothing,
 			"-json":     complete.PredictNothing,
 			"-t":        complete.PredictAnything,
+			"-ui":       complete.PredictNothing,
 		})
 }
 
@@ -69,7 +73,7 @@ func (c *ServerMembersCommand) Synopsis() string {
 func (c *ServerMembersCommand) Name() string { return "server members" }
 
 func (c *ServerMembersCommand) Run(args []string) int {
-	var detailed, verbose, json bool
+	var detailed, verbose, json, openURL bool
 	var tmpl string
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
@@ -77,6 +81,7 @@ func (c *ServerMembersCommand) Run(args []string) int {
 	flags.BoolVar(&detailed, "detailed", false, "Show detailed output")
 	flags.BoolVar(&verbose, "verbose", false, "Show detailed output")
 	flags.BoolVar(&json, "json", false, "")
+	flags.BoolVar(&openURL, "ui", false, "Open the servers page in the browser")
 	flags.StringVar(&tmpl, "t", "", "")
 
 	if err := flags.Parse(args); err != nil {
@@ -146,11 +151,9 @@ func (c *ServerMembersCommand) Run(args []string) int {
 	// Dump the list
 	c.Ui.Output(columnize.SimpleFormat(out))
 
-	// c.Meta.showUIPath(UIHintContext{
-	// 	Command: "server members",
-	// })
 	hint, _ := c.Meta.showUIPath(UIHintContext{
 		Command: c.Name(),
+		OpenURL: openURL,
 	})
 	if hint != "" {
 		c.Ui.Output(hint)

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -156,7 +156,7 @@ func (c *ServerMembersCommand) Run(args []string) int {
 		OpenURL: openURL,
 	})
 	if hint != "" {
-		c.Ui.Output(hint)
+		c.Ui.Warn(hint)
 	}
 
 	// If there were leader errors display a warning

--- a/command/status.go
+++ b/command/status.go
@@ -17,6 +17,7 @@ type StatusCommand struct {
 
 	// Placeholder bool to allow passing of verbose flags to subcommands.
 	verbose bool
+	openURL bool
 }
 
 func (c *StatusCommand) Help() string {
@@ -38,6 +39,9 @@ Status Options:
 
   -verbose
     Display full information.
+
+  -ui
+    Open the status page in the browser.
 `
 
 	return strings.TrimSpace(helpText)
@@ -51,6 +55,7 @@ func (c *StatusCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
 			"-verbose": complete.PredictNothing,
+			"-ui":      complete.PredictNothing,
 		})
 }
 
@@ -84,7 +89,7 @@ func (c *StatusCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet("status", FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.BoolVar(&c.verbose, "verbose", false, "")
-
+	flags.BoolVar(&c.openURL, "ui", false, "")
 	if err := flags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error parsing arguments: %q", err))
 		return 1

--- a/command/testing_test.go
+++ b/command/testing_test.go
@@ -25,6 +25,9 @@ func testServer(t *testing.T, runClient bool, cb func(*agent.Config)) (*agent.Te
 	a := agent.NewTestAgent(t, t.Name(), func(config *agent.Config) {
 		config.Client.Enabled = runClient
 
+		// Disable UI hints in test by default
+		config.UI.CLIURLLinks = pointer.Of(false)
+
 		if cb != nil {
 			cb(config)
 		}

--- a/command/testing_test.go
+++ b/command/testing_test.go
@@ -26,7 +26,7 @@ func testServer(t *testing.T, runClient bool, cb func(*agent.Config)) (*agent.Te
 		config.Client.Enabled = runClient
 
 		// Disable UI hints in test by default
-		config.UI.CLIURLLinks = pointer.Of(false)
+		config.UI.ShowCLIHints = pointer.Of(false)
 
 		if cb != nil {
 			cb(config)

--- a/command/var_get.go
+++ b/command/var_get.go
@@ -50,7 +50,7 @@ Get Options:
      Template to render output with. Required when output is "go-template".
 
   -ui
-    Open the variable get page in the browser.
+    Open the variable page in the browser.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/var_get.go
+++ b/command/var_get.go
@@ -176,7 +176,7 @@ func (c *VarGetCommand) Run(args []string) int {
 			OpenURL: openURL,
 		})
 		if hint != "" {
-			c.Ui.Output(hint)
+			c.Ui.Warn(hint)
 		}
 
 		return 0
@@ -193,7 +193,7 @@ func (c *VarGetCommand) Run(args []string) int {
 		OpenURL: openURL,
 	})
 	if hint != "" {
-		c.Ui.Output(hint)
+		c.Ui.Warn(hint)
 	}
 	return 0
 }

--- a/command/var_list.go
+++ b/command/var_list.go
@@ -217,15 +217,25 @@ func (c *VarListCommand) Run(args []string) int {
 		c.Ui.Warn(fmt.Sprintf("Next page token: %s", qm.NextToken))
 	}
 
-	hint, _ := c.Meta.showUIPath(UIHintContext{
-		Command: "var list",
-		PathParams: map[string]string{
-			"prefix": prefix,
-		},
-		OpenURL: openURL,
-	})
-	if hint != "" {
-		c.Ui.Output(hint)
+	if prefix != "" {
+		hint, _ := c.Meta.showUIPath(UIHintContext{
+			Command: "var list prefix",
+			PathParams: map[string]string{
+				"prefix": prefix,
+			},
+			OpenURL: openURL,
+		})
+		if hint != "" {
+			c.Ui.Output(hint)
+		}
+	} else {
+		hint, _ := c.Meta.showUIPath(UIHintContext{
+			Command: "var list",
+			OpenURL: openURL,
+		})
+		if hint != "" {
+			c.Ui.Output(hint)
+		}
 	}
 
 	return 0

--- a/command/var_list.go
+++ b/command/var_list.go
@@ -226,7 +226,7 @@ func (c *VarListCommand) Run(args []string) int {
 			OpenURL: openURL,
 		})
 		if hint != "" {
-			c.Ui.Output(hint)
+			c.Ui.Warn(hint)
 		}
 	} else {
 		hint, _ := c.Meta.showUIPath(UIHintContext{
@@ -234,7 +234,7 @@ func (c *VarListCommand) Run(args []string) int {
 			OpenURL: openURL,
 		})
 		if hint != "" {
-			c.Ui.Output(hint)
+			c.Ui.Warn(hint)
 		}
 	}
 

--- a/command/var_put.go
+++ b/command/var_put.go
@@ -368,7 +368,7 @@ func (c *VarPutCommand) Run(args []string) int {
 			OpenURL: openURL,
 		})
 		if hint != "" {
-			c.Ui.Output(hint)
+			c.Ui.Warn(hint)
 		}
 		return 0
 	default:
@@ -382,7 +382,7 @@ func (c *VarPutCommand) Run(args []string) int {
 			OpenURL: openURL,
 		})
 		if hint != "" {
-			c.Ui.Output(hint)
+			c.Ui.Warn(hint)
 		}
 		return 0
 	}
@@ -397,7 +397,7 @@ func (c *VarPutCommand) Run(args []string) int {
 		OpenURL: openURL,
 	})
 	if hint != "" {
-		c.Ui.Output(hint)
+		c.Ui.Warn(hint)
 	}
 	return 0
 }

--- a/command/var_put.go
+++ b/command/var_put.go
@@ -103,7 +103,7 @@ Var put Options:
      output (stdout) for redirected output.
 
   -ui
-    Open the variable put page in the browser.
+    Open the variable page in the browser.
 
 `
 	return strings.TrimSpace(helpText)

--- a/helper/pluginutils/catalog/register.go
+++ b/helper/pluginutils/catalog/register.go
@@ -3,13 +3,11 @@
 
 package catalog
 
-// TODO: changes made to get mac buildin' again.
-
 import (
 	"github.com/hashicorp/nomad/drivers/docker"
-	// "github.com/hashicorp/nomad/drivers/exec"
-	// "github.com/hashicorp/nomad/drivers/java"
-	// "github.com/hashicorp/nomad/drivers/qemu"
+	"github.com/hashicorp/nomad/drivers/exec"
+	"github.com/hashicorp/nomad/drivers/java"
+	"github.com/hashicorp/nomad/drivers/qemu"
 	"github.com/hashicorp/nomad/drivers/rawexec"
 )
 
@@ -18,8 +16,8 @@ import (
 // register_XXX.go file.
 func init() {
 	RegisterDeferredConfig(rawexec.PluginID, rawexec.PluginConfig, rawexec.PluginLoader)
-	// Register(exec.PluginID, exec.PluginConfig)
-	// Register(qemu.PluginID, qemu.PluginConfig)
-	// Register(java.PluginID, java.PluginConfig)
+	Register(exec.PluginID, exec.PluginConfig)
+	Register(qemu.PluginID, qemu.PluginConfig)
+	Register(java.PluginID, java.PluginConfig)
 	RegisterDeferredConfig(docker.PluginID, docker.PluginConfig, docker.PluginLoader)
 }

--- a/helper/pluginutils/catalog/register.go
+++ b/helper/pluginutils/catalog/register.go
@@ -3,11 +3,13 @@
 
 package catalog
 
+// TODO: changes made to get mac buildin' again.
+
 import (
 	"github.com/hashicorp/nomad/drivers/docker"
-	"github.com/hashicorp/nomad/drivers/exec"
-	"github.com/hashicorp/nomad/drivers/java"
-	"github.com/hashicorp/nomad/drivers/qemu"
+	// "github.com/hashicorp/nomad/drivers/exec"
+	// "github.com/hashicorp/nomad/drivers/java"
+	// "github.com/hashicorp/nomad/drivers/qemu"
 	"github.com/hashicorp/nomad/drivers/rawexec"
 )
 
@@ -16,8 +18,8 @@ import (
 // register_XXX.go file.
 func init() {
 	RegisterDeferredConfig(rawexec.PluginID, rawexec.PluginConfig, rawexec.PluginLoader)
-	Register(exec.PluginID, exec.PluginConfig)
-	Register(qemu.PluginID, qemu.PluginConfig)
-	Register(java.PluginID, java.PluginConfig)
+	// Register(exec.PluginID, exec.PluginConfig)
+	// Register(qemu.PluginID, qemu.PluginConfig)
+	// Register(java.PluginID, java.PluginConfig)
 	RegisterDeferredConfig(docker.PluginID, docker.PluginConfig, docker.PluginLoader)
 }

--- a/nomad/structs/config/ui.go
+++ b/nomad/structs/config/ui.go
@@ -28,6 +28,9 @@ type UIConfig struct {
 
 	// Label configures UI label styles
 	Label *LabelUIConfig `hcl:"label"`
+
+	// CLIURLLinks controls whether CLI commands that return URLs will output that url as a hint
+	CLIURLLinks *bool `hcl:"cli_url_links"`
 }
 
 // only covers the elements of
@@ -136,12 +139,14 @@ type LabelUIConfig struct {
 // DefaultUIConfig returns the canonical defaults for the Nomad
 // `ui` configuration.
 func DefaultUIConfig() *UIConfig {
+	enabled := true
 	return &UIConfig{
-		Enabled:               true,
+		Enabled:               enabled,
 		Consul:                &ConsulUIConfig{},
 		Vault:                 &VaultUIConfig{},
 		Label:                 &LabelUIConfig{},
 		ContentSecurityPolicy: DefaultCSPConfig(),
+		CLIURLLinks:           &enabled,
 	}
 }
 
@@ -176,6 +181,10 @@ func (old *UIConfig) Merge(other *UIConfig) *UIConfig {
 	result.Vault = result.Vault.Merge(other.Vault)
 	result.Label = result.Label.Merge(other.Label)
 	result.ContentSecurityPolicy = result.ContentSecurityPolicy.Merge(other.ContentSecurityPolicy)
+
+	if other.CLIURLLinks != nil {
+		result.CLIURLLinks = other.CLIURLLinks
+	}
 
 	return result
 }

--- a/nomad/structs/config/ui.go
+++ b/nomad/structs/config/ui.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"github.com/hashicorp/nomad/helper/pointer"
 )
 
 // UIConfig contains the operator configuration of the web UI
@@ -139,14 +141,13 @@ type LabelUIConfig struct {
 // DefaultUIConfig returns the canonical defaults for the Nomad
 // `ui` configuration.
 func DefaultUIConfig() *UIConfig {
-	enabled := true
 	return &UIConfig{
-		Enabled:               enabled,
+		Enabled:               true,
 		Consul:                &ConsulUIConfig{},
 		Vault:                 &VaultUIConfig{},
 		Label:                 &LabelUIConfig{},
 		ContentSecurityPolicy: DefaultCSPConfig(),
-		ShowCLIHints:          &enabled,
+		ShowCLIHints:          pointer.Of(true),
 	}
 }
 

--- a/nomad/structs/config/ui.go
+++ b/nomad/structs/config/ui.go
@@ -29,8 +29,8 @@ type UIConfig struct {
 	// Label configures UI label styles
 	Label *LabelUIConfig `hcl:"label"`
 
-	// CLIURLLinks controls whether CLI commands that return URLs will output that url as a hint
-	CLIURLLinks *bool `hcl:"cli_url_links"`
+	// ShowCLIHints controls whether CLI commands that return URLs will output that url as a hint
+	ShowCLIHints *bool `hcl:"show_cli_hints"`
 }
 
 // only covers the elements of
@@ -146,7 +146,7 @@ func DefaultUIConfig() *UIConfig {
 		Vault:                 &VaultUIConfig{},
 		Label:                 &LabelUIConfig{},
 		ContentSecurityPolicy: DefaultCSPConfig(),
-		CLIURLLinks:           &enabled,
+		ShowCLIHints:          &enabled,
 	}
 }
 
@@ -182,8 +182,8 @@ func (old *UIConfig) Merge(other *UIConfig) *UIConfig {
 	result.Label = result.Label.Merge(other.Label)
 	result.ContentSecurityPolicy = result.ContentSecurityPolicy.Merge(other.ContentSecurityPolicy)
 
-	if other.CLIURLLinks != nil {
-		result.CLIURLLinks = other.CLIURLLinks
+	if other.ShowCLIHints != nil {
+		result.ShowCLIHints = other.ShowCLIHints
 	}
 
 	return result

--- a/website/content/docs/commands/alloc/status.mdx
+++ b/website/content/docs/commands/alloc/status.mdx
@@ -35,6 +35,7 @@ When ACLs are enabled, this command requires a token with the `read-job` and
 - `-verbose`: Show full information.
 - `-json` : Output the allocation in its JSON format.
 - `-t` : Format and display the allocation using a Go template.
+- `-ui` : Open the allocation status page in the browser.
 
 ## Examples
 

--- a/website/content/docs/commands/deployment/status.mdx
+++ b/website/content/docs/commands/deployment/status.mdx
@@ -40,6 +40,7 @@ capability for the deployment's namespace.
 - `-monitor`: Enter monitor mode to poll for updates to the deployment status.
 - `-wait`: How long to wait before polling an update, used in conjunction with monitor
     mode. Defaults to 2s.
+- `-ui`: Open the deployment page in the browser.
 
 ## Examples
 
@@ -135,8 +136,8 @@ $ nomad deployment status -monitor e45
     web         false        1        1       1        0          2021-06-09T15:59:58-07:00
 ```
 
-**Please note**: The library used for updating terminal output in place currently isn't fully 
-Windows compatible so there may be some formatting differences (different margins, no spinner 
+**Please note**: The library used for updating terminal output in place currently isn't fully
+Windows compatible so there may be some formatting differences (different margins, no spinner
 indicating deployment is in progress).
 
 [`auto_revert`]: /nomad/docs/job-specification/update#auto_revert

--- a/website/content/docs/commands/eval/list.mdx
+++ b/website/content/docs/commands/eval/list.mdx
@@ -34,6 +34,7 @@ capability for the requested namespace.
 - `-status`: Only show evaluations with this status.
 - `-json`: Output the evaluation in its JSON format.
 - `-t`: Format and display evaluation using a Go template.
+- `-ui`: Open the evaluations page in the browser.
 
 ## Examples
 

--- a/website/content/docs/commands/eval/status.mdx
+++ b/website/content/docs/commands/eval/status.mdx
@@ -50,6 +50,7 @@ indicated by exit code 1.
   -json`. In Nomad 1.4.0 the behavior of this option will change to
   output only the selected evaluation in JSON.
 - `-t` : Format and display evaluation using a Go template.
+- `-ui`: Open the evaluation in the browser.
 
 ## Examples
 

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -94,6 +94,8 @@ flags.
 
 - `NOMAD_CLI_NO_COLOR` - Disables colored command output.
 
+- `NOMAD_SHOW_CLI_HINTS` - Enables ui-hints in common CLI command output.
+
 #### mTLS Environment Variables
 
 - `NOMAD_CLIENT_CERT` - Path to a PEM encoded client certificate for TLS

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -94,7 +94,7 @@ flags.
 
 - `NOMAD_CLI_NO_COLOR` - Disables colored command output.
 
-- `NOMAD_SHOW_CLI_HINTS` - Enables ui-hints in common CLI command output.
+- `NOMAD_CLI_SHOW_HINTS` - Enables ui-hints in common CLI command output.
 
 #### mTLS Environment Variables
 

--- a/website/content/docs/commands/job/dispatch.mdx
+++ b/website/content/docs/commands/job/dispatch.mdx
@@ -76,6 +76,8 @@ dispatching parameterized jobs.
 
 - `-verbose`: Show full information.
 
+- `-ui`: Open the dispatched job in the browser.
+
 ## Examples
 
 Dispatch against a parameterized job with the ID "video-encode" and

--- a/website/content/docs/commands/job/run.mdx
+++ b/website/content/docs/commands/job/run.mdx
@@ -97,6 +97,8 @@ that volume.
 
 - `-verbose`: Show full information.
 
+- `-ui`: Open the job page in the browser.
+
 ## Examples
 
 Schedule the job contained in the file `example.nomad.hcl`, monitoring placement and deployment:

--- a/website/content/docs/commands/job/status.mdx
+++ b/website/content/docs/commands/job/status.mdx
@@ -53,6 +53,8 @@ run the command with a job prefix instead of the exact job ID.
 - `-verbose`: Show full information. Allocation create and modify times are
   shown in `yyyy/mm/dd hh:mm:ss` format.
 
+- `-ui`: Open the job status page in the browser.
+
 ## Examples
 
 List of all jobs:

--- a/website/content/docs/commands/node/status.mdx
+++ b/website/content/docs/commands/node/status.mdx
@@ -61,6 +61,8 @@ capability.
 
 - `-t` : Format and display node using a Go template.
 
+- `-ui` : Open the node status page in the browser
+
 ## Examples
 
 List view:

--- a/website/content/docs/commands/server/members.mdx
+++ b/website/content/docs/commands/server/members.mdx
@@ -40,6 +40,8 @@ capability.
 
 - `-t`: Format and display the server memebers using a Go template.
 
+- `-ui`: Open the servers page in the browser.
+
 ## Examples
 
 Default view:

--- a/website/content/docs/commands/var/get.mdx
+++ b/website/content/docs/commands/var/get.mdx
@@ -39,6 +39,8 @@ documentation for details.
 - `-template` `(string: "")` Template to render output with. Required when
   output is "go-template".
 
+- `-ui`: Open the variable page in the browser.
+
 ## Examples
 
 Retrieve the variable stored at path "secret/creds":

--- a/website/content/docs/commands/var/list.mdx
+++ b/website/content/docs/commands/var/list.mdx
@@ -52,6 +52,8 @@ documentation for details.
 - `-template` `(string: "")` Template to render output with. Required when
   output is "go-template".
 
+- `-ui`: Open the variable list page in the browser.
+
 ## Examples
 
 List values under the key "nomad/jobs":

--- a/website/content/docs/commands/var/put.mdx
+++ b/website/content/docs/commands/var/put.mdx
@@ -83,6 +83,8 @@ taking the sum of the length in bytes of all of the unencrypted keys and values.
 - `-verbose`: Provides additional information via standard error to preserve
   standard output (stdout) for redirected output.
 
+- `-ui`: Open the variable page in the browser.
+
 ## Examples
 
 Writes the data to the path "secret/creds":

--- a/website/content/docs/configuration/ui.mdx
+++ b/website/content/docs/configuration/ui.mdx
@@ -60,6 +60,11 @@ and the configuration is individual to each agent.
 - `label` <code>([Label]: nil)</code> - Configures a user-defined
   label to display in the Nomad Web UI header.
 
+- `cli_url_links` `(bool: true)` - Controls whether CLI commands display hints
+  about equivalent UI pages. For example, when running `nomad server members`,
+  the CLI will show a message indicating where to find server information in
+  the web UI. Set to `false` to disable these hints.
+
 ## `content_security_policy` Parameters
 
 The `content_security_policy` block configures the HTTP

--- a/website/content/docs/configuration/ui.mdx
+++ b/website/content/docs/configuration/ui.mdx
@@ -62,7 +62,7 @@ and the configuration is individual to each agent.
 
 - `show_cli_hints` `(bool: true)` - Controls whether CLI commands display hints
   about equivalent UI pages. For example, when running `nomad server members`,
-  the CLI will show a message indicating where to find server information in
+  the CLI shows a message indicating where to find server information in
   the web UI. Set to `false` to disable these hints.
 
 ## `content_security_policy` Parameters
@@ -113,10 +113,10 @@ header sent with the web UI response.
 - `text` `(string: "")` - Specifies the text of the label that will be
   displayed in the header of the Web UI.
 - `background_color` `(string: "")` - The background color of the label to
-  be displayed. The Web UI will default to a black background. HEX values
+  be displayed. The Web UI defaults to a black background. HEX values
   may be used.
 - `text_color` `(string: "")` - The text color of the label to be displayed.
-  The Web UI will default to white text. HEX values may be used.
+  The Web UI defaults to white text. HEX values may be used.
 
 
 

--- a/website/content/docs/configuration/ui.mdx
+++ b/website/content/docs/configuration/ui.mdx
@@ -60,7 +60,7 @@ and the configuration is individual to each agent.
 - `label` <code>([Label]: nil)</code> - Configures a user-defined
   label to display in the Nomad Web UI header.
 
-- `cli_url_links` `(bool: true)` - Controls whether CLI commands display hints
+- `show_cli_hints` `(bool: true)` - Controls whether CLI commands display hints
   about equivalent UI pages. For example, when running `nomad server members`,
   the CLI will show a message indicating where to find server information in
   the web UI. Set to `false` to disable these hints.


### PR DESCRIPTION
Adds a "View more in the Web UI: $url" message at the end of common CLI commands to give users a way to dive deeper with a single click (or copy/paste)

<img width="1011" alt="image" src="https://github.com/user-attachments/assets/2ff222c3-c6b1-4056-af63-f2a96f26a72e">

Modify the `ui` block of your agent config with the following to disable: `cli_url_links = false`

Add a `-ui` flag to several common commands (`nomad job status` for example) for your default browser to open to the suggested page