### PR TITLE
executor: fail early on reattach if listener is not executor

### DIFF
--- a/.changelog/24538.txt
+++ b/.changelog/24538.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+executor: validate executor on reattach to avoid possibility of killing non-Nomad processes
+```

--- a/drivers/shared/executor/utils.go
+++ b/drivers/shared/executor/utils.go
@@ -75,7 +75,10 @@ func CreateExecutor(
 	return newExecutorClient(config, logger)
 }
 
-// ReattachToExecutor launches a plugin with a given plugin config
+// ReattachToExecutor launches a plugin with a given plugin config and validates it can call the executor.
+// On Windows, go-plugin listens on a localhost port. It is possible on a reboot that another process is
+// listening on that port, and a process is running with the previous executors PID, leading Nomad to kill
+// "random" processes. Fail early via the Version RPC if we detect the listener isn't actually an Executor.
 func ReattachToExecutor(reattachConfig *plugin.ReattachConfig, logger hclog.Logger, compute cpustats.Compute) (Executor, *plugin.Client, error) {
 	config := &plugin.ClientConfig{
 		HandshakeConfig:  base.Handshake,
@@ -84,7 +87,14 @@ func ReattachToExecutor(reattachConfig *plugin.ReattachConfig, logger hclog.Logg
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		Logger:           logger.Named("executor"),
 	}
-	return newExecutorClient(config, logger)
+	exec, pluginClient, err := newExecutorClient(config, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+	if _, err := exec.Version(); err != nil {
+		return nil, nil, err
+	}
+	return exec, pluginClient, nil
 }
 
 func newExecutorClient(config *plugin.ClientConfig, logger hclog.Logger) (Executor, *plugin.Client, error) {

--- a/drivers/shared/executor/utils.go
+++ b/drivers/shared/executor/utils.go
@@ -76,9 +76,10 @@ func CreateExecutor(
 }
 
 // ReattachToExecutor launches a plugin with a given plugin config and validates it can call the executor.
-// On Windows, go-plugin listens on a localhost port. It is possible on a reboot that another process is
-// listening on that port, and a process is running with the previous executors PID, leading Nomad to kill
-// "random" processes. Fail early via the Version RPC if we detect the listener isn't actually an Executor.
+// Note: On Windows, go-plugin listens on a localhost port. It is possible on a reboot that another process
+// is listening on that port, and a process is running with the previous executors PID, leading the Nomad
+// TaskRunner to kill the PID after it errors calling the Wait RPC. So, fail early via the Version RPC if
+// we detect the listener isn't actually an Executor.
 func ReattachToExecutor(reattachConfig *plugin.ReattachConfig, logger hclog.Logger, compute cpustats.Compute) (Executor, *plugin.Client, error) {
 	config := &plugin.ClientConfig{
 		HandshakeConfig:  base.Handshake,


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Fixes a bug reported by Windows users where Nomad was killing random processes on reboot.  This was due to the reattach config containing a PID and RPC address that was now occupied by other processes/listeners.  When Nomad would attempt to make an RPC, it would fail, and kill the process. With this change, we fail early on reattach, and do not kill the process.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
Reproduction involves simulating this scenario via overriding the reattach PID when starting a task to a known PID (another bash session), rebooting Nomad, killing the executor process, and listening on the reattach address.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes [GH #23969](https://github.com/hashicorp/nomad/issues/23969)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
