### PR TITLE
scheduler: preserve allocations enriched during placement as 'informational'

### DIFF
--- a/scheduler/reconcile_test.go
+++ b/scheduler/reconcile_test.go
@@ -388,6 +388,9 @@ func TestReconciler_Place_Existing(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		allocs = append(allocs, alloc)
 	}
 
@@ -429,6 +432,9 @@ func TestReconciler_ScaleDown_Partial(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		allocs = append(allocs, alloc)
 	}
 
@@ -471,6 +477,9 @@ func TestReconciler_ScaleDown_Zero(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		allocs = append(allocs, alloc)
 	}
 
@@ -514,6 +523,9 @@ func TestReconciler_ScaleDown_Zero_DuplicateNames(t *testing.T) {
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i%2))
 		allocs = append(allocs, alloc)
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		expectedStopped = append(expectedStopped, i%2)
 	}
 
@@ -552,6 +564,9 @@ func TestReconciler_Inplace(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		allocs = append(allocs, alloc)
 	}
 
@@ -593,6 +608,9 @@ func TestReconciler_Inplace_ScaleUp(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		allocs = append(allocs, alloc)
 	}
 
@@ -636,6 +654,9 @@ func TestReconciler_Inplace_ScaleDown(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		allocs = append(allocs, alloc)
 	}
 
@@ -686,6 +707,9 @@ func TestReconciler_Inplace_Rollback(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		allocs = append(allocs, alloc)
 	}
 	// allocs[0] is an allocation from version 0
@@ -746,6 +770,9 @@ func TestReconciler_Destructive(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		allocs = append(allocs, alloc)
 	}
 
@@ -782,6 +809,9 @@ func TestReconciler_DestructiveMaxParallel(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		allocs = append(allocs, alloc)
 	}
 
@@ -821,6 +851,9 @@ func TestReconciler_Destructive_ScaleUp(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		allocs = append(allocs, alloc)
 	}
 
@@ -863,6 +896,9 @@ func TestReconciler_Destructive_ScaleDown(t *testing.T) {
 		alloc.JobID = job.ID
 		alloc.NodeID = uuid.Generate()
 		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		// set host volume IDs on running allocations to make sure their presence doesn't
+		// interfere with reconciler behavior
+		alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 		allocs = append(allocs, alloc)
 	}
 
@@ -1017,6 +1053,10 @@ func TestReconciler_LostNode_PreventRescheduleOnLost(t *testing.T) {
 				alloc.NodeID = uuid.Generate()
 				alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
 				alloc.DesiredStatus = structs.AllocDesiredStatusRun
+
+				// set host volume IDs on running allocations to make sure their presence doesn't
+				// interfere with reconciler behavior
+				alloc.HostVolumeIDs = []string{"host-volume1", "host-volume2"}
 
 				// Set one of the allocations to failed
 				if i == 4 {


### PR DESCRIPTION
During [the work on stateful deployments](https://github.com/hashicorp/nomad/pull/24869) we discovered that if a job uses stateful deployments and gets deployed into a cluster with multiple volumes that have the same label, and we drain the node that job is running on, the scheduler would replace it on another node—ignoring the logic that requires a feasible node to have a particular volume ID. The reason for this behavior is the design of the reconciler: allocations that are being `migrated` (not `rescheduled`) are marked as `ignored` by the reconciler, and new allocations do not know about their `previousAllocations`, they have no "history." This has not been a problem until now, but stateful deployments "enrich" allocations with host volume IDs _during_ placement, the task group itself carries no information other than the volume label. 

This PR introduces a new category of allocations in the reconciler, we call them `informational.` These allocations are still ignored as it was before, but before landing in the `ignore` bucket they are retained for future reference. For now, only stateful deployments use these allocations, but future Nomad features (or indeed a refactoring of the reconciler...) could well use this new category. 

This PR fixes the issue discovered in https://github.com/hashicorp/nomad/pull/24869