### PR TITLE
dynamic host volumes: document option for node pool governance

### DIFF
--- a/website/content/docs/other-specifications/namespace.mdx
+++ b/website/content/docs/other-specifications/namespace.mdx
@@ -108,20 +108,22 @@ consul {
 
 ### `node_pool_config` Parameters <EnterpriseAlert inline />
 
-- `default` `(string: "default")` - Specifies the node pool to use for jobs in
-  this namespace that don't define a node pool in their specification.
+- `default` `(string: "default")` - Specifies the node pool to use for jobs or
+  dynamic host volumes in this namespace that don't define a node pool in their
+  specification.
 
 - `allowed` `(array<string>: nil)` - Specifies the node pools that are allowed
-  to be used by jobs in this namespace. By default, all node pools are allowed.
-  If an empty list is provided only the namespace's default node pool is
-  allowed. This field supports wildcard globbing through the use of `*` for
-  multi-character matching. This field cannot be used with `denied`.
+  to be used by jobs or dynamic host volumes in this namespace. By default, all
+  node pools are allowed. If an empty list is provided only the namespace's
+  default node pool is allowed. This field supports wildcard globbing through
+  the use of `*` for multi-character matching. This field cannot be used with
+  `denied`.
 
 - `denied` `(array<string>: nil)` - Specifies the node pools that are not
-  allowed to be used by jobs in this namespace. This field supports wildcard
-  globbing through the use of `*` for multi-character matching. If specified,
-  any node pool is allowed to be used, except for those that match any of these
-  patterns. This field cannot be used with `allowed`.
+  allowed to be used by jobs or dynamic host volumes in this namespace. This
+  field supports wildcard globbing through the use of `*` for multi-character
+  matching. If specified, any node pool is allowed to be used, except for those
+  that match any of these patterns. This field cannot be used with `allowed`.
 
 ### `vault` Parameters <EnterpriseAlert inline />
 

--- a/website/content/docs/other-specifications/namespace.mdx
+++ b/website/content/docs/other-specifications/namespace.mdx
@@ -112,18 +112,19 @@ consul {
   dynamic host volumes in this namespace that don't define a node pool in their
   specification.
 
-- `allowed` `(array<string>: nil)` - Specifies the node pools that are allowed
-  to be used by jobs or dynamic host volumes in this namespace. By default, all
+- `allowed` `(array<string>: nil)` - Specifies the node pools that jobs or
+  dynamic host volumes in this namespace are allowed to use. By default, all
   node pools are allowed. If an empty list is provided only the namespace's
   default node pool is allowed. This field supports wildcard globbing through
   the use of `*` for multi-character matching. This field cannot be used with
   `denied`.
 
-- `denied` `(array<string>: nil)` - Specifies the node pools that are not
-  allowed to be used by jobs or dynamic host volumes in this namespace. This
-  field supports wildcard globbing through the use of `*` for multi-character
-  matching. If specified, any node pool is allowed to be used, except for those
-  that match any of these patterns. This field cannot be used with `allowed`.
+- `denied` `(array<string>: nil)` - Specifies the node pools that jobs or
+  dynamic host volumes in this namespace are not allowed to use. This field
+  supports wildcard globbing through the use of `*` for multi-character
+  matching. If specified, jobs and dynamic host volumes are allowed to use any
+  node pool, except for those that match any of these patterns. This field
+  cannot be used with `allowed`.
 
 ### `vault` Parameters <EnterpriseAlert inline />
 


### PR DESCRIPTION
For Nomad Enterprise, the namespace specification's node pool configuration can control access to node pools for dynamic host volumes as well.

Ref: https://github.com/hashicorp/nomad/pull/24797
Ref: https://hashicorp.atlassian.net/browse/NET-11482