### PR TITLE
plan: inform user if a deployment will be created

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1525,6 +1525,7 @@ type JobPlanResponse struct {
 	CreatedEvals       []*Evaluation
 	Diff               *JobDiff
 	Annotations        *PlanAnnotations
+	CauseDeployment    bool
 	FailedTGAllocs     map[string]*AllocationMetric
 	NextPeriodicLaunch time.Time
 

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -310,6 +310,12 @@ func (c *JobPlanCommand) outputPlannedJob(job *api.Job, resp *api.JobPlanRespons
 			c.Colorize().Color(strings.TrimSpace(formatJobDiff(resp.Diff, verbose)))))
 	}
 
+	if resp.CauseDeployment {
+		c.Ui.Output("deployment time!")
+	} else {
+		c.Ui.Output("no deployment")
+	}
+
 	// Print the scheduler dry-run output
 	c.Ui.Output(c.Colorize().Color("[bold]Scheduler dry-run:[reset]"))
 	c.Ui.Output(c.Colorize().Color(formatDryRun(resp, job)))

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1984,6 +1984,7 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 	reply.FailedTGAllocs = updatedEval.FailedTGAllocs
 	reply.JobModifyIndex = index
 	reply.Annotations = annotations
+	reply.CauseDeployment = planner.Plans[0].Deployment != nil
 	reply.CreatedEvals = planner.CreateEvals
 	reply.Index = index
 	return nil

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1689,6 +1689,10 @@ type JobPlanResponse struct {
 	// causes an in-place update or create/destroy
 	Diff *JobDiff
 
+	// CauseDeployment is true if the plan causes a deployment to be created or
+	// modified.
+	CauseDeployment bool
+
 	// NextPeriodicLaunch is the time duration till the job would be launched if
 	// submitted.
 	NextPeriodicLaunch time.Time


### PR DESCRIPTION
### Description

Just a proof of concept because the plan output when deployments are involved is a bit non-obvious. When updating a job with count=3, the plan will only show the first step of the deployment (as determined by update.max_parallel):

```
+/- Job: "sleeper"
+/- Task Group: "sleeper" (1 create/destroy update, 2 ignore)
  +/- Task: "sleeper" (forces create/destroy update)
      +/- Config {
```

This hack plumbs through whether a deployment was attached to the plan. Obviously the output and field names need improving. For backward compatibility we probably shouldn't output _anything_ if there isn't a deployment, but this PoC includes a message for either case for ease of testing/demonstration.

<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps

1. `nomad job run -var dur=60 sleeper.nomad.hcl`
2. `nomad job plan -var dur=900 sleeper.nomad.hcl`

> sleep.nomad.hcl
```hcl
variable "dur" {
  type = string
}

job "sleeper" {
  group "sleeper" {
    count = 3

    task "sleeper" {
      driver = "raw_exec"

      config {
        command = "sleep"
        args = [var.dur]
      }
    }
  }
}
```

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
