### PR TITLE
Docs: update Virt beta callout to use Note component

### DIFF
--- a/website/content/partials/virt-beta-callout.mdx
+++ b/website/content/partials/virt-beta-callout.mdx
@@ -1,3 +1,6 @@
-~> Beta Feature: The Virt task driver is in beta and under active development.
-Refer to the [repo README](https://github.com/hashicorp/nomad-driver-virt) for
-the latest updates. Do not use this driver in production environments.
+<Note title="Beta Feature">
+
+The Virt task driver is under active development. Refer to the [repo
+README](https://github.com/hashicorp/nomad-driver-virt) for the latest updates. Do not use this driver in production environments.
+
+</Note>

--- a/website/content/plugins/drivers/virt/index.mdx
+++ b/website/content/plugins/drivers/virt/index.mdx
@@ -7,14 +7,14 @@ description: >-
 
 # Virt task driver plugin
 
-@include 'virt-beta-callout.mdx'
-
 Name: `virt`
 
 The Virt task driver utilizes the [libvirt][] API to run and manage virtual
 machines using hypervisors such as [QEMU][]. The task driver supports a wide
 variety of Nomad features including [workload identity][], [task templates][],
 and [service discovery][].
+
+@include 'virt-beta-callout.mdx'
 
 ## Driver Capabilities
 

--- a/website/content/plugins/drivers/virt/install.mdx
+++ b/website/content/plugins/drivers/virt/install.mdx
@@ -7,11 +7,11 @@ description: >-
 
 # Install the Virt task driver plugin
 
-@include 'virt-beta-callout.mdx'
-
 The Virt task driver plugin for Linux operating systems is not bundled with
 Nomad. You must install the driver into each Nomad client's [configured plugin
 directory][plugin_dir].
+
+@include 'virt-beta-callout.mdx'
 
 ## Prerequisites
 

--- a/website/content/plugins/drivers/virt/task-config.mdx
+++ b/website/content/plugins/drivers/virt/task-config.mdx
@@ -1,10 +1,12 @@
 ---
 layout: docs
 page_title: Configure a Virt job task
-description: Learn how to use the Virt task driver in your Nomad job specification. Configure a base virtual machine (VM) image, network interface,  and parameters for bootstrapping the VM instance.
+description: Learn how to use the Virt task driver in your Nomad job specification. Configure a base virtual machine (VM) image, network interface, and parameters for bootstrapping the VM instance.
 ---
 
 # Configure a Virt job task
+
+This page provides reference information on how to use the Virt task driver in your Nomad job specification. Configure a base virtual machine (VM) image, network interface, and parameters for bootstrapping the VM instance.
 
 @include 'virt-beta-callout.mdx'
 


### PR DESCRIPTION
### Description
- Update the Virt beta callout partial to use the Note component
- Move the callout after the intro text because for SEO, the first paragraph is super important. We don't want Google to display a beta feature note in search results.
- Add intro paragraph to Configure... page.

### Links

Jira: [CE-819]
Deploy previews:
- https://nomad-git-virtbeta-hashicorp.vercel.app/nomad/plugins/drivers/virt
- https://nomad-git-virtbeta-hashicorp.vercel.app/nomad/plugins/drivers/virt/install
- https://nomad-git-virtbeta-hashicorp.vercel.app/nomad/plugins/drivers/virt/task-config

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[CE-819]: https://hashicorp.atlassian.net/browse/CE-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