### PR TITLE
stateful deployments: remove CSIVolumeIDs

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -279,7 +279,6 @@ type Allocation struct {
 	TaskResources         map[string]*Resources
 	AllocatedResources    *AllocatedResources
 	HostVolumeIDs         []string
-	CSIVolumeIDs          []string
 	Services              map[string]string
 	Metrics               *AllocationMetric
 	DesiredStatus         string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -11118,9 +11118,6 @@ type Allocation struct {
 	// has claimed.
 	HostVolumeIDs []string
 
-	// CSIVolumeIDs is a list of CSI volume IDs that this allocation has claimed.
-	CSIVolumeIDs []string
-
 	// Metrics associated with this allocation
 	Metrics *AllocMetric
 


### PR DESCRIPTION
These aren't needed afterall. 