### PR TITLE
docs: Update CNI install detail to use 1.6.2

### DIFF
--- a/website/content/partials/install/install-cni-plugins.mdx
+++ b/website/content/partials/install/install-cni-plugins.mdx
@@ -4,14 +4,14 @@ that use network namespaces. Refer to the [CNI Plugins external
 guide](https://www.cni.dev/plugins/current/) for details on individual plugins.
 
 The following series of commands determines your operating system architecture,
-downloads the [CNI 1.6.1
-release](https://github.com/containernetworking/plugins/releases/tag/v1.6.1),
+downloads the [CNI 1.6.2
+release](https://github.com/containernetworking/plugins/releases/tag/v1.6.2),
 and then extracts the CNI plugin binaries into the `/opt/cni/bin` directory.
 Update the `CNI_PLUGIN_VERSION` value to use a different release version.
 
 ```shell-session
 $ export ARCH_CNI=$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64)
-$ export CNI_PLUGIN_VERSION=v1.6.1
+$ export CNI_PLUGIN_VERSION=v1.6.2
 $ curl -L -o cni-plugins.tgz "https://github.com/containernetworking/plugins/releases/download/${CNI_PLUGIN_VERSION}/cni-plugins-linux-${ARCH_CNI}-${CNI_PLUGIN_VERSION}".tgz && \
   sudo mkdir -p /opt/cni/bin && \
   sudo tar -C /opt/cni/bin -xzf cni-plugins.tgz


### PR DESCRIPTION
CNI had release problems which meant 1.6.1 got pulled and 1.6.2 is identical.

### Links
Closes #24975 

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
