### PR TITLE
Docs: Clarify Job status mapping on Job page

### DIFF
--- a/website/content/docs/commands/job/status.mdx
+++ b/website/content/docs/commands/job/status.mdx
@@ -30,6 +30,8 @@ When ACLs are enabled, this command requires a token with the `read-job`
 capability for the job's namespace. The `list-jobs` capability is required to
 run the command with a job prefix instead of the exact job ID.
 
+@include 'job-status-map.mdx'
+
 ## General Options
 
 @include 'general_options.mdx'

--- a/website/content/docs/concepts/job.mdx
+++ b/website/content/docs/concepts/job.mdx
@@ -26,27 +26,10 @@ job state matches your desired state.
 ## Job statuses
 
 After you submit your job, Nomad assigns a status to indicate how a job is
-performing. This status indicates how the job's current allocations compare to the desired
-job state.
+performing. This status indicates how the job's current allocations compare to
+the desired job state.
 
-Nomad uses one of three values to describe a job's status.
-
-- `complete`
-- `dead`
-- `running`
-
-The CLI and API return these rigid statuses, which are useful for scheduling and
-garbage collection. However, the Nomad UI displays additional human-readable
-statuses to help you manage jobs.
-
-The following table maps the CLI and API statuses to the statuses that appear in the Nomad UI.
-
-| CLI and API status | UI status |
-| ------------------ | --------- |
-| `complete `        | `Complete`    |
-| `dead`             | `Failed`, `Scaled Down` |
-| `dead (stopped)`   | `Stopped` |
-| `running`          | `Degraded`, `Deploying`, `Healthy`, `Recovering`, `Running`, `Scaled Down` |
+@include 'job-status-map.mdx'
 
 ### UI statuses
 

--- a/website/content/docs/concepts/job.mdx
+++ b/website/content/docs/concepts/job.mdx
@@ -42,9 +42,10 @@ statuses to help you manage jobs.
 The following table maps the CLI and API statuses to the statuses that appear in the Nomad UI.
 
 | CLI and API status | UI status |
-| ---------------    | --------------- |
+| ------------------ | --------- |
 | `complete `        | `Complete`    |
-| `dead`             | `Failed`, `Scaled Down`, `Stopped` |
+| `dead`             | `Failed`, `Scaled Down` |
+| `dead (stopped)`   | `Stopped` |
 | `running`          | `Degraded`, `Deploying`, `Healthy`, `Recovering`, `Running`, `Scaled Down` |
 
 ### UI statuses

--- a/website/content/docs/concepts/job.mdx
+++ b/website/content/docs/concepts/job.mdx
@@ -31,13 +31,31 @@ the desired job state.
 
 @include 'job-status-map.mdx'
 
+### CLI statuses
+
+Only the CLI returns these job statuses.
+
+#### `running`
+
+The `running` status indicates that the job has non-terminal allocations.
+
+#### `dead`
+
+The `dead` status indicates that all evaluations and allocations are in a
+terminal state.
+
+#### `dead (stopped)`
+
+The `dead (stopped)` status indicates that a user has manually stopped the job.
+You may start this job again.
+
 ### UI statuses
 
 These job statuses only appear in the Nomad UI.
 
 #### Complete
 
-The `Complete` status indicated that all expected allocations are complete. This
+The `Complete` status indicates that all expected allocations are complete. This
 status applies to batch and sysbatch jobs only.
 
 #### Degraded

--- a/website/content/docs/concepts/job.mdx
+++ b/website/content/docs/concepts/job.mdx
@@ -60,7 +60,8 @@ status applies to batch and sysbatch jobs only.
 
 #### Degraded
 
-The `Degraded` status indicates that a [deployment] is not taking place. Some allocations are failed, lost, or unplaced.
+The `Degraded` status indicates that a [deployment] is not taking place. Some
+allocations are failed, lost, or unplaced.
 
 #### Deploying
 
@@ -72,7 +73,8 @@ The `Failed` status indicates that all allocations are failed, lost, or unplaced
 
 #### Healthy
 
-The `Healthy` status indicates that all expected allocations are running and healthy.
+The `Healthy` status indicates that all expected allocations are running and
+healthy.
 
 #### Recovering
 

--- a/website/content/partials/job-status-map.mdx
+++ b/website/content/partials/job-status-map.mdx
@@ -1,6 +1,5 @@
-Nomad uses one of three values to describe a job's status.
+Nomad uses one of these values to describe a job's status.
 
