### PR TITLE
volume status: default type to show both DHV and CSI volumes

### DIFF
--- a/command/volume_status.go
+++ b/command/volume_status.go
@@ -38,7 +38,8 @@ General Options:
 Status Options:
 
   -type <type>
-    List only volumes of type <type>.
+    List only volumes of type <type> (one of "host" or "csi"). If omitted, the
+    command will query for both dynamic host volumes and CSI volumes.
 
   -short
     Display short output. Used only when a single volume is being
@@ -147,17 +148,61 @@ func (c *VolumeStatusCommand) Run(args []string) int {
 		id = args[0]
 	}
 
+	opts := formatOpts{
+		verbose:  c.verbose,
+		short:    c.short,
+		length:   c.length,
+		json:     c.json,
+		template: c.template,
+	}
+
 	switch typeArg {
-	case "csi", "":
+	case "csi":
 		if nodeID != "" || nodePool != "" {
 			c.Ui.Error("-node and -node-pool can only be used with -type host")
 			return 1
 		}
-		return c.csiStatus(client, id)
+		if err := c.csiVolumeStatus(client, id, opts); err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
 	case "host":
-		return c.hostVolumeStatus(client, id, nodeID, nodePool)
+		if err := c.hostVolumeStatus(client, id, nodeID, nodePool, opts); err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+	case "":
+		if id == "" {
+			// for list, we want to show both
+			dhvErr := c.hostVolumeList(client, nodeID, nodePool, opts)
+			if dhvErr != nil {
+				c.Ui.Error(dhvErr.Error())
+			}
+			c.Ui.Output("")
+			csiErr := c.csiVolumesList(client, opts)
+			if csiErr != nil {
+				c.Ui.Error(csiErr.Error())
+			}
+			if dhvErr == nil && csiErr == nil {
+				return 0
+			}
+			return 1
+		} else {
+			// for read, we only want to show whichever has results
+			hostErr := c.hostVolumeStatus(client, id, nodeID, nodePool, opts)
+			if hostErr != nil {
+				csiErr := c.csiVolumeStatus(client, id, opts)
+				if csiErr != nil {
+					c.Ui.Error(hostErr.Error())
+					c.Ui.Error(csiErr.Error())
+					return 1
+				}
+			}
+		}
 	default:
 		c.Ui.Error(fmt.Sprintf("No such volume type %q", typeArg))
 		return 1
 	}
+
+	return 0
 }

--- a/command/volume_status_host_test.go
+++ b/command/volume_status_host_test.go
@@ -161,7 +161,7 @@ capability {
 	code = cmd.Run(args)
 	must.Eq(t, 1, code)
 	must.StrContains(t, ui.ErrorWriter.String(),
-		"Error listing volumes: no volumes with prefix or ID")
+		"Error listing host volumes: no volumes with prefix or ID")
 	ui.ErrorWriter.Reset()
 
 	args = []string{"-address", url, "-type", "host", "-namespace", "prod", id}

--- a/website/content/docs/commands/volume/status.mdx
+++ b/website/content/docs/commands/volume/status.mdx
@@ -8,7 +8,7 @@ description: |
 # Command: volume status
 
 The `volume status` command displays status information for [Container
-Storage Interface (CSI)][csi] volumes.
+Storage Interface (CSI)][csi] volumes or [dynamic host volumes][dhv].
 
 ## Usage
 
