### PR TITLE
fingerprint: initial fingerprint of Vault/Consul should be periodic

### DIFF
--- a/.changelog/25102.txt
+++ b/.changelog/25102.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fingerprint: Fixed a bug where Consul/Vault would never be fingerprinted if not available on agent start
+```

--- a/.release/linux/package/usr/lib/systemd/system/nomad.service
+++ b/.release/linux/package/usr/lib/systemd/system/nomad.service
@@ -4,9 +4,8 @@ Documentation=https://nomadproject.io/docs/
 Wants=network-online.target
 After=network-online.target
 
-# When using Nomad with Consul it is not necessary to start Consul first. These
-# lines start Consul before Nomad as an optimization to avoid Nomad logging
-# that Consul is unavailable at startup.
+# When using Nomad with Consul you should start Consul first, so that running
+# allocations using Consul are restored correctly during startup.
 #Wants=consul.service
 #After=consul.service
 

--- a/client/fingerprint/fingerprint.go
+++ b/client/fingerprint/fingerprint.go
@@ -124,8 +124,11 @@ type Fingerprint interface {
 	Periodic() (bool, time.Duration)
 }
 
-// ReloadableFingerprint can be implemented if the fingerprinter needs to be run during client reload.
-// If implemented, the client will call Reload during client reload then immediately Fingerprint
+// ReloadableFingerprint can be implemented if the fingerprinter needs to be run
+// during client reload. If implemented, the client will call Reload during
+// client reload then immediately Fingerprint. The Reload call is not protected
+// by the same mutex that Fingerprint is, so implementations must ensure they
+// are safe to call concurrently with a Fingerprint
 type ReloadableFingerprint interface {
 	Fingerprint
 	Reload()


### PR DESCRIPTION
In #24526 we updated the Consul and Vault fingerprints so that they are no longer periodic. This fixed a problem that cluster admins reported where rolling updates of Vault or Consul would cause a thundering herd of fingerprint updates across the whole cluster.

But if Consul/Vault is not available during the initial fingerprint, it will never get fingerprinted again. This is challenging for cluster updates and black starts because the implicit service startup ordering may require reloads. Instead, have the fingerprinter run periodically but mark that it has made its first successful fingerprint of all Consul/Vault clusters. At that point, we can skip further periodic updates. The `Reload` method will reset the mark and allow the subsequent fingerprint to run normally.

Fixes: https://github.com/hashicorp/nomad/issues/25097
Ref: https://github.com/hashicorp/nomad/pull/24526
Ref: https://github.com/hashicorp/nomad/issues/24049

### Testing

The following was run on a client agent's host where Nomad had not previously been run:

```sh
$ sudo systemctl stop consul
$ sudo systemctl start nomad
$ nomad node status
ID        Node Pool  DC        Name     Class      Drain  Eligibility  Status
847fba46  default    philly-1  client0  multipass  false  eligible     ready
$ nomad node status -verbose 847f | grep consul
$ # no fingerprint
```

Now start Consul and see that we eventually fingerprint as expected:

```sh
$ sudo systemctl start consul
$ # wait 15+ seconds
$ nomad node status -verbose 847f | grep consul
consul.connect                    = true
consul.datacenter                 = dc1
consul.dns.addr                   = 10.37.105.67
consul.dns.port                   = 8600
consul.ft.namespaces              = true
consul.grpc                       = 8502
consul.partition                  = default
consul.revision                   = 5781fc51
consul.server                     = false
consul.sku                        = ent
consul.version                    = 1.18.2+ent
unique.consul.name                = nomad0
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
