### PR TITLE
dynamic host volumes: remove multi-node access modes

### DIFF
--- a/nomad/structs/host_volumes.go
+++ b/nomad/structs/host_volumes.go
@@ -275,9 +275,8 @@ func (hvc *HostVolumeCapability) Validate() error {
 	switch hvc.AccessMode {
 	case HostVolumeAccessModeSingleNodeReader,
 		HostVolumeAccessModeSingleNodeWriter,
-		HostVolumeAccessModeMultiNodeReader,
-		HostVolumeAccessModeMultiNodeSingleWriter,
-		HostVolumeAccessModeMultiNodeMultiWriter:
+		HostVolumeAccessModeSingleNodeSingleWriter,
+		HostVolumeAccessModeSingleNodeMultiWriter:
 	default:
 		return fmt.Errorf("invalid access mode: %q", hvc.AccessMode)
 	}
@@ -302,12 +301,10 @@ type HostVolumeAccessMode string
 const (
 	HostVolumeAccessModeUnknown HostVolumeAccessMode = ""
 
-	HostVolumeAccessModeSingleNodeReader HostVolumeAccessMode = "single-node-reader-only"
-	HostVolumeAccessModeSingleNodeWriter HostVolumeAccessMode = "single-node-writer"
-
-	HostVolumeAccessModeMultiNodeReader       HostVolumeAccessMode = "multi-node-reader-only"
-	HostVolumeAccessModeMultiNodeSingleWriter HostVolumeAccessMode = "multi-node-single-writer"
-	HostVolumeAccessModeMultiNodeMultiWriter  HostVolumeAccessMode = "multi-node-multi-writer"
+	HostVolumeAccessModeSingleNodeReader       HostVolumeAccessMode = "single-node-reader-only"
+	HostVolumeAccessModeSingleNodeWriter       HostVolumeAccessMode = "single-node-writer"
+	HostVolumeAccessModeSingleNodeSingleWriter HostVolumeAccessMode = "single-node-single-writer"
+	HostVolumeAccessModeSingleNodeMultiWriter  HostVolumeAccessMode = "single-node-multi-writer"
 )
 
 // HostVolumeStub is used for responses for the list volumes endpoint

--- a/nomad/structs/host_volumes_test.go
+++ b/nomad/structs/host_volumes_test.go
@@ -45,7 +45,7 @@ func TestHostVolume_Copy(t *testing.T) {
 	out.Constraints[0].LTarget = "${meta.node_class}"
 	out.RequestedCapabilities = append(out.RequestedCapabilities, &HostVolumeCapability{
 		AttachmentMode: HostVolumeAttachmentModeBlockDevice,
-		AccessMode:     HostVolumeAccessModeMultiNodeReader,
+		AccessMode:     HostVolumeAccessModeSingleNodeMultiWriter,
 	})
 	out.Parameters["foo"] = "baz"
 
@@ -195,7 +195,7 @@ func TestHostVolume_CanonicalizeForUpdate(t *testing.T) {
 		RequestedCapacityMaxBytes: 500000,
 		RequestedCapabilities: []*HostVolumeCapability{{
 			AttachmentMode: HostVolumeAttachmentModeFilesystem,
-			AccessMode:     HostVolumeAccessModeMultiNodeMultiWriter,
+			AccessMode:     HostVolumeAccessModeSingleNodeMultiWriter,
 		}},
 	}
 	existing := &HostVolume{
@@ -240,7 +240,7 @@ func TestHostVolume_CanonicalizeForUpdate(t *testing.T) {
 
 	must.Eq(t, []*HostVolumeCapability{{
 		AttachmentMode: HostVolumeAttachmentModeFilesystem,
-		AccessMode:     HostVolumeAccessModeMultiNodeMultiWriter,
+		AccessMode:     HostVolumeAccessModeSingleNodeMultiWriter,
 	}}, vol.RequestedCapabilities)
 
 	must.Eq(t, "/var/nomad/alloc_mounts/82f357d6.ext4", vol.HostPath)

--- a/nomad/structs/volumes_test.go
+++ b/nomad/structs/volumes_test.go
@@ -31,9 +31,9 @@ func TestVolumeRequest_Validate(t *testing.T) {
 		{
 			name: "host volume with CSI volume config",
 			expected: []string{
-				"host volumes cannot have an access mode",
-				"host volumes cannot have an attachment mode",
+				"volume has an empty source",
 				"host volumes cannot have mount options",
+				"single-node-reader-only volumes must be read-only",
 				"volume cannot be per_alloc for system or sysbatch jobs",
 				"volume cannot be per_alloc when canaries are in use",
 			},


### PR DESCRIPTION
CSI volumes support multi-node access patterns on the same volume ID, but dynamic host volumes by nature do not. The underlying volume may actually be multi-node (ex. NFS), but Nomad is ignorant of this. Remove the CSI-specific multi-node access modes and instead include the single-node access modes that are currently in the alpha edition of the CSI spec but which are better suited for DHV.

This PR has been extracted from #24684 to keep reviews manageable.

Ref: https://github.com/hashicorp/nomad/pull/24479
Ref: https://github.com/hashicorp/nomad/pull/24684