### PR TITLE
dynamic host volumes: delete by single volume ID

### DIFF
--- a/api/host_volumes.go
+++ b/api/host_volumes.go
@@ -175,6 +175,10 @@ type HostVolumeListRequest struct {
 	NodePool string
 }
 
+type HostVolumeDeleteRequest struct {
+	ID string
+}
+
 // Create forwards to client agents so a host volume can be created on those
 // hosts, and registers the volume with Nomad servers.
 func (hv *HostVolumes) Create(req *HostVolumeCreateRequest, opts *WriteOptions) (*HostVolumeCreateResponse, *WriteMeta, error) {
@@ -234,8 +238,8 @@ func (hv *HostVolumes) List(req *HostVolumeListRequest, opts *QueryOptions) ([]*
 }
 
 // Delete deletes a host volume
-func (hv *HostVolumes) Delete(id string, opts *WriteOptions) (*WriteMeta, error) {
-	path, err := url.JoinPath("/v1/volume/host/", url.PathEscape(id))
+func (hv *HostVolumes) Delete(req *HostVolumeDeleteRequest, opts *WriteOptions) (*WriteMeta, error) {
+	path, err := url.JoinPath("/v1/volume/host/", url.PathEscape(req.ID))
 	if err != nil {
 		return nil, err
 	}

--- a/api/host_volumes.go
+++ b/api/host_volumes.go
@@ -175,10 +175,6 @@ type HostVolumeListRequest struct {
 	NodePool string
 }
 
-type HostVolumeDeleteRequest struct {
-	VolumeIDs []string
-}
-
 // Create forwards to client agents so a host volume can be created on those
 // hosts, and registers the volume with Nomad servers.
 func (hv *HostVolumes) Create(req *HostVolumeCreateRequest, opts *WriteOptions) (*HostVolumeCreateResponse, *WriteMeta, error) {

--- a/command/agent/host_volume_endpoint.go
+++ b/command/agent/host_volume_endpoint.go
@@ -129,7 +129,7 @@ func (s *HTTPServer) hostVolumeCreate(resp http.ResponseWriter, req *http.Reques
 func (s *HTTPServer) hostVolumeDelete(id string, resp http.ResponseWriter, req *http.Request) (any, error) {
 	// HTTP API only supports deleting a single ID because of compatibility with
 	// the existing HTTP routes for CSI
-	args := structs.HostVolumeDeleteRequest{VolumeIDs: []string{id}}
+	args := structs.HostVolumeDeleteRequest{VolumeID: id}
 	s.parseWriteRequest(req, &args.WriteRequest)
 
 	var out structs.HostVolumeDeleteResponse

--- a/command/volume_delete.go
+++ b/command/volume_delete.go
@@ -150,7 +150,7 @@ func (c *VolumeDeleteCommand) deleteCSIVolume(client *api.Client, volID string, 
 }
 
 func (c *VolumeDeleteCommand) deleteHostVolume(client *api.Client, volID string) int {
-	_, err := client.HostVolumes().Delete(volID, nil)
+	_, err := client.HostVolumes().Delete(&api.HostVolumeDeleteRequest{ID: volID}, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error deleting volume: %s", err))
 		return 1

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2443,7 +2443,7 @@ func (n *nomadFSM) applyHostVolumeDelete(msgType structs.MessageType, buf []byte
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	if err := n.state.DeleteHostVolumes(index, req.RequestNamespace(), req.VolumeIDs); err != nil {
+	if err := n.state.DeleteHostVolume(index, req.RequestNamespace(), req.VolumeID); err != nil {
 		n.logger.Error("DeleteHostVolumes failed", "error", err)
 		return err
 	}

--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -13,7 +13,6 @@ import (
 	"github.com/armon/go-metrics"
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
-	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/acl"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper"
@@ -562,11 +561,10 @@ func (v *HostVolume) Delete(args *structs.HostVolumeDeleteRequest, reply *struct
 		return structs.ErrPermissionDenied
 	}
 
-	if len(args.VolumeIDs) == 0 {
-		return fmt.Errorf("missing volumes to delete")
+	if args.VolumeID == "" {
+		return fmt.Errorf("missing volume ID to delete")
 	}
 
-	var deletedVols []string
 	var index uint64
 
 	snap, err := v.srv.State().Snapshot()
@@ -574,45 +572,36 @@ func (v *HostVolume) Delete(args *structs.HostVolumeDeleteRequest, reply *struct
 		return err
 	}
 
-	var mErr *multierror.Error
 	ns := args.RequestNamespace()
+	id := args.VolumeID
 
-	for _, id := range args.VolumeIDs {
-		vol, err := snap.HostVolumeByID(nil, ns, id, true)
-		if err != nil {
-			return fmt.Errorf("could not query host volume: %w", err)
-		}
-		if vol == nil {
-			return fmt.Errorf("no such volume: %s", id)
-		}
-		if len(vol.Allocations) > 0 {
-			allocIDs := helper.ConvertSlice(vol.Allocations,
-				func(a *structs.AllocListStub) string { return a.ID })
-			mErr = multierror.Append(mErr,
-				fmt.Errorf("volume %s in use by allocations: %v", id, allocIDs))
-			continue
-		}
-
-		err = v.deleteVolume(vol)
-		if err != nil {
-			mErr = multierror.Append(mErr, err)
-		} else {
-			deletedVols = append(deletedVols, id)
-		}
+	vol, err := snap.HostVolumeByID(nil, ns, id, true)
+	if err != nil {
+		return fmt.Errorf("could not query host volume: %w", err)
+	}
+	if vol == nil {
+		return fmt.Errorf("no such volume: %s", id)
+	}
+	if len(vol.Allocations) > 0 {
+		allocIDs := helper.ConvertSlice(vol.Allocations,
+			func(a *structs.AllocListStub) string { return a.ID })
+		return fmt.Errorf("volume %s in use by allocations: %v", id, allocIDs)
 	}
 
-	if len(deletedVols) > 0 {
-		args.VolumeIDs = deletedVols
-		_, index, err = v.srv.raftApply(structs.HostVolumeDeleteRequestType, args)
-		if err != nil {
-			v.logger.Error("raft apply failed", "error", err, "method", "delete")
-			mErr = multierror.Append(mErr, err)
-		}
+	err = v.deleteVolume(vol)
+	if err != nil {
+		return err
 	}
 
-	reply.VolumeIDs = deletedVols
+	_, index, err = v.srv.raftApply(structs.HostVolumeDeleteRequestType, args)
+	if err != nil {
+		v.logger.Error("raft apply failed", "error", err, "method", "delete")
+		return err
+	}
+
+	reply.VolumeID = args.VolumeID // db TODO(1.10.0) why?
 	reply.Index = index
-	return helper.FlattenMultierror(mErr)
+	return nil
 }
 
 func (v *HostVolume) deleteVolume(vol *structs.HostVolume) error {

--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -599,7 +599,6 @@ func (v *HostVolume) Delete(args *structs.HostVolumeDeleteRequest, reply *struct
 		return err
 	}
 
-	reply.VolumeID = args.VolumeID // db TODO(1.10.0) why?
 	reply.Index = index
 	return nil
 }

--- a/nomad/host_volume_endpoint_test.go
+++ b/nomad/host_volume_endpoint_test.go
@@ -321,7 +321,7 @@ func TestHostVolumeEndpoint_CreateRegisterGetDelete(t *testing.T) {
 			index, []*structs.Allocation{alloc}))
 
 		delReq := &structs.HostVolumeDeleteRequest{
-			VolumeIDs: []string{vol1.ID, vol2.ID},
+			VolumeID: vol2.ID,
 			WriteRequest: structs.WriteRequest{
 				Region:    srv.Region(),
 				Namespace: ns,
@@ -336,20 +336,6 @@ func TestHostVolumeEndpoint_CreateRegisterGetDelete(t *testing.T) {
 		err = msgpackrpc.CallWithCodec(codec, "HostVolume.Delete", delReq, &delResp)
 		must.EqError(t, err, fmt.Sprintf("volume %s in use by allocations: [%s]", vol2.ID, alloc.ID))
 
-		// volume not in use will be deleted even if we got an error
-		getReq := &structs.HostVolumeGetRequest{
-			ID: vol1.ID,
-			QueryOptions: structs.QueryOptions{
-				Region:    srv.Region(),
-				Namespace: ns,
-				AuthToken: token,
-			},
-		}
-		var getResp structs.HostVolumeGetResponse
-		err = msgpackrpc.CallWithCodec(codec, "HostVolume.Get", getReq, &getResp)
-		must.NoError(t, err)
-		must.Nil(t, getResp.Volume)
-
 		// update the allocations terminal so the delete works
 		alloc = alloc.Copy()
 		alloc.ClientStatus = structs.AllocClientStatusFailed
@@ -361,14 +347,27 @@ func TestHostVolumeEndpoint_CreateRegisterGetDelete(t *testing.T) {
 		}
 		err = msgpackrpc.CallWithCodec(codec, "Node.UpdateAlloc", nArgs, &structs.GenericResponse{})
 
-		delReq.VolumeIDs = []string{vol2.ID}
 		err = msgpackrpc.CallWithCodec(codec, "HostVolume.Delete", delReq, &delResp)
 		must.NoError(t, err)
 
-		getReq.ID = vol2.ID
+		getReq := &structs.HostVolumeGetRequest{
+			ID: vol2.ID,
+			QueryOptions: structs.QueryOptions{
+				Region:    srv.Region(),
+				Namespace: ns,
+				AuthToken: token,
+			},
+		}
+		var getResp structs.HostVolumeGetResponse
 		err = msgpackrpc.CallWithCodec(codec, "HostVolume.Get", getReq, &getResp)
 		must.NoError(t, err)
 		must.Nil(t, getResp.Volume)
+
+		// delete vol1 to finish cleaning up
+		delReq.VolumeID = vol1.ID
+		err = msgpackrpc.CallWithCodec(codec, "HostVolume.Delete", delReq, &delResp)
+		must.NoError(t, err)
+		must.Eq(t, vol1.ID, delResp.VolumeID)
 	})
 }
 

--- a/nomad/structs/host_volumes.go
+++ b/nomad/structs/host_volumes.go
@@ -365,12 +365,12 @@ type HostVolumeRegisterResponse struct {
 }
 
 type HostVolumeDeleteRequest struct {
-	VolumeIDs []string
+	VolumeID string
 	WriteRequest
 }
 
 type HostVolumeDeleteResponse struct {
-	VolumeIDs []string // volumes actually deleted
+	VolumeID string // volume actually deleted
 	WriteMeta
 }
 

--- a/nomad/structs/host_volumes.go
+++ b/nomad/structs/host_volumes.go
@@ -370,7 +370,6 @@ type HostVolumeDeleteRequest struct {
 }
 
 type HostVolumeDeleteResponse struct {
-	VolumeID string // volume actually deleted
 	WriteMeta
 }
 


### PR DESCRIPTION
the `Delete` side of #24545 which did this for `Create` and `Register` -- `id string` instead of `ids []string`