### PR TITLE
API: host volume access modes should match list in structs package

### DIFF
--- a/api/host_volumes.go
+++ b/api/host_volumes.go
@@ -110,12 +110,10 @@ type HostVolumeAccessMode string
 const (
 	HostVolumeAccessModeUnknown HostVolumeAccessMode = ""
 
-	HostVolumeAccessModeSingleNodeReader HostVolumeAccessMode = "single-node-reader-only"
-	HostVolumeAccessModeSingleNodeWriter HostVolumeAccessMode = "single-node-writer"
-
-	HostVolumeAccessModeMultiNodeReader       HostVolumeAccessMode = "multi-node-reader-only"
-	HostVolumeAccessModeMultiNodeSingleWriter HostVolumeAccessMode = "multi-node-single-writer"
-	HostVolumeAccessModeMultiNodeMultiWriter  HostVolumeAccessMode = "multi-node-multi-writer"
+	HostVolumeAccessModeSingleNodeReader       HostVolumeAccessMode = "single-node-reader-only"
+	HostVolumeAccessModeSingleNodeWriter       HostVolumeAccessMode = "single-node-writer"
+	HostVolumeAccessModeSingleNodeSingleWriter HostVolumeAccessMode = "single-node-single-writer"
+	HostVolumeAccessModeSingleNodeMultiWriter  HostVolumeAccessMode = "single-node-multi-writer"
 )
 
 // HostVolumeStub is used for responses for the List Volumes endpoint


### PR DESCRIPTION
We changed the list of access modes available for dynamic host volumes in #24705 but neglected to change them in the API package. Update the API package to match.

Ref: https://github.com/hashicorp/nomad/pull/24705