### PR TITLE
dynamic host volumes: capacity_max may be unset during register

### DIFF
--- a/nomad/structs/host_volumes.go
+++ b/nomad/structs/host_volumes.go
@@ -135,7 +135,7 @@ func (hv *HostVolume) Validate() error {
 	var mErr *multierror.Error
 
 	if hv.ID != "" && !helper.IsUUID(hv.ID) {
-		mErr = multierror.Append(mErr, errors.New("invalid ID"))
+		mErr = multierror.Append(mErr, fmt.Errorf("invalid ID %q", hv.ID))
 	}
 
 	if hv.Name == "" {
@@ -196,7 +196,8 @@ func (hv *HostVolume) ValidateUpdate(existing *HostVolume) error {
 		mErr = multierror.Append(mErr, errors.New("node pool cannot be updated"))
 	}
 
-	if hv.RequestedCapacityMaxBytes < existing.CapacityBytes {
+	if hv.RequestedCapacityMaxBytes > 0 &&
+		hv.RequestedCapacityMaxBytes < existing.CapacityBytes {
 		mErr = multierror.Append(mErr, fmt.Errorf(
 			"capacity_max (%d) cannot be less than existing provisioned capacity (%d)",
 			hv.RequestedCapacityMaxBytes, existing.CapacityBytes))

--- a/nomad/structs/host_volumes_test.go
+++ b/nomad/structs/host_volumes_test.go
@@ -94,7 +94,7 @@ func TestHostVolume_Validate(t *testing.T) {
 	}
 	err = invalid.Validate()
 	must.EqError(t, err, `4 errors occurred:
-	* invalid ID
+	* invalid ID "../../not-a-uuid"
 	* capacity_max (100000) must be larger than capacity_min (200000)
 	* invalid attachment mode: "bad"
 	* invalid constraint: 1 error occurred:


### PR DESCRIPTION
When using the register workflow, `capacity_max` is ignored so is likely unset. If the volume is then updated later, the check we had for valid updates assumes that the value was previously. Only perform this check if the value is set.