### PR TITLE
Docs: Add link to published clone and edit tutorial

### DIFF
--- a/website/content/docs/concepts/job.mdx
+++ b/website/content/docs/concepts/job.mdx
@@ -135,12 +135,16 @@ the Job versions guide for examples using the CLI, API, and web UI.
 
 ### Clone and edit
 
-Using the web UI, you may clone a version as a new version of same job or as a
-new job. After you select the version to clone, Nomad loads a screen where you
-can edit, plan, and run the new version.
+Using the web UI, you may clone a version as a new version of the same job or as
+a new job. After you select the version to clone, you may edit, plan, and run
+the new version.
 
-Because Nomad passes job version attributes using query params, you can copy the
-browser address bar URL on the **Jobs/Run** screen to send a link to an editable job spec.
+Because Nomad passes job version attributes using query parameters, you can copy
+the browser address bar URL on the **Jobs/Run** screen to send a link to an
+editable job spec.
+
+Refer to the [Clone a version section][clone-version-section] of
+the Job versions guide for cloning examples.
 
 ## Related resources
 
@@ -173,3 +177,4 @@ configure them:
 [job-versions-guide]: /nomad/tutorials/manage-jobs/jobs-version
 [compare-versions-section]: /nomad/tutorials/manage-jobs/jobs-version#compare-versions
 [revert-version-section]: /nomad/tutorials/manage-jobs/jobs-version#revert-to-a-version
+[clone-version-section]: /nomad/tutorials/manage-jobs/jobs-version#clone-a-version


### PR DESCRIPTION
### Description
The clone and edit tutorial has been published, so I am adding a link to that tutorial in the Job concept page's clone/edit section. This is a 1.9.4 feature.
I also cleaned up a few typos.

### Links

Jira: [CE-801]
Deploy preview: https://nomad-git-ce801-hashicorp.vercel.app/nomad/docs/concepts/job#clone-and-edit

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[CE-801]: https://hashicorp.atlassian.net/browse/CE-801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