### PR TITLE
e2e: Fix TF output SSH key path.

### DIFF
--- a/e2e/terraform/provision-infra/outputs.tf
+++ b/e2e/terraform/provision-infra/outputs.tf
@@ -26,16 +26,16 @@ Then you can run tests from the e2e directory with:
 ssh into servers with:
 
 %{for ip in aws_instance.server.*.public_ip~}
-   ssh -i keys/${local.random_name}/${local.random_name}.pem ubuntu@${ip}
+   ssh -i ${local.keys_dir}/${local.random_name}.pem ubuntu@${ip}
 %{endfor~}
 
 ssh into clients with:
 
 %{for ip in aws_instance.client_ubuntu_jammy.*.public_ip~}
-    ssh -i keys/${local.random_name}/${local.random_name}.pem ubuntu@${ip}
+    ssh -i ${local.keys_dir}/${local.random_name}.pem ubuntu@${ip}
 %{endfor~}
 %{for ip in aws_instance.client_windows_2016.*.public_ip~}
-    ssh -i keys/${local.random_name}/${local.random_name}.pem Administrator@${ip}
+    ssh -i ${local.keys_dir}/${local.random_name}.pem Administrator@${ip}
 %{endfor~}
 
 EOM


### PR DESCRIPTION
The pathing needed updating due to recent changes in the directory structure of the e2e Terraform.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
