### PR TITLE
Manual Backport of Docs SEO: Update runtime, networking, Nomad vs K8s, Nomad Enterprise,…

### DIFF
--- a/website/content/docs/ecosystem.mdx
+++ b/website/content/docs/ecosystem.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: Nomad Ecosystem
-description: Comparison between Nomad and Kubernetes
+description: Learn about the Nomad ecosystem, which includes CI/CD, task drivers, service mesh, service proxy, secrets management, observability, autoscaling, storage, provisioning, GPUs, and cloud native support.
 ---
 
 # Nomad Ecosystem

--- a/website/content/docs/enterprise/index.mdx
+++ b/website/content/docs/enterprise/index.mdx
@@ -3,19 +3,18 @@ layout: docs
 page_title: Nomad Enterprise
 description: >-
   Nomad Enterprise adds operations, collaboration, and governance capabilities
-  to Nomad.
-
-  Features include Resource Quotas, Sentinel Policies, and Advanced Autopilot.
+  such as resource quotas, Sentinel policies, audit logging, multi-region deployments, and advanced server management using Nomad Autopilot.
 ---
 
 # Nomad Enterprise
 
-Nomad Enterprise adds collaboration, operational, and governance capabilities
-to Nomad. Nomad Enterprise is available as a base Platform package with an
-optional Governance & Policy add-on module.
+This page provides an overview of Nomad Enterprise features that
+add operations, collaboration, and governance capabilities such as resource
+quotas, Sentinel policies, audit logging, multi-region deployments, and advanced
+server management using Nomad Autopilot.
 
-Please navigate the sub-sections for more information about each package and
-its features in detail.
+Nomad Enterprise is available as a base Platform package with an optional
+Governance & Policy add-on module.
 
 ~> **Note:** A Nomad Enterprise cluster cannot be downgraded to the open
 source version of Nomad. Servers running the open source version of Nomad will
@@ -37,7 +36,7 @@ an LTS release.
 LTS releases have the following benefits for Nomad operators:
 
 - **Extended maintenance:** Two years of critical fixes provided through minor
-releases 
+releases
 - **Efficient upgrades:** Support for direct upgrades from one LTS release
 to the next, reducing major-version upgrade risk and improving operational
 efficiency.

--- a/website/content/docs/enterprise/license/faq.mdx
+++ b/website/content/docs/enterprise/license/faq.mdx
@@ -5,7 +5,7 @@ description: >-
   Frequently Asked Questions pertaining to Nomad Enterprise Licensing.
 ---
 
-# Frequently Asked Questions (FAQ)
+# Nomad Enterprise License FAQ
 
 This FAQ is for the license changes introduced in Nomad Enterprise version v1.6.0+ent.
 

--- a/website/content/docs/enterprise/license/index.mdx
+++ b/website/content/docs/enterprise/license/index.mdx
@@ -2,17 +2,26 @@
 layout: docs
 page_title: Nomad Enterprise Licensing
 description: >-
-  Learn about how Nomad Enterprise licensing works.
+  Learn how to configure, apply, and replace your Nomad Enterprise license. Use the `nomad license` command to review your license details.
 ---
 
-## Nomad Enterprise Licensing
+# Nomad Enterprise Licensing
 
-Licensing capabilities were added to Nomad Enterprise v0.12.0. Each server in
-the cluster must have a license to start. Nomad Enterprise can be downloaded from
-the [releases site].
+<EnterpriseAlert product="nomad"/>
 
