### PR TITLE
[ui, ci] Ember Exam failures should cause overall test failures

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -10,6 +10,8 @@ on:
       - test-ui
     paths:
       - "ui/**"
+      - "scripts/combine-ui-test-results.js"
+      - ".github/workflows/test-ui.yml"
 
 jobs:
   pre-test:
@@ -68,17 +70,17 @@ jobs:
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: |
           yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results/test-results.json
-      # We have continue-on-error set to true, but we still want to alert the author if
-      # there are test failures or timeouts. Without it, we'll get errors in our output,
-      # but the workflow will still succeed / have a green checkmark.
-      - name: Express timeout failure
-        if: ${{ failure() }}
-        run: exit 1
-      - name: Check test status
-        if: steps.exam.outcome != 'success'
-        run: |
-          echo "Tests failed or timed out in partition ${{ matrix.partition }}"
-          exit 1
+      # # We have continue-on-error set to true, but we still want to alert the author if
+      # # there are test failures or timeouts. Without it, we'll get errors in our output,
+      # # but the workflow will still succeed / have a green checkmark.
+      # - name: Express timeout failure
+      #   if: ${{ failure() }}
+      #   run: exit 1
+      # - name: Check test status
+      #   if: steps.exam.outcome != 'success'
+      #   run: |
+      #     echo "Tests failed or timed out in partition ${{ matrix.partition }}"
+      #     exit 1
       - name: Upload partition test results
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -36,6 +36,7 @@ jobs:
       - pre-test
     runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-latest' }}
     timeout-minutes: 30
+    continue-on-error: true
     defaults:
       run:
         working-directory: ui
@@ -61,15 +62,23 @@ jobs:
           secrets: |-
             kv/data/teams/nomad/ui PERCY_TOKEN ;
       - name: ember exam
+        id: exam
         env:
           PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: |
           yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results/test-results.json
-        continue-on-error: true
+      # We have continue-on-error set to true, but we still want to alert the author if
+      # there are test failures or timeouts. Without it, we'll get errors in our output,
+      # but the workflow will still succeed / have a green checkmark.
       - name: Express timeout failure
         if: ${{ failure() }}
         run: exit 1
+      - name: Check test status
+        if: steps.exam.outcome != 'success'
+        run: |
+          echo "Tests failed or timed out in partition ${{ matrix.partition }}"
+          exit 1
       - name: Upload partition test results
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3

--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -24,6 +24,7 @@
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
+
     <script src="{{rootURL}}assets/nomad-ui.js"></script>
 
     {{content-for "body-footer"}}

--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -24,7 +24,6 @@
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
-
     <script src="{{rootURL}}assets/nomad-ui.js"></script>
 
     {{content-for "body-footer"}}

--- a/ui/tests/acceptance/clients-list-test.js
+++ b/ui/tests/acceptance/clients-list-test.js
@@ -44,7 +44,8 @@ module('Acceptance | clients list', function (hooks) {
 
     await percySnapshot(assert);
 
-    assert.equal(ClientsList.nodes.length, ClientsList.pageSize);
+    // assert.equal(ClientsList.nodes.length, ClientsList.pageSize);
+    assert.equal(ClientsList.nodes.length, 31); // deliberate failure
     assert.ok(ClientsList.hasPagination, 'Pagination found on the page');
 
     const sortedNodes = server.db.nodes.sortBy('modifyIndex').reverse();


### PR DESCRIPTION
### Description
Noticed that failing ember-exam tests were still yielding green checkmarks (see `ember exam` in https://github.com/hashicorp/nomad/actions/runs/12143968210/job/33862207314)

This moves the continue-on-error declaration out of the sub block and:
1. allows all tests in a partition to run to completion, even if one errors (up to 30 minutes)
2. has an explicit "Did something fail?" check step to throw the wider failure.

This builds on the work done in https://github.com/hashicorp/nomad/pull/24555