### PR TITLE
volume delete: allow prefix for ID

### DIFF
--- a/.changelog/24997.txt
+++ b/.changelog/24997.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+csi: Accept ID prefixes and wildcard namespace for the volume delete command
+```

--- a/command/volume_delete_host_test.go
+++ b/command/volume_delete_host_test.go
@@ -83,11 +83,17 @@ capability {
 	must.StrContains(t, ui.ErrorWriter.String(), "no such volume")
 	ui.ErrorWriter.Reset()
 
-	// fix the namespace
-	args = []string{"-address", url, "-type", "host", "-namespace", "prod", id}
+	// missing the namespace, but use a prefix
+	args = []string{"-address", url, "-type", "host", id[:12]}
+	code = cmd.Run(args)
+	must.Eq(t, 1, code)
+	must.StrContains(t, ui.ErrorWriter.String(), "no volumes with prefix")
+	ui.ErrorWriter.Reset()
+
+	// fix the namespace, and use a prefix
+	args = []string{"-address", url, "-type", "host", "-namespace", "prod", id[:12]}
 	code = cmd.Run(args)
 	must.Eq(t, 0, code, must.Sprintf("got error: %s", ui.ErrorWriter.String()))
 	out = ui.OutputWriter.String()
 	must.StrContains(t, out, fmt.Sprintf("Successfully deleted volume %q!", id))
-
 }


### PR DESCRIPTION
The `volume delete` command doesn't allow using a prefix for the volume ID for either CSI or dynamic host volumes. Use a prefix search and wildcard namespace as we do for other CLI commands.

Ref: https://hashicorp.atlassian.net/browse/NET-12057

---

Example of use:

```
$ nomad volume create ./internal-plugin.volume.hcl
==> Created host volume internal-plugin with ID aeea91a0-06df-c16e-5403-ff82a2f28fd4
  ✓ Host volume "aeea91a0" ready

    2025-01-31T15:55:14-05:00
    ID        = aeea91a0-06df-c16e-5403-ff82a2f28fd4
    Name      = internal-plugin
    Namespace = default
    Plugin ID = mkdir
    Node ID   = b4611abd-d4a8-c83a-b05e-7d9f5b44a179
    Node Pool = default
    Capacity  = 0 B
    State     = ready
    Host Path = /run/nomad/dev/data/host_volumes/aeea91a0-06df-c16e-5403-ff82a2f28fd4

$ nomad volume delete -type host aeea91a0
Successfully deleted volume "aeea91a0-06df-c16e-5403-ff82a2f28fd4"!
```