### PR TITLE
client: always initialize node.HostVolumes map

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1568,16 +1568,12 @@ func (c *Client) setupNode() error {
 	}
 	node.CgroupParent = newConfig.CgroupParent
 	if node.HostVolumes == nil {
-		if l := len(newConfig.HostVolumes); l != 0 {
-			node.HostVolumes = make(map[string]*structs.ClientHostVolumeConfig, l)
-			for k, v := range newConfig.HostVolumes {
-				if _, err := os.Stat(v.Path); err != nil {
-					return fmt.Errorf("failed to validate volume %s, err: %v", v.Name, err)
-				}
-				node.HostVolumes[k] = v.Copy()
+		node.HostVolumes = make(map[string]*structs.ClientHostVolumeConfig, len(newConfig.HostVolumes))
+		for k, v := range newConfig.HostVolumes {
+			if _, err := os.Stat(v.Path); err != nil {
+				return fmt.Errorf("failed to validate volume %s, err: %w", v.Name, err)
 			}
-		} else {
-			node.HostVolumes = make(map[string]*structs.ClientHostVolumeConfig, 0)
+			node.HostVolumes[k] = v.Copy()
 		}
 	}
 	if node.HostNetworks == nil {

--- a/client/client.go
+++ b/client/client.go
@@ -1576,6 +1576,8 @@ func (c *Client) setupNode() error {
 				}
 				node.HostVolumes[k] = v.Copy()
 			}
+		} else {
+			node.HostVolumes = make(map[string]*structs.ClientHostVolumeConfig, 0)
 		}
 	}
 	if node.HostNetworks == nil {

--- a/client/hostvolumemanager/volume_fingerprint.go
+++ b/client/hostvolumemanager/volume_fingerprint.go
@@ -40,6 +40,9 @@ func UpdateVolumeMap(log hclog.Logger, volumes VolumeMap, name string, vol *stru
 			log.Warn("overriding static host volume with dynamic", "name", name, "id", vol.ID)
 		}
 		if !exists || !vol.Equal(current) {
+			if volumes == nil {
+				volumes = VolumeMap{}
+			}
 			volumes[name] = vol
 			changed = true
 		}

--- a/client/hostvolumemanager/volume_fingerprint.go
+++ b/client/hostvolumemanager/volume_fingerprint.go
@@ -40,9 +40,6 @@ func UpdateVolumeMap(log hclog.Logger, volumes VolumeMap, name string, vol *stru
 			log.Warn("overriding static host volume with dynamic", "name", name, "id", vol.ID)
 		}
 		if !exists || !vol.Equal(current) {
-			if volumes == nil {
-				volumes = VolumeMap{}
-			}
 			volumes[name] = vol
 			changed = true
 		}


### PR DESCRIPTION
The default `node` configuration in the client should always set an empty `HostVolumes` map. Otherwise callers can panic, e.g.,:

```
goroutine 179 [running]:
github.com/hashicorp/nomad/client/hostvolumemanager.UpdateVolumeMap({0x36042b0, 0xc000c62a80}, 0x0, {0xc000a802a0, 0xd}, 0xc000691940)
	github.com/hashicorp/nomad/client/hostvolumemanager/volume_fingerprint.go:43 +0x1b2
github.com/hashicorp/nomad/client.(*Client).batchFirstFingerprints.func1({0xc000a802a0, 0xd}, 0xc000691940)
	github.com/hashicorp/nomad/client/node_updater.go:54 +0xd7
github.com/hashicorp/nomad/client.(*batchNodeUpdates).batchHostVolumeUpdates(0xc000912608?, 0xc0009f2f88)
	github.com/hashicorp/nomad/client/node_updater.go:417 +0x152
github.com/hashicorp/nomad/client.(*Client).batchFirstFingerprints(0xc000c2d188)
	github.com/hashicorp/nomad/client/node_updater.go:53 +0x1c5
created by github.com/hashicorp/nomad/client.NewClient in goroutine 1
	github.com/hashicorp/nomad/client/client.go:557 +0x2069
```
is a panic of the HVM when restarting a client that _doesn't_ have any static host volumes, but _does_ have a dynamic host volume. 