### PR TITLE
dynamic host volumes quotas (CE)

### DIFF
--- a/api/quota.go
+++ b/api/quota.go
@@ -157,6 +157,11 @@ type QuotaStorageResources struct {
 	// Variable.EncryptedData, in megabytes (2^20 bytes). A value of zero is
 	// treated as unlimited and a negative value is treated as fully disallowed.
 	VariablesMB int `hcl:"variables"`
+
+	// HostVolumesMB is the maximum provisioned size of all dynamic host
+	// volumes, in megabytes (2^20 bytes). A value of zero is treated as
+	// unlimited and a negative value is treated as fully disallowed.
+	HostVolumesMB int `hcl:"host_volumes"`
 }
 
 // QuotaUsage is the resource usage of a Quota

--- a/command/quota_apply_test.go
+++ b/command/quota_apply_test.go
@@ -8,7 +8,10 @@ import (
 	"testing"
 
 	"github.com/hashicorp/cli"
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/pointer"
+	"github.com/shoenig/test/must"
 )
 
 func TestQuotaApplyCommand_Implements(t *testing.T) {
@@ -37,4 +40,54 @@ func TestQuotaApplyCommand_Fails(t *testing.T) {
 		t.Fatalf("name required error, got: %s", out)
 	}
 	ui.ErrorWriter.Reset()
+}
+
+func TestQuotaParse(t *testing.T) {
+
+	in := []byte(`
+name        = "default-quota"
+description = "Limit the shared default namespace"
+
+limit {
+  region = "global"
+  region_limit {
+    cores      = 0
+    cpu        = 2500
+    memory     = 1000
+    memory_max = 1000
+    device "nvidia/gpu/1080ti" {
+      count = 1
+    }
+    storage {
+      variables    = 1000   # in MB
+      host_volumes = "100 GiB"
+    }
+  }
+}
+`)
+
+	spec, err := parseQuotaSpec(in)
+	must.NoError(t, err)
+
+	must.Eq(t, &api.QuotaSpec{
+		Name:        "default-quota",
+		Description: "Limit the shared default namespace",
+		Limits: []*api.QuotaLimit{{
+			Region: "global",
+			RegionLimit: &api.QuotaResources{
+				CPU:         pointer.Of(2500),
+				Cores:       pointer.Of(0),
+				MemoryMB:    pointer.Of(1000),
+				MemoryMaxMB: pointer.Of(1000),
+				Devices: []*api.RequestedDevice{{
+					Name:  "nvidia/gpu/1080ti",
+					Count: pointer.Of(uint64(1)),
+				}},
+				Storage: &api.QuotaStorageResources{
+					VariablesMB:   1000,
+					HostVolumesMB: 102_400,
+				},
+			},
+		}},
+	}, spec)
 }

--- a/command/quota_init.go
+++ b/command/quota_init.go
@@ -127,7 +127,8 @@ limit {
       count = 1
     }
     storage {
-      variables = 1000
+      variables    = 1000   # in MB
+      host_volumes = 100000 # in MB
     }
   }
 }
@@ -151,9 +152,10 @@ var defaultJsonQuotaSpec = strings.TrimSpace(`
             "Count": 1
           }
         ],
-       "Storage": {
-       "Variables": 1000
-}
+        "Storage": {
+          "Variables": 1000,
+          "HostVolumes": 100000
+        }
       }
     }
   ]

--- a/nomad/state/state_store_host_volumes.go
+++ b/nomad/state/state_store_host_volumes.go
@@ -66,12 +66,18 @@ func (s *StateStore) UpsertHostVolume(index uint64, vol *structs.HostVolume) err
 	if err != nil {
 		return err
 	}
+	var old *structs.HostVolume
 	if obj != nil {
-		old := obj.(*structs.HostVolume)
+		old = obj.(*structs.HostVolume)
 		vol.CreateIndex = old.CreateIndex
 		vol.CreateTime = old.CreateTime
 	} else {
 		vol.CreateIndex = index
+	}
+
+	err = s.enforceHostVolumeQuotaTxn(txn, index, vol, old, true)
+	if err != nil {
+		return err
 	}
 
 	// If the fingerprint is written from the node before the create RPC handler

--- a/nomad/state/state_store_host_volumes_ce.go
+++ b/nomad/state/state_store_host_volumes_ce.go
@@ -1,0 +1,16 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+
+package state
+
+import "github.com/hashicorp/nomad/nomad/structs"
+
+func (s *StateStore) EnforceHostVolumeQuota(_ *structs.HostVolume, _ *structs.HostVolume) error {
+	return nil
+}
+
+func (s *StateStore) enforceHostVolumeQuotaTxn(_ Txn, _ uint64, _ *structs.HostVolume, _ *structs.HostVolume, _ bool) error {
+	return nil
+}


### PR DESCRIPTION
Allow users to configure a host volumes quota in MB. This will be enforced at the time of provisioning via create/register RPCs. This changeset is the CE version of ENT/2114. I'll have a separate PR for docs.

Ref: https://github.com/hashicorp/nomad-enterprise/pull/2114
Ref: https://hashicorp.atlassian.net/browse/NET-11549