### PR TITLE
E2E: use a variable for region

### DIFF
--- a/e2e/terraform/nomad.tf
+++ b/e2e/terraform/nomad.tf
@@ -12,6 +12,7 @@ module "nomad_server" {
   index    = count.index
   instance = aws_instance.server[count.index]
 
+  nomad_region       = var.nomad_region
   nomad_local_binary = count.index < length(var.nomad_local_binary_server) ? var.nomad_local_binary_server[count.index] : var.nomad_local_binary
 
   nomad_license = var.nomad_license
@@ -42,6 +43,7 @@ module "nomad_client_ubuntu_jammy_amd64" {
   index    = count.index
   instance = aws_instance.client_ubuntu_jammy_amd64[count.index]
 
+  nomad_region       = var.nomad_region
   nomad_local_binary = count.index < length(var.nomad_local_binary_client_ubuntu_jammy_amd64) ? var.nomad_local_binary_client_ubuntu_jammy_amd64[count.index] : var.nomad_local_binary
 
   tls_ca_key  = tls_private_key.ca.private_key_pem
@@ -69,6 +71,7 @@ module "nomad_client_windows_2016_amd64" {
   index    = count.index
   instance = aws_instance.client_windows_2016_amd64[count.index]
 
+  nomad_region       = var.nomad_region
   nomad_local_binary = count.index < length(var.nomad_local_binary_client_windows_2016_amd64) ? var.nomad_local_binary_client_windows_2016_amd64[count.index] : ""
 
   tls_ca_key  = tls_private_key.ca.private_key_pem

--- a/e2e/terraform/provision-nomad/etc/nomad.d/base.hcl
+++ b/e2e/terraform/provision-nomad/etc/nomad.d/base.hcl
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-region       = "e2e"
+region       = "${nomad_region}"
 bind_addr    = "0.0.0.0"
 data_dir     = "${data_dir}"
 enable_debug = true

--- a/e2e/terraform/provision-nomad/main.tf
+++ b/e2e/terraform/provision-nomad/main.tf
@@ -18,7 +18,7 @@ resource "local_sensitive_file" "nomad_environment" {
 
 resource "local_sensitive_file" "nomad_base_config" {
   content = templatefile("${path.module}/etc/nomad.d/base.hcl", {
-    data_dir = var.platform != "windows" ? "/opt/nomad/data" : "C://opt/nomad/data"
+    data_dir     = var.platform != "windows" ? "/opt/nomad/data" : "C://opt/nomad/data"
     nomad_region = var.nomad_region
   })
   filename        = "${local.upload_dir}/nomad.d/base.hcl"

--- a/e2e/terraform/provision-nomad/main.tf
+++ b/e2e/terraform/provision-nomad/main.tf
@@ -19,6 +19,7 @@ resource "local_sensitive_file" "nomad_environment" {
 resource "local_sensitive_file" "nomad_base_config" {
   content = templatefile("${path.module}/etc/nomad.d/base.hcl", {
     data_dir = var.platform != "windows" ? "/opt/nomad/data" : "C://opt/nomad/data"
+    nomad_region = var.nomad_region
   })
   filename        = "${local.upload_dir}/nomad.d/base.hcl"
   file_permission = "0600"

--- a/e2e/terraform/provision-nomad/tls.tf
+++ b/e2e/terraform/provision-nomad/tls.tf
@@ -9,10 +9,10 @@ resource "tls_private_key" "nomad" {
 resource "tls_cert_request" "nomad" {
   private_key_pem = tls_private_key.nomad.private_key_pem
   ip_addresses    = [var.instance.public_ip, var.instance.private_ip, "127.0.0.1"]
-  dns_names       = ["${var.role}.global.nomad"]
+  dns_names       = ["${var.role}.${var.nomad_region}.nomad"]
 
   subject {
-    common_name = "${var.role}.global.nomad"
+    common_name = "${var.role}.${var.nomad_region}.nomad"
   }
 }
 

--- a/e2e/terraform/provision-nomad/variables.tf
+++ b/e2e/terraform/provision-nomad/variables.tf
@@ -1,6 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+variable "nomad_region" {
+  type        = string
+  description = "Cluster region"
+  default     = "e2e"
+}
+
 variable "nomad_local_binary" {
   type        = string
   description = "Path to local Nomad build (ex. \"/home/me/bin/nomad\")"

--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -3,7 +3,7 @@
 
 # this default tfvars file expects that you have built nomad
 # with `make dev` or similar (../../ = this repository root)
-# before running `terraform apply` and created the /pkg/goos_goarch/binary 
+# before running `terraform apply` and created the /pkg/goos_goarch/binary
 # folder
 
 nomad_local_binary                           = "../../pkg/linux_amd64/nomad"

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -57,6 +57,11 @@ variable "nomad_license" {
   default     = ""
 }
 
+variable "nomad_region" {
+  description = "The name of the Nomad region."
+  default     = "e2e"
+}
+
 variable "consul_license" {
   type        = string
   description = "If consul_license is set, deploy a license"


### PR DESCRIPTION
In #24644 we set the region to "e2e" but forgot to setup the TLS certificate names appropriately. Swap the region out for a variable instead.
