### PR TITLE
sec: fix alloc workload identity namespace permission

### DIFF
--- a/.changelog/24683.txt
+++ b/.changelog/24683.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-security: sanitizing the SignedIdentities in allocations to prevent privilege escalation through unredacted workload identity token associated with ACL policies.
+security: sanitizing the SignedIdentities in allocations to prevent privilege escalation through unredacted workload identity token impersonation associated with ACL policies.
 ```

--- a/.changelog/24683.txt
+++ b/.changelog/24683.txt
@@ -1,0 +1,3 @@
+```release-note:security
+security: sanitizing the SignedIdentities in allocations to prevent privilege escalation through unredacted workload identity token associated with ACL policies.
+```

--- a/.changelog/24683.txt
+++ b/.changelog/24683.txt
@@ -1,3 +1,3 @@
 ```release-note:security
-security: sanitizing the SignedIdentities in allocations to prevent privilege escalation through unredacted workload identity token impersonation associated with ACL policies.
+api: sanitize the SignedIdentities in allocations to prevent privilege escalation through unredacted workload identity token impersonation associated with ACL policies.
 ```

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -105,6 +105,7 @@ func (s *HTTPServer) nodeAllocations(resp http.ResponseWriter, req *http.Request
 		out.Allocs = make([]*structs.Allocation, 0)
 	}
 	for _, alloc := range out.Allocs {
+		alloc = alloc.Sanitize()
 		alloc.SetEventDisplayMessages()
 	}
 	return out.Allocs, nil

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -172,8 +172,9 @@ func (a *Alloc) GetAlloc(args *structs.AllocSpecificRequest,
 			}
 
 			// Setup the output
-			reply.Alloc = out
 			if out != nil {
+				out = out.Sanitize()
+				reply.Alloc = out
 				// Re-check namespace in case it differs from request.
 				if !aclObj.AllowClientOp() && !allowNsOp(aclObj, out.Namespace) {
 					return structs.NewErrUnknownAllocation(args.AllocID)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -11199,6 +11199,23 @@ func (a *Allocation) GetID() string {
 	return a.ID
 }
 
+// Sanitize returns a copy of the allocation with the SignedIdentities field
+// removed. This is useful for returning allocations to clients where the
+// SignedIdentities field is not needed.
+func (a *Allocation) Sanitize() *Allocation {
+	if a == nil {
+		return nil
+	}
+
+	if a.SignedIdentities == nil {
+		return a
+	}
+
+	clean := a.Copy()
+	clean.SignedIdentities = nil
+	return clean
+}
+
 // GetNamespace implements the NamespaceGetter interface, required for
 // pagination and filtering namespaces in endpoints that support glob namespace
 // requests using tokens with limited access.


### PR DESCRIPTION
### Description
Sanitize the Allocations SignedIdentities to prevent privilege escalation within a namespace through unauthorized impersonation of [workload associated with ACL policies](https://developer.hashicorp.com/nomad/docs/concepts/workload-identity#workload-associated-acl-policies) in any workload within the namespace. 
This resolves CVE-2024-12678.

### Testing & Reproduction steps
Current tests are passing.

### Links
https://github.com/hashicorp/nomad-enterprise/pull/2098

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
