### PR TITLE
E2E: dynamic host volumes sticky volumes drain test fix

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/hashicorp/nomad/e2e/consultemplate"
 	_ "github.com/hashicorp/nomad/e2e/disconnectedclients"
 	_ "github.com/hashicorp/nomad/e2e/docker"
+	_ "github.com/hashicorp/nomad/e2e/dynamic_host_volumes"
 	_ "github.com/hashicorp/nomad/e2e/isolation"
 	_ "github.com/hashicorp/nomad/e2e/metrics"
 	_ "github.com/hashicorp/nomad/e2e/namespaces"


### PR DESCRIPTION
I merged #24869 having forgotten we don't run these tests in PR CI, so there's a compile error in the test. Fix that error and add the no-op import we use to catch this kind of thing.

Ref: https://github.com/hashicorp/nomad/pull/24869

---

Unfortunately the test still does not pass, even following https://github.com/hashicorp/nomad/pull/24993

```
$ NOMAD_E2E_VERBOSE=1 go test -v -count=1 ./e2e/dynamic_host_volumes -run TestDynamicHostVolumes_StickyVolumes
=== RUN   TestDynamicHostVolumes_StickyVolumes
    dynamic_host_volumes_test.go:163: [54.688678ms] volume "cfad0d80-3b91-4e53-c06c-d4938a0b2919" created
    dynamic_host_volumes_test.go:163: [5.203492879s] volume "cfad0d80-3b91-4e53-c06c-d4938a0b2919" is "ready" on node "2426901b-0887-f851-4479-990c9ec4db25"
    dynamic_host_volumes_test.go:167: [42.248497ms] volume "3b272944-6589-104d-44f7-8f331c984d50" created
    dynamic_host_volumes_test.go:167: [8.93212636s] volume "3b272944-6589-104d-44f7-8f331c984d50" is "ready" on node "c5b3c050-9e0a-9e06-9ae3-e56c27733318"
    dynamic_host_volumes_test.go:176: [14.269095986s] submitting sticky volume mounter job
    jobs3.go:321: register (service) job: "example-517"
    jobs3.go:369: checking eval: 576b013f-3c1b-7617-002a-d989d149c6c0, status: pending
    jobs3.go:369: checking eval: 576b013f-3c1b-7617-002a-d989d149c6c0, status: complete
    jobs3.go:429: checking deployment: 754da3c5-a3e2-235c-29e6-cd43c221224e, status: running
    jobs3.go:429: checking deployment: 754da3c5-a3e2-235c-29e6-cd43c221224e, status: running
    jobs3.go:429: checking deployment: 754da3c5-a3e2-235c-29e6-cd43c221224e, status: running
    jobs3.go:429: checking deployment: 754da3c5-a3e2-235c-29e6-cd43c221224e, status: running
    jobs3.go:429: checking deployment: 754da3c5-a3e2-235c-29e6-cd43c221224e, status: successful
    jobs3.go:445: deployment 754da3c5-a3e2-235c-29e6-cd43c221224e was a success
    dynamic_host_volumes_test.go:187: [19.318423218s] volume "cfad0d80-3b91-4e53-c06c-d4938a0b2919" on node "2426901b-0887-f851-4479-990c9ec4db25" was selected
    dynamic_host_volumes_test.go:195: [19.331417419s] stopped allocation "1477b499-4619-9a1c-fcf9-1f23e21bd2a5"
    dynamic_host_volumes_test.go:223: [25.685720894s] replacement alloc "54f3d1e9-e5c0-0a3b-3861-5fd486afa92a" is running
    dynamic_host_volumes_test.go:227: [25.685797741s] draining node "2426901b-0887-f851-4479-990c9ec4db25"
    dynamic_host_volumes_test.go:232:
        dynamic_host_volumes_test.go:232: expected condition to pass within wait context
        ↪ error: wait: timeout exceeded: expected blocked eval, got evals => map[string]string{"194aa0fa":"status=\"complete\" trigger=\"alloc-stop\" create_index=114", "44a44730":"status=\"complete\" trigger=\"node-drain\" create_index=122", "576b013f":"status=\"complete\" trigger=\"job-register\" create_index=105", "e249436f":"status=\"complete\" trigger=\"deployment-watcher\" create_index=111"}
    jobs3.go:218: deregister job "example-517"
    jobs3.go:226: system gc
    host3.go:169: deleting volume "3b272944-6589-104d-44f7-8f331c984d50"
    host3.go:169: deleting volume "cfad0d80-3b91-4e53-c06c-d4938a0b2919"
--- FAIL: TestDynamicHostVolumes_StickyVolumes (52.25s)
FAIL
FAIL    github.com/hashicorp/nomad/e2e/dynamic_host_volumes     52.258s
FAIL
```