### PR TITLE
state store: fix logic for evaluating job status

### DIFF
--- a/.changelog/24974.txt
+++ b/.changelog/24974.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-state store: fix for setting correct job status in various scenarios
+state store: fix for setting correct status for a job version when reverting, and also fixes an issue where jobs were briefly marked dead during restarts
 ```

--- a/.changelog/24974.txt
+++ b/.changelog/24974.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+state store: fix for setting correct job status in various scenarios
+```

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -1147,6 +1147,7 @@ func TestCoreScheduler_JobGC_OutstandingAllocs(t *testing.T) {
 	// Insert two allocs, one terminal and one not
 	alloc := mock.Alloc()
 	alloc.JobID = job.ID
+	alloc.Job = job
 	alloc.EvalID = eval.ID
 	alloc.DesiredStatus = structs.AllocDesiredStatusRun
 	alloc.ClientStatus = structs.AllocClientStatusComplete
@@ -1154,6 +1155,7 @@ func TestCoreScheduler_JobGC_OutstandingAllocs(t *testing.T) {
 
 	alloc2 := mock.Alloc()
 	alloc2.JobID = job.ID
+	alloc.Job = job
 	alloc2.EvalID = eval.ID
 	alloc2.DesiredStatus = structs.AllocDesiredStatusRun
 	alloc2.ClientStatus = structs.AllocClientStatusRunning

--- a/nomad/core_sched_test.go
+++ b/nomad/core_sched_test.go
@@ -1704,7 +1704,6 @@ func TestCoreScheduler_jobGC(t *testing.T) {
 		mockJob1Alloc1 := mock.Alloc()
 		mockJob1Alloc1.EvalID = mockEval1.ID
 		mockJob1Alloc1.JobID = inputJob.ID
-		mockJob1Alloc1.Job.Version = inputJob.Version
 		mockJob1Alloc1.ClientStatus = structs.AllocClientStatusRunning
 		mockJob1Alloc1.CreateTime = time.Now().Add(-6 * time.Hour).UnixNano()
 		mockJob1Alloc1.ModifyTime = time.Now().Add(-5 * time.Hour).UnixNano()
@@ -1712,7 +1711,6 @@ func TestCoreScheduler_jobGC(t *testing.T) {
 		mockJob1Alloc2 := mock.Alloc()
 		mockJob1Alloc2.EvalID = mockEval1.ID
 		mockJob1Alloc2.JobID = inputJob.ID
-		mockJob1Alloc2.Job.Version = inputJob.Version
 		mockJob1Alloc2.ClientStatus = structs.AllocClientStatusRunning
 		mockJob1Alloc2.CreateTime = time.Now().Add(-6 * time.Hour).UnixNano()
 		mockJob1Alloc2.ModifyTime = time.Now().Add(-5 * time.Hour).UnixNano()
@@ -1780,10 +1778,8 @@ func TestCoreScheduler_jobGC(t *testing.T) {
 		// Mark that the allocations have reached a terminal state.
 		mockJob1Alloc1.DesiredStatus = structs.AllocDesiredStatusStop
 		mockJob1Alloc1.ClientStatus = structs.AllocClientStatusComplete
-		mockJob1Alloc1.Job.Version = inputJob.Version
 		mockJob1Alloc2.DesiredStatus = structs.AllocDesiredStatusStop
 		mockJob1Alloc2.ClientStatus = structs.AllocClientStatusComplete
-		mockJob1Alloc2.Job.Version = inputJob.Version
 
 		must.NoError(t,
 			testServer.fsm.State().UpsertAllocs(structs.MsgTypeTestSetup, 30, []*structs.Allocation{

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -948,18 +948,19 @@ func (n *nomadFSM) applyAllocClientUpdate(msgType structs.MessageType, buf []byt
 		}
 	}
 
-	// Update all the client allocations
-	if err := n.state.UpdateAllocsFromClient(msgType, index, req.Alloc); err != nil {
-		n.logger.Error("UpdateAllocFromClient failed", "error", err)
-		return err
-	}
-
-	// Update any evals
+	// Update any evals first.  During a reschedule, we don't want to mark the job dead, which
+	// would happen if all the allocs were terminal and there wasn't a pending eval
 	if len(req.Evals) > 0 {
 		if err := n.upsertEvals(msgType, index, req.Evals); err != nil {
 			n.logger.Error("applyAllocClientUpdate failed to update evaluations", "error", err)
 			return err
 		}
+	}
+
+	// Update all the client allocations
+	if err := n.state.UpdateAllocsFromClient(msgType, index, req.Alloc); err != nil {
+		n.logger.Error("UpdateAllocFromClient failed", "error", err)
+		return err
 	}
 
 	// Unblock evals for the nodes computed node class if the client has

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -422,7 +422,7 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 		return nil
 	}
 
-	if eval != nil && !submittedEval {
+	if !submittedEval {
 		eval.JobModifyIndex = reply.JobModifyIndex
 		update := &structs.EvalUpdateRequest{
 			Evals:        []*structs.Evaluation{eval},

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -659,6 +659,10 @@ func (j *Job) Revert(args *structs.JobRevertRequest, reply *structs.JobRegisterR
 	// Clear out the VersionTag to prevent tag duplication
 	revJob.VersionTag = nil
 
+	// Set the stable flag to false as this is functionally a new registration
+	// and should handle deployment updates
+	revJob.Stable = false
+
 	reg := &structs.JobRegisterRequest{
 		Job:          revJob,
 		WriteRequest: args.WriteRequest,

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1800,7 +1800,6 @@ func (s *StateStore) upsertJobImpl(index uint64, sub *structs.JobSubmission, job
 		// Compute the job status
 		var err error
 		job.Status, err = s.getJobStatus(txn, job, false)
-		s.logger.Info("setting job status", "status", job.Status)
 		if err != nil {
 			return fmt.Errorf("setting job status for %q failed: %v", job.ID, err)
 		}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -4870,6 +4870,7 @@ func TestStateStore_UpsertEvals_Eval_ChildJob(t *testing.T) {
 	eval := mock.Eval()
 	eval.Status = structs.EvalStatusComplete
 	eval.JobID = child.ID
+	eval.JobModifyIndex = child.ModifyIndex
 
 	// Create watchsets so we can test that upsert fires the watch
 	ws := memdb.NewWatchSet()

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -5798,6 +5798,7 @@ func TestStateStore_UpdateAllocsFromClient(t *testing.T) {
 	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 998, nil, parent))
 
 	child := mock.Job()
+	child.Type = structs.JobTypeBatch
 	child.Status = ""
 	child.ParentID = parent.ID
 	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, child))
@@ -7796,13 +7797,15 @@ func TestStateStore_GetJobStatus(t *testing.T) {
 			exp: structs.JobStatusPending,
 		},
 		{
-			name: "job has all terminal allocs, with no evals",
+			name: "batch job has all terminal allocs, with no evals",
 			setup: func(txn *txn) (*structs.Job, error) {
 				j := mock.Job()
-				a := mock.Alloc()
+				j.Type = structs.JobTypeBatch
 
+				a := mock.Alloc()
 				a.ClientStatus = structs.AllocClientStatusFailed
 				a.JobID = j.ID
+				a.Job = j
 
 				if err := txn.Insert("allocs", a); err != nil {
 					return nil, err

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -7678,7 +7678,7 @@ func TestStateStore_SetJobStatus(t *testing.T) {
 	}
 }
 
-func TestStateStore_GetJobStatus_new(t *testing.T) {
+func TestStateStore_GetJobStatus(t *testing.T) {
 	ci.Parallel(t)
 
 	testCases := []struct {

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -7781,6 +7781,7 @@ func TestStateStore_GetJobStatus(t *testing.T) {
 
 				e := mock.Eval()
 				e.JobID = j.ID
+				e.JobModifyIndex = j.ModifyIndex
 				e.Status = structs.EvalStatusPending
 
 				if err := txn.Insert("allocs", a); err != nil {

--- a/nomad/system_endpoint_test.go
+++ b/nomad/system_endpoint_test.go
@@ -41,6 +41,7 @@ func TestSystemEndpoint_GarbageCollect(t *testing.T) {
 	eval := mock.Eval()
 	eval.Status = structs.EvalStatusComplete
 	eval.JobID = job.ID
+	eval.JobModifyIndex = job.ModifyIndex
 	// set modify time older than now but still newer than default GC threshold
 	eval.ModifyTime = time.Now().Add(-10 * time.Millisecond).UnixNano()
 	must.NoError(t, state.UpsertEvals(structs.MsgTypeTestSetup, 1001, []*structs.Evaluation{eval}))


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
The state store persists the correct job version for job summaries, but not for specific versions.  This fix attempts to simplify the logic around evaluating a job's status, and then make's sure it is persisted.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
See GH issue for replication steps

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes [GH #24957](https://github.com/hashicorp/nomad/issues/24957)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