@@ -16,17 +16,18 @@ Storage Interface (CSI)][csi] volumes.
 nomad volume status [options] [volume]
 ```
 
-This command accepts an optional volume ID or prefix as the sole argument. If there
-is an exact match based on the provided volume ID or prefix, then information about
-the specific volume is queried and displayed. Otherwise, a list of matching volumes
-and information will be displayed.
+This command accepts an optional volume ID or prefix as the sole argument. If
+there is an exact match based on the provided volume ID or prefix, then
+information about the specific volume is queried and displayed. Otherwise, a
+list of matching volumes and information will be displayed.
 
-If the ID is omitted, the command lists out all of the existing volumes and a few
-of the most useful status fields for each.
+If the ID is omitted, the command lists out all of the existing volumes and a
+few of the most useful status fields for each.
 
-When ACLs are enabled, this command requires a token with the
-`csi-read-volume` and `csi-list-volumes` capability for the volume's
-namespace.
+When ACLs are enabled, this command requires a token with the appropriate
+capability in the volume's namespace: the `csi-read-volume` and
+`csi-list-volumes` capability for CSI volumes, or `host-volume-read` for dynamic
+host volumes.
 
 ## General Options
 
@@ -34,9 +35,9 @@ namespace.
 
 ## Status Options
 
-- `-type`: Display only volumes of a particular type. Currently only
-  the `csi` type is supported, so this option can be omitted when
-  querying the status of CSI volumes.
+- `-type`: Display only volumes of a particular type (one of `"host"` or
+  `"csi"`). If omitted, the command will query for both dynamic host volumes and
+  CSI volumes.
 
 - `-plugin_id`: Display only volumes managed by a particular [CSI
   plugin][csi_plugin].
@@ -57,15 +58,21 @@ namespace.
 List of all volumes:
 
 ```shell-session
-$ nomad volume [-type csi] status
+$ nomad volume status
+Dynamic Host Volumes
+ID        Name             Namespace  Plugin ID            Node ID   Node Pool  State
+070dc8ca  internal-plugin  default    mkdir                c3c27514  default    ready
+7ce38017  external-plugin  default    example-plugin-mkfs  c3c27514  default    ready
+
+Container Storage Interface
 ID            Name      Namespace  Plugin ID  Schedulable  Access Mode
 ebs_prod_db1  database  default    ebs-prod   true         single-node-writer
 ```
 
-List of all volumes, with external provider info:
+List of all CSI volumes, with external provider info:
 
 ```shell-session
-$ nomad volume [-type csi] status -verbose
+$ nomad volume -type csi status -verbose
 ID            Name      Namespace  Plugin ID  Schedulable  Access Mode
 ebs_prod_db1  database  default    ebs-prod   true         single-node-writer
 
@@ -127,3 +134,4 @@ b00fa322  28be17d5  write         csi         0        run
 [csi]: https://github.com/container-storage-interface/spec
 [csi_plugin]: /nomad/docs/job-specification/csi_plugin
 [`volume create`]: /nomad/docs/commands/volume/create
+[dhv]: /nomad/docs/other-specifications/volume/host


### PR DESCRIPTION
The `-type` option for `volume status` is a UX papercut because for many clusters there will be only one sort of volume in use. Update the CLI so that the default behavior is to query CSI and/or DHV.

This behavior is subtly different when the user provides an ID or not. If the user doesn't provide an ID, we query both CSI and DHV and show both tables. If the user provides an ID, we query DHV first and then CSI, and show only the appropriate volume. Because DHV IDs are UUIDs, we're sure we won't have collisions between the two. We only show errors if both queries return an error.

Fixes: https://hashicorp.atlassian.net/browse/NET-12214

---

Example outputs

<details><summary>Neither CSI or dynamic host volumes</summary>

```sh
$ nomad volume status -type host
Dynamic Host Volumes
No dynamic host volumes

$ nomad volume status -type csi
Container Storage Interface
No CSI volumes

$ nomad volume status
Dynamic Host Volumes
No dynamic host volumes

Container Storage Interface
No CSI volumes

$ nomad volume status -type csi not-existing
Error listing CSI volumes: No volumes with prefix or ID "not-existing" found

$ nomad volume status -type host not-existing
Error listing host volumes: no volumes with prefix or ID "not-existing" found

$ nomad volume status not-existing
Error listing host volumes: no volumes with prefix or ID "not-existing" found
Error listing CSI volumes: No volumes with prefix or ID "not-existing" found
```

</details>

<details><summary>Only dynamic host volumes</summary>

