### PR TITLE
plugins: validate logmon process during reattach

### DIFF
--- a/.changelog/24798.txt
+++ b/.changelog/24798.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+drivers: validate logmon plugin during reattach
+```

--- a/client/logmon/plugin.go
+++ b/client/logmon/plugin.go
@@ -59,6 +59,16 @@ func LaunchLogMon(logger hclog.Logger, reattachConfig *plugin.ReattachConfig) (L
 		return nil, nil, err
 	}
 
+	// Note: Similar to reattaching to executors, Go-plugin uses localhost
+	// ports on Windows. On reattach, it may attach to another process
+	// listening on that port. We should validate it is actually a plugin.
+	if conf.Reattach != nil {
+		if err := rpcClient.Ping(); err != nil {
+			logger.Warn("failed to ping plugin process during reattach", "error", err)
+			return nil, nil, err
+		}
+	}
+
 	l := raw.(LogMon)
 	return l, client, nil
 }


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
This PR is similar to [PR # 24538](https://github.com/hashicorp/nomad/pull/24538) which fixes an edge case on Windows where Nomad would kill random processes on reboot while attempting to reattach to executors.  The problem was reported as half fixed, with Nomad still killing some processes on occasion.  The previous PR did not fix reattaching to the logmon process, which is very similar to reattaching to executors.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

Reproduction involves simulating this scenario via overriding the reattach PID when starting a task to a known PID (another bash session), rebooting Nomad, killing the logmon process, and listening on the reattach address.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes [GH #23969](https://github.com/hashicorp/nomad/issues/23969)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
