### PR TITLE
stateful deployments: fix return in the `hasVolumes` feasibility check

### DIFF
--- a/scheduler/feasible.go
+++ b/scheduler/feasible.go
@@ -252,6 +252,7 @@ func (h *HostVolumeChecker) hasVolumes(n *structs.Node) bool {
 						return true
 					}
 				}
+				return false
 			}
 		} else if !req.ReadOnly {
 			// this is a static host volume and can only be mounted ReadOnly,


### PR DESCRIPTION
A return statement was missing in the sticky volume check—when we weren't able to find a suitable volume, we did not return `false`. This was caught by e2e test. 

This PR fixes the issue, and corrects and expands the unit test. 

E2E run on this branch:
```
=== RUN   TestDynamicHostVolumes_CreateWorkflow
    dynamic_host_volumes_test.go:34: [8.449645s] submitting mounter job
    dynamic_host_volumes_test.go:37: [10.121018s] test complete, cleaning up
--- PASS: TestDynamicHostVolumes_CreateWorkflow (10.71s)
=== RUN   TestDynamicHostVolumes_RegisterWorkflow
    dynamic_host_volumes_test.go:54: [988.745416ms] register job "register-volumes-769" created
    dynamic_host_volumes_test.go:61: [1.3541875s] ACL policy for job "register-volumes-769" created
    dynamic_host_volumes_test.go:69: [3.232239833s] job dispatched
    dynamic_host_volumes_test.go:92: [4.012607083s] dispatched job done
    dynamic_host_volumes_test.go:137: [12.286929875s] volume "88d0c683-a00d-4ddd-f968-df01b71d12bc" is ready
    dynamic_host_volumes_test.go:144: [12.287161541s] submitting mounter job
    dynamic_host_volumes_test.go:147: [12.846163416s] test complete, cleaning up
--- PASS: TestDynamicHostVolumes_RegisterWorkflow (13.70s)
=== RUN   TestDynamicHostVolumes_StickyVolumes
    dynamic_host_volumes_test.go:176: [17.172221583s] submitting sticky volume mounter job
    dynamic_host_volumes_test.go:187: [22.46152825s] volume "b6f2122d-2b0e-508a-ba0e-c99a51c7cfdf" on node "5258811f-893c-589d-5b06-c59550ec8463" was selected
    dynamic_host_volumes_test.go:195: [22.566851s] stopped allocation "089bf161-f3cc-48d4-86a2-7c3b40651390"
    dynamic_host_volumes_test.go:223: [29.399482167s] replacement alloc "41149fc6-8e21-6b6e-b8e9-c0280a6bb464" is running
    dynamic_host_volumes_test.go:227: [29.399648083s] draining node "5258811f-893c-589d-5b06-c59550ec8463"
    dynamic_host_volumes_test.go:258: [45.955586875s] undraining node "5258811f-893c-589d-5b06-c59550ec8463"
    dynamic_host_volumes_test.go:286: [47.951152792s] replacement alloc "5b373eaa-d61a-2bcb-d8e2-18b98c8c8c3a" is running
--- PASS: TestDynamicHostVolumes_StickyVolumes (49.11s)
PASS
ok  	github.com/hashicorp/nomad/e2e/dynamic_host_volumes	74.275s
```