### PR TITLE
dynamic host volumes: capabilities check during scheduling

### DIFF
--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -118,6 +118,10 @@ type State interface {
 	// CSIVolumeByID fetch CSI volumes, containing controller jobs
 	CSIVolumesByNodeID(memdb.WatchSet, string, string) (memdb.ResultIterator, error)
 
+	HostVolumeByID(memdb.WatchSet, string, string, bool) (*structs.HostVolume, error)
+
+	HostVolumesByNodeID(memdb.WatchSet, string, state.SortOption) (memdb.ResultIterator, error)
+
 	// LatestIndex returns the greatest index value for all indexes.
 	LatestIndex() (uint64, error)
 }

--- a/scheduler/stack.go
+++ b/scheduler/stack.go
@@ -51,6 +51,7 @@ type GenericStack struct {
 	wrappedChecks        *FeasibilityWrapper
 	quota                FeasibleIterator
 	jobVersion           *uint64
+	jobNamespace         string
 	jobConstraint        *ConstraintChecker
 	taskGroupDrivers     *DriverChecker
 	taskGroupConstraint  *ConstraintChecker
@@ -101,6 +102,7 @@ func (s *GenericStack) SetJob(job *structs.Job) {
 
 	jobVer := job.Version
 	s.jobVersion = &jobVer
+	s.jobNamespace = job.Namespace
 
 	s.jobConstraint.SetConstraints(job.Constraints)
 	s.distinctHostsConstraint.SetJob(job)
@@ -154,7 +156,7 @@ func (s *GenericStack) Select(tg *structs.TaskGroup, options *SelectOptions) *Ra
 	s.taskGroupDrivers.SetDrivers(tgConstr.drivers)
 	s.taskGroupConstraint.SetConstraints(tgConstr.constraints)
 	s.taskGroupDevices.SetTaskGroup(tg)
-	s.taskGroupHostVolumes.SetVolumes(options.AllocName, tg.Volumes)
+	s.taskGroupHostVolumes.SetVolumes(options.AllocName, s.jobNamespace, tg.Volumes)
 	s.taskGroupCSIVolumes.SetVolumes(options.AllocName, tg.Volumes)
 	if len(tg.Networks) > 0 {
 		s.taskGroupNetwork.SetNetwork(tg.Networks[0])
@@ -202,6 +204,7 @@ type SystemStack struct {
 	ctx    Context
 	source *StaticIterator
 
+	jobNamespace         string
 	wrappedChecks        *FeasibilityWrapper
 	quota                FeasibleIterator
 	jobConstraint        *ConstraintChecker
@@ -313,6 +316,7 @@ func (s *SystemStack) SetNodes(baseNodes []*structs.Node) {
 }
 
 func (s *SystemStack) SetJob(job *structs.Job) {
+	s.jobNamespace = job.Namespace
 	s.jobConstraint.SetConstraints(job.Constraints)
 	s.distinctPropertyConstraint.SetJob(job)
 	s.binPack.SetJob(job)
@@ -345,7 +349,7 @@ func (s *SystemStack) Select(tg *structs.TaskGroup, options *SelectOptions) *Ran
 	s.taskGroupDrivers.SetDrivers(tgConstr.drivers)
 	s.taskGroupConstraint.SetConstraints(tgConstr.constraints)
 	s.taskGroupDevices.SetTaskGroup(tg)
-	s.taskGroupHostVolumes.SetVolumes(options.AllocName, tg.Volumes)
+	s.taskGroupHostVolumes.SetVolumes(options.AllocName, s.jobNamespace, tg.Volumes)
 	s.taskGroupCSIVolumes.SetVolumes(options.AllocName, tg.Volumes)
 	if len(tg.Networks) > 0 {
 		s.taskGroupNetwork.SetNetwork(tg.Networks[0])


### PR DESCRIPTION
Static host volumes have a simple readonly toggle, but dynamic host volumes have a more complex set of capabilities similar to CSI volumes. Update the feasibility checker to account for these capabilities and volume readiness.

Also fixes a minor bug in the state store where a soft-delete (not yet implemented) could cause a volume to be marked ready again. This is needed to support testing the readiness checking in the scheduler.

Ref: https://github.com/hashicorp/nomad/pull/24479