### PR TITLE
scheduler: fix a bug where force GC wasn't respected

### DIFF
--- a/.changelog/24456.txt
+++ b/.changelog/24456.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fix bug where forced garbage collection does not ignore GC thresholds
+```

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -107,46 +107,34 @@ func (c *CoreScheduler) forceGC(eval *structs.Evaluation) error {
 	if err := c.jobGC(eval); err != nil {
 		return err
 	}
-
 	if err := c.evalGC(); err != nil {
 		return err
 	}
-
 	if err := c.deploymentGC(); err != nil {
 		return err
 	}
-
 	if err := c.csiPluginGC(eval); err != nil {
 		return err
 	}
-
 	if err := c.csiVolumeClaimGC(eval); err != nil {
 		return err
 	}
-
 	if err := c.expiredOneTimeTokenGC(eval); err != nil {
 		return err
 	}
-
 	if err := c.expiredACLTokenGC(eval, false); err != nil {
 		return err
 	}
-
 	if err := c.expiredACLTokenGC(eval, true); err != nil {
 		return err
 	}
-
 	if err := c.rootKeyGC(eval, time.Now()); err != nil {
 		return err
 	}
 
 	// Node GC must occur after the others to ensure the allocations are
 	// cleared.
-	if err := c.nodeGC(eval); err != nil {
-		return err
-	}
-
-	return nil
+	return c.nodeGC(eval)
 }
 
 // jobGC is used to garbage collect eligible jobs.

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -527,9 +527,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 
 	// set a shorter GC threshold this time
 	gc = s1.coreJobEval(structs.CoreJobEvalGC, jobModifyIdx*2)
-	core.(*CoreScheduler).customBatchEvalGCThreshold = time.Minute
-	//core.(*CoreScheduler).customEvalGCThreshold = time.Minute
-	//core.(*CoreScheduler).customJobGCThreshold = time.Minute
+	core.(*CoreScheduler).setCustomThresholdForObject("batchEval", time.Minute)
 	must.NoError(t, core.Process(gc))
 
 	// We expect the following:

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -527,7 +527,7 @@ func TestCoreScheduler_EvalGC_Batch(t *testing.T) {
 
 	// set a shorter GC threshold this time
 	gc = s1.coreJobEval(structs.CoreJobEvalGC, jobModifyIdx*2)
-	core.(*CoreScheduler).setCustomThresholdForObject("batchEval", time.Minute)
+	core.(*CoreScheduler).customThresholdForObject[structs.CoreJobEvalGC] = pointer.Of(time.Minute)
 	must.NoError(t, core.Process(gc))
 
 	// We expect the following:
@@ -2511,7 +2511,7 @@ func TestCoreScheduler_CSIVolumeClaimGC(t *testing.T) {
 	index++
 	gc := srv.coreJobEval(structs.CoreJobForceGC, index)
 	c := core.(*CoreScheduler)
-	require.NoError(t, c.csiVolumeClaimGC(gc))
+	require.NoError(t, c.csiVolumeClaimGC(gc, nil))
 
 	// the only remaining claim is for a deleted alloc with no path to
 	// the non-existent node, so volumewatcher will release the
@@ -2549,7 +2549,7 @@ func TestCoreScheduler_CSIBadState_ClaimGC(t *testing.T) {
 	index++
 	gc := srv.coreJobEval(structs.CoreJobForceGC, index)
 	c := core.(*CoreScheduler)
-	must.NoError(t, c.csiVolumeClaimGC(gc))
+	must.NoError(t, c.csiVolumeClaimGC(gc, nil))
 
 	vol, err := srv.State().CSIVolumeByID(nil, structs.DefaultNamespace, "csi-volume-nfs0")
 	must.NoError(t, err)

--- a/nomad/system_endpoint_test.go
+++ b/nomad/system_endpoint_test.go
@@ -34,15 +34,15 @@ func TestSystemEndpoint_GarbageCollect(t *testing.T) {
 	job := mock.Job()
 	job.Type = structs.JobTypeBatch
 	job.Stop = true
-	// submit time must be older than default job GC
-	job.SubmitTime = time.Now().Add(-6 * time.Hour).UnixNano()
+	// set submit time older than now but still newer than default GC threshold
+	job.SubmitTime = time.Now().Add(-10 * time.Millisecond).UnixNano()
 	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job))
 
 	eval := mock.Eval()
 	eval.Status = structs.EvalStatusComplete
 	eval.JobID = job.ID
-	// modify time must be older than default eval GC
-	eval.ModifyTime = time.Now().Add(-5 * time.Hour).UnixNano()
+	// set modify time older than now but still newer than default GC threshold
+	eval.ModifyTime = time.Now().Add(-10 * time.Millisecond).UnixNano()
 	must.NoError(t, state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval}))
 
 	// Make the GC request


### PR DESCRIPTION
This PR fixes a bug where `System.GarbageCollect` endpoint didn't work on objects that weren't older than their respective GC thresholds. `System.GarbageCollect` is used to force garbage collection (also used by the `system gc` command) and should ignore any GC threshold settings. 

Fixes #24455
Internal ref: https://hashicorp.atlassian.net/browse/NET-11747