### PR TITLE
ui: Fill service check background object for pending checks.

### DIFF
--- a/.changelog/24818.txt
+++ b/.changelog/24818.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Ensure pending service check blocks are filled
+```

--- a/ui/app/styles/components/services.scss
+++ b/ui/app/styles/components/services.scss
@@ -119,6 +119,9 @@ table.health-checks {
           &.status-success {
             background-color: $nomad-green;
           }
+          &.status-pending {
+            background-color: $gray-300;
+          }
           &.status-failure {
             background-color: $red;
           }


### PR DESCRIPTION
Fills the service check marker with a grey when in pending state, whereas it was previously empty. I personally found the empty space a little confusing at first glance, whereas having this addition makes it obvious what is happening with the check and that you can hover and see the status.

I chose the colour based on a quick look, trying to find a grey that wasn't too dark, but I don't really know what I am doing, so please let me know what changes to make.

I think it makes sense to backport. Let me know if you think I should add a changelog entry.

Before:
![image](https://github.com/user-attachments/assets/c6bb4e08-2be1-4848-863e-b42cd07cd893)

After:
![image](https://github.com/user-attachments/assets/5423e6f8-fc24-4d6d-b34d-eb81c7793893)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
