### PR TITLE
taskrunner: fix panic when a task that has a dynamic user is recovered

### DIFF
--- a/client/allocrunner/taskrunner/dynamic_users_hook.go
+++ b/client/allocrunner/taskrunner/dynamic_users_hook.go
@@ -59,6 +59,7 @@ func (h *dynamicUsersHook) Prestart(_ context.Context, request *interfaces.TaskP
 		return nil
 	}
 
+	response.State = make(map[string]string, 1)
 	// if this is the restart case, the UGID will already be acquired and we
 	// just need to read it back out of the hook's state
 	if request.PreviousState != nil {
@@ -86,7 +87,6 @@ func (h *dynamicUsersHook) Prestart(_ context.Context, request *interfaces.TaskP
 	request.Task.User = dynamic.String(ugid)
 
 	// set the user on the hook so we may release it later
-	response.State = make(map[string]string, 1)
 	response.State[dynamicUsersStateKey] = request.Task.User
 
 	return nil

--- a/client/allocrunner/taskrunner/dynamic_users_hook_test.go
+++ b/client/allocrunner/taskrunner/dynamic_users_hook_test.go
@@ -35,6 +35,36 @@ func TestTaskRunner_DynamicUsersHook_Prestart_unusable(t *testing.T) {
 	must.NoError(t, h.Prestart(ctx, request, response))
 }
 
+func TestTaskRunner_DynamicUsersHook_Prestart_State(t *testing.T) {
+	ci.Parallel(t)
+
+	const capable = false
+	ctx := context.Background()
+	logger := testlog.HCLogger(t)
+
+	var pool dynamic.Pool = nil
+	request := &interfaces.TaskPrestartRequest{
+		Task: &structs.Task{},
+		PreviousState: map[string]string{
+			dynamicUsersStateKey: "1",
+		},
+	}
+
+	response := &interfaces.TaskPrestartResponse{}
+	h := newDynamicUsersHook(ctx, capable, logger, pool)
+
+	// mark as usable
+	h.usable = true
+
+	must.NoError(t, h.Prestart(ctx, request, response))
+
+	// make sure the user exists in the state
+	// by the dynamic user key
+	user, ok := response.State[dynamicUsersStateKey]
+	must.True(t, ok)
+	must.Eq(t, "1", user)
+}
+
 func TestTaskRunner_DynamicUsersHook_Prestart_unnecessary(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
Before this, the nomad client would crash with:
```
panic: assignment to entry in nil map
```

### Description
We are seeing in our production clusters the following crash when this codepath is being hit.

### Testing & Reproduction steps
The unit test I added doesn't pass without this change.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

