### PR TITLE
dynamic host volumes: allow for node pool and plugin ID changes

### DIFF
--- a/nomad/structs/host_volumes.go
+++ b/nomad/structs/host_volumes.go
@@ -221,8 +221,12 @@ func (hv *HostVolume) CanonicalizeForCreate(existing *HostVolume, now time.Time)
 		hv.HostPath = ""     // returned by plugin
 		hv.CreateTime = now.UnixNano()
 	} else {
-		hv.PluginID = existing.PluginID
-		hv.NodePool = existing.NodePool
+		if hv.PluginID == "" {
+			hv.PluginID = existing.PluginID
+		}
+		if hv.NodePool == "" {
+			hv.NodePool = existing.NodePool
+		}
 		hv.NodeID = existing.NodeID
 		hv.Constraints = existing.Constraints
 		hv.CapacityBytes = existing.CapacityBytes
@@ -244,8 +248,12 @@ func (hv *HostVolume) CanonicalizeForRegister(existing *HostVolume, now time.Tim
 		hv.ID = uuid.Generate()
 		hv.CreateTime = now.UnixNano()
 	} else {
-		hv.PluginID = existing.PluginID
-		hv.NodePool = existing.NodePool
+		if hv.PluginID == "" {
+			hv.PluginID = existing.PluginID
+		}
+		if hv.NodePool == "" {
+			hv.NodePool = existing.NodePool
+		}
 		hv.NodeID = existing.NodeID
 		hv.Constraints = existing.Constraints
 		hv.CreateTime = existing.CreateTime


### PR DESCRIPTION
Update dynamic host volume validation and update logic to allow for changes to the node pool and plugin ID. If the client's node pool changes we'll sync up the correct node pool for the volumes already placed on that client. We'll also allow the plugin ID to be changed to allow for new versions of plugins supporting the same volume over time.

Ref: https://github.com/hashicorp/nomad/pull/24810#discussion_r1911366838
Ref: https://github.com/hashicorp/nomad/pull/24810#discussion_r1911361745

(Note this PR will conflict with https://github.com/hashicorp/nomad/pull/24857, so whichever one lands last will need rebasing.)