### PR TITLE
discovery: correctly handle IPv6 addresses from go-discover

### DIFF
--- a/.changelog/24649.txt
+++ b/.changelog/24649.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+discovery: Fixed a bug where IPv6 addresses would not be accepted from cloud autojoin
+```

--- a/client/rpc_test.go
+++ b/client/rpc_test.go
@@ -130,9 +130,15 @@ func Test_resolveServer(t *testing.T) {
 		expectErr string
 	}{
 		{
-			name:      "ipv6 no brackets",
-			addr:      "2001:db8::1",
-			expectErr: "address 2001:db8::1: too many colons in address",
+			name:   "ipv6 no brackets",
+			addr:   "2001:db8::1",
+			expect: "[2001:db8::1]:4647",
+		},
+		{
+			// expected bad result
+			name:   "ambiguous ipv6 no brackets with port",
+			addr:   "2001:db8::1:4647",
+			expect: "[2001:db8::1:4647]:4647",
 		},
 		{
 			name:   "ipv6 no port",


### PR DESCRIPTION
Nomad sets a default port when resolving server addresses that don't have one. When we get a "bare" IPv6 address without a port, we end up with an unexpected error "too many colons in address" when we try to split the address and host, because the standard library function expects IPv6 addresses to be wrapped in brackets as recommended by RFC5952. User-configured addresses avoid this problem by accepting IP address and port as separate configuration values, but go-discover emits "bare" IPv6 addresses without a port in IPv6 environments.

Fix this by adding brackets to IPv6 addresses when we get the "too many colons" error from the stdlib. This will still give erroneous results if the address includes the port but is missing brackets, but there's no way to unambiguously parse that address.

Ref: https://www.rfc-editor.org/rfc/rfc5952
Fixes: https://github.com/hashicorp/nomad/issues/24608
Ref: https://hashicorp.atlassian.net/browse/NET-11857

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
