### PR TITLE
event stream: fix wildcard namespace bypass

### DIFF
--- a/nomad/event_endpoint_test.go
+++ b/nomad/event_endpoint_test.go
@@ -312,7 +312,7 @@ OUTER:
 	}
 }
 
-func TestEventStream_validateACL(t *testing.T) {
+func TestEventStream_validateNsOp(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 
@@ -480,10 +480,72 @@ func TestEventStream_validateACL(t *testing.T) {
 			testACL, err := acl.NewACL(tc.Management, []*acl.Policy{p})
 			require.NoError(err)
 
-			err = validateACL(tc.Namespace, tc.Topics, testACL)
+			err = validateNsOp(tc.Namespace, tc.Topics, testACL)
 			require.Equal(tc.ExpectedErr, err)
 		})
 	}
+}
+
+func TestEventStream_validateACL(t *testing.T) {
+	ci.Parallel(t)
+
+	s1, _, cleanupS := TestACLServer(t, nil)
+	defer cleanupS()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	ns1 := mock.Namespace()
+
+	err := s1.State().UpsertNamespaces(0, []*structs.Namespace{ns1})
+	must.NoError(t, err)
+
+	testEvent := &Event{srv: s1}
+
+	t.Run("single namespace ACL errors on wildcard", func(t *testing.T) {
+		policy, err := acl.Parse(mock.NamespacePolicy(ns1.Name, "", []string{acl.NamespaceCapabilityReadJob}))
+		must.NoError(t, err)
+
+		// does not contain policy for default NS
+		testAcl, err := acl.NewACL(false, []*acl.Policy{policy})
+		must.NoError(t, err)
+
+		topics := map[structs.Topic][]string{
+			structs.TopicJob: {"*"},
+		}
+		_, err = testEvent.validateACL("*", topics, testAcl)
+		must.Error(t, err)
+	})
+
+	t.Run("all namespace ACL succeeds on wildcard", func(t *testing.T) {
+		policy1, err := acl.Parse(mock.NamespacePolicy("default", "", []string{acl.NamespaceCapabilityReadJob}))
+		must.NoError(t, err)
+		policy2, err := acl.Parse(mock.NamespacePolicy(ns1.Name, "", []string{acl.NamespaceCapabilityReadJob}))
+		must.NoError(t, err)
+
+		testAcl, err := acl.NewACL(false, []*acl.Policy{policy1, policy2})
+		must.NoError(t, err)
+
+		topics := map[structs.Topic][]string{
+			structs.TopicJob: {"*"},
+		}
+		nses, err := testEvent.validateACL("*", topics, testAcl)
+		must.NoError(t, err)
+		must.Eq(t, nses, []string{"default", ns1.Name})
+	})
+
+	t.Run("single namespace ACL succeeds with correct NS", func(t *testing.T) {
+		policy, err := acl.Parse(mock.NamespacePolicy("default", "", []string{acl.NamespaceCapabilityReadJob}))
+		must.NoError(t, err)
+
+		testAcl, err := acl.NewACL(false, []*acl.Policy{policy})
+		must.NoError(t, err)
+
+		topics := map[structs.Topic][]string{
+			structs.TopicJob: {"*"},
+		}
+		nses, err := testEvent.validateACL("default", topics, testAcl)
+		must.NoError(t, err)
+		must.Eq(t, nses, []string{"default"})
+	})
 }
 
 // TestEventStream_ACL_Update_Close_Stream asserts that an active subscription

--- a/nomad/fsm_test.go
+++ b/nomad/fsm_test.go
@@ -3676,7 +3676,7 @@ func TestFSM_ACLEvents(t *testing.T) {
 				Topics: map[structs.Topic][]string{
 					tc.reqTopic: {"*"},
 				},
-				Namespace: "default",
+				Namespaces: []string{"default"},
 			}
 
 			sub, err := broker.Subscribe(subReq)
@@ -3730,7 +3730,7 @@ func TestFSM_EventBroker_JobRegisterFSMEvents(t *testing.T) {
 		Topics: map[structs.Topic][]string{
 			structs.TopicJob: {"*"},
 		},
-		Namespace: "default",
+		Namespaces: []string{"default"},
 	}
 
 	sub, err := broker.Subscribe(subReq)

