### PR TITLE
dynamic host volumes: set namespace from volume spec when monitoring

### DIFF
--- a/command/volume_create_host.go
+++ b/command/volume_create_host.go
@@ -50,6 +50,10 @@ func (c *VolumeCreateCommand) hostVolumeCreate(
 		lastIndex = vol.ModifyIndex
 	}
 
+	if vol.Namespace != "" {
+		client.SetNamespace(vol.Namespace)
+	}
+
 	err = c.monitorHostVolume(client, volID, lastIndex, verbose)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("==> %s: %v", formatTime(time.Now()), err.Error()))


### PR DESCRIPTION
In #24528 we added monitoring to the CLI for dynamic host volume creation. But when the volume's namespace is set by the volume specification instead of the `-namespace` flag, the API client doesn't have the right namespace and gets a 404 when setting up the monitoring. The specification always overrides the `-namespace` flag, so use that when available for all subsequent API calls.

Ref: https://github.com/hashicorp/nomad/pull/24479
