### PR TITLE
agent: Ensure logger set up method is public.

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -549,8 +549,11 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 	return true
 }
 
-// setupLoggers is used to set up the logGate and our logOutput.
-func setupLoggers(ui cli.Ui, config *Config) (*gatedwriter.Writer, io.Writer) {
+// SetupLoggers is used to set up the logGate and our logOutput.
+//
+// The function needs to be public due to the way it is used within the Nomad
+// Enterprise codebase.
+func SetupLoggers(ui cli.Ui, config *Config) (*gatedwriter.Writer, io.Writer) {
 
 	// Pull the log level from the configuration, ensure it is titled and then
 	// perform validation. Do this before the gated writer, as this can
@@ -801,7 +804,7 @@ func (c *Command) Run(args []string) int {
 	}
 
 	// Set up the log outputs.
-	logGate, logOutput := setupLoggers(c.Ui, config)
+	logGate, logOutput := SetupLoggers(c.Ui, config)
 	if logGate == nil {
 		return 1
 	}

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -639,7 +639,7 @@ func Test_setupLoggers_logFile(t *testing.T) {
 	}
 
 	// Generate the loggers and ensure the correct error is generated.
-	gatedWriter, writer := setupLoggers(mockUI, cfg)
+	gatedWriter, writer := SetupLoggers(mockUI, cfg)
 	must.Nil(t, gatedWriter)
 	must.Nil(t, writer)
 	must.StrContains(t, mockUI.ErrorWriter.String(), "Invalid log level: WARNING")
@@ -650,7 +650,7 @@ func Test_setupLoggers_logFile(t *testing.T) {
 	// Update the log level, so that it is a valid option and set up the
 	// loggers again.
 	cfg.LogLevel = "warn"
-	gatedWriter, writer = setupLoggers(mockUI, cfg)
+	gatedWriter, writer = SetupLoggers(mockUI, cfg)
 	must.NotNil(t, gatedWriter)
 	must.NotNil(t, writer)
 


### PR DESCRIPTION
This is needed by a Nomad Enterprise code path.

Initially changed within: https://github.com/hashicorp/nomad/pull/24873

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
