### PR TITLE
A dedicated variable at nomad/ui/defaults

### DIFF
--- a/nomad/structs/variables.go
+++ b/nomad/structs/variables.go
@@ -440,6 +440,9 @@ func ValidatePath(path string) error {
 	case parts[1] == "job-templates":
 		// Disallow exactly nomad/job-templates with no further paths
 		return fmt.Errorf("\"nomad/job-templates\" is a reserved directory path, but you may write variables at the level below it, for example, \"nomad/job-templates/template-name\"")
+	case parts[1] == "ui" && parts[2] == "defaults":
+		// Allow nomad/ui/defaults
+		return nil
 	default:
 		// Disallow arbitrary sub-paths beneath nomad/
 		return fmt.Errorf("only paths at \"nomad/jobs\" or \"nomad/job-templates\" and below are valid paths under the top-level \"nomad\" directory")

--- a/nomad/structs/variables.go
+++ b/nomad/structs/variables.go
@@ -440,12 +440,15 @@ func ValidatePath(path string) error {
 	case parts[1] == "job-templates":
 		// Disallow exactly nomad/job-templates with no further paths
 		return fmt.Errorf("\"nomad/job-templates\" is a reserved directory path, but you may write variables at the level below it, for example, \"nomad/job-templates/template-name\"")
-	case parts[1] == "ui" && parts[2] == "defaults":
-		// Allow nomad/ui/defaults
+	case parts[1] == "ui" && parts[2] == "defaults" && len(parts) == 4:
+		// Paths including "nomad/ui/defaults" are valid, provided they have single further path part
 		return nil
+	case parts[1] == "ui" && parts[2] == "defaults":
+		// Disallow exactly nomad/ui/defaults with no further paths
+		return fmt.Errorf("\"nomad/ui/defaults\" is a reserved directory path, but you may write variables at the level below it, for example, \"nomad/ui/defaults/region\"")
 	default:
 		// Disallow arbitrary sub-paths beneath nomad/
-		return fmt.Errorf("only paths at \"nomad/jobs\" or \"nomad/job-templates\" and below are valid paths under the top-level \"nomad\" directory")
+		return fmt.Errorf("only paths at \"nomad/jobs\", \"nomad/ui/defaults\", or \"nomad/job-templates\" and below are valid paths under the top-level \"nomad\" directory")
 	}
 }
 

--- a/ui/app/components/profile-navbar-item.hbs
+++ b/ui/app/components/profile-navbar-item.hbs
@@ -7,7 +7,7 @@
   <Hds::Dropdown @color="secondary" class="profile-dropdown"
     {{keyboard-shortcut menuLevel=true pattern=(array "g" "p") }}
     as |dd|>
-    <dd.ToggleButton @color="secondary" @icon="user-circle" @text={{this.token.selfToken.name}} @size="small" data-test-header-profile-dropdown />
+    <dd.ToggleButton @color="secondary" @icon="user-circle" @text={{or this.token.selfToken.name ""}} @size="small" data-test-header-profile-dropdown />
     <dd.Description @text="Signed In" />
     <dd.Separator />
     <dd.Interactive @route="settings.tokens" @text="Profile" data-test-profile-dropdown-profile-link />

--- a/ui/app/components/variable-form.hbs
+++ b/ui/app/components/variable-form.hbs
@@ -49,6 +49,17 @@
     </div>
   {{/if}}
 
