### PR TITLE
Allocation API: fix "no path to region" errors for non-global regions

### DIFF
--- a/.changelog/24644.txt
+++ b/.changelog/24644.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fixed a bug where alloc exec/logs/fs APIs would return errors for non-global regions
+```

--- a/api/api.go
+++ b/api/api.go
@@ -234,7 +234,6 @@ func (c *Config) ClientConfig(region, address string, tlsEnabled bool) *Config {
 		HttpAuth:   c.HttpAuth,
 		WaitTime:   c.WaitTime,
 		TLSConfig:  c.TLSConfig.Copy(),
-		url:        copyURL(c.url),
 	}
 
 	// Update the tls server name for connecting to a client

--- a/e2e/terraform/provision-nomad/etc/nomad.d/base.hcl
+++ b/e2e/terraform/provision-nomad/etc/nomad.d/base.hcl
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+region       = "e2e"
 bind_addr    = "0.0.0.0"
 data_dir     = "${data_dir}"
 enable_debug = true


### PR DESCRIPTION
In #16872 we added support for unix domain sockets, but this required mutating the `Config` when parsing the address so as to remove the port number. In #23785 we fixed a bug where if the configuration was used across multiple clients (as in the autoscaler) that mutation would happen multiple times and the address would be incorrectly parsed.

When making `alloc log`, `alloc fs`, or `alloc exec` calls where we have line-of-sight to the client, we attempt to make a HTTP API call directly to the client node. So we create a new API client from the same configuration and then set the address. But in this case we copy the private `url` field and that causes the URL parsing to be skipped for the new client.

This results in the region always being set to the string literal `"global"` (because of mTLS handling code introduced all the way back in 4d3b75d867da), unless the user has set the region specifically. This fails with an error "no path to region" when the cluster isn't non-global and requests are sent to a non-leader.

Arguably the "right" way of fixing this would be for `ClientConfig` not to change the API client's region to `"global"` in the first place, but as this is a public API and extremely longstanding behavior, it could potentially be a breaking change for some downstream consumers. Instead, we'll avoid copying the private `url` field so that the new address is re-parsed.

Fixes: https://github.com/hashicorp/nomad/issues/24635
Fixes: https://github.com/hashicorp/nomad/issues/24609
Ref: https://github.com/hashicorp/nomad/pull/16872
Ref: https://github.com/hashicorp/nomad/pull/23785
Ref: https://github.com/hashicorp/nomad/commit/4d3b75d867dae508011c198c84318f54b4aa6684
Ref: https://hashicorp.atlassian.net/browse/NET-11858

### Testing & Reproduction steps

To reproduce, stand up a cluster with `region = "example"` with at least one client, in an environment where you have line-of-sight to all nodes (ex. local development environment should work fine). Deploy a job to that client and run `nomad alloc logs :alloc_id`.