### PR TITLE
[cli] Adds Actions to job status command output

### DIFF
--- a/.changelog/24959.txt
+++ b/.changelog/24959.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added actions available to a job when running nomad job status command
+```

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -406,11 +406,15 @@ func (c *JobStatusCommand) outputJobInfo(client *api.Client, job *api.Job) error
 		return fmt.Errorf("Error querying latest job deployment: %s", err)
 	}
 
-	jobActions := make([]string, 0)
+	jobActions := make([]map[string]string, 0)
 	for _, tg := range job.TaskGroups {
 		for _, task := range tg.Tasks {
 			for _, action := range task.Actions {
-				jobActions = append(jobActions, fmt.Sprintf("%s|%s|%s", *tg.Name, task.Name, action.Name))
+				jobActions = append(jobActions, map[string]string{
+					"group":  *tg.Name,
+					"task":   task.Name,
+					"action": action.Name,
+				})
 			}
 		}
 	}
@@ -507,7 +511,7 @@ func (c *JobStatusCommand) formatDeployment(client *api.Client, d *api.Deploymen
 	return base
 }
 
-func formatJobActions(actions []string) string {
+func formatJobActions(actions []map[string]string) string {
 	if len(actions) == 0 {
 		return "No actions configured"
 	}
@@ -516,11 +520,10 @@ func formatJobActions(actions []string) string {
 	actionsOut[0] = "Action Name|Task Group|Task"
 
 	for i, action := range actions {
-		parts := strings.Split(action, "|")
-		if len(parts) != 3 {
+		group, task, actionName := action["group"], action["task"], action["action"]
+		if group == "" || task == "" || actionName == "" {
 			continue
 		}
-		group, task, actionName := parts[0], parts[1], parts[2]
 
 		actionsOut[i+1] = fmt.Sprintf("%s|%s|%s",
 			actionName,

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -406,6 +406,15 @@ func (c *JobStatusCommand) outputJobInfo(client *api.Client, job *api.Job) error
 		return fmt.Errorf("Error querying latest job deployment: %s", err)
 	}
 
+	jobActions := make([]string, 0)
+	for _, tg := range job.TaskGroups {
+		for _, task := range tg.Tasks {
+			for _, action := range task.Actions {
+				jobActions = append(jobActions, fmt.Sprintf("%s|%s|%s", *tg.Name, task.Name, action.Name))
+			}
+		}
+	}
+
 	// Output the summary
 	if err := c.outputJobSummary(client, job); err != nil {
 		return err
@@ -459,6 +468,11 @@ func (c *JobStatusCommand) outputJobInfo(client *api.Client, job *api.Job) error
 		c.Ui.Output(c.Colorize().Color(c.formatDeployment(client, latestDeployment)))
 	}
 
+	if len(jobActions) > 0 {
+		c.Ui.Output(c.Colorize().Color("\n[bold]Actions[reset]"))
+		c.Ui.Output(formatJobActions(jobActions))
+	}
+
 	// Format the allocs
 	c.Ui.Output(c.Colorize().Color("\n[bold]Allocations[reset]"))
 	c.Ui.Output(formatAllocListStubs(jobAllocs, c.verbose, c.length))
@@ -491,6 +505,30 @@ func (c *JobStatusCommand) formatDeployment(client *api.Client, d *api.Deploymen
 	base += "\n\n[bold]Deployed[reset]\n"
 	base += formatDeploymentGroups(d, c.length)
 	return base
+}
+
+func formatJobActions(actions []string) string {
+	if len(actions) == 0 {
+		return "No actions configured"
+	}
+
+	actionsOut := make([]string, len(actions)+1)
+	actionsOut[0] = "Action Name|Task Group|Task"
+
+	for i, action := range actions {
+		parts := strings.Split(action, "|")
+		if len(parts) != 3 {
+			continue
+		}
+		group, task, actionName := parts[0], parts[1], parts[2]
+
+		actionsOut[i+1] = fmt.Sprintf("%s|%s|%s",
+			actionName,
+			group,
+			task)
+	}
+
+	return formatList(actionsOut)
 }
 
 func formatAllocListStubs(stubs []*api.AllocationListStub, verbose bool, uuidLength int) string {

--- a/website/content/docs/commands/job/status.mdx
+++ b/website/content/docs/commands/job/status.mdx
@@ -21,7 +21,7 @@ the specific job is queried and displayed. Otherwise, a list of matching jobs
 and information will be displayed.
 
 If the ID is omitted, the command lists out all of the existing jobs and a few
-of the most useful status fields for each. Alloc status also shows allocation 
+of the most useful status fields for each. Alloc status also shows allocation
 modification time in addition to create time. When the `-verbose` flag is not set,
 allocation creation and modify times are shown in a shortened relative time format
 like `5m ago`.
@@ -104,6 +104,10 @@ Description = Deployment completed successfully
 Deployed
 Task Group  Desired  Placed  Healthy  Unhealthy
 cache       1        1       1        0
+
+Actions
+Action Name     Task Group  Task
+my-action       cache       my-task
 
 Allocations
 ID        Node ID   Task Group  Version  Desired  Status   Created   Modified

--- a/website/content/docs/commands/status.mdx
+++ b/website/content/docs/commands/status.mdx
@@ -58,6 +58,8 @@ cache       1        1       0        0
 Allocations
 ID        Node ID   Task Group  Version  Desired  Status   Created At
 e1d14a39  f9dabe93  cache       0        run      running  08/28/17 23:01:39 UTC
+
+TODO: actions here.
 ```
 
 Display the status of an allocation:

--- a/website/content/docs/commands/status.mdx
+++ b/website/content/docs/commands/status.mdx
@@ -55,11 +55,13 @@ Deployed
 Task Group  Desired  Placed  Healthy  Unhealthy
 cache       1        1       0        0
 
+Actions
+Action Name     Task Group  Task
+my-action       cache       my-task
+
 Allocations
 ID        Node ID   Task Group  Version  Desired  Status   Created At
 e1d14a39  f9dabe93  cache       0        run      running  08/28/17 23:01:39 UTC
-
-TODO: actions here.
 ```
 
 Display the status of an allocation:


### PR DESCRIPTION
Provides a little table showing Nomad Actions available to a job when running `nomad job status $jobid`. Mimics what we show in the Web UI (where there's an Actions dropdown on the main page of jobs that have 'em)

```
nomad job status actions-demo-service
ID            = actions-demo-service
Name          = actions-demo-service
Submit Date   = 2025-01-23T16:13:22-05:00
Type          = service

Summary
Task Group  Queued  Starting  Running  Failed  Complete  Lost  Unknown
actionless  0       0         3        0       16        0     0
group1      0       0         1        0       7         0     0
group2      0       0         6        0       25        0     0

.....

Actions
Action Name     Task Group  Task
weather         group1      task
get-alloc-info  group1      task
echo-time       group1      task
get-alloc-info  group2      task
echo-time       group2      task

.....

Allocations
ID        Node ID   Task Group  Version  Desired  Status   Created    Modified
13ab36c1  c1b3d83b  actionless  6        run      running  3d20h ago  3d20h ago
5125fdda  c1b3d83b  group1      6        run      running  3d20h ago  3d20h ago
664ec7e8  c1b3d83b  group2      6        run      running  3d20h ago  3d20h ago
```