+  {{#if this.isUIDefaultsVariable}}
+    <Hds::Alert @type="inline" @color="highlight" @title="UI Defaults" as |A|>
+      <A.Title>UI Defaults</A.Title>
+      <A.Description>
+        <p>This variable is used to set the default values using the UI.</p>
+        <p>Currently-accepted values are <code>namespace</code>, <code>nodepool</code>, and <code>region</code>.</p>
+        <p>You can comma-separate strings to set multiple defaults for namespaces and node pools.</p>
+      </A.Description>
+    </Hds::Alert>
+  {{/if}}
+
   <div class={{if this.namespaceOptions "path-namespace"}}>
 
 		<Hds::Form::TextInput::Field
@@ -62,7 +73,7 @@
       data-test-path-input
 		as |F|>
 			<F.Label>Path</F.Label>
-      
+
       {{#if this.duplicatePathWarning}}
         <F.Error data-test-duplicate-variable-error>
           There is already a variable located at
@@ -94,8 +105,8 @@
 		</Hds::Form::TextInput::Field>
 
 
-    <VariableForm::NamespaceFilter 
-      @data={{hash 
+    <VariableForm::NamespaceFilter
+      @data={{hash
         disabled=(not @model.isNew)
         selection=this.variableNamespace
         namespaceOptions=this.namespaceOptions

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -77,7 +77,8 @@ export default class VariableFormComponent extends Component {
       !(
         this.path?.startsWith('nomad/jobs') ||
         (this.path?.startsWith('nomad/job-templates') &&
-          trimPath([this.path]) !== 'nomad/job-templates')
+          trimPath([this.path]) !== 'nomad/job-templates') ||
+        this.path === 'nomad/ui/defaults'
       );
     return !!this.JSONError || !this.path || disallowedPath;
   }
@@ -138,6 +139,12 @@ export default class VariableFormComponent extends Component {
   get duplicatePathWarning() {
     const existingVariables = this.args.existingVariables || [];
     const pathValue = trimPath([this.path]);
+    // TODO: temporary hack! This is happening because I'm separately loading the default variable
+    // in the application route, and it's not showing up as this.args.model-equivalent here, so the
+    // .without() call is failing.
+    if (pathValue === 'nomad/ui/defaults') {
+      return null;
+    }
     let existingVariable = existingVariables
       .without(this.args.model)
       .find(
@@ -420,6 +427,10 @@ export default class VariableFormComponent extends Component {
       this.args.model.pathLinkedEntities?.task ||
       trimPath([this.path]) === 'nomad/jobs'
     );
+  }
+
+  get isUIDefaultsVariable() {
+    return this.path === 'nomad/ui/defaults';
   }
 
   //#region Unsaved Changes Confirmation

--- a/ui/app/components/variable-form.js
+++ b/ui/app/components/variable-form.js
@@ -78,7 +78,7 @@ export default class VariableFormComponent extends Component {
         this.path?.startsWith('nomad/jobs') ||
         (this.path?.startsWith('nomad/job-templates') &&
           trimPath([this.path]) !== 'nomad/job-templates') ||
-        this.path === 'nomad/ui/defaults'
+        this.path.startsWith('nomad/ui/defaults/')
       );
     return !!this.JSONError || !this.path || disallowedPath;
   }
@@ -142,7 +142,7 @@ export default class VariableFormComponent extends Component {
     // TODO: temporary hack! This is happening because I'm separately loading the default variable
     // in the application route, and it's not showing up as this.args.model-equivalent here, so the
     // .without() call is failing.
-    if (pathValue === 'nomad/ui/defaults') {
+    if (pathValue?.startsWith('nomad/ui/defaults/')) {
       return null;
     }
     let existingVariable = existingVariables
@@ -430,7 +430,7 @@ export default class VariableFormComponent extends Component {
   }
 
   get isUIDefaultsVariable() {
-    return this.path === 'nomad/ui/defaults';
+    return this.path.startsWith('nomad/ui/defaults/');
   }
 
   //#region Unsaved Changes Confirmation

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -50,6 +50,8 @@ export default class Tokens extends Controller {
     this.signInStatus = null;
     // Clear out all data to ensure only data the anonymous token is privileged to see is shown
     this.resetStore();
+    // Unset the active region so that the application will re-read the defaults
+    this.system.set('activeRegion', null);
     this.token.reset();
     this.store.findAll('auth-method');
   }
@@ -159,12 +161,15 @@ export default class Tokens extends Controller {
       this.set('secret', null);
 
       TokenAdapter.findSelf().then(
-        () => {
+        async () => {
           // Clear out all data to ensure only data the new token is privileged to see is shown
           this.resetStore();
 
           // Refetch the token and associated policies
           this.token.get('fetchSelfTokenAndPolicies').perform().catch();
+
+          await this.system.establishUIDefaults();
+          await this.system.defaults;
 
           if (!this.system.activeRegion) {
             this.system.get('defaultRegion').then((res) => {

--- a/ui/app/controllers/settings/user-settings.js
+++ b/ui/app/controllers/settings/user-settings.js
@@ -252,7 +252,7 @@ export default class SettingsUserSettingsController extends Controller {
 
   // You may be asking: why isn't there a clearDefaultRegion() action like there is for namespaces?
   // Your localStorage settings get an activeRegion/default region every time you change regions via the header switcher,
-  // but also when you load the application route, so at best you'd have "no default" until you refresh the page.
+  // but also when you load the application route (caveat: whenever there are 2+ regions), so at best you'd have "no default" until you refresh the page.
   // If we ever decide to get rid of "save your active region for when you load the app in the future" as a convention,
   // then we can add a clearDefaultRegion() action.
 }

--- a/ui/app/controllers/settings/user-settings.js
+++ b/ui/app/controllers/settings/user-settings.js
@@ -85,10 +85,18 @@ export default class SettingsUserSettingsController extends Controller {
       ? this.system.agentDefaults.Namespace.split(',')
       : [];
 
+    let variableDefaultNamespaces = this.system.variableDefaults?.Namespace
+      ? this.system.variableDefaults.Namespace.split(',')
+      : [];
+
     if (userDefaultNamespaces.length) {
       return `${userDefaultNamespaces.length} default namespace${
         userDefaultNamespaces.length > 1 ? 's' : ''
       } (via localStorage)`;
+    } else if (variableDefaultNamespaces.length) {
+      return `${variableDefaultNamespaces.length} default namespace${
+        variableDefaultNamespaces.length > 1 ? 's' : ''
+      } (via variable defaults)`;
     } else if (agentDefaultNamespaces.length) {
       return `${agentDefaultNamespaces.length} default namespace${
         agentDefaultNamespaces.length > 1 ? 's' : ''
@@ -121,10 +129,18 @@ export default class SettingsUserSettingsController extends Controller {
       ? this.system.agentDefaults.NodePool.split(',')
       : [];
 
+    let variableDefaultNodePools = this.system.variableDefaults?.NodePool
+      ? this.system.variableDefaults.NodePool.split(',')
+      : [];
+
     if (userDefaultNodePools.length) {
       return `${userDefaultNodePools.length} default node pool${
         userDefaultNodePools.length > 1 ? 's' : ''
       } (via localStorage)`;
+    } else if (variableDefaultNodePools.length) {
+      return `${variableDefaultNodePools.length} default node pool${
+        variableDefaultNodePools.length > 1 ? 's' : ''
+      } (via variable defaults)`;
     } else if (agentDefaultNodePools.length) {
       return `${agentDefaultNodePools.length} default node pool${
         agentDefaultNodePools.length > 1 ? 's' : ''
@@ -171,7 +187,9 @@ export default class SettingsUserSettingsController extends Controller {
     set(this, 'system.userDefaultNamespace', null);
     this.notifications.add({
       title: 'Default Namespaces Cleared',
-      message: this.system.agentDefaults?.Namespace
+      message: this.system.variableDefaults?.Namespace
+        ? `Namespaces ${this.system.variableDefaults.Namespace} are now default via variable defaults`
+        : this.system.agentDefaults?.Namespace
         ? `Namespaces ${this.system.agentDefaults.Namespace} are now default via agent`
         : 'No default namespaces set',
       color: 'success',
@@ -203,7 +221,9 @@ export default class SettingsUserSettingsController extends Controller {
     set(this, 'system.userDefaultNodePool', null);
     this.notifications.add({
       title: 'Default Node Pools Cleared',
-      message: this.system.agentDefaults?.NodePool
+      message: this.system.variableDefaults?.NodePool
+        ? `Node Pools ${this.system.variableDefaults.NodePool} are now default via variable defaults`
+        : this.system.agentDefaults?.NodePool
         ? `Node Pools ${this.system.agentDefaults.NodePool} are now default via agent`
         : 'No default node pools set',
       color: 'success',

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -79,6 +79,24 @@ export default class ApplicationRoute extends Route {
       ]);
     }
 
+    // If a variable is set at nomad/ui/defaults, set its results in the system service
+    // TODO: need to do this fetch upon sign-in, not just on app load. Same with agent config.
+    try {
+      const variableDefaults = await this.store.findRecord(
+        'variable',
+        'nomad/ui/defaults@default'
+      );
+      if (variableDefaults) {
+        this.set('system.variableDefaults', {
+          Namespace: variableDefaults.items.namespace,
+          NodePool: variableDefaults.items.nodepool,
+          Region: variableDefaults.items.region,
+        });
+      }
+    } catch (e) {
+      // No default variable found, fall back to agent config or "default".
+    }
+
     if (!this.get('system.shouldShowRegions')) return promises;
 
     const queryParam = transition.to.queryParams.region;

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -233,11 +233,6 @@ export default class SystemService extends Service {
     'variableDefaults.{Namespace,NodePool,Region}'
   )
   get defaults() {
-    // TODO: Monday: this gets called a LOT from basically every page, because everything calls system.defaultRegion,
-    // which now calls system.defaults,
-    // which now calls this.establishUIDefaults().
-    // This results in a TON of network requests, most failing because signed out or other-region, etc.
-    // return this.establishUIDefaults().then(() => {
     /**
      * @type {Defaults}
      */
@@ -263,7 +258,6 @@ export default class SystemService extends Service {
           .map((np) => np.trim()),
       });
     });
-    // });
   }
 
   @computed('regions.[]', 'userDefaultRegion')

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -138,6 +138,7 @@ export default class SystemService extends Service {
   @localStorageProperty('nomadActiveRegion') userDefaultRegion;
 
   @tracked agentDefaults = {};
+  @tracked variableDefaults = {};
 
   /**
    * First read agent config for cluster-level defaults,
@@ -149,7 +150,8 @@ export default class SystemService extends Service {
     'agentDefaults.{Namespace,NodePool,Region}',
     'userDefaultNamespace',
     'userDefaultNodePool',
-    'userDefaultRegion'
+    'userDefaultRegion',
+    'variableDefaults.{Namespace,NodePool,Region}'
   )
   get defaults() {
     return this.agent.then((agent) => {
@@ -159,11 +161,22 @@ export default class SystemService extends Service {
       // eslint-disable-next-line ember/no-side-effects
       this.agentDefaults = agent?.config?.UI?.Defaults || {};
       return {
-        region: this.userDefaultRegion || this.agentDefaults.Region,
-        namespace: (this.userDefaultNamespace || this.agentDefaults.Namespace)
+        region:
+          this.userDefaultRegion ||
+          this.variableDefaults.Region ||
+          this.agentDefaults.Region,
+        namespace: (
+          this.userDefaultNamespace ||
+          this.variableDefaults.Namespace || // TODO: probably have to split/map/trim variableDefaults, too.
+          this.agentDefaults.Namespace
+        )
           ?.split(',')
           .map((ns) => ns.trim()),
-        nodePool: (this.userDefaultNodePool || this.agentDefaults.NodePool)
+        nodePool: (
+          this.userDefaultNodePool ||
+          this.variableDefaults.NodePool ||
+          this.agentDefaults.NodePool
+        )
           ?.split(',')
           .map((np) => np.trim()),
       };

--- a/ui/app/styles/components/authorization.scss
+++ b/ui/app/styles/components/authorization.scss
@@ -63,3 +63,16 @@
     gap: 0.5rem;
   }
 }
+
+.user-settings-page {
+  .hds-alert {
+    margin-bottom: 1.5rem;
+  }
+  ol li {
+    margin-left: 1rem;
+    a, a strong {
+      color: $blue-500;
+      text-decoration-color: $blue-500;
+    }
+  }
+}

--- a/ui/app/templates/components/gutter-menu.hbs
+++ b/ui/app/templates/components/gutter-menu.hbs
@@ -24,7 +24,7 @@
       </span>
     </header>
     <aside class="menu">
-      {{#if this.system.shouldShowRegions}}
+      {{#if (or this.system.shouldShowRegions this.system.hasNonDefaultRegion)}}
         <div class="collapsed-only">
           <p class="menu-label">
             Region

--- a/ui/app/templates/components/region-switcher.hbs
+++ b/ui/app/templates/components/region-switcher.hbs
@@ -22,7 +22,9 @@
     </PowerSelect>
   </span>
 {{else if this.system.hasNonDefaultRegion}}
-  <div class="navbar-item single-region">
-    <span>Region: </span>{{this.system.activeRegion}}
-  </div>
+  {{#if this.system.activeRegion}}
+    <div class="navbar-item single-region">
+      <span>Region: </span>{{this.system.activeRegion}}
+    </div>
+  {{/if}}
 {{/if}}

--- a/ui/app/templates/settings/user-settings.hbs
+++ b/ui/app/templates/settings/user-settings.hbs
@@ -203,7 +203,7 @@
         {{/if}}
       </Hds::Form::HelperText>
 
-      {{#if this.system.shouldShowRegions}}
+      {{#if (or this.system.shouldShowRegions this.system.hasNonDefaultRegion)}}
         <Hds::Separator />
         <Hds::Form::Label>
           Default Region

--- a/ui/app/templates/settings/user-settings.hbs
+++ b/ui/app/templates/settings/user-settings.hbs
@@ -4,19 +4,21 @@
 ~}}
 
 {{page-title "User Settings"}}
-<section class="section">
-  <Hds::Alert @type="inline" @title="Local Storage Settings" as |A|>
+<section class="section user-settings-page">
+  <Hds::Alert @type="inline" @title="User Settings" as |A|>
     <A.Title>User Settings</A.Title>
-    <A.Description>These settings will be saved to your browser settings via Local Storage.</A.Description>
+    <A.Description>These settings will be saved to your browser settings via
+      Local Storage.</A.Description>
     <A.Generic>
-      <Hds::Separator/>
+      <Hds::Separator />
       <Hds::Form::Toggle::Group as |G|>
         <G.ToggleField
           name="word-wrap"
           @id="word-wrap"
           checked={{this.wordWrap}}
           {{on "change" (action (mut this.wordWrap) (not this.wordWrap))}}
-        as |F|>
+          as |F|
+        >
           <F.Label>Word Wrap</F.Label>
           <F.HelperText>Wrap lines of text in logs and exec terminals in the UI</F.HelperText>
         </G.ToggleField>
@@ -24,14 +26,39 @@
           name="jostle"
           @id="jostle"
           checked={{this.liveUpdateJobsIndex}}
-          {{on "change" (action (mut this.liveUpdateJobsIndex) (not this.liveUpdateJobsIndex))}}
-        as |F|>
-          <F.Label>Live Updates to <LinkTo @route="jobs.index">Jobs Index</LinkTo></F.Label>
-          <F.HelperText>When enabled, new or removed jobs will pop into and out of view on your jobs page. When disabled, you will be notified that changes are pending.</F.HelperText>
+          {{on
+            "change"
+            (action
+              (mut this.liveUpdateJobsIndex) (not this.liveUpdateJobsIndex)
+            )
+          }}
+          as |F|
+        >
+          <F.Label>Live Updates to
+            <LinkTo @route="jobs.index">Jobs Index</LinkTo></F.Label>
+          <F.HelperText>When enabled, new or removed jobs will pop into and out
+            of view on your jobs page. When disabled, you will be notified that
+            changes are pending.</F.HelperText>
         </G.ToggleField>
       </Hds::Form::Toggle::Group>
 
-      <Hds::Separator/>
+    </A.Generic>
+  </Hds::Alert>
+
+  <Hds::Alert @type="inline" @title="Defaults" as |A|>
+    <A.Title>Defaults</A.Title>
+    <A.Description>
+      You can set defaults for the UI when it comes to filtering viewing certain pages. You can configure these, in ascending order of precedence:
+      <ol>
+        <li><a href="https://developer.hashicorp.com/nomad/docs/configuration/ui#ui-parameters"><strong>Agent configuration</strong></a>, which is overridden by</li>
+        <li><LinkTo @route="variables.variable.edit"  @model="nomad/ui/defaults@default"><strong>Variable defaults</strong></LinkTo>, which is overridden by</li>
+        <li><strong>Local Storage settings</strong> (which you can modify by making changes on this page), which is overridden by</li>
+        <li><strong>Query Parameters</strong> in your URL.</li>
+      </ol>
+    </A.Description>
+
+    <A.Generic>
+      <Hds::Separator />
       <Hds::Form::Label>
         Default Namespace
         <Hds::Dropdown @height="300px" @listPosition="bottom-left" as |dd|>
@@ -45,7 +72,10 @@
               placeholder="Filter namespaces"
               @value={{this.namespaceFilter}}
               {{autofocus}}
-              {{on "input" (action (mut this.namespaceFilter) value="target.value") }}
+              {{on
+                "input"
+                (action (mut this.namespaceFilter) value="target.value")
+              }}
               data-test-namespace-filter-searchbox
             />
           </dd.Header>
@@ -56,7 +86,10 @@
               checked={{option.checked}}
               data-test-dropdown-option={{option.label}}
             >
-              {{option.label}} {{#if (includes option.id this.namespaceDefaults)}}(default){{/if}}
+              {{option.label}}
+              {{#if
+                (includes option.id this.namespaceDefaults)
+              }}(default){{/if}}
             </dd.Checkbox>
           {{else}}
             <dd.Generic data-test-dropdown-empty>
@@ -73,11 +106,18 @@
         You can set which namespaces are selected by default in the UI.
         {{#if this.system.agentDefaults.Namespace}}
           <br />
-          Your agent configuration has set the default namespace to <strong>{{this.system.agentDefaults.Namespace}}</strong>.
+          Your agent configuration has set the default namespace to
+          <strong>{{this.system.agentDefaults.Namespace}}</strong>.
+        {{/if}}
+        {{#if this.system.variableDefaults.Namespace}}
+          <br />
+          Your <LinkTo @route="variables.variable.edit" @model="nomad/ui/defaults@default">variable defaults</LinkTo> have set the default namespace to
+          <strong>{{this.system.variableDefaults.Namespace}}</strong>.
         {{/if}}
         {{#if this.system.userDefaultNamespace}}
           <br />
-          Your user settings have set the default namespace to <strong>{{this.system.userDefaultNamespace}}</strong>.
+          Your user settings have set the default namespace to
+          <strong>{{this.system.userDefaultNamespace}}</strong>.
 
           <Hds::Button
             @isInline={{true}}
@@ -90,7 +130,7 @@
         {{/if}}
       </Hds::Form::HelperText>
 
-      <Hds::Separator/>
+      <Hds::Separator />
 
       <Hds::Form::Label>
         Default Node Pool
@@ -105,7 +145,10 @@
               placeholder="Filter node pools"
               @value={{this.nodepoolFilter}}
               {{autofocus}}
-              {{on "input" (action (mut this.nodepoolFilter) value="target.value") }}
+              {{on
+                "input"
+                (action (mut this.nodepoolFilter) value="target.value")
+              }}
               data-test-nodepool-filter-searchbox
             />
           </dd.Header>
@@ -116,7 +159,8 @@
               checked={{option.checked}}
               data-test-dropdown-option={{option.label}}
             >
-              {{option.label}} {{#if (includes option.id this.nodepoolDefaults)}}(default){{/if}}
+              {{option.label}}
+              {{#if (includes option.id this.nodepoolDefaults)}}(default){{/if}}
             </dd.Checkbox>
           {{else}}
             <dd.Generic data-test-dropdown-empty>
@@ -133,11 +177,18 @@
         You can set which node pools are selected by default in the UI.
         {{#if this.system.agentDefaults.NodePool}}
           <br />
-          Your agent configuration has set the default node pool to <strong>{{this.system.agentDefaults.NodePool}}</strong>.
+          Your agent configuration has set the default node pool to
+          <strong>{{this.system.agentDefaults.NodePool}}</strong>.
+        {{/if}}
+        {{#if this.system.variableDefaults.NodePool}}
+          <br />
+          Your <LinkTo @route="variables.variable.edit" @model="nomad/ui/defaults@default">variable defaults</LinkTo> have set the default node pool to
+          <strong>{{this.system.variableDefaults.NodePool}}</strong>.
         {{/if}}
         {{#if this.system.userDefaultNodePool}}
           <br />
-          Your user settings have set the default node pool to <strong>{{this.system.userDefaultNodePool}}</strong>.
+          Your user settings have set the default node pool to
+          <strong>{{this.system.userDefaultNodePool}}</strong>.
 
           <Hds::Button
             @isInline={{true}}
@@ -150,8 +201,8 @@
         {{/if}}
       </Hds::Form::HelperText>
 
-      {{#if this.system.shouldShowRegions}}      
-        <Hds::Separator/>
+      {{#if this.system.shouldShowRegions}}
+        <Hds::Separator />
         <Hds::Form::Label>
           Default Region
           {{!-- <RegionSwitcher @onChange={{this.setDefaultRegion}} /> --}}
@@ -169,8 +220,9 @@
               >
                 {{option.label}} {{#if (includes option.id this.regionDefaults)}}(default){{/if}}
               </dd.Checkbox> --}}
-							<dd.Interactive
-                {{on "click" (action this.setDefaultRegion option)}} @text={{option}}
+              <dd.Interactive
+                {{on "click" (action this.setDefaultRegion option)}}
+                @text={{option}}
               />
             {{/each}}
           </Hds::Dropdown>
@@ -179,11 +231,19 @@
           You can set which region is selected by default in the UI.
           {{#if this.system.agentDefaults.Region}}
             <br />
-            Your agent configuration has set the default region to <strong>{{this.system.agentDefaults.Region}}</strong>.
+            Your agent configuration has set the default region to
+            <strong>{{this.system.agentDefaults.Region}}</strong>.
+          {{/if}}
+          {{#if this.system.variableDefaults.Region}}
+            <br />
+            Your <LinkTo @route="variables.variable.edit" @model="nomad/ui/defaults@default">variable defaults</LinkTo> have set the default region to
+            <strong>{{this.system.variableDefaults.Region}}</strong>.
           {{/if}}
           {{#if this.system.userDefaultRegion}}
             <br />
-            Your user settings have set the default region to <strong>{{this.system.userDefaultRegion}}</strong> (This updates every time you change regions via the UI)
+            Your user settings have set the default region to
+            <strong>{{this.system.userDefaultRegion}}</strong>
+            (This updates every time you change regions via the UI)
           {{/if}}
         </Hds::Form::HelperText>
 

--- a/ui/app/templates/settings/user-settings.hbs
+++ b/ui/app/templates/settings/user-settings.hbs
@@ -48,10 +48,12 @@
   <Hds::Alert @type="inline" @title="Defaults" as |A|>
     <A.Title>Defaults</A.Title>
     <A.Description>
-      You can set defaults for the UI when it comes to filtering viewing certain pages. You can configure these, in ascending order of precedence:
+      You can set defaults for the UI when it comes to viewing certain pages. You can configure these, in ascending order of precedence:
       <ol>
         <li><a href="https://developer.hashicorp.com/nomad/docs/configuration/ui#ui-parameters"><strong>Agent configuration</strong></a>, which is overridden by</li>
-        <li><LinkTo @route="variables.variable.edit"  @model="nomad/ui/defaults@default"><strong>Variable defaults</strong></LinkTo>, which is overridden by</li>
+        {{#if (can "read variable" path="nomad/ui/defaults" namespace="*")}}
+          <li><LinkTo @route="variables.variable.edit"  @model="nomad/ui/defaults@default"><strong>Variable defaults</strong></LinkTo>, which is overridden by</li>
+        {{/if}}
         <li><strong>Local Storage settings</strong> (which you can modify by making changes on this page), which is overridden by</li>
         <li><strong>Query Parameters</strong> in your URL.</li>
       </ol>

--- a/ui/app/utils/properties/local-storage.js
+++ b/ui/app/utils/properties/local-storage.js
@@ -14,7 +14,13 @@ export default function localStorageProperty(localStorageKey, defaultValue) {
   return computed({
     get() {
       const persistedValue = window.localStorage.getItem(localStorageKey);
-      return persistedValue ? JSON.parse(persistedValue) : defaultValue;
+      if (!persistedValue) return defaultValue;
+      try {
+        return JSON.parse(persistedValue);
+      } catch (e) {
+        window.localStorage.removeItem(localStorageKey);
+        return defaultValue;
+      }
     },
     set(key, value) {
       if (value === null || value === undefined) {


### PR DESCRIPTION
Adds a variable at `nomad/ui/defaults` to override agent config ui defaults, but can still be overriden by localStorage and queryParams.

A nice middle ground between "Everybody gets this because it's part of the agent configuration" and "Only you, in this browser, get it", because you can turn variable access on/off via ACL policy definitions, with the added benefit of "You can change this without having to restart your server", which is a problem the agent UI config block has.