### PR TITLE
[ui] Fixes an issue where system jobs' status were set to Scaled Down when their allocs get garbage collected

### DIFF
--- a/.changelog/24620.txt
+++ b/.changelog/24620.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix an issue where system jobs with garbage-collected allocations were showing as Scaled Down
+```

--- a/ui/app/components/job-status/panel/steady.js
+++ b/ui/app/components/job-status/panel/steady.js
@@ -224,7 +224,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
       };
     }
 
-    if (this.totalAllocs === 0) {
+    if (this.totalAllocs === 0 && !this.job.hasClientStatus) {
       return {
         label: 'Scaled Down',
         state: 'neutral',
@@ -246,7 +246,7 @@ export default class JobStatusPanelSteadyComponent extends Component {
     }
 
     const healthyAllocs = this.allocBlocks.running?.healthy?.nonCanary;
-    if (healthyAllocs?.length === totalAllocs) {
+    if (healthyAllocs?.length && healthyAllocs?.length === totalAllocs) {
       return { label: 'Healthy', state: 'success' };
     }
 

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -251,7 +251,11 @@ export default class Job extends Model {
 
     // If the job is scaled down to 0 desired allocations, we shouldn't call it "failed";
     // we should indicate that it is deliberately set to not have any running parts.
-    if (totalAllocs === 0) {
+    // System/Sysbatch jobs (hasClientStatus) get their totalAllocs from expectedRunningAllocCount,
+    // which is a best-guess-based-on-whats-running number. This means that if there are no current allocs,
+    // because they've been GC'd, we don't know if they were deliberately scaled down or failed.
+    // Safer in this case to show as failed rather than imply a deliberate scale-down.
+    if (totalAllocs === 0 && !this.hasClientStatus) {
       return { label: 'Scaled Down', state: 'neutral' };
     }
 

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -707,6 +707,14 @@ module('Acceptance | jobs list', function (hooks) {
       status: 'dead',
     });
 
+    server.create('job', {
+      ...defaultJobParams,
+      id: 'ancient-system-job',
+      status: 'dead',
+      type: 'system',
+      groupAllocCount: 0,
+    });
+
     await JobsList.visit();
 
     assert
@@ -742,6 +750,9 @@ module('Acceptance | jobs list', function (hooks) {
     assert
       .dom('[data-test-job-row="scaled-down-job"] [data-test-job-status]')
       .hasText('Scaled Down', 'Scaled down job is scaled down');
+    assert
+      .dom('[data-test-job-row="ancient-system-job"] [data-test-job-status]')
+      .hasText('Failed', 'System job with no allocs is failed');
 
     await percySnapshot(assert);
   });


### PR DESCRIPTION
### Description
Found a fun UI bug today: my system job had allocations fail, and then I worked on something else for several hours, and the garbage collector subsequently removed my terminal allocs.

When viewing the job in the UI, the job showed up as "Scaled Down". This is a new status we added [this summer](https://github.com/hashicorp/nomad/pull/23829) to help show when an operator manually set a job's group counts to 0 to let it sit dormant.

While there are problems with showing an alloc-less system job as "Failed" (it may in fact have been deliberately "scaled down" by virtue of taking all eligible nodes offline, for example), this seems like it's by far the most common reason you'd have an un-GC'd system job with no allocs, and so "Scaled Down" shouldn't be the default label for it. This PR makes it so system/sysbatch jobs cannot be labelled "Scaled Down" as such.