### PR TITLE
deps: remove actions updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,13 +40,3 @@ updates:
     labels:
       - "theme/dependencies"
       - "theme/website"
-  - package-ecosystem: github-actions
-    open-pull-requests-limit: 5
-    directory: /
-    labels:
-      - "theme/dependencies"
-      - "theme/ci"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-      time: "09:00"


### PR DESCRIPTION
Dependabot can update actions to versions that are not in the TSCCR allowlist. The TSCCR check doesn't happen in CE, which means we don't learn we have a problem until after we've spent the effort to backport them. Remove the automation that updates actions automatically until this issue is resolved on the security team's side.

Ref (internal): https://github.com/hashicorp/nomad-enterprise/pull/2379
Ref (internal): https://hashicorp.slack.com/archives/C02V6HVS98E/p1740495088397829