### PR TITLE
[e2e, ui] Update playwright to 1.50.0 for e2e ui tests

### DIFF
--- a/e2e/ui/package-lock.json
+++ b/e2e/ui/package-lock.json
@@ -1,21 +1,20 @@
 {
-  "name": "src",
+  "name": "ui",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "devDependencies": {
-        "@playwright/test": "^1.48.0"
+        "@playwright/test": "^1.50.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
-      "integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
+      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.48.0"
+        "playwright": "1.50.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -30,7 +29,6 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -40,13 +38,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
-      "integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
+      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.48.0"
+        "playwright-core": "1.50.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -59,11 +56,10 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
-      "integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
+      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -74,12 +70,12 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
-      "integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
+      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
       "dev": true,
       "requires": {
-        "playwright": "1.48.0"
+        "playwright": "1.50.0"
       }
     },
     "fsevents": {
@@ -90,19 +86,19 @@
       "optional": true
     },
     "playwright": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
-      "integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
+      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.48.0"
+        "playwright-core": "1.50.0"
       }
     },
     "playwright-core": {
-      "version": "1.48.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
-      "integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
+      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
       "dev": true
     }
   }

--- a/e2e/ui/package.json
+++ b/e2e/ui/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "@playwright/test": "^1.48.0"
+    "@playwright/test": "^1.50.0"
   }
 }

--- a/e2e/ui/run.sh
+++ b/e2e/ui/run.sh
@@ -33,7 +33,7 @@ EOF
 }
 
 
-IMAGE="mcr.microsoft.com/playwright:v1.49.0-jammy"
+IMAGE="mcr.microsoft.com/playwright:v1.50.0-jammy"
 pushd $(dirname "${BASH_SOURCE[0]}") > /dev/null
 
 run_tests() {


### PR DESCRIPTION
Spiritual successor to https://github.com/hashicorp/nomad/pull/24158


```
Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1155/chrome-linux/headless_shell
╔══════════════════════════════════════════════════════════════════════╗
║ Looks like Playwright Test or Playwright was just updated to 1.50.0. ║
║ Please update docker image as well.                                  ║
║ -  current: mcr.microsoft.com/playwright:v1.49.0-jammy               ║
║ - required: mcr.microsoft.com/playwright:v1.50.0-jammy               ║
║                                                                      ║
║ <3 Playwright Team                                                   ║
╚══════════════════════════════════════════════════════════════════════╝
```