### PR TITLE
template: fix client's default retry configuration

### DIFF
--- a/.changelog/25113.txt
+++ b/.changelog/25113.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+template: Fixed a bug where unset client.template retry blocks ignored defaults
+```

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -346,7 +346,7 @@ func TestNewRunnerConfig_Retries(t *testing.T) {
 		VaultConfig:  &sconfig.VaultConfig{Enabled: pointer.Of(true)},
 	}
 	ct := ctconf.DefaultTemplateConfig()
-	mapping := map[*ctconf.TemplateConfig]*structs.Template{ct: &structs.Template{}}
+	mapping := map[*ctconf.TemplateConfig]*structs.Template{ct: {}}
 	tconfig, err := newRunnerConfig(managerCfg, mapping)
 	must.NoError(t, err)
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -465,13 +465,19 @@ func DefaultTemplateConfig() *ClientTemplateConfig {
 			Max: pointer.Of(4 * time.Minute),
 		},
 		ConsulRetry: &RetryConfig{
-			Attempts: pointer.Of(0), // unlimited
+			Attempts:   pointer.Of(12),
+			Backoff:    pointer.Of(time.Millisecond * 250),
+			MaxBackoff: pointer.Of(time.Minute),
 		},
 		VaultRetry: &RetryConfig{
-			Attempts: pointer.Of(0), // unlimited
+			Attempts:   pointer.Of(12),
+			Backoff:    pointer.Of(time.Millisecond * 250),
+			MaxBackoff: pointer.Of(time.Minute),
 		},
 		NomadRetry: &RetryConfig{
-			Attempts: pointer.Of(0), // unlimited
+			Attempts:   pointer.Of(12),
+			Backoff:    pointer.Of(time.Millisecond * 250),
+			MaxBackoff: pointer.Of(time.Minute),
 		},
 	}
 }

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -1566,21 +1566,21 @@ func TestConfig_LoadConsulTemplateConfig(t *testing.T) {
 
 		// Consul Retry
 		must.NotNil(t, templateConfig.ConsulRetry)
-		must.Eq(t, 0, *templateConfig.ConsulRetry.Attempts)
-		must.Nil(t, templateConfig.ConsulRetry.Backoff)
-		must.Nil(t, templateConfig.ConsulRetry.MaxBackoff)
+		must.Eq(t, 12, *templateConfig.ConsulRetry.Attempts)
+		must.Eq(t, time.Millisecond*250, *templateConfig.ConsulRetry.Backoff)
+		must.Eq(t, time.Minute, *templateConfig.ConsulRetry.MaxBackoff)
 
 		// Vault Retry
 		must.NotNil(t, templateConfig.VaultRetry)
-		must.Eq(t, 0, *templateConfig.VaultRetry.Attempts)
-		must.Nil(t, templateConfig.VaultRetry.Backoff)
-		must.Nil(t, templateConfig.VaultRetry.MaxBackoff)
+		must.Eq(t, 12, *templateConfig.VaultRetry.Attempts)
+		must.Eq(t, time.Millisecond*250, *templateConfig.VaultRetry.Backoff)
+		must.Eq(t, time.Minute, *templateConfig.VaultRetry.MaxBackoff)
 
 		// Nomad Retry
 		must.NotNil(t, templateConfig.NomadRetry)
-		must.Eq(t, 0, *templateConfig.NomadRetry.Attempts)
-		must.Nil(t, templateConfig.NomadRetry.Backoff)
-		must.Nil(t, templateConfig.NomadRetry.MaxBackoff)
+		must.Eq(t, 12, *templateConfig.NomadRetry.Attempts)
+		must.Eq(t, time.Millisecond*250, *templateConfig.NomadRetry.Backoff)
+		must.Eq(t, time.Minute, *templateConfig.NomadRetry.MaxBackoff)
 	})
 
 	t.Run("client config with full template block", func(t *testing.T) {
@@ -1626,13 +1626,13 @@ func TestConfig_LoadConsulTemplateConfig(t *testing.T) {
 
 		// Vault Retry
 		must.NotNil(t, templateConfig.VaultRetry)
-		must.Eq(t, 10, *templateConfig.VaultRetry.Attempts)
+		must.Eq(t, 0, *templateConfig.VaultRetry.Attempts)
 		must.Eq(t, 15*time.Second, *templateConfig.VaultRetry.Backoff)
 		must.Eq(t, 20*time.Second, *templateConfig.VaultRetry.MaxBackoff)
 
 		// Nomad Retry
 		must.NotNil(t, templateConfig.NomadRetry)
-		must.Eq(t, 15, *templateConfig.NomadRetry.Attempts)
+		must.Eq(t, 12, *templateConfig.NomadRetry.Attempts)
 		must.Eq(t, 20*time.Second, *templateConfig.NomadRetry.Backoff)
 		must.Eq(t, 25*time.Second, *templateConfig.NomadRetry.MaxBackoff)
 	})

--- a/command/agent/test-resources/client_with_template.hcl
+++ b/command/agent/test-resources/client_with_template.hcl
@@ -25,13 +25,13 @@ client {
     }
 
     vault_retry {
-      attempts    = 10
+      attempts    = 0 // unlimited
       backoff     = "15s"
       max_backoff = "20s"
     }
 
     nomad_retry {
-      attempts    = 15
+      // unset attempts=12, should fallback to default
       backoff     = "20s"
       max_backoff = "25s"
     }


### PR DESCRIPTION
In #20165 we fixed a bug where a partially configured `client.template` retry block would set any unset fields to nil instead of their default values. But this patch introduced a regression in the default values, so we were now defaulting to unlimited retries. Restore the correct behavior and add better test coverage at both the config parsing and template configuration code.

Ref: https://github.com/hashicorp/nomad/pull/20165
Ref: https://github.com/hashicorp/nomad/issues/23305#issuecomment-2643731565

### Testing & Reproduction steps

In addition to the new and fixed unit tests, I tested with Vault and a template that would never succeed due to permission denied errors, with different client configurations as show here.

Empty (default)

```hcl
template {}
```

> * permission denied (retry attempt 1 after "250ms")
> * permission denied (retry attempt 2 after "500ms")
> * permission denied (retry attempt 3 after "1s")
> * permission denied (retry attempt 4 after "2s")
> * permission denied (retry attempt 5 after "4s")
> * permission denied (retry attempt 6 after "8s")
> * permission denied (retry attempt 7 after "16s")
> * permission denied (retry attempt 8 after "32s")
> * permission denied (retry attempt 9 after "1m")
> * permission denied (retry attempt 10 after "1m")
> * permission denied (retry attempt 11 after "1m")
> * permission denied (retry attempt 12 after "1m")
> * permission denied (exceeded maximum retries)


Configured retries with limit

```hcl
template {
  vault_retry {
    backoff     = "50ms"
    attempts    = 5
    max_backoff = "5s"
  }
}
```

> * permission denied (retry attempt 1 after "50ms")
> * permission denied (retry attempt 2 after "100ms")
> * permission denied (retry attempt 3 after "200ms")
> * permission denied (retry attempt 4 after "400ms")
> * permission denied (retry attempt 5 after "800ms")
> * permission denied (exceeded maximum retries)


Configured unlimited retries

```hcl
template {
  vault_retry {
    backoff     = "50ms"
    attempts    = 0
    max_backoff = "5s"
  }
}
```

> * permission denied (retry attempt 1 after "50ms")
> * permission denied (retry attempt 2 after "100ms")
> * permission denied (retry attempt 3 after "200ms")
> * permission denied (retry attempt 4 after "400ms")
> * permission denied (retry attempt 5 after "800ms")
> * permission denied (retry attempt 6 after "1.6s")
> * permission denied (retry attempt 7 after "3.2s")
> * permission denied (retry attempt 8 after "5s")
> * permission denied (retry attempt 9 after "5s")
> * permission denied (retry attempt 10 after "5s")
> * permission denied (retry attempt 11 after "5s")
> * permission denied (retry attempt 12 after "5s")
> * permission denied (retry attempt 13 after "5s")
> * permission denied (retry attempt 14 after "5s")
> * permission denied (retry attempt 15 after "5s")
> * permission denied (retry attempt 16 after "5s")
> * permission denied (retry attempt 17 after "5s")
> * permission denied (retry attempt 18 after "5s")
> (gave up after this)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
