### PR TITLE
nsutil: wrap error that comes from the syscall so caller can do errors.As

### DIFF
--- a/client/lib/nsutil/netns_linux.go
+++ b/client/lib/nsutil/netns_linux.go
@@ -133,11 +133,11 @@ func UnmountNS(nsPath string) error {
 	// Only unmount if it's been bind-mounted (don't touch namespaces in /proc...)
 	if strings.HasPrefix(nsPath, NetNSRunDir) {
 		if err := unix.Unmount(nsPath, 0); err != nil {
-			return fmt.Errorf("failed to unmount NS: at %s: %v", nsPath, err)
+			return fmt.Errorf("failed to unmount NS: at %s: %w", nsPath, err)
 		}
 
 		if err := os.Remove(nsPath); err != nil {
-			return fmt.Errorf("failed to remove ns path %s: %v", nsPath, err)
+			return fmt.Errorf("failed to remove ns path %s: %w", nsPath, err)
 		}
 	}
 


### PR DESCRIPTION
### Description

User of `nsutil` library should be able to do the following and for it to work:

```
   var errno syscall.Errno
   if errors.As(err, &errno) {
       if errno == unix.EBUSY { ... }
   }
```

This commit fixes that issue.

### Testing & Reproduction steps
Call the function and try to do errors.As error handling, it won't work.

### Links
...

### Contributor Checklist
- [x] **Changelog Entry** No user facing behavior
- [x] **Testing** Seems like a pretty simple fix, I can add a test for nsutil if reviewer thinks its necessary
- [x] **Documentation** Doesn't apply.
