### PR TITLE
dynamic host volumes: refactor HTTP routes for volumes list dispatch

### DIFF
--- a/command/agent/csi_endpoint.go
+++ b/command/agent/csi_endpoint.go
@@ -20,28 +20,12 @@ func (s *HTTPServer) CSIVolumesRequest(resp http.ResponseWriter, req *http.Reque
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
 
-	// Type filters volume lists to a specific type. When support for non-CSI volumes is
-	// introduced, we'll need to dispatch here
-	query := req.URL.Query()
-	qtype, ok := query["type"]
-	if !ok {
-		return []*structs.CSIVolListStub{}, nil
-	}
-	// TODO(1.10.0): move handling of GET /v1/volumes/ out so that we're not
-	// co-mingling the call for listing host volume here
-	switch qtype[0] {
-	case "host":
-		return s.HostVolumesListRequest(resp, req)
-	case "csi":
-	default:
-		return nil, nil
-	}
-
 	args := structs.CSIVolumeListRequest{}
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
 		return nil, nil
 	}
 
+	query := req.URL.Query()
 	args.Prefix = query.Get("prefix")
 	args.PluginID = query.Get("plugin_id")
 	args.NodeID = query.Get("node_id")

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -404,6 +404,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/deployments", s.wrap(s.DeploymentsRequest))
 	s.mux.HandleFunc("/v1/deployment/", s.wrap(s.DeploymentSpecificRequest))
 
+	s.mux.HandleFunc("GET /v1/volumes", s.wrap(s.ListVolumesRequest))
 	s.mux.HandleFunc("/v1/volumes", s.wrap(s.CSIVolumesRequest))
 	s.mux.HandleFunc("/v1/volumes/external", s.wrap(s.CSIExternalVolumesRequest))
 	s.mux.HandleFunc("/v1/volumes/snapshot", s.wrap(s.CSISnapshotsRequest))

--- a/command/agent/volumes_endpoint.go
+++ b/command/agent/volumes_endpoint.go
@@ -1,0 +1,27 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package agent
+
+import (
+	"net/http"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// ListVolumesRequest dispatches requests for listing volumes to a specific type.
+func (s *HTTPServer) ListVolumesRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+	query := req.URL.Query()
+	qtype, ok := query["type"]
+	if !ok {
+		return []*structs.CSIVolListStub{}, nil
+	}
+	switch qtype[0] {
+	case "host":
+		return s.HostVolumesListRequest(resp, req)
+	case "csi":
+		return s.CSIVolumesRequest(resp, req)
+	default:
+		return nil, CodedError(404, resourceNotFoundErr)
+	}
+}


### PR DESCRIPTION
The List Volumes API was originally written for CSI but assumed we'd have future volume types, dispatched on a query parameter. Dynamic host volumes uses this, but the resulting code has host volumes concerns comingled in the CSI volumes endpoint. Refactor this so that we have a top-level `GET /v1/volumes` route that's shared between CSI and DHV, and have it dispatch to the appropriate handler in the type-specific endpoints.

Ref: https://github.com/hashicorp/nomad/pull/24479

---

I did extra testing of this by running the hostpath CSI plugin demo and creating a bunch of host volumes, and verifying the CLI worked as expected for both.