### PR TITLE
Character restrictions in action names were unduly oppressive

### DIFF
--- a/.changelog/24642.txt
+++ b/.changelog/24642.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+actions: Nomad Actions names now accept a wider range of names
+```

--- a/nomad/structs/actions.go
+++ b/nomad/structs/actions.go
@@ -9,15 +9,10 @@ package structs
 
 import (
 	"errors"
-	"fmt"
-	"regexp"
 	"slices"
 
 	"github.com/hashicorp/go-multierror"
 )
-
-// validJobActionName is used to validate a job action name.
-var validJobActionName = regexp.MustCompile("^[a-zA-Z0-9-]{1,128}$")
 
 type Action struct {
 	Name    string
@@ -84,9 +79,6 @@ func (a *Action) Validate() error {
 	var mErr *multierror.Error
 	if a.Command == "" {
 		mErr = multierror.Append(mErr, errors.New("command cannot be empty"))
-	}
-	if !validJobActionName.MatchString(a.Name) {
-		mErr = multierror.Append(mErr, fmt.Errorf("invalid name '%s'", a.Name))
 	}
 
 	return mErr.ErrorOrNil()

--- a/nomad/structs/actions.go
+++ b/nomad/structs/actions.go
@@ -9,10 +9,15 @@ package structs
 
 import (
 	"errors"
+	"fmt"
+	"regexp"
 	"slices"
 
 	"github.com/hashicorp/go-multierror"
 )
+
+// validJobActionName is used to validate a action name.
+var validJobActionName = regexp.MustCompile(`^[^\x00\s]{1,128}$`)
 
 type Action struct {
 	Name    string
@@ -79,6 +84,9 @@ func (a *Action) Validate() error {
 	var mErr *multierror.Error
 	if a.Command == "" {
 		mErr = multierror.Append(mErr, errors.New("command cannot be empty"))
+	}
+	if !validJobActionName.MatchString(a.Name) {
+		mErr = multierror.Append(mErr, fmt.Errorf("invalid name '%s'", a.Name))
 	}
 
 	return mErr.ErrorOrNil()

--- a/nomad/structs/actions_test.go
+++ b/nomad/structs/actions_test.go
@@ -178,12 +178,28 @@ func TestAction_Validate(t *testing.T) {
 			expectedError: errors.New(`invalid name 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'`),
 		},
 		{
-			name: "invalid character name",
+			name: "invalid character name with spaces",
 			inputAction: &Action{
-				Name:    `\//?|?|?%&%@$&£@$)`,
+				Name:    "invalid name with spaces",
 				Command: "env",
 			},
-			expectedError: errors.New(`invalid name '\//?|?|?%&%@$&£@$)'`),
+			expectedError: errors.New(`invalid name 'invalid name with spaces'`),
+		},
+		{
+			name: "invalid character name with nulls",
+			inputAction: &Action{
+				Name:    "invalid\x00name",
+				Command: "env",
+			},
+			expectedError: fmt.Errorf("1 error occurred:\n\t* invalid name 'invalid\x00name'\n\n"), // had to use fmt.Errorf to show the null character
+		},
+		{
+			name: "Emoji characters are valid",
+			inputAction: &Action{
+				Name:    "🇳🇴🇲🇦🇩",
+				Command: "env",
+			},
+			expectedError: nil,
 		},
 		{
 			name: "valid",


### PR DESCRIPTION
### Description
Lifts the naming restriction on task actions so that you can put user-friendly emoji in there if you were so inclined.

<img width="231" alt="image" src="https://github.com/user-attachments/assets/b2b5dcee-9a8c-4cf9-ba54-c6b04a3e6b94">
