### PR TITLE
remove addresses from node class hash

### DIFF
--- a/.changelog/24942.txt
+++ b/.changelog/24942.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+scheduler: Fixed a bug where node class hashes included unique attributes, making scheduling more costly
+```
+
+```release-note:breaking-change
+node: The node attribute `consul.addr.dns` has been changed to `unique.consul.addr.dns`. The node attribute `nomad.advertise.address` has been changed to `unique.advertise.address`.
+```

--- a/client/allocrunner/networking_cni.go
+++ b/client/allocrunner/networking_cni.go
@@ -413,10 +413,10 @@ func (c *cniNetworkConfigurator) setupTransparentProxyArgs(alloc *structs.Alloca
 func (c *cniNetworkConfigurator) dnsFromAttrs(cluster string) (string, int) {
 	var dnsAddrAttr, dnsPortAttr string
 	if cluster == structs.ConsulDefaultCluster || cluster == "" {
-		dnsAddrAttr = "consul.dns.addr"
+		dnsAddrAttr = "unique.consul.dns.addr"
 		dnsPortAttr = "consul.dns.port"
 	} else {
-		dnsAddrAttr = "consul." + cluster + ".dns.addr"
+		dnsAddrAttr = "unique.consul." + cluster + ".dns.addr"
 		dnsPortAttr = "consul." + cluster + ".dns.port"
 	}
 

--- a/client/allocrunner/networking_cni_test.go
+++ b/client/allocrunner/networking_cni_test.go
@@ -257,8 +257,8 @@ func TestSetup(t *testing.T) {
 	}
 
 	nodeAddrs := map[string]string{
-		"consul.dns.addr": "192.168.1.117",
-		"consul.dns.port": "8600",
+		"unique.consul.dns.addr": "192.168.1.117",
+		"consul.dns.port":        "8600",
 	}
 	nodeMeta := map[string]string{
 		"connect.transparent_proxy.default_outbound_port": "15001",
@@ -554,8 +554,8 @@ func TestCNI_setupTproxyArgs(t *testing.T) {
 	}
 
 	nodeAttrs := map[string]string{
-		"consul.dns.addr": "192.168.1.117",
-		"consul.dns.port": "8600",
+		"unique.consul.dns.addr": "192.168.1.117",
+		"consul.dns.port":        "8600",
 	}
 
 	alloc := mock.ConnectAlloc()
@@ -716,8 +716,8 @@ func TestCNI_setupTproxyArgs(t *testing.T) {
 		{
 			name: "tproxy with consul dns disabled",
 			nodeAttrs: map[string]string{
-				"consul.dns.port": "-1",
-				"consul.dns.addr": "192.168.1.117",
+				"consul.dns.port":        "-1",
+				"unique.consul.dns.addr": "192.168.1.117",
 			},
 			tproxySpec: &structs.ConsulTransparentProxy{},
 			expectIPConfig: &iptables.Config{
@@ -732,10 +732,10 @@ func TestCNI_setupTproxyArgs(t *testing.T) {
 			name:    "tproxy for other cluster with default consul dns disabled",
 			cluster: "infra",
 			nodeAttrs: map[string]string{
-				"consul.dns.port":       "-1",
-				"consul.dns.addr":       "192.168.1.110",
-				"consul.infra.dns.port": "8600",
-				"consul.infra.dns.addr": "192.168.1.117",
+				"consul.dns.port":              "-1",
+				"unique.consul.dns.addr":       "192.168.1.110",
+				"consul.infra.dns.port":        "8600",
+				"unique.consul.infra.dns.addr": "192.168.1.117",
 			},
 			tproxySpec: &structs.ConsulTransparentProxy{},
 			expectIPConfig: &iptables.Config{

--- a/client/fingerprint/consul.go
+++ b/client/fingerprint/consul.go
@@ -186,34 +186,34 @@ func (cfs *consulState) initialize(cfg *config.ConsulConfig, logger hclog.Logger
 
 	if cfg.Name == structs.ConsulDefaultCluster {
 		cfs.readers = map[string]valueReader{
-			"consul.server":        cfs.server,
-			"consul.version":       cfs.version,
-			"consul.sku":           cfs.sku,
-			"consul.revision":      cfs.revision,
-			"unique.consul.name":   cfs.name, // note: won't have this for non-default clusters
-			"consul.datacenter":    cfs.dc,
-			"consul.segment":       cfs.segment,
-			"consul.connect":       cfs.connect,
-			"consul.grpc":          cfs.grpc(consulConfig.Scheme, logger),
-			"consul.ft.namespaces": cfs.namespaces,
-			"consul.partition":     cfs.partition,
-			"consul.dns.port":      cfs.dnsPort,
-			"consul.dns.addr":      cfs.dnsAddr(logger),
+			"consul.server":          cfs.server,
+			"consul.version":         cfs.version,
+			"consul.sku":             cfs.sku,
+			"consul.revision":        cfs.revision,
+			"unique.consul.name":     cfs.name, // note: won't have this for non-default clusters
+			"consul.datacenter":      cfs.dc,
+			"consul.segment":         cfs.segment,
+			"consul.connect":         cfs.connect,
+			"consul.grpc":            cfs.grpc(consulConfig.Scheme, logger),
+			"consul.ft.namespaces":   cfs.namespaces,
+			"consul.partition":       cfs.partition,
+			"consul.dns.port":        cfs.dnsPort,
+			"unique.consul.dns.addr": cfs.dnsAddr(logger),
 		}
 	} else {
 		cfs.readers = map[string]valueReader{
-			fmt.Sprintf("consul.%s.server", cfg.Name):        cfs.server,
-			fmt.Sprintf("consul.%s.version", cfg.Name):       cfs.version,
-			fmt.Sprintf("consul.%s.sku", cfg.Name):           cfs.sku,
-			fmt.Sprintf("consul.%s.revision", cfg.Name):      cfs.revision,
-			fmt.Sprintf("consul.%s.datacenter", cfg.Name):    cfs.dc,
-			fmt.Sprintf("consul.%s.segment", cfg.Name):       cfs.segment,
-			fmt.Sprintf("consul.%s.connect", cfg.Name):       cfs.connect,
-			fmt.Sprintf("consul.%s.grpc", cfg.Name):          cfs.grpc(consulConfig.Scheme, logger),
-			fmt.Sprintf("consul.%s.ft.namespaces", cfg.Name): cfs.namespaces,
-			fmt.Sprintf("consul.%s.partition", cfg.Name):     cfs.partition,
-			fmt.Sprintf("consul.%s.dns.port", cfg.Name):      cfs.dnsPort,
-			fmt.Sprintf("consul.%s.dns.addr", cfg.Name):      cfs.dnsAddr(logger),
+			fmt.Sprintf("consul.%s.server", cfg.Name):          cfs.server,
+			fmt.Sprintf("consul.%s.version", cfg.Name):         cfs.version,
+			fmt.Sprintf("consul.%s.sku", cfg.Name):             cfs.sku,
+			fmt.Sprintf("consul.%s.revision", cfg.Name):        cfs.revision,
+			fmt.Sprintf("consul.%s.datacenter", cfg.Name):      cfs.dc,
+			fmt.Sprintf("consul.%s.segment", cfg.Name):         cfs.segment,
+			fmt.Sprintf("consul.%s.connect", cfg.Name):         cfs.connect,
+			fmt.Sprintf("consul.%s.grpc", cfg.Name):            cfs.grpc(consulConfig.Scheme, logger),
+			fmt.Sprintf("consul.%s.ft.namespaces", cfg.Name):   cfs.namespaces,
+			fmt.Sprintf("consul.%s.partition", cfg.Name):       cfs.partition,
+			fmt.Sprintf("consul.%s.dns.port", cfg.Name):        cfs.dnsPort,
+			fmt.Sprintf("unique.consul.%s.dns.addr", cfg.Name): cfs.dnsAddr(logger),
 		}
 	}
 

--- a/client/fingerprint/consul_test.go
+++ b/client/fingerprint/consul_test.go
@@ -696,19 +696,19 @@ func TestConsulFingerprint_Fingerprint_ent(t *testing.T) {
 	err := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp)
 	must.NoError(t, err)
 	must.Eq(t, map[string]string{
-		"consul.datacenter":    "dc1",
-		"consul.revision":      "22ce6c6ad",
-		"consul.segment":       "seg1",
-		"consul.server":        "true",
-		"consul.sku":           "ent",
-		"consul.version":       "1.9.5+ent",
-		"consul.ft.namespaces": "true",
-		"consul.connect":       "true",
-		"consul.grpc":          "8502",
-		"consul.dns.addr":      "192.168.1.117",
-		"consul.dns.port":      "8600",
-		"consul.partition":     "default",
-		"unique.consul.name":   "HAL9000",
+		"consul.datacenter":      "dc1",
+		"consul.revision":        "22ce6c6ad",
+		"consul.segment":         "seg1",
+		"consul.server":          "true",
+		"consul.sku":             "ent",
+		"consul.version":         "1.9.5+ent",
+		"consul.ft.namespaces":   "true",
+		"consul.connect":         "true",
+		"consul.grpc":            "8502",
+		"unique.consul.dns.addr": "192.168.1.117",
+		"consul.dns.port":        "8600",
+		"consul.partition":       "default",
+		"unique.consul.name":     "HAL9000",
 	}, resp.Attributes)
 	must.True(t, resp.Detected)
 
@@ -752,19 +752,19 @@ func TestConsulFingerprint_Fingerprint_ent(t *testing.T) {
 	err4 := cf.Fingerprint(&FingerprintRequest{Config: cfg, Node: node}, &resp4)
 	must.NoError(t, err4)
 	must.Eq(t, map[string]string{
-		"consul.datacenter":    "dc1",
-		"consul.revision":      "22ce6c6ad",
-		"consul.segment":       "seg1",
-		"consul.server":        "true",
-		"consul.sku":           "ent",
-		"consul.version":       "1.9.5+ent",
-		"consul.ft.namespaces": "true",
-		"consul.connect":       "true",
-		"consul.grpc":          "8502",
-		"consul.dns.addr":      "192.168.1.117",
-		"consul.dns.port":      "8600",
-		"consul.partition":     "default",
-		"unique.consul.name":   "HAL9000",
+		"consul.datacenter":      "dc1",
+		"consul.revision":        "22ce6c6ad",
+		"consul.segment":         "seg1",
+		"consul.server":          "true",
+		"consul.sku":             "ent",
+		"consul.version":         "1.9.5+ent",
+		"consul.ft.namespaces":   "true",
+		"consul.connect":         "true",
+		"consul.grpc":            "8502",
+		"unique.consul.dns.addr": "192.168.1.117",
+		"consul.dns.port":        "8600",
+		"consul.partition":       "default",
+		"unique.consul.name":     "HAL9000",
 	}, resp4.Attributes)
 
 	// consul now available again

--- a/client/fingerprint/nomad.go
+++ b/client/fingerprint/nomad.go
@@ -22,7 +22,7 @@ func NewNomadFingerprint(logger log.Logger) Fingerprint {
 }
 
 func (f *NomadFingerprint) Fingerprint(req *FingerprintRequest, resp *FingerprintResponse) error {
-	resp.AddAttribute("nomad.advertise.address", req.Node.HTTPAddr)
+	resp.AddAttribute("unique.advertise.address", req.Node.HTTPAddr)
 	resp.AddAttribute("nomad.version", req.Config.Version.VersionNumber())
 	resp.AddAttribute("nomad.revision", req.Config.Version.Revision)
 	resp.AddAttribute("nomad.service_discovery", strconv.FormatBool(req.Config.NomadServiceDiscovery))

--- a/client/fingerprint/nomad_test.go
+++ b/client/fingerprint/nomad_test.go
@@ -57,7 +57,7 @@ func TestNomadFingerprint(t *testing.T) {
 		t.Fatalf("incorrect revision")
 	}
 
-	if response.Attributes["nomad.advertise.address"] != h {
+	if response.Attributes["unique.advertise.address"] != h {
 		t.Fatalf("incorrect advertise address")
 	}
 

--- a/nomad/structs/node_class.go
+++ b/nomad/structs/node_class.go
@@ -123,6 +123,8 @@ func EscapedConstraints(constraints []*Constraint) []*Constraint {
 // computed node class optimization.
 func constraintTargetEscapes(target string) bool {
 	switch {
+	case strings.HasPrefix(target, "${unique."):
+		return true
 	case strings.HasPrefix(target, "${node.unique."):
 		return true
 	case strings.HasPrefix(target, "${attr.unique."):

--- a/nomad/structs/node_class_test.go
+++ b/nomad/structs/node_class_test.go
@@ -4,7 +4,6 @@
 package structs
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
@@ -276,8 +275,7 @@ func TestNode_EscapedConstraints(t *testing.T) {
 		Operand: "!=",
 	}
 	constraints := []*Constraint{ne1, ne2, ne3, e1, e2, e3}
-	expected := []*Constraint{ne1, ne2, ne3}
-	if act := EscapedConstraints(constraints); reflect.DeepEqual(act, expected) {
-		t.Fatalf("EscapedConstraints(%v) returned %v; want %v", constraints, act, expected)
-	}
+	expected := []*Constraint{e1, e2, e3}
+	must.Eq(t, expected, EscapedConstraints(constraints),
+		must.Sprintf("expected unique fields to escape constraints"))
 }

--- a/scheduler/testing.go
+++ b/scheduler/testing.go
@@ -65,6 +65,9 @@ type Harness struct {
 
 	optimizePlan              bool
 	serversMeetMinimumVersion bool
+
+	// don't actually write plans back to state
+	noSubmit bool
 }
 
 // NewHarness is used to make a new testing harness
@@ -177,6 +180,10 @@ func (h *Harness) SubmitPlan(plan *structs.Plan) (*structs.PlanResult, State, er
 		}
 
 		req.NodePreemptions = preemptedAllocs
+	}
+
+	if h.noSubmit {
+		return result, nil, nil
 	}
 
 	// Apply the full plan
@@ -302,4 +309,8 @@ func (h *Harness) AssertEvalStatus(t testing.TB, state string) {
 	require.Len(t, h.Evals, 1)
 	update := h.Evals[0]
 	require.Equal(t, state, update.Status)
+}
+
+func (h *Harness) SetNoSubmit() {
+	h.noSubmit = true
 }


### PR DESCRIPTION
When a node is fingerprinted, we calculate a "computed class" from a hash over a subset of its fields and attributes. In the scheduler, when a given node fails feasibility checking (before fit checking) we know that no other node of that same class will be feasible, and we add the hash to a map so we can reject them early. This hash cannot include any values that are unique to a given node, otherwise no other node will have the same hash and we'll never save ourselves the work of feasibility checking those nodes.

In #4390 we introduce the `nomad.advertise.address` attribute and in #19969 we introduced `consul.dns.addr` attribute. Both of these are unique per node and break the hash.

Additionally, we were not correctly filtering attributes out when checking if a node escaped the class by not filtering for attributes that start with `unique.`. The test for this introduced in #708 had an inverted assertion, which allowed this to pass unnoticed since the early days of Nomad.

Ref: https://github.com/hashicorp/nomad/pull/708
Ref: https://github.com/hashicorp/nomad/pull/4390
Ref: https://github.com/hashicorp/nomad/pull/19969

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
