### PR TITLE
dynamic host volume: set default capability

### DIFF
--- a/command/asset/volume.host.hcl
+++ b/command/asset/volume.host.hcl
@@ -9,9 +9,10 @@ plugin_id = "plugin_id"
 capacity_min = "10GiB"
 capacity_max = "20G"
 
-# Required (at least one): for 'nomad volume create', specify one or more
-# capabilities to validate. Registering an existing volume will record but
-# ignore these fields.
+# Optional: for 'nomad volume create', specify one or more capabilities to
+# validate. Registering an existing volume will record but ignore these fields.
+# If omitted, the single-node-writer + file-system capability will be used as a
+# default.
 capability {
   access_mode     = "single-node-writer"
   attachment_mode = "file-system"

--- a/nomad/mock/host_volumes.go
+++ b/nomad/mock/host_volumes.go
@@ -23,14 +23,8 @@ func HostVolumeRequest(ns string) *structs.HostVolume {
 		},
 		RequestedCapacityMinBytes: 100000,
 		RequestedCapacityMaxBytes: 200000,
-		RequestedCapabilities: []*structs.HostVolumeCapability{
-			{
-				AttachmentMode: structs.HostVolumeAttachmentModeFilesystem,
-				AccessMode:     structs.HostVolumeAccessModeSingleNodeWriter,
-			},
-		},
-		Parameters: map[string]string{"foo": "bar"},
-		State:      structs.HostVolumeStatePending,
+		Parameters:                map[string]string{"foo": "bar"},
+		State:                     structs.HostVolumeStatePending,
 	}
 	return vol
 

--- a/nomad/structs/host_volumes.go
+++ b/nomad/structs/host_volumes.go
@@ -148,14 +148,10 @@ func (hv *HostVolume) Validate() error {
 			hv.RequestedCapacityMaxBytes, hv.RequestedCapacityMinBytes))
 	}
 
-	if len(hv.RequestedCapabilities) == 0 {
-		mErr = multierror.Append(mErr, errors.New("must include at least one capability block"))
-	} else {
-		for _, cap := range hv.RequestedCapabilities {
-			err := cap.Validate()
-			if err != nil {
-				mErr = multierror.Append(mErr, err)
-			}
+	for _, cap := range hv.RequestedCapabilities {
+		err := cap.Validate()
+		if err != nil {
+			mErr = multierror.Append(mErr, err)
 		}
 	}
 
@@ -221,6 +217,14 @@ func (hv *HostVolume) CanonicalizeForCreate(existing *HostVolume, now time.Time)
 		hv.CapacityBytes = 0 // returned by plugin
 		hv.HostPath = ""     // returned by plugin
 		hv.CreateTime = now.UnixNano()
+
+		if len(hv.RequestedCapabilities) == 0 {
+			hv.RequestedCapabilities = []*HostVolumeCapability{{
+				AttachmentMode: HostVolumeAttachmentModeFilesystem,
+				AccessMode:     HostVolumeAccessModeSingleNodeWriter,
+			}}
+		}
+
 	} else {
 		if hv.PluginID == "" {
 			hv.PluginID = existing.PluginID
@@ -248,6 +252,14 @@ func (hv *HostVolume) CanonicalizeForRegister(existing *HostVolume, now time.Tim
 	if existing == nil {
 		hv.ID = uuid.Generate()
 		hv.CreateTime = now.UnixNano()
+
+		if len(hv.RequestedCapabilities) == 0 {
+			hv.RequestedCapabilities = []*HostVolumeCapability{{
+				AttachmentMode: HostVolumeAttachmentModeFilesystem,
+				AccessMode:     HostVolumeAccessModeSingleNodeWriter,
+			}}
+		}
+
 	} else {
 		if hv.PluginID == "" {
 			hv.PluginID = existing.PluginID

--- a/nomad/structs/host_volumes_test.go
+++ b/nomad/structs/host_volumes_test.go
@@ -58,18 +58,19 @@ func TestHostVolume_Copy(t *testing.T) {
 func TestHostVolume_Validate(t *testing.T) {
 	ci.Parallel(t)
 
-	invalid := &HostVolume{}
+	invalid := &HostVolume{RequestedCapabilities: []*HostVolumeCapability{
+		{AttachmentMode: "foo"}}}
 	err := invalid.Validate()
 	must.EqError(t, err, `2 errors occurred:
 	* missing name
-	* must include at least one capability block
+	* invalid attachment mode: "foo"
 
 `)
 
-	invalid = &HostVolume{Name: "example"}
+	invalid = &HostVolume{}
 	err = invalid.Validate()
 	// single error should be flattened
-	must.EqError(t, err, "must include at least one capability block")
+	must.EqError(t, err, "missing name")
 
 	invalid = &HostVolume{
 		ID:       "../../not-a-uuid",


### PR DESCRIPTION
We can reduce the amount of volume specification configuration many users will need by setting a default capability on a dynamic host volume if none is set. The default capability will allow using the volume in read/write mode on its node, with no further restrictions except those that might be set in the jobspec.

(Note this PR will conflict with https://github.com/hashicorp/nomad/pull/24851, so whichever one lands last will need rebasing.)
