### PR TITLE
enos: improve documentation around required variables

### DIFF
--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -4,7 +4,7 @@
 scenario "upgrade" {
   description = <<-EOF
     The upgrade scenario verifies in-place upgrades between previously released versions of Nomad
-    against another candidate build. 
+    against another candidate build.
     EOF
 
   matrix {
@@ -37,7 +37,7 @@ scenario "upgrade" {
     description = <<-EOF
     Determine which Nomad artifact we want to use for the scenario, depending on the
     'arch', 'edition' and 'os' and bring it from the artifactory to the local instance
-    running enos.   
+    running enos.
     EOF
 
     module = module.build_artifactory
@@ -49,7 +49,7 @@ scenario "upgrade" {
       edition              = matrix.edition
       product_version      = var.product_version
       os                   = matrix.os
-      binary_path          = "${var.nomad_local_binary}/${matrix.os}-${matrix.arch}-${matrix.edition}-${var.product_version}"
+      download_binary_path = "${var.download_binary_path}/${matrix.os}-${matrix.arch}-${matrix.edition}-${var.product_version}"
     }
   }
 
@@ -101,7 +101,7 @@ scenario "upgrade" {
     depends_on = [step.run_initial_workloads]
 
     description = <<-EOF
-    Verify the health of the cluster by checking the status of all servers, nodes, 
+    Verify the health of the cluster by checking the status of all servers, nodes,
     jobs and allocs and stopping random allocs to check for correct reschedules"
     EOF
 
@@ -158,11 +158,11 @@ scenario "upgrade" {
     Takes the servers one by one, makes a snapshot, updates the binary with the
     new one previously fetched and restarts the servers.
 
-    Important: The path where the binary will be placed is hardcoded to match 
+    Important: The path where the binary will be placed is hardcoded to match
     what the provision-cluster module does. It can be configurable in the future
     but for now it is:
 
-     * "C:/opt/nomad.exe" for windows 
+     * "C:/opt/nomad.exe" for windows
      * "/usr/local/bin/nomad" for linux
 
     To ensure the servers are upgraded one by one, they use the depends_on meta,
@@ -194,7 +194,7 @@ scenario "upgrade" {
   step "server_upgrade_test_cluster_health" {
     depends_on  = [step.upgrade_servers]
     description = <<-EOF
-    Verify the health of the cluster by checking the status of all servers, nodes, 
+    Verify the health of the cluster by checking the status of all servers, nodes,
     jobs and allocs and stopping random allocs to check for correct reschedules"
     EOF
 
@@ -242,7 +242,7 @@ scenario "upgrade" {
     ]
 
     variables {
-        cc_update_type = "client"  
+        cc_update_type = "client"
         nomad_upgraded_binary             = step.copy_initial_binary.nomad_local_binary
         // ...
     }
@@ -250,7 +250,7 @@ scenario "upgrade" {
 
   step "run_clients_workloads" {
      // ...
-  } 
+  }
 
   step "client_upgrade_test_cluster_health" {
     depends_on  = [step.run_initial_workloads]

--- a/enos/enos-vars.hcl
+++ b/enos/enos-vars.hcl
@@ -16,7 +16,7 @@ variable "artifactory_token" {
 }
 
 variable "product_version" {
-  description = "The version of Nomad we are testing"
+  description = "The version of Nomad we are starting from"
   type        = string
   default     = null
 }
@@ -27,15 +27,11 @@ variable "upgrade_version" {
   default     = null
 }
 
-variable "binary_local_path" {
-  description = "The path to donwload and unzip the binary"
-  type        = string
+variable "download_binary_path" {
+  description = "The path to a local directory where binaries will be downloaded to provision"
 }
 
 # Variables for the provision_cluster module
-variable "nomad_local_binary" {
-  description = "The path to a local binary to provision"
-}
 
 variable "nomad_license" {
   type        = string
@@ -47,11 +43,6 @@ variable "consul_license" {
   type        = string
   description = "If consul_license is set, deploy a license"
   default     = ""
-}
-
-variable "nomad_region" {
-  description = "The AWS region to deploy to."
-  default     = "us-east-1"
 }
 
 variable "server_count" {

--- a/enos/modules/fetch_artifactory/main.tf
+++ b/enos/modules/fetch_artifactory/main.tf
@@ -27,7 +27,7 @@ resource "enos_local_exec" "install_binary" {
 
   environment = {
     URL         = data.enos_artifactory_item.nomad.results[0].url
-    BINARY_PATH = var.binary_path
+    BINARY_PATH = var.download_binary_path
     TOKEN       = var.artifactory_token
     LOCAL_ZIP   = local.artifact_zip
   }

--- a/enos/modules/fetch_artifactory/variables.tf
+++ b/enos/modules/fetch_artifactory/variables.tf
@@ -28,7 +28,7 @@ variable "artifactory_repo" {
 
 variable "edition" {
   type        = string
-  description = "The edition of the binary to search, it can be either CE or ENT"
+  description = "The edition of the binary to search, it can be either \"ce\" or \"ent\""
 }
 
 variable "os" {
@@ -48,13 +48,13 @@ variable "arch" {
   type        = string
 }
 
-variable "binary_path" {
-  description = "The path to donwload and unzip the binary"
-  type        = string
-  default     = "/home/ubuntu/nomad"
-}
-
 variable "download_binary" {
   description = "Used to control if the artifact should be downloaded to the local instance or not"
   default     = true
+}
+
+variable "download_binary_path" {
+  description = "A directory path on the local instance where the artifacts will be installed (requires download_binary is true)"
+  type        = string
+  default     = "/home/ubuntu/nomad"
 }

--- a/enos/modules/fetch_artifactory/variables.tf
+++ b/enos/modules/fetch_artifactory/variables.tf
@@ -28,7 +28,12 @@ variable "artifactory_repo" {
 
 variable "edition" {
   type        = string
-  description = "The edition of the binary to search, it can be either \"ce\" or \"ent\""
+  description = "The edition of the binary to search (one of ce or ent)"
+
+  validation {
+    condition     = contains(["ent", "ce"], var.edition)
+    error_message = "must be one of ent or ce"
+  }
 }
 
 variable "os" {


### PR DESCRIPTION
The variables definitions for Enos upgrade scenarios have a couple of unused variables and some of the documentation strings are ambiguous:

* `nomad_region` and `binary_local_path` variables are unused and can be removed.
* `nomad_local_binary` refers to the directory where the binaries will be download, not the binaries themselves. Rename to make it clear this belongs to the artifactory fetch and not the provisioning step (which uses the artifactory fetch outputs).