### PR TITLE
sentinel: remove default scope for Sentinel apply command

### DIFF
--- a/.changelog/24601.txt
+++ b/.changelog/24601.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+sentinel: The sentinel apply command now requires the -scope option
+```

--- a/api/sentinel.go
+++ b/api/sentinel.go
@@ -82,3 +82,9 @@ type SentinelPolicyListStub struct {
 	CreateIndex      uint64
 	ModifyIndex      uint64
 }
+
+// Possible Sentinel scopes
+const (
+	SentinelScopeSubmitJob        = "submit-job"
+	SentinelScopeSubmitHostVolume = "submit-host-volume"
+)

--- a/command/sentinel_apply.go
+++ b/command/sentinel_apply.go
@@ -37,8 +37,9 @@ Apply Options:
   -description
     Sets a human readable description for the policy.
 
-  -scope (default: submit-job)
-    Sets the scope of the policy and when it should be enforced.
+  -scope
+    Sets the scope of the policy and when it should be enforced. One of
+    "submit-job" or "submit-host-volume".
 
   -level (default: advisory)
     Sets the enforcement level of the policy. Must be one of advisory,
@@ -73,7 +74,7 @@ func (c *SentinelApplyCommand) Run(args []string) int {
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.StringVar(&description, "description", "", "")
-	flags.StringVar(&scope, "scope", "submit-job", "")
+	flags.StringVar(&scope, "scope", "", "")
 	flags.StringVar(&enfLevel, "level", "advisory", "")
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -105,6 +106,16 @@ func (c *SentinelApplyCommand) Run(args []string) int {
 			c.Ui.Error(fmt.Sprintf("Failed to read file: %v", err))
 			return 1
 		}
+	}
+
+	switch scope {
+	case api.SentinelScopeSubmitJob, api.SentinelScopeSubmitHostVolume:
+	case "":
+		c.Ui.Error("-scope flag is required")
+		return 1
+	default:
+		c.Ui.Error(fmt.Sprintf("Error: invalid -scope value: %q", scope))
+		return 1
 	}
 
 	// Construct the policy


### PR DESCRIPTION
When we add a Sentinel scope for dynamic host volumes, having a default `-scope` value for `sentinel apply` risks accidentally adding policies for volumes to the job scope. This would immediately prevent any job from being submitted. Forcing the administrator to pass a `-scope` will prevent accidental misuse.

Ref: https://github.com/hashicorp/nomad-enterprise/pull/2087
Ref: https://github.com/hashicorp/nomad/pull/24479