--- a/nomad/state/deployment_events_test.go
+++ b/nomad/state/deployment_events_test.go
@@ -97,7 +97,7 @@ func EventsForIndex(t *testing.T, s *StateStore, index uint64) []structs.Event {
 		Topics: map[structs.Topic][]string{
 			"*": {"*"},
 		},
-		Namespace:           "default",
+		Namespaces:          []string{"default"},
 		Index:               index,
 		StartExactlyAtIndex: true,
 	})

--- a/nomad/stream/subscription.go
+++ b/nomad/stream/subscription.go
@@ -6,6 +6,7 @@ package stream
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync/atomic"
 
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -48,9 +49,9 @@ type Subscription struct {
 }
 
 type SubscribeRequest struct {
-	Token     string
-	Index     uint64
-	Namespace string
+	Token      string
+	Index      uint64
+	Namespaces []string
 
 	Topics map[structs.Topic][]string
 
@@ -130,15 +131,10 @@ func filter(req *SubscribeRequest, events []structs.Event) []structs.Event {
 
 	allTopicKeys := req.Topics[structs.TopicAll]
 
-	// Return all events if subscribed to all namespaces and all topics
-	if req.Namespace == "*" && len(allTopicKeys) == 1 && allTopicKeys[0] == string(structs.TopicAll) {
-		return events
-	}
-
 	var result []structs.Event
 
 	for _, event := range events {
-		if req.Namespace != "*" && event.Namespace != "" && event.Namespace != req.Namespace {
+		if event.Namespace != "" && !slices.Contains(req.Namespaces, event.Namespace) {
 			continue
 		}
 

--- a/nomad/stream/subscription_test.go
+++ b/nomad/stream/subscription_test.go
@@ -44,8 +44,10 @@ func TestFilter_AllKeys(t *testing.T) {
 func TestFilter_PartialMatch_Topic(t *testing.T) {
 	ci.Parallel(t)
 
-	events := make([]structs.Event, 0, 5)
-	events = append(events, structs.Event{Topic: "Test", Key: "One"}, structs.Event{Topic: "Test", Key: "Two"}, structs.Event{Topic: "Exclude", Key: "Two"})
+	event1 := structs.Event{Topic: "Test", Key: "One"}
+	event2 := structs.Event{Topic: "Test", Key: "Two"}
+	event3 := structs.Event{Topic: "Exclude", Key: "Two"}
+	events := []structs.Event{event1, event2, event3}
 
 	req := &SubscribeRequest{
 		Topics: map[structs.Topic][]string{
@@ -53,7 +55,7 @@ func TestFilter_PartialMatch_Topic(t *testing.T) {
 		},
 	}
 	actual := filter(req, events)
-	expected := []structs.Event{{Topic: "Test", Key: "One"}, {Topic: "Test", Key: "Two"}}
+	expected := []structs.Event{event1, event2}
 	require.Equal(t, expected, actual)
 
 	require.Equal(t, 2, cap(actual))
@@ -62,11 +64,10 @@ func TestFilter_PartialMatch_Topic(t *testing.T) {
 func TestFilter_Match_TopicAll_SpecificKey(t *testing.T) {
 	ci.Parallel(t)
 
-	events := []structs.Event{
-		{Topic: "Match", Key: "Two"},
-		{Topic: "NoMatch", Key: "One"},
-		{Topic: "OtherMatch", Key: "Two"},
-	}
+	event1 := structs.Event{Topic: "Match", Key: "Two"}
+	event2 := structs.Event{Topic: "NoMatch", Key: "One"}
+	event3 := structs.Event{Topic: "OtherMatch", Key: "Two"}
+	events := []structs.Event{event1, event2, event3}
 
 	req := &SubscribeRequest{
 		Topics: map[structs.Topic][]string{
@@ -75,21 +76,17 @@ func TestFilter_Match_TopicAll_SpecificKey(t *testing.T) {
 	}
 
 	actual := filter(req, events)
-	expected := []structs.Event{
-		{Topic: "Match", Key: "Two"},
-		{Topic: "OtherMatch", Key: "Two"},
-	}
+	expected := []structs.Event{event1, event3}
 	require.Equal(t, expected, actual)
 }
 
 func TestFilter_Match_TopicAll_SpecificKey_Plus(t *testing.T) {
 	ci.Parallel(t)
 
-	events := []structs.Event{
-		{Topic: "FirstTwo", Key: "Two"},
-		{Topic: "Test", Key: "One"},
-		{Topic: "SecondTwo", Key: "Two"},
-	}
+	event1 := structs.Event{Topic: "FirstTwo", Key: "Two"}
+	event2 := structs.Event{Topic: "Test", Key: "One"}
+	event3 := structs.Event{Topic: "SecondTwo", Key: "Two"}
+	events := []structs.Event{event1, event2, event3}
 
 	req := &SubscribeRequest{
 		Topics: map[structs.Topic][]string{
@@ -99,19 +96,16 @@ func TestFilter_Match_TopicAll_SpecificKey_Plus(t *testing.T) {
 	}
 
 	actual := filter(req, events)
-	expected := []structs.Event{
-		{Topic: "FirstTwo", Key: "Two"},
-		{Topic: "Test", Key: "One"},
-		{Topic: "SecondTwo", Key: "Two"},
-	}
+	expected := []structs.Event{event1, event2, event3}
 	require.Equal(t, expected, actual)
 }
 
 func TestFilter_PartialMatch_Key(t *testing.T) {
 	ci.Parallel(t)
 
-	events := make([]structs.Event, 0, 5)
-	events = append(events, structs.Event{Topic: "Test", Key: "One"}, structs.Event{Topic: "Test", Key: "Two"})
+	event1 := structs.Event{Topic: "Test", Key: "One"}
+	event2 := structs.Event{Topic: "Test", Key: "Two"}
+	events := []structs.Event{event1, event2}
 
 	req := &SubscribeRequest{
 		Topics: map[structs.Topic][]string{
@@ -119,7 +113,7 @@ func TestFilter_PartialMatch_Key(t *testing.T) {
 		},
 	}
 	actual := filter(req, events)
-	expected := []structs.Event{{Topic: "Test", Key: "One"}}
+	expected := []structs.Event{event1}
 	require.Equal(t, expected, actual)
 
 	require.Equal(t, 1, cap(actual))
@@ -147,66 +141,39 @@ func TestFilter_NoMatch(t *testing.T) {
 func TestFilter_Namespace(t *testing.T) {
 	ci.Parallel(t)
 
-	events := make([]structs.Event, 0, 5)
-	events = append(events, structs.Event{Topic: "Test", Key: "One", Namespace: "foo"}, structs.Event{Topic: "Test", Key: "Two"}, structs.Event{Topic: "Test", Key: "Two", Namespace: "bar"})
+	event1 := structs.Event{Topic: "Test", Key: "One", Namespace: "foo"}
+	event2 := structs.Event{Topic: "Test", Key: "Two", Namespace: "foo"}
+	event3 := structs.Event{Topic: "Test", Key: "Two", Namespace: "bar"}
+	events := []structs.Event{event1, event2, event3}
 
 	req := &SubscribeRequest{
 		Topics: map[structs.Topic][]string{
 			"*": {"*"},
 		},
-		Namespace: "foo",
+		Namespaces: []string{"foo"},
 	}
 	actual := filter(req, events)
-	expected := []structs.Event{
-		{Topic: "Test", Key: "One", Namespace: "foo"},
-		{Topic: "Test", Key: "Two"},
-	}
+	// expect namespace "bar" to be filtered out
+	expected := []structs.Event{event1, event2}
 	require.Equal(t, expected, actual)
-
 	require.Equal(t, 2, cap(actual))
-}
-
-func TestFilter_NamespaceAll(t *testing.T) {
-	ci.Parallel(t)
-
-	events := make([]structs.Event, 0, 5)
-	events = append(events,
-		structs.Event{Topic: "Test", Key: "One", Namespace: "foo"},
-		structs.Event{Topic: "Test", Key: "Two", Namespace: "bar"},
-		structs.Event{Topic: "Test", Key: "Three", Namespace: "default"},
-	)
-
-	req := &SubscribeRequest{
-		Topics: map[structs.Topic][]string{
-			"*": {"*"},
-		},
-		Namespace: "*",
-	}
-	actual := filter(req, events)
-	expected := []structs.Event{
-		{Topic: "Test", Key: "One", Namespace: "foo"},
-		{Topic: "Test", Key: "Two", Namespace: "bar"},
-		{Topic: "Test", Key: "Three", Namespace: "default"},
-	}
-	require.Equal(t, expected, actual)
 }
 
 func TestFilter_FilterKeys(t *testing.T) {
 	ci.Parallel(t)
 
-	events := make([]structs.Event, 0, 5)
-	events = append(events, structs.Event{Topic: "Test", Key: "One", FilterKeys: []string{"extra-key"}}, structs.Event{Topic: "Test", Key: "Two"}, structs.Event{Topic: "Test", Key: "Two"})
+	event1 := structs.Event{Topic: "Test", Key: "One", FilterKeys: []string{"extra-key"}}
+	event2 := structs.Event{Topic: "Test", Key: "Two"}
+	event3 := structs.Event{Topic: "Test", Key: "Two"}
+	events := []structs.Event{event1, event2, event3}
 
 	req := &SubscribeRequest{
 		Topics: map[structs.Topic][]string{
 			"Test": {"extra-key"},
 		},
-		Namespace: "foo",
 	}
 	actual := filter(req, events)
-	expected := []structs.Event{
-		{Topic: "Test", Key: "One", FilterKeys: []string{"extra-key"}},
-	}
+	expected := []structs.Event{event1}
 	require.Equal(t, expected, actual)
 
 	require.Equal(t, 1, cap(actual))


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Fixes an issue when reading from the [Event stream API](https://developer.hashicorp.com/nomad/api-docs/events#event-stream), the wildcard namespace can be used to bypass ACL policy checks that would not otherwise permit access to a given namespace. Having policy = "read" for any namespace allows the equivalent of policy = "read" for all namespaces.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
<details>
Create two namespaces:

```
$ nomad namespace apply dev
Successfully applied namespace "dev"!

$ nomad namespace apply prod
Successfully applied namespace "prod"!
```

Create the following ACL policy file:

```hcl
namespace "dev" {
  policy = "read"
}
```

Apply that policy and create a token that uses that policy

```
$ nomad acl policy apply developer ./developer.acl.hcl
Successfully wrote "developer" ACL policy!

$ nomad acl token create -type client -name dev -policy developer
Accessor ID  = 6a78c08a-df74-6f33-de84-ddceef9a0a6a
Secret ID    = 6dc3baba-e362-4c27-e6f7-db9ac0aec27e
Name         = dev
Type         = client
Global       = false
Create Time  = 2025-01-29 21:14:44.219254895 +0000 UTC
Expiry Time  = <none>
Create Index = 17
Modify Index = 17
Policies     = [developer]

Roles
<none>
```

In another terminal, set `NOMAD_TOKEN` to the new token secret:

```
export NOMAD_TOKEN=6dc3baba-e362-4c27-e6f7-db9ac0aec27e
```

In the original terminal, create this minimal jobspec:

```hcl
job "example" {

  group "group" {

    task "task" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}
```

Run it and deploy it to the `dev` namespace:

```
$ nomad job run -namespace dev ./example.nomad.hcl
```

In the "dev" terminal, read the event stream for the Job topic in the "dev" namespace:

```
$ nomad operator api '/v1/event/stream?topic=Job&namespace=dev'
```

You'll see events for the job deployed to the dev namespace, as expected. Hit Ctrl-C and try again, this time using the wildcard namespace.

```
$ nomad operator api '/v1/event/stream?topic=Job&namespace=*'
```

You'll see the same set of events for the job deployed to the dev namespace. Leave this running.

Go back to the other terminal where you have the management token and run the job again, this time deploying to the `prod` namespace:

```
$ nomad job run -namespace prod ./example.nomad.hcl
```

Watch the other terminal, and you'll see events for the job in the `prod` namespace appear, in violation of the ACL policy. Note that if you hit Ctrl-C and try again, this time using the `prod` namespace, it will fail as expected:

```
$ nomad operator api '/v1/event/stream?topic=Job&namespace=prod'
Permission denied%
```
</details>

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [X] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
