### PR TITLE
Fix the docker image parser to account for private repos

### DIFF
--- a/drivers/docker/coordinator.go
+++ b/drivers/docker/coordinator.go
@@ -189,9 +189,9 @@ func (d *dockerCoordinator) pullImageImpl(imageID string, authOptions *registry.
 	pullTimeout, pullActivityTimeout time.Duration) (string, string, error) {
 	defer d.clearPullLogger(imageID)
 	// Parse the repo and tag
-	repo, tag := parseDockerImage(imageID)
-	if repo == "" {
-		return "", "", errors.New("no image name or path found")
+	repo, tag, err := parseDockerImage(imageID)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to pull docker image: %w", err)
 	}
 
 	pullCtx, cancel := context.WithTimeout(d.ctx, pullTimeout)

--- a/drivers/docker/coordinator.go
+++ b/drivers/docker/coordinator.go
@@ -190,10 +190,11 @@ func (d *dockerCoordinator) pullImageImpl(imageID string, authOptions *registry.
 	defer d.clearPullLogger(imageID)
 	// Parse the repo and tag
 	repo, tag := parseDockerImage(imageID)
+	if repo == "" {
+		return "", "", errors.New("no image name or path found")
+	}
 
 	pullCtx, cancel := context.WithTimeout(d.ctx, pullTimeout)
-	defer cancel()
-
 	pm := newImageProgressManager(imageID, cancel, pullActivityTimeout, d.handlePullInactivity,
 		d.handlePullProgressReport, d.handleSlowPullProgressReport)
 	defer pm.stop()

--- a/drivers/docker/coordinator.go
+++ b/drivers/docker/coordinator.go
@@ -191,7 +191,7 @@ func (d *dockerCoordinator) pullImageImpl(imageID string, authOptions *registry.
 	// Parse the repo and tag
 	repo, tag, err := parseDockerImage(imageID)
 	if err != nil {
-		return "", "", fmt.Errorf("unable to pull docker image: %w", err)
+		return "", "", fmt.Errorf("unable to pull docker image %q: %w", imageID, err)
 	}
 
 	pullCtx, cancel := context.WithTimeout(d.ctx, pullTimeout)

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -613,6 +613,9 @@ START:
 func (d *Driver) createImage(task *drivers.TaskConfig, driverConfig *TaskConfig, client *client.Client) (string, string, error) {
 	image := driverConfig.Image
 	repo, tag := parseDockerImage(image)
+	if repo == "" {
+		return "", "", errors.New("no image name or path found")
+	}
 
 	// We're going to check whether the image is already downloaded. If the tag
 	// is "latest", or ForcePull is set, we have to check for a new version every time so we don't

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -612,9 +612,9 @@ START:
 // loading it from the file system
 func (d *Driver) createImage(task *drivers.TaskConfig, driverConfig *TaskConfig, client *client.Client) (string, string, error) {
 	image := driverConfig.Image
-	repo, tag := parseDockerImage(image)
-	if repo == "" {
-		return "", "", errors.New("no image name or path found")
+	repo, tag, err := parseDockerImage(image)
+	if err != nil {
+		return "", "", fmt.Errorf("unable to create local docker image: %w", err)
 	}
 
 	// We're going to check whether the image is already downloaded. If the tag

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -614,7 +614,7 @@ func (d *Driver) createImage(task *drivers.TaskConfig, driverConfig *TaskConfig,
 	image := driverConfig.Image
 	repo, tag, err := parseDockerImage(image)
 	if err != nil {
-		return "", "", fmt.Errorf("unable to create local docker image: %w", err)
+		return "", "", fmt.Errorf("unable to create local docker image %q: %w", image, err)
 	}
 
 	// We're going to check whether the image is already downloaded. If the tag

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -2852,30 +2852,6 @@ func TestDockerDriver_AdvertiseIPv6Address(t *testing.T) {
 	}
 }
 
-func TestParseDockerImage(t *testing.T) {
-	ci.Parallel(t)
-
-	tests := []struct {
-		Image string
-		Repo  string
-		Tag   string
-	}{
-		{"host:5000/library/hello-world", "host:5000/library/hello-world", "latest"},
-		{"host:5000/library/hello-world:1.0", "host:5000/library/hello-world", "1.0"},
-		{"library/hello-world:1.0", "library/hello-world", "1.0"},
-		{"library/hello-world", "library/hello-world", "latest"},
-		{"library/hello-world:latest", "library/hello-world", "latest"},
-		{"library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", "library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", ""},
-	}
-	for _, test := range tests {
-		t.Run(test.Image, func(t *testing.T) {
-			repo, tag := parseDockerImage(test.Image)
-			must.Eq(t, test.Repo, repo)
-			must.Eq(t, test.Tag, tag)
-		})
-	}
-}
-
 func TestDockerImageRef(t *testing.T) {
 	ci.Parallel(t)
 	tests := []struct {

--- a/drivers/docker/network.go
+++ b/drivers/docker/network.go
@@ -186,7 +186,7 @@ func (d *Driver) createSandboxContainerConfig(allocID string, createSpec *driver
 func (d *Driver) pullInfraImage(allocID string) error {
 	repo, tag, err := parseDockerImage(d.config.InfraImage)
 	if err != nil {
-		return fmt.Errorf("unable to pull infra docker image: %w", err)
+		return fmt.Errorf("unable to pull infra docker image %q: %w", d.config.InfraImage, err)
 	}
 
 	dockerClient, err := d.getDockerClient()

--- a/drivers/docker/network.go
+++ b/drivers/docker/network.go
@@ -4,6 +4,7 @@
 package docker
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
@@ -185,6 +186,9 @@ func (d *Driver) createSandboxContainerConfig(allocID string, createSpec *driver
 // only if its name uses the "latest" tag or the image doesn't already exist locally.
 func (d *Driver) pullInfraImage(allocID string) error {
 	repo, tag := parseDockerImage(d.config.InfraImage)
+	if repo == "" {
+		return errors.New("no repo found on image name")
+	}
 
 	dockerClient, err := d.getDockerClient()
 	if err != nil {

--- a/drivers/docker/network.go
+++ b/drivers/docker/network.go
@@ -4,7 +4,6 @@
 package docker
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/docker/docker/api/types"
@@ -185,9 +184,9 @@ func (d *Driver) createSandboxContainerConfig(allocID string, createSpec *driver
 // pullInfraImage conditionally pulls the `infra_image` from the Docker registry
 // only if its name uses the "latest" tag or the image doesn't already exist locally.
 func (d *Driver) pullInfraImage(allocID string) error {
-	repo, tag := parseDockerImage(d.config.InfraImage)
-	if repo == "" {
-		return errors.New("no repo found on image name")
+	repo, tag, err := parseDockerImage(d.config.InfraImage)
+	if err != nil {
+		return fmt.Errorf("unable to pull infra docker image: %w", err)
 	}
 
 	dockerClient, err := d.getDockerClient()

--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	NoPathInImageErr = errors.New("no repo found on imageID")
+	NoPathInImageErr = errors.New("does not match registry specification")
 )
 
 func parseDockerImage(image string) (string, string, error) {

--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -6,6 +6,7 @@ package docker
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -21,14 +22,18 @@ import (
 	"github.com/docker/docker/registry"
 )
 
-func parseDockerImage(image string) (repo, tag string) {
+var (
+	NoPathInImageErr = errors.New("no repo found on imageID")
+)
+
+func parseDockerImage(image string) (string, string, error) {
 	matches := reference.ReferenceRegexp.FindStringSubmatch(image)
 	if matches == nil {
-		return "", ""
+		return "", "", NoPathInImageErr
 	}
 
-	repo = matches[1]
-	tag = matches[2]
+	repo := matches[1]
+	tag := matches[2]
 	digest := matches[3]
 
 	if digest == "" {
@@ -42,7 +47,7 @@ func parseDockerImage(image string) (repo, tag string) {
 		tag = ""
 	}
 
-	return repo, tag
+	return repo, tag, nil
 }
 
 func dockerImageRef(repo string, tag string) string {

--- a/drivers/docker/utils_test.go
+++ b/drivers/docker/utils_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/require"
 )
 
@@ -79,6 +80,33 @@ func TestParseVolumeSpec_Linux(t *testing.T) {
 		t.Run("invalid:"+c, func(t *testing.T) {
 			hp, cp, m, err := parseVolumeSpec(c, "linux")
 			require.Errorf(t, err, "expected error but parsed as %s:%s:%s", hp, cp, m)
+		})
+	}
+}
+
+func TestParseDockerImage(t *testing.T) {
+	ci.Parallel(t)
+
+	tests := []struct {
+		Image string
+		Repo  string
+		Tag   string
+	}{
+		{"host:5000/library/hello-world", "host:5000/library/hello-world", "latest"},
+		{"host:5000/library/hello-world:1.0", "host:5000/library/hello-world", "1.0"},
+		{"library/hello-world:1.0", "library/hello-world", "1.0"},
+		{"library/hello-world", "library/hello-world", "latest"},
+		{"library/hello-world:latest", "library/hello-world", "latest"},
+		{"library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", "library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", ""},
+		{"my-registry:9090/hello-world@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", "my-registry:9090/hello-world@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", ""},
+		{"my-registry:9090/hello-world:my-tag@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", "my-registry:9090/hello-world@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", ""},
+	}
+	for _, test := range tests {
+		t.Run(test.Image, func(t *testing.T) {
+			repo, tag := parseDockerImage(test.Image)
+			print("repo", repo)
+			must.Eq(t, test.Repo, repo)
+			must.Eq(t, test.Tag, tag)
 		})
 	}
 }

--- a/drivers/docker/utils_test.go
+++ b/drivers/docker/utils_test.go
@@ -88,25 +88,29 @@ func TestParseDockerImage(t *testing.T) {
 	ci.Parallel(t)
 
 	tests := []struct {
-		Image string
-		Repo  string
-		Tag   string
+		Image  string
+		Repo   string
+		Tag    string
+		ExpErr error
 	}{
-		{"host:5000/library/hello-world", "host:5000/library/hello-world", "latest"},
-		{"host:5000/library/hello-world:1.0", "host:5000/library/hello-world", "1.0"},
-		{"library/hello-world:1.0", "library/hello-world", "1.0"},
-		{"library/hello-world", "library/hello-world", "latest"},
-		{"library/hello-world:latest", "library/hello-world", "latest"},
-		{"library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", "library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", ""},
-		{"my-registry:9090/hello-world@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", "my-registry:9090/hello-world@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", ""},
-		{"my-registry:9090/hello-world:my-tag@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", "my-registry:9090/hello-world@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", ""},
+		{"host:5000/library/hello-world", "host:5000/library/hello-world", "latest", nil},
+		{"host:5000/library/hello-world:1.0", "host:5000/library/hello-world", "1.0", nil},
+		{"library/hello-world:1.0", "library/hello-world", "1.0", nil},
+		{"library/hello-world", "library/hello-world", "latest", nil},
+		{"library/hello-world:latest", "library/hello-world", "latest", nil},
+		{"library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", "library/hello-world@sha256:f5233545e43561214ca4891fd1157e1c3c563316ed8e237750d59bde73361e77", "", nil},
+		{"my-registry:9090/hello-world@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", "my-registry:9090/hello-world@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", "", nil},
+		{"my-registry:9090/hello-world:my-tag@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", "my-registry:9090/hello-world@sha256:c7e3309ebb8805855bc1ccc24d24588748710e43925b39e563bd5541cbcbad91", "", nil},
+		{"wrong-docker-image:", "", "", NoPathInImageErr},
+		{"", "", "", NoPathInImageErr},
 	}
 	for _, test := range tests {
 		t.Run(test.Image, func(t *testing.T) {
-			repo, tag := parseDockerImage(test.Image)
+			repo, tag, err := parseDockerImage(test.Image)
 			print("repo", repo)
 			must.Eq(t, test.Repo, repo)
 			must.Eq(t, test.Tag, tag)
+			must.Eq(t, test.ExpErr, err)
 		})
 	}
 }


### PR DESCRIPTION
### Description
This PR addresses this[ issue](https://github.com/hashicorp/nomad/issues/24913).

There was a little bug in the `parseDockerImage` where we were using `/`  the determine the tag and if none was found, it would add latest, completely ignoring the cases where there is a sha present.

This PR refactors the logic to avoid adding the `latest` tag if a sha is provided. 

The extra change corresponds to moving the tests to the `utils_test.go` for clarity.

### Testing & Reproduction steps
<!--
Run a job with an image that includes a sha and see how nomad adds the `latest` tag to the call.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
