### PR TITLE
vault: fix bug in logging logic around renewals

### DIFF
--- a/.changelog/25040.txt
+++ b/.changelog/25040.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault: Fixed a bug where successful renewal was logged as an error
+```

--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -451,11 +451,11 @@ func (c *vaultClient) renew(req *vaultClientRenewalRequest) error {
 			strings.Contains(errMsg, "permission denied") ||
 			strings.Contains(errMsg, "token not found") {
 			fatal = true
+		} else {
+			c.logger.Debug("renewal error details", "req.increment", req.increment, "lease_duration", leaseDuration, "renewal_duration", renewalDuration)
+			c.logger.Error("error during renewal of lease or token failed due to a non-fatal error; retrying",
+				"error", renewalErr, "period", next)
 		}
-	} else {
-		c.logger.Debug("renewal error details", "req.increment", req.increment, "lease_duration", leaseDuration, "renewal_duration", renewalDuration)
-		c.logger.Error("error during renewal of lease or token failed due to a non-fatal error; retrying",
-			"error", renewalErr, "period", next)
 	}
 
 	if c.isTracked(req.id) {


### PR DESCRIPTION
In #24409 we fixed a bug where some of the error messages we get from Vault weren't being caught correctly. This fix itself contains a bug where we changed the logic that logged the non-fatal errors so that it logs when there is no renewal error.

Ref: https://github.com/hashicorp/nomad/pull/24409
Fixes: https://github.com/hashicorp/nomad/issues/24933
