### PR TITLE
[ui] System, Batch, and Sysbatch jobs' Start Job buttons let you revert to previous versions

### DIFF
--- a/.changelog/25104.txt
+++ b/.changelog/25104.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: System, Batch and Sysbatch jobs get a "Revert to prev version" button on their main pages
+```

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -455,10 +455,15 @@ export default class Job extends Model {
       .any((version) => version.get('stable'));
   }
 
-  @computed('versions.@each.stable')
+  @computed('versions.@each.stable', 'aggregateAllocStatus.label')
   get latestStableVersion() {
     return this.versions.filterBy('stable').sortBy('number').reverse().slice(1)
       .firstObject;
+  }
+
+  @computed('versions.[]', 'aggregateAllocStatus.label')
+  get latestVersion() {
+    return this.versions.sortBy('number').reverse().slice(1).firstObject;
   }
 
   get actions() {

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -351,6 +351,18 @@ export default class Job extends Model {
     return this.type === 'system' || this.type === 'sysbatch';
   }
 
+  // version.Stable is determined by having an associated healthy deployment
+  // but System, Sysbatch, and Batch jobs do not have deployments.
+  // Use this as a boolean to determine if we should show the version stability badge
+  @computed('type')
+  get hasVersionStability() {
+    return (
+      this.type !== 'system' &&
+      this.type !== 'sysbatch' &&
+      this.type !== 'batch'
+    );
+  }
+
   @belongsTo('job', { inverse: 'children' }) parent;
   @hasMany('job', { inverse: 'parent' }) children;
 

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -101,6 +101,25 @@
             @awaitingConfirmation={{this.revertTo.isRunning}}
             @onConfirm={{perform this.revertTo this.job.latestStableVersion}}
           />
+        {{else if
+          (and
+            (or (eq this.job.type "batch") (eq this.job.type "system") (eq this.job.type "sysbatch"))
+            this.job.latestVersion
+          )
+        }}
+          <TwoStepButton
+            data-test-revert
+            @alignRight={{true}}
+            @idleText="Revert to last version (v{{this.job.latestVersion.number}})"
+            @cancelText="Cancel"
+            @confirmText="Yes, Revert to last version"
+            @confirmationMessage="Are you sure you want to revert to the last version?"
+            @awaitingConfirmation={{this.revertTo.isRunning}}
+            @onConfirm={{perform this.revertTo this.job.latestVersion}}
+          />
+          <Hds::Button
+            data-test-edit-and-resubmit
+            @color="primary" @isInline={{true}} @text="Edit and Resubmit job" @route={{"jobs.job.definition" this.job.id}} @query={{hash isEditing=true}} />
         {{else}}
           <Hds::Button
             data-test-edit-and-resubmit

--- a/ui/app/templates/components/job-page/parts/title.hbs
+++ b/ui/app/templates/components/job-page/parts/title.hbs
@@ -103,7 +103,7 @@
           />
         {{else if
           (and
-            (or (eq this.job.type "batch") (eq this.job.type "system") (eq this.job.type "sysbatch"))
+            (not this.job.hasVersionStability)
             this.job.latestVersion
           )
         }}

--- a/ui/app/templates/components/job-version.hbs
+++ b/ui/app/templates/components/job-version.hbs
@@ -8,7 +8,8 @@
   <div class="boxed-section {{if this.version.versionTag "tagged"}}" data-test-tagged-version={{if this.version.versionTag "true" "false"}}>
     <header class="boxed-section-head is-light inline-definitions">
       Version #{{this.version.number}}
-      {{#if this.version.hasVersionStability}}
+
+      {{#if this.version.job.hasVersionStability}}
         <span class="bumper-left pair is-faded">
           <span class="term">Stable</span>
           <span class="badge is-light is-faded" data-test-version-stability><code>{{this.version.stable}}</code></span>

--- a/ui/app/templates/components/job-version.hbs
+++ b/ui/app/templates/components/job-version.hbs
@@ -8,10 +8,14 @@
   <div class="boxed-section {{if this.version.versionTag "tagged"}}" data-test-tagged-version={{if this.version.versionTag "true" "false"}}>
     <header class="boxed-section-head is-light inline-definitions">
       Version #{{this.version.number}}
-      <span class="bumper-left pair is-faded">
-        <span class="term">Stable</span>
-        <span class="badge is-light is-faded" data-test-version-stability><code>{{this.version.stable}}</code></span>
-      </span>
+      {{#if this.version.hasVersionStability}}
+        <span class="bumper-left pair is-faded">
+          <span class="term">Stable</span>
+          <span class="badge is-light is-faded" data-test-version-stability><code>{{this.version.stable}}</code></span>
+        </span>
+      {{else}}
+        <span class="bumper-left" />
+      {{/if}}
       <span class="pair is-faded">
         <span class="term">Submitted</span>
         <span data-test-version-submit-time class="submit-date">{{format-ts this.version.submitTime}}</span>

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -1237,6 +1237,7 @@ export function createRestartableJobs(server) {
     shallow: true,
     createAllocations: false,
     groupAllocCount: 0,
+    type: 'service',
   });
 
   const nonRevertableJob = server.create('job', {
@@ -1246,6 +1247,7 @@ export function createRestartableJobs(server) {
     shallow: true,
     createAllocations: false,
     groupAllocCount: 0,
+    type: 'service',
   });
 
   // So it shows up as "Failed" instead of "Scaled Down"

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -848,6 +848,15 @@ module('Job Start/Stop/Revert/Edit and Resubmit', function (hooks) {
     assert.ok(JobDetail.editAndResubmit.isPresent);
   });
 
+  test('A batch job with a previous version can be reverted', async function (assert) {
+    const revertableSystemJob = server.db.jobs.findBy(
+      (j) => j.name === 'revertable-batch-job'
+    );
+    await JobDetail.visit({ id: revertableSystemJob.id });
+    assert.ok(JobDetail.revert.isPresent);
+    assert.equal(JobDetail.revert.text, 'Revert to last stable version (v0)');
+  });
+
   test('Clicking the resubmit button navigates to the job definition page in edit mode', async function (assert) {
     const job = server.db.jobs.findBy((j) => j.name === 'non-revertable-job');
     await JobDetail.visit({ id: job.id });

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -854,7 +854,7 @@ module('Job Start/Stop/Revert/Edit and Resubmit', function (hooks) {
     );
     await JobDetail.visit({ id: revertableSystemJob.id });
     assert.ok(JobDetail.revert.isPresent);
-    assert.equal(JobDetail.revert.text, 'Revert to last stable version (v0)');
+    assert.equal(JobDetail.revert.text, 'Revert to last version (v0)');
   });
 
   test('Clicking the resubmit button navigates to the job definition page in edit mode', async function (assert) {

--- a/ui/tests/acceptance/job-versions-test.js
+++ b/ui/tests/acceptance/job-versions-test.js
@@ -31,6 +31,7 @@ module('Acceptance | job versions', function (hooks) {
       namespaceId: namespace.id,
       createAllocations: false,
       noDeployments: true,
+      type: 'service',
     });
 
     // Create some versions


### PR DESCRIPTION
Follow-up on #24985: Because that PR looks for a previous `stable=true` version of a job, and system/batch/sysbatch jobs don't have the concept of version stability<sup>1</sup>, this allows for both a "Revert to prev version" and "Edit and Resubmit" (when at least one other version is present), or just an "Edit and Resubmit" button (when there are no previous versions)

![image](https://github.com/user-attachments/assets/059e84cd-12c7-4e76-80b1-77b270743c01)



<sup>1</sup> ~TODO: I should probably remove that label from the versions component in the UI if it's one of these job types~ done like dinner