### PR TITLE
docker: Fix a bug where images with port number and no tags weren't parsed correctly

### DIFF
--- a/.changelog/24547.txt
+++ b/.changelog/24547.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fix a bug where images with port number and no tags weren't parsed correctly
+```

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -2860,6 +2860,8 @@ func TestParseDockerImage(t *testing.T) {
 		Repo  string
 		Tag   string
 	}{
+		{"host:5000/library/hello-world", "host:5000/library/hello-world", "latest"},
+		{"host:5000/library/hello-world:1.0", "host:5000/library/hello-world", "1.0"},
 		{"library/hello-world:1.0", "library/hello-world", "1.0"},
 		{"library/hello-world", "library/hello-world", "latest"},
 		{"library/hello-world:latest", "library/hello-world", "latest"},

--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -31,6 +31,9 @@ func parseDockerImage(image string) (repo, tag string) {
 	} else if t := repoTag[idx+1:]; !strings.Contains(t, "/") {
 		repo = repoTag[:idx]
 		tag = t
+	} else if t := repoTag[idx+1:]; strings.Contains(t, "/") {
+		repo = image
+		tag = "latest"
 	}
 
 	if tag != "" {


### PR DESCRIPTION
### Description

when using private registry without any image tag pull get *Invalid reference format* issue

### Testing & Reproduction steps

on version 1.9.4 send a job with image with following format:

```
ghcr.service.consul:5000/paperless-ngx/paperless-ng
```


### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
