### PR TITLE
state store: remove reschedulable check when getting job status

### DIFF
--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -7896,7 +7896,7 @@ func TestStateStore_GetJobStatus(t *testing.T) {
 			exp: structs.JobStatusPending,
 		},
 		{
-			name: "batch job has all terminal allocs, with no evals",
+			name: "batch job has all terminal allocs and terminal evals",
 			setup: func(t *testing.T, txn *txn) *structs.Job {
 				j := mock.Job()
 				j.Type = structs.JobTypeBatch
@@ -7907,6 +7907,12 @@ func TestStateStore_GetJobStatus(t *testing.T) {
 				a.Job = j
 
 				err := txn.Insert("allocs", a)
+				must.NoError(t, err)
+
+				e := mock.Eval()
+				e.JobID = j.ID
+				e.Status = structs.EvalStatusComplete
+				err = txn.Insert("evals", e)
 				must.NoError(t, err)
 				return j
 			},
@@ -7983,6 +7989,12 @@ func TestStateStore_GetJobStatus(t *testing.T) {
 				a2.NextAllocation = a.ID
 
 				err = txn.Insert("allocs", a2)
+				must.NoError(t, err)
+
+				e := mock.Eval()
+				e.JobID = j.ID
+				e.Status = structs.EvalStatusComplete
+				err = txn.Insert("evals", e)
 				must.NoError(t, err)
 				return j
 			},


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
This change removes some logic from the `getJobStatus()` method in order to remove the call to `time.Now()`.  With this logic removed, we revert back the edge case where jobs that should be pending can be marked dead for a very brief period of time until an evaluation is created for them.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
