### PR TITLE
volume spec: fix `access_mode` field in examples

### DIFF
--- a/command/asset/volume.csi.hcl
+++ b/command/asset/volume.csi.hcl
@@ -28,7 +28,7 @@ capability {
 }
 
 capability {
-  access_mode     = "single-node-reader"
+  access_mode     = "single-node-reader-only"
   attachment_mode = "block-device"
 }
 

--- a/command/asset/volume.csi.json
+++ b/command/asset/volume.csi.json
@@ -14,7 +14,7 @@
       "attachment_mode": "file-system"
     },
     {
-      "access_mode": "single-node-reader",
+      "access_mode": "single-node-reader-only",
       "attachment_mode": "block-device"
     }
   ],

--- a/command/asset/volume.host.hcl
+++ b/command/asset/volume.host.hcl
@@ -19,7 +19,7 @@ capability {
 }
 
 capability {
-  access_mode     = "single-node-reader"
+  access_mode     = "single-node-reader-only"
   attachment_mode = "block-device"
 }
 

--- a/command/asset/volume.host.json
+++ b/command/asset/volume.host.json
@@ -12,7 +12,7 @@
       "attachment_mode": "file-system"
     },
     {
-      "access_mode": "single-node-reader",
+      "access_mode": "single-node-reader-only",
       "attachment_mode": "block-device"
     }
   ],


### PR DESCRIPTION
The `volume init` command creates example volume specifications. But one of the values for `capability.access_mode` is not a valid value. Correct the example to match the validation logic.
