### PR TITLE
test: set AuthToken in tests to match Client code

### DIFF
--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -4198,13 +4198,15 @@ func TestClientEndpoint_DeriveVaultToken_Bad(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
+	badSecret := uuid.Generate()
 	req := &structs.DeriveVaultTokenRequest{
 		NodeID:   node.ID,
-		SecretID: uuid.Generate(),
+		SecretID: badSecret,
 		AllocID:  alloc.ID,
 		Tasks:    tasks,
 		QueryOptions: structs.QueryOptions{
-			Region: "global",
+			Region:    "global",
+			AuthToken: badSecret,
 		},
 	}
 
@@ -4311,7 +4313,8 @@ func TestClientEndpoint_DeriveVaultToken(t *testing.T) {
 		AllocID:  alloc.ID,
 		Tasks:    tasks,
 		QueryOptions: structs.QueryOptions{
-			Region: "global",
+			Region:    "global",
+			AuthToken: node.SecretID,
 		},
 	}
 
@@ -4395,7 +4398,8 @@ func TestClientEndpoint_DeriveVaultToken_VaultError(t *testing.T) {
 		AllocID:  alloc.ID,
 		Tasks:    tasks,
 		QueryOptions: structs.QueryOptions{
-			Region: "global",
+			Region:    "global",
+			AuthToken: node.SecretID,
 		},
 	}
 
@@ -4518,11 +4522,14 @@ func TestClientEndpoint_DeriveSIToken(t *testing.T) {
 	r.NoError(err)
 
 	request := &structs.DeriveSITokenRequest{
-		NodeID:       node.ID,
-		SecretID:     node.SecretID,
-		AllocID:      alloc.ID,
-		Tasks:        []string{sidecarTask.Name},
-		QueryOptions: structs.QueryOptions{Region: "global"},
+		NodeID:   node.ID,
+		SecretID: node.SecretID,
+		AllocID:  alloc.ID,
+		Tasks:    []string{sidecarTask.Name},
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			AuthToken: node.SecretID,
+		},
 	}
 
 	var response structs.DeriveSITokenResponse
@@ -4576,11 +4583,14 @@ func TestClientEndpoint_DeriveSIToken_ConsulError(t *testing.T) {
 	r.NoError(err)
 
 	request := &structs.DeriveSITokenRequest{
-		NodeID:       node.ID,
-		SecretID:     node.SecretID,
-		AllocID:      alloc.ID,
-		Tasks:        []string{sidecarTask.Name},
-		QueryOptions: structs.QueryOptions{Region: "global"},
+		NodeID:   node.ID,
+		SecretID: node.SecretID,
+		AllocID:  alloc.ID,
+		Tasks:    []string{sidecarTask.Name},
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			AuthToken: node.SecretID,
+		},
 	}
 
 	var response structs.DeriveSITokenResponse


### PR DESCRIPTION
tl;dr - runtime code is fine but tests should match reality

The Nomad Client Agent is the only consumer of the `Node.Derive{SI,Vault}Token` RPCs, therefore tests of the RPCs should match Nomad Client behavior.

- DeriveVaultToken code: https://github.com/hashicorp/nomad/blob/a9ee66a6ef358097783d1bf745051124cc0f14f2/client/client.go#L2904-L2917
- DeriveSIToken code: https://github.com/hashicorp/nomad/blob/a9ee66a6ef358097783d1bf745051124cc0f14f2/client/client.go#L2988-L2997

Both of those client code paths include the Node SecretID in both the request's SecretID field as well as the embedded
`QueryOptions.AuthToken` field.

This patch updates server tests to match that behavior. The tests pass either way.

### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
