### PR TITLE
dynamic host volumes: Enterprise stubs and refactor API

### DIFF
--- a/api/host_volumes.go
+++ b/api/host_volumes.go
@@ -147,11 +147,11 @@ func (c *Client) HostVolumes() *HostVolumes {
 }
 
 type HostVolumeCreateRequest struct {
-	Volumes []*HostVolume
+	Volume *HostVolume
 }
 
 type HostVolumeRegisterRequest struct {
-	Volumes []*HostVolume
+	Volume *HostVolume
 }
 
 type HostVolumeListRequest struct {
@@ -163,30 +163,30 @@ type HostVolumeDeleteRequest struct {
 	VolumeIDs []string
 }
 
-// Create forwards to client agents so host volumes can be created on those
-// hosts, and registers the volumes with Nomad servers.
-func (hv *HostVolumes) Create(req *HostVolumeCreateRequest, opts *WriteOptions) ([]*HostVolume, *WriteMeta, error) {
+// Create forwards to client agents so a host volume can be created on those
+// hosts, and registers the volume with Nomad servers.
+func (hv *HostVolumes) Create(req *HostVolumeCreateRequest, opts *WriteOptions) (*HostVolume, *WriteMeta, error) {
 	var out struct {
-		Volumes []*HostVolume
+		Volume *HostVolume
 	}
 	wm, err := hv.client.put("/v1/volume/host/create", req, &out, opts)
 	if err != nil {
 		return nil, wm, err
 	}
-	return out.Volumes, wm, nil
+	return out.Volume, wm, nil
 }
 
-// Register registers host volumes that were created out-of-band with the Nomad
+// Register registers a host volume that was created out-of-band with the Nomad
 // servers.
-func (hv *HostVolumes) Register(req *HostVolumeRegisterRequest, opts *WriteOptions) ([]*HostVolume, *WriteMeta, error) {
+func (hv *HostVolumes) Register(req *HostVolumeRegisterRequest, opts *WriteOptions) (*HostVolume, *WriteMeta, error) {
 	var out struct {
-		Volumes []*HostVolume
+		Volume *HostVolume
 	}
 	wm, err := hv.client.put("/v1/volume/host/register", req, &out, opts)
 	if err != nil {
 		return nil, wm, err
 	}
-	return out.Volumes, wm, nil
+	return out.Volume, wm, nil
 }
 
 // Get queries for a single host volume, by ID

--- a/command/agent/host_volume_endpoint_test.go
+++ b/command/agent/host_volume_endpoint_test.go
@@ -24,8 +24,8 @@ func TestHostVolumeEndpoint_CRUD(t *testing.T) {
 		vol.NodePool = ""
 		vol.Constraints = nil
 		reqBody := struct {
-			Volumes []*structs.HostVolume
-		}{Volumes: []*structs.HostVolume{vol}}
+			Volume *structs.HostVolume
+		}{Volume: vol}
 		buf := encodeReq(reqBody)
 		req, err := http.NewRequest(http.MethodPut, "/v1/volume/host/create", buf)
 		must.NoError(t, err)
@@ -37,12 +37,12 @@ func TestHostVolumeEndpoint_CRUD(t *testing.T) {
 		must.NoError(t, err)
 		must.NotNil(t, obj)
 		resp := obj.(*structs.HostVolumeCreateResponse)
-		must.Len(t, 1, resp.Volumes)
-		must.Eq(t, vol.Name, resp.Volumes[0].Name)
-		must.Eq(t, s.client.NodeID(), resp.Volumes[0].NodeID)
+		must.NotNil(t, resp.Volume)
+		must.Eq(t, vol.Name, resp.Volume.Name)
+		must.Eq(t, s.client.NodeID(), resp.Volume.NodeID)
 		must.NotEq(t, "", respW.Result().Header.Get("X-Nomad-Index"))
 
-		volID := resp.Volumes[0].ID
+		volID := resp.Volume.ID
 
 		// Verify volume was created
 
@@ -61,8 +61,8 @@ func TestHostVolumeEndpoint_CRUD(t *testing.T) {
 		vol = respVol.Copy()
 		vol.Parameters = map[string]string{"bar": "foo"} // swaps key and value
 		reqBody = struct {
-			Volumes []*structs.HostVolume
-		}{Volumes: []*structs.HostVolume{vol}}
+			Volume *structs.HostVolume
+		}{Volume: vol}
 		buf = encodeReq(reqBody)
 		req, err = http.NewRequest(http.MethodPut, "/v1/volume/host/register", buf)
 		must.NoError(t, err)
@@ -70,8 +70,8 @@ func TestHostVolumeEndpoint_CRUD(t *testing.T) {
 		must.NoError(t, err)
 		must.NotNil(t, obj)
 		regResp := obj.(*structs.HostVolumeRegisterResponse)
-		must.Len(t, 1, regResp.Volumes)
-		must.Eq(t, map[string]string{"bar": "foo"}, regResp.Volumes[0].Parameters)
+		must.NotNil(t, regResp.Volume)
+		must.Eq(t, map[string]string{"bar": "foo"}, regResp.Volume.Parameters)
 
 		// Verify volume was updated
 

--- a/command/volume_create_host.go
+++ b/command/volume_create_host.go
@@ -28,9 +28,9 @@ func (c *VolumeCreateCommand) hostVolumeCreate(
 	}
 
 	req := &api.HostVolumeCreateRequest{
-		Volumes: []*api.HostVolume{vol},
+		Volume: vol,
 	}
-	vols, _, err := client.HostVolumes().Create(req, nil)
+	vol, _, err = client.HostVolumes().Create(req, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error creating volume: %s", err))
 		return 1
@@ -39,19 +39,15 @@ func (c *VolumeCreateCommand) hostVolumeCreate(
 	var volID string
 	var lastIndex uint64
 
-	// note: the command only ever returns 1 volume from the API
-	for _, vol := range vols {
-		if detach || vol.State == api.HostVolumeStateReady {
-			c.Ui.Output(fmt.Sprintf(
-				"Created host volume %s with ID %s", vol.Name, vol.ID))
-			return 0
-		} else {
-			c.Ui.Output(fmt.Sprintf(
-				"==> Created host volume %s with ID %s", vol.Name, vol.ID))
-			volID = vol.ID
-			lastIndex = vol.ModifyIndex
-			break
-		}
+	if detach || vol.State == api.HostVolumeStateReady {
+		c.Ui.Output(fmt.Sprintf(
+			"Created host volume %s with ID %s", vol.Name, vol.ID))
+		return 0
+	} else {
+		c.Ui.Output(fmt.Sprintf(
+			"==> Created host volume %s with ID %s", vol.Name, vol.ID))
+		volID = vol.ID
+		lastIndex = vol.ModifyIndex
 	}
 
 	err = c.monitorHostVolume(client, volID, lastIndex, verbose)

--- a/command/volume_register_host.go
+++ b/command/volume_register_host.go
@@ -18,18 +18,15 @@ func (c *VolumeRegisterCommand) hostVolumeRegister(client *api.Client, ast *ast.
 	}
 
 	req := &api.HostVolumeRegisterRequest{
-		Volumes: []*api.HostVolume{vol},
+		Volume: vol,
 	}
-	vols, _, err := client.HostVolumes().Register(req, nil)
+	vol, _, err = client.HostVolumes().Register(req, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error registering volume: %s", err))
 		return 1
 	}
-	for _, vol := range vols {
-		// note: the command only ever returns 1 volume from the API
-		c.Ui.Output(fmt.Sprintf(
-			"Registered host volume %s with ID %s", vol.Name, vol.ID))
-	}
+	c.Ui.Output(fmt.Sprintf(
+		"Registered host volume %s with ID %s", vol.Name, vol.ID))
 
 	return 0
 }

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2428,7 +2428,7 @@ func (n *nomadFSM) applyHostVolumeRegister(msgType structs.MessageType, buf []by
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	if err := n.state.UpsertHostVolumes(index, req.Volumes); err != nil {
+	if err := n.state.UpsertHostVolume(index, req.Volume); err != nil {
 		n.logger.Error("UpsertHostVolumes failed", "error", err)
 		return err
 	}

--- a/nomad/host_volume_endpoint_ce.go
+++ b/nomad/host_volume_endpoint_ce.go
@@ -1,0 +1,23 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+// +build !ent
+
+package nomad
+
+import (
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// enforceEnterprisePolicy is the CE stub for Enterprise governance via
+// Sentinel policy, quotas, and node pools
+func (v *HostVolume) enforceEnterprisePolicy(
+	_ *state.StateSnapshot,
+	_ *structs.HostVolume,
+	_ *structs.ACLToken,
+	_ bool,
+) (error, error) {
+	return nil, nil
+}

--- a/nomad/search_endpoint_test.go
+++ b/nomad/search_endpoint_test.go
@@ -1058,14 +1058,14 @@ func TestSearch_PrefixSearch_HostVolume(t *testing.T) {
 
 	id := uuid.Generate()
 	index++
-	err := store.UpsertHostVolumes(index, []*structs.HostVolume{{
+	err := store.UpsertHostVolume(index, &structs.HostVolume{
 		ID:        id,
 		Name:      "example",
 		Namespace: structs.DefaultNamespace,
 		PluginID:  "glade",
 		NodeID:    node.ID,
 		NodePool:  node.NodePool,
-	}})
+	})
 	must.NoError(t, err)
 
 	req := &structs.SearchRequest{
@@ -1998,14 +1998,14 @@ func TestSearch_FuzzySearch_HostVolume(t *testing.T) {
 
 	id := uuid.Generate()
 	index++
-	err := store.UpsertHostVolumes(index, []*structs.HostVolume{{
+	err := store.UpsertHostVolume(index, &structs.HostVolume{
 		ID:        id,
 		Name:      "example",
 		Namespace: structs.DefaultNamespace,
 		PluginID:  "glade",
 		NodeID:    node.ID,
 		NodePool:  node.NodePool,
-	}})
+	})
 	must.NoError(t, err)
 
 	req := &structs.FuzzySearchRequest{

--- a/nomad/state/state_store_host_volumes_test.go
+++ b/nomad/state/state_store_host_volumes_test.go
@@ -54,7 +54,10 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 	vols[3].NodePool = nodes[2].NodePool
 
 	index++
-	must.NoError(t, store.UpsertHostVolumes(index, vols))
+	must.NoError(t, store.UpsertHostVolume(index, vols[0]))
+	must.NoError(t, store.UpsertHostVolume(index, vols[1]))
+	must.NoError(t, store.UpsertHostVolume(index, vols[2]))
+	must.NoError(t, store.UpsertHostVolume(index, vols[3]))
 
 	vol, err := store.HostVolumeByID(nil, vols[0].Namespace, vols[0].ID, true)
 	must.NoError(t, err)
@@ -108,13 +111,13 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 	must.NoError(t, store.UpsertNode(structs.MsgTypeTestSetup, index, nodes[2]))
 
 	// update all the volumes, which should update the state of vol2 as well
+	index++
 	for i, vol := range vols {
 		vol = vol.Copy()
 		vol.RequestedCapacityMaxBytes = 300000
 		vols[i] = vol
+		must.NoError(t, store.UpsertHostVolume(index, vol))
 	}
-	index++
-	must.NoError(t, store.UpsertHostVolumes(index, vols))
 
 	iter, err = store.HostVolumesByName(nil, structs.DefaultNamespace, "example", SortDefault)
 	must.NoError(t, err)
@@ -221,7 +224,10 @@ func TestStateStore_UpdateHostVolumesFromFingerprint(t *testing.T) {
 
 	index++
 	oldIndex := index
-	must.NoError(t, store.UpsertHostVolumes(index, vols))
+	must.NoError(t, store.UpsertHostVolume(index, vols[0]))
+	must.NoError(t, store.UpsertHostVolume(index, vols[1]))
+	must.NoError(t, store.UpsertHostVolume(index, vols[2]))
+	must.NoError(t, store.UpsertHostVolume(index, vols[3]))
 
 	vol0, err := store.HostVolumeByID(nil, ns, vols[0].ID, false)
 	must.NoError(t, err)

--- a/nomad/structs/host_volumes.go
+++ b/nomad/structs/host_volumes.go
@@ -329,22 +329,38 @@ type HostVolumeStub struct {
 }
 
 type HostVolumeCreateRequest struct {
-	Volumes []*HostVolume
+	Volume *HostVolume
+
+	// PolicyOverride is set when the user is attempting to override any
+	// Enterprise policy enforcement
+	PolicyOverride bool
+
 	WriteRequest
 }
 
 type HostVolumeCreateResponse struct {
-	Volumes []*HostVolume
+	Volume *HostVolume
+
+	// Warnings are non-fatal messages from Enterprise policy enforcement
+	Warnings string
 	WriteMeta
 }
 
 type HostVolumeRegisterRequest struct {
-	Volumes []*HostVolume
+	Volume *HostVolume
+
+	// PolicyOverride is set when the user is attempting to override any
+	// Enterprise policy enforcement
+	PolicyOverride bool
+
 	WriteRequest
 }
 
 type HostVolumeRegisterResponse struct {
-	Volumes []*HostVolume
+	Volume *HostVolume
+
+	// Warnings are non-fatal messages from Enterprise policy enforcement
+	Warnings string
 	WriteMeta
 }
 


### PR DESCRIPTION
Most Nomad upsert RPCs accept a single object with the notable exception of CSI. But in CSI we don't actually expose this to users except through the Go API. It deeply complicates how we present errors to users, especially once Sentinel policy enforcement enters the mix.

Refactor the `HostVolume.Create` and `HostVolume.Register` RPCs to take a single volume instead of a slice of volumes.

Add a stub function for Enterprise policy enforcement. This requires splitting out placement from the `createVolume` function so that we can ensure we've completed placement before trying to enforce policy.

Ref: https://github.com/hashicorp/nomad/pull/24479