### PR TITLE
add noswap to secretdir tmpfs

### DIFF
--- a/.changelog/24645.txt
+++ b/.changelog/24645.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-client: Add noswap mount option to secrets directory wheree supported on Linux
+client: Add noswap mount option to secrets directory where supported on Linux
 ```

--- a/.changelog/24645.txt
+++ b/.changelog/24645.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: Add noswap mount option to secrets directory wheree supported on Linux
+```

--- a/client/allocdir/fs_linux.go
+++ b/client/allocdir/fs_linux.go
@@ -73,7 +73,7 @@ func createSecretDir(dir string, size int) error {
 		}
 
 		flags := uintptr(syscall.MS_NOEXEC)
-		// Permanantly disable swap for tmpfs for SecretDir.
+		// Permanently disable swap for tmpfs for SecretDir.
 		options := fmt.Sprintf("size=%dm,noswap", size)
 		if err := syscall.Mount("tmpfs", dir, "tmpfs", flags, options); err != nil {
 			return os.NewSyscallError("mount", err)

--- a/client/allocdir/fs_linux.go
+++ b/client/allocdir/fs_linux.go
@@ -79,9 +79,9 @@ func createSecretDir(dir string, size int) error {
 		if err != nil {
 			// Not all kernels support noswap, remove if unsupported.
 			options = fmt.Sprintf("size=%dm", size)
-		}
-		if err = syscall.Mount("tmpfs", dir, "tmpfs", flags, options); err != nil {
-			return os.NewSyscallError("mount", err)
+			if fallbackErr := syscall.Mount("tmpfs", dir, "tmpfs", flags, options); fallbackErr != nil {
+				return os.NewSyscallError("mount", fallbackErr)
+			}
 		}
 
 		// Create the marker file so we don't try to mount more than once

--- a/client/allocdir/fs_linux.go
+++ b/client/allocdir/fs_linux.go
@@ -73,7 +73,8 @@ func createSecretDir(dir string, size int) error {
 		}
 
 		flags := uintptr(syscall.MS_NOEXEC)
-		options := fmt.Sprintf("size=%dm", size)
+		// Permanantly disable swap for tmpfs for SecretDir.
+		options := fmt.Sprintf("size=%dm,noswap", size)
 		if err := syscall.Mount("tmpfs", dir, "tmpfs", flags, options); err != nil {
 			return os.NewSyscallError("mount", err)
 		}

--- a/client/allocdir/fs_linux.go
+++ b/client/allocdir/fs_linux.go
@@ -75,7 +75,12 @@ func createSecretDir(dir string, size int) error {
 		flags := uintptr(syscall.MS_NOEXEC)
 		// Permanently disable swap for tmpfs for SecretDir.
 		options := fmt.Sprintf("size=%dm,noswap", size)
-		if err := syscall.Mount("tmpfs", dir, "tmpfs", flags, options); err != nil {
+		err := syscall.Mount("tmpfs", dir, "tmpfs", flags, options)
+		if err != nil {
+			// Not all kernels support noswap, remove if unsupported.
+			options = fmt.Sprintf("size=%dm", size)
+		}
+		if err = syscall.Mount("tmpfs", dir, "tmpfs", flags, options); err != nil {
 			return os.NewSyscallError("mount", err)
 		}
 

--- a/website/content/docs/concepts/filesystem.mdx
+++ b/website/content/docs/concepts/filesystem.mdx
@@ -353,7 +353,7 @@ $ mount
 ...
 /dev/mapper/root on /alloc type ext4 (rw,relatime,errors=remount-ro,data=ordered)
 tmpfs on /private type tmpfs (rw,noexec,relatime,size=1024k)
-tmpfs on /secrets type tmpfs (rw,noexec,relatime,size=1024k)
+tmpfs on /secrets type tmpfs (rw,noexec,relatime,size=1024k,noswap)
 ...
 ```
 


### PR DESCRIPTION
### Description
This adds `noswap` mount option to the `SecretDir` mount.

### Testing & Reproduction steps
- Create an allocation that triggers a secret dir creation

(having a hell of a time trying to get tests to run locally so I'm going to rely on GHA to run unit tests (fingers crossed))

### Links
todo issue

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
