### PR TITLE
auth: adds option to enable verbose logging during sso

### DIFF
--- a/.changelog/24892.txt
+++ b/.changelog/24892.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+auth: adds VerboseLogging option for debugging when creating auth-method
+```

--- a/.changelog/24892.txt
+++ b/.changelog/24892.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-auth: adds VerboseLogging option for debugging when creating auth-method
+auth: adds VerboseLogging option to auth-method config for debugging SSO
 ```

--- a/.changelog/24892.txt
+++ b/.changelog/24892.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-auth: adds VerboseLogging option to auth-method config for debugging SSO
+auth: adds `VerboseLogging` option to auth-method config for debugging SSO
 ```

--- a/api/acl.go
+++ b/api/acl.go
@@ -857,6 +857,9 @@ type ACLAuthMethodConfig struct {
 	// (value).
 	ClaimMappings     map[string]string
 	ListClaimMappings map[string]string
+	// Enables logging of claims and binding-rule evaluations when
+	// debug level logging is enabled.
+	VerboseLogging bool
 }
 
 // MarshalJSON implements the json.Marshaler interface and allows

--- a/lib/auth/binder_test.go
+++ b/lib/auth/binder_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shoenig/test/must"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -115,7 +116,8 @@ func TestBinder_Bind(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := testBind.Bind(tt.authMethod, tt.identity)
+			l := hclog.NewNullLogger()
+			got, err := testBind.Bind(l, tt.authMethod, tt.identity)
 			if tt.wantErr {
 				must.Error(t, err)
 			} else {

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -5,6 +5,7 @@ package nomad
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -52,6 +53,10 @@ const (
 	// aclLoginRequestExpiryTime is the deadline used when performing HTTP
 	// requests to external APIs during the validation of bearer tokens.
 	aclLoginRequestExpiryTime = 60 * time.Second
+
+	// verboseLoggingMessage is the message displayed to a user when
+	// this auth config is enabled
+	verboseLoggingMessage = "attempting login with verbose logging enabled"
 )
 
 // ACL endpoint is used for manipulating ACL tokens and policies
@@ -2691,6 +2696,14 @@ func (a *ACL) OIDCCompleteAuth(
 		return structs.NewErrRPCCodedf(http.StatusBadRequest, "auth-method %q not found", args.AuthMethodName)
 	}
 
+	// vlog is a verbose logger used for debugging OIDC in test environments
+	vlog := hclog.NewNullLogger()
+	if authMethod.Config.VerboseLogging {
+		vlog = a.logger
+	}
+
+	vlog.Debug(verboseLoggingMessage)
+
 	// If the authentication method generates global ACL tokens, we need to
 	// forward the request onto the authoritative regional leader.
 	if authMethod.TokenLocalityIsGlobal() {
@@ -2761,6 +2774,30 @@ func (a *ACL) OIDCCompleteAuth(
 		return err
 	}
 
+	// No need to do all this marshaling if VerboseLogging is disabled
+	if authMethod.Config.VerboseLogging {
+		idTokenClaimBytes, err := json.MarshalIndent(idTokenClaims, "", " ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal ID token claims")
+		}
+
+		userClaimBytes, err := json.MarshalIndent(userClaims, "", " ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal user claims")
+		}
+
+		internalClaimBytes, err := json.MarshalIndent(oidcInternalClaims.List, "", " ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal OIDC internal claims list")
+		}
+
+		vlog.Debug("Claims",
+			"Token Claims", string(idTokenClaimBytes),
+			"User Claims", string(userClaimBytes),
+			"Claims after mapping to Nomad identity attributes", string(internalClaimBytes),
+		)
+	}
+
 	// Create a new binder object based on the current state snapshot to
 	// provide consistency within the RPC handler.
 	oidcBinder := auth.NewBinder(stateSnapshot)
@@ -2768,7 +2805,7 @@ func (a *ACL) OIDCCompleteAuth(
 	// Generate the role and policy bindings that will be assigned to the ACL
 	// token. Ensure we have at least 1 role or policy, otherwise the RPC will
 	// fail anyway.
-	tokenBindings, err := oidcBinder.Bind(authMethod, auth.NewIdentity(authMethod.Config, oidcInternalClaims))
+	tokenBindings, err := oidcBinder.Bind(vlog, authMethod, auth.NewIdentity(authMethod.Config, oidcInternalClaims))
 	if err != nil {
 		return err
 	}
@@ -2910,6 +2947,14 @@ func (a *ACL) Login(args *structs.ACLLoginRequest, reply *structs.ACLLoginRespon
 		)
 	}
 
+	// vlog is a verbose logger used for debugging in test environments
+	vlog := hclog.NewNullLogger()
+	if authMethod.Config.VerboseLogging {
+		vlog = a.logger
+	}
+
+	vlog.Debug(verboseLoggingMessage)
+
 	// Create a new binder object based on the current state snapshot to
 	// provide consistency within the RPC handler.
 	jwtBinder := auth.NewBinder(stateSnapshot)
@@ -2921,7 +2966,25 @@ func (a *ACL) Login(args *structs.ACLLoginRequest, reply *structs.ACLLoginRespon
 		return err
 	}
 
-	tokenBindings, err := jwtBinder.Bind(authMethod, auth.NewIdentity(authMethod.Config, jwtClaims))
+	// No need to do marshaling if VerboseLogging is not enabled
+	if authMethod.Config.VerboseLogging {
+		idTokenClaimBytes, err := json.MarshalIndent(claims, "", " ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal token claims")
+		}
+
+		internalClaimBytes, err := json.MarshalIndent(jwtClaims.List, "", " ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal claims list")
+		}
+
+		vlog.Debug("Claims",
+			"Token Claims", string(idTokenClaimBytes),
+			"Claims after mapping to Nomad identity attributes", string(internalClaimBytes),
+		)
+	}
+
+	tokenBindings, err := jwtBinder.Bind(vlog, authMethod, auth.NewIdentity(authMethod.Config, jwtClaims))
 	if err != nil {
 		return err
 	}

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -2778,24 +2778,23 @@ func (a *ACL) OIDCCompleteAuth(
 	if authMethod.Config.VerboseLogging {
 		idTokenClaimBytes, err := json.MarshalIndent(idTokenClaims, "", " ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal ID token claims")
+			vlog.Debug("failed to marshal ID token claims")
 		}
 
 		userClaimBytes, err := json.MarshalIndent(userClaims, "", " ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal user claims")
+			vlog.Debug("failed to marshal user claims")
 		}
+		vlog.Debug("claims from jwt token and user info endpoint",
+			"token_claims", string(idTokenClaimBytes),
+			"user_claims", string(userClaimBytes),
+		)
 
 		internalClaimBytes, err := json.MarshalIndent(oidcInternalClaims.List, "", " ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal OIDC internal claims list")
+			vlog.Debug("failed to marshal OIDC internal claims list")
 		}
-
-		vlog.Debug("Claims",
-			"Token Claims", string(idTokenClaimBytes),
-			"User Claims", string(userClaimBytes),
-			"Claims after mapping to Nomad identity attributes", string(internalClaimBytes),
-		)
+		vlog.Debug("claims after mapping to nomad identity attributes", "internal_claims", string(internalClaimBytes))
 	}
 
 	// Create a new binder object based on the current state snapshot to
@@ -2970,18 +2969,15 @@ func (a *ACL) Login(args *structs.ACLLoginRequest, reply *structs.ACLLoginRespon
 	if authMethod.Config.VerboseLogging {
 		idTokenClaimBytes, err := json.MarshalIndent(claims, "", " ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal token claims")
+			vlog.Debug("failed to marshal token claims")
 		}
+		vlog.Debug("jwt token claims", "token_claims", string(idTokenClaimBytes))
 
 		internalClaimBytes, err := json.MarshalIndent(jwtClaims.List, "", " ")
 		if err != nil {
-			return fmt.Errorf("failed to marshal claims list")
+			vlog.Debug("failed to marshal claims list")
 		}
-
-		vlog.Debug("Claims",
-			"Token Claims", string(idTokenClaimBytes),
-			"Claims after mapping to Nomad identity attributes", string(internalClaimBytes),
-		)
+		vlog.Debug("claims after mapping to nomad identity attributes", "internal_claims", string(internalClaimBytes))
 	}
 
 	tokenBindings, err := jwtBinder.Bind(vlog, authMethod, auth.NewIdentity(authMethod.Config, jwtClaims))

--- a/nomad/mock/acl.go
+++ b/nomad/mock/acl.go
@@ -283,6 +283,7 @@ func ACLOIDCAuthMethod() *structs.ACLAuthMethod {
 			SigningAlgs:         []string{"RS256"},
 			ClaimMappings:       map[string]string{"foo": "bar"},
 			ListClaimMappings:   map[string]string{"foo": "bar"},
+			VerboseLogging:      false,
 		},
 		CreateTime:  time.Now().UTC(),
 		CreateIndex: 10,

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -795,6 +795,7 @@ func (a *ACLAuthMethod) SetHash() []byte {
 		_, _ = hash.Write([]byte(a.Config.OIDCClientID))
 		_, _ = hash.Write([]byte(a.Config.OIDCClientSecret))
 		_, _ = hash.Write([]byte(strconv.FormatBool(a.Config.OIDCDisableUserInfo)))
+		_, _ = hash.Write([]byte(strconv.FormatBool(a.Config.VerboseLogging)))
 		_, _ = hash.Write([]byte(a.Config.ExpirationLeeway.String()))
 		_, _ = hash.Write([]byte(a.Config.NotBeforeLeeway.String()))
 		_, _ = hash.Write([]byte(a.Config.ClockSkewLeeway.String()))
@@ -1043,6 +1044,10 @@ type ACLAuthMethodConfig struct {
 	// (value).
 	ClaimMappings     map[string]string
 	ListClaimMappings map[string]string
+
+	// Enables logging of claims and binding-rule evaluations when
+	// debug level logging is enabled.
+	VerboseLogging bool
 }
 
 func (a *ACLAuthMethodConfig) Copy() *ACLAuthMethodConfig {

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -116,6 +116,10 @@ The table below shows this endpoint's support for
     copied to a metadata field (value). Use this if the claim you are capturing is
     list-like (such as groups).
 
+  - `VerboseLogging` `(bool: false)` - When set to `true`, Nomad will log token claims
+    and information related to binding-rule and role/policy evaluations. Not recommended
+    in production since sensitive information may be present.
+
 ### Sample payload
 
 ```json


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Adds the ability to enable a verbose logger when configuring an auth-method.  This logger will output token claims and information related to how claims are mapped to Nomad identities, and how those identities map to Nomad binding-rules and role/policies.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
Create an auth-method and enable the `VerboseLogging` option.  Then start the process of configuring SSO and see the logs.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes [GH #16360](https://github.com/hashicorp/nomad/issues/16360)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
