### PR TITLE
stateful deployments: validate there are no sticky per_alloc volume requests

### DIFF
--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -165,6 +165,9 @@ func (v *VolumeRequest) Validate(jobType string, taskGroupCount, canaries int) e
 		if canaries > 0 {
 			addErr("volume cannot be per_alloc when canaries are in use")
 		}
+		if v.Sticky {
+			addErr("volume cannot be per_alloc and sticky at the same time")
+		}
 	}
 
 	switch v.Type {

--- a/nomad/structs/volumes_test.go
+++ b/nomad/structs/volumes_test.go
@@ -85,6 +85,17 @@ func TestVolumeRequest_Validate(t *testing.T) {
 				PerAlloc: true,
 			},
 		},
+		{
+			name: "per_alloc sticky",
+			expected: []string{
+				"volume cannot be per_alloc and sticky at the same time",
+			},
+			req: &VolumeRequest{
+				Type:     VolumeTypeCSI,
+				PerAlloc: true,
+				Sticky:   true,
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
This changeset adds an additional validation that prevents users from setting `per_alloc` and `sticky` flags on volume requests. 

Ref: https://github.com/hashicorp/nomad/pull/24479