### PR TITLE
build: recommend dmidecode for rpm and deb packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,8 @@ jobs:
           binary: "pkg/${{ matrix.goos }}_${{ matrix.goarch }}/${{ env.PKG_NAME }}"
           deb_depends: "openssl"
           rpm_depends: "openssl"
+          deb_recommends: "dmidecode"
+          rpm_recommends: "dmidecode"
           config_dir: ".release/linux/package/"
           preinstall: ".release/linux/preinst"
           postinstall: ".release/linux/postinst"


### PR DESCRIPTION
Add `dmidecode` to "recommended" dependencies to improve UX on Linux machines that install Nomad via official packages. 

Resolves [#19382](https://github.com/hashicorp/nomad/issues/19382)
Internal ref: https://hashicorp.atlassian.net/browse/NET-10747