### PR TITLE
dynamic host volumes: create/register RPC validation

### DIFF
--- a/command/agent/host_volume_endpoint_test.go
+++ b/command/agent/host_volume_endpoint_test.go
@@ -20,7 +20,7 @@ func TestHostVolumeEndpoint_CRUD(t *testing.T) {
 
 		// Create a volume on the test node
 
-		vol := mock.HostVolumeRequest()
+		vol := mock.HostVolumeRequest(structs.DefaultNamespace)
 		reqBody := struct {
 			Volumes []*structs.HostVolume
 		}{Volumes: []*structs.HostVolume{vol}}

--- a/command/volume_create_host_test.go
+++ b/command/volume_create_host_test.go
@@ -54,7 +54,7 @@ capability {
 }
 
 capability {
-  access_mode     = "single-node-reader"
+  access_mode     = "single-node-reader-only"
   attachment_mode = "block-device"
 }
 

--- a/command/volume_delete_host_test.go
+++ b/command/volume_delete_host_test.go
@@ -39,6 +39,10 @@ type      = "host"
 plugin_id = "plugin_id"
 node_id   = "%s"
 node_pool = "default"
+capability {
+  access_mode     = "single-node-reader-only"
+  attachment_mode = "file-system"
+}
 `, nodeID)
 
 	file, err := os.CreateTemp(t.TempDir(), "volume-test-*.hcl")

--- a/command/volume_status_host_test.go
+++ b/command/volume_status_host_test.go
@@ -63,6 +63,10 @@ type      = "host"
 plugin_id = "plugin_id"
 node_id   = "%s"
 node_pool = "default"
+capability {
+  access_mode     = "single-node-reader-only"
+  attachment_mode = "file-system"
+}
 `, vol.Namespace, vol.ID, nodeID)
 
 		file, err := os.CreateTemp(t.TempDir(), "volume-test-*.hcl")
@@ -114,6 +118,10 @@ type      = "host"
 plugin_id = "plugin_id"
 node_id   = "%s"
 node_pool = "default"
