### PR TITLE
Update install command for Fedora to match install page

### DIFF
--- a/website/content/docs/install/index.mdx
+++ b/website/content/docs/install/index.mdx
@@ -79,8 +79,7 @@ $ sudo dnf install -y dnf-plugins-core
 Use `dnf config-manager` to add the official HashiCorp Linux repository.
 
 ```shell-session
-$ sudo dnf config-manager \
-  --add-repo https://rpm.releases.hashicorp.com/fedora/hashicorp.repo
+$ sudo dnf config-manager addrepo --from-repofile=https://rpm.releases.hashicorp.com/fedora/hashicorp.repo
 ```
 
 Install.


### PR DESCRIPTION
### Description

For all HashiCorp tools, the install command has been updated for Fedora. This PR updates the docs to match the install page
