### PR TITLE
ui: Remove unrequired node read from task log streaming page.

### DIFF
--- a/.changelog/24973.txt
+++ b/.changelog/24973.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Remove unrequired node read API call when attempting to stream task logs
+```

--- a/ui/app/components/task-log.js
+++ b/ui/app/components/task-log.js
@@ -25,7 +25,7 @@ class MockAbortController {
 export default class TaskLog extends Component {
   @service token;
   @service userSettings;
-
+  @service can;
   allocation = null;
   task = null;
 
@@ -50,11 +50,13 @@ export default class TaskLog extends Component {
 
   @computed('allocation.{id,node.httpAddr}', 'useServer')
   get logUrl() {
-    const address = this.get('allocation.node.httpAddr');
+    let address;
     const allocation = this.get('allocation.id');
-
+    if (this.can.can('read client')) {
+      address = this.get('allocation.node.httpAddr');
+    }
     const url = `/v1/client/fs/logs/${allocation}`;
-    return this.useServer ? url : `//${address}${url}`;
+    return this.useServer ? url : address ? `//${address}${url}` : url;
   }
 
   @computed('task', 'mode')

--- a/ui/app/routes/allocations/allocation/task/logs.js
+++ b/ui/app/routes/allocations/allocation/task/logs.js
@@ -7,7 +7,6 @@ import Route from '@ember/routing/route';
 
 export default class LogsRoute extends Route {
   model() {
-    const task = super.model(...arguments);
-    return task && task.get('allocation.node').then(() => task);
+    return super.model(...arguments);
   }
 }


### PR DESCRIPTION
### Description
The node read on the task logs page is not required and therefore should be callable by users which do not have node:read in their ACL token capabilities. The job allocation logs work without this currently, so this not only fixes the bug, but also creates better consistency across pages.

### Testing & Reproduction steps
Linked GitHub issue has good reproduction steps.

### Links
Jira: https://hashicorp.atlassian.net/browse/NET-11262
Closes: https://github.com/hashicorp/nomad/issues/23786

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
