### PR TITLE
github: Fix lock threads syntax and permissions.

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -11,16 +11,18 @@ jobs:
       - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:
           github-token: ${{ github.token }}
-          issue-lock-comment: >
+          process-only: 'issues, prs'
+          issue-comment: >
             I'm going to lock this issue because it has been closed for _120 days_ ⏳. This helps our maintainers find and focus on the active issues.
 
             If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          issue-lock-inactive-days: '120'
-          pr-lock-comment: >
+          issue-inactive-days: '120'
+          pr-comment: >
             I'm going to lock this pull request because it has been closed for _120 days_ ⏳. This helps our maintainers find and focus on the active contributions.
 
             If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
-          pr-lock-inactive-days: '120'
-permissions:
-  contents: read
+          pr-inactive-days: '120'
 
+permissions:
+  issues: write
+  pull-requests: write


### PR DESCRIPTION
The parameters used for the reusable action were incorrect since the 5.0.1 update. The permissions were also incorrect as the workflow needs to write to issues and PRs.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
