### PR TITLE
[ui] Fixes double-namespace-query-param when getting versions

### DIFF
--- a/.changelog/24466.txt
+++ b/.changelog/24466.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix a bug where namespaced jobs wouldn't show diffs on the versions page
+```

--- a/ui/app/adapters/job.js
+++ b/ui/app/adapters/job.js
@@ -172,22 +172,8 @@ export default class JobAdapter extends WatchableNamespaceIDs {
   }
 
   getVersions(job, diffVersion) {
-    const url = addToPath(
-      this.urlForFindRecord(job.get('id'), 'job'),
-      '/versions'
-    );
-
-    const namespace = job.get('namespace.name') || 'default';
-
-    const query = {
-      namespace,
-      diffs: true,
-    };
-
-    if (diffVersion) {
-      query.diff_version = diffVersion;
-    }
-    return this.ajax(url, 'GET', { data: query });
+    let url = this.urlForVersions(job, diffVersion);
+    return this.ajax(url, 'GET');
   }
 
   /**
@@ -274,6 +260,17 @@ export default class JobAdapter extends WatchableNamespaceIDs {
       }
     }
     return result;
+  }
+
+  urlForVersions(job, diffVersion) {
+    let url = this.urlForFindRecord(job.get('id'), 'job', null, 'versions');
+
+    let paramString = 'diffs=true';
+    if (diffVersion) {
+      paramString += `&diff_version=${diffVersion}`;
+    }
+    url = addToPath(url, '', paramString);
+    return url;
   }
 
   urlForQuery(query, modelName, method) {


### PR DESCRIPTION
Resolves #24444 

I was using a custom `+=`-based url modifier to add the `?diffVersion` to the query to get job versions, ignoring that this was also happening in a nested `addToPath` method if other query params were inherently present — which is the case if the job has a non-default namespace.

This resulted in a url like `job/:jobid/versions?namespace=myNS?diffs=true&diffVersion=3`

This PR fixes the double `?` and lets the well-vested addToPath() handle all relevant URL param appending.

To test, try applying a namespace, running a job within it, making a new version of it, and checking out the versions page. Before, you'd get 404s and "No changes"; now you should get 200s and version changes.

<img width="1234" alt="image" src="https://github.com/user-attachments/assets/7d0d6273-1745-4ee9-8b93-f93d49bf9760">
