### PR TITLE
dynamic host volumes: require node ID on register

### DIFF
--- a/command/volume_register_host.go
+++ b/command/volume_register_host.go
@@ -16,6 +16,10 @@ func (c *VolumeRegisterCommand) hostVolumeRegister(client *api.Client, ast *ast.
 		c.Ui.Error(fmt.Sprintf("Error decoding the volume definition: %s", err))
 		return 1
 	}
+	if vol.NodeID == "" {
+		c.Ui.Error("Node ID is required for registering")
+		return 1
+	}
 
 	req := &api.HostVolumeRegisterRequest{
 		Volume:         vol,

--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -4,6 +4,7 @@
 package nomad
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -314,6 +315,10 @@ func (v *HostVolume) Register(args *structs.HostVolumeRegisterRequest, reply *st
 	snap, err := v.srv.State().Snapshot()
 	if err != nil {
 		return err
+	}
+
+	if vol.NodeID == "" {
+		return errors.New("cannot register volume: node ID is required")
 	}
 
 	now := time.Now()

--- a/nomad/host_volume_endpoint_test.go
+++ b/nomad/host_volume_endpoint_test.go
@@ -127,6 +127,10 @@ func TestHostVolumeEndpoint_CreateRegisterGetDelete(t *testing.T) {
 		must.EqError(t, err, fmt.Sprintf(
 			`validating volume "example" against state failed: node %q does not exist`,
 			invalidNode.ID))
+
+		req.Volume.NodeID = ""
+		err = msgpackrpc.CallWithCodec(codec, "HostVolume.Register", req, &resp)
+		must.EqError(t, err, "cannot register volume: node ID is required")
 	})
 
 	var expectIndex uint64
@@ -211,7 +215,7 @@ func TestHostVolumeEndpoint_CreateRegisterGetDelete(t *testing.T) {
 	t.Run("invalid updates", func(t *testing.T) {
 
 		invalidVol1 := vol1.Copy()
-		invalidVol2 := &structs.HostVolume{}
+		invalidVol2 := &structs.HostVolume{NodeID: uuid.Generate()}
 
 		createReq := &structs.HostVolumeCreateRequest{
 			Volume: invalidVol2,


### PR DESCRIPTION
When registering a host volume created out-of-band, the volume will have been created on a specific node. Require the node ID field to be set.

Ref: https://github.com/hashicorp/nomad/pull/24789#discussion_r1904690799