### PR TITLE
windows: revert process listing logic to that of v1.6.10

### DIFF
--- a/.changelog/24494.txt
+++ b/.changelog/24494.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+windows: Restore process accounting logic from Nomad 1.6.x
+```

--- a/drivers/shared/executor/procstats/list_test.go
+++ b/drivers/shared/executor/procstats/list_test.go
@@ -63,31 +63,26 @@ func Test_list(t *testing.T) {
 		name     string
 		needles  int
 		haystack int
-		expect   int
 	}{
 		{
 			name:     "minimal",
 			needles:  2,
 			haystack: 10,
-			expect:   16,
 		},
 		{
 			name:     "small needles small haystack",
 			needles:  5,
 			haystack: 200,
-			expect:   212,
 		},
 		{
 			name:     "small needles large haystack",
 			needles:  10,
 			haystack: 1000,
-			expect:   1022,
 		},
 		{
 			name:     "moderate needles giant haystack",
 			needles:  20,
 			haystack: 2000,
-			expect:   2042,
 		},
 	}
 
@@ -100,11 +95,10 @@ func Test_list(t *testing.T) {
 				return procs, nil
 			}
 
-			result, examined := list(executorPID, lister)
+			result := list(executorPID, lister)
 			must.SliceContainsAll(t, expect, result.Slice(),
 				must.Sprintf("exp: %v; got: %v", expect, result),
 			)
-			must.Eq(t, tc.expect, examined)
 		})
 	}
 }

--- a/drivers/shared/executor/procstats/list_windows.go
+++ b/drivers/shared/executor/procstats/list_windows.go
@@ -26,6 +26,6 @@ import (
 // happens when you use syscalls to work your way from the root down to its
 // descendants.
 func List(executorPID int) set.Collection[ProcessID] {
-	procs, _ := list(executorPID, ps.Processes)
+	procs := list(executorPID, ps.Processes)
 	return procs
 }


### PR DESCRIPTION
In Nomad 1.7 much of the process management code was refactored, including
a rewrite of how the process tree of an executor was determined on Windows
machines. Unfortunately that rewrite has been cursed with performance issues
and bugs. Instead, revert to the logic used in [v1.6.10](https://github.com/hashicorp/nomad/blob/v1.6.10/drivers/shared/executor/pid_collector.go#L84).

Fixes #23984
