### PR TITLE
ListProcesses through PID when cgroup is not found in Linux

### DIFF
--- a/drivers/shared/executor/executor_basic.go
+++ b/drivers/shared/executor/executor_basic.go
@@ -38,7 +38,7 @@ func withNetworkIsolation(f func() error, _ *drivers.NetworkIsolationSpec) error
 func setCmdUser(*exec.Cmd, string) error { return nil }
 
 func (e *UniversalExecutor) ListProcesses() set.Collection[int] {
-	return procstats.List(e.childCmd.Process.Pid)
+	return procstats.ListByPid(e.childCmd.Process.Pid)
 }
 
 func (e *UniversalExecutor) setSubCmdCgroup(*exec.Cmd, string) (func(), error) {

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -103,7 +103,13 @@ func (e *UniversalExecutor) setSubCmdCgroup(cmd *exec.Cmd, cgroup string) (func(
 }
 
 func (e *UniversalExecutor) ListProcesses() set.Collection[procstats.ProcessID] {
-	return procstats.List(e.command)
+	switch cgroupslib.GetMode() {
+	case cgroupslib.OFF:
+		// cgroup is unavailable, could possibly due to rootless nomad client
+		return procstats.ListByPid(e.childCmd.Process.Pid)
+	default:
+		return procstats.List(e.command)
+	}
 }
 
 func (e *UniversalExecutor) statCG(cgroup string) (int, func(), error) {

--- a/drivers/shared/executor/procstats/list_default.go
+++ b/drivers/shared/executor/procstats/list_default.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-//go:build !linux && !windows
+//go:build !windows
 
 package procstats
 
@@ -15,7 +15,7 @@ import (
 )
 
 // List the process tree starting at the given executorPID
-func List(executorPID int) set.Collection[ProcessID] {
+func ListByPid(executorPID int) set.Collection[ProcessID] {
 	result := set.New[ProcessID](10)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)


### PR DESCRIPTION
### Description
when nomad is running rootless in linux, it fails to output CPU and memory metrics. 
Specifically speaking, actually it fails to read associated PIDs in this scenerios, which leads to zero for all downstream operations.
When cgroup == OFF, where rooless client fails into this category, we should fallback to classic list PIds through executor pid. 

### Testing & Reproduction steps
the reproduction test of the bug: https://github.com/hashicorp/nomad/issues/20285 

### Links
#20285 
#19828 

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
