### PR TITLE
dynamic host volumes: search endpoint

### DIFF
--- a/api/contexts/contexts.go
+++ b/api/contexts/contexts.go
@@ -23,6 +23,7 @@ const (
 	Plugins         Context = "plugins"
 	Variables       Context = "vars"
 	Volumes         Context = "volumes"
+	HostVolumes     Context = "host_volumes"
 
 	// These Context types are used to associate a search result from a lower
 	// level Nomad object with one of the higher level Context types above.

--- a/nomad/search_endpoint_test.go
+++ b/nomad/search_endpoint_test.go
@@ -1039,6 +1039,53 @@ func TestSearch_PrefixSearch_CSIVolume(t *testing.T) {
 	require.False(t, resp.Truncations[structs.Volumes])
 }
 
+func TestSearch_PrefixSearch_HostVolume(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, cleanup := TestServer(t, func(c *Config) {
+		c.NumSchedulers = 0
+	})
+	defer cleanup()
+	codec := rpcClient(t, srv)
+	testutil.WaitForLeader(t, srv.RPC)
+
+	store := srv.fsm.State()
+	index, _ := store.LatestIndex()
+
+	node := mock.Node()
+	index++
+	must.NoError(t, store.UpsertNode(structs.MsgTypeTestSetup, index, node))
+
+	id := uuid.Generate()
+	index++
+	err := store.UpsertHostVolumes(index, []*structs.HostVolume{{
+		ID:        id,
+		Name:      "example",
+		Namespace: structs.DefaultNamespace,
+		PluginID:  "glade",
+		NodeID:    node.ID,
+		NodePool:  node.NodePool,
+	}})
+	must.NoError(t, err)
+
+	req := &structs.SearchRequest{
+		Prefix:  id[:6],
+		Context: structs.HostVolumes,
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			Namespace: structs.DefaultNamespace,
+		},
+	}
+
+	var resp structs.SearchResponse
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, "Search.PrefixSearch", req, &resp))
+
+	must.Len(t, 1, resp.Matches[structs.HostVolumes])
+	must.Len(t, 0, resp.Matches[structs.Volumes])
+	must.Eq(t, id, resp.Matches[structs.HostVolumes][0])
+	must.False(t, resp.Truncations[structs.HostVolumes])
+}
+
 func TestSearch_PrefixSearch_Namespace(t *testing.T) {
 	ci.Parallel(t)
 
@@ -1930,6 +1977,52 @@ func TestSearch_FuzzySearch_CSIVolume(t *testing.T) {
 	require.Len(t, resp.Matches[structs.Volumes], 1)
 	require.Equal(t, id, resp.Matches[structs.Volumes][0].ID)
 	require.False(t, resp.Truncations[structs.Volumes])
+}
+
+func TestSearch_FuzzySearch_HostVolume(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, cleanup := TestServer(t, func(c *Config) {
+		c.NumSchedulers = 0
+	})
+	defer cleanup()
+	codec := rpcClient(t, srv)
+	testutil.WaitForLeader(t, srv.RPC)
+
+	store := srv.fsm.State()
+	index, _ := store.LatestIndex()
+
+	node := mock.Node()
+	index++
+	must.NoError(t, store.UpsertNode(structs.MsgTypeTestSetup, index, node))
+
+	id := uuid.Generate()
+	index++
+	err := store.UpsertHostVolumes(index, []*structs.HostVolume{{
+		ID:        id,
+		Name:      "example",
+		Namespace: structs.DefaultNamespace,
+		PluginID:  "glade",
+		NodeID:    node.ID,
+		NodePool:  node.NodePool,
+	}})
+	must.NoError(t, err)
+
+	req := &structs.FuzzySearchRequest{
+		Text:    id[0:3], // volumes are prefix searched
+		Context: structs.HostVolumes,
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			Namespace: structs.DefaultNamespace,
+		},
+	}
+
+	var resp structs.FuzzySearchResponse
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, "Search.FuzzySearch", req, &resp))
+
+	must.Len(t, 1, resp.Matches[structs.HostVolumes])
+	must.Eq(t, id, resp.Matches[structs.HostVolumes][0].ID)
+	must.False(t, resp.Truncations[structs.HostVolumes])
 }
 
 func TestSearch_FuzzySearch_Namespace(t *testing.T) {

--- a/nomad/state/state_store_host_volumes_test.go
+++ b/nomad/state/state_store_host_volumes_test.go
@@ -163,6 +163,17 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 	must.NoError(t, err)
 	got = consumeIter(iter)
 	must.MapLen(t, 3, got, must.Sprint(`expected 3 volumes remain`))
+
+	prefix := vol.ID[:30] // sufficiently long prefix to avoid flakes
+	iter, err = store.HostVolumesByIDPrefix(nil, "*", prefix, SortDefault)
+	must.NoError(t, err)
+	got = consumeIter(iter)
+	must.MapLen(t, 1, got, must.Sprint(`expected only one volume to match prefix`))
+
+	iter, err = store.HostVolumesByIDPrefix(nil, vol.Namespace, prefix, SortDefault)
+	must.NoError(t, err)
+	got = consumeIter(iter)
+	must.MapLen(t, 1, got, must.Sprint(`expected only one volume to match prefix`))
 }
 
 func TestStateStore_UpdateHostVolumesFromFingerprint(t *testing.T) {

--- a/nomad/structs/search.go
+++ b/nomad/structs/search.go
@@ -22,6 +22,7 @@ const (
 	Plugins         Context = "plugins"
 	Variables       Context = "vars"
 	Volumes         Context = "volumes"
+	HostVolumes     Context = "host_volumes"
 
 	// Subtypes used in fuzzy matching.
 	Groups   Context = "groups"


### PR DESCRIPTION
Add support for dynamic host volumes to the search endpoint. Like many other objects with UUID identifiers, we're not supporting fuzzy search here, just prefix search on the fuzzy search endpoint.

Because the search endpoint only returns IDs, we need to seperate CSI volumes and host volumes for it to be useful. The new context is called `"host_volumes"` to disambiguate it from `"volumes"`. In future versions of Nomad we should consider deprecating the `"volumes"` context in lieu of a `"csi_volumes"` context.

Ref: https://github.com/hashicorp/nomad/pull/24479

---

To test end-to-end, create sufficient volumes to have at least 2 matching prefix characters in the ID (this may take quite a few tries!).

```
$ nomad volume create ./demo/hostvolume/host.volume.hcl
Created host volume test with ID f6a8949a-55dd-f6cc-985c-216fe98989c8

$ nomad volume create ./demo/hostvolume/host.volume.hcl
Created host volume test with ID f6f8ed01-0f4d-c300-a8da-02e0c78e3dde
```

Then you can use `curl` and get the expected results as shown below. I also verified that the queries the UI makes get the correct results, but because the UI doesn't yet have the models built for host volumes, it doesn't know what do to with the host volumes context and shows no results.

<details><summary>Fuzzy search results</summary>

```
$ curl -sd '{"Text": "f6", "Context": "all", "Namespace": "*"}' "http://localhost:4646/v1/search/fuzzy" | jq .
{
  "Index": 18,
  "KnownLeader": true,
  "LastContact": 0,
  "Matches": {
    "host_volumes": [
      {
        "ID": "f6a8949a-55dd-f6cc-985c-216fe98989c8"
      },
      {
        "ID": "f6f8ed01-0f4d-c300-a8da-02e0c78e3dde"
      }
    ],
    "evals": [],
    "deployment": [],
    "volumes": [],
    "scaling_policy": []
  },
  "NextToken": "",
  "Truncations": {
    "volumes": false,
    "scaling_policy": false,
    "host_volumes": false,
    "jobs": false,
    "nodes": false,
    "vars": false,
    "namespaces": false,
    "deployment": false,
    "node_pools": false,
    "plugins": false,
    "allocs": false,
    "evals": false
  }
}
```

</details>

<details><summary>Prefix search results</summary>

```
$ curl -sd '{"Prefix": "f6", "Context": "all", "Namespace": "*"}' "http://localhost:4646/v1/search" | jq .
{
  "Index": 18,
  "KnownLeader": true,
  "LastContact": 0,
  "Matches": {
    "evals": null,
    "vars": null,
    "namespaces": null,
    "volumes": null,
    "allocs": null,
    "node_pools": null,
    "scaling_policy": null,
    "jobs": null,
    "nodes": null,
    "deployment": null,
    "plugins": null,
    "host_volumes": [
      "f6a8949a-55dd-f6cc-985c-216fe98989c8",
      "f6f8ed01-0f4d-c300-a8da-02e0c78e3dde"
    ]
  },
  "NextToken": "",
  "Truncations": {
    "host_volumes": false,
    "volumes": false,
    "allocs": false,
    "nodes": false,
    "node_pools": false,
    "deployment": false,
    "plugins": false,
    "evals": false,
    "vars": false,
    "namespaces": false,
    "scaling_policy": false,
    "jobs": false
  }
}
```

</details>
