### PR TITLE
quotas: refactor storage limit specification

### DIFF
--- a/.changelog/24785.txt
+++ b/.changelog/24785.txt
@@ -3,7 +3,7 @@ api: QuotaSpec.RegionLimit is now of type QuotaResources instead of Resources
 ```
 
 ```release-note:deprecation
-api: QuotaSpec.VariablesLimit field is deprecated in lieu of QuotaSpec.RegionLimit.Storage.Variables and will be removed in Nomad 1.12.0
+api: QuotaSpec.VariablesLimit field is deprecated and will be removed in Nomad 1.12.0. Use QuotaSpec.RegionLimit.Storage.Variables instead.
 ```
 
 ```release-note:deprecation

--- a/.changelog/24785.txt
+++ b/.changelog/24785.txt
@@ -1,0 +1,11 @@
+```release-note:breaking-change
+api: QuotaSpec.RegionLimit is now of type QuotaResources instead of Resources
+```
+
+```release-note:deprecation
+api: QuotaSpec.VariablesLimit field is deprecated in lieu of QuotaSpec.RegionLimit.Storage.Variables and will be removed in Nomad 1.12.0
+```
+
+```release-note:deprecation
+quotas: the variables_limit field in the quota specification is deprecated and replaced by a new storage block under the region_limit block, with a variables field. The variables_limit field will be removed in Nomad 1.12.0
+```

