### PR TITLE
client: skip shutdown delay when tasks already deregistered

### DIFF
--- a/.changelog/25157.txt
+++ b/.changelog/25157.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-client: skip shutdown_delay if task already deregistered
+client: skip a task groups shutdown_delay when all tasks have already been deregistered
 ```

--- a/.changelog/25157.txt
+++ b/.changelog/25157.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: skip shutdown_delay if task already deregistered
+```

--- a/client/allocrunner/group_service_hook.go
+++ b/client/allocrunner/group_service_hook.go
@@ -215,8 +215,8 @@ func (h *groupServiceHook) PreKill() {
 //
 // caller must hold h.mu
 func (h *groupServiceHook) preKillLocked() {
-	// Optimization: If this allocation has already been deregistered
-	// because it ran PostRun hooks, skip shutdown_delay
+	// Optimization: If this allocation has already been deregistered,
+	// skip waiting for the shutdown_delay again.
 	if h.deregistered && h.delay != 0 {
 		h.logger.Debug("tasks already deregistered, skipping shutdown_delay")
 		return

--- a/client/allocrunner/group_service_hook.go
+++ b/client/allocrunner/group_service_hook.go
@@ -215,6 +215,13 @@ func (h *groupServiceHook) PreKill() {
 //
 // caller must hold h.mu
 func (h *groupServiceHook) preKillLocked() {
+	// Optimization: If this allocation has already been deregistered
+	// because it ran PostRun hooks, skip shutdown_delay
+	if h.deregistered && h.delay != 0 {
+		h.logger.Debug("tasks already deregistered, skipping shutdown_delay")
+		return
+	}
+
 	// If we have a shutdown delay deregister group services and then wait
 	// before continuing to kill tasks.
 	h.deregisterLocked()

--- a/client/allocrunner/group_service_hook_test.go
+++ b/client/allocrunner/group_service_hook_test.go
@@ -339,9 +339,8 @@ func TestGroupServiceHook_PreKill(t *testing.T) {
 		go func() {
 			before := time.Now()
 			h.PreKill()
-			after := time.Now()
-			// we respected the shutdown_delay and did not return immediately
-			if after.Sub(before) < delay {
+			// we did not respect the shutdown_delay and returned immediately
+			if time.Since(before) < delay {
 				t.Fail()
 			}
 			successChan <- struct{}{}


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
When all the tasks in an allocation have completed, the allocation will run the PostRun hooks, and deregister the task.  When that happens, it is not necessary to wait on the shutdown_delay during garbage collection.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
