### PR TITLE
helper: sanitize method on ACL token object

### DIFF
--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -474,6 +474,16 @@ func (a *ACLToken) UnmarshalJSON(data []byte) (err error) {
 	return nil
 }
 
+func (a *ACLToken) Sanitize() *ACLToken {
+	if a == nil {
+		return nil
+	}
+
+	out := a.Copy()
+	out.SecretID = ""
+	return out
+}
+
 // ACLRole is an abstraction for the ACL system which allows the grouping of
 // ACL policies into a single object. ACL tokens can be created and linked to
 // a role; the token then inherits all the permissions granted by the policies.

--- a/nomad/structs/event.go
+++ b/nomad/structs/event.go
@@ -155,8 +155,7 @@ type ServiceRegistrationStreamEvent struct {
 // NewACLTokenEvent takes a token and creates a new ACLTokenEvent.  It creates
 // a copy of the passed in ACLToken and empties out the copied tokens SecretID
 func NewACLTokenEvent(token *ACLToken) *ACLTokenEvent {
-	c := token.Copy()
-	c.SecretID = ""
+	c := token.Sanitize()
 
 	return &ACLTokenEvent{
 		ACLToken: c,


### PR DESCRIPTION
There are several places where we want to redact the secret ID of an ACL token, some of which are in the Enterprise code base for Sentinel. Add a new method `Sanitize` that mirrors the one we have on `Node`.

This changeset doesn't change any existing behavior, just makes it easier to reuse.

Ref: https://github.com/hashicorp/nomad-enterprise/pull/2087