### PR TITLE
client: mark the remote_task hook as deprecated.

### DIFF
--- a/client/allocrunner/taskrunner/remotetask_hook.go
+++ b/client/allocrunner/taskrunner/remotetask_hook.go
@@ -16,6 +16,7 @@ var _ interfaces.TaskPrestartHook = (*remoteTaskHook)(nil)
 var _ interfaces.TaskPreKillHook = (*remoteTaskHook)(nil)
 
 // remoteTaskHook reattaches to remotely executing tasks.
+// Deprecated: remote tasks drivers are no longer developed or supported.
 type remoteTaskHook struct {
 	tr *TaskRunner
 


### PR DESCRIPTION
### Description
Driver capabilities and ECS driver were deprecated in 1.9; marking this in a similar way for future removal. 

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
