### PR TITLE
docker: respect image_pull_timeout

### DIFF
--- a/.changelog/24991.txt
+++ b/.changelog/24991.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fixed a bug that prevented image_pull_timeout from being applied
+```


### PR DESCRIPTION
I believe the `docker` driver stopped respecting [image_pull_timeout](https://developer.hashicorp.com/nomad/docs/drivers/docker#image_pull_timeout) in Nomad `1.9.0` in [this refactor](https://github.com/hashicorp/nomad/commit/981ca3604965b6934a96559634887ee443106bfb#diff-a812e02f32452925890f1c3f229cc5ea705e7c1db1637b0295796236fbbc6affL192).

This makes the timeout apply again.  There is some risk that folks are unwittingly depending on the timeout not working (it is a generous 5 minutes by default), but since it has only been this way since `1.9` (as far as I can tell), the exposure is somewhat limited.

The different `context`s around here are pretty confusing. I hope I got them right, and left informative enough var names and comments to help future folks keep them straight.

This PR extends #24981, which makes `recoverablePullError()` properly wrap the passed error (such as a context timeout).