### PR TITLE
dynamic host volumes: add implicit constraints on plugin fingerprint

### DIFF
--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -480,15 +480,17 @@ func (v *HostVolume) placeHostVolume(snap *state.StateSnapshot, vol *structs.Hos
 	}
 
 	var checker *scheduler.ConstraintChecker
-
-	if len(vol.Constraints) > 0 {
-		ctx := &placementContext{
-			regexpCache:  make(map[string]*regexp.Regexp),
-			versionCache: make(map[string]scheduler.VerConstraints),
-			semverCache:  make(map[string]scheduler.VerConstraints),
-		}
-		checker = scheduler.NewConstraintChecker(ctx, vol.Constraints)
+	ctx := &placementContext{
+		regexpCache:  make(map[string]*regexp.Regexp),
+		versionCache: make(map[string]scheduler.VerConstraints),
+		semverCache:  make(map[string]scheduler.VerConstraints),
 	}
+	constraints := []*structs.Constraint{{
+		LTarget: fmt.Sprintf("${attr.plugins.host_volume.version.%s}", vol.PluginID),
+		Operand: "is_set",
+	}}
+	constraints = append(constraints, vol.Constraints...)
+	checker = scheduler.NewConstraintChecker(ctx, constraints)
 
 	for {
 		raw := iter.Next()


### PR DESCRIPTION
Node fingerprints include attributes for the host volume plugins, including the built-in plugins. Add an implicit constraint on this fingerprint during volume placement to ensure we only place volumes on hosts with the right plugins.

Ref: https://github.com/hashicorp/nomad/pull/24479