-Click [here](https://www.hashicorp.com/go/nomad-enterprise) to set up a demo of Nomad Enterprise
-or [here](/nomad/tutorials/enterprise/hashicorp-enterprise-license#request-a-trial-license)
+This page provides information on how to configure, apply, inspect, and replace
+your Nomad Enterprise license.
+
+Each server in a Nomad Enterprise cluster must have a license to start. Download
+Nomad Enterprise from the [releases site].
+
+[Contact sales](https://www.hashicorp.com/go/nomad-enterprise) to set up a demo
+of Nomad Enterprise.
+
+Refer to the Enterprise license
+[tutorial](/nomad/tutorials/enterprise/hashicorp-enterprise-license) for
+step-by-step license instructions. Review the [Request a trial license section
+](/nomad/tutorials/enterprise/hashicorp-enterprise-license#request-a-trial-license)
 for instructions on how to get a trial license.
 
 ~> **Note:** A Nomad Enterprise cluster cannot be downgraded to the open
@@ -54,8 +63,6 @@ operations will return an error.
 See the server [license configuration] reference documentation on all the
 options to set an enterprise license. Nomad will load the license file from
 disk or environment when it starts.
-
-~> **Note:** An Enterprise license [tutorial](/nomad/tutorials/enterprise/hashicorp-enterprise-license) is available to help you install the license on the server.
 
 In order to immediately alert operators of a bad configuration setting, if a
 license configuration option is an invalid or expired license, the Nomad server

--- a/website/content/docs/enterprise/license/utilization-reporting.mdx
+++ b/website/content/docs/enterprise/license/utilization-reporting.mdx
@@ -2,32 +2,40 @@
 layout: docs
 page_title: Automated license utilization reporting
 description: >-
-  Learn what data HashiCorp collects to meter Enterprise license utilization. Enable or disable reporting. Review sample payloads and logs.
+  Learn what data HashiCorp collects to monitor Enterprise license utilization. Enable or opt out of automatic reporting. Review sample payloads and logs.
 ---
 
 # Automated license utilization reporting
 
-Automated license utilization reporting sends license utilization data to HashiCorp without requiring you 
-to manually collect and report them. It also lets you review your license usage with the monitoring 
-solution you already use (for example Splunk, Datadog, or others) so you can optimize and manage your 
-deployments. Use these reports to understand how much more you can deploy under your current contract, 
-protect against overutilization, and budget for predicted consumption.  
+<EnterpriseAlert product="nomad" />
 
-Automated reporting shares the minimum data required to validate license utilization as defined in our 
-contracts. They consist of mostly computed metrics and will never contain Personal Identifiable Information 
-(PII) or other sensitive information. Automated reporting shares the data with HashiCorp using a secure, 
-unidirectional HTTPS API and makes an auditable record in the product logs each time it submits a report. 
+This page provides information on the data HashiCorp collects to monitor
+Enterprise license utilization. Learn how to enable or opt out of automatic
+reporting. Review sample payloads and logs.
+
+## Introduction
+
+Automated license utilization reporting sends license utilization data to HashiCorp without requiring you
+to manually collect and report them. It also lets you review your license usage with the monitoring
+solution you already use (for example Splunk, Datadog, or others) so you can optimize and manage your
+deployments. Use these reports to understand how much more you can deploy under your current contract,
+protect against overutilization, and budget for predicted consumption.
+
+Automated reporting shares the minimum data required to validate license utilization as defined in our
+contracts. They consist of mostly computed metrics and will never contain Personal Identifiable Information
+(PII) or other sensitive information. Automated reporting shares the data with HashiCorp using a secure,
+unidirectional HTTPS API and makes an auditable record in the product logs each time it submits a report.
 The reporting process is GDPR compliant and submits reports roughly once every 24 hours.
 
 ## Enable automated reporting
 
-To enable automated reporting, you need to make sure that outbound network traffic is configured correctly 
-and upgrade your enterprise product to a version that supports it. If your installation is air-gapped or 
-network settings are not in place, automated reporting will not work. 
+To enable automated reporting, you need to make sure that outbound network traffic is configured correctly
+and upgrade your enterprise product to a version that supports it. If your installation is air-gapped or
+network settings are not in place, automated reporting will not work.
 
 ### 1. Allow outbound HTTPS traffic on port 443
 
-Make sure that your network allows HTTPS egress on port 443 from https://reporting.hashicorp.services by 
+Make sure that your network allows HTTPS egress on port 443 from https://reporting.hashicorp.services by
 allow-listing the following IP addresses:
 
 - 100.20.70.12
@@ -42,10 +50,10 @@ Upgrade to a release that supports license utilization reporting. These releases
 
 ### 3. Check logs
 
-Automatic license utilization reporting will start sending data within roughly 24 hours. Check the product 
+Automatic license utilization reporting will start sending data within roughly 24 hours. Check the product
 logs for records that the data sent successfully.
 
-Instructions on how to check logs. 
+Instructions on how to check logs.
 
 ```
 [DEBUG] core.reporting: beginning snapshot export
@@ -61,8 +69,8 @@ Instructions on how to check logs.
 [DEBUG] core.reporting: export finished successfully
 ```
 
-If your installation is air-gapped or your network doesn’t allow the correct egress, logs will show an 
-error. 
+If your installation is air-gapped or your network doesn’t allow the correct egress, logs will show an
+error.
 
 ```
 [DEBUG] core.reporting: beginning snapshot export
@@ -75,25 +83,25 @@ error.
 [DEBUG] core.reporting: error status code received: statusCode=403
 ```
 
-In this case, reconfigure your network to allow egress and check back in 24 hours. 
+In this case, reconfigure your network to allow egress and check back in 24 hours.
 
 ## Opt out
 
-If your installation is air-gapped or you want to manually collect and report on the same license 
-utilization metrics, you can opt-out of automated reporting. 
+If your installation is air-gapped or you want to manually collect and report on the same license
+utilization metrics, you can opt-out of automated reporting.
 
-Manually reporting these metrics can be time consuming. Opting out of automated reporting does not mean that 
-you also opt out from sending license utilization metrics. Customers who opt out of automated reporting will 
-still be required to manually collect and send license utilization metrics to HashiCorp. 
+Manually reporting these metrics can be time consuming. Opting out of automated reporting does not mean that
+you also opt out from sending license utilization metrics. Customers who opt out of automated reporting will
+still be required to manually collect and send license utilization metrics to HashiCorp.
 
-If you are considering opting out because you’re worried about the data, we strongly recommend that you 
-review the [example payloads](#example-payloads) before opting out. If you have concerns with any of the 
-automatically-reported data please bring them to your account manager. 
+If you are considering opting out because you’re worried about the data, we strongly recommend that you
+review the [example payloads](#example-payloads) before opting out. If you have concerns with any of the
+automatically-reported data please bring them to your account manager.
 
-You have two options to opt out of automated reporting: HCL configuration (recommended) and Environment 
+You have two options to opt out of automated reporting: HCL configuration (recommended) and Environment
 variable (requires restart).
 
-Opting out in your product’s configuration file doesn’t require a system restart, and is the method we 
+Opting out in your product’s configuration file doesn’t require a system restart, and is the method we
 recommend. Add the following block to your `server.hcl` file.
 
 ```hcl
@@ -104,8 +112,8 @@ reporting {
 }
 ```
 
-If you need to, you can also opt out using an environment variable, which will provide a startup message 
-confirming that you have disabled automated reporting. This option requires a system restart. 
+If you need to, you can also opt out using an environment variable, which will provide a startup message
+confirming that you have disabled automated reporting. This option requires a system restart.
 
 Set the following environment variable.
 
@@ -113,12 +121,12 @@ Set the following environment variable.
 $ export OPTOUT_LICENSE_REPORTING=true
 ```
 
-Now restart your system by following [these instructions](/nomad/docs/operations/nomad-agent). 
+Now restart your system by following [these instructions](/nomad/docs/operations/nomad-agent).
 
-Check your product logs roughly 24 hours after opting out to make sure that the system isn’t trying to send 
+Check your product logs roughly 24 hours after opting out to make sure that the system isn’t trying to send
 reports.
 
-If your configuration file and environment variable differ, the environment variable setting will take 
+If your configuration file and environment variable differ, the environment variable setting will take
 precedence.
 
 ## Example payloads

--- a/website/content/docs/enterprise/sentinel.mdx
+++ b/website/content/docs/enterprise/sentinel.mdx
@@ -2,10 +2,16 @@
 layout: docs
 page_title: Sentinel Policy Reference
 description: >-
-  Learn about Nomad Sentinel Policy Objects
+  Use the Nomad Enterprise Sentinel policy feature to implement fine-grained control over jobs, such as restricting when jobs can run or ensuring jobs use specific images. Learn about policy structure, job objects, Access Control List (ACL) token objects, and namespace objects.
 ---
 
-## Sentinel
+# Sentinel Policy Reference
+
+<EnterpriseAlert product="nomad" />
+
+This page provides reference information on using the Nomad Sentinel policy feature to implement fine-grained policies such as restricting when jobs can run or ensuring job use specific images. Learn about policy structure, job objects, Access Control List (ACL) token objects, and namespace objects.
+
+## Introduction to Sentinel Policies
 
 In Nomad Enterprise, operators can create Sentinel policies for fine-grained
 policy enforcement. Sentinel policies build on top of the ACL system and allow
@@ -14,11 +20,11 @@ production on Fridays or only allowing users to run jobs that use pre-authorized
 Docker images. Sentinel policies are defined as code, giving operators
 considerable flexibility to meet compliance requirements.
 
-See the [Nomad Sentinel Tutorial][] for more information about deploying
+Refer to the [Nomad Sentinel Tutorial][] for more information about deploying
 Sentinel policies, as well as the documentation for the [`nomad sentinel`][]
 subcommands.
 
-### Sentinel Policies
+## Sentinel Policy Structure
 
 Sentinel policies are specified in the [Sentinel Language][sentinel]. The
 language is designed to be understandable for people who are reading and writing

--- a/website/content/docs/faq.mdx
+++ b/website/content/docs/faq.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: Frequently Asked Questions
-description: Frequently asked questions and answers for Nomad
+description: Nomad frequently asked question topics include checkpoint, gossip and consensus protocols, Nomad datacenter versus Consul datacenter, bootstrapping a cluster, and connecting to a host network with Docker Desktop.
 ---
 
 # Frequently Asked Questions

--- a/website/content/docs/glossary.mdx
+++ b/website/content/docs/glossary.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: Glossary
-description: Learn the definition of important Nomad concepts.
+description: Nomad key concepts include allocation, authoritative regions, bin packing, client, datacenters, deployment, driver, evaluation, job, node, node pool, regions, server, task, and task group.
 ---
 
 # Glossary

--- a/website/content/docs/index.mdx
+++ b/website/content/docs/index.mdx
@@ -2,13 +2,13 @@
 layout: docs
 page_title: Documentation
 description: |-
-  Nomad is a flexible workload orchestrator to deploy and manage any containerized or legacy application using a single, unified workflow. It can run diverse workloads including Docker, non-containerized, microservice, and batch applications.
+  Nomad is a flexible workload orchestrator to deploy and manage any containerized or legacy application using a single, unified workflow. Nomad can run diverse workloads including Docker, non-containerized, microservice, and batch applications.
 ---
 
 # Nomad Documentation
 
 Nomad is a flexible workload orchestrator to deploy and manage any containerized
-or legacy application using a single, unified workflow. It can run diverse
+or legacy application using a single, unified workflow. Nomad can run diverse
 workloads including Docker, non-containerized, microservice, and batch
 applications.
 

--- a/website/content/docs/networking/cni.mdx
+++ b/website/content/docs/networking/cni.mdx
@@ -2,19 +2,19 @@
 layout: docs
 page_title: CNI plugins and bridge networking
 description: |-
-  Learn how to install Container Network Interface (CNI) reference plugins, configure Nomad's bridge networking, and how to use CNI networks with Nomad jobs.
+  Learn how to install Container Network Interface (CNI) reference plugins, configure Nomad's bridge networking, and use CNI networks with Nomad jobs.
 ---
 
 # Container Network Interface (CNI)
 
-This page show you how to install the [CNI reference plugins][cni-plugin-docs]
+This page shows you how to install the [CNI reference plugins][cni-plugin-docs]
 on your Linux distribution and configure bridge networking on your Nomad
 clients. You can apply this guide's workflow to installing any plugin that
 complies with the [Container Network Interface (CNI) Specification][cni-spec],
 but you should verify plugin compatibility with Nomad before deploying in
 production.
 
-## Introduction
+## Background
 
 The CNI specification defines a network configuration format for administrators.
 The configuration contains directives for both the orchestrator and the plugins

--- a/website/content/docs/networking/index.mdx
+++ b/website/content/docs/networking/index.mdx
@@ -2,11 +2,16 @@
 layout: docs
 page_title: Networking
 description: |-
-  Learn about Nomad's networking internals and how it compares with other
-  tools.
+  Nomad's networking features connect your workloads without running additional component tools like DNS servers and load balancers. Learn about workload allocation networking and bridge networking, which uses Container Network Interface (CNI) plugins or Docker. Review how Nomad networking differs from Kubernetes networking.
 ---
 
 # Networking
+
+This page provides conceptual information about Nomad's networking feature, how
+networking works in Nomad, different patterns and configurations, and how Nomad
+networking differs from Kubernetes networking.
+
+## Introduction
 
 Nomad is a workload orchestrator and focuses on the scheduling aspects of a
 deployment, touching areas such as networking as little as possible.
@@ -15,11 +20,6 @@ Networking in Nomad is usually done via _configuration_ instead of
 _infrastructure_. This means that Nomad provides ways for you to access the
 information you need to connect your workloads instead of running additional
 components behind the scenes, such as DNS servers and load balancers.
-
-Nomad networking is quite different from what you may familiar with from other
-tools. This section explains how networking works in Nomad, some of the
-different patterns and configurations you are likely to find and use, and how
-Nomad differs from other tools in this aspect.
 
 ## Allocation networking
 

--- a/website/content/docs/networking/service-discovery.mdx
+++ b/website/content/docs/networking/service-discovery.mdx
@@ -2,10 +2,14 @@
 layout: docs
 page_title: Service Discovery
 description: |-
-  Learn about how service discovery works in Nomad to connect workloads.
+  Nomad service discovery helps you automatically connects workloads. Compare Nomad's built-in service discovery feature to Consul service discovery, which adds a DSN interface and service mesh. Learn about health checks, configuring tags in job specification service blocks, and how to specify tags for canary and blue/green allocations.
 ---
 
 # Service discovery
+
+This page provides conceptual information about Nomad service discovery. Compare Nomad's built-in service discovery feature to using Consul service discovery, which adds a DSN interface and service mesh. Learn about health checks, configuring tags in job specification service blocks, and how to specify tags for canary and blue/green allocations.
+
+## Introduction
 
 Service discovery is the process of retrieving the low-level information
 necessary to access a service, such as its IP and port, via a high-level

--- a/website/content/docs/networking/service-mesh.mdx
+++ b/website/content/docs/networking/service-mesh.mdx
@@ -2,11 +2,18 @@
 layout: docs
 page_title: Service Mesh
 description: |-
-  Learn about how service mesh works in Nomad to securely connect and isolate
-  your workloads.
+  Nomad integrates with Consul service mesh to securely connect and isolate
+  your workloads. Review example job configurations that use service mesh. Learn about the Envoy proxy as well as mesh, ingress, and terminating gateways.
 ---
 
 # Service mesh
+
+This page provides conceptual information on using Consul service mesh with
+Nomad to securely connect and isolate your workloads. Review example job
+configurations that use service mesh. Learn about the Envoy proxy as well as
+mesh, ingress, and terminating gateways.
+
+## Introduction
 
 Service mesh is a networking pattern that deploys and configures
 infrastructure to directly connect workloads. One of the most common pieces of

--- a/website/content/docs/nomad-vs-kubernetes/alternative.mdx
+++ b/website/content/docs/nomad-vs-kubernetes/alternative.mdx
@@ -1,10 +1,10 @@
 ---
 layout: docs
 page_title: Alternative to Kubernetes
-description: Nomad as an alternative to Kubernetes
+description: Learn why Nomad's "run anything anywhere" workload orchestration is a robust alternative to Kubernetes.
 ---
 
-# An alternative to Kubernetes
+# Alternative to Kubernetes
 
 While known for its goal of automating and simplifying application deployment, an orchestrator itself can be extremely complex to implement and manage. Kubernetes requires significant time and deep understanding to deploy, operate, and troubleshoot. Teams and organizations choose Nomad as an alternative to Kubernetes for its two core strengths:
 

--- a/website/content/docs/nomad-vs-kubernetes/index.mdx
+++ b/website/content/docs/nomad-vs-kubernetes/index.mdx
@@ -1,17 +1,20 @@
 ---
 layout: docs
-page_title: Nomad vs. Kubernetes
-description: Comparison between Nomad and Kubernetes
+page_title: Nomad versus Kubernetes
+description: Nomad is a superior workload scheduling and orchestration tool compared to Kubernetes. Compare architecture, flexible workload support, consistent deployment, and scalability.
 ---
 
-# Nomad vs. Kubernetes
+# Nomad versus Kubernetes
+
+This page compares Nomad to Kubernetes and illustrates why Nomad is the superior
+workload scheduling and orchestration tool. Compare architecture, flexible workload support, consistent deployment, and scalability.
 
 ~> Interested in talking with HashiCorp about your experience building, deploying,
 or managing your applications? [Set up a time to chat!](https://forms.gle/2tAmxJbyPbcL2nRW9)
 
 Kubernetes is an orchestration system for containers originally designed by Google, now governed by the Cloud Native Computing Foundation (CNCF) and developed by Google, Red Hat, and many others. Kubernetes and Nomad support similar core use cases for application deployment and management, but they differ in a few key ways. Kubernetes aims to provide all the features needed to run Linux container-based applications including cluster management, scheduling, service discovery, monitoring, secrets management and more. Nomad only aims to focus on cluster management and scheduling and is designed with the Unix philosophy of having a small scope while composing with tools like Consul for service discovery/service mesh and Vault for secret management.
 
-The following characteristics generally differentiate Nomad from Kubernetes:
+The following characteristics generally differentiate Nomad from Kubernetes.
 
 ## Simplicity
 

--- a/website/content/docs/nomad-vs-kubernetes/supplement.mdx
+++ b/website/content/docs/nomad-vs-kubernetes/supplement.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: Supplement to Kubernetes
-description: Comparison between Nomad and Kubernetes
+description: Learn how Nomad's "run anything anywhere" capability can supplement Kubernetes' container-only approach to workload orchestration.
 ---
 
 # Supplement to Kubernetes

--- a/website/content/docs/partnerships.mdx
+++ b/website/content/docs/partnerships.mdx
@@ -1,10 +1,12 @@
 ---
 layout: docs
-page_title: Nomad Partnerships
-description: Update this content
+page_title: Nomad Integration Program
+description: The HashiCorp Nomad Integration Program is the process for building and certifying products that integrate with Nomad. Review the integration categories and development process.
 ---
 
 # Nomad Integration Program
+
+This page provides an overview of the HashiCorp Nomad Integration Program.
 
 ## Introduction
 

--- a/website/content/docs/release-notes/index.mdx
+++ b/website/content/docs/release-notes/index.mdx
@@ -2,11 +2,12 @@
 layout: docs
 page_title: Release Notes
 description: |-
-  Release notes for the major software packages for Nomad
+  Hashicorp Nomad release notes.
 ---
 
 # Release Notes
 
 Choose a version from the navigation sidebar to view the release notes for Nomad.
 
-Documentation for maintenance releases (e.g., 0.1.x) is on the bottom of each release notes page.
+Documentation for maintenance releases (e.g., 0.1.x) is on the bottom of each
+release notes page.

--- a/website/content/docs/release-notes/nomad/upcoming.mdx
+++ b/website/content/docs/release-notes/nomad/upcoming.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: Upcoming
 description: >-
-  Notices of upcoming Nomad changes
+  Review upcoming HashiCorp Nomad release changes.
 ---
 
 # Upcoming

--- a/website/content/docs/release-notes/nomad/v1_8_x.mdx
+++ b/website/content/docs/release-notes/nomad/v1_8_x.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: 1.8.x
 description: >-
-  Nomad release notes for version 1.8.x
+  HashiCorp Nomad version 1.8.x release notes. Long term support release. Exec2 task driver beta, transparent proxy support for Consul service mesh, Consul API Gateway for Nomad support, UI jobs page updates, time-based task execution, Sentinel policy management in the UI, nomad-bench.
 ---
 
 # Nomad 1.8.0

--- a/website/content/docs/release-notes/nomad/v1_9_x.mdx
+++ b/website/content/docs/release-notes/nomad/v1_9_x.mdx
@@ -2,7 +2,7 @@
 layout: docs
 page_title: 1.9.x
 description: >-
-  Nomad release notes for Nomad version 1.9.x
+  HashiCorp Nomad version 1.9.x release notes. Multi-Instance GPU (MIG) support, quotas for device resources, NUMA-aware scheduling, job versions, Virt task driver beta, Exec2 task driver GA, improved IPv6 support.
 ---
 
 # Nomad 1.9.0
@@ -19,7 +19,7 @@ details.
 
 - **Quotas for device resources (Enterprise)**: This release extends quotas to
 allow limiting [device resources](/nomad/docs/job-specification/device). Refer
-to [Resource quotas]() for configuration details.
+to [Resource quotas](/nomad/docs/other-specifications/quota) for configuration details.
 
 - **NUMA awareness for device resources (Enterprise)**: Nomad is able to
   correlate CPU cores with memory nodes and assign tasks to run on specific CPU

--- a/website/content/docs/runtime/environment.mdx
+++ b/website/content/docs/runtime/environment.mdx
@@ -1,17 +1,22 @@
 ---
 layout: docs
-page_title: Environment - Runtime
-description: Learn how to configure the Nomad runtime environment.
+page_title: Runtime Environment Settings
+description: Nomad provides runtime environment variables that you can use in your workloads. Learn about task identifiers, CPU and memory resources, IP addresses, task directories, and host variables. Review job, network, and Consul variables. Supply arbitrary configuration to a job task.
 ---
 
-# Runtime Environment
+# Runtime Environment Settings
+
+This page provides reference information for runtime environment settings in
+your Nomad job specification. Learn about task identifiers, CPU and memory resources, IP addresses, task directories, and host variables. Review job, network, and Consul variables. Supply arbitrary configuration to a job task.
+
+## Introduction
 
 Some settings you specify in your [job specification][jobspec] are passed
 to tasks when they start. Other settings are dynamically allocated when your job
 is scheduled. Both types of values are made available to your job through
 environment variables.
 
-## Summary
+## Variables Summary
 
 @include 'envvars.mdx'
 
@@ -87,14 +92,14 @@ directories can be read through the `NOMAD_ALLOC_DIR`, `NOMAD_TASK_DIR`, and
 
 For more details on the task directories, see the [Filesystem internals][].
 
-## Meta
+## Meta block for arbitrary configuration
 
 The job specification also allows you to specify a `meta` block to supply
 arbitrary configuration to a task. This allows you to easily provide
 job-specific configuration even if you use the same executable unit in multiple
 jobs. These key-value pairs are passed through to the job as
 `NOMAD_META_<key>=<value>` environment variables. Any character in a key other
-than `[A-Za-z0-9_.]` will be converted to `_`. Both the original case and an uppercased 
+than `[A-Za-z0-9_.]` will be converted to `_`. Both the original case and an uppercased
 version are injected. The uppercased version will be deprecated in a future release.
 
 Currently there is no enforcement that the meta keys be lowercase, but using

--- a/website/content/docs/runtime/index.mdx
+++ b/website/content/docs/runtime/index.mdx
@@ -2,14 +2,13 @@
 layout: docs
 page_title: Runtime
 description: |-
-  Learn about Nomad's runtime environment variables, interpolation, caveats,
-  and more.
+  Learn about Nomad's runtime environment variables, interpolation, and schedulers.
 ---
 
 # Runtime
 
 This section details Nomad's runtime information, including environment
-variables, interpolations, caveats, and more.
+variables, interpolations, and caveats.
 
 To learn more about Nomad's runtime, choose an item from the sidebar, or choose
 one of the options below:

--- a/website/content/docs/runtime/interpolation.mdx
+++ b/website/content/docs/runtime/interpolation.mdx
@@ -1,10 +1,14 @@
 ---
 layout: docs
 page_title: Variable Interpolation
-description: Learn about the Nomad's interpolation and interpreted variables.
+description: Nomad supports interpreting node attributes and runtime environment variables in a Nomad workload. Learn the syntax for interpreting variables in a Nomad job specification. Review node attributes for clients, hardware, platform, and OS. Review job, network, and Consul environment variables.
 ---
 
 # Variable Interpolation
+
+This page provides reference information on interpreting node attributes and runtime environment variables in a Nomad workload. Learn the syntax for interpreting variables in a Nomad job specification. Review node attributes for clients, hardware, platform, and OS. Review Review job, network, and Consul environment variables.
+
+## Introduction
 
 Nomad supports interpreting two classes of variables: node attributes and
 runtime environment variables. Node attributes are interpretable in constraints,

--- a/website/content/docs/schedulers.mdx
+++ b/website/content/docs/schedulers.mdx
@@ -1,14 +1,13 @@
 ---
 layout: docs
 page_title: Schedulers
-description: Learn about Nomad's various schedulers.
+description: Learn how Nomad's service, batch, system, and system batch job schedulers enable flexible workloads.
 ---
 
 # Schedulers
 
-Nomad has four scheduler types that can be used when creating your job:
-`service`, `batch`, `system` and `sysbatch`. Here we will describe the differences
-between each of these schedulers.
+This page provides conceptual information about Nomad service, batch, system,
+and system batch job schedulers.
 
 ## Service
 

--- a/website/content/docs/upgrade/index.mdx
+++ b/website/content/docs/upgrade/index.mdx
@@ -1,12 +1,18 @@
 ---
 layout: docs
-page_title: 'Upgrading'
+page_title: 'Upgrade Nomad'
 sidebar_current: 'guides-upgrade'
 description: |-
-  Learn how to upgrade Nomad.
+  Upgrade HashiCorp Nomad without causing an outage. Review the upgrade process for a new version, for moving from Nomad community edition to Nomad Enterprise, and for Raft protocol version three.
 ---
 
-# Upgrading
+# Upgrade Nomad
+
+This page provides guidance on upgrading HashiCorp Nomad without causing an
+outage. Review the upgrade process for a new version, for moving from Nomad
+Community to Nomad Enterprise, and for Raft protocol version three.
+
+## Introduction
 
 Nomad is designed to be flexible and resilient when upgrading from one Nomad
 version to the next. Upgrades should cause neither a Nomad nor a service

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -2,8 +2,7 @@
 layout: docs
 page_title: Upgrade Guides
 description: |-
-  Specific versions of Nomad may have additional information about the upgrade
-  process beyond the standard flow.
+  Review upgrade details for specific versions of Nomad.
 ---
 
 # Upgrade Guides

--- a/website/content/docs/who-uses-nomad.mdx
+++ b/website/content/docs/who-uses-nomad.mdx
@@ -2,15 +2,12 @@
 layout: docs
 page_title: Who Uses Nomad
 description: >-
-  This page features many ways Nomad is used in production today across many
-  industries to solve critical, real-world business objectives
+  Learn how companies use Nomad in production to solve critical, real-world business objectives.
 ---
 
 # Who Uses Nomad
 
 This page features talks from users on how they use Nomad today to solve critical, real-world business objectives.
-
-Nomad is widely adopted and used in production by PagerDuty, Cloudflare, Target, and more.
 
 #### Cloudflare
 
@@ -116,4 +113,3 @@ Nomad is widely adopted and used in production by PagerDuty, Cloudflare, Target,
 
 - [Cluster Schedulers & Why We Chose Nomad Over Kubernetes (2017)](https://medium.com/@copyconstruct/schedulers-kubernetes-and-nomad-b0f2e14a896)
 
-...and more!


### PR DESCRIPTION
Manual backport of Backport of Docs SEO: Update runtime, networking, Nomad vs K8s, Nomad Enterprise, upgrading, release notes, and sectionless pages into stable-website (https://github.com/hashicorp/nomad/pull/24764)

Replaces https://github.com/hashicorp/nomad/pull/25009

