### PR TITLE
docker: properly handle "error reading image pull progress"

### DIFF
--- a/.changelog/24981.txt
+++ b/.changelog/24981.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fixed a bug where "error reading image pull progress" caused the allocation to get stuck pending
+```

--- a/drivers/docker/coordinator.go
+++ b/drivers/docker/coordinator.go
@@ -216,6 +216,7 @@ func (d *dockerCoordinator) pullImageImpl(imageID string, authOptions *registry.
 		_, err = io.Copy(pm, reader)
 		if err != nil && !errors.Is(err, io.EOF) {
 			d.logger.Error("error reading image pull progress", "error", err)
+			future.set("", "", recoverablePullError(err, imageID))
 			return
 		}
 	}
@@ -420,5 +421,5 @@ func recoverablePullError(err error, image string) error {
 	if imageNotFoundMatcher.MatchString(err.Error()) {
 		recoverable = false
 	}
-	return structs.NewRecoverableError(fmt.Errorf("Failed to pull `%s`: %s", image, err), recoverable)
+	return structs.NewRecoverableError(fmt.Errorf("Failed to pull `%s`: %w", image, err), recoverable)
 }


### PR DESCRIPTION
### Description

With the `docker` driver, if an error is encountered while reading image pull progress, the allocation gets stuck `pending`.

This happens because `dockerCoordinator.PullImage()` gets deadlocked at `future.wait()`, because this one error path (introduced [here](https://github.com/hashicorp/nomad/commit/981ca3604965b6934a96559634887ee443106bfb#diff-a812e02f32452925890f1c3f229cc5ea705e7c1db1637b0295796236fbbc6affR218-R219) in v1.9.0) does not do a `future.set()` to close the channel that `future.wait()` blocks on.

Worse, the whole `TaskRunner.Run()` goroutine from the allocrunner remains stuck until the client is forcibly restarted (it can not shut down gracefully). This same bug could be introduced again in the future by mistake, but since the error path fixed in this PR is the only one (that I know of) that does it today, addressing the broader problem to protect against potential regression will be addressed in a separate PR (edit: this one: #24992).

### Testing & Reproduction steps

Reporter encountered this when there was an issue with their image repository. I reproduced it by changing the source to always hit the relevant error path, and without the fix commit, the new test deadlocks (this isn't great even for a test, but as I said, a problem for another PR).

### Links

Fixes #24955

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
