### PR TITLE
dynamic host volumes: move node pool governance to placement filter (CE)

### DIFF
--- a/nomad/host_volume_endpoint_ce.go
+++ b/nomad/host_volume_endpoint_ce.go
@@ -12,7 +12,7 @@ import (
 )
 
 // enforceEnterprisePolicy is the CE stub for Enterprise governance via
-// Sentinel policy, quotas, and node pools
+// Sentinel policy and quotas
 func (v *HostVolume) enforceEnterprisePolicy(
 	_ *state.StateSnapshot,
 	_ *structs.HostVolume,
@@ -20,4 +20,10 @@ func (v *HostVolume) enforceEnterprisePolicy(
 	_ bool,
 ) (error, error) {
 	return nil, nil
+}
+
+// enterpriseNodePoolFilter is the CE stub for filtering nodes during placement
+// via Enterprise node pool governance.
+func (v *HostVolume) enterpriseNodePoolFilter(_ *state.StateSnapshot, _ *structs.HostVolume) (func(string) bool, error) {
+	return func(_ string) bool { return true }, nil
 }

--- a/nomad/host_volume_endpoint_test.go
+++ b/nomad/host_volume_endpoint_test.go
@@ -168,12 +168,12 @@ func TestHostVolumeEndpoint_CreateRegisterGetDelete(t *testing.T) {
 		var resp structs.HostVolumeCreateResponse
 		req.AuthToken = token
 		err := msgpackrpc.CallWithCodec(codec, "HostVolume.Create", req, &resp)
-		must.EqError(t, err, `could not place volume "example1": no node meets constraints`)
+		must.EqError(t, err, `could not place volume "example1": no node meets constraints: 0 nodes had existing volume, 0 nodes filtered by node pool governance, 1 nodes were infeasible`)
 
 		req.Volume = vol2.Copy()
 		resp = structs.HostVolumeCreateResponse{}
 		err = msgpackrpc.CallWithCodec(codec, "HostVolume.Create", req, &resp)
-		must.EqError(t, err, `could not place volume "example2": no node meets constraints`)
+		must.EqError(t, err, `could not place volume "example2": no node meets constraints: 0 nodes had existing volume, 0 nodes filtered by node pool governance, 1 nodes were infeasible`)
 	})
 
 	t.Run("valid create", func(t *testing.T) {
@@ -725,12 +725,12 @@ func TestHostVolumeEndpoint_placeVolume(t *testing.T) {
 						Operand: "=",
 					},
 				}},
-			expectErr: "no node meets constraints",
+			expectErr: "no node meets constraints: 0 nodes had existing volume, 0 nodes filtered by node pool governance, 4 nodes were infeasible",
 		},
 		{
 			name:      "no matching plugin",
 			vol:       &structs.HostVolume{PluginID: "not-mkdir"},
-			expectErr: "no node meets constraints",
+			expectErr: "no node meets constraints: 0 nodes had existing volume, 0 nodes filtered by node pool governance, 4 nodes were infeasible",
 		},
 		{
 			name: "match already has a volume with the same name",
@@ -744,7 +744,7 @@ func TestHostVolumeEndpoint_placeVolume(t *testing.T) {
 						Operand: "=",
 					},
 				}},
-			expectErr: "no node meets constraints",
+			expectErr: "no node meets constraints: 1 nodes had existing volume, 0 nodes filtered by node pool governance, 3 nodes were infeasible",
 		},
 	}
 


### PR DESCRIPTION
Enterprise governance checks happen after dynamic host volumes are placed, so if node pool governance is active and you don't set a node pool or node ID for a volume, it's possible to get a placement that fails node pool governance even though there might be other nodes in the cluster that would be valid placements.

Move the node pool governance for host volumes into the placement path, so that we're checking a specific node pool when node pool or node ID are set, but otherwise filtering out candidate nodes by node pool.

This changset is the CE version of ENT/2200.

Ref: https://hashicorp.atlassian.net/browse/NET-11549
Ref: https://github.com/hashicorp/nomad-enterprise/pull/2200