### PR TITLE
Docs: Add workload identity and Consul Enterprise info to partition parameter

### DIFF
--- a/website/content/docs/job-specification/consul.mdx
+++ b/website/content/docs/job-specification/consul.mdx
@@ -105,7 +105,7 @@ The [`template`][template] block can use the Consul token as well.
 
   - [Consul Enterprise]
   - Workload identity integration. The `partition` field does not work
-    with a legacy tokens. Refer to [Nomad Workload Identities] for more
+    with a legacy Consul token. Refer to [Nomad Workload Identities] for more
     information on integrating Nomad's workload identity with Consul authentication.
 
 ## `consul` Examples

--- a/website/content/docs/job-specification/consul.mdx
+++ b/website/content/docs/job-specification/consul.mdx
@@ -300,4 +300,4 @@ job "docs" {
 [admin partition]: /consul/docs/enterprise/admin-partitions
 [agent configuration reference]: /consul/docs/agent/config/config-files#partition-1
 [Consul Enterprise]: /consul/docs/enterprise
-[Nomad Workload Identities]: nomad/docs/integrations/consul/acl#nomad-workload-identities
+[Nomad Workload Identities]: /nomad/docs/integrations/consul/acl#nomad-workload-identities

--- a/website/content/docs/job-specification/consul.mdx
+++ b/website/content/docs/job-specification/consul.mdx
@@ -62,14 +62,15 @@ and binding rules in Consul before configuring the Nomad servers with
 Authentication][] for more details.
 
 <Warning>
+
 Starting in Nomad 1.10, the fallback options to use the -consul-token flag when
 submitting a job, the agent's consul.token configuration, or the
 CONSUL_HTTP_TOKEN environment variable, will be removed.  This means service and
 template blocks will not be able to use the agent's Consul token or one provided
 by the job submitter. You should be prepared to migrate to the Workload Identity
-workflow for Consul and Vault before upgrading to Nomad 1.10. Refer to <a
-href="/nomad/docs/integrations/consul-integration#migrating-to-using-workload-identity-with-consul">Migrating
-to Using Workload Identity with Consul</a>
+workflow for Consul and Vault before upgrading to Nomad 1.10. Refer to
+[Migrating to Using Workload Identity with Consul] for more information.
+
 </Warning>
 
 ### Access to Token
@@ -100,9 +101,12 @@ The [`template`][template] block can use the Consul token as well.
 - `partition` `(string: "")` - When this field is set, a constraint will be
   added to the group or task to ensure that the allocation is placed on a Nomad
   client that has a Consul Enterprise agent in the specified Consul [admin
-  partition][]. Note that Consul Community Edition agents are not assigned to
-  any admin partition, so this field should not be used without Consul
-  Enterprise.
+  partition][]. Using this field requires the following:
+
+  - [Consul Enterprise]
+  - Workload identity integration. The `partition` field does not work
+    with a legacy tokens. Refer to [Nomad Workload Identities] for more
+    information on integrating Nomad's workload identity with Consul authentication.
 
 ## `consul` Examples
 
@@ -284,8 +288,8 @@ job "docs" {
 [`consul.service_identity`]: /nomad/docs/configuration/consul#service_identity
 [flag_consul_token]: /nomad/docs/commands/job/run#consul-token
 [`consul.token`]: /nomad/docs/configuration/consul#token
-[Configuring Consul Authentication]: /nomad/docs/integrations/consul-integration#TODO
-[Migrating to Using Workload Identity with Consul]: /nomad/docs/integrations/consul-integration#migrating-to-using-workload-identity-with-consul
+[Configuring Consul Authentication]: /nomad/docs/integrations/consul/acl#configuring-consul-authentication
+[Migrating to Using Workload Identity with Consul]: /nomad/docs/integrations/consul/acl#migrating-to-using-workload-identity-with-consul
 [config_consul_namespace]: /nomad/docs/configuration/consul#namespace
 [Consul Namespaces]: /consul/docs/enterprise/namespaces
 [Consul Admin Partitions]: /consul/docs/enterprise/admin-partitions
@@ -295,3 +299,5 @@ job "docs" {
 [Connect]: /nomad/docs/job-specification/connect
 [admin partition]: /consul/docs/enterprise/admin-partitions
 [agent configuration reference]: /consul/docs/agent/config/config-files#partition-1
+[Consul Enterprise]: /consul/docs/enterprise
+[Nomad Workload Identities]: nomad/docs/integrations/consul/acl#nomad-workload-identities


### PR DESCRIPTION
### Description

- `partition` parameter: add that using this parameter requires Consul Enterprise and Nomad workload identity integration with Consul authentication.
- Fixed a few outdated links.

### Links
Jira: [CE-820] (created by Dan Hung in Support)
Deploy preview: https://nomad-git-ce820note-hashicorp.vercel.app/nomad/docs/job-specification/consul#partition

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[CE-820]: https://hashicorp.atlassian.net/browse/CE-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