### PR TITLE
dynamic host volumes: client configuration docs

### DIFF
--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -201,6 +201,13 @@ client {
 - `host_volume` <code>([host_volume](#host_volume-block): nil)</code> - Exposes
   paths from the host as volumes that can be mounted into jobs.
 
+- `host_volume_plugin_dir` `(string: "")` - Specifies the directory to find host
+  volume plugins. When this parameter is empty, Nomad will generate the path
+  using the [top-level `data_dir`][top_level_data_dir] suffixed with
+  `host_volume_plugins`, like `"/opt/nomad/host_volume_plugins"`. This must be
+  an absolute path. Nomad will create the directory on the host, if it does not
+  exist when the agent process starts.
+
 - `host_network` <code>([host_network](#host_network-block): nil)</code> - Registers
   additional host networks with the node that can be selected when port mapping.
 
@@ -613,11 +620,14 @@ see the [drivers documentation](/nomad/docs/drivers).
 
 ### `host_volume` Block
 
-The `host_volume` block is used to make volumes available to jobs.
+The `host_volume` block is used to make volumes available to jobs. You can also
+configure [dynamic host volumes][] via the [`volume create`][] or [`volume
+register`][] commands.
 
 The key of the block corresponds to the name of the volume for use in the
-`source` parameter of a `"host"` type [`volume`](/nomad/docs/job-specification/volume)
-and ACLs.
+`source` parameter of a `"host"` type
+[`volume`](/nomad/docs/job-specification/volume) and ACLs. Host volumes in the
+configuration cannot have the same names as dynamic host volumes.
 
 ```hcl
 client {
@@ -807,3 +817,6 @@ client {
 [`TimeoutStopSec`]: https://www.freedesktop.org/software/systemd/man/systemd.service.html#TimeoutStopSec=
 [top_level_data_dir]: /nomad/docs/configuration#data_dir
 [unveil]: /nomad/docs/concepts/plugins/task-drivers#fsisolation-unveil
+[dynamic host volumes]: /nomad/docs/other-specifications/volume/host
+[`volume create`]: /nomad/docs/commands/volume/create
+[`volume register`]: /nomad/docs/commands/volume/register

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -205,8 +205,7 @@ client {
   volume plugins. When this parameter is empty, Nomad generates the path
   using the [top-level `data_dir`][top_level_data_dir] suffixed with
   `host_volume_plugins`, like `"/opt/nomad/host_volume_plugins"`. This must be
-  an absolute path. Nomad creates the directory on the host, if it does not
-  exist when the agent process starts.
+  an absolute path.
 
 - `host_network` <code>([host_network](#host_network-block): nil)</code> - Registers
   additional host networks with the node that can be selected when port mapping.
@@ -626,8 +625,8 @@ register`][] commands.
 
 The key of the block corresponds to the name of the volume for use in the
 `source` parameter of a `"host"` type
-[`volume`](/nomad/docs/job-specification/volume) and ACLs. Host volumes in the
-configuration cannot have the same names as dynamic host volumes.
+[`volume`](/nomad/docs/job-specification/volume) and ACLs. A host volume in the
+configuration cannot have the same name as a dynamic host volume on the same node.
 
 ```hcl
 client {

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -202,10 +202,10 @@ client {
   paths from the host as volumes that can be mounted into jobs.
 
 - `host_volume_plugin_dir` `(string: "")` - Specifies the directory to find host
-  volume plugins. When this parameter is empty, Nomad will generate the path
+  volume plugins. When this parameter is empty, Nomad generates the path
   using the [top-level `data_dir`][top_level_data_dir] suffixed with
   `host_volume_plugins`, like `"/opt/nomad/host_volume_plugins"`. This must be
-  an absolute path. Nomad will create the directory on the host, if it does not
+  an absolute path. Nomad creates the directory on the host, if it does not
   exist when the agent process starts.
 
 - `host_network` <code>([host_network](#host_network-block): nil)</code> - Registers


### PR DESCRIPTION
Document the client configuration changes needed to support dynamic host volumes. This changeset excludes the plugin specification/concepts, which will be under a separate PR.

Ref: https://github.com/hashicorp/nomad/pull/24797
Ref: https://hashicorp.atlassian.net/browse/NET-11482