### PR TITLE
dynamic host volumes: ensure unique name per node

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -408,6 +408,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 	}
 
 	c.batchNodeUpdates = newBatchNodeUpdates(
+		c.logger,
 		c.updateNodeFromDriver,
 		c.updateNodeFromDevices,
 		c.updateNodeFromCSI,

--- a/client/hostvolumemanager/host_volumes.go
+++ b/client/hostvolumemanager/host_volumes.go
@@ -6,7 +6,6 @@ package hostvolumemanager
 import (
 	"context"
 	"errors"
-	"fmt"
 	"path/filepath"
 	"sync"
 
@@ -212,7 +211,10 @@ func (hvm *HostVolumeManager) restoreFromState(ctx context.Context) (VolumeMap, 
 			// prior to node registration, so new creates shouldn't come in
 			// concurrently, but check for error just in case.
 			if err != nil {
-				hvm.log.Error("error during restore", "volume_id", vol.ID, "error", err)
+				hvm.log.Error("error during restore",
+					"volume_name", vol.CreateReq.Name,
+					"volume_id", vol.CreateReq.ID,
+					"error", err)
 				// don't stop the world if it does happen, because an admin
 				// couldn't do anything about it short of wiping client state.
 				return nil
@@ -260,7 +262,7 @@ type volLocker struct {
 func (l *volLocker) lock(name, id string) error {
 	current, exists := l.locks.LoadOrStore(name, id)
 	if exists && id != current.(string) {
-		return fmt.Errorf("%w: name=%q id=%q", ErrVolumeNameExists, name, id)
+		return ErrVolumeNameExists
 	}
 	return nil
 }

--- a/client/hostvolumemanager/host_volumes_test.go
+++ b/client/hostvolumemanager/host_volumes_test.go
@@ -27,7 +27,7 @@ func TestHostVolumeManager(t *testing.T) {
 	tmp := t.TempDir()
 	errDB := &cstate.ErrDB{}
 	memDB := cstate.NewMemDB(log)
-	node := newFakeNode()
+	node := newFakeNode(t)
 
 	hvm := NewHostVolumeManager(log, Config{
 		PluginDir:      "./test_fixtures",
@@ -231,7 +231,7 @@ func TestHostVolumeManager_restoreFromState(t *testing.T) {
 			PluginID: "mkdir",
 		},
 	}
-	node := newFakeNode()
+	node := newFakeNode(t)
 
 	t.Run("no vols", func(t *testing.T) {
 		state := cstate.NewMemDB(log)
@@ -332,15 +332,17 @@ func TestHostVolumeManager_restoreFromState(t *testing.T) {
 
 type fakeNode struct {
 	vols VolumeMap
+	log  hclog.Logger
 }
 
 func (n *fakeNode) updateVol(name string, volume *structs.ClientHostVolumeConfig) {
-	UpdateVolumeMap(n.vols, name, volume)
+	UpdateVolumeMap(n.log, n.vols, name, volume)
 }
 
-func newFakeNode() *fakeNode {
+func newFakeNode(t *testing.T) *fakeNode {
 	return &fakeNode{
 		vols: make(VolumeMap),
+		log:  testlog.HCLogger(t),
 	}
 }
 

--- a/client/hostvolumemanager/host_volumes_test.go
+++ b/client/hostvolumemanager/host_volumes_test.go
@@ -213,12 +213,12 @@ func (p *fakePlugin) Delete(_ context.Context, req *cstructs.ClientHostVolumeDel
 
 func assertLocked(t *testing.T, hvm *HostVolumeManager, name string) {
 	t.Helper()
-	must.True(t, hvm.names.isLocked(name), must.Sprintf("vol name %q should be locked", name))
+	must.True(t, hvm.locker.isLocked(name), must.Sprintf("vol name %q should be locked", name))
 }
 
 func assertNotLocked(t *testing.T, hvm *HostVolumeManager, name string) {
 	t.Helper()
-	must.False(t, hvm.names.isLocked(name), must.Sprintf("vol name %q should not be locked", name))
+	must.False(t, hvm.locker.isLocked(name), must.Sprintf("vol name %q should not be locked", name))
 }
 
 func TestHostVolumeManager_restoreFromState(t *testing.T) {

--- a/client/hostvolumemanager/volume_fingerprint.go
+++ b/client/hostvolumemanager/volume_fingerprint.go
@@ -6,6 +6,7 @@ package hostvolumemanager
 import (
 	"context"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -24,7 +25,7 @@ type VolumeMap map[string]*structs.ClientHostVolumeConfig
 //
 // Since it may mutate the map, the caller should make a copy
 // or acquire a lock as appropriate for their context.
-func UpdateVolumeMap(volumes VolumeMap, name string, vol *structs.ClientHostVolumeConfig) (changed bool) {
+func UpdateVolumeMap(log hclog.Logger, volumes VolumeMap, name string, vol *structs.ClientHostVolumeConfig) (changed bool) {
 	current, exists := volumes[name]
 	if vol == nil {
 		if exists {
@@ -32,6 +33,12 @@ func UpdateVolumeMap(volumes VolumeMap, name string, vol *structs.ClientHostVolu
 			changed = true
 		}
 	} else {
+		// if the volume already exists with no ID, it will be because it was
+		// added to client agent config after having been previously created
+		// as a dynamic vol. dynamic takes precedence, but log a warning.
+		if exists && current.ID == "" {
+			log.Warn("overriding static host volume with dynamic", "name", name, "id", vol.ID)
+		}
 		if !exists || !vol.Equal(current) {
 			volumes[name] = vol
 			changed = true


### PR DESCRIPTION
Volume name must be unique per node.

For existing static host vols, the scheduler will prevent creation of duplicate names ("no node meets constraints"), and it will similarly prevent duplicate dynamic vols _after_ fingerprint (node re-registration), but we need to prevent concurrent duplicate creation that may happen within a fingerprint interval, too.

Here a lock is set for name+id during `Create` (and restore), then released when `Delete`d to prevent such very-fast or concurrent creates.

If the a volume spec is submitted again with a valid `id` set, it can still update the volume, and the plugin's `Create` will be run with the new spec.  I'm guessing that folks may want to do this if either A) the plugin has been updated and folks want to regenerate their vols in place? or B) to increase the vol size (in CSI parlance, "expand").  Not sure if perhaps any other reasons, but I wanted to leave this door open.

A last funny caveat is if a _static_ host volume is added to agent config after a dynamic one has been created, and the agent restarted to use it, the dynamic one will take precedence. A warning is logged to inform the user if this happens.