```sh
$ nomad volume status -type host
Dynamic Host Volumes
ID        Name             Namespace  Plugin ID            Node ID   Node Pool  State
070dc8ca  internal-plugin  default    mkdir                c3c27514  default    ready
7ce38017  external-plugin  default    example-plugin-mkfs  c3c27514  default    ready

$ nomad volume status -type csi
Container Storage Interface
No CSI volumes

$ nomad volume status
Dynamic Host Volumes
ID        Name             Namespace  Plugin ID            Node ID   Node Pool  State
070dc8ca  internal-plugin  default    mkdir                c3c27514  default    ready
7ce38017  external-plugin  default    example-plugin-mkfs  c3c27514  default    ready

Container Storage Interface
No CSI volumes

$ nomad volume status -type csi 070d
Error listing CSI volumes: No volumes with prefix or ID "070d" found

# identical for nomad volume status -type csi 070d
$ nomad volume status 070d
ID        = 070dc8ca-cc20-5638-b032-cc7d032d99d6
Name      = internal-plugin
Namespace = default
Plugin ID = mkdir
Node ID   = c3c27514-3869-f3a1-f5b6-c79fb1761c26
Node Pool = default
Capacity  = 0 B
State     = ready
Host Path = /run/nomad/dev/data/host_volumes/070dc8ca-cc20-5638-b032-cc7d032d99d6

Capabilities
Access Mode         Attachment Mode
single-node-writer  file-system

Allocations
ID        Node ID   Task Group  Version  Desired  Status   Created    Modified
49d51b88  c3c27514  g           0        run      running  1m54s ago  1m43s ago
```

</details>

<details><summary>Both CSI and dynamic host volumes</summary>

```sh
$ nomad volume status
Dynamic Host Volumes
ID        Name             Namespace  Plugin ID            Node ID   Node Pool  State
070dc8ca  internal-plugin  default    mkdir                c3c27514  default    ready
7ce38017  external-plugin  default    example-plugin-mkfs  c3c27514  default    ready

Container Storage Interface
ID              Name            Namespace  Plugin ID         Schedulable  Access Mode
test-volume[0]  test-volume[0]  default    hostpath-plugin0  true         single-node-reader-only
test-volume[1]  test-volume[1]  default    hostpath-plugin0  true         single-node-reader-only

$ nomad volume status -verbose
Dynamic Host Volumes
ID                                    Name             Namespace  Plugin ID            Node ID                               Node Pool  State
070dc8ca-cc20-5638-b032-cc7d032d99d6  internal-plugin  default    mkdir                c3c27514-3869-f3a1-f5b6-c79fb1761c26  default    ready
7ce38017-1c5f-d76c-2c3b-3e37c1f7c110  external-plugin  default    example-plugin-mkfs  c3c27514-3869-f3a1-f5b6-c79fb1761c26  default    ready

Container Storage Interface
ID              Name            Namespace  Plugin ID         Schedulable  Access Mode
test-volume[0]  test-volume[0]  default    hostpath-plugin0  true         single-node-reader-only
test-volume[1]  test-volume[1]  default    hostpath-plugin0  true         single-node-reader-only

External ID                           Condition  Nodes
134b54af-f08d-11ef-b160-1a227be3fda2  OK         node-0
13457a45-f08d-11ef-b160-1a227be3fda2  OK         node-0

$ nomad volume status -type csi
Container Storage Interface
ID              Name            Namespace  Plugin ID         Schedulable  Access Mode
test-volume[0]  test-volume[0]  default    hostpath-plugin0  true         single-node-reader-only
test-volume[1]  test-volume[1]  default    hostpath-plugin0  true         single-node-reader-only

$ nomad volume status -type host 'test-volume[0]'
Error listing host volumes: no volumes with prefix or ID "test-volume[0]" found

$ nomad volume status 'test-volume[0]'
ID                   = test-volume[0]
Name                 = test-volume[0]
Namespace            = default
External ID          = 13457a45-f08d-11ef-b160-1a227be3fda2
Plugin ID            = hostpath-plugin0
Provider             = csi-hostpath
Version              = v1.9.0
Capacity             = 977 KiB
Schedulable          = true
Controllers Healthy  = 1
Controllers Expected = 1
Nodes Healthy        = 1
Nodes Expected       = 1
Access Mode          = single-node-reader-only
Attachment Mode      = file-system
Mount Options        = flags: [REDACTED]

Topologies
Topology  Segments
01        topology.hostpath.csi/node=node-0

Capabilities
Access Mode              Attachment Mode
single-node-reader-only  file-system
single-node-writer       file-system

Allocations
ID        Node ID   Task Group  Version  Desired  Status   Created   Modified
0565d599  c3c27514  cache       0        run      running  1m7s ago  54s ago
```

</details>
