### PR TITLE
consul: handle nil multierror pointer correctly

### DIFF
--- a/.changelog/24513.txt
+++ b/.changelog/24513.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul: Fixed a bug where failures when syncing Consul checks could panic the Nomad agent
+```

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1105,7 +1105,7 @@ func (c *ServiceClient) sync(reason syncReason) error {
 		if err != nil {
 			metrics.IncrCounter([]string{"client", "consul", "sync_failure"}, 1)
 			err = fmt.Errorf("failed to query Consul checks: %w", err)
-			if mErr.Len() == 0 {
+			if mErr == nil || mErr.Len() == 0 {
 				return err
 			} else {
 				mErr = multierror.Append(mErr, err)


### PR DESCRIPTION
When the service client syncs to Consul, we accumulate service sync errors in a multierror before reading all the local checks. If the API call to the local checks fails, we either return that error or append it to the multierror and return the set of errors. But `multierror.Error.Len()` doesn't nil-check, so we need to do this ourselves.

I've also made a quick pass through the rest of the code base looking for multierror `Len` method calls to see if we have this pattern elsewhere.

Fixes: https://github.com/hashicorp/nomad/issues/24512
