### PR TITLE
reset max query time of blocking queries in client after retries

### DIFF
--- a/.changelog/25039.txt
+++ b/.changelog/25039.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where temporary RPC errors cause the client to poll for changes more frequently thereafter
+```

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -127,10 +127,15 @@ TRY:
 	}
 
 	if time.Now().After(deadline) {
-		// Blocking queries are tricky.  jitters and rpcholdtimes in multiple places can result in our server call taking longer than we wanted it to. For example:
-		// a block time of 5s may easily turn into the server blocking for 10s since it applies its own RPCHoldTime. If the server dies at t=7s we still want to retry
-		// so before we give up on blocking queries make one last attempt for an immediate answer
+		// Blocking queries are tricky.  jitters and rpcholdtimes in multiple
+		// places can result in our server call taking longer than we wanted it
+		// to. For example: a block time of 5s may easily turn into the server
+		// blocking for 10s since it applies its own RPCHoldTime. If the server
+		// dies at t=7s we still want to retry so before we give up on blocking
+		// queries make one last attempt for an immediate answer
 		if info, ok := args.(structs.RPCInfo); ok && info.TimeToBlock() > 0 {
+			oldBlockTime := info.TimeToBlock()
+			defer info.SetTimeToBlock(oldBlockTime)
 			info.SetTimeToBlock(0)
 			return c.RPC(method, args, reply)
 		}
@@ -144,13 +149,18 @@ TRY:
 
 	select {
 	case <-timer.C:
-		// If we are going to retry a blocking query we need to update the time to block so it finishes by our deadline.
+		// If we are going to retry a blocking query we need to update the time
+		// to block so it finishes by our deadline.
+
 		if info, ok := args.(structs.RPCInfo); ok && info.TimeToBlock() > 0 {
 			newBlockTime := time.Until(deadline)
-			// We can get below 0 here on slow computers because we slept for jitter so at least try to get an immediate response
+			// We can get below 0 here on slow computers because we slept for
+			// jitter so at least try to get an immediate response
 			if newBlockTime < 0 {
 				newBlockTime = 0
 			}
+			oldBlockTime := info.TimeToBlock()
+			defer info.SetTimeToBlock(oldBlockTime)
 			info.SetTimeToBlock(newBlockTime)
 			return c.RPC(method, args, reply)
 		}


### PR DESCRIPTION
When a blocking query on the client hits a retryable error, we change the max query time so that it falls within the `RPCHoldTimeout` timeout. But when the retry succeeds we don't reset it to the original value.

Because the calls to `Node.GetClientAllocs` reuse the same request struct instead of reallocating it, any retry will cause the agent to poll at a faster frequency until the agent restarts. No other RPC on the client currently has this behavior, but we'll fix this in the `rpc` method rather than in the caller so that any future users of the `rpc` method don't have to remember this detail.

Fixes: https://github.com/hashicorp/nomad/issues/25033
Ref: https://hashicorp.atlassian.net/browse/NET-12116

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
