### PR TITLE
Fix CSITopology matching logic for csi storage driver

### DIFF
--- a/.changelog/24522.txt
+++ b/.changelog/24522.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: fix compatibility issue with aws-ebs-csi driver > 1.26.1
+```

--- a/.changelog/24522.txt
+++ b/.changelog/24522.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-csi: fix compatibility issue with aws-ebs-csi driver > 1.26.1
+csi: Fixed a bug where drivers that emit multiple topology segments would cause placements to fail
 ```

--- a/e2e/csi/input/plugin-aws-ebs-controller.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-controller.nomad
@@ -25,7 +25,7 @@ job "plugin-aws-ebs-controller" {
       driver = "docker"
 
       config {
-        image = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.5.1"
+        image = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.33.0"
 
         args = [
           "controller",

--- a/e2e/csi/input/plugin-aws-ebs-nodes.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-nodes.nomad
@@ -22,7 +22,7 @@ job "plugin-aws-ebs-nodes" {
       driver = "docker"
 
       config {
-        image = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.5.1"
+        image = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.33.0"
 
         args = [
           "node",

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -68,7 +68,6 @@ func (t *CSITopology) Equal(o *CSITopology) bool {
 	return maps.Equal(t.Segments, o.Segments)
 }
 
-
 func (t *CSITopology) EqualOrContains(o *CSITopology) bool {
 	if t == nil || o == nil {
 		return t == o

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -61,6 +61,14 @@ func (t *CSITopology) Copy() *CSITopology {
 	}
 }
 
+func (t *CSITopology) Equal(o *CSITopology) bool {
+	if t == nil || o == nil {
+		return t == o
+	}
+	return maps.Equal(t.Segments, o.Segments)
+}
+
+
 func (t *CSITopology) EqualOrContains(o *CSITopology) bool {
 	if t == nil || o == nil {
 		return t == o

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -65,7 +65,15 @@ func (t *CSITopology) Equal(o *CSITopology) bool {
 	if t == nil || o == nil {
 		return t == o
 	}
-	return maps.Equal(t.Segments, o.Segments)
+
+	// check this segments is a superset of other topology's segments
+	for k, ov := range o.Segments {
+		if tv, ok := t.Segments[k]; !ok || tv != ov {
+			return false
+		}
+	}
+
+	return true
 }
 
 func (t *CSITopology) MatchFound(o []*CSITopology) bool {

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -68,7 +68,7 @@ func (t *CSITopology) Equal(o *CSITopology) bool {
 	return maps.Equal(t.Segments, o.Segments)
 }
 
-func (t *CSITopology) EqualOrContains(o *CSITopology) bool {
+func (t *CSITopology) Contains(o *CSITopology) bool {
 	if t == nil || o == nil {
 		return t == o
 	}
@@ -88,7 +88,7 @@ func (t *CSITopology) MatchFound(o []*CSITopology) bool {
 	}
 
 	for _, other := range o {
-		if t.EqualOrContains(other) {
+		if t.Contains(other) {
 			return true
 		}
 	}

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -61,12 +61,11 @@ func (t *CSITopology) Copy() *CSITopology {
 	}
 }
 
-func (t *CSITopology) Equal(o *CSITopology) bool {
+func (t *CSITopology) EqualOrContains(o *CSITopology) bool {
 	if t == nil || o == nil {
 		return t == o
 	}
 
-	// check this segments is a superset of other topology's segments
 	for k, ov := range o.Segments {
 		if tv, ok := t.Segments[k]; !ok || tv != ov {
 			return false
@@ -82,7 +81,7 @@ func (t *CSITopology) MatchFound(o []*CSITopology) bool {
 	}
 
 	for _, other := range o {
-		if t.Equal(other) {
+		if t.EqualOrContains(other) {
 			return true
 		}
 	}

--- a/nomad/structs/node_test.go
+++ b/nomad/structs/node_test.go
@@ -167,16 +167,14 @@ func TestNodeMeta_Validate(t *testing.T) {
 func TestCSITopology_Contains(t *testing.T) {
 	ci.Parallel(t)
 
-	require := require.New(t)
 	cases := []struct {
 		name     string
 		this     *CSITopology
 		other    *CSITopology
 		expected bool
-		errorMsg string
 	}{
 		{
-			name: "pre 1.27 behavior",
+			name: "AWS EBS pre 1.27 behavior",
 			this: &CSITopology{
 				Segments: map[string]string{
 					"topology.ebs.csi.aws.com/zone": "us-east-1a",
@@ -188,10 +186,9 @@ func TestCSITopology_Contains(t *testing.T) {
 				},
 			},
 			expected: true,
-			errorMsg: "pre 1.27 behavior should pass",
 		},
 		{
-			name: "post 1.27 behavior",
+			name: "AWS EBS post 1.27 behavior",
 			this: &CSITopology{
 				Segments: map[string]string{
 					"topology.kubernetes.io/zone":   "us-east-1a",
@@ -205,10 +202,9 @@ func TestCSITopology_Contains(t *testing.T) {
 				},
 			},
 			expected: true,
-			errorMsg: "post 1.27 behavior should pass",
 		},
 		{
-			name: "invalid case 1",
+			name: "other contains invalid segment value for matched key",
 			this: &CSITopology{
 				Segments: map[string]string{
 					"topology.kubernetes.io/zone":   "us-east-1a",
@@ -223,10 +219,9 @@ func TestCSITopology_Contains(t *testing.T) {
 				},
 			},
 			expected: false,
-			errorMsg: "invalid case 1 should not pass",
 		},
 		{
-			name: "invalid case 2",
+			name: "other contains invalid segment key",
 			this: &CSITopology{
 				Segments: map[string]string{
 					"topology.kubernetes.io/zone": "us-east-1a",
@@ -239,10 +234,9 @@ func TestCSITopology_Contains(t *testing.T) {
 				},
 			},
 			expected: false,
-			errorMsg: "invalid case 2 should not pass",
 		},
 		{
-			name: "invalid case 3",
+			name: "other is nil",
 			this: &CSITopology{
 				Segments: map[string]string{
 					"topology.kubernetes.io/zone": "us-east-1a",
@@ -250,14 +244,12 @@ func TestCSITopology_Contains(t *testing.T) {
 			},
 			other:    nil,
 			expected: false,
-			errorMsg: "invalid case 3 should not pass",
 		},
 	}
 
-	for i := range cases {
-		tc := cases[i]
+	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(tc.expected, tc.this.Contains(tc.other), tc.errorMsg)
+			must.Eq(t, tc.expected, tc.this.Contains(tc.other))
 		})
 	}
 


### PR DESCRIPTION
### Description

CSI volume is created with following topology
```
  "Topologies": [
        null,
        {
            "Segments": {
                "topology.kubernetes.io/zone": "us-east-1a"
            }
        }
    ],
```

and Node Accessible Topology is reported as 

```
  "6befce82-c4e5-8509-55ad-3b69bde1fa22": {
            "AllocID": "b6b6f136-d4c4-691e-47b6-330e1fbf4c4f",
            "HealthDescription": "healthy",
            "Healthy": true,
            "NodeInfo": {
                "AccessibleTopology": {
                    "Segments": {
                        "topology.kubernetes.io/zone": "us-east-1a",
                        "kubernetes.io/os": "linux",
                        "topology.ebs.csi.aws.com/zone": "us-east-1a"
                    }
                },
                "ID": "i-05feecab254e44c60",
                "MaxVolumes": 26,
                "RequiresNodeStageVolume": true,
                "SupportsCondition": false,
                "SupportsExpand": true,
                "SupportsStats": true
            },
            "PluginID": "aws-ebs",
            "RequiresControllerPlugin": true,
            "RequiresTopologies": true,
            "UpdateTime": "2024-11-20T21:41:43.593062188Z"
        },
```

The current logic assume they completely match, where the accessible topology's Segements just need to be a  superset of the volume topology's Segements

Up until EBS CSI driver version < 1.26.1  , the reported value matches exactly, and after v1.27.0 it has been broken since.

### Testing & Reproduction steps

without this patch , the e2e test for csi driver with a ebs-csi driver > 1.26.1 will fail.

### Links

fix #20094

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [X] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
