### PR TITLE
scheduler: prevent nil pointer ref when reschedule policy is missing

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -11474,8 +11474,8 @@ func (a *Allocation) NextRescheduleTime() (time.Time, bool) {
 	failTime := a.LastEventTime()
 	reschedulePolicy := a.ReschedulePolicy()
 
-	//If reschedule is disabled, return early
-	if reschedulePolicy.Attempts == 0 && !reschedulePolicy.Unlimited {
+	// If reschedule is disabled, return early
+	if reschedulePolicy == nil || (reschedulePolicy.Attempts == 0 && !reschedulePolicy.Unlimited) {
 		return time.Time{}, false
 	}
 


### PR DESCRIPTION
When upgrading from older versions of Nomad, the reschedule policy block may be nil. There is logic to handle this safely in the `NextRescheduleTimeByTime` used for allocs on disconnected clients, but it's missing from the `NextRescheduleTime` method used by more typical allocations. Return an empty time object in this case.

Fixes: https://github.com/hashicorp/nomad/issues/24846