+capability {
+  access_mode     = "single-node-reader-only"
+  attachment_mode = "file-system"
+}
 `, nodeID)
 
 	file, err := os.CreateTemp(t.TempDir(), "volume-test-*.hcl")

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -506,7 +506,12 @@ func Merge[T comparable](a, b T) T {
 
 // FlattenMultierror takes a multierror and unwraps it if there's only one error
 // in the output, otherwise returning the multierror or nil.
-func FlattenMultierror(mErr *multierror.Error) error {
+func FlattenMultierror(err error) error {
+	mErr, ok := err.(*multierror.Error)
+	if !ok {
+		return err
+	}
+	// note: mErr is a pointer so we still need to nil-check even after the cast
 	if mErr == nil {
 		return nil
 	}

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -488,11 +488,21 @@ func Test_SliceSetEq(t *testing.T) {
 
 func TestFlattenMultiError(t *testing.T) {
 
+	err := FlattenMultierror(nil)
+	must.Nil(t, err)
+
+	err0 := errors.New("oh no!")
+	err = FlattenMultierror(err0)
+	must.Eq(t, `oh no!`, err.Error())
+
 	var mErr0 *multierror.Error
+	err = FlattenMultierror(mErr0)
+	must.Nil(t, err)
+
 	mErr0 = multierror.Append(mErr0, func() error {
 		return nil
 	}())
-	err := FlattenMultierror(mErr0)
+	err = FlattenMultierror(mErr0)
 	must.Nil(t, err)
 
 	var mErr1 *multierror.Error

--- a/nomad/host_volume_endpoint_test.go
+++ b/nomad/host_volume_endpoint_test.go
@@ -177,9 +177,14 @@ func TestHostVolumeEndpoint_CreateRegisterGetDelete(t *testing.T) {
 			volCh <- getResp.Volume
 		}()
 
-		var registerResp structs.HostVolumeRegisterResponse
-		err = msgpackrpc.CallWithCodec(codec, "HostVolume.Register", registerReq, &registerResp)
-		must.NoError(t, err)
+		// re-register the volume long enough later that we can be sure we won't
+		// win a race with the get RPC goroutine
+		time.AfterFunc(200*time.Millisecond, func() {
+			codec := rpcClient(t, srv)
+			var registerResp structs.HostVolumeRegisterResponse
+			err = msgpackrpc.CallWithCodec(codec, "HostVolume.Register", registerReq, &registerResp)
+			must.NoError(t, err)
+		})
 
 		select {
 		case <-ctx.Done():
@@ -480,8 +485,14 @@ func TestHostVolumeEndpoint_List(t *testing.T) {
 			respCh <- &listResp
 		}()
 
-		err = msgpackrpc.CallWithCodec(codec, "HostVolume.Register", registerReq, &registerResp)
-		must.NoError(t, err)
+		// re-register the volume long enough later that we can be sure we won't
+		// win a race with the get RPC goroutine
+		time.AfterFunc(200*time.Millisecond, func() {
+			codec := rpcClient(t, srv)
+			var registerResp structs.HostVolumeRegisterResponse
+			err = msgpackrpc.CallWithCodec(codec, "HostVolume.Register", registerReq, &registerResp)
+			must.NoError(t, err)
+		})
 
 		select {
 		case <-ctx.Done():

--- a/nomad/mock/host_volumes.go
+++ b/nomad/mock/host_volumes.go
@@ -8,9 +8,9 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-func HostVolumeRequest() *structs.HostVolume {
+func HostVolumeRequest(ns string) *structs.HostVolume {
 	vol := &structs.HostVolume{
-		Namespace: structs.DefaultNamespace,
+		Namespace: ns,
 		Name:      "example",
 		PluginID:  "example-plugin",
 		NodePool:  structs.NodePoolDefault,
@@ -36,9 +36,16 @@ func HostVolumeRequest() *structs.HostVolume {
 
 }
 
+func HostVolumeRequestForNode(ns string, node *structs.Node) *structs.HostVolume {
+	vol := HostVolumeRequest(ns)
+	vol.NodeID = node.ID
+	vol.NodePool = node.NodePool
+	return vol
+}
+
 func HostVolume() *structs.HostVolume {
 	volID := uuid.Generate()
-	vol := HostVolumeRequest()
+	vol := HostVolumeRequest(structs.DefaultNamespace)
 	vol.ID = volID
 	vol.NodeID = uuid.Generate()
 	vol.CapacityBytes = 150000

--- a/nomad/state/state_store_host_volumes.go
+++ b/nomad/state/state_store_host_volumes.go
@@ -13,10 +13,12 @@ import (
 // HostVolumeByID retrieve a specific host volume
 func (s *StateStore) HostVolumeByID(ws memdb.WatchSet, ns, id string, withAllocs bool) (*structs.HostVolume, error) {
 	txn := s.db.ReadTxn()
-	obj, err := txn.First(TableHostVolumes, indexID, ns, id)
+	watchCh, obj, err := txn.FirstWatch(TableHostVolumes, indexID, ns, id)
 	if err != nil {
 		return nil, err
 	}
+	ws.Add(watchCh)
+
 	if obj == nil {
 		return nil, nil
 	}

--- a/nomad/structs/host_volumes_test.go
+++ b/nomad/structs/host_volumes_test.go
@@ -5,6 +5,7 @@ package structs
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -52,4 +53,194 @@ func TestHostVolume_Copy(t *testing.T) {
 	must.Eq(t, "${meta.rack}", vol.Constraints[0].LTarget)
 	must.Len(t, 1, vol.RequestedCapabilities)
 	must.Eq(t, "bar", vol.Parameters["foo"])
+}
+
+func TestHostVolume_Validate(t *testing.T) {
+	ci.Parallel(t)
+
+	invalid := &HostVolume{}
+	err := invalid.Validate()
+	must.EqError(t, err, `2 errors occurred:
+	* missing name
+	* must include at least one capability block
+
+`)
+
+	invalid = &HostVolume{
+		Name:     "example",
+		PluginID: "example-plugin",
+		Constraints: []*Constraint{{
+			RTarget: "r1",
+			Operand: "=",
+		}},
+		RequestedCapacityMinBytes: 200000,
+		RequestedCapacityMaxBytes: 100000,
+		RequestedCapabilities: []*HostVolumeCapability{
+			{
+				AttachmentMode: HostVolumeAttachmentModeFilesystem,
+				AccessMode:     HostVolumeAccessModeSingleNodeWriter,
+			},
+			{
+				AttachmentMode: "bad",
+				AccessMode:     "invalid",
+			},
+		},
+	}
+	err = invalid.Validate()
+	must.EqError(t, err, `3 errors occurred:
+	* capacity_max (100000) must be larger than capacity_min (200000)
+	* invalid attachment mode: "bad"
+	* invalid constraint: 1 error occurred:
+	* No LTarget provided but is required by constraint
+
+
+
+`)
+
+	vol := &HostVolume{
+		Namespace: DefaultNamespace,
+		ID:        uuid.Generate(),
+		Name:      "example",
+		PluginID:  "example-plugin",
+		NodePool:  NodePoolDefault,
+		NodeID:    uuid.Generate(),
+		Constraints: []*Constraint{{
+			LTarget: "${meta.rack}",
+			RTarget: "r1",
+			Operand: "=",
+		}},
+		RequestedCapacityMinBytes: 100000,
+		RequestedCapacityMaxBytes: 200000,
+		CapacityBytes:             150000,
+		RequestedCapabilities: []*HostVolumeCapability{{
+			AttachmentMode: HostVolumeAttachmentModeFilesystem,
+			AccessMode:     HostVolumeAccessModeSingleNodeWriter,
+		}},
+		Parameters: map[string]string{"foo": "bar"},
+	}
+	must.NoError(t, vol.Validate())
+}
+
+func TestHostVolume_ValidateUpdate(t *testing.T) {
+	ci.Parallel(t)
+
+	vol := &HostVolume{
+		NodePool:                  NodePoolDefault,
+		NodeID:                    uuid.Generate(),
+		RequestedCapacityMinBytes: 100000,
+		RequestedCapacityMaxBytes: 120000,
+		Parameters:                map[string]string{"baz": "qux"},
+	}
+	err := vol.ValidateUpdate(nil)
+	must.NoError(t, err)
+
+	existing := &HostVolume{
+		NodePool:                  "prod",
+		NodeID:                    uuid.Generate(),
+		RequestedCapacityMinBytes: 100000,
+		RequestedCapacityMaxBytes: 200000,
+		CapacityBytes:             150000,
+		RequestedCapabilities: []*HostVolumeCapability{{
+			AttachmentMode: HostVolumeAttachmentModeFilesystem,
+			AccessMode:     HostVolumeAccessModeSingleNodeWriter,
+		}},
+		Parameters: map[string]string{"foo": "bar"},
+		Allocations: []*AllocListStub{
+			{ID: "6bd66bfa"},
+			{ID: "7032e570"},
+		},
+	}
+
+	err = vol.ValidateUpdate(existing)
+	must.EqError(t, err, `4 errors occurred:
+	* cannot update a volume in use: claimed by allocs (6bd66bfa, 7032e570)
+	* node ID cannot be updated
+	* node pool cannot be updated
+	* capacity_max (120000) cannot be less than existing provisioned capacity (150000)
+
+`)
+
+}
+
+func TestHostVolume_CanonicalizeForUpdate(t *testing.T) {
+	now := time.Now()
+	vol := &HostVolume{
+		CapacityBytes: 100000,
+		HostPath:      "/etc/passwd",
+		Allocations: []*AllocListStub{
+			{ID: "6bd66bfa"},
+			{ID: "7032e570"},
+		},
+	}
+	vol.CanonicalizeForUpdate(nil, now)
+
+	must.NotEq(t, "", vol.ID)
+	must.Eq(t, now.UnixNano(), vol.CreateTime)
+	must.Eq(t, now.UnixNano(), vol.ModifyTime)
+	must.Eq(t, HostVolumeStatePending, vol.State)
+	must.Nil(t, vol.Allocations)
+	must.Eq(t, "", vol.HostPath)
+	must.Zero(t, vol.CapacityBytes)
+
+	vol = &HostVolume{
+		ID:                        "82f357d6-a5ec-11ef-9e36-3f9884222736",
+		RequestedCapacityMinBytes: 100000,
+		RequestedCapacityMaxBytes: 500000,
+		RequestedCapabilities: []*HostVolumeCapability{{
+			AttachmentMode: HostVolumeAttachmentModeFilesystem,
+			AccessMode:     HostVolumeAccessModeMultiNodeMultiWriter,
+		}},
+	}
+	existing := &HostVolume{
+		ID:                        "82f357d6-a5ec-11ef-9e36-3f9884222736",
+		PluginID:                  "example_plugin",
+		NodePool:                  "prod",
+		NodeID:                    uuid.Generate(),
+		RequestedCapacityMinBytes: 100000,
+		RequestedCapacityMaxBytes: 200000,
+		CapacityBytes:             150000,
+		RequestedCapabilities: []*HostVolumeCapability{{
+			AttachmentMode: HostVolumeAttachmentModeFilesystem,
+			AccessMode:     HostVolumeAccessModeSingleNodeWriter,
+		}},
+		Constraints: []*Constraint{{
+			LTarget: "${meta.rack}",
+			RTarget: "r1",
+			Operand: "=",
+		}},
+		Parameters: map[string]string{"foo": "bar"},
+		Allocations: []*AllocListStub{
+			{ID: "6bd66bfa"},
+			{ID: "7032e570"},
+		},
+		HostPath:   "/var/nomad/alloc_mounts/82f357d6.ext4",
+		CreateTime: 1,
+	}
+
+	vol.CanonicalizeForUpdate(existing, now)
+	must.Eq(t, existing.ID, vol.ID)
+	must.Eq(t, existing.PluginID, vol.PluginID)
+	must.Eq(t, existing.NodePool, vol.NodePool)
+	must.Eq(t, existing.NodeID, vol.NodeID)
+	must.Eq(t, []*Constraint{{
+		LTarget: "${meta.rack}",
+		RTarget: "r1",
+		Operand: "=",
+	}}, vol.Constraints)
+	must.Eq(t, 100000, vol.RequestedCapacityMinBytes)
+	must.Eq(t, 500000, vol.RequestedCapacityMaxBytes)
+	must.Eq(t, 150000, vol.CapacityBytes)
+
+	must.Eq(t, []*HostVolumeCapability{{
+		AttachmentMode: HostVolumeAttachmentModeFilesystem,
+		AccessMode:     HostVolumeAccessModeMultiNodeMultiWriter,
+	}}, vol.RequestedCapabilities)
+
+	must.Eq(t, "/var/nomad/alloc_mounts/82f357d6.ext4", vol.HostPath)
+	must.Eq(t, HostVolumeStatePending, vol.State)
+
+	must.Eq(t, existing.CreateTime, vol.CreateTime)
+	must.Eq(t, now.UnixNano(), vol.ModifyTime)
+	must.Nil(t, vol.Allocations)
+
 }


### PR DESCRIPTION
Add several validation steps in the create/register RPCs for dynamic host volumes. We first check that submitted volumes are self-consistent (ex. max capacity is more than min capacity), then that any updates we've made are valid. And we validate against state: preventing claimed volumes from being updated and preventing placement requests for nodes that don't exist.

Ref: https://github.com/hashicorp/nomad/issues/15489
