### PR TITLE
client: move 'waiting for previous alloc to terminate' log messages to info

### DIFF
--- a/client/allocwatcher/alloc_watcher.go
+++ b/client/allocwatcher/alloc_watcher.go
@@ -249,7 +249,7 @@ func (p *localPrevAlloc) Wait(ctx context.Context) error {
 	}
 
 	// Block until previous alloc exits
-	p.logger.Debug("waiting for previous alloc to terminate")
+	p.logger.Info("waiting for previous alloc to terminate")
 	for {
 		select {
 		case prevAlloc, ok := <-p.prevListener.Ch():
@@ -350,7 +350,7 @@ func (p *remotePrevAlloc) Wait(ctx context.Context) error {
 		p.waitingLock.Unlock()
 	}()
 
-	p.logger.Debug("waiting for remote previous alloc to terminate")
+	p.logger.Info("waiting for remote previous alloc to terminate")
 	req := structs.AllocSpecificRequest{
 		AllocID: p.prevAllocID,
 		QueryOptions: structs.QueryOptions{


### PR DESCRIPTION
I'm not a 100% sure if this is the right move, but seeing as some users are hit by bugs that cause allocations to be stuck in `pending` state, they are forced to run agents with `debug` log levels which is very noisy. 

On the other hand, having these messages at `info` will significantly increase the noise of that level. I welcome comments and opinions on whether that's the right way to handle this issue. 