### PR TITLE
services: Support TLS Skip Verify within Nomad service checks.

### DIFF
--- a/.changelog/24781.txt
+++ b/.changelog/24781.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+services: Nomad service checks now support the `tls_skip_verify` parameter
+```

--- a/client/serviceregistration/checks/result.go
+++ b/client/serviceregistration/checks/result.go
@@ -18,16 +18,17 @@ func GetCheckQuery(c *structs.ServiceCheck) *Query {
 		protocol = "http"
 	}
 	return &Query{
-		Mode:        structs.GetCheckMode(c),
-		Type:        c.Type,
-		Timeout:     c.Timeout,
-		AddressMode: c.AddressMode,
-		PortLabel:   c.PortLabel,
-		Protocol:    protocol,
-		Path:        c.Path,
-		Method:      c.Method,
-		Headers:     maps.Clone(c.Header),
-		Body:        c.Body,
+		Mode:          structs.GetCheckMode(c),
+		Type:          c.Type,
+		Timeout:       c.Timeout,
+		AddressMode:   c.AddressMode,
+		PortLabel:     c.PortLabel,
+		Protocol:      protocol,
+		Path:          c.Path,
+		Method:        c.Method,
+		Headers:       maps.Clone(c.Header),
+		Body:          c.Body,
+		TLSSkipVerify: c.TLSSkipVerify,
 	}
 }
 
@@ -42,11 +43,12 @@ type Query struct {
 	AddressMode string // host, driver, or alloc
 	PortLabel   string // label or value
 
-	Protocol string      // http checks only (http or https)
-	Path     string      // http checks only
-	Method   string      // http checks only
-	Headers  http.Header // http checks only
-	Body     string      // http checks only
+	Protocol      string      // http checks only (http or https)
+	Path          string      // http checks only
+	Method        string      // http checks only
+	Headers       http.Header // http checks only
+	Body          string      // http checks only
+	TLSSkipVerify bool        // http checks only, https protocol
 }
 
 // A QueryContext contains allocation and service parameters necessary for

--- a/client/serviceregistration/checks/result_test.go
+++ b/client/serviceregistration/checks/result_test.go
@@ -13,79 +13,97 @@ import (
 
 func TestChecks_GetCheckQuery(t *testing.T) {
 	cases := []struct {
-		name        string
-		cType       string
-		protocol    string
-		onUpdate    string
-		expMode     structs.CheckMode
-		expProtocol string
+		name               string
+		cType              string
+		protocol           string
+		onUpdate           string
+		expMode            structs.CheckMode
+		expProtocol        string
+		inputTLSSkipVerify bool
 	}{
 		{
-			name:        "http check and http set",
-			cType:       "http",
-			protocol:    "http",
-			onUpdate:    "checks",
-			expMode:     structs.Healthiness,
-			expProtocol: "http",
+			name:               "http check and http set",
+			cType:              "http",
+			protocol:           "http",
+			onUpdate:           "checks",
+			expMode:            structs.Healthiness,
+			expProtocol:        "http",
+			inputTLSSkipVerify: false,
 		},
 		{
-			name:        "http check and https set",
-			cType:       "http",
-			protocol:    "https",
-			onUpdate:    "checks",
-			expMode:     structs.Healthiness,
-			expProtocol: "https",
+			name:               "http check and https set",
+			cType:              "http",
+			protocol:           "https",
+			onUpdate:           "checks",
+			expMode:            structs.Healthiness,
+			expProtocol:        "https",
+			inputTLSSkipVerify: false,
 		},
 		{
-			name:        "http check and protocol unset",
-			cType:       "http",
-			protocol:    "",
-			onUpdate:    "checks",
-			expMode:     structs.Healthiness,
-			expProtocol: "http", // inherit default
+			name:               "http check and protocol unset",
+			cType:              "http",
+			protocol:           "",
+			onUpdate:           "checks",
+			expMode:            structs.Healthiness,
+			expProtocol:        "http", // inherit default
+			inputTLSSkipVerify: false,
 		},
 		{
-			name:        "tcp check and protocol unset",
-			cType:       "tcp",
-			protocol:    "",
-			onUpdate:    "checks",
-			expMode:     structs.Healthiness,
-			expProtocol: "",
+			name:               "tcp check and protocol unset",
+			cType:              "tcp",
+			protocol:           "",
+			onUpdate:           "checks",
+			expMode:            structs.Healthiness,
+			expProtocol:        "",
+			inputTLSSkipVerify: false,
 		},
 		{
-			name:        "http check and http set",
-			cType:       "http",
-			protocol:    "http",
-			onUpdate:    "checks",
-			expMode:     structs.Healthiness,
-			expProtocol: "http",
+			name:               "http check and http set",
+			cType:              "http",
+			protocol:           "http",
+			onUpdate:           "checks",
+			expMode:            structs.Healthiness,
+			expProtocol:        "http",
+			inputTLSSkipVerify: false,
 		},
 		{
-			name:        "on-update ignore",
-			cType:       "http",
-			protocol:    "http",
-			onUpdate:    structs.OnUpdateIgnore,
-			expMode:     structs.Readiness,
-			expProtocol: "http",
+			name:               "on-update ignore",
+			cType:              "http",
+			protocol:           "http",
+			onUpdate:           structs.OnUpdateIgnore,
+			expMode:            structs.Readiness,
+			expProtocol:        "http",
+			inputTLSSkipVerify: false,
+		},
+		{
+			name:               "tls-skip-verify",
+			cType:              "http",
+			protocol:           "https",
+			onUpdate:           structs.OnUpdateIgnore,
+			expMode:            structs.Readiness,
+			expProtocol:        "https",
+			inputTLSSkipVerify: true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			serviceCheck := &structs.ServiceCheck{
-				Type:        tc.cType,
-				Path:        "/",
-				Protocol:    tc.protocol,
-				PortLabel:   "web",
-				AddressMode: "host",
-				Interval:    10 * time.Second,
-				Timeout:     2 * time.Second,
-				Method:      "GET",
-				OnUpdate:    tc.onUpdate,
+				Type:          tc.cType,
+				Path:          "/",
+				Protocol:      tc.protocol,
+				PortLabel:     "web",
+				AddressMode:   "host",
+				Interval:      10 * time.Second,
+				Timeout:       2 * time.Second,
+				Method:        "GET",
+				OnUpdate:      tc.onUpdate,
+				TLSSkipVerify: tc.inputTLSSkipVerify,
 			}
 			query := GetCheckQuery(serviceCheck)
 			must.Eq(t, tc.expMode, query.Mode)
 			must.Eq(t, tc.expProtocol, query.Protocol)
+			must.Eq(t, tc.inputTLSSkipVerify, query.TLSSkipVerify)
 		})
 	}
 }

--- a/nomad/structs/check_test.go
+++ b/nomad/structs/check_test.go
@@ -15,17 +15,18 @@ func TestChecks_NomadCheckID(t *testing.T) {
 	ci.Parallel(t)
 
 	orig := ServiceCheck{
-		Name:        "c1",
-		Type:        "http",
-		Path:        "/health",
-		Protocol:    "https",
-		PortLabel:   "web",
-		AddressMode: "host",
-		Interval:    1 * time.Minute,
-		Timeout:     10 * time.Second,
-		Method:      "GET",
-		TaskName:    "t1",
-		OnUpdate:    OnUpdateIgnore,
+		Name:          "c1",
+		Type:          "http",
+		Path:          "/health",
+		Protocol:      "https",
+		PortLabel:     "web",
+		AddressMode:   "host",
+		Interval:      1 * time.Minute,
+		Timeout:       10 * time.Second,
+		Method:        "GET",
+		TaskName:      "t1",
+		OnUpdate:      OnUpdateIgnore,
+		TLSSkipVerify: false,
 	}
 
 	different := func(a, b ServiceCheck) bool {
@@ -102,6 +103,12 @@ func TestChecks_NomadCheckID(t *testing.T) {
 	t.Run("different on update", func(t *testing.T) {
 		c := orig
 		c.OnUpdate = "checks"
+		must.True(t, different(orig, c))
+	})
+
+	t.Run("different TLS skip verify", func(t *testing.T) {
+		c := orig
+		c.TLSSkipVerify = true
 		must.True(t, different(orig, c))
 	})
 }

--- a/nomad/structs/checks.go
+++ b/nomad/structs/checks.go
@@ -6,6 +6,7 @@ package structs
 import (
 	"crypto/md5"
 	"fmt"
+	"strconv"
 )
 
 // The CheckMode of a Nomad check is either Healthiness or Readiness.
@@ -90,6 +91,7 @@ func NomadCheckID(allocID, group string, c *ServiceCheck) CheckID {
 	hashString(sum, c.Protocol)
 	hashString(sum, c.Path)
 	hashString(sum, c.Method)
+	hashString(sum, strconv.FormatBool(c.TLSSkipVerify))
 	h := sum.Sum(nil)
 	return CheckID(fmt.Sprintf("%x", h))
 }

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -403,11 +403,6 @@ func (sc *ServiceCheck) validateNomad() error {
 		return errors.New("tls_server_name may only be set for Consul service checks")
 	}
 
-	// tls_skip_verify is consul only
-	if sc.TLSSkipVerify {
-		return errors.New("tls_skip_verify may only be set for Consul service checks")
-	}
-
 	return nil
 }
 

--- a/website/content/docs/job-specification/check.mdx
+++ b/website/content/docs/job-specification/check.mdx
@@ -134,7 +134,7 @@ job "example" {
   this value takes precedence over the `service.port` value. This is useful for
   services which operate on multiple ports. `grpc`, `http`, and `tcp` checks
   require a port while `script` checks do not. Checks will use the host IP and
-  ports by default. Numeric ports may be used if `address_mode="driver"` is set 
+  ports by default. Numeric ports may be used if `address_mode="driver"` is set
   on the check.
 
 - `protocol` `(string: "http")` - Specifies the protocol for the HTTP-based
@@ -179,11 +179,10 @@ job "example" {
       server being checked. Note: setting `tls_server_name` will also override
       the hostname used for SNI.
 
-  This field is only supported in the Consul service provider. 
+  This field is only supported in the Consul service provider.
 
 - `tls_skip_verify` `(bool: false)` - Skip verification of certificates for
-  `https` and `grpc` with `grpc_use_tls` checks . Only supported in the Consul
-  service provider.
+  `https` and `grpc` with `grpc_use_tls` checks.
 
 - `on_update` `(string: "require_healthy")` - Specifies how checks should be
   evaluated when determining deployment health (including a job's initial


### PR DESCRIPTION
### Description
Checks within a service using the Nomad provider can now utilise the `tls_skip_verify` parameter.

### Testing & Reproduction steps
I tested this locally on macOS running a single Nomad agent (with this change) using additional config to enable the raw_exec driver:
```hcl
plugin "raw_exec" {
  config {
    enabled = true
  }
}
```

I then used the following job specification to test the parameter. Note: you'll need to add your own TLS certificate data to the templates which can be generated using the `nomad tls` command.

<details>
<summary>nomad-server.nomad.hcl</summary>

```hcl
variable "nomad-binary-path" {
  type        = string
  description = "The path to the Nomad binary to run."
  default     = "/Users/jrasell/go/bin/nomad"
}

