### PR TITLE
keyring: warn if removing a key that was used for encrypting variables

### DIFF
--- a/.changelog/24766.txt
+++ b/.changelog/24766.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+keyring: Warn if deleting a key previously used to encrypt a variable
+```

--- a/.changelog/24766.txt
+++ b/.changelog/24766.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-keyring: Warn if deleting a key previously used to encrypt a variable
+keyring: Warn if deleting a key previously used to encrypt an existing variable
 ```

--- a/api/keyring.go
+++ b/api/keyring.go
@@ -69,6 +69,8 @@ func (k *Keyring) Delete(opts *KeyringDeleteOptions, w *WriteOptions) (*WriteMet
 // KeyringDeleteOptions are parameters for the Delete API
 type KeyringDeleteOptions struct {
 	KeyID string // UUID
+	// Force can be used to force deletion of a root keyring that was used to encrypt
+	// an existing variable or to sign a workload identity
 	Force bool
 }
 

--- a/api/keyring.go
+++ b/api/keyring.go
@@ -6,6 +6,7 @@ package api
 import (
 	"fmt"
 	"net/url"
+	"strconv"
 )
 
 // Keyring is used to access the Variables keyring.
@@ -60,14 +61,15 @@ func (k *Keyring) List(q *QueryOptions) ([]*RootKeyMeta, *QueryMeta, error) {
 
 // Delete deletes a specific inactive key from the keyring
 func (k *Keyring) Delete(opts *KeyringDeleteOptions, w *WriteOptions) (*WriteMeta, error) {
-	wm, err := k.client.delete(fmt.Sprintf("/v1/operator/keyring/key/%v",
-		url.PathEscape(opts.KeyID)), nil, nil, w)
+	wm, err := k.client.delete(fmt.Sprintf("/v1/operator/keyring/key/%v?force=%v",
+		url.PathEscape(opts.KeyID), strconv.FormatBool(opts.Force)), nil, nil, w)
 	return wm, err
 }
 
 // KeyringDeleteOptions are parameters for the Delete API
 type KeyringDeleteOptions struct {
 	KeyID string // UUID
+	Force bool
 }
 
 // Rotate requests a key rotation

--- a/api/keyring_test.go
+++ b/api/keyring_test.go
@@ -37,8 +37,8 @@ func TestKeyring_CRUD(t *testing.T) {
 	assertQueryMeta(t, qm)
 	must.Len(t, 2, keys)
 
-	// Delete the old key
-	wm, err = kr.Delete(&KeyringDeleteOptions{KeyID: oldKeyID}, nil)
+	// Delete the old key with force
+	wm, err = kr.Delete(&KeyringDeleteOptions{KeyID: oldKeyID, Force: true}, nil)
 	must.NoError(t, err)
 	assertWriteMeta(t, wm)
 

--- a/command/agent/keyring_endpoint.go
+++ b/command/agent/keyring_endpoint.go
@@ -116,9 +116,14 @@ func (s *HTTPServer) KeyringRequest(resp http.ResponseWriter, req *http.Request)
 		return s.keyringListRequest(resp, req)
 	case strings.HasPrefix(path, "key"):
 		keyID := strings.TrimPrefix(req.URL.Path, "/v1/operator/keyring/key/")
+		force := req.URL.Query()["force"][0]
+		forceBool, err := strconv.ParseBool(force)
+		if err != nil {
+			return nil, CodedError(422, "invalid force parameter")
+		}
 		switch req.Method {
 		case http.MethodDelete:
-			return s.keyringDeleteRequest(resp, req, keyID)
+			return s.keyringDeleteRequest(resp, req, keyID, forceBool)
 		default:
 			return nil, CodedError(405, ErrInvalidMethod)
 		}
@@ -185,9 +190,9 @@ func (s *HTTPServer) keyringRotateRequest(resp http.ResponseWriter, req *http.Re
 	return out, nil
 }
 
-func (s *HTTPServer) keyringDeleteRequest(resp http.ResponseWriter, req *http.Request, keyID string) (interface{}, error) {
+func (s *HTTPServer) keyringDeleteRequest(resp http.ResponseWriter, req *http.Request, keyID string, force bool) (interface{}, error) {
 
-	args := structs.KeyringDeleteRootKeyRequest{KeyID: keyID}
+	args := structs.KeyringDeleteRootKeyRequest{KeyID: keyID, Force: force}
 	s.parseWriteRequest(req, &args.WriteRequest)
 
 	var out structs.KeyringDeleteRootKeyResponse

--- a/command/agent/keyring_endpoint.go
+++ b/command/agent/keyring_endpoint.go
@@ -116,8 +116,14 @@ func (s *HTTPServer) KeyringRequest(resp http.ResponseWriter, req *http.Request)
 		return s.keyringListRequest(resp, req)
 	case strings.HasPrefix(path, "key"):
 		keyID := strings.TrimPrefix(req.URL.Path, "/v1/operator/keyring/key/")
-		force := req.URL.Query()["force"][0]
-		forceBool, err := strconv.ParseBool(force)
+
+		var forceBool bool
+		var err error
+		forceQuery, ok := req.URL.Query()["force"]
+		if ok {
+			forceBool, err = strconv.ParseBool(forceQuery[0])
+		}
+
 		if err != nil {
 			return nil, CodedError(422, "invalid force parameter")
 		}

--- a/command/operator_root_keyring_remove.go
+++ b/command/operator_root_keyring_remove.go
@@ -51,11 +51,12 @@ func (c *OperatorRootKeyringRemoveCommand) Name() string {
 }
 
 func (c *OperatorRootKeyringRemoveCommand) Run(args []string) int {
-	var verbose bool
+	var force, verbose bool
 
 	flags := c.Meta.FlagSet("root keyring remove", FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.BoolVar(&verbose, "verbose", false, "")
+	flags.BoolVar(&force, "force", false, "Forces deletion of the root keyring even if it's in use.")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -76,6 +77,7 @@ func (c *OperatorRootKeyringRemoveCommand) Run(args []string) int {
 	}
 	_, err = client.Keyring().Delete(&api.KeyringDeleteOptions{
 		KeyID: removeKey,
+		Force: force,
 	}, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("error: %s", err))

--- a/command/operator_root_keyring_remove.go
+++ b/command/operator_root_keyring_remove.go
@@ -29,7 +29,14 @@ Usage: nomad operator root keyring remove [options] <key ID>
 
 General Options:
 
-  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
+
+Keyring Options:
+
+  -force
+    Remove the key even if it was used to sign an existing variable
+    or workload identity.
+`
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/operator_root_keyring_remove.go
+++ b/command/operator_root_keyring_remove.go
@@ -31,7 +31,7 @@ General Options:
 
   ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
 
-Keyring Options:
+Remove Options:
 
   -force
     Remove the key even if it was used to sign an existing variable

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -348,6 +348,15 @@ func (k *Keyring) Delete(args *structs.KeyringDeleteRootKeyRequest, reply *struc
 		return fmt.Errorf("active root key cannot be deleted - call rotate first")
 	}
 
+	// make sure the key was used to encrypt an existing variable
+	rootKeyInUse, err := snap.IsRootKeyInUse(args.KeyID)
+	if err != nil {
+		return err
+	}
+	if rootKeyInUse && !args.Force {
+		return fmt.Errorf("root key in use, cannot delete")
+	}
+
 	_, index, err = k.srv.raftApply(structs.WrappedRootKeysDeleteRequestType, args)
 	if err != nil {
 		return err

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -345,6 +345,11 @@ func (k *Keyring) Delete(args *structs.KeyringDeleteRootKeyRequest, reply *struc
 	if err != nil {
 		return err
 	}
+
+	if rootKey == nil {
+		return errors.New("root key not found")
+	}
+
 	if rootKey != nil && rootKey.IsActive() {
 		return fmt.Errorf("active root key cannot be deleted - call rotate first")
 	}

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -4,6 +4,7 @@
 package nomad
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -354,7 +355,7 @@ func (k *Keyring) Delete(args *structs.KeyringDeleteRootKeyRequest, reply *struc
 		return err
 	}
 	if rootKeyInUse && !args.Force {
-		return fmt.Errorf("root key in use, cannot delete")
+		return errors.New("root key in use, cannot delete")
 	}
 
 	_, index, err = k.srv.raftApply(structs.WrappedRootKeysDeleteRequestType, args)

--- a/nomad/structs/keyring.go
+++ b/nomad/structs/keyring.go
@@ -500,6 +500,7 @@ type KeyringUpdateRootKeyMetaResponse struct {
 
 type KeyringDeleteRootKeyRequest struct {
 	KeyID string
+	Force bool
 	WriteRequest
 }
 

--- a/website/content/api-docs/operator/keyring.mdx
+++ b/website/content/api-docs/operator/keyring.mdx
@@ -233,6 +233,11 @@ The table below shows this endpoint's support for [blocking queries] and
 |------------------|--------------|
 | `NO`             | `management` |
 
+### Parameters
+
+- `force` `(bool: false)` - Remove the key even if it was used to sign an existing variable
+or workload identity.
+
 ### Sample Request
 
 ```shell-session

--- a/website/content/docs/commands/operator/root/keyring-remove.mdx
+++ b/website/content/docs/commands/operator/root/keyring-remove.mdx
@@ -23,6 +23,12 @@ nomad operator root keyring remove [options] <key ID>
 
 @include 'general_options.mdx'
 
+## Remove Options
+
+- `-force`: Remove the key even if it was used to sign an existing variable
+or workload identity.
+
+
 ## Examples
 
 ```shell-session


### PR DESCRIPTION
This PR adds an additional check in the `Keyring.Delete` RPC to make sure we're not trying to delete a key that's been used to encrypt a variable. It also adds a `-force` flag for the CLI/API to sidestep that check. 

Resolves https://github.com/hashicorp/nomad/issues/24591
Internal ref: https://hashicorp.atlassian.net/browse/NET-11829