### PR TITLE
dynamic host volumes: add `-id` arg for updates of existing volumes

### DIFF
--- a/command/volume_create.go
+++ b/command/volume_create.go
@@ -42,6 +42,10 @@ Create Options:
     command. If -detach is omitted or false, the command will monitor the state
     of the volume until it is ready to be scheduled.
 
+  -id
+    Update a volume previously created with this ID prefix. Used for dynamic
+    host volumes only.
+
   -verbose
     Display full information when monitoring volume state. Used for dynamic host
     volumes only.
@@ -60,6 +64,7 @@ func (c *VolumeCreateCommand) AutocompleteFlags() complete.Flags {
 			"-detach":          complete.PredictNothing,
 			"-verbose":         complete.PredictNothing,
 			"-policy-override": complete.PredictNothing,
+			"-id":              complete.PredictNothing,
 		})
 }
 
@@ -75,10 +80,12 @@ func (c *VolumeCreateCommand) Name() string { return "volume create" }
 
 func (c *VolumeCreateCommand) Run(args []string) int {
 	var detach, verbose, override bool
+	var volID string
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.BoolVar(&detach, "detach", false, "detach from monitor")
 	flags.BoolVar(&verbose, "verbose", false, "display full volume IDs")
 	flags.BoolVar(&override, "policy-override", false, "override soft mandatory Sentinel policies")
+	flags.StringVar(&volID, "id", "", "update an existing dynamic host volume")
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 
 	if err := flags.Parse(args); err != nil {
@@ -129,7 +136,7 @@ func (c *VolumeCreateCommand) Run(args []string) int {
 	case "csi":
 		return c.csiCreate(client, ast)
 	case "host":
-		return c.hostVolumeCreate(client, ast, detach, verbose, override)
+		return c.hostVolumeCreate(client, ast, detach, verbose, override, volID)
 	default:
 		c.Ui.Error(fmt.Sprintf("Error unknown volume type: %s", volType))
 		return 1

--- a/command/volume_create_host_test.go
+++ b/command/volume_create_host_test.go
@@ -80,6 +80,13 @@ parameters {
 	got, _, err := client.HostVolumes().Get(id, &api.QueryOptions{Namespace: "prod"})
 	must.NoError(t, err)
 	must.NotNil(t, got)
+
+	// Verify we can update the volume without changes
+	args = []string{"-address", url, "-detach", "-id", got.ID, file.Name()}
+	code = cmd.Run(args)
+	must.Eq(t, 0, code, must.Sprintf("got error: %s", ui.ErrorWriter.String()))
+	list, _, err := client.HostVolumes().List(nil, &api.QueryOptions{Namespace: "prod"})
+	must.Len(t, 1, list, must.Sprintf("new volume should not be created on update"))
 }
 
 func TestHostVolume_HCLDecode(t *testing.T) {

--- a/command/volume_register.go
+++ b/command/volume_register.go
@@ -38,6 +38,10 @@ General Options:
 
 Register Options:
 
+  -id
+    Update a volume previously created with this ID prefix. Used for dynamic
+    host volumes only.
+
   -policy-override
     Sets the flag to force override any soft mandatory Sentinel policies. Used
     for dynamic host volumes only.
@@ -50,6 +54,7 @@ func (c *VolumeRegisterCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
 			"-policy-override": complete.PredictNothing,
+			"-id":              complete.PredictNothing,
 		})
 }
 
@@ -65,8 +70,10 @@ func (c *VolumeRegisterCommand) Name() string { return "volume register" }
 
 func (c *VolumeRegisterCommand) Run(args []string) int {
 	var override bool
+	var volID string
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.BoolVar(&override, "policy-override", false, "override soft mandatory Sentinel policies")
+	flags.StringVar(&volID, "id", "", "update an existing dynamic host volume")
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 
 	if err := flags.Parse(args); err != nil {
@@ -118,7 +125,7 @@ func (c *VolumeRegisterCommand) Run(args []string) int {
 	case "csi":
 		return c.csiRegister(client, ast)
 	case "host":
-		return c.hostVolumeRegister(client, ast, override)
+		return c.hostVolumeRegister(client, ast, override, volID)
 	default:
 		c.Ui.Error(fmt.Sprintf("Error unknown volume type: %s", volType))
 		return 1

--- a/command/volume_register_host_test.go
+++ b/command/volume_register_host_test.go
@@ -92,4 +92,11 @@ parameters {
 	got, _, err := client.HostVolumes().Get(id, &api.QueryOptions{Namespace: "prod"})
 	must.NoError(t, err)
 	must.NotNil(t, got)
+
+	// Verify we can update the volume without changes
+	args = []string{"-address", url, "-id", got.ID, file.Name()}
+	code = cmd.Run(args)
+	must.Eq(t, 0, code, must.Sprintf("got error: %s", ui.ErrorWriter.String()))
+	list, _, err := client.HostVolumes().List(nil, &api.QueryOptions{Namespace: "prod"})
+	must.Len(t, 1, list, must.Sprintf("new volume should not be registered on update"))
 }

--- a/command/volume_status_host.go
+++ b/command/volume_status_host.go
@@ -34,7 +34,7 @@ func (c *VolumeStatusCommand) hostVolumeStatus(client *api.Client, id, nodeID, n
 	// if an exact match is not found. note we can't use the shared getByPrefix
 	// helper here because the List API doesn't match the required signature
 
-	volStub, possible, err := c.getByPrefix(client, id)
+	volStub, possible, err := getHostVolumeByPrefix(client, id, c.namespace)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error listing volumes: %s", err))
 		return 1
@@ -91,10 +91,10 @@ func (c *VolumeStatusCommand) listHostVolumes(client *api.Client, nodeID, nodePo
 	return 0
 }
 
-func (c *VolumeStatusCommand) getByPrefix(client *api.Client, prefix string) (*api.HostVolumeStub, []*api.HostVolumeStub, error) {
+func getHostVolumeByPrefix(client *api.Client, prefix, ns string) (*api.HostVolumeStub, []*api.HostVolumeStub, error) {
 	vols, _, err := client.HostVolumes().List(nil, &api.QueryOptions{
 		Prefix:    prefix,
-		Namespace: c.namespace,
+		Namespace: ns,
 	})
 
 	if err != nil {


### PR DESCRIPTION
If you create a volume via `volume create/register` and want to update it later, you need to change the volume spec to add the ID that was returned. This isn't a very nice UX, so let's add an `-id` argument that allows you to update existing volumes that have that ID.

Ref: https://hashicorp.atlassian.net/browse/NET-12083

---

Example of use:

```
$ nomad volume create ./internal-plugin.volume.hcl
==> Created host volume internal-plugin with ID 78898137-6457-03be-1960-8f2ad946ff11
  ✓ Host volume "78898137" ready

    2025-01-31T15:39:19-05:00
    ID        = 78898137-6457-03be-1960-8f2ad946ff11
    Name      = internal-plugin
    Namespace = default
    Plugin ID = mkdir
    Node ID   = d361ff13-df88-b944-2c06-1f01d3e16557
    Node Pool = default
    Capacity  = 0 B
    State     = ready
    Host Path = /run/nomad/dev/data/host_volumes/78898137-6457-03be-1960-8f2ad946ff11

$ nomad volume create -id 78898137 ./internal-plugin.volume.hcl
==> Created host volume internal-plugin with ID 78898137-6457-03be-1960-8f2ad946ff11
  ✓ Host volume "78898137" ready

    2025-01-31T15:39:28-05:00
    ID        = 78898137-6457-03be-1960-8f2ad946ff11
    Name      = internal-plugin
    Namespace = default
    Plugin ID = mkdir
    Node ID   = d361ff13-df88-b944-2c06-1f01d3e16557
    Node Pool = default
    Capacity  = 0 B
    State     = ready
    Host Path = /run/nomad/dev/data/host_volumes/78898137-6457-03be-1960-8f2ad946ff11
```
