### PR TITLE
Make consul & vault initially periodic

### DIFF
--- a/client/fingerprint_manager.go
+++ b/client/fingerprint_manager.go
@@ -166,7 +166,11 @@ func (fm *FingerprintManager) setupFingerprinters(fingerprints []string) error {
 
 // runFingerprint runs each fingerprinter individually on an ongoing basis
 func (fm *FingerprintManager) runFingerprint(f fingerprint.Fingerprint, name string) {
-	_, period := f.Periodic()
+	keep, period := f.Periodic()
+	if !keep {
+		// This should never happen, but just in case
+		return
+	}
 	fm.logger.Debug("fingerprinting periodically", "fingerprinter", name, "initial_period", period)
 
 	timer := time.NewTimer(period)
@@ -181,7 +185,10 @@ func (fm *FingerprintManager) runFingerprint(f fingerprint.Fingerprint, name str
 				continue
 			}
 
-			_, period = f.Periodic()
+			keep, period = f.Periodic()
+			if !keep {
+				return
+			}
 			timer.Reset(period)
 		case <-fm.shutdownCh:
 			return


### PR DESCRIPTION
With the change of consul & vault fingerprints to be reloadable, if nomad fails to contact them initially it will require a reload, which can be another step to take into account at the start of the instance. 

This PR changes the fingerpint manager to be able to accept some fingerprints that are both reloadable and periodic. 
Also makes the vault and consul fingerprints periodic until initially discovered and then only reloadable.

I think with this change, if for whatever reason, consul boots up later or a call to vault ends up in timeout the nomad client will still configure them initially. This also maintains the initial objective of making these fingerprints periodic, which was to leave the power in the user of re-fingerprint.
