### PR TITLE
Fix: Inaccurate Memory Resource Example

### DIFF
--- a/website/content/docs/job-specification/resources.mdx
+++ b/website/content/docs/job-specification/resources.mdx
@@ -83,11 +83,11 @@ If `cores` and `cpu` are both defined in the same resource block, validation of 
 ### Memory
 
 This example specifies the task requires 2 GB of RAM to operate. 2 GB is the
-equivalent of 2000 MB:
+equivalent of 2048 MB:
 
 ```hcl
 resources {
-  memory = 2000
+  memory = 2048
 }
 ```
 


### PR DESCRIPTION
### Description
Fix: Inaccurate Memory Resource Example

Nomad memory sizes are always in binary units (plenty of places with e.g. `MemoryMB * 1024 * 1024` around the codebase). This snippet of documentation, however, is misleading, and implies that Nomad manages/tracks memory with decimal units.

Without going crazy changing "MB"->"MiB" everywhere, causing mass confusion and horrid edit wars, let's just change this one number! This is a subtle but effective way to signal to developers that we're using binary-based sizes.

(Even if this argument fails, this documentation is plain _wrong_: `MemoryMB = 2000` will use ~2.1GB: 2000 binary megabytes, 1048576 bytes each.)

### Testing & Reproduction steps
N/A

### Links

[Example of size computation in Docker driver, clearly computing mibibytes](https://github.com/hashicorp/nomad/blob/9367929d87c0a5d654fb4deacfd4f008de6b6a78/drivers/docker/driver.go#L933)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
