### PR TITLE
event stream: add events for CSI volumes and plugins

### DIFF
--- a/.changelog/24724.txt
+++ b/.changelog/24724.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+csi: Added CSI volume and plugin events to the event stream
+```

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -1216,7 +1216,6 @@ func Test_eventsFromChanges_ACLBindingRule(t *testing.T) {
 }
 
 func TestEvents_HostVolumes(t *testing.T) {
-
 	ci.Parallel(t)
 	store := TestStateStoreCfg(t, TestStateStorePublisher(t))
 	defer store.StopEventBroker()
@@ -1256,6 +1255,84 @@ func TestEvents_HostVolumes(t *testing.T) {
 	must.Eq(t, "NodeRegistration", events[3].Type)
 	must.Eq(t, "HostVolume", events[4].Topic)
 	must.Eq(t, "HostVolumeDeleted", events[4].Type)
+}
+
+func TestEvents_CSIVolumes(t *testing.T) {
+	ci.Parallel(t)
+	store := TestStateStoreCfg(t, TestStateStorePublisher(t))
+	defer store.StopEventBroker()
+
+	index, err := store.LatestIndex()
+	must.NoError(t, err)
+
+	plugin := mock.CSIPlugin()
+	vol := mock.CSIVolume(plugin)
+
+	index++
+	must.NoError(t, store.UpsertCSIVolume(index, []*structs.CSIVolume{vol}))
+
+	alloc := mock.Alloc()
+	index++
+	store.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc})
+
+	claim := &structs.CSIVolumeClaim{
+		AllocationID:   alloc.ID,
+		NodeID:         uuid.Generate(),
+		Mode:           structs.CSIVolumeClaimGC,
+		AccessMode:     structs.CSIVolumeAccessModeSingleNodeWriter,
+		AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
+		State:          structs.CSIVolumeClaimStateReadyToFree,
+	}
+	index++
+	must.NoError(t, store.CSIVolumeClaim(index, time.Now().UnixNano(), vol.Namespace, vol.ID, claim))
+
+	index++
+	must.NoError(t, store.CSIVolumeDeregister(index, vol.Namespace, []string{vol.ID}, false))
+
+	events := WaitForEvents(t, store, 0, 3, 1*time.Second)
+	must.Len(t, 3, events)
+	must.Eq(t, "CSIVolume", events[0].Topic)
+	must.Eq(t, "CSIVolumeRegistered", events[0].Type)
+	must.Eq(t, "CSIVolume", events[1].Topic)
+	must.Eq(t, "CSIVolumeClaim", events[1].Type)
+	must.Eq(t, "CSIVolume", events[2].Topic)
+	must.Eq(t, "CSIVolumeDeregistered", events[2].Type)
+
+}
+
+func TestEvents_CSIPlugins(t *testing.T) {
+	ci.Parallel(t)
+	store := TestStateStoreCfg(t, TestStateStorePublisher(t))
+	defer store.StopEventBroker()
+
+	index, err := store.LatestIndex()
+	must.NoError(t, err)
+
+	node := mock.Node()
+	plugin := mock.CSIPlugin()
+
+	index++
+	must.NoError(t, store.UpsertNode(structs.NodeRegisterRequestType, index, node))
+
+	node = node.Copy()
+	node.CSINodePlugins = map[string]*structs.CSIInfo{
+		plugin.ID: {
+			PluginID:   plugin.ID,
+			Healthy:    true,
+			UpdateTime: time.Now(),
+		},
+	}
+	index++
+	must.NoError(t, store.UpsertNode(structs.NodeRegisterRequestType, index, node))
+
+	events := WaitForEvents(t, store, 0, 3, 1*time.Second)
+	must.Len(t, 3, events)
+	must.Eq(t, "Node", events[0].Topic)
+	must.Eq(t, "NodeRegistration", events[0].Type)
+	must.Eq(t, "Node", events[1].Topic)
+	must.Eq(t, "NodeRegistration", events[1].Type)
+	must.Eq(t, "CSIPlugin", events[2].Topic)
+	must.Eq(t, "NodeRegistration", events[2].Type)
 }
 
 func requireNodeRegistrationEventEqual(t *testing.T, want, got structs.Event) {

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -27,6 +27,8 @@ const (
 	TableAllocs               = "allocs"
 	TableJobSubmission        = "job_submission"
 	TableHostVolumes          = "host_volumes"
+	TableCSIVolumes           = "csi_volumes"
+	TableCSIPlugins           = "csi_plugins"
 )
 
 const (
@@ -1150,7 +1152,7 @@ func clusterMetaTableSchema() *memdb.TableSchema {
 // CSIVolumes are identified by id globally, and searchable by driver
 func csiVolumeTableSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: "csi_volumes",
+		Name: TableCSIVolumes,
 		Indexes: map[string]*memdb.IndexSchema{
 			"id": {
 				Name:         "id",
@@ -1182,7 +1184,7 @@ func csiVolumeTableSchema() *memdb.TableSchema {
 // CSIPlugins are identified by id globally, and searchable by driver
 func csiPluginTableSchema() *memdb.TableSchema {
 	return &memdb.TableSchema{
-		Name: "csi_plugins",
+		Name: TableCSIPlugins,
 		Indexes: map[string]*memdb.IndexSchema{
 			"id": {
 				Name:         "id",

--- a/nomad/state/state_store_restore.go
+++ b/nomad/state/state_store_restore.go
@@ -181,7 +181,7 @@ func (r *StateRestore) ScalingPolicyRestore(scalingPolicy *structs.ScalingPolicy
 
 // CSIPluginRestore is used to restore a CSI plugin
 func (r *StateRestore) CSIPluginRestore(plugin *structs.CSIPlugin) error {
-	if err := r.txn.Insert("csi_plugins", plugin); err != nil {
+	if err := r.txn.Insert(TableCSIPlugins, plugin); err != nil {
 		return fmt.Errorf("csi plugin insert failed: %v", err)
 	}
 	return nil
@@ -189,7 +189,7 @@ func (r *StateRestore) CSIPluginRestore(plugin *structs.CSIPlugin) error {
 
 // CSIVolumeRestore is used to restore a CSI volume
 func (r *StateRestore) CSIVolumeRestore(volume *structs.CSIVolume) error {
-	if err := r.txn.Insert("csi_volumes", volume); err != nil {
+	if err := r.txn.Insert(TableCSIVolumes, volume); err != nil {
 		return fmt.Errorf("csi volume insert failed: %v", err)
 	}
 	return nil

--- a/nomad/stream/event_broker.go
+++ b/nomad/stream/event_broker.go
@@ -367,6 +367,14 @@ func aclAllowsSubscription(aclObj *acl.ACL, subReq *SubscribeRequest) bool {
 			if ok := aclObj.AllowNsOp(subReq.Namespace, acl.NamespaceCapabilityHostVolumeRead); !ok {
 				return false
 			}
+		case structs.TopicCSIVolume:
+			if ok := aclObj.AllowNsOp(subReq.Namespace, acl.NamespaceCapabilityCSIReadVolume); !ok {
+				return false
+			}
+		case structs.TopicCSIPlugin:
+			if ok := aclObj.AllowNsOp(subReq.Namespace, acl.NamespaceCapabilityReadJob); !ok {
+				return false
+			}
 		case structs.TopicNode:
 			if ok := aclObj.AllowNodeRead(); !ok {
 				return false

--- a/nomad/structs/event.go
+++ b/nomad/structs/event.go
@@ -32,6 +32,8 @@ const (
 	TopicACLBindingRule Topic = "ACLBindingRule"
 	TopicService        Topic = "Service"
 	TopicHostVolume     Topic = "HostVolume"
+	TopicCSIVolume      Topic = "CSIVolume"
+	TopicCSIPlugin      Topic = "CSIPlugin"
 	TopicAll            Topic = "*"
 
 	TypeNodeRegistration              = "NodeRegistration"
@@ -66,6 +68,9 @@ const (
 	TypeServiceDeregistration         = "ServiceDeregistration"
 	TypeHostVolumeRegistered          = "HostVolumeRegistered"
 	TypeHostVolumeDeleted             = "HostVolumeDeleted"
+	TypeCSIVolumeRegistered           = "CSIVolumeRegistered"
+	TypeCSIVolumeDeregistered         = "CSIVolumeDeregistered"
+	TypeCSIVolumeClaim                = "CSIVolumeClaim"
 )
 
 // Event represents a change in Nomads state.
@@ -196,4 +201,16 @@ type ACLBindingRuleEvent struct {
 // used as an event in the event stream
 type HostVolumeEvent struct {
 	Volume *HostVolume
+}
+
+// CSIVolumeEvent holds a newly updated or deleted CSI volume to be
+// used as an event in the event stream
+type CSIVolumeEvent struct {
+	Volume *CSIVolume
+}
+
+// CSIPluginEvent holds a newly updated or deleted CSI plugin to be
+// used as an event in the event stream
+type CSIPluginEvent struct {
+	Plugin *CSIPlugin
 }

--- a/nomad/volumewatcher/volumes_watcher.go
+++ b/nomad/volumewatcher/volumes_watcher.go
@@ -141,9 +141,9 @@ func (w *Watcher) getVolumes(ctx context.Context, minIndex uint64) ([]*structs.C
 }
 
 // getVolumesImpl retrieves all volumes from the passed state store.
-func (w *Watcher) getVolumesImpl(ws memdb.WatchSet, state *state.StateStore) (interface{}, uint64, error) {
+func (w *Watcher) getVolumesImpl(ws memdb.WatchSet, store *state.StateStore) (interface{}, uint64, error) {
 
-	iter, err := state.CSIVolumes(ws)
+	iter, err := store.CSIVolumes(ws)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -159,7 +159,7 @@ func (w *Watcher) getVolumesImpl(ws memdb.WatchSet, state *state.StateStore) (in
 	}
 
 	// Use the last index that affected the volume table
-	index, err := state.Index("csi_volumes")
+	index, err := store.Index(state.TableCSIVolumes)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/website/content/api-docs/events.mdx
+++ b/website/content/api-docs/events.mdx
@@ -28,6 +28,7 @@ the nature of this endpoint individual topics require specific policies.
 Note that if you do not include a `topic` parameter all topics will be included
 by default, requiring a management token.
 
+
 | Topic        | ACL Required                 |
 |--------------|------------------------------|
 | `*`          | `management`                 |
@@ -35,6 +36,8 @@ by default, requiring a management token.
 | `ACLRole`    | `management`                 |
 | `ACLToken`   | `management`                 |
 | `Allocation` | `namespace:read-job`         |
+| `CSIPlugin`  | `namespace:read-job`         |
+| `CSIVolume`  | `namespace:csi-read-volume`  |
 | `Deployment` | `namespace:read-job`         |
 | `Evaluation` | `namespace:read-job`         |
 | `HostVolume` | `namespace:host-volume-read` |
@@ -72,6 +75,8 @@ by default, requiring a management token.
 | ACLRoles   | ACLRole                                |
 | ACLToken   | ACLToken                               |
 | Allocation | Allocation (no job information)        |
+| CSIPlugin  | CSIPlugin                              |
+| CSIVolume  | CSIVolume                              |
 | Deployment | Deployment                             |
 | Evaluation | Evaluation                             |
 | HostVolume | HostVolume (dynamic host volumes only) |
@@ -94,6 +99,8 @@ by default, requiring a management token.
 | AllocationCreated             |
 | AllocationUpdateDesiredStatus |
 | AllocationUpdated             |
+| CSIVolumeDeregistered         |
+| CSIVolumeRegistered           |
 | DeploymentAllocHealth         |
 | DeploymentPromotion           |
 | DeploymentStatusUpdate        |


### PR DESCRIPTION
Adds new topics to the event stream for CSI volumes and CSI plugins. We'll emit events when either is created or deleted, and when CSI volumes are claimed.

Ref: https://github.com/hashicorp/nomad/pull/24721

### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps

In addition to the unit tests, you can use nomad operator api "/v1/event/stream?topic=CSIVolume" to poll for CSI volume events while running the [host path demo](https://github.com/hashicorp/nomad/tree/main/demo/csi/hostpath).

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
