### PR TITLE
Show HCL variable input on job submission.

### DIFF
--- a/.changelog/24622.txt
+++ b/.changelog/24622.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Added possibility to supply HCL variable values on job submission
+```

--- a/ui/app/templates/components/job-editor/edit.hbs
+++ b/ui/app/templates/components/job-editor/edit.hbs
@@ -70,10 +70,14 @@
       }}
     ></div>
   </div>
-  {{#if (eq @data.view "job-spec")}}
+  {{#if (or (eq @data.view "job-spec") @data.job.isNew)}}
     <div class="boxed-section" style="margin-top: 10px">
       <div class="boxed-section-head">
+        {{#if @data.job.isNew}}
+        HCL Variable Values
+        {{else}}
         Edit HCL Variable Values
+        {{/if}}
       </div>
       <div class="boxed-section-body is-full-bleed">
         <div


### PR DESCRIPTION
### Description
This PR will show the text area for entering HCL variable values on job submission, as suggested in #23582.
It was already shown when editing a job using the UI, but not when submitting a new job.
The underlying model already supports the this, only the UI was missing.

### Testing & Reproduction steps
- Submit a new job using variables
- Enter the variables in the new text area below the job spec

### Links
- Github Issue: #23582

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
