### PR TITLE
goflags: go:build linux for tests that won't compile on other platforms

### DIFF
--- a/client/allocrunner/networking_iptables_test.go
+++ b/client/allocrunner/networking_iptables_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
+//go:build linux
+
 package allocrunner
 
 import (

--- a/client/allocrunner/taskrunner/sids_hook_test.go
+++ b/client/allocrunner/taskrunner/sids_hook_test.go
@@ -1,8 +1,8 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-//go:build !windows
-// +build !windows
+//go:build linux
+// +build linux
 
 // todo(shoenig): Once Connect is supported on Windows, we'll need to make this
 //  set of tests work there too.

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -1,6 +1,8 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
+//go:build linux
+
 package taskrunner
 
 import (

--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build !windows
+//go:build linux
 
 package executor
 


### PR DESCRIPTION
I'm a heavy LSP user and I frequently goto:next_error. This confuses my editor on macOS.