### PR TITLE
dynamic host volumes: cleanup comments

### DIFF
--- a/nomad/structs/volumes.go
+++ b/nomad/structs/volumes.go
@@ -174,7 +174,6 @@ func (v *VolumeRequest) Validate(jobType string, taskGroupCount, canaries int) e
 
 	case VolumeTypeHost:
 		if v.MountOptions != nil {
-			// TODO(1.10.0): support mount options for dynamic host volumes
 			addErr("host volumes cannot have mount options")
 		}
 

--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -206,10 +206,11 @@ func (h *HostVolumeChecker) hasVolumes(n *structs.Node) bool {
 		if volCfg.ID != "" { // dynamic host volume
 			vol, err := h.ctx.State().HostVolumeByID(nil, h.namespace, volCfg.ID, false)
 			if err != nil || vol == nil {
-				// node fingerprint has a dynamic volume that's no longer in the
-				// state store; this is only possible if the batched fingerprint
-				// update from a delete RPC is written before the delete RPC's
-				// raft entry completes
+				// the dynamic host volume in the node fingerprint does not
+				// belong to the namespace we need. or the volume is no longer
+				// in the state store because the batched fingerprint update
+				// from a delete RPC is written before the delete RPC's raft
+				// entry completes
 				return false
 			}
 			if !h.hostVolumeIsAvailable(vol,


### PR DESCRIPTION
Some comment cleanups as we're wrapping up dynamic host volumes work:

* We're not going to implement mount_options for host volumes, as the dynamic host volumes don't have the equivalent of the stage/publish phase that CSI volumes do. Users who want that sort of thing will pass them as `parameter` field during volume create/register.

* The scheduler feasibility check prevents a dynamic host volume being claimed by a job in the wrong namespace, but the comment incorrectly identifies that code path as only being about the race between fingerprint and delete. Update the comment to make the intent clear so that we don't accidentally remove this behavior in the future.