variable "nomad-region" {
  type        = string
  description = "The Nomad region identifier to configure the agent with."
  default     = "global"
}

job "nomad-server" {

  group "agent" {

    network {
      port "http" {}
      port "rpc" {}
      port "serf" {}
    }

    service {
      name     = "http"
      port     = "http"
      provider = "nomad"
      check {
        name            = "alive"
        type            = "http"
        protocol        = "https"
        method          = "GET"
        path            = "/v1/status/leader"
        interval        = "10s"
        timeout         = "1s"
        tls_skip_verify = true
      }
    }

    task "server" {
      driver = "raw_exec"

      meta {
        nomad_agent_region = var.nomad-region
      }

      config {
        command = var.nomad-binary-path
        args = [
          "agent",
          "-config=${NOMAD_TASK_DIR}/config.hcl",
        ]
      }

      template {
        data = <<EOH
data_dir     = "{{ env "NOMAD_TASK_DIR" }}/data"
name         = "server-1"
region       = "{{ env "NOMAD_META_nomad_agent_region" }}"
enable_debug = true

server {
  enabled          = true
  bootstrap_expect = 1
}

ports {
  http = {{ env "NOMAD_PORT_http" }}
  rpc  = {{ env "NOMAD_PORT_rpc" }}
  serf = {{ env "NOMAD_PORT_serf" }}
}

telemetry {
  publish_allocation_metrics = true
  publish_node_metrics       = true
}

tls {
  http = true
  rpc  = true

  ca_file   = "{{ env "NOMAD_TASK_DIR" }}/ca.pem"
  cert_file = "{{ env "NOMAD_TASK_DIR" }}/nomad.pem"
  key_file  = "{{ env "NOMAD_TASK_DIR" }}/nomad-key.pem"
}
EOH

        change_mode = "restart"
        destination = "${NOMAD_TASK_DIR}/config.hcl"
      }

      template {
        data        = <<EOH

EOH
        destination = "${NOMAD_TASK_DIR}/ca.pem"
      }

      template {
        data        = <<EOH

EOH
        destination = "${NOMAD_TASK_DIR}/nomad.pem"
      }

      template {
        data        = <<EOH

EOH
        destination = "${NOMAD_TASK_DIR}/nomad-key.pem"
      }

      resources {
        cpu    = 1000
        memory = 1024
      }
    }
  }
}
```

</details>

### Links
Closes https://github.com/hashicorp/nomad/issues/16213
Jira: https://hashicorp.atlassian.net/browse/NET-10930

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
