### PR TITLE
agent: Fixed a bug where syslog error messages marked as notice.

### DIFF
--- a/.changelog/24820.txt
+++ b/.changelog/24820.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fixed a bug where Nomad error log messages within syslog showed via the notice priority
+```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -574,20 +574,13 @@ func SetupLoggers(ui cli.Ui, config *Config) (*logutils.LevelFilter, *gatedwrite
 	// Create a log writer, and wrap a logOutput around it
 	writers := []io.Writer{logFilter}
 	logLevel := strings.ToUpper(config.LogLevel)
-	logLevelMap := map[string]gsyslog.Priority{
-		"ERROR": gsyslog.LOG_ERR,
-		"WARN":  gsyslog.LOG_WARNING,
-		"INFO":  gsyslog.LOG_INFO,
-		"DEBUG": gsyslog.LOG_DEBUG,
-		"TRACE": gsyslog.LOG_DEBUG,
-	}
 	if logLevel == "OFF" {
 		config.EnableSyslog = false
 	}
 	// Check if syslog is enabled
 	if config.EnableSyslog {
 		ui.Output(fmt.Sprintf("Config enable_syslog is `true` with log_level=%v", config.LogLevel))
-		l, err := gsyslog.NewLogger(logLevelMap[logLevel], config.SyslogFacility, "nomad")
+		l, err := gsyslog.NewLogger(getSysLogPriority(logLevel), config.SyslogFacility, "nomad")
 		if err != nil {
 			ui.Error(fmt.Sprintf("Syslog setup failed: %v", err))
 			return nil, nil, nil

--- a/command/agent/syslog_test.go
+++ b/command/agent/syslog_test.go
@@ -4,46 +4,86 @@
 package agent
 
 import (
-	"os"
 	"runtime"
 	"testing"
 
 	gsyslog "github.com/hashicorp/go-syslog"
-	"github.com/hashicorp/logutils"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
 )
+
+func Test_getSysLogPriority(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Syslog not supported on Windows")
+	}
+
+	testCases := []struct {
+		name                   string
+		inputLogLevel          string
+		expectedSyslogPriority gsyslog.Priority
+	}{
+		{
+			name:                   "trace",
+			inputLogLevel:          "TRACE",
+			expectedSyslogPriority: gsyslog.LOG_DEBUG,
+		},
+		{
+			name:                   "debug",
+			inputLogLevel:          "DEBUG",
+			expectedSyslogPriority: gsyslog.LOG_INFO,
+		},
+		{
+			name:                   "info",
+			inputLogLevel:          "INFO",
+			expectedSyslogPriority: gsyslog.LOG_NOTICE,
+		},
+		{
+			name:                   "warn",
+			inputLogLevel:          "WARN",
+			expectedSyslogPriority: gsyslog.LOG_WARNING,
+		},
+		{
+			name:                   "error",
+			inputLogLevel:          "ERROR",
+			expectedSyslogPriority: gsyslog.LOG_ERR,
+		},
+		{
+			name:                   "unknown",
+			inputLogLevel:          "UNKNOWN",
+			expectedSyslogPriority: gsyslog.LOG_NOTICE,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualPriority := getSysLogPriority(tc.inputLogLevel)
+			must.Eq(t, tc.expectedSyslogPriority, actualPriority)
+		})
+	}
+}
 
 func TestSyslogFilter(t *testing.T) {
 	ci.Parallel(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("Syslog not supported on Windows")
 	}
-	if os.Getenv("TRAVIS") == "true" {
-		t.Skip("Syslog not supported on travis-ci")
-	}
 
-	l, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, "LOCAL0", "consul")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	l, err := gsyslog.NewLogger(gsyslog.LOG_NOTICE, "LOCAL0", "nomad")
+	must.NoError(t, err)
 
 	filt := LevelFilter()
-	filt.MinLevel = logutils.LogLevel("INFO")
+	filt.MinLevel = "INFO"
 
 	s := &SyslogWrapper{l, filt}
 	n, err := s.Write([]byte("[INFO] test"))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	if n == 0 {
-		t.Fatalf("should have logged")
-	}
+	must.NonZero(t, n)
 
 	n, err = s.Write([]byte("[DEBUG] test"))
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	if n != 0 {
-		t.Fatalf("should not have logged")
-	}
+	must.NoError(t, err)
+	must.Zero(t, n)
 }


### PR DESCRIPTION
The mapping between Nomad log level identifiers and syslog priorities did not handle the error level string correctly.

The change includes a new function which can be used for lookups in all places the conversion is needed. This function makes the translation easier to test.

### Testing & Reproduction steps
Running on a Linux workstation (Ubuntu 24.04) I added the following lines to the `/etc/rsyslog.conf` before restarting rsyslog via `sudo service rsyslog restart`.
```conf
$template verbose, "%syslogseverity-text%, %syslogfacility%, %timegenerated%, %HOSTNAME%, %syslogtag%, %msg%\n"
*.* /var/log/all-messages.log;verbose
```

I then ran Nomad via `sudo -i nomad agent -config=/home/jrasell/config.hcl` using the following configuration to ensure errors are generated in the log:
```hcl
enable_syslog = true
data_dir      = "/var/lib/nomad"

server {
  enabled          = true
  bootstrap_expect = 3
}
```

Error log lines are successfully and correctly entered via the `err` priority:
```console
err, 16, Jan  9 10:29:42, workstation-0, nomad[26105]:,  worker: failed to dequeue evaluation: worker_id=c933e716-c5dc-c73a-571f-0bccb052a727 error="No cluster leader"
err, 16, Jan  9 10:29:42, workstation-0, nomad[26105]:,  worker: failed to dequeue evaluation: worker_id=5d982fbd-1d5f-c0eb-b091-f14d8afdd178 error="No cluster leader"
err, 16, Jan  9 10:29:42, workstation-0, nomad[26105]:,  worker: failed to dequeue evaluation: worker_id=a5c2f0dd-88d6-347f-4527-ef2b1d653987 error="No cluster leader"
err, 16, Jan  9 10:29:42, workstation-0, nomad[26105]:,  worker: failed to dequeue evaluation: worker_id=60463b64-adc9-d344-ad95-21b4dbd4214b error="No cluster leader"
```

### Links
Jira: https://hashicorp.atlassian.net/browse/NET-11972

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
