### PR TITLE
E2E: refactor volume_mounts test

### DIFF
--- a/e2e/volume_mounts/input/volumes.nomad
+++ b/e2e/volume_mounts/input/volumes.nomad
@@ -2,11 +2,14 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 job "volumes" {
-  datacenters = ["dc1", "dc2"]
 
   constraint {
     attribute = "${attr.kernel.name}"
     value     = "linux"
+  }
+
+  update {
+    min_healthy_time = "5s"
   }
 
   group "group" {


### PR DESCRIPTION
The volume_mounts test is flaky due to slow starts from the exec-driver and some incorrect wait code. Refactor the volume_mounts test to use the `e2e/v3` package helpers, and use these to give it enough time to start the exec tasks.

---

Run against a 3-node E2E cluster:

```
$ go test -v -count=1 ./e2e/volume_mounts
=== RUN   TestVolumeMounts
    jobs3.go:321: register (service) job: "volumes-247"
    jobs3.go:369: checking eval: fb0f3879-8ea9-9763-e3a0-2d0975d727fe, status: pending
    jobs3.go:369: checking eval: fb0f3879-8ea9-9763-e3a0-2d0975d727fe, status: complete
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: running
    jobs3.go:429: checking deployment: 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10, status: successful
    jobs3.go:445: deployment 1941ddd5-18c5-6a0e-85da-2b9a8b6c5d10 was a success
    allocexec3.go:48: alloc exec [cat /tmp/foo/645a5da3-8e68-7998-67da-7a9a3f2da54b] in group/docker_task, id: 645a5da3-8e68-7998-67da-7a9a3f2da54b
    allocexec3.go:61: alloc exec exit code: 0 in: 645a5da3-8e68-7998-67da-7a9a3f2da54b
    allocexec3.go:48: alloc exec [cat /tmp/foo/645a5da3-8e68-7998-67da-7a9a3f2da54b] in group/exec_task, id: 645a5da3-8e68-7998-67da-7a9a3f2da54b
    allocexec3.go:61: alloc exec exit code: 0 in: 645a5da3-8e68-7998-67da-7a9a3f2da54b
    jobs3.go:218: deregister job "volumes-247"
    jobs3.go:226: system gc
    jobs3.go:321: register (service) job: "volumes-688"
    jobs3.go:369: checking eval: 3a4e0998-4187-1ae2-e8cb-ebc08107c613, status: pending
    jobs3.go:369: checking eval: 3a4e0998-4187-1ae2-e8cb-ebc08107c613, status: complete
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: running
    jobs3.go:429: checking deployment: 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77, status: successful
    jobs3.go:445: deployment 0402d3e2-e466-6fd2-5b51-3e8ea5ae4f77 was a success
    allocexec3.go:48: alloc exec [cat /tmp/foo/dce364c3-00ec-395b-5757-af5d37102f02] in group/docker_task, id: dce364c3-00ec-395b-5757-af5d37102f02
    allocexec3.go:61: alloc exec exit code: 0 in: dce364c3-00ec-395b-5757-af5d37102f02
    allocexec3.go:48: alloc exec [cat /tmp/foo/645a5da3-8e68-7998-67da-7a9a3f2da54b] in group/docker_task, id: dce364c3-00ec-395b-5757-af5d37102f02
    allocexec3.go:61: alloc exec exit code: 0 in: dce364c3-00ec-395b-5757-af5d37102f02
    allocexec3.go:48: alloc exec [cat /tmp/foo/dce364c3-00ec-395b-5757-af5d37102f02] in group/exec_task, id: dce364c3-00ec-395b-5757-af5d37102f02
    allocexec3.go:61: alloc exec exit code: 0 in: dce364c3-00ec-395b-5757-af5d37102f02
    allocexec3.go:48: alloc exec [cat /tmp/foo/645a5da3-8e68-7998-67da-7a9a3f2da54b] in group/exec_task, id: dce364c3-00ec-395b-5757-af5d37102f02
    allocexec3.go:61: alloc exec exit code: 0 in: dce364c3-00ec-395b-5757-af5d37102f02
    jobs3.go:218: deregister job "volumes-688"
    jobs3.go:226: system gc
--- PASS: TestVolumeMounts (43.26s)
PASS
ok      github.com/hashicorp/nomad/e2e/volume_mounts    43.277s
```

