### PR TITLE
dynamic host volumes: plugin spec tweaks

### DIFF
--- a/client/fingerprint/dynamic_host_volumes.go
+++ b/client/fingerprint/dynamic_host_volumes.go
@@ -87,9 +87,9 @@ func GetHostVolumePluginVersions(log hclog.Logger, pluginDir string) (map[string
 	mut := sync.Mutex{}
 	var wg sync.WaitGroup
 
-	for file, fullPath := range files {
+	for file := range files {
 		wg.Add(1)
-		go func(file, fullPath string) {
+		go func(file string) {
 			defer wg.Done()
 			// really should take way less than a second
 			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -97,7 +97,7 @@ func GetHostVolumePluginVersions(log hclog.Logger, pluginDir string) (map[string
 
 			log := log.With("plugin_id", file)
 
-			p, err := hvm.NewHostVolumePluginExternal(log, file, fullPath, "")
+			p, err := hvm.NewHostVolumePluginExternal(log, pluginDir, file, "")
 			if err != nil {
 				log.Warn("error getting plugin", "error", err)
 				return
@@ -112,7 +112,7 @@ func GetHostVolumePluginVersions(log hclog.Logger, pluginDir string) (map[string
 			mut.Lock()
 			plugins[file] = fprint.Version.String()
 			mut.Unlock()
-		}(file, fullPath)
+		}(file)
 	}
 
 	wg.Wait()

--- a/client/hostvolumemanager/host_volume_plugin.go
+++ b/client/hostvolumemanager/host_volume_plugin.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
@@ -177,7 +178,11 @@ type HostVolumePluginExternal struct {
 // {"version": "0.0.1"}
 // The version value should be a valid version number as allowed by
 // version.NewVersion()
+//
+// Must complete within 5 seconds
 func (p *HostVolumePluginExternal) Fingerprint(ctx context.Context) (*PluginFingerprint, error) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
 	cmd := exec.CommandContext(ctx, p.Executable, "fingerprint")
 	cmd.Env = []string{EnvOperation + "=fingerprint"}
 	stdout, stderr, err := runCommand(cmd)
@@ -213,6 +218,8 @@ func (p *HostVolumePluginExternal) Fingerprint(ctx context.Context) (*PluginFing
 // "path" must be provided to confirm that the requested path is what was
 // created by the plugin. "bytes" is the actual size of the volume created
 // by the plugin; if excluded, it will default to 0.
+//
+// Must complete within 60 seconds (timeout on RPC)
 func (p *HostVolumePluginExternal) Create(ctx context.Context,
 	req *cstructs.ClientHostVolumeCreateRequest) (*HostVolumePluginCreateResponse, error) {
 
@@ -257,6 +264,8 @@ func (p *HostVolumePluginExternal) Create(ctx context.Context,
 // DHV_PARAMETERS={json of parameters from the volume spec}
 //
 // Response on stdout is discarded.
+//
+// Must complete within 60 seconds (timeout on RPC)
 func (p *HostVolumePluginExternal) Delete(ctx context.Context,
 	req *cstructs.ClientHostVolumeDeleteRequest) error {
 

--- a/client/hostvolumemanager/host_volume_plugin_test.go
+++ b/client/hostvolumemanager/host_volume_plugin_test.go
@@ -79,22 +79,23 @@ func TestNewHostVolumePluginExternal(t *testing.T) {
 	log := testlog.HCLogger(t)
 	var err error
 
-	_, err = NewHostVolumePluginExternal(log, "test-id", "non-existent", "target")
+	_, err = NewHostVolumePluginExternal(log, ".", "non-existent", "target")
 	must.ErrorIs(t, err, ErrPluginNotExists)
 
-	_, err = NewHostVolumePluginExternal(log, "test-id", "host_volume_plugin_test.go", "target")
+	_, err = NewHostVolumePluginExternal(log, ".", "host_volume_plugin_test.go", "target")
 	must.ErrorIs(t, err, ErrPluginNotExecutable)
 
 	t.Run("unix", func(t *testing.T) {
 		if runtime.GOOS == "windows" {
 			t.Skip("skipped because windows") // db TODO(1.10.0)
 		}
-		p, err := NewHostVolumePluginExternal(log, "test-id", "./test_fixtures/test_plugin.sh", "test-target")
+		p, err := NewHostVolumePluginExternal(log, "./test_fixtures", "test_plugin.sh", "test-target")
 		must.NoError(t, err)
 		must.Eq(t, &HostVolumePluginExternal{
-			ID:         "test-id",
-			Executable: "./test_fixtures/test_plugin.sh",
+			ID:         "test_plugin.sh",
+			Executable: "test_fixtures/test_plugin.sh",
 			TargetPath: "test-target",
+			PluginDir:  "./test_fixtures",
 			log:        log,
 		}, p)
 	})
@@ -115,12 +116,8 @@ func TestHostVolumePluginExternal(t *testing.T) {
 	t.Run("happy", func(t *testing.T) {
 
 		log, getLogs := logRecorder(t)
-		plug := &HostVolumePluginExternal{
-			ID:         "test-external-plugin",
-			Executable: "./test_fixtures/test_plugin.sh",
-			TargetPath: tmp,
-			log:        log,
-		}
+		plug, err := NewHostVolumePluginExternal(log, "./test_fixtures", "test_plugin.sh", tmp)
+		must.NoError(t, err)
 
 		// fingerprint
 		v, err := plug.Fingerprint(timeout(t))
@@ -167,15 +164,11 @@ func TestHostVolumePluginExternal(t *testing.T) {
 	t.Run("sad", func(t *testing.T) {
 
 		log, getLogs := logRecorder(t)
-		plug := &HostVolumePluginExternal{
-			ID:         "test-external-plugin-sad",
-			Executable: "./test_fixtures/test_plugin_sad.sh",
-			TargetPath: tmp,
-			log:        log,
-		}
+		plug, err := NewHostVolumePluginExternal(log, "./test_fixtures", "test_plugin_sad.sh", tmp)
+		must.NoError(t, err)
 
 		v, err := plug.Fingerprint(timeout(t))
-		must.EqError(t, err, `error getting version from plugin "test-external-plugin-sad": exit status 1`)
+		must.EqError(t, err, `error getting version from plugin "test_plugin_sad.sh": exit status 1`)
 		must.Nil(t, v)
 		logged := getLogs()
 		must.StrContains(t, logged, "fingerprint: sad plugin is sad")
@@ -193,7 +186,7 @@ func TestHostVolumePluginExternal(t *testing.T) {
 				RequestedCapacityMaxBytes: 10,
 				Parameters:                map[string]string{"key": "val"},
 			})
-		must.EqError(t, err, `error creating volume "test-vol-id" with plugin "test-external-plugin-sad": exit status 1`)
+		must.EqError(t, err, `error creating volume "test-vol-id" with plugin "test_plugin_sad.sh": exit status 1`)
 		must.Nil(t, resp)
 		logged = getLogs()
 		must.StrContains(t, logged, "create: sad plugin is sad")
@@ -208,7 +201,7 @@ func TestHostVolumePluginExternal(t *testing.T) {
 				NodeID:     "test-node",
 				Parameters: map[string]string{"key": "val"},
 			})
-		must.EqError(t, err, `error deleting volume "test-vol-id" with plugin "test-external-plugin-sad": exit status 1`)
+		must.EqError(t, err, `error deleting volume "test-vol-id" with plugin "test_plugin_sad.sh": exit status 1`)
 		logged = getLogs()
 		must.StrContains(t, logged, "delete: sad plugin is sad")
 		must.StrContains(t, logged, "delete: it tells you all about it in stderr")

--- a/client/hostvolumemanager/host_volumes.go
+++ b/client/hostvolumemanager/host_volumes.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/hashicorp/go-hclog"
@@ -217,8 +216,7 @@ func (hvm *HostVolumeManager) getPlugin(id string) (HostVolumePlugin, error) {
 		return plug, nil
 	}
 	log := hvm.log.With("plugin_id", id)
-	path := filepath.Join(hvm.pluginDir, id)
-	return NewHostVolumePluginExternal(log, id, path, hvm.sharedMountDir)
+	return NewHostVolumePluginExternal(log, hvm.pluginDir, id, hvm.sharedMountDir)
 }
 
 // restoreFromState loads all volumes from client state and runs Create for

--- a/client/hostvolumemanager/host_volumes_test.go
+++ b/client/hostvolumemanager/host_volumes_test.go
@@ -426,6 +426,7 @@ func logRecorder(t *testing.T) (hclog.Logger, func() string) {
 	return logger, func() string {
 		bts, err := io.ReadAll(buf)
 		test.NoError(t, err)
+		buf.Reset()
 		return string(bts)
 	}
 }

--- a/client/hostvolumemanager/test_fixtures/test_plugin.sh
+++ b/client/hostvolumemanager/test_fixtures/test_plugin.sh
@@ -7,26 +7,42 @@ set -xeuo pipefail
 
 env 1>&2
 
-test "$1" == "$OPERATION"
+test "$1" == "$DHV_OPERATION"
 
 echo 'all operations should ignore stderr' 1>&2
+
+# since we will be running `rm -rf` (frightening),
+# check to make sure DHV_HOST_PATH has a uuid shape in it.
+# Nomad generates a volume ID and includes it in the path.
+validate_path() {
+  if [[ ! "$DHV_HOST_PATH" =~ "test-vol-id" ]]; then
+    1>&2 echo "expected test vol ID in the DHV_HOST_PATH; got: '$DHV_HOST_PATH'"
+    exit 1
+  fi
+}
 
 case $1 in
   fingerprint)
     echo '{"version": "0.0.2"}' ;;
   create)
-    test "$2" == "$HOST_PATH"
-    test "$NODE_ID" == 'test-node'
-    test "$PARAMETERS" == '{"key":"val"}'
-    test "$CAPACITY_MIN_BYTES" -eq 5
-    test "$CAPACITY_MAX_BYTES" -eq 10
+    test "$2" == "$DHV_HOST_PATH"
+    test "$DHV_NODE_ID" == 'test-node'
+    test "$DHV_VOLUME_NAME" == 'test-vol-name'
+    test "$DHV_VOLUME_ID" == 'test-vol-id'
+    test "$DHV_PARAMETERS" == '{"key":"val"}'
+    test "$DHV_CAPACITY_MIN_BYTES" -eq 5
+    test "$DHV_CAPACITY_MAX_BYTES" -eq 10
+    validate_path "$DHV_HOST_PATH"
     mkdir "$2"
-    printf '{"path": "%s", "bytes": 5, "context": %s}' "$2" "$PARAMETERS"
+    printf '{"path": "%s", "bytes": 5, "context": %s}' "$2" "$DHV_PARAMETERS"
     ;;
   delete)
-    test "$2" == "$HOST_PATH"
-    test "$NODE_ID" == 'test-node'
-    test "$PARAMETERS" == '{"key":"val"}'
+    test "$2" == "$DHV_HOST_PATH"
+    test "$DHV_NODE_ID" == 'test-node'
+    test "$DHV_VOLUME_NAME" == 'test-vol-name'
+    test "$DHV_VOLUME_ID" == 'test-vol-id'
+    test "$DHV_PARAMETERS" == '{"key":"val"}'
+    validate_path "$DHV_HOST_PATH"
     rm -rfv "$2" ;;
   *)
     echo "unknown operation $1"

--- a/client/hostvolumemanager/test_fixtures/test_plugin.sh
+++ b/client/hostvolumemanager/test_fixtures/test_plugin.sh
@@ -32,6 +32,7 @@ case $1 in
     test "$DHV_PARAMETERS" == '{"key":"val"}'
     test "$DHV_CAPACITY_MIN_BYTES" -eq 5
     test "$DHV_CAPACITY_MAX_BYTES" -eq 10
+    test "$DHV_PLUGIN_DIR" == './test_fixtures'
     validate_path "$DHV_HOST_PATH"
     mkdir "$2"
     printf '{"path": "%s", "bytes": 5, "context": %s}' "$2" "$DHV_PARAMETERS"
@@ -42,6 +43,7 @@ case $1 in
     test "$DHV_VOLUME_NAME" == 'test-vol-name'
     test "$DHV_VOLUME_ID" == 'test-vol-id'
     test "$DHV_PARAMETERS" == '{"key":"val"}'
+    test "$DHV_PLUGIN_DIR" == './test_fixtures'
     validate_path "$DHV_HOST_PATH"
     rm -rfv "$2" ;;
   *)

--- a/demo/hostvolume/_test-plugin.sh
+++ b/demo/hostvolume/_test-plugin.sh
@@ -43,6 +43,7 @@ op="$2"
 alloc_mounts="${3:-/tmp}"
 uuid="${4:-74564d17-ce50-0bc1-48e5-6feaa41ede48}"
 node_id='0b62d807-6101-a80f-374d-e1c430abbf47'
+plugin_dir="$(dirname "$plugin")" 
 
 case $op in
   fingerprint)
@@ -60,6 +61,7 @@ case $op in
     export DHV_CAPACITY_MAX_BYTES=50000000 # 50mb
     export DHV_CAPACITY_MIN_BYTES=50000000 # 50mb
     export DHV_PARAMETERS='{"a": "ayy"}'
+    export DHV_PLUGIN_DIR="$plugin_dir"
     ;;
 
   delete)
@@ -70,6 +72,7 @@ case $op in
     export DHV_VOLUME_NAME=test
     export DHV_VOLUME_ID="$uuid"
     export DHV_PARAMETERS='{"a": "ayy"}'
+    export DHV_PLUGIN_DIR="$plugin_dir"
     ;;
 
   *)

--- a/demo/hostvolume/_test-plugin.sh
+++ b/demo/hostvolume/_test-plugin.sh
@@ -42,26 +42,34 @@ plugin="$1"
 op="$2"
 alloc_mounts="${3:-/tmp}"
 uuid="${4:-74564d17-ce50-0bc1-48e5-6feaa41ede48}"
+node_id='0b62d807-6101-a80f-374d-e1c430abbf47'
 
 case $op in
   fingerprint)
     args='fingerprint'
+    export DHV_OPERATION='fingerprint'
     ;;
 
 	create)
     args="create $alloc_mounts/$uuid"
-    export HOST_PATH="$alloc_mounts/$uuid"
-    export VOLUME_NAME=test
-    export NODE_ID=0b62d807-6101-a80f-374d-e1c430abbf47
-    export CAPACITY_MAX_BYTES=50000000 # 50mb
-    export CAPACITY_MIN_BYTES=50000000 # 50mb
-    export PARAMETERS='{"a": "ayy"}'
+    export DHV_OPERATION='create'
+    export DHV_HOST_PATH="$alloc_mounts/$uuid"
+    export DHV_VOLUME_NAME=test
+    export DHV_VOLUME_ID="$uuid"
+    export DHV_NODE_ID="$node_id"
+    export DHV_CAPACITY_MAX_BYTES=50000000 # 50mb
+    export DHV_CAPACITY_MIN_BYTES=50000000 # 50mb
+    export DHV_PARAMETERS='{"a": "ayy"}'
     ;;
 
   delete)
     args="delete $alloc_mounts/$uuid"
-    export HOST_PATH="$alloc_mounts/$uuid"
-    export PARAMETERS='{"a": "ayy"}'
+    export DHV_OPERATION='delete'
+    export DHV_HOST_PATH="$alloc_mounts/$uuid"
+    export DHV_NODE_ID="$node_id"
+    export DHV_VOLUME_NAME=test
+    export DHV_VOLUME_ID="$uuid"
+    export DHV_PARAMETERS='{"a": "ayy"}'
     ;;
 
   *)
@@ -69,6 +77,5 @@ case $op in
 	  ;;
 esac
 
-export OPERATION="$op"
 set -x
 eval "$plugin $args"

--- a/demo/hostvolume/example-plugin-mkfs
+++ b/demo/hostvolume/example-plugin-mkfs
@@ -120,7 +120,7 @@ delete_volume() {
 
 case "$1" in
   "create")
-    create_volume "$host_path" "$CAPACITY_MIN_BYTES"
+    create_volume "$host_path" "$DHV_CAPACITY_MIN_BYTES"
     # output what Nomad expects
     bytes="$(st "$host_path".$ext)"
     printf '{"path": "%s", "bytes": %s}' "$host_path" "$bytes"


### PR DESCRIPTION
Some plugin spec changes based on recent discussion.

* All env prefixed with `DHV_`
* Add: `DHV_VOLUME_ID`, `DHV_PLUGIN_DIR`
* 5 second timeout for `fingerprint` operation

Notice to anyone using the `example-plugin-mkfs` demo plugin: you'll need to copy this changed version of it.