### PR TITLE
dynamic host volumes: mark volumes on down nodes as unavailable

### DIFF
--- a/nomad/state/state_store_host_volumes.go
+++ b/nomad/state/state_store_host_volumes.go
@@ -248,14 +248,19 @@ func upsertHostVolumeForNode(txn *txn, node *structs.Node, index uint64) error {
 		_, ok := node.HostVolumes[vol.Name]
 
 		switch {
-		case ok && vol.State != structs.HostVolumeStateReady:
-			// the fingerprint has been updated on the client for this volume
+		case ok && node.Status == structs.NodeStatusReady &&
+			vol.State != structs.HostVolumeStateReady:
+			// the fingerprint has been updated on a healthy client
 			volState = structs.HostVolumeStateReady
 
 		case !ok && vol.State == structs.HostVolumeStateReady:
 			// the volume was previously fingerprinted but is no longer showing
 			// up in the fingerprint; this will usually be because of a failed
 			// restore on the client
+			volState = structs.HostVolumeStateUnavailable
+
+		case ok && node.Status == structs.NodeStatusDown:
+			// volumes on down nodes will never pass feasibility checks
 			volState = structs.HostVolumeStateUnavailable
 
 		case ok && vol.NodePool != node.NodePool:


### PR DESCRIPTION
We update the status of a volume when the node fingerprint changes. But if a node goes down, we still show the volume as available. The scheduler behavior is correct because a down node can never have work scheduled on it, but it might be confusing for job authors who are looking at volumes that are showing as available.

Update the volume update logic we have on node updates to include marking the volume as unavailable when a node goes down.

Fixes: https://hashicorp.atlassian.net/browse/NET-12068
