### PR TITLE
E2E: fix column parsing for dynamic host volumes test

### DIFF
--- a/e2e/dynamic_host_volumes/dynamic_host_volumes_test.go
+++ b/e2e/dynamic_host_volumes/dynamic_host_volumes_test.go
@@ -98,7 +98,10 @@ func TestDynamicHostVolumes_RegisterWorkflow(t *testing.T) {
 
 	out, err := e2eutil.Command("nomad", "volume", "status", "-verbose", "-type", "host")
 	must.NoError(t, err)
-	vols, err := e2eutil.ParseColumns(out)
+
+	section, err := e2eutil.GetSection(out, "Dynamic Host Volumes")
+	must.NoError(t, err)
+	vols, err := e2eutil.ParseColumns(section)
 	must.NoError(t, err)
 
 	var volID string


### PR DESCRIPTION
In #25185 we changed the output of `volume status` to include both DHV and CSI volumes by default. When the E2E test parses the output, it's not expecting the new section header.

Ref: https://github.com/hashicorp/nomad/pull/25185

---

Before:

```
$ go test -v -count=1 ./e2e/dynamic_host_volumes -run TestDynamicHostVolumes_RegisterWorkflow
=== RUN   TestDynamicHostVolumes_RegisterWorkflow
    dynamic_host_volumes_test.go:54: [146.351879ms] register job "register-volumes-902" created
    dynamic_host_volumes_test.go:61: [204.457851ms] ACL policy for job "register-volumes-902" created
    dynamic_host_volumes_test.go:69: [1.270517466s] job dispatched
    dynamic_host_volumes_test.go:92: [1.334329081s] dispatched job done
    dynamic_host_volumes_test.go:102:
        dynamic_host_volumes_test.go:102: expected nil error
        ↪ error: section is misaligned with header
        Dynamic Host Volumes
        ID      Name    Namespace       Plugin ID       Node ID Node Pool       State
        ca9673c4-6a80-313f-d1d0-486e2cef3676    registered-volume       default <none>  b8fbe3db-39a7-589f-d1b1-d3a65a9b8ba2    default     pending
--- FAIL: TestDynamicHostVolumes_RegisterWorkflow (1.40s)
FAIL
FAIL    github.com/hashicorp/nomad/e2e/dynamic_host_volumes     1.424s
FAIL
```

After:

```
$ go test -v -count=1 ./e2e/dynamic_host_volumes -run TestDynamicHostVolumes_RegisterWorkflow
=== RUN   TestDynamicHostVolumes_RegisterWorkflow
    dynamic_host_volumes_test.go:54: [145.490737ms] register job "register-volumes-766" created
    dynamic_host_volumes_test.go:61: [199.1545ms] ACL policy for job "register-volumes-766" created
    dynamic_host_volumes_test.go:69: [1.273930234s] job dispatched
    dynamic_host_volumes_test.go:92: [1.337201601s] dispatched job done
    dynamic_host_volumes_test.go:140: [1.511102086s] volume "436d8899-fc3b-6f70-8c74-f6a30f97c973" is ready
    dynamic_host_volumes_test.go:147: [1.511196746s] submitting mounter job
    dynamic_host_volumes_test.go:150: [2.524939273s] test complete, cleaning up
--- PASS: TestDynamicHostVolumes_RegisterWorkflow (2.59s)
PASS
ok      github.com/hashicorp/nomad/e2e/dynamic_host_volumes     2.619s
```