### PR TITLE
docs: clarify workload-associated policy parameters

### DIFF
--- a/website/content/api-docs/acl/policies.mdx
+++ b/website/content/api-docs/acl/policies.mdx
@@ -82,20 +82,19 @@ The table below shows this endpoint's support for
 
 - `Rules` `(string: <required>)` - Specifies the Policy rules in HCL or JSON format.
 
-- `JobACL` `(JobACL: <optional>)` - Associates the policy with a given
-  namespace, job, group, or task. Refer to [Workload Associated ACL
+- `JobACL` `(JobACL: <optional>)` - Associates the policy with a given job,
+  group, or task. Refer to [Workload Associated ACL
   Policies][concepts_workload_identity_acl] for more information.
 
-  - `Namespace` `(string: <optional>)` - The namespace to attach the policy.
-    Required if `JobID` is set.
+  - `Namespace` `(string: <optional>)` - Attach the policy to the job in this
+    namespace.  Required if `JobID` is set.
 
-  - `JobID` `(string: <optional>)` - The job to attach to the policy. Required
-    if `Group` is set.
+  - `JobID` `(string)` - Attach the policy to this job. Required to use `JobACL`.
 
-  - `Group` `(string: <optional>)` - The group to attach to the policy.
-    Required if `Task` is set.
+  - `Group` `(string: <optional>)` - Attach the policy to this group within the
+    job.  Required if `Task` is set.
 
-  - `Task` `(string: <optional>)` - The task to attach to the policy.
+  - `Task` `(string: <optional>)` - Attach the policy to this task within the job.
 
 ### Sample Payload
 

--- a/website/content/docs/commands/acl/policy/apply.mdx
+++ b/website/content/docs/commands/acl/policy/apply.mdx
@@ -29,7 +29,7 @@ This command requires a management ACL token.
 - `-description`: Sets the human readable description for the ACL policy.
 
 - `-job`: Attaches the policy to the specified job. Requires that `-namespace` is
-    also set.
+    also set. Refer to [Workload Associated ACL Policies][] for more details.
 
 - `-namespace`: Attaches the policy to the specified namespace. Requires that
     `-job` is also set.
@@ -58,3 +58,5 @@ $ nomad acl policy apply \
     my-policy my-policy.json
 Successfully wrote 'my-policy' ACL policy!
 ```
+
+[Workload Associated ACL Policies]: /nomad/docs/concepts/workload-identity#workload-associated-acl-policies


### PR DESCRIPTION
Workload-associated ACL policies can only be set on a specific job within a namespace, not the namespace as a whole. Clarify the documentation for the CLI and API.

Fixes: https://github.com/hashicorp/terraform-provider-nomad/issues/500
Ref: https://github.com/hashicorp/terraform-provider-nomad/pull/504
Ref: https://hashicorp.atlassian.net/browse/NET-11994