### PR TITLE
dynamic host volumes: node selection via constraints

### DIFF
--- a/command/agent/host_volume_endpoint_test.go
+++ b/command/agent/host_volume_endpoint_test.go
@@ -21,6 +21,8 @@ func TestHostVolumeEndpoint_CRUD(t *testing.T) {
 		// Create a volume on the test node
 
 		vol := mock.HostVolumeRequest(structs.DefaultNamespace)
+		vol.NodePool = ""
+		vol.Constraints = nil
 		reqBody := struct {
 			Volumes []*structs.HostVolume
 		}{Volumes: []*structs.HostVolume{vol}}

--- a/command/volume_create_host_test.go
+++ b/command/volume_create_host_test.go
@@ -11,13 +11,16 @@ import (
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/command/agent"
 	"github.com/mitchellh/cli"
 	"github.com/shoenig/test/must"
 )
 
 func TestHostVolumeCreateCommand_Run(t *testing.T) {
 	ci.Parallel(t)
-	srv, client, url := testServer(t, true, nil)
+	srv, client, url := testServer(t, true, func(c *agent.Config) {
+		c.Client.Meta = map[string]string{"rack": "foo"}
+	})
 	t.Cleanup(srv.Shutdown)
 
 	waitForNodes(t, client)
@@ -37,11 +40,6 @@ node_pool = "default"
 
 capacity_min = "10GiB"
 capacity_max = "20G"
-
-constraint {
-  attribute = "${attr.kernel.name}"
-  value     = "linux"
-}
 
 constraint {
   attribute = "${meta.rack}"

--- a/nomad/state/state_store_host_volumes.go
+++ b/nomad/state/state_store_host_volumes.go
@@ -87,6 +87,8 @@ func (s *StateStore) UpsertHostVolumes(index uint64, volumes []*structs.HostVolu
 		if _, ok := node.HostVolumes[v.Name]; ok {
 			v.State = structs.HostVolumeStateReady
 		}
+		// Register RPCs for new volumes may not have the node pool set
+		v.NodePool = node.NodePool
 
 		// Allocations are denormalized on read, so we don't want these to be
 		// written to the state store.

--- a/nomad/structs/host_volumes.go
+++ b/nomad/structs/host_volumes.go
@@ -159,6 +159,12 @@ func (hv *HostVolume) Validate() error {
 		if err := constraint.Validate(); err != nil {
 			mErr = multierror.Append(mErr, fmt.Errorf("invalid constraint: %v", err))
 		}
+		switch constraint.Operand {
+		case ConstraintDistinctHosts, ConstraintDistinctProperty:
+			mErr = multierror.Append(mErr, fmt.Errorf(
+				"invalid constraint %s: host volumes of the same name are always on distinct hosts", constraint.Operand))
+		default:
+		}
 	}
 
 	return mErr.ErrorOrNil()

--- a/scheduler/context.go
+++ b/scheduler/context.go
@@ -51,6 +51,13 @@ type Context interface {
 	SendEvent(event interface{})
 }
 
+type ConstraintContext interface {
+	Metrics() *structs.AllocMetric
+	RegexpCache() map[string]*regexp.Regexp
+	VersionConstraintCache() map[string]VerConstraints
+	SemverConstraintCache() map[string]VerConstraints
+}
+
 // EvalCache is used to cache certain things during an evaluation
 type EvalCache struct {
 	reCache      map[string]*regexp.Regexp

--- a/scheduler/feasible_test.go
+++ b/scheduler/feasible_test.go
@@ -1263,7 +1263,7 @@ func TestCheckVersionConstraint(t *testing.T) {
 	for _, tc := range cases {
 		_, ctx := testContext(t)
 		p := newVersionConstraintParser(ctx)
-		if res := checkVersionMatch(ctx, p, tc.lVal, tc.rVal); res != tc.result {
+		if res := checkVersionMatch(p, tc.lVal, tc.rVal); res != tc.result {
 			t.Fatalf("TC: %#v, Result: %v", tc, res)
 		}
 	}
@@ -1345,7 +1345,7 @@ func TestCheckSemverConstraint(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, ctx := testContext(t)
 			p := newSemverConstraintParser(ctx)
-			actual := checkVersionMatch(ctx, p, tc.lVal, tc.rVal)
+			actual := checkVersionMatch(p, tc.lVal, tc.rVal)
 			must.Eq(t, tc.result, actual)
 		})
 	}


### PR DESCRIPTION
When making a request to create a dynamic host volume, users can pass a node pool and constraints instead of a specific node ID.

This changeset implements a node scheduling logic by instantiating a filter by node pool and constraint checker borrowed from the scheduler package. Because host volumes with the same name can't land on the same host, we don't need to support `distinct_hosts`/`distinct_property`; this would be challenging anyways without building out a much larger node iteration mechanism to keep track of usage across multiple hosts.

Ref: https://github.com/hashicorp/nomad/pull/24479