### PR TITLE
[ui] Bugfix: prevent parent job from showing another job's dispatches when it has none

### DIFF
--- a/.changelog/24668.txt
+++ b/.changelog/24668.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix an issue where 2 parent jobs would see the others dispatches if it were otherwise empty
+```

--- a/ui/app/controllers/jobs/job/index.js
+++ b/ui/app/controllers/jobs/job/index.js
@@ -98,6 +98,7 @@ export default class IndexController extends Controller.extend(
     { id, namespace },
     throttle = Ember.testing ? 0 : 2000
   ) {
+    this.childJobs = [];
     while (true) {
       let params = {
         filter: `ParentID == "${id}"`,


### PR DESCRIPTION
Resolves #24666

We had a bug where our `watchChildJobs` ember concurrency task (which kicks off whenever you hit a parameterized/periodic parent job route) would have a memoized list of childjobs from whenever it was last run. These components are not route-bound, and so don't shed data automatically when their route changes, and since we don't return a `[]` on /statuses with an ?index=1 parameter, but instead hold the blocking query open for further updates, we don't get any kind of "Clear what the app has in cache" signal.

This explicitly clears what the app has in cache on parent job route load.