### PR TITLE
dynamic host volumes: policy-override flag on CLI

### DIFF
--- a/api/host_volumes.go
+++ b/api/host_volumes.go
@@ -160,6 +160,16 @@ type HostVolumeRegisterRequest struct {
 	PolicyOverride bool
 }
 
+type HostVolumeCreateResponse struct {
+	Volume   *HostVolume
+	Warnings string
+}
+
+type HostVolumeRegisterResponse struct {
+	Volume   *HostVolume
+	Warnings string
+}
+
 type HostVolumeListRequest struct {
 	NodeID   string
 	NodePool string
@@ -171,28 +181,24 @@ type HostVolumeDeleteRequest struct {
 
 // Create forwards to client agents so a host volume can be created on those
 // hosts, and registers the volume with Nomad servers.
-func (hv *HostVolumes) Create(req *HostVolumeCreateRequest, opts *WriteOptions) (*HostVolume, *WriteMeta, error) {
-	var out struct {
-		Volume *HostVolume
-	}
+func (hv *HostVolumes) Create(req *HostVolumeCreateRequest, opts *WriteOptions) (*HostVolumeCreateResponse, *WriteMeta, error) {
+	var out *HostVolumeCreateResponse
 	wm, err := hv.client.put("/v1/volume/host/create", req, &out, opts)
 	if err != nil {
 		return nil, wm, err
 	}
-	return out.Volume, wm, nil
+	return out, wm, nil
 }
 
 // Register registers a host volume that was created out-of-band with the Nomad
 // servers.
-func (hv *HostVolumes) Register(req *HostVolumeRegisterRequest, opts *WriteOptions) (*HostVolume, *WriteMeta, error) {
-	var out struct {
-		Volume *HostVolume
-	}
+func (hv *HostVolumes) Register(req *HostVolumeRegisterRequest, opts *WriteOptions) (*HostVolumeRegisterResponse, *WriteMeta, error) {
+	var out *HostVolumeRegisterResponse
 	wm, err := hv.client.put("/v1/volume/host/register", req, &out, opts)
 	if err != nil {
 		return nil, wm, err
 	}
-	return out.Volume, wm, nil
+	return out, wm, nil
 }
 
 // Get queries for a single host volume, by ID

--- a/api/host_volumes.go
+++ b/api/host_volumes.go
@@ -148,10 +148,16 @@ func (c *Client) HostVolumes() *HostVolumes {
 
 type HostVolumeCreateRequest struct {
 	Volume *HostVolume
+
+	// PolicyOverride overrides Sentinel soft-mandatory policy enforcement
+	PolicyOverride bool
 }
 
 type HostVolumeRegisterRequest struct {
 	Volume *HostVolume
+
+	// PolicyOverride overrides Sentinel soft-mandatory policy enforcement
+	PolicyOverride bool
 }
 
 type HostVolumeListRequest struct {

--- a/command/volume_create.go
+++ b/command/volume_create.go
@@ -46,6 +46,9 @@ Create Options:
     Display full information when monitoring volume state. Used for dynamic host
     volumes only.
 
+  -policy-override
+    Sets the flag to force override any soft mandatory Sentinel policies. Used
+    for dynamic host volumes only.
 `
 
 	return strings.TrimSpace(helpText)
@@ -54,8 +57,9 @@ Create Options:
 func (c *VolumeCreateCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
-			"-detach":  complete.PredictNothing,
-			"-verbose": complete.PredictNothing,
+			"-detach":          complete.PredictNothing,
+			"-verbose":         complete.PredictNothing,
+			"-policy-override": complete.PredictNothing,
 		})
 }
 
@@ -70,10 +74,11 @@ func (c *VolumeCreateCommand) Synopsis() string {
 func (c *VolumeCreateCommand) Name() string { return "volume create" }
 
 func (c *VolumeCreateCommand) Run(args []string) int {
-	var detach, verbose bool
+	var detach, verbose, override bool
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.BoolVar(&detach, "detach", false, "detach from monitor")
 	flags.BoolVar(&verbose, "verbose", false, "display full volume IDs")
+	flags.BoolVar(&override, "policy-override", false, "override soft mandatory Sentinel policies")
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 
 	if err := flags.Parse(args); err != nil {
@@ -124,7 +129,7 @@ func (c *VolumeCreateCommand) Run(args []string) int {
 	case "csi":
 		return c.csiCreate(client, ast)
 	case "host":
-		return c.hostVolumeCreate(client, ast, detach, verbose)
+		return c.hostVolumeCreate(client, ast, detach, verbose, override)
 	default:
 		c.Ui.Error(fmt.Sprintf("Error unknown volume type: %s", volType))
 		return 1

--- a/command/volume_create_host.go
+++ b/command/volume_create_host.go
@@ -19,7 +19,7 @@ import (
 )
 
 func (c *VolumeCreateCommand) hostVolumeCreate(
-	client *api.Client, ast *ast.File, detach, verbose bool) int {
+	client *api.Client, ast *ast.File, detach, verbose, override bool) int {
 
 	vol, err := decodeHostVolume(ast)
 	if err != nil {
@@ -28,7 +28,8 @@ func (c *VolumeCreateCommand) hostVolumeCreate(
 	}
 
 	req := &api.HostVolumeCreateRequest{
-		Volume: vol,
+		Volume:         vol,
+		PolicyOverride: override,
 	}
 	vol, _, err = client.HostVolumes().Create(req, nil)
 	if err != nil {

--- a/command/volume_create_host.go
+++ b/command/volume_create_host.go
@@ -31,10 +31,17 @@ func (c *VolumeCreateCommand) hostVolumeCreate(
 		Volume:         vol,
 		PolicyOverride: override,
 	}
-	vol, _, err = client.HostVolumes().Create(req, nil)
+	resp, _, err := client.HostVolumes().Create(req, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error creating volume: %s", err))
 		return 1
+	}
+	vol = resp.Volume
+
+	if resp.Warnings != "" {
+		c.Ui.Output(
+			c.Colorize().Color(
+				fmt.Sprintf("[bold][yellow]Volume Warnings:\n%s[reset]\n", resp.Warnings)))
 	}
 
 	var volID string

--- a/command/volume_register_host.go
+++ b/command/volume_register_host.go
@@ -21,11 +21,19 @@ func (c *VolumeRegisterCommand) hostVolumeRegister(client *api.Client, ast *ast.
 		Volume:         vol,
 		PolicyOverride: override,
 	}
-	vol, _, err = client.HostVolumes().Register(req, nil)
+	resp, _, err := client.HostVolumes().Register(req, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error registering volume: %s", err))
 		return 1
 	}
+	vol = resp.Volume
+
+	if resp.Warnings != "" {
+		c.Ui.Output(
+			c.Colorize().Color(
+				fmt.Sprintf("[bold][yellow]Volume Warnings:\n%s[reset]\n", resp.Warnings)))
+	}
+
 	c.Ui.Output(fmt.Sprintf(
 		"Registered host volume %s with ID %s", vol.Name, vol.ID))
 

--- a/command/volume_register_host.go
+++ b/command/volume_register_host.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/nomad/api"
 )
 
-func (c *VolumeRegisterCommand) hostVolumeRegister(client *api.Client, ast *ast.File) int {
+func (c *VolumeRegisterCommand) hostVolumeRegister(client *api.Client, ast *ast.File, override bool) int {
 	vol, err := decodeHostVolume(ast)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error decoding the volume definition: %s", err))
@@ -18,7 +18,8 @@ func (c *VolumeRegisterCommand) hostVolumeRegister(client *api.Client, ast *ast.
 	}
 
 	req := &api.HostVolumeRegisterRequest{
-		Volume: vol,
+		Volume:         vol,
+		PolicyOverride: override,
 	}
 	vol, _, err = client.HostVolumes().Register(req, nil)
 	if err != nil {


### PR DESCRIPTION
The create/register volume RPCs support a policy override flag for soft-mandatory Sentinel policies, but the CLI and Go API were missing support for it.

Also add support for Sentinel warnings to the Go API and CLI.

Ref: https://github.com/hashicorp/nomad/pull/24479

---

Testing with the following policy file:

```hcl
has_tag = func() {
  print("volume is missing tag")
  tag = volume.parameters["tag"] else 0
  return tag is not 0
}

main = rule { has_tag() }
```

After applying this branch on top of https://github.com/hashicorp/nomad-enterprise/pull/2087:

```sh
$ nomad sentinel apply -scope=submit-volume -level=soft-mandatory no-untagged-volumes ./policy.hcl
Successfully wrote "no-untagged-volumes" Sentinel policy!

$ nomad volume create ./demo/hostvolume/host.volume.hcl
Error creating volume: Unexpected response code: 500 (1 error occurred:
        * no-untagged-volumes : Result: false

Print messages:

volume is missing tag

no-untagged-volumes:7:1 - Rule "main"
  Value:
    false)

$ nomad volume create -policy-override ./demo/hostvolume/host.volume.hcl
==> Created host volume test with ID 533bd0e0-ec17-2607-97b4-56eb2079aaad
  ⠦ Monitoring volume "533bd0e0" in progress...

    2024-12-02T16:07:59-05:00
    ID        = 533bd0e0-ec17-2607-97b4-56eb2079aaad
    Name      = test
    Namespace = default
    Plugin ID = example-host-volume
    Node ID   = 876ae9a8-4a89-1f50-2d87-a8ecdd01be5b
    Node Pool = default
    Capacity  = 47 MiB
    State     = pending
    Host Path = /run/nomad/dev/alloc_mounts/533bd0e0-ec17-2607-97b4-56eb2079aaad^C
```