### PR TITLE
Update the dnsconfig script to handle multiple interfaces

### DIFF
--- a/e2e/terraform/packer/ubuntu-jammy-amd64/dnsconfig.sh
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/dnsconfig.sh
@@ -30,7 +30,7 @@ cp /tmp/resolv.conf /etc/resolv.conf
 
 # need to get the interface for dnsmasq config so that we can
 # accomodate both "predictable" and old-style interface names
-IFACE=$(ip route | grep default | awk '{print $5}')
+IFACE=$(ip route | grep default | awk '{print "interface="$5}')
 
 cat <<EOF > /tmp/dnsmasq
 port=53
@@ -38,7 +38,7 @@ resolv-file=/var/run/dnsmasq/resolv.conf
 bind-interfaces
 interface=docker0
 interface=lo
-interface=$IFACE
+$IFACE
 listen-address=127.0.0.1
 server=/consul/127.0.0.1#8600
 EOF


### PR DESCRIPTION
### Description
When creating the packer images for the e2e tests, the dns is configured on boot to add the default network interfaces available to the instance, but the script didn't account for more than one:

```
IFACE=$(ip route | grep default | awk '{print $5}')
cat <<EOF > /tmp/dnsmasq
port=53
resolv-file=/var/run/dnsmasq/resolv.conf
bind-interfaces
interface=docker0
interface=lo
interface=$IFACE
listen-address=127.0.0.1
server=/consul/127.0.0.1#8600
EOF
```

resulting in configurations like this:
```
port=53
resolv-file=/var/run/dnsmasq/resolv.conf
bind-interfaces
interface=docker0
interface=lo
interface=eth0
interface=ens5
ens6
listen-address=127.0.0.1
server=/consul/127.0.0.1#8600
```

Which caused dnsmasq to fail, draging consul and nomad along with it.

This PR accounts for multiple default interfaces.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