-- `complete`
 - `dead`
 - `running`
 
@@ -10,9 +9,8 @@ statuses to help you manage jobs.
 
 The following table maps the CLI statuses to the statuses that appear in the Nomad UI.
 
-| CLI status | UI status |
-| ---------- | --------- |
-| `dead`      | `Complete`    |
-| `dead`           | `Failed`, `Scaled Down` |
+| CLI status       | UI status |
+| ---------------- | --------- |
+| `dead`           | `Complete`, `Failed`, `Scaled Down` |
 | `dead (stopped)` | `Stopped` |
 | `running`        | `Degraded`, `Deploying`, `Healthy`, `Recovering`, `Running`, `Scaled Down` |

--- a/website/content/partials/job-status-map.mdx
+++ b/website/content/partials/job-status-map.mdx
@@ -1,4 +1,4 @@
-Nomad uses one of these values to describe a job's status.
+Nomad uses one of these values to describe a job's status:
 
 - `dead`
 - `running`

--- a/website/content/partials/job-status-map.mdx
+++ b/website/content/partials/job-status-map.mdx
@@ -1,0 +1,18 @@
+Nomad uses one of three values to describe a job's status.
+
+- `complete`
+- `dead`
+- `running`
+
+The CLI returns these rigid statuses, which are useful for scheduling and
+garbage collection. However, the Nomad UI displays additional human-readable
+statuses to help you manage jobs.
+
+The following table maps the CLI statuses to the statuses that appear in the Nomad UI.
+
+| CLI status | UI status |
+| ---------- | --------- |
+| `complete `      | `Complete`    |
+| `dead`           | `Failed`, `Scaled Down` |
+| `dead (stopped)` | `Stopped` |
+| `running`        | `Degraded`, `Deploying`, `Healthy`, `Recovering`, `Running`, `Scaled Down` |

--- a/website/content/partials/job-status-map.mdx
+++ b/website/content/partials/job-status-map.mdx
@@ -7,7 +7,8 @@ The CLI returns these rigid statuses, which are useful for scheduling and
 garbage collection. However, the Nomad UI displays additional human-readable
 statuses to help you manage jobs.
 
-The following table maps the CLI statuses to the statuses that appear in the Nomad UI.
+The following table maps the CLI statuses to the statuses that appear in the
+Nomad UI.
 
 | CLI status       | UI status |
 | ---------------- | --------- |

--- a/website/content/partials/job-status-map.mdx
+++ b/website/content/partials/job-status-map.mdx
@@ -12,7 +12,7 @@ The following table maps the CLI statuses to the statuses that appear in the Nom
 
 | CLI status | UI status |
 | ---------- | --------- |
-| `complete `      | `Complete`    |
+| `dead`      | `Complete`    |
 | `dead`           | `Failed`, `Scaled Down` |
 | `dead (stopped)` | `Stopped` |
 | `running`        | `Degraded`, `Deploying`, `Healthy`, `Recovering`, `Running`, `Scaled Down` |


### PR DESCRIPTION
### Description
- Add `dead (stopped)` row to status mapping table in Job statuses section. This small change is a result of clarification provided to me in reviewing https://github.com/hashicorp/nomad/pull/24150  ([comment](https://github.com/hashicorp/nomad/pull/24150#discussion_r1951623749))
- In mapping table, change `complete` to `dead` since the job status is actually `dead` when the allocation status is `complete` (suggestion by Michael in DM conversation)
- pull job status mapping into partial and include in the job status command page so users don't have to refer to another page 
- remove API from table since the API endpoint lists different statuses
- Add CLI status definitions based on [code](https://github.com/hashicorp/nomad/blob/main/nomad/structs/structs.go#L4361-L4365)
- Additional feedback in [Slack conversation](https://hashicorp.slack.com/archives/C02V6HVS98E/p1739545350132279)

### Links
Jira [CE-816]
Deploy previews
- Job statuses https://nomad-git-ce816dead-hashicorp.vercel.app/nomad/docs/concepts/job#job-statuses
- nomad job status https://nomad-git-ce816dead-hashicorp.vercel.app/nomad/docs/commands/job/status

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[CE-816]: https://hashicorp.atlassian.net/browse/CE-816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