### PR TITLE
[ui, tests] Various acceptance test fixups (v main)

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Express failure
         if: steps.ember_exam.outcome == 'failure'
         run: |
-          echo "Tests failed in partition ${{ matrix.partition }}"
+          echo "Tests failed in ember-exam for partition ${{ matrix.partition }}"
           exit 1
       - name: Upload partition test results
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -66,10 +66,10 @@ jobs:
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: |
           yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results/test-results.json
-        continue-on-error: true
-      - name: Express timeout failure
-        if: ${{ failure() }}
-        run: exit 1
+        continue-on-error: false
+      # - name: Express timeout failure
+      #   if: ${{ failure() }}
+      #   run: exit 1
       - name: Upload partition test results
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -73,6 +73,14 @@ jobs:
         if: steps.ember_exam.outcome == 'failure'
         run: |
           echo "Tests failed in ember-exam for partition ${{ matrix.partition }}"
+          echo "Failed tests:"
+          node -e "
+            const results = JSON.parse(require('fs').readFileSync('test-results/test-results.json'));
+            results.tests.filter(t => !t.passed).forEach(test => {
+              console.error('\n❌ ' + test.name);
+              if (test.error) console.error(test.error);
+            });
+          "
           exit 1
       - name: Upload partition test results
         if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -40,6 +40,7 @@ jobs:
       run:
         working-directory: ui
     strategy:
+      fail-fast: false
       matrix:
         partition: [1, 2, 3, 4]
         split: [4]

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -75,7 +75,7 @@ jobs:
           echo "Tests failed in ember-exam for partition ${{ matrix.partition }}"
           exit 1
       - name: Upload partition test results
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: test-results-${{ matrix.partition }}

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -61,15 +61,18 @@ jobs:
           secrets: |-
             kv/data/teams/nomad/ui PERCY_TOKEN ;
       - name: ember exam
+        id: ember_exam
         env:
           PERCY_TOKEN: ${{ env.PERCY_TOKEN || secrets.PERCY_TOKEN }}
           PERCY_PARALLEL_NONCE: ${{ needs.pre-test.outputs.nonce }}
         run: |
           yarn exam:parallel --split=${{ matrix.split }} --partition=${{ matrix.partition }} --json-report=test-results/test-results.json
-        continue-on-error: false
-      # - name: Express timeout failure
-      #   if: ${{ failure() }}
-      #   run: exit 1
+        continue-on-error: true
+      - name: Express failure
+        if: steps.ember_exam.outcome == 'failure'
+        run: |
+          echo "Tests failed in partition ${{ matrix.partition }}"
+          exit 1
       - name: Upload partition test results
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0

--- a/ui/mirage/factories/job.js
+++ b/ui/mirage/factories/job.js
@@ -175,6 +175,9 @@ export default Factory.extend({
   // When true, the job will have no versions or deployments (and in turn no latest deployment)
   noDeployments: false,
 
+  // When true, the job will have a previous stable version. Useful for testing "start job" loop.
+  withPreviousStableVersion: false,
+
   // When true, an evaluation with a high modify index and placement failures is created
   failedPlacements: false,
 
@@ -317,8 +320,20 @@ export default Factory.extend({
             version: index,
             noActiveDeployment: job.noActiveDeployment,
             activeDeployment: job.activeDeployment,
+            stable: true,
           });
         });
+
+      if (job.withPreviousStableVersion) {
+        server.create('job-version', {
+          job,
+          namespace: job.namespace,
+          version: 1,
+          noActiveDeployment: job.noActiveDeployment,
+          activeDeployment: job.activeDeployment,
+          stable: true,
+        });
+      }
     }
 
     if (job.activeDeployment) {

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -305,6 +305,9 @@ moduleForJob(
       type: 'service',
       noActiveDeployment: true,
       withPreviousStableVersion: true,
+      allocStatusDistribution: {
+        running: 1,
+      },
     }),
   {
     'the subnav links to deployment': async (job, assert) => {

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -300,7 +300,12 @@ moduleForJob(
 moduleForJob(
   'Acceptance | job detail (service)',
   'allocations',
-  () => server.create('job', { type: 'service', noActiveDeployment: true, withPreviousStableVersion: true }),
+  () =>
+    server.create('job', {
+      type: 'service',
+      noActiveDeployment: true,
+      withPreviousStableVersion: true,
+    }),
   {
     'the subnav links to deployment': async (job, assert) => {
       await JobDetail.tabFor('deployments').visit();

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -27,6 +27,7 @@ moduleForJob('Acceptance | job detail (batch)', 'allocations', () =>
     allocStatusDistribution: {
       running: 1,
     },
+    withPreviousStableVersion: true,
   })
 );
 
@@ -39,6 +40,7 @@ moduleForJob('Acceptance | job detail (system)', 'allocations', () =>
     allocStatusDistribution: {
       running: 1,
     },
+    withPreviousStableVersion: true,
   })
 );
 
@@ -52,6 +54,7 @@ moduleForJob('Acceptance | job detail (sysbatch)', 'allocations', () =>
       running: 1,
       failed: 1,
     },
+    withPreviousStableVersion: true,
   })
 );
 
@@ -65,6 +68,7 @@ moduleForJobWithClientStatus(
       type: 'sysbatch',
       createAllocations: false,
       noActiveDeployment: true,
+      withPreviousStableVersion: true,
     });
   }
 );
@@ -80,6 +84,7 @@ moduleForJobWithClientStatus(
       namespaceId: namespace.name,
       createAllocations: false,
       noActiveDeployment: true,
+      withPreviousStableVersion: true,
     });
   }
 );
@@ -95,6 +100,7 @@ moduleForJobWithClientStatus(
       namespaceId: namespace.name,
       createAllocations: false,
       noActiveDeployment: true,
+      withPreviousStableVersion: true,
     });
   }
 );
@@ -109,6 +115,7 @@ moduleForJob('Acceptance | job detail (sysbatch child)', 'allocations', () => {
       running: 1,
     },
     noActiveDeployment: true,
+    withPreviousStableVersion: true,
   });
   return server.db.jobs.where({ parentId: parent.id })[0];
 });
@@ -212,6 +219,7 @@ moduleForJob(
     server.create('job', 'parameterized', {
       shallow: true,
       noActiveDeployment: true,
+      withPreviousStableVersion: true,
     }),
   {
     'the default sort is submitTime descending': async (job, assert) => {
@@ -292,7 +300,7 @@ moduleForJob(
 moduleForJob(
   'Acceptance | job detail (service)',
   'allocations',
-  () => server.create('job', { type: 'service', noActiveDeployment: true }),
+  () => server.create('job', { type: 'service', noActiveDeployment: true, withPreviousStableVersion: true }),
   {
     'the subnav links to deployment': async (job, assert) => {
       await JobDetail.tabFor('deployments').visit();

--- a/ui/tests/acceptance/server-detail-test.js
+++ b/ui/tests/acceptance/server-detail-test.js
@@ -20,6 +20,7 @@ module('Acceptance | server detail', function (hooks) {
 
   hooks.beforeEach(async function () {
     server.createList('agent', 3);
+    server.create('region', { id: 'global' });
     agent = server.db.agents[0];
     await ServerDetail.visit({ name: agent.name });
   });

--- a/ui/tests/acceptance/task-logs-test.js
+++ b/ui/tests/acceptance/task-logs-test.js
@@ -62,9 +62,7 @@ module('Acceptance | task logs', function (hooks) {
 
   test('the stdout log immediately starts streaming', async function (assert) {
     await TaskLogs.visit({ id: allocation.id, name: task.name });
-    const logUrlRegex = new RegExp(
-      `/v1/client/fs/logs/${allocation.id}`
-    );
+    const logUrlRegex = new RegExp(`/v1/client/fs/logs/${allocation.id}`);
     assert.ok(
       server.pretender.handledRequests.filter((req) =>
         logUrlRegex.test(req.url)

--- a/ui/tests/acceptance/task-logs-test.js
+++ b/ui/tests/acceptance/task-logs-test.js
@@ -62,9 +62,8 @@ module('Acceptance | task logs', function (hooks) {
 
   test('the stdout log immediately starts streaming', async function (assert) {
     await TaskLogs.visit({ id: allocation.id, name: task.name });
-    const node = server.db.nodes.find(allocation.nodeId);
     const logUrlRegex = new RegExp(
-      `${node.httpAddr}/v1/client/fs/logs/${allocation.id}`
+      `/v1/client/fs/logs/${allocation.id}`
     );
     assert.ok(
       server.pretender.handledRequests.filter((req) =>

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -92,7 +92,11 @@ export default function moduleForJob(
 
     test('the title buttons are dependent on job status', async function (assert) {
       if (job.status === 'dead') {
-        assert.ok(JobDetail.start.isPresent);
+        if (job.stopped) {
+          assert.ok(JobDetail.start.isPresent);
+        } else {
+          assert.ok(JobDetail.revert.isPresent);
+        }
         assert.ok(JobDetail.purge.isPresent);
         assert.notOk(JobDetail.stop.isPresent);
         assert.notOk(JobDetail.execButton.isPresent);

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -11,7 +11,6 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import JobDetail from 'nomad-ui/tests/pages/jobs/detail';
 import setPolicy from 'nomad-ui/tests/utils/set-policy';
-import { percySnapshot } from '@percy/ember';
 
 const jobTypesWithStatusPanel = ['service', 'system', 'batch', 'sysbatch'];
 async function switchToHistorical() {
@@ -168,17 +167,12 @@ export default function moduleForJob(
           await switchToHistorical(job);
         }
 
-        if (percySnapshot) {
-          await percySnapshot(`TODO: TEMP: legend item? ${job.type}`);
-        }
-
         // explicitly setting allocationStatusDistribution when creating the job that gets passed here
         // is the best way to ensure we don't end up with an unlinkable "queued" allocation status,
         // but we can be redundant for the sake of future-proofing this here.
         const legendItem = find(
           '.legend li.is-clickable:not([data-test-legend-label="queued"]) a'
         );
-        console.log(`legend item ${job.type}`, legendItem);
 
         const status = legendItem.parentElement.getAttribute(
           'data-test-legend-label'

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -11,6 +11,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import JobDetail from 'nomad-ui/tests/pages/jobs/detail';
 import setPolicy from 'nomad-ui/tests/utils/set-policy';
+import { percySnapshot } from '@percy/ember';
 
 const jobTypesWithStatusPanel = ['service', 'system', 'batch', 'sysbatch'];
 async function switchToHistorical() {
@@ -167,12 +168,16 @@ export default function moduleForJob(
           await switchToHistorical(job);
         }
 
+        await percySnapshot(`TODO: TEMP: legend item? ${job.type}`);
+
         // explicitly setting allocationStatusDistribution when creating the job that gets passed here
         // is the best way to ensure we don't end up with an unlinkable "queued" allocation status,
         // but we can be redundant for the sake of future-proofing this here.
         const legendItem = find(
           '.legend li.is-clickable:not([data-test-legend-label="queued"]) a'
         );
+        console.log(`legend item ${job.type}`, legendItem);
+        await this.pauseTest();
 
         const status = legendItem.parentElement.getAttribute(
           'data-test-legend-label'

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -168,7 +168,9 @@ export default function moduleForJob(
           await switchToHistorical(job);
         }
 
-        await percySnapshot(`TODO: TEMP: legend item? ${job.type}`);
+        if (percySnapshot) {
+          await percySnapshot(`TODO: TEMP: legend item? ${job.type}`);
+        }
 
         // explicitly setting allocationStatusDistribution when creating the job that gets passed here
         // is the best way to ensure we don't end up with an unlinkable "queued" allocation status,
@@ -177,7 +179,6 @@ export default function moduleForJob(
           '.legend li.is-clickable:not([data-test-legend-label="queued"]) a'
         );
         console.log(`legend item ${job.type}`, legendItem);
-        await this.pauseTest();
 
         const status = legendItem.parentElement.getAttribute(
           'data-test-legend-label'

--- a/ui/tests/integration/components/job-page/periodic-test.js
+++ b/ui/tests/integration/components/job-page/periodic-test.js
@@ -202,6 +202,8 @@ module('Integration | Component | job-page/periodic', function (hooks) {
       childrenCount: 0,
       createAllocations: false,
       status: 'dead',
+      withPreviousStableVersion: true,
+      stopped: true,
     });
     await this.store.findAll('job');
 
@@ -223,6 +225,8 @@ module('Integration | Component | job-page/periodic', function (hooks) {
       childrenCount: 0,
       createAllocations: false,
       status: 'dead',
+      withPreviousStableVersion: true,
+      stopped: true,
     });
     await this.store.findAll('job');
 
@@ -243,6 +247,8 @@ module('Integration | Component | job-page/periodic', function (hooks) {
       childrenCount: 0,
       createAllocations: false,
       status: 'dead',
+      withPreviousStableVersion: true,
+      stopped: true,
     });
     await this.store.findAll('job');
 

--- a/ui/tests/integration/components/job-page/service-test.js
+++ b/ui/tests/integration/components/job-page/service-test.js
@@ -112,7 +112,11 @@ module('Integration | Component | job-page/service', function (hooks) {
   test('Starting a job sends a post request for the job using the current definition', async function (assert) {
     assert.expect(1);
 
-    const mirageJob = makeMirageJob(this.server, { status: 'dead' });
+    const mirageJob = makeMirageJob(this.server, {
+      status: 'dead',
+      withPreviousStableVersion: true,
+      stopped: true,
+    });
     await this.store.findAll('job');
 
     const job = this.store.peekAll('job').findBy('plainId', mirageJob.id);
@@ -129,7 +133,11 @@ module('Integration | Component | job-page/service', function (hooks) {
 
     this.server.pretender.post('/v1/job/:id', () => [403, {}, '']);
 
-    const mirageJob = makeMirageJob(this.server, { status: 'dead' });
+    const mirageJob = makeMirageJob(this.server, {
+      status: 'dead',
+      withPreviousStableVersion: true,
+      stopped: true,
+    });
     await this.store.findAll('job');
 
     const job = this.store.peekAll('job').findBy('plainId', mirageJob.id);
@@ -144,7 +152,10 @@ module('Integration | Component | job-page/service', function (hooks) {
   test('Purging a job sends a purge request for the job', async function (assert) {
     assert.expect(1);
 
-    const mirageJob = makeMirageJob(this.server, { status: 'dead' });
+    const mirageJob = makeMirageJob(this.server, {
+      status: 'dead',
+      withPreviousStableVersion: true,
+    });
     await this.store.findAll('job');
 
     const job = this.store.peekAll('job').findBy('plainId', mirageJob.id);

--- a/ui/tests/integration/components/job-page/service-test.js
+++ b/ui/tests/integration/components/job-page/service-test.js
@@ -114,8 +114,8 @@ module('Integration | Component | job-page/service', function (hooks) {
 
     const mirageJob = makeMirageJob(this.server, {
       status: 'dead',
-      withPreviousStableVersion: true,
-      stopped: true,
+      // withPreviousStableVersion: true,
+      // stopped: true,
     });
     await this.store.findAll('job');
 

--- a/ui/tests/integration/components/job-page/service-test.js
+++ b/ui/tests/integration/components/job-page/service-test.js
@@ -114,8 +114,6 @@ module('Integration | Component | job-page/service', function (hooks) {
 
     const mirageJob = makeMirageJob(this.server, {
       status: 'dead',
-      // withPreviousStableVersion: true,
-      // stopped: true,
     });
     await this.store.findAll('job');
 

--- a/ui/tests/integration/components/job-page/service-test.js
+++ b/ui/tests/integration/components/job-page/service-test.js
@@ -114,6 +114,8 @@ module('Integration | Component | job-page/service', function (hooks) {
 
     const mirageJob = makeMirageJob(this.server, {
       status: 'dead',
+      withPreviousStableVersion: true,
+      stopped: true,
     });
     await this.store.findAll('job');
 


### PR DESCRIPTION
In https://github.com/hashicorp/nomad/pull/24555, I changed up our `ember-exam` step in `test-ui` tests to use a custom test runner. In CI, it runs in parallel in 4 partitions.

This code had a bug: my tests were being reported locally in each partition, but because `continue-on-error` was set, they would also report back with a green checkmark / passing. A PR author or reviewer would have to click through passed test logs to see the failures.

**This PR does two main things:**
- Fixes the failing tests that have resulted from (and been suppressed during) new feature work since this has been in place
- Adds an `Express failure` step afterward `ember-exam` that summarizes failures and acts as the red-x for failing tests/checks.
  - In order to do this, this PR keeps `continue-on-error` (so ember-exam doesn't stop after a single failure) and sets `fail-fast` to disabled (to allow follow-up steps, like this one, to run)

![image](https://github.com/user-attachments/assets/8fe65321-ffc0-4407-816a-8ba24ed64d8e)

### Summary of tests that needed fixing
- *generally*: failing tests were isolated to mirage-related issues (mocked data, not user-facing). The features that caused these failures all had their own tests that were validated at development time, and the failures here had dependencies on things these features changed in various ways. Details:
- *streaming task logs*: In https://github.com/hashicorp/nomad/pull/24973, we removed the `read node` ACL policy requirement. Several of our acceptance tests looked for specific URLs that presupposed the existence of the node.httpAddr for the logs being streamed, so rather than change all the hardcoded URLs, I gave the test runner a token that has node read access.
- *the start button*: In https://github.com/hashicorp/nomad/pull/24985, we changed the "Start Job" button to be conditional (If the job has stop=true, it behaves as it ever did. Otherwise, it checks for versions to see if there is a previously stable one to fall back to). Several tests (of the job page title bar, etc.) checked for the existence of the start button to prove that a job was stopped, among other things. This is kind of checking for a symptom rather than a cause, but to not shake things up too much, I added a `withPreviousStableVersion` property to our mock job factory) and had our job-detail tests add it where appropriate.
- *server leadership is determined across all regions*: In https://github.com/hashicorp/nomad/pull/24723 we changed the `server.isLeader` property to work more nicely in multi-region federated clusters. This means that for each region, we now make a request to the `/status/leader?region=${region}` endpoint. This endpoint requires sufficient permissions, so those are added to the test runner conditionally.


TODO: 
- [ ] After this is merged, I will cherry-pick this and the original work in #24555  back to releases/1.9.x