--- a/api/quota.go
+++ b/api/quota.go
@@ -146,7 +146,6 @@ type QuotaResources struct {
 	Cores       *int                   `hcl:"cores,optional"`
 	MemoryMB    *int                   `mapstructure:"memory" hcl:"memory,optional"`
 	MemoryMaxMB *int                   `mapstructure:"memory_max" hcl:"memory_max,optional"`
-	DiskMB      *int                   `mapstructure:"disk" hcl:"disk,optional"`
 	Devices     []*RequestedDevice     `hcl:"device,block"`
 	NUMA        *NUMAResource          `hcl:"numa,block"`
 	SecretsMB   *int                   `mapstructure:"secrets" hcl:"secrets,optional"`

--- a/api/quota.go
+++ b/api/quota.go
@@ -127,15 +127,37 @@ type QuotaLimit struct {
 	// referencing namespace in the region. A value of zero is treated as
 	// unlimited and a negative value is treated as fully disallowed. This is
 	// useful for once we support GPUs
-	RegionLimit *Resources
+	RegionLimit *QuotaResources
 
 	// VariablesLimit is the maximum total size of all variables
 	// Variable.EncryptedData. A value of zero is treated as unlimited and a
 	// negative value is treated as fully disallowed.
+	//
+	// DEPRECATED: use RegionLimit.Storage.VariablesMB instead. This field will
+	// be removed in Nomad 1.12.0.
 	VariablesLimit *int `mapstructure:"variables_limit" hcl:"variables_limit,optional"`
 
 	// Hash is the hash of the object and is used to make replication efficient.
 	Hash []byte
+}
+
+type QuotaResources struct {
+	CPU         *int                   `hcl:"cpu,optional"`
+	Cores       *int                   `hcl:"cores,optional"`
+	MemoryMB    *int                   `mapstructure:"memory" hcl:"memory,optional"`
+	MemoryMaxMB *int                   `mapstructure:"memory_max" hcl:"memory_max,optional"`
+	DiskMB      *int                   `mapstructure:"disk" hcl:"disk,optional"`
+	Devices     []*RequestedDevice     `hcl:"device,block"`
+	NUMA        *NUMAResource          `hcl:"numa,block"`
+	SecretsMB   *int                   `mapstructure:"secrets" hcl:"secrets,optional"`
+	Storage     *QuotaStorageResources `mapstructure:"storage" hcl:"storage,block"`
+}
+
+type QuotaStorageResources struct {
+	// VariablesMB is the maximum total size of all variables
+	// Variable.EncryptedData, in megabytes (2^20 bytes). A value of zero is
+	// treated as unlimited and a negative value is treated as fully disallowed.
+	VariablesMB int `hcl:"variables"`
 }
 
 // QuotaUsage is the resource usage of a Quota

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -116,7 +116,7 @@ func testQuotaSpec() *QuotaSpec {
 		Limits: []*QuotaLimit{
 			{
 				Region: "global",
-				RegionLimit: &Resources{
+				RegionLimit: &QuotaResources{
 					CPU:      pointerOf(2000),
 					MemoryMB: pointerOf(2000),
 					Devices: []*RequestedDevice{{

--- a/command/quota_delete_test.go
+++ b/command/quota_delete_test.go
@@ -101,7 +101,7 @@ func testQuotaSpec() *api.QuotaSpec {
 		Limits: []*api.QuotaLimit{
 			{
 				Region: "global",
-				RegionLimit: &api.Resources{
+				RegionLimit: &api.QuotaResources{
 					CPU: pointer.Of(100),
 				},
 			},

--- a/command/quota_init.go
+++ b/command/quota_init.go
@@ -126,8 +126,10 @@ limit {
     device "nvidia/gpu/1080ti" {
       count = 1
     }
+    storage {
+      variables = 1000
+    }
   }
-  variables_limit = 1000
 }
 `)
 
@@ -148,9 +150,11 @@ var defaultJsonQuotaSpec = strings.TrimSpace(`
             "Name": "nvidia/gpu/1080ti",
             "Count": 1
           }
-        ]
-      },
-      "VariablesLimit": 1000
+        ],
+       "Storage": {
+       "Variables": 1000
+}
+      }
     }
   ]
 }

--- a/command/quota_init_test.go
+++ b/command/quota_init_test.go
@@ -18,7 +18,6 @@ func TestQuotaInitCommand_Implements(t *testing.T) {
 }
 
 func TestQuotaInitCommand_Run_HCL(t *testing.T) {
-	ci.Parallel(t)
 	ui := cli.NewMockUi()
 	cmd := &QuotaInitCommand{Meta: Meta{Ui: ui}}
 
@@ -31,7 +30,7 @@ func TestQuotaInitCommand_Run_HCL(t *testing.T) {
 	// Ensure we change the cwd back
 	origDir, err := os.Getwd()
 	must.NoError(t, err)
-	defer os.Chdir(origDir)
+	t.Cleanup(func() { os.Chdir(origDir) })
 
 	// Create a temp dir and change into it
 	dir := t.TempDir()
@@ -65,7 +64,6 @@ func TestQuotaInitCommand_Run_HCL(t *testing.T) {
 }
 
 func TestQuotaInitCommand_Run_JSON(t *testing.T) {
-	ci.Parallel(t)
 	ui := cli.NewMockUi()
 	cmd := &QuotaInitCommand{Meta: Meta{Ui: ui}}
 
@@ -78,7 +76,7 @@ func TestQuotaInitCommand_Run_JSON(t *testing.T) {
 	// Ensure we change the cwd back
 	origDir, err := os.Getwd()
 	must.NoError(t, err)
-	defer os.Chdir(origDir)
+	t.Cleanup(func() { os.Chdir(origDir) })
 
 	// Create a temp dir and change into it
 	dir := t.TempDir()

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -13,6 +13,23 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 1.10.0
+
+#### Quota specification variable_limits deprecated
+
+In Nomad 1.10.0, the quota specification's `variable_limits` field is
+deprecated. It is replaced by a new `storage` block with a `variables` field,
+under the `region_limit` block. Existing quotas will be automatically migrated
+during server upgrade. The `variables_limit` field will be removed from the
+quota specification in Nomad 1.12.0.
+
+#### Go SDK API change for quota limits
+
+In Nomad 1.10.0, the Go API for quotas has a breaking change. The
+`QuotaSpec.RegionLimit` field is now of type `QuotaResources` instead of
+`Resources`. The `QuotaSpec.VariablesLimit` field is deprecated in lieu of
+`QuotaSpec.RegionLimit.Storage.Variables` and will be removed in Nomad 1.12.0.
+
 ## Nomad 1.9.5
 
 #### CNI plugins


### PR DESCRIPTION
In anticipation of having quotas for dynamic host volumes, we want the user experience of the storage limits to feel integrated with the other resource limits. This is currently prevented by reusing the `Resources` type instead of having a specific type for `QuotaResources`.

Update the quota limit/usage types to use a `QuotaResources` that includes a new storage resources quota block. The wire format for the two types are compatible such that we can migrate the existing variables limit in the FSM.

Also fixes improper parallelism in the quota init test where we change working directory to avoid file write conflicts but this breaks when multiple tests are executed in the same process.

Ref: https://github.com/hashicorp/nomad-enterprise/pull/2096

### Testing & Reproduction steps

Upgrade testing (from the ENT version of this PR):
* Created a 3 node cluster on Nomad 1.9.3+ent with a quota that had a variables limit. Applied the quota to a namespace and created variables in that namespace. Did a stepwise upgrade to this branch and verified that the quota spec and quota usage now shows the new storage block.
* Created a 3 node cluster on Nomad 1.9.3+ent with a quota that had a variables limit. Applied the quota to a namespace and created variables in that namespace. Took a raft snapshot. Stopped all servers and wiped their data dirs. Started the servers back up on this branch and restore the snapshot. Verified that the quota spec and quota usage now shows the new storage block.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
