### PR TITLE
[ui, ci] retain artifacts from test runs including test timing

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -65,7 +65,7 @@ jobs:
           PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: |
-          yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results/test-results-${{ matrix.partition }}.json
+          yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results/test-results.json
         continue-on-error: true
       - name: Express timeout failure
         if: ${{ failure() }}

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -70,7 +70,7 @@ jobs:
           yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results-${{ matrix.partition }}.json
       - name: Upload partition test results
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: test-results-partition-${{ matrix.partition }}
           path: ui/test-results-${{ matrix.partition }}.json
@@ -100,7 +100,7 @@ jobs:
             kv/data/teams/nomad/ui PERCY_TOKEN ;
       - name: Download all test results
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: test-results-partition-*
           path: test-results
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload combined results for comparison
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: test-results-${{ github.sha }}
           path: combined-test-results.json

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -71,7 +71,7 @@ jobs:
         if: ${{ failure() }}
         run: exit 1
       - name: Upload partition test results
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: test-results-${{ matrix.partition }}
@@ -101,14 +101,14 @@ jobs:
           secrets: |-
             kv/data/teams/nomad/ui PERCY_TOKEN ;
       - name: Download all test results
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           pattern: test-results-*
           path: test-results
 
       - name: Combine test results for comparison
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         # Note: iterator is hardcoded to 4 to match matrix partitions
         run: |
           node -e "
@@ -142,7 +142,7 @@ jobs:
           "
 
       - name: Upload combined results for comparison
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: test-results-${{ github.sha }}

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -61,20 +61,22 @@ jobs:
           jwtGithubAudience: ${{ vars.CI_VAULT_AUD }}
           secrets: |-
             kv/data/teams/nomad/ui PERCY_TOKEN ;
-      - name: Create results directory
-        run: mkdir -p ui/test-results
-      - name: ember exam
-        env:
-          PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}
-          PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
-        run: |
-          yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results-${{ matrix.partition }}.json
+      # - name: Create results directory
+      #   run: mkdir -p ui/test-results
+      # - name: ember exam
+      #   env:
+      #     PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}
+      #     PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
+      #   run: |
+      #     yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results-${{ matrix.partition }}.json
+      - name: Create fake file
+        run: touch test-results/faux-${{ matrix.partition }}.json
       - name: Upload partition test results
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: test-results-${{ matrix.partition }}
-          path: ui/test-results-${{ matrix.partition }}.json
+          path: test-results-${{ matrix.partition }}.json
           retention-days: 90
   finalize:
     needs:

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -36,7 +36,6 @@ jobs:
       - pre-test
     runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-latest' }}
     timeout-minutes: 30
-    continue-on-error: true
     defaults:
       run:
         working-directory: ui
@@ -67,6 +66,10 @@ jobs:
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: |
           yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results/test-results-${{ matrix.partition }}.json
+        continue-on-error: true
+      - name: Express timeout failure
+        if: ${{ failure() }}
+        run: exit 1
       - name: Upload partition test results
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -111,10 +111,16 @@ jobs:
           node -e "
             const fs = require('fs');
             const results = [];
+            let duration = 0;
+            let aggregateSummary = { total: 0, passed: 0, failed: 0 };
             for (let i = 1; i <= 4; i++) {
               try {
                 const data = JSON.parse(fs.readFileSync('../test-results/test-results-' + i + '/test-results.json'));
                 results.push(...data.tests);
+                duration += data.duration;
+                aggregateSummary.total += data.summary.total;
+                aggregateSummary.passed += data.summary.passed;
+                aggregateSummary.failed += data.summary.failed;
               } catch (err) {
                 console.error('Error reading partition ' + i + ':', err);
               }
@@ -123,10 +129,11 @@ jobs:
               timestamp: new Date().toISOString(),
               sha: process.env.GITHUB_SHA,
               summary: {
-                total: results.length,
-                passed: results.filter(r => r.passed).length,
-                failed: results.filter(r => !r.passed).length
+                total: aggregateSummary.total,
+                passed: aggregateSummary.passed,
+                failed: aggregateSummary.failed
               },
+              duration,
               tests: results
             }, null, 2));
           "

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -61,33 +61,18 @@ jobs:
           jwtGithubAudience: ${{ vars.CI_VAULT_AUD }}
           secrets: |-
             kv/data/teams/nomad/ui PERCY_TOKEN ;
-      # - name: Create results directory
-      #   run: mkdir -p ui/test-results
-      # - name: ember exam
-      #   env:
-      #     PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}
-      #     PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
-      #   run: |
-      #     yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results-${{ matrix.partition }}.json
-      - name: Create fake file
-        working-directory: ui
+      - name: ember exam
+        env:
+          PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}
+          PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: |
-          mkdir -p test-results
-          # touch test-results/faux-${{ matrix.partition }}.json
-          echo '{"testResults": [{"name": "Test '${{ matrix.partition }}'", "time": '${{ matrix.partition }}'00}]}' > test-results/faux-${{ matrix.partition }}.json
-          ls -la test-results/  # Debug: List directory contents
-          pwd                   # Debug: Show current directory
-          echo "File exists: $(test -f test-results/faux-${{ matrix.partition }}.json && echo "yes" || echo "no")"
-
-      #   run: |
-      #     mkdir -p test-results
-      #     touch test-results/faux-${{ matrix.partition }}.json
+          yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results/test-results-${{ matrix.partition }}.json
       - name: Upload partition test results
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: test-results-${{ matrix.partition }}
-          path: ui/test-results/faux-${{ matrix.partition }}.json
+          path: ui/test-results/test-results-${{ matrix.partition }}.json
           retention-days: 90
   finalize:
     needs:
@@ -119,15 +104,6 @@ jobs:
           pattern: test-results-*
           path: test-results
 
-      - name: Debug directory structure
-        run: |
-          echo "Current directory:"
-          pwd
-          echo "Root directory contents:"
-          ls -la ..
-          echo "Test results directory contents:"
-          ls -la ../test-results || echo "test-results directory not found"
-            
       - name: Combine test results for comparison
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         # Note: iterator is hardcoded to 4 to match matrix partitions
@@ -135,11 +111,8 @@ jobs:
           node -e "
             const fs = require('fs');
             const results = [];
-            // Log where I am
-            console.log('Current directory:', process.cwd());
-
             for (let i = 1; i <= 4; i++) {
-              const data = JSON.parse(fs.readFileSync('../test-results/test-results-' + i + '/faux-' + i + '.json'));
+              const data = JSON.parse(fs.readFileSync('../test-results/test-results-' + i + '/test-results-' + i + '.json'));
               results.push(...data.testResults);
             }
             fs.writeFileSync('combined-test-results.json', JSON.stringify({

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -70,13 +70,24 @@ jobs:
       #   run: |
       #     yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results-${{ matrix.partition }}.json
       - name: Create fake file
-        run: touch test-results/faux-${{ matrix.partition }}.json
+        working-directory: ui
+        run: |
+          mkdir -p test-results
+          # touch test-results/faux-${{ matrix.partition }}.json
+          echo '{"testResults": [{"name": "Test '${{ matrix.partition }}'", "time": '${{ matrix.partition }}'00}]}' > test-results/faux-${{ matrix.partition }}.json
+          ls -la test-results/  # Debug: List directory contents
+          pwd                   # Debug: Show current directory
+          echo "File exists: $(test -f test-results/faux-${{ matrix.partition }}.json && echo "yes" || echo "no")"
+
+      #   run: |
+      #     mkdir -p test-results
+      #     touch test-results/faux-${{ matrix.partition }}.json
       - name: Upload partition test results
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: test-results-${{ matrix.partition }}
-          path: test-results-${{ matrix.partition }}.json
+          path: ui/test-results/faux-${{ matrix.partition }}.json
           retention-days: 90
   finalize:
     needs:
@@ -108,6 +119,15 @@ jobs:
           pattern: test-results-*
           path: test-results
 
+      - name: Debug directory structure
+        run: |
+          echo "Current directory:"
+          pwd
+          echo "Root directory contents:"
+          ls -la ..
+          echo "Test results directory contents:"
+          ls -la ../test-results || echo "test-results directory not found"
+            
       - name: Combine test results for comparison
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         # Note: iterator is hardcoded to 4 to match matrix partitions
@@ -115,8 +135,11 @@ jobs:
           node -e "
             const fs = require('fs');
             const results = [];
+            // Log where I am
+            console.log('Current directory:', process.cwd());
+
             for (let i = 1; i <= 4; i++) {
-              const data = JSON.parse(fs.readFileSync('test-results/test-results-' + i));
+              const data = JSON.parse(fs.readFileSync('../test-results/test-results-' + i + '/faux-' + i + '.json'));
               results.push(...data.testResults);
             }
             fs.writeFileSync('combined-test-results.json', JSON.stringify({
@@ -131,7 +154,7 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: test-results-${{ github.sha }}
-          path: combined-test-results.json
+          path: ui/combined-test-results.json
           retention-days: 90
 
       - name: finalize

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -72,7 +72,7 @@ jobs:
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
           name: test-results-${{ matrix.partition }}
-          path: ui/test-results/test-results-${{ matrix.partition }}.json
+          path: ui/test-results/test-results.json
           retention-days: 90
   finalize:
     needs:
@@ -112,13 +112,22 @@ jobs:
             const fs = require('fs');
             const results = [];
             for (let i = 1; i <= 4; i++) {
-              const data = JSON.parse(fs.readFileSync('../test-results/test-results-' + i + '/test-results-' + i + '.json'));
-              results.push(...data.testResults);
+              try {
+                const data = JSON.parse(fs.readFileSync('../test-results/test-results-' + i + '/test-results.json'));
+                results.push(...data.tests);
+              } catch (err) {
+                console.error('Error reading partition ' + i + ':', err);
+              }
             }
             fs.writeFileSync('combined-test-results.json', JSON.stringify({
               timestamp: new Date().toISOString(),
               sha: process.env.GITHUB_SHA,
-              testResults: results
+              summary: {
+                total: results.length,
+                passed: results.filter(r => r.passed).length,
+                failed: results.filter(r => !r.passed).length
+              },
+              tests: results
             }, null, 2));
           "
 

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -61,18 +61,19 @@ jobs:
           jwtGithubAudience: ${{ vars.CI_VAULT_AUD }}
           secrets: |-
             kv/data/teams/nomad/ui PERCY_TOKEN ;
+      - name: Create results directory
+        run: mkdir -p ui/test-results
       - name: ember exam
         env:
           PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
-        # run: yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }}
         run: |
           yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results-${{ matrix.partition }}.json
       - name: Upload partition test results
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: test-results-partition-${{ matrix.partition }}
+          name: test-results-${{ matrix.partition }}
           path: ui/test-results-${{ matrix.partition }}.json
           retention-days: 90
   finalize:
@@ -102,7 +103,7 @@ jobs:
         # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          pattern: test-results-partition-*
+          pattern: test-results-*
           path: test-results
 
       - name: Combine test results for comparison
@@ -113,8 +114,7 @@ jobs:
             const fs = require('fs');
             const results = [];
             for (let i = 1; i <= 4; i++) {
-              const filePath = 'test-results/test-results-partition-' + i + '/test-results-' + i + '.json';
-              const data = JSON.parse(fs.readFileSync(filePath));
+              const data = JSON.parse(fs.readFileSync('test-results/test-results-' + i));
               results.push(...data.testResults);
             }
             fs.writeFileSync('combined-test-results.json', JSON.stringify({

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -109,38 +109,7 @@ jobs:
 
       - name: Combine test results for comparison
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        # Note: iterator is hardcoded to 4 to match matrix partitions
-        run: |
-          node -e "
-            const fs = require('fs');
-            const results = [];
-            let duration = 0;
-            let aggregateSummary = { total: 0, passed: 0, failed: 0 };
-            for (let i = 1; i <= 4; i++) {
-              try {
-                const data = JSON.parse(fs.readFileSync('../test-results/test-results-' + i + '/test-results.json'));
-                results.push(...data.tests);
-                duration += data.duration;
-                aggregateSummary.total += data.summary.total;
-                aggregateSummary.passed += data.summary.passed;
-                aggregateSummary.failed += data.summary.failed;
-              } catch (err) {
-                console.error('Error reading partition ' + i + ':', err);
-              }
-            }
-            fs.writeFileSync('combined-test-results.json', JSON.stringify({
-              timestamp: new Date().toISOString(),
-              sha: process.env.GITHUB_SHA,
-              summary: {
-                total: aggregateSummary.total,
-                passed: aggregateSummary.passed,
-                failed: aggregateSummary.failed
-              },
-              duration,
-              tests: results
-            }, null, 2));
-          "
-
+        run: node ../scripts/combine-ui-test-results.js
       - name: Upload combined results for comparison
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -2,14 +2,14 @@ name: test-ui
 on:
   pull_request:
     paths:
-      - 'ui/**'
+      - "ui/**"
   push:
     branches:
       - main
       - release/**
       - test-ui
     paths:
-      - 'ui/**'
+      - "ui/**"
 
 jobs:
   pre-test:
@@ -44,6 +44,8 @@ jobs:
       matrix:
         partition: [1, 2, 3, 4]
         split: [4]
+        # Note: If we ever change the number of partitions, we'll need to update the
+        # finalize.combine step to match
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-js
@@ -63,8 +65,16 @@ jobs:
         env:
           PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
-        run: yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }}
-
+        # run: yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }}
+        run: |
+          yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results-${{ matrix.partition }}.json
+      - name: Upload partition test results
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-partition-${{ matrix.partition }}
+          path: ui/test-results-${{ matrix.partition }}.json
+          retention-days: 90
   finalize:
     needs:
       - pre-test
@@ -88,6 +98,40 @@ jobs:
           jwtGithubAudience: ${{ vars.CI_VAULT_AUD }}
           secrets: |-
             kv/data/teams/nomad/ui PERCY_TOKEN ;
+      - name: Download all test results
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: test-results-partition-*
+          path: test-results
+
+      - name: Combine test results for comparison
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        # Note: iterator is hardcoded to 4 to match matrix partitions
+        run: |
+          node -e "
+            const fs = require('fs');
+            const results = [];
+            for (let i = 1; i <= 4; i++) {
+              const filePath = 'test-results/test-results-partition-' + i + '/test-results-' + i + '.json';
+              const data = JSON.parse(fs.readFileSync(filePath));
+              results.push(...data.testResults);
+            }
+            fs.writeFileSync('combined-test-results.json', JSON.stringify({
+              timestamp: new Date().toISOString(),
+              sha: process.env.GITHUB_SHA,
+              testResults: results
+            }, null, 2));
+          "
+
+      - name: Upload combined results for comparison
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-${{ github.sha }}
+          path: combined-test-results.json
+          retention-days: 90
+
       - name: finalize
         env:
           PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}

--- a/scripts/combine-ui-test-results.js
+++ b/scripts/combine-ui-test-results.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+'use strict';
+const fs = require('fs');
+
+const NUM_PARTITIONS = 4;
+
+function combineResults() {
+  const results = [];
+  let duration = 0;
+  let aggregateSummary = { total: 0, passed: 0, failed: 0 };
+
+  for (let i = 1; i <= NUM_PARTITIONS; i++) {
+    try {
+      const data = JSON.parse(
+        fs.readFileSync(`../test-results/test-results-${i}/test-results.json`).toString()
+      );
+      results.push(...data.tests);
+      duration += data.duration;
+      aggregateSummary.total += data.summary.total;
+      aggregateSummary.passed += data.summary.passed;
+      aggregateSummary.failed += data.summary.failed;
+    } catch (err) {
+      console.error(`Error reading partition ${i}:`, err);
+    }
+  }
+
+  const output = {
+    timestamp: new Date().toISOString(),
+    sha: process.env.GITHUB_SHA,
+    summary: {
+      total: aggregateSummary.total,
+      passed: aggregateSummary.passed,
+      failed: aggregateSummary.failed
+    },
+    duration,
+    tests: results
+  };
+
+  fs.writeFileSync('../ui/combined-test-results.json', JSON.stringify(output, null, 2));
+}
+
+if (require.main === module) {
+  combineResults();
+}
+
+module.exports = combineResults;

--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -24,6 +24,7 @@
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
+
     <script src="{{rootURL}}assets/nomad-ui.js"></script>
 
     {{content-for "body-footer"}}

--- a/ui/test-reporter.js
+++ b/ui/test-reporter.js
@@ -128,12 +128,12 @@ class JsonReporter {
 
       // Print a summary
       console.log('\n[Reporter] Test Summary:');
-      console.log(`Total:  ${total}`);
-      console.log(`Passed: ${passed}`);
-      console.log(`Failed: ${failed}`);
-      console.log(`Duration: ${duration}ms`);
+      console.log(`- Total:  ${total}`);
+      console.log(`- Passed: ${passed}`);
+      console.log(`- Failed: ${failed}`);
+      console.log(`- Duration: ${duration}ms`);
       if (failed > 0) {
-        console.log('\nFailed Tests:');
+        console.log('\n[Reporter] Failed Tests:');
         this.results
           .filter((r) => !r.passed)
           .forEach((r) => {

--- a/ui/test-reporter.js
+++ b/ui/test-reporter.js
@@ -15,30 +15,36 @@ class JsonReporter {
     this.results = [];
 
     // Get output file from Testem config
-    this.outputFile =
-      config.fileOptions.custom_report_file || 'test-results/test-results.json';
+    this.outputFile = config?.fileOptions?.custom_report_file;
+    this.generateReport = !!this.outputFile;
 
-    console.log(`[Reporter] Initializing with output file: ${this.outputFile}`);
-
-    try {
-      fs.mkdirSync(path.dirname(this.outputFile), { recursive: true });
-
-      // Initialize the results file
-      fs.writeFileSync(
-        this.outputFile,
-        JSON.stringify(
-          {
-            summary: { total: 0, passed: 0, failed: 0 },
-            timestamp: new Date().toISOString(),
-            tests: [],
-          },
-          null,
-          2
-        )
+    if (this.generateReport) {
+      console.log(
+        `[Reporter] Initializing with output file: ${this.outputFile}`
       );
-      console.log('[Reporter] Initialized results file');
-    } catch (err) {
-      console.error('[Reporter] Error initializing results file:', err);
+
+      try {
+        fs.mkdirSync(path.dirname(this.outputFile), { recursive: true });
+
+        // Initialize the results file
+        fs.writeFileSync(
+          this.outputFile,
+          JSON.stringify(
+            {
+              summary: { total: 0, passed: 0, failed: 0 },
+              timestamp: new Date().toISOString(),
+              tests: [],
+            },
+            null,
+            2
+          )
+        );
+        console.log('[Reporter] Initialized results file');
+      } catch (err) {
+        console.error('[Reporter] Error initializing results file:', err);
+      }
+    } else {
+      console.log('[Reporter] No report file configured, skipping JSON output');
     }
 
     process.on('SIGINT', () => {
@@ -116,7 +122,9 @@ class JsonReporter {
         tests: this.results,
       };
 
-      fs.writeFileSync(this.outputFile, JSON.stringify(output, null, 2));
+      if (this.generateReport) {
+        fs.writeFileSync(this.outputFile, JSON.stringify(output, null, 2));
+      }
 
       // Print a summary
       console.log('\n[Reporter] Test Summary:');

--- a/ui/test-reporter.js
+++ b/ui/test-reporter.js
@@ -49,6 +49,23 @@ class JsonReporter {
     });
   }
 
+  filterLogs(logs) {
+    return logs.filter((log) => {
+      // Filter out token-related logs
+      if (
+        log.text &&
+        (log.text.includes('Accessor:') ||
+          log.text === 'TOKENS:' ||
+          log.text === '=====================================')
+      ) {
+        return false;
+      }
+
+      // Keep non-warning logs that aren't token-related
+      return log.type !== 'warn';
+    });
+  }
+
   report(prefix, data) {
     if (!data || !data.name) {
       console.log(`[Reporter] Skipping invalid test result: ${data.name}`);
@@ -57,14 +74,25 @@ class JsonReporter {
 
     console.log(`[Reporter] Processing test: ${data.name}`);
 
+    const partitionMatch = data.name.match(/^Exam Partition (\d+) - (.*)/);
+
     const result = {
-      name: data.name.trim(),
+      name: partitionMatch ? partitionMatch[2] : data.name.trim(),
+      partition: partitionMatch ? parseInt(partitionMatch[1], 10) : null,
       browser: prefix,
       passed: !data.failed,
       duration: data.runDuration,
       error: data.failed ? data.error : null,
-      logs: (data.logs || []).filter((log) => log.type !== 'warn'),
+      logs: this.filterLogs(data.logs || []),
     };
+
+    if (result.passed) {
+      console.log('- [PASS]');
+    } else {
+      console.log('- [FAIL]');
+      console.log('- Error:', result.error);
+      console.log('- Logs:', result.logs);
+    }
 
     this.results.push(result);
   }
@@ -72,23 +100,41 @@ class JsonReporter {
   writeCurrentResults() {
     console.log('[Reporter] Writing current results...');
     try {
+      const passed = this.results.filter((r) => r.passed).length;
+      const failed = this.results.filter((r) => !r.passed).length;
+      const total = this.results.length;
+
       const output = {
-        summary: {
-          total: this.results.length,
-          passed: this.results.filter((r) => r.passed).length,
-          failed: this.results.filter((r) => !r.passed).length,
-        },
+        summary: { total, passed, failed },
         timestamp: new Date().toISOString(),
         tests: this.results,
       };
 
       fs.writeFileSync(this.outputFile, JSON.stringify(output, null, 2));
+
+      // Print a summary
+      console.log('\n[Reporter] Test Summary:');
+      console.log(`Total:  ${total}`);
+      console.log(`Passed: ${passed}`);
+      console.log(`Failed: ${failed}`);
+
+      if (failed > 0) {
+        console.log('\nFailed Tests:');
+        this.results
+          .filter((r) => !r.passed)
+          .forEach((r) => {
+            console.log(`❌ ${r.name}`);
+            if (r.error) {
+              console.log(`   ${r.error}`);
+            }
+          });
+      }
+
       console.log('[Reporter] Successfully wrote results');
     } catch (err) {
       console.error('[Reporter] Error writing results:', err);
     }
   }
-
   finish() {
     console.log('[Reporter] Finishing up...');
     this.writeCurrentResults();

--- a/ui/test-reporter.js
+++ b/ui/test-reporter.js
@@ -1,0 +1,99 @@
+/* eslint-env node */
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const path = require('path');
+
+class JsonReporter {
+  constructor(out, socket, config) {
+    // Prevent double initialization
+    if (JsonReporter.instance) {
+      return JsonReporter.instance;
+    }
+    JsonReporter.instance = this;
+
+    this.out = out || process.stdout;
+    this.results = [];
+
+    // Get output file from Testem config
+    this.outputFile = config.fileOptions.report_file || 'test-results.json';
+
+    console.log(`[Reporter] Initializing with output file: ${this.outputFile}`);
+
+    try {
+      // Ensure output directory exists
+      fs.mkdirSync(path.dirname(this.outputFile), { recursive: true });
+
+      // Initialize the results file
+      fs.writeFileSync(
+        this.outputFile,
+        JSON.stringify(
+          {
+            summary: { total: 0, passed: 0, failed: 0 },
+            timestamp: new Date().toISOString(),
+            tests: [],
+          },
+          null,
+          2
+        )
+      );
+      console.log('[Reporter] Initialized results file');
+    } catch (err) {
+      console.error('[Reporter] Error initializing results file:', err);
+    }
+
+    process.on('SIGINT', () => {
+      console.log('[Reporter] Received SIGINT, finishing up...');
+      this.finish();
+      process.exit(0);
+    });
+  }
+
+  report(prefix, data) {
+    if (!data || !data.name) {
+      console.log(`[Reporter] Skipping invalid test result: ${data.name}`);
+      return;
+    }
+
+    console.log(`[Reporter] Processing test: ${data.name}`);
+
+    const result = {
+      name: data.name.trim(),
+      browser: prefix,
+      passed: !data.failed,
+      duration: data.runDuration,
+      error: data.failed ? data.error : null,
+      logs: (data.logs || []).filter((log) => log.type !== 'warn'),
+    };
+
+    this.results.push(result);
+  }
+
+  writeCurrentResults() {
+    console.log('[Reporter] Writing current results...');
+    try {
+      const output = {
+        summary: {
+          total: this.results.length,
+          passed: this.results.filter((r) => r.passed).length,
+          failed: this.results.filter((r) => !r.passed).length,
+        },
+        timestamp: new Date().toISOString(),
+        tests: this.results,
+      };
+
+      fs.writeFileSync(this.outputFile, JSON.stringify(output, null, 2));
+      console.log('[Reporter] Successfully wrote results');
+    } catch (err) {
+      console.error('[Reporter] Error writing results:', err);
+    }
+  }
+
+  finish() {
+    console.log('[Reporter] Finishing up...');
+    this.writeCurrentResults();
+    console.log('[Reporter] Done.');
+  }
+}
+
+module.exports = JsonReporter;

--- a/ui/test-reporter.js
+++ b/ui/test-reporter.js
@@ -14,7 +14,7 @@ class JsonReporter {
     this.out = out || process.stdout;
     this.results = [];
 
-    // Get output file from Testem config
+    // Get output file from Testem config, which is set by the --json-report=path argument
     this.outputFile = config?.fileOptions?.custom_report_file;
     this.generateReport = !!this.outputFile;
 

--- a/ui/testem.js
+++ b/ui/testem.js
@@ -15,7 +15,11 @@ const config = {
   parallel: -1,
   framework: 'qunit',
   reporter: JsonReporter,
-  report_file: 'test-results/test-results.json',
+  custom_report_file: 'test-results/test-results.json',
+  // report_file: 'test-results/test-results.json',
+  // NOTE: See https://github.com/testem/testem/issues/1073, report_file + custom reporter results in double output.
+  debug: true,
+
   browser_args: {
     // New format in testem/master, but not in a release yet
     // Chrome: {

--- a/ui/testem.js
+++ b/ui/testem.js
@@ -13,7 +13,6 @@ const JsonReporter = require('./test-reporter');
  * @returns {string} The path to the test results file
  */
 const getReportPath = () => {
-  // Look for --json-report=path
   const jsonReportArg = process.argv.find((arg) =>
     arg.startsWith('--json-report=')
   );

--- a/ui/testem.js
+++ b/ui/testem.js
@@ -4,6 +4,7 @@
  */
 
 'use strict';
+const JsonReporter = require('./test-reporter');
 
 const config = {
   test_page: 'tests/index.html?hidepassed',
@@ -13,6 +14,8 @@ const config = {
   browser_start_timeout: 120,
   parallel: -1,
   framework: 'qunit',
+  reporter: JsonReporter,
+  report_file: 'test-results/test-results.json',
   browser_args: {
     // New format in testem/master, but not in a release yet
     // Chrome: {

--- a/ui/testem.js
+++ b/ui/testem.js
@@ -3,8 +3,24 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
+// @ts-check
+
 'use strict';
 const JsonReporter = require('./test-reporter');
+
+
+/**
+ * Get the path for the test results file based on the command line arguments
+ * @returns {string} The path to the test results file
+ */
+const getReportPath = () => {
+  // Look for --json-report=path
+  const jsonReportArg = process.argv.find(arg => arg.startsWith('--json-report='));
+  if (jsonReportArg) {
+    return jsonReportArg.split('=')[1];
+  }
+  return null;
+};
 
 const config = {
   test_page: 'tests/index.html?hidepassed',
@@ -15,9 +31,9 @@ const config = {
   parallel: -1,
   framework: 'qunit',
   reporter: JsonReporter,
-  custom_report_file: 'test-results/test-results.json',
-  // report_file: 'test-results/test-results.json',
-  // NOTE: See https://github.com/testem/testem/issues/1073, report_file + custom reporter results in double output.
+  custom_report_file: getReportPath(),
+  // NOTE: we output this property as custom_report_file instead of report_file.
+  // See https://github.com/testem/testem/issues/1073, report_file + custom reporter results in double output.
   debug: true,
 
   browser_args: {

--- a/ui/testem.js
+++ b/ui/testem.js
@@ -8,14 +8,15 @@
 'use strict';
 const JsonReporter = require('./test-reporter');
 
-
 /**
  * Get the path for the test results file based on the command line arguments
  * @returns {string} The path to the test results file
  */
 const getReportPath = () => {
   // Look for --json-report=path
-  const jsonReportArg = process.argv.find(arg => arg.startsWith('--json-report='));
+  const jsonReportArg = process.argv.find((arg) =>
+    arg.startsWith('--json-report=')
+  );
   if (jsonReportArg) {
     return jsonReportArg.split('=')[1];
   }

--- a/ui/tests/acceptance/variables-test.js
+++ b/ui/tests/acceptance/variables-test.js
@@ -717,7 +717,7 @@ module('Acceptance | variables', function (hooks) {
       assert.ok(confirmFired, 'Confirm fired when leaving with unsaved form');
       assert.equal(
         currentURL(),
-        '/variables/var/Auto-conflicting%20Variable@default/edit',
+        '/variables/var/Auto-conflicting%20Variable@default/editte',
         'Opted to stay, did not leave page'
       );
 

--- a/ui/tests/acceptance/variables-test.js
+++ b/ui/tests/acceptance/variables-test.js
@@ -717,7 +717,7 @@ module('Acceptance | variables', function (hooks) {
       assert.ok(confirmFired, 'Confirm fired when leaving with unsaved form');
       assert.equal(
         currentURL(),
-        '/variables/var/Auto-conflicting%20Variable@default/editte',
+        '/variables/var/Auto-conflicting%20Variable@default/edit',
         'Opted to stay, did not leave page'
       );
 


### PR DESCRIPTION
### Description
Our `ember-test-audit` action is currently failing, and I'm using that as an excuse to improve our front-end testing story generally.

This will be a two-step approach, and this PR is the first step:
1. Save artifacts, including test timing, from `test-ui` test results on merge to `main`
2. Compare to a rolling window of these test results on subsequent PRs

This PR adds artifact uploads on the back of `test-ui`. Because those are partitioned/run concurrently 4x, part of this is combining those.

The artifact generated looks like this:

```
{
  "timestamp": "2024-12-02T18:20:59.531Z",
  "sha": "7fd10531ef3e12672a19a7a9aa7a6e4f4f874614",
  "summary": {
    "total": 1606,
    "passed": 1606,
    "failed": 0
  },
  "duration": 841403,
  "tests": [
    {
      "name": "Acceptance | allocation fs: it passes an accessibility audit",
      "partition": 1,
      "browser": "Chrome 131.0",
      "passed": true,
      "duration": 1331,
      "error": null,
      "logs": []
    },
    {
      "name": "Acceptance | allocation fs: visiting filesystem root",
      "partition": 1,
      "browser": "Chrome 131.0",
      "passed": true,
      "duration": 505,
      "error": null,
      "logs": []
    },
    {
      "name": "Acceptance | allocation fs: visiting filesystem paths",
      "partition": 1,
      "browser": "Chrome 131.0",
      "passed": true,
      "duration": 542,
      "error": null,
      "logs": []
    },
...
```

In phase 2 of this, we'll be able to do test-by-test duration averages and comparisons, and tease out those tests with the greatest deltas, find flakes, etc.