### PR TITLE
Remove triggers from null resources

### DIFF
--- a/e2e/terraform/provision-infra/provision-nomad/install-linux.tf
+++ b/e2e/terraform/provision-infra/provision-nomad/install-linux.tf
@@ -8,8 +8,7 @@ resource "local_sensitive_file" "nomad_systemd_unit_file" {
 }
 
 resource "null_resource" "install_nomad_binary_linux" {
-  count    = var.platform == "linux" ? 1 : 0
-  triggers = { nomad_binary_sha = filemd5(var.nomad_local_binary) }
+  count = var.platform == "linux" ? 1 : 0
 
   connection {
     type        = "ssh"

--- a/e2e/terraform/provision-infra/provision-nomad/install-windows.tf
+++ b/e2e/terraform/provision-infra/provision-nomad/install-windows.tf
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 resource "null_resource" "install_nomad_binary_windows" {
-  count    = var.platform == "windows" ? 1 : 0
-  triggers = { nomad_binary_sha = filemd5(var.nomad_local_binary) }
+  count = var.platform == "windows" ? 1 : 0
 
   connection {
     type            = "ssh"


### PR DESCRIPTION
…remote instances

### Description
The[ `resource`](https://github.com/hashicorp/nomad/blob/d9e2cb23b9af3fbf7e172d3547b004a25fa9cff2/e2e/terraform/provision-infra/provision-nomad/install-linux.tf#L10) in charge of installing the nomad binary in the terraform was written with the idea of allowing "hot" upgrades, by triggering a new installation every time the binary it was using as an input was changed. It presents a problem when using it in conjunction with other modules because any change in that path will trigger the resource, preventing the use of dynamic inputs.

This PR removes the trigger.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
