### PR TITLE
reporting: Update server to accommodate new enterprise reporting.

### DIFF
--- a/nomad/reporting/reporting_ce.go
+++ b/nomad/reporting/reporting_ce.go
@@ -5,5 +5,4 @@
 
 package reporting
 
-type Manager struct {
-}
+type Manager struct{}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -36,7 +36,6 @@ import (
 	"github.com/hashicorp/nomad/helper/codec"
 	"github.com/hashicorp/nomad/helper/goruntime"
 	"github.com/hashicorp/nomad/helper/group"
-	"github.com/hashicorp/nomad/helper/iterator"
 	"github.com/hashicorp/nomad/helper/pool"
 	"github.com/hashicorp/nomad/helper/tlsutil"
 	"github.com/hashicorp/nomad/lib/auth/oidc"
@@ -2186,20 +2185,6 @@ func (s *Server) ClusterMetadata() (structs.ClusterMetadata, error) {
 
 func (s *Server) isSingleServerCluster() bool {
 	return s.config.BootstrapExpect == 1
-}
-
-func (s *Server) GetClientNodesCount() (int, error) {
-	stateSnapshot, err := s.State().Snapshot()
-	if err != nil {
-		return 0, err
-	}
-
-	iter, err := stateSnapshot.Nodes(nil)
-	if err != nil {
-		return 0, err
-	}
-
-	return iterator.Len(iter), nil
 }
 
 // peersInfoContent is used to help operators understand what happened to the


### PR DESCRIPTION
Nomad Enterprise will utilise new reporting metrics and the changes here allow this work to be conducted.

The server specific GetClientNodesCount function has been removed from CE as this is only called within enterprise code. A new heartbeater function allows us to get the number of active timers, which can be used by the heartbeater metrics and any other callers that want this data.

### PR Process Notes
This has been originally reviewed within the enterprise codebase.

In order to juggle the CE and Enterprise specific code portions, I plan on backporting this change to CE only and then performing manual merging into Enterprise along with the specific changes needed there.

Once the merging juggling has been complete, I will raise a followup documentation and changelog PR.

### Links
Jira: https://hashicorp.atlassian.net/browse/NET-9340

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
