### PR TITLE
semgrep: Fix invalid RPC rule and add validation GHA workflow.

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -6,8 +6,19 @@ on:
   # push:
 
 jobs:
+  semgrep-validate:
+    name: Semgrep Validate
+    if: (github.actor != 'dependabot[bot]')
+    runs-on: ubuntu-latest
+    container:
+      image: returntocorp/semgrep:1.107.0
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - run: semgrep --metrics=off --validate --config=.semgrep/
+
   semgrep:
     name: Semgrep Scan
+    needs: [semgrep-validate]
     runs-on: ubuntu-latest
     container:
       image: returntocorp/semgrep:1.36.0
@@ -18,5 +29,6 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - run: semgrep ci --config=.semgrep/
+
 permissions:
   contents: read

--- a/.semgrep/rpc_endpoint.yml
+++ b/.semgrep/rpc_endpoint.yml
@@ -49,7 +49,7 @@ rules:
             return err
           }
           ...
-          if !aclObj.AllowClientOp()
+          if !aclObj.AllowClientOp() {
             return structs.ErrPermissionDenied
           }
           ...


### PR DESCRIPTION
### Description
Fixes an error in the RPC endpoint rule which meant semgrep was not correctly running all rules in CI. The change also includes a new semgrep-validate workflow which will trigger to ensure the rules are valid before running the semgrep scan.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
