### PR TITLE
Add tag to instances with OS and add merged output

### DIFF
--- a/e2e/terraform/provision-infra/compute.tf
+++ b/e2e/terraform/provision-infra/compute.tf
@@ -38,6 +38,7 @@ resource "aws_instance" "client_ubuntu_jammy" {
     Name           = "${local.random_name}-client-ubuntu-jammy-${count.index}"
     ConsulAutoJoin = "auto-join-${local.random_name}"
     User           = data.aws_caller_identity.current.arn
+    OS             = "linux"
   }
 }
 
@@ -59,6 +60,7 @@ resource "aws_instance" "client_windows_2016" {
     Name           = "${local.random_name}-client-windows-2016-${count.index}"
     ConsulAutoJoin = "auto-join-${local.random_name}"
     User           = data.aws_caller_identity.current.arn
+    OS             = "window"
   }
 }
 

--- a/e2e/terraform/provision-infra/compute.tf
+++ b/e2e/terraform/provision-infra/compute.tf
@@ -60,7 +60,7 @@ resource "aws_instance" "client_windows_2016" {
     Name           = "${local.random_name}-client-windows-2016-${count.index}"
     ConsulAutoJoin = "auto-join-${local.random_name}"
     User           = data.aws_caller_identity.current.arn
-    OS             = "window"
+    OS             = "windows"
   }
 }
 

--- a/e2e/terraform/provision-infra/outputs.tf
+++ b/e2e/terraform/provision-infra/outputs.tf
@@ -14,7 +14,7 @@ output "windows_clients" {
 }
 
 output "clients" {
-  value = concat(output.linux_clients, output.windows_clients)
+  value = concat(aws_instance.client_ubuntu_jammy.*.public_ip, aws_instance.client_windows_2016.*.public_ip)
 }
 
 output "message" {

--- a/e2e/terraform/provision-infra/outputs.tf
+++ b/e2e/terraform/provision-infra/outputs.tf
@@ -13,6 +13,10 @@ output "windows_clients" {
   value = aws_instance.client_windows_2016.*.public_ip
 }
 
+output "clients" {
+  value = concat(output.linux_clients, output.windows_clients)
+}
+
 output "message" {
   value = <<EOM
 Your cluster has been provisioned! To prepare your environment, run:


### PR DESCRIPTION


### Description
Having only one output for both clients simplifies the scenario definition of the upgrade tests because the steps variable inputs don't accept dynamic values, forcing us to do an intermediate step only to determine which clients are being used.
But thinking on a future where we could make mixed cluster, a tag with the OS is added to each instance so we can differentiate them later.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
