### PR TITLE
sec: Suppress additional yamux advisory and AWS v1 indirect dep.

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -29,7 +29,9 @@ binary {
   triage {
     suppress {
       vulnerabilities = [
-        "GO-2025-3408", // github.com/hashicorp/yamux@v0.1.2 TODO(jrasell): remove when dep updated.
+        "GO-2025-3408",         // github.com/hashicorp/yamux@v0.1.2 TODO(jrasell): remove when dep updated.
+        "GHSA-29qp-crvh-w22m ", // github.com/hashicorp/yamux@v0.1.2 TODO(jrasell): remove when dep updated.
+        "GO-2022-0635",         // github.com/aws/aws-sdk-go@v1.55.6 TODO(jrasell): remove when dep updated.
       ]
     }
   }


### PR DESCRIPTION
GHSA-29qp-crvh-w22m: Additional advisory to the same yamux GO-2025-3408: https://github.com/hashicorp/yamux/pull/143
GO-2022-0635: Advisory for go-getter use of AWS SDK V1: https://github.com/hashicorp/go-getter/pull/467

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
