### PR TITLE
generic paginator

### DIFF
--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -900,7 +900,7 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 				return err
 			}
 
-			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions, nil,
 				tokenizer,
 				(*structs.ACLToken).Stub)
 			if err != nil {

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -900,7 +900,8 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 				return err
 			}
 
-			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				tokenizer,
 				(*structs.ACLToken).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -900,19 +900,16 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 				return err
 			}
 
-			var tokens []*structs.ACLTokenListStub
-			paginator, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-				func(raw interface{}) error {
-					token := raw.(*structs.ACLToken)
-					tokens = append(tokens, token.Stub())
-					return nil
+			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+				func(a *structs.ACLToken) (*structs.ACLTokenListStub, error) {
+					return a.Stub(), nil
 				})
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}
 
-			nextToken, err := paginator.Page()
+			tokens, nextToken, err := pager.Page()
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to read result page: %v", err)

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -901,7 +901,7 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 			}
 
 			var tokens []*structs.ACLTokenListStub
-			paginator, err := paginator.NewPaginator(iter, tokenizer, nil, args.QueryOptions,
+			paginator, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
 				func(raw interface{}) error {
 					token := raw.(*structs.ACLToken)
 					tokens = append(tokens, token.Stub())

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -901,9 +901,7 @@ func (a *ACL) ListTokens(args *structs.ACLTokenListRequest, reply *structs.ACLTo
 			}
 
 			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-				func(a *structs.ACLToken) (*structs.ACLTokenListStub, error) {
-					return a.Stub(), nil
-				})
+				(*structs.ACLToken).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -90,7 +90,7 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 					return err
 				}
 
-				pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+				pager, err := paginator.NewPaginator(iter, args.QueryOptions, tokenizer,
 					func(a *structs.Allocation) (*structs.AllocListStub, error) {
 						return a.Stub(args.Fields), nil
 					},

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -91,7 +91,7 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 				}
 
 				pager, err := paginator.NewPaginator(iter, args.QueryOptions,
-					paginator.NamespaceFilterFunc[*structs.Allocation](allowableNamespaces),
+					paginator.NamespaceSelectorFunc[*structs.Allocation](allowableNamespaces),
 					tokenizer,
 					func(a *structs.Allocation) (*structs.AllocListStub, error) {
 						return a.Stub(args.Fields), nil

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -90,7 +90,9 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 					return err
 				}
 
-				pager, err := paginator.NewPaginator(iter, args.QueryOptions, tokenizer,
+				pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+					paginator.NamespaceFilterFunc[*structs.Allocation](allowableNamespaces),
+					tokenizer,
 					func(a *structs.Allocation) (*structs.AllocListStub, error) {
 						return a.Stub(args.Fields), nil
 					},
@@ -99,8 +101,7 @@ func (a *Alloc) List(args *structs.AllocListRequest, reply *structs.AllocListRes
 					return structs.NewErrRPCCodedf(
 						http.StatusBadRequest, "failed to create result paginator: %v", err)
 				}
-				filter := paginator.NamespaceFilterFunc[*structs.Allocation](allowableNamespaces)
-				pager = pager.WithFilter(filter)
+
 				stubs, nextToken, err := pager.Page()
 				if err != nil {
 					return structs.NewErrRPCCodedf(

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -113,13 +113,7 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 				return err
 			}
 
-			tokenizer := paginator.NewStructsTokenizer(
-				iter,
-				paginator.StructsTokenizerOptions{
-					WithNamespace: true,
-					WithID:        true,
-				},
-			)
+			tokenizer := paginator.NamespaceIDTokenizer[*structs.CSIVolume](args.NextToken)
 			volFilter := paginator.GenericFilter{
 				Allow: func(raw interface{}) (bool, error) {
 					vol := raw.(*structs.CSIVolume)

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -113,7 +113,7 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 				return err
 			}
 
-			filter := func(vol *structs.CSIVolume) bool {
+			selector := func(vol *structs.CSIVolume) bool {
 				// Remove (possibly again) by PluginID to handle passing both
 				// NodeID and PluginID
 				if args.PluginID != "" && args.PluginID != vol.PluginID {
@@ -130,7 +130,7 @@ func (v *CSIVolume) List(args *structs.CSIVolumeListRequest, reply *structs.CSIV
 			}
 
 			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
-				filter,
+				selector,
 				paginator.NamespaceIDTokenizer[*structs.CSIVolume](args.NextToken),
 				func(vol *structs.CSIVolume) (*structs.CSIVolListStub, error) {
 					vol, err := snap.CSIVolumeDenormalizePlugins(ws, vol.Copy())

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -493,7 +493,8 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 				return err
 			}
 
-			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				tokenizer,
 				(*structs.Deployment).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -493,14 +493,10 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 				return err
 			}
 
-			filters := []paginator.Filter{
-				paginator.NamespaceFilter{
-					AllowableNamespaces: allowableNamespaces,
-				},
-			}
+			filter := paginator.NamespaceFilterFunc[*structs.Deployment](allowableNamespaces)
 
 			var deploys []*structs.Deployment
-			pnator, err := paginator.NewPaginator(iter, tokenizer, filters, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
 				func(raw interface{}) error {
 					deploy := raw.(*structs.Deployment)
 					deploys = append(deploys, deploy)
@@ -510,8 +506,9 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}
+			pager = pager.WithFilter(filter)
 
-			nextToken, err := pnator.Page()
+			nextToken, err := pager.Page()
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to read result page: %v", err)

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -494,7 +494,7 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 			}
 
 			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
-				paginator.NamespaceFilterFunc[*structs.Deployment](allowableNamespaces),
+				paginator.NamespaceSelectorFunc[*structs.Deployment](allowableNamespaces),
 				tokenizer,
 				(*structs.Deployment).Stub)
 			if err != nil {

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -494,15 +494,13 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 			}
 
 			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				paginator.NamespaceFilterFunc[*structs.Deployment](allowableNamespaces),
 				tokenizer,
 				(*structs.Deployment).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}
-
-			filter := paginator.NamespaceFilterFunc[*structs.Deployment](allowableNamespaces)
-			pager = pager.WithFilter(filter)
 
 			deploys, nextToken, err := pager.Page()
 			if err != nil {

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -494,7 +494,7 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 			}
 
 			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-				func(d *structs.Deployment) (*structs.Deployment, error) { return d, nil })
+				(*structs.Deployment).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -493,22 +493,17 @@ func (d *Deployment) List(args *structs.DeploymentListRequest, reply *structs.De
 				return err
 			}
 
-			filter := paginator.NamespaceFilterFunc[*structs.Deployment](allowableNamespaces)
-
-			var deploys []*structs.Deployment
 			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-				func(raw interface{}) error {
-					deploy := raw.(*structs.Deployment)
-					deploys = append(deploys, deploy)
-					return nil
-				})
+				func(d *structs.Deployment) (*structs.Deployment, error) { return d, nil })
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}
+
+			filter := paginator.NamespaceFilterFunc[*structs.Deployment](allowableNamespaces)
 			pager = pager.WithFilter(filter)
 
-			nextToken, err := pager.Page()
+			deploys, nextToken, err := pager.Page()
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to read result page: %v", err)

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -712,7 +712,7 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 
 				// note this endpoint does not return EvaluationStub, so we
 				// can't use the Stub method here
-				pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+				pager, err := paginator.NewPaginator(iter, args.QueryOptions, tokenizer,
 					func(e *structs.Evaluation) (*structs.Evaluation, error) { return e, nil })
 				if err != nil {
 					return structs.NewErrRPCCodedf(

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -710,6 +710,8 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 					return false
 				})
 
+				// note this endpoint does not return EvaluationStub, so we
+				// can't use the Stub method here
 				pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
 					func(e *structs.Evaluation) (*structs.Evaluation, error) { return e, nil })
 				if err != nil {

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -712,15 +712,14 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 
 				// note this endpoint does not return EvaluationStub, so we
 				// can't use the Stub method here
-				pager, err := paginator.NewPaginator(iter, args.QueryOptions, tokenizer,
+				pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+					paginator.NamespaceFilterFunc[*structs.Evaluation](allowableNamespaces),
+					tokenizer,
 					func(e *structs.Evaluation) (*structs.Evaluation, error) { return e, nil })
 				if err != nil {
 					return structs.NewErrRPCCodedf(
 						http.StatusBadRequest, "failed to create result paginator: %v", err)
 				}
-
-				filter := paginator.NamespaceFilterFunc[*structs.Evaluation](allowableNamespaces)
-				pager = pager.WithFilter(filter)
 
 				evals, nextToken, err := pager.Page()
 				if err != nil {

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -713,7 +713,7 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 				// note this endpoint does not return EvaluationStub, so we
 				// can't use the Stub method here
 				pager, err := paginator.NewPaginator(iter, args.QueryOptions,
-					paginator.NamespaceFilterFunc[*structs.Evaluation](allowableNamespaces),
+					paginator.NamespaceSelectorFunc[*structs.Evaluation](allowableNamespaces),
 					tokenizer,
 					func(e *structs.Evaluation) (*structs.Evaluation, error) { return e, nil })
 				if err != nil {

--- a/nomad/eval_endpoint.go
+++ b/nomad/eval_endpoint.go
@@ -710,22 +710,17 @@ func (e *Eval) List(args *structs.EvalListRequest, reply *structs.EvalListRespon
 					return false
 				})
 
-				filter := paginator.NamespaceFilterFunc[*structs.Evaluation](allowableNamespaces)
-
-				var evals []*structs.Evaluation
 				pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-					func(raw interface{}) error {
-						eval := raw.(*structs.Evaluation)
-						evals = append(evals, eval)
-						return nil
-					})
+					func(e *structs.Evaluation) (*structs.Evaluation, error) { return e, nil })
 				if err != nil {
 					return structs.NewErrRPCCodedf(
 						http.StatusBadRequest, "failed to create result paginator: %v", err)
 				}
+
+				filter := paginator.NamespaceFilterFunc[*structs.Evaluation](allowableNamespaces)
 				pager = pager.WithFilter(filter)
 
-				nextToken, err := pager.Page()
+				evals, nextToken, err := pager.Page()
 				if err != nil {
 					return structs.NewErrRPCCodedf(
 						http.StatusBadRequest, "failed to read result page: %v", err)

--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -132,9 +132,7 @@ func (v *HostVolume) List(args *structs.HostVolumeListRequest, reply *structs.Ho
 
 			tokenizer := paginator.NamespaceIDTokenizer[*structs.HostVolume](args.NextToken)
 			pages, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-				func(vol *structs.HostVolume) (*structs.HostVolumeStub, error) {
-					return vol.Stub(), nil
-				})
+				(*structs.HostVolume).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)

--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -130,14 +130,7 @@ func (v *HostVolume) List(args *structs.HostVolumeListRequest, reply *structs.Ho
 				return err
 			}
 
-			// Generate the tokenizer to use for pagination using namespace and
-			// ID to ensure complete uniqueness.
-			tokenizer := paginator.NewStructsTokenizer(iter,
-				paginator.StructsTokenizerOptions{
-					WithNamespace: true,
-					WithID:        true,
-				},
-			)
+			tokenizer := paginator.NamespaceIDTokenizer[*structs.HostVolume](args.NextToken)
 
 			filters := []paginator.Filter{
 				paginator.GenericFilter{

--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -130,8 +130,8 @@ func (v *HostVolume) List(args *structs.HostVolumeListRequest, reply *structs.Ho
 				return err
 			}
 
-			tokenizer := paginator.NamespaceIDTokenizer[*structs.HostVolume](args.NextToken)
-			pages, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				paginator.NamespaceIDTokenizer[*structs.HostVolume](args.NextToken),
 				(*structs.HostVolume).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(
@@ -159,11 +159,11 @@ func (v *HostVolume) List(args *structs.HostVolumeListRequest, reply *structs.Ho
 				return allowVolume(aclObj, ns)
 
 			}
-			pages = pages.WithFilter(filter)
+			pager = pager.WithFilter(filter)
 
 			// Calling page populates our output variable stub array as well as
 			// returns the next token.
-			vols, nextToken, err := pages.Page()
+			vols, nextToken, err := pager.Page()
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to read result page: %v", err)

--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -130,7 +130,7 @@ func (v *HostVolume) List(args *structs.HostVolumeListRequest, reply *structs.Ho
 				return err
 			}
 
-			filter := func(vol *structs.HostVolume) bool {
+			selector := func(vol *structs.HostVolume) bool {
 				if !strings.HasPrefix(vol.Name, args.Prefix) &&
 					!strings.HasPrefix(vol.ID, args.Prefix) {
 					return false
@@ -152,7 +152,7 @@ func (v *HostVolume) List(args *structs.HostVolumeListRequest, reply *structs.Ho
 
 			}
 
-			pager, err := paginator.NewPaginator(iter, args.QueryOptions, filter,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions, selector,
 				paginator.NamespaceIDTokenizer[*structs.HostVolume](args.NextToken),
 				(*structs.HostVolume).Stub)
 			if err != nil {

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1488,13 +1488,7 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 					return err
 				}
 
-				tokenizer := paginator.NewStructsTokenizer(
-					iter,
-					paginator.StructsTokenizerOptions{
-						WithNamespace: true,
-						WithID:        true,
-					},
-				)
+				tokenizer := paginator.NamespaceIDTokenizer[*structs.Job](args.NextToken)
 				filters := []paginator.Filter{
 					paginator.NamespaceFilter{
 						AllowableNamespaces: allowableNamespaces,

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1497,14 +1497,13 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 				}
 
 				pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+					paginator.NamespaceFilterFunc[*structs.Job](allowableNamespaces),
 					paginator.NamespaceIDTokenizer[*structs.Job](args.NextToken),
 					stubFn)
 				if err != nil {
 					return structs.NewErrRPCCodedf(
 						http.StatusBadRequest, "failed to create result paginator: %v", err)
 				}
-				filter := paginator.NamespaceFilterFunc[*structs.Job](allowableNamespaces)
-				pager = pager.WithFilter(filter)
 
 				jobs, nextToken, err := pager.Page()
 				if err != nil {

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1488,8 +1488,6 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 					return err
 				}
 
-				tokenizer := paginator.NamespaceIDTokenizer[*structs.Job](args.NextToken)
-
 				stubFn := func(job *structs.Job) (*structs.JobListStub, error) {
 					summary, err := state.JobSummaryByID(ws, job.Namespace, job.ID)
 					if err != nil || summary == nil {
@@ -1498,7 +1496,9 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 					return job.Stub(summary, args.Fields), nil
 				}
 
-				pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions, stubFn)
+				pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+					paginator.NamespaceIDTokenizer[*structs.Job](args.NextToken),
+					stubFn)
 				if err != nil {
 					return structs.NewErrRPCCodedf(
 						http.StatusBadRequest, "failed to create result paginator: %v", err)

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1497,7 +1497,7 @@ func (j *Job) List(args *structs.JobListRequest, reply *structs.JobListResponse)
 				}
 
 				pager, err := paginator.NewPaginator(iter, args.QueryOptions,
-					paginator.NamespaceFilterFunc[*structs.Job](allowableNamespaces),
+					paginator.NamespaceSelectorFunc[*structs.Job](allowableNamespaces),
 					paginator.NamespaceIDTokenizer[*structs.Job](args.NextToken),
 					stubFn)
 				if err != nil {

--- a/nomad/job_endpoint_statuses.go
+++ b/nomad/job_endpoint_statuses.go
@@ -108,11 +108,9 @@ func (j *Job) Statuses(
 				return err
 			}
 
-			// set up tokenizer and filters
-			tokenizer := paginator.ModifyIndexTokenizer[*structs.Job](args.NextToken)
-
 			newJobs := set.New[structs.NamespacedID](0)
-			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				paginator.ModifyIndexTokenizer[*structs.Job](args.NextToken),
 				func(job *structs.Job) (structs.JobStatusesJob, error) {
 					var none structs.JobStatusesJob
 					// this is where the sausage is made

--- a/nomad/job_endpoint_statuses.go
+++ b/nomad/job_endpoint_statuses.go
@@ -109,12 +109,8 @@ func (j *Job) Statuses(
 			}
 
 			// set up tokenizer and filters
-			tokenizer := paginator.NewStructsTokenizer(
-				iter,
-				paginator.StructsTokenizerOptions{
-					OnlyModifyIndex: true,
-				},
-			)
+			tokenizer := paginator.ModifyIndexTokenizer[*structs.Job](args.NextToken)
+
 			filters := []paginator.Filter{
 				paginator.NamespaceFilter{
 					AllowableNamespaces: allowableNamespaces,

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -1088,17 +1088,18 @@ func TestLeader_DiffACLTokens(t *testing.T) {
 	assert.Nil(t, state.UpsertACLTokens(structs.MsgTypeTestSetup, 100, []*structs.ACLToken{p0, p1, p2, p3}))
 
 	// Simulate a remote list
-	p2Stub := p2.Stub()
+	p2Stub, _ := p2.Stub()
 	p2Stub.ModifyIndex = 50 // Ignored, same index
-	p3Stub := p3.Stub()
+	p3Stub, _ := p3.Stub()
 	p3Stub.ModifyIndex = 100 // Updated, higher index
 	p3Stub.Hash = []byte{0, 1, 2, 3}
 	p4 := mock.ACLToken()
 	p4.Global = true
+	p4Stub, _ := p4.Stub()
 	remoteList := []*structs.ACLTokenListStub{
 		p2Stub,
 		p3Stub,
-		p4.Stub(),
+		p4Stub,
 	}
 	delete, update := diffACLTokens(state, 50, remoteList)
 

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1610,14 +1610,11 @@ func (n *Node) List(args *structs.NodeListRequest,
 			// region, therefore we only need WithID on the paginator options.
 			tokenizer := paginator.IDTokenizer[*structs.Node](args.NextToken)
 
-			var nodes []*structs.NodeListStub
-
 			// Build the paginator. This includes the function that is
 			// responsible for appending a node to the nodes array.
-			paginatorImpl, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-				func(raw interface{}) error {
-					nodes = append(nodes, raw.(*structs.Node).Stub(args.Fields))
-					return nil
+			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+				func(node *structs.Node) (*structs.NodeListStub, error) {
+					return node.Stub(args.Fields), nil
 				})
 			if err != nil {
 				return structs.NewErrRPCCodedf(
@@ -1626,7 +1623,7 @@ func (n *Node) List(args *structs.NodeListRequest,
 
 			// Calling page populates our output nodes array as well as returns
 			// the next token.
-			nextToken, err := paginatorImpl.Page()
+			nodes, nextToken, err := pager.Page()
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to read result page: %v", err)

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1605,7 +1605,7 @@ func (n *Node) List(args *structs.NodeListRequest,
 				return err
 			}
 
-			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions, nil,
 				paginator.IDTokenizer[*structs.Node](args.NextToken),
 				func(node *structs.Node) (*structs.NodeListStub, error) {
 					return node.Stub(args.Fields), nil

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1614,7 +1614,7 @@ func (n *Node) List(args *structs.NodeListRequest,
 
 			// Build the paginator. This includes the function that is
 			// responsible for appending a node to the nodes array.
-			paginatorImpl, err := paginator.NewPaginator(iter, tokenizer, nil, args.QueryOptions,
+			paginatorImpl, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
 				func(raw interface{}) error {
 					nodes = append(nodes, raw.(*structs.Node).Stub(args.Fields))
 					return nil

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1608,7 +1608,7 @@ func (n *Node) List(args *structs.NodeListRequest,
 			// Generate the tokenizer to use for pagination using the populated
 			// paginatorOpts object. The ID of a node must be unique within the
 			// region, therefore we only need WithID on the paginator options.
-			tokenizer := paginator.NewStructsTokenizer(iter, paginator.StructsTokenizerOptions{WithID: true})
+			tokenizer := paginator.IDTokenizer[*structs.Node](args.NextToken)
 
 			var nodes []*structs.NodeListStub
 

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1605,14 +1605,8 @@ func (n *Node) List(args *structs.NodeListRequest,
 				return err
 			}
 
-			// Generate the tokenizer to use for pagination using the populated
-			// paginatorOpts object. The ID of a node must be unique within the
-			// region, therefore we only need WithID on the paginator options.
-			tokenizer := paginator.IDTokenizer[*structs.Node](args.NextToken)
-
-			// Build the paginator. This includes the function that is
-			// responsible for appending a node to the nodes array.
-			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				paginator.IDTokenizer[*structs.Node](args.NextToken),
 				func(node *structs.Node) (*structs.NodeListStub, error) {
 					return node.Stub(args.Fields), nil
 				})
@@ -1621,8 +1615,6 @@ func (n *Node) List(args *structs.NodeListRequest,
 					http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}
 
-			// Calling page populates our output nodes array as well as returns
-			// the next token.
 			nodes, nextToken, err := pager.Page()
 			if err != nil {
 				return structs.NewErrRPCCodedf(

--- a/nomad/node_pool_endpoint.go
+++ b/nomad/node_pool_endpoint.go
@@ -68,8 +68,8 @@ func (n *NodePool) List(args *structs.NodePoolListRequest, reply *structs.NodePo
 				return err
 			}
 
-			pageOpts := paginator.StructsTokenizerOptions{WithID: true}
-			tokenizer := paginator.NewStructsTokenizer(iter, pageOpts)
+			tokenizer := paginator.IDTokenizer[*structs.NodePool](args.NextToken)
+
 			filters := []paginator.Filter{
 				// Filter out node pools based on ACL token capabilities.
 				paginator.GenericFilter{
@@ -466,14 +466,7 @@ func (n *NodePool) ListJobs(args *structs.NodePoolJobsRequest, reply *structs.No
 					return err
 				}
 
-				tokenizer := paginator.NewStructsTokenizer(
-					iter,
-					paginator.StructsTokenizerOptions{
-						WithNamespace: true,
-						WithID:        true,
-					},
-				)
-
+				tokenizer := paginator.NamespaceIDTokenizer[*structs.Job](args.NextToken)
 				var jobs []*structs.JobListStub
 
 				paginator, err := paginator.NewPaginator(iter, tokenizer, filters, args.QueryOptions,
@@ -571,11 +564,7 @@ func (n *NodePool) ListNodes(args *structs.NodePoolNodesRequest, reply *structs.
 			}
 
 			// Setup paginator by node ID.
-			pageOpts := paginator.StructsTokenizerOptions{
-				WithID: true,
-			}
-			tokenizer := paginator.NewStructsTokenizer(iter, pageOpts)
-
+			tokenizer := paginator.IDTokenizer[*structs.Node](args.NextToken)
 			var nodes []*structs.NodeListStub
 			pager, err := paginator.NewPaginator(iter, tokenizer, nil, args.QueryOptions,
 				func(raw interface{}) error {

--- a/nomad/node_pool_endpoint.go
+++ b/nomad/node_pool_endpoint.go
@@ -68,9 +68,8 @@ func (n *NodePool) List(args *structs.NodePoolListRequest, reply *structs.NodePo
 				return err
 			}
 
-			tokenizer := paginator.IDTokenizer[*structs.NodePool](args.NextToken)
-
-			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				paginator.IDTokenizer[*structs.NodePool](args.NextToken),
 				(*structs.NodePool).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(http.StatusBadRequest, "failed to create result paginator: %v", err)
@@ -451,9 +450,8 @@ func (n *NodePool) ListJobs(args *structs.NodePoolJobsRequest, reply *structs.No
 					return err
 				}
 
-				tokenizer := paginator.NamespaceIDTokenizer[*structs.Job](args.NextToken)
-
-				pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+				pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+					paginator.NamespaceIDTokenizer[*structs.Job](args.NextToken),
 					func(job *structs.Job) (*structs.JobListStub, error) {
 						summary, err := store.JobSummaryByID(ws, job.Namespace, job.ID)
 						if err != nil || summary == nil {
@@ -546,9 +544,8 @@ func (n *NodePool) ListNodes(args *structs.NodePoolNodesRequest, reply *structs.
 				return err
 			}
 
-			// Setup paginator by node ID.
-			tokenizer := paginator.IDTokenizer[*structs.Node](args.NextToken)
-			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				paginator.IDTokenizer[*structs.Node](args.NextToken),
 				func(node *structs.Node) (*structs.NodeListStub, error) {
 					return node.Stub(args.Fields), nil
 				})

--- a/nomad/node_pool_endpoint.go
+++ b/nomad/node_pool_endpoint.go
@@ -71,9 +71,7 @@ func (n *NodePool) List(args *structs.NodePoolListRequest, reply *structs.NodePo
 			tokenizer := paginator.IDTokenizer[*structs.NodePool](args.NextToken)
 
 			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-				func(pool *structs.NodePool) (*structs.NodePool, error) {
-					return pool, nil
-				})
+				(*structs.NodePool).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -361,7 +361,7 @@ func (s *ServiceRegistration) GetService(
 				return err
 			}
 
-			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions, nil,
 				paginator.NamespaceIDTokenizer[*structs.ServiceRegistration](args.NextToken),
 				(*structs.ServiceRegistration).Stub)
 			if err != nil {

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -361,11 +361,8 @@ func (s *ServiceRegistration) GetService(
 				return err
 			}
 
-			// Generate the tokenizer to use for pagination using namespace and
-			// ID to ensure complete uniqueness.
-			tokenizer := paginator.NamespaceIDTokenizer[*structs.ServiceRegistration](args.NextToken)
-
-			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				paginator.NamespaceIDTokenizer[*structs.ServiceRegistration](args.NextToken),
 				(*structs.ServiceRegistration).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -366,9 +366,7 @@ func (s *ServiceRegistration) GetService(
 			tokenizer := paginator.NamespaceIDTokenizer[*structs.ServiceRegistration](args.NextToken)
 
 			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-				func(svc *structs.ServiceRegistration) (*structs.ServiceRegistration, error) {
-					return svc, nil
-				})
+				(*structs.ServiceRegistration).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -365,24 +365,16 @@ func (s *ServiceRegistration) GetService(
 			// ID to ensure complete uniqueness.
 			tokenizer := paginator.NamespaceIDTokenizer[*structs.ServiceRegistration](args.NextToken)
 
-			// Set up our output after we have checked the error.
-			var services []*structs.ServiceRegistration
-
-			// Build the paginator. This includes the function that is
-			// responsible for appending a registration to the services array.
-			paginatorImpl, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-				func(raw interface{}) error {
-					services = append(services, raw.(*structs.ServiceRegistration))
-					return nil
+			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+				func(svc *structs.ServiceRegistration) (*structs.ServiceRegistration, error) {
+					return svc, nil
 				})
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}
 
-			// Calling page populates our output services array as well as
-			// returns the next token.
-			nextToken, err := paginatorImpl.Page()
+			services, nextToken, err := pager.Page()
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to read result page: %v", err)

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -363,12 +363,7 @@ func (s *ServiceRegistration) GetService(
 
 			// Generate the tokenizer to use for pagination using namespace and
 			// ID to ensure complete uniqueness.
-			tokenizer := paginator.NewStructsTokenizer(iter,
-				paginator.StructsTokenizerOptions{
-					WithNamespace: true,
-					WithID:        true,
-				},
-			)
+			tokenizer := paginator.NamespaceIDTokenizer[*structs.ServiceRegistration](args.NextToken)
 
 			// Set up our output after we have checked the error.
 			var services []*structs.ServiceRegistration

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -370,7 +370,7 @@ func (s *ServiceRegistration) GetService(
 
 			// Build the paginator. This includes the function that is
 			// responsible for appending a registration to the services array.
-			paginatorImpl, err := paginator.NewPaginator(iter, tokenizer, nil, args.QueryOptions,
+			paginatorImpl, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
 				func(raw interface{}) error {
 					services = append(services, raw.(*structs.ServiceRegistration))
 					return nil

--- a/nomad/state/paginator/filter.go
+++ b/nomad/state/paginator/filter.go
@@ -3,14 +3,14 @@
 
 package paginator
 
-// FilterFunc is an interface for functions that return true if the object
+// SelectorFunc is an interface for functions that return true if the object
 // evaluated should be included in the page.
 //
 // Warning: this is the opposite of a memdb.FilterFunc, where returning true
 // excludes the object!
-type FilterFunc[T any] func(T) bool
+type SelectorFunc[T any] func(T) bool
 
-func NamespaceFilterFunc[T namespaceGetter](allowedNS map[string]bool) func(obj T) bool {
+func NamespaceSelectorFunc[T namespaceGetter](allowedNS map[string]bool) func(obj T) bool {
 	return func(obj T) bool {
 		if allowedNS == nil {
 			return true // management tokens always have nil here

--- a/nomad/state/paginator/filter.go
+++ b/nomad/state/paginator/filter.go
@@ -3,42 +3,19 @@
 
 package paginator
 
-// Filter is the interface that must be implemented to skip values when using
-// the Paginator.
-type Filter interface {
-	// Evaluate returns true if the element should be added to the page.
-	Evaluate(interface{}) (bool, error)
-}
+// FilterFunc is an interface for functions that return true if the object
+// evaluated should be included in the page.
+//
+// Warning: this is the opposite of a memdb.FilterFunc, where returning true
+// excludes the object!
+type FilterFunc[T any] func(T) bool
 
-// GenericFilter wraps a function that can be used to provide simple or in
-// scope filtering.
-type GenericFilter struct {
-	Allow func(interface{}) (bool, error)
-}
-
-func (f GenericFilter) Evaluate(raw interface{}) (bool, error) {
-	return f.Allow(raw)
-}
-
-// NamespaceFilter skips elements with a namespace value that is not in the
-// allowable set.
-type NamespaceFilter struct {
-	AllowableNamespaces map[string]bool
-}
-
-func (f NamespaceFilter) Evaluate(raw interface{}) (bool, error) {
-	if raw == nil {
-		return false, nil
+func NamespaceFilterFunc[T namespaceGetter](allowedNS map[string]bool) func(obj T) bool {
+	return func(obj T) bool {
+		if allowedNS == nil {
+			return true // management tokens always have nil here
+		}
+		ns := obj.GetNamespace()
+		return allowedNS[ns]
 	}
-
-	item, _ := raw.(namespaceGetter)
-	namespace := item.GetNamespace()
-
-	if f.AllowableNamespaces == nil {
-		return true, nil
-	}
-	if f.AllowableNamespaces[namespace] {
-		return true, nil
-	}
-	return false, nil
 }

--- a/nomad/state/paginator/filter.go
+++ b/nomad/state/paginator/filter.go
@@ -31,7 +31,7 @@ func (f NamespaceFilter) Evaluate(raw interface{}) (bool, error) {
 		return false, nil
 	}
 
-	item, _ := raw.(NamespaceGetter)
+	item, _ := raw.(namespaceGetter)
 	namespace := item.GetNamespace()
 
 	if f.AllowableNamespaces == nil {

--- a/nomad/state/paginator/filter_test.go
+++ b/nomad/state/paginator/filter_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 func TestGenericFilter(t *testing.T) {
@@ -32,14 +32,14 @@ func TestGenericFilter(t *testing.T) {
 		func(result *mockObject) (string, error) { return result.id, nil })
 	pager.WithFilter(filter)
 
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	results, nextToken, err := pager.Page()
-	require.NoError(t, err)
+	must.NoError(t, err)
 
 	expected := []string{"6", "7", "8"}
-	require.Equal(t, "9", nextToken)
-	require.Equal(t, expected, results)
+	must.Eq(t, "9", nextToken)
+	must.Eq(t, expected, results)
 }
 
 func TestNamespaceFilter(t *testing.T) {
@@ -82,13 +82,13 @@ func TestNamespaceFilter(t *testing.T) {
 
 			pager, err := NewPaginator(iter, opts, IDTokenizer[*mockObject](""),
 				func(result *mockObject) (string, error) { return result.namespace, nil })
-			require.NoError(t, err)
+			must.NoError(t, err)
 			pager = pager.WithFilter(NamespaceFilterFunc[*mockObject](tc.allowable))
 
 			results, nextToken, err := pager.Page()
-			require.NoError(t, err)
-			require.Equal(t, "", nextToken)
-			require.Equal(t, tc.expected, results)
+			must.NoError(t, err)
+			must.Eq(t, "", nextToken)
+			must.Eq(t, tc.expected, results)
 		})
 	}
 }

--- a/nomad/state/paginator/filter_test.go
+++ b/nomad/state/paginator/filter_test.go
@@ -28,9 +28,8 @@ func TestGenericFilter(t *testing.T) {
 		PerPage: 3,
 	}
 	results := []string{}
-	pager, err := NewPaginator(iter, opts, IDTokenizer[*mockObject](""),
+	pager, err := NewPaginator(iter, opts, filter, IDTokenizer[*mockObject](""),
 		func(result *mockObject) (string, error) { return result.id, nil })
-	pager.WithFilter(filter)
 
 	must.NoError(t, err)
 
@@ -80,10 +79,11 @@ func TestNamespaceFilter(t *testing.T) {
 				PerPage: int32(len(mocks)),
 			}
 
-			pager, err := NewPaginator(iter, opts, IDTokenizer[*mockObject](""),
+			pager, err := NewPaginator(iter, opts,
+				NamespaceFilterFunc[*mockObject](tc.allowable),
+				IDTokenizer[*mockObject](""),
 				func(result *mockObject) (string, error) { return result.namespace, nil })
 			must.NoError(t, err)
-			pager = pager.WithFilter(NamespaceFilterFunc[*mockObject](tc.allowable))
 
 			results, nextToken, err := pager.Page()
 			must.NoError(t, err)
@@ -159,7 +159,7 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.EvalsByNamespace(nil, structs.DefaultNamespace)
-			paginator, err := NewPaginator(iter, opts, IDTokenizer[*structs.Evaluation](""),
+			paginator, err := NewPaginator(iter, opts, nil, IDTokenizer[*structs.Evaluation](""),
 				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {
 				b.Fatalf("failed: %v", err)
@@ -178,7 +178,7 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.Evals(nil, false)
-			paginator, err := NewPaginator(iter, opts, IDTokenizer[*structs.Evaluation](""),
+			paginator, err := NewPaginator(iter, opts, nil, IDTokenizer[*structs.Evaluation](""),
 				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {
 				b.Fatalf("failed: %v", err)
@@ -211,7 +211,7 @@ func BenchmarkEvalListFilter(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.EvalsByNamespace(nil, structs.DefaultNamespace)
 
-			paginator, err := NewPaginator(iter, opts,
+			paginator, err := NewPaginator(iter, opts, nil,
 				IDTokenizer[*structs.Evaluation](opts.NextToken),
 				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {
@@ -245,7 +245,7 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.Evals(nil, false)
-			paginator, err := NewPaginator(iter, opts,
+			paginator, err := NewPaginator(iter, opts, nil,
 				IDTokenizer[*structs.Evaluation](opts.NextToken),
 				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {

--- a/nomad/state/paginator/filter_test.go
+++ b/nomad/state/paginator/filter_test.go
@@ -24,12 +24,11 @@ func TestGenericFilter(t *testing.T) {
 	}
 
 	iter := newTestIterator(ids)
-	tokenizer := IDTokenizer[*mockObject]("")
 	opts := structs.QueryOptions{
 		PerPage: 3,
 	}
 	results := []string{}
-	pager, err := NewPaginator(iter, tokenizer, opts,
+	pager, err := NewPaginator(iter, opts, IDTokenizer[*mockObject](""),
 		func(result *mockObject) (string, error) { return result.id, nil })
 	pager.WithFilter(filter)
 
@@ -77,12 +76,11 @@ func TestNamespaceFilter(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			iter := newTestIteratorWithMocks(mocks)
-			tokenizer := IDTokenizer[*mockObject]("")
 			opts := structs.QueryOptions{
 				PerPage: int32(len(mocks)),
 			}
 
-			pager, err := NewPaginator(iter, tokenizer, opts,
+			pager, err := NewPaginator(iter, opts, IDTokenizer[*mockObject](""),
 				func(result *mockObject) (string, error) { return result.namespace, nil })
 			require.NoError(t, err)
 			pager = pager.WithFilter(NamespaceFilterFunc[*mockObject](tc.allowable))
@@ -161,8 +159,7 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.EvalsByNamespace(nil, structs.DefaultNamespace)
-			tokenizer := IDTokenizer[*structs.Evaluation]("")
-			paginator, err := NewPaginator(iter, tokenizer, opts,
+			paginator, err := NewPaginator(iter, opts, IDTokenizer[*structs.Evaluation](""),
 				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {
 				b.Fatalf("failed: %v", err)
@@ -181,9 +178,7 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.Evals(nil, false)
-			tokenizer := IDTokenizer[*structs.Evaluation]("")
-
-			paginator, err := NewPaginator(iter, tokenizer, opts,
+			paginator, err := NewPaginator(iter, opts, IDTokenizer[*structs.Evaluation](""),
 				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {
 				b.Fatalf("failed: %v", err)
@@ -215,9 +210,9 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.EvalsByNamespace(nil, structs.DefaultNamespace)
-			tokenizer := IDTokenizer[*structs.Evaluation](opts.NextToken)
 
-			paginator, err := NewPaginator(iter, tokenizer, opts,
+			paginator, err := NewPaginator(iter, opts,
+				IDTokenizer[*structs.Evaluation](opts.NextToken),
 				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {
 				b.Fatalf("failed: %v", err)
@@ -250,9 +245,8 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.Evals(nil, false)
-			tokenizer := IDTokenizer[*structs.Evaluation](opts.NextToken)
-
-			paginator, err := NewPaginator(iter, tokenizer, opts,
+			paginator, err := NewPaginator(iter, opts,
+				IDTokenizer[*structs.Evaluation](opts.NextToken),
 				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {
 				b.Fatalf("failed: %v", err)

--- a/nomad/state/paginator/filter_test.go
+++ b/nomad/state/paginator/filter_test.go
@@ -30,17 +30,12 @@ func TestGenericFilter(t *testing.T) {
 	}
 	results := []string{}
 	pager, err := NewPaginator(iter, tokenizer, opts,
-		func(raw interface{}) error {
-			result := raw.(*mockObject)
-			results = append(results, result.id)
-			return nil
-		},
-	)
+		func(result *mockObject) (string, error) { return result.id, nil })
 	pager.WithFilter(filter)
 
 	require.NoError(t, err)
 
-	nextToken, err := pager.Page()
+	results, nextToken, err := pager.Page()
 	require.NoError(t, err)
 
 	expected := []string{"6", "7", "8"}
@@ -87,18 +82,12 @@ func TestNamespaceFilter(t *testing.T) {
 				PerPage: int32(len(mocks)),
 			}
 
-			results := []string{}
 			pager, err := NewPaginator(iter, tokenizer, opts,
-				func(raw interface{}) error {
-					result := raw.(*mockObject)
-					results = append(results, result.namespace)
-					return nil
-				},
-			)
+				func(result *mockObject) (string, error) { return result.namespace, nil })
 			require.NoError(t, err)
 			pager = pager.WithFilter(NamespaceFilterFunc[*mockObject](tc.allowable))
 
-			nextToken, err := pager.Page()
+			results, nextToken, err := pager.Page()
 			require.NoError(t, err)
 			require.Equal(t, "", nextToken)
 			require.Equal(t, tc.expected, results)
@@ -173,12 +162,8 @@ func BenchmarkEvalListFilter(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.EvalsByNamespace(nil, structs.DefaultNamespace)
 			tokenizer := IDTokenizer[*structs.Evaluation]("")
-			var evals []*structs.Evaluation
-			paginator, err := NewPaginator(iter, tokenizer, opts, func(raw interface{}) error {
-				eval := raw.(*structs.Evaluation)
-				evals = append(evals, eval)
-				return nil
-			})
+			paginator, err := NewPaginator(iter, tokenizer, opts,
+				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {
 				b.Fatalf("failed: %v", err)
 			}
@@ -198,12 +183,8 @@ func BenchmarkEvalListFilter(b *testing.B) {
 			iter, _ := state.Evals(nil, false)
 			tokenizer := IDTokenizer[*structs.Evaluation]("")
 
-			var evals []*structs.Evaluation
-			paginator, err := NewPaginator(iter, tokenizer, opts, func(raw interface{}) error {
-				eval := raw.(*structs.Evaluation)
-				evals = append(evals, eval)
-				return nil
-			})
+			paginator, err := NewPaginator(iter, tokenizer, opts,
+				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {
 				b.Fatalf("failed: %v", err)
 			}
@@ -236,12 +217,8 @@ func BenchmarkEvalListFilter(b *testing.B) {
 			iter, _ := state.EvalsByNamespace(nil, structs.DefaultNamespace)
 			tokenizer := IDTokenizer[*structs.Evaluation](opts.NextToken)
 
-			var evals []*structs.Evaluation
-			paginator, err := NewPaginator(iter, tokenizer, opts, func(raw interface{}) error {
-				eval := raw.(*structs.Evaluation)
-				evals = append(evals, eval)
-				return nil
-			})
+			paginator, err := NewPaginator(iter, tokenizer, opts,
+				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {
 				b.Fatalf("failed: %v", err)
 			}
@@ -275,12 +252,8 @@ func BenchmarkEvalListFilter(b *testing.B) {
 			iter, _ := state.Evals(nil, false)
 			tokenizer := IDTokenizer[*structs.Evaluation](opts.NextToken)
 
-			var evals []*structs.Evaluation
-			paginator, err := NewPaginator(iter, tokenizer, opts, func(raw interface{}) error {
-				eval := raw.(*structs.Evaluation)
-				evals = append(evals, eval)
-				return nil
-			})
+			paginator, err := NewPaginator(iter, tokenizer, opts,
+				func(eval *structs.Evaluation) (*structs.Evaluation, error) { return eval, nil })
 			if err != nil {
 				b.Fatalf("failed: %v", err)
 			}

--- a/nomad/state/paginator/filter_test.go
+++ b/nomad/state/paginator/filter_test.go
@@ -19,7 +19,7 @@ func TestGenericFilter(t *testing.T) {
 	ci.Parallel(t)
 	ids := []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}
 
-	filter := func(obj *mockObject) bool {
+	selector := func(obj *mockObject) bool {
 		return obj.id > "5"
 	}
 
@@ -28,7 +28,7 @@ func TestGenericFilter(t *testing.T) {
 		PerPage: 3,
 	}
 	results := []string{}
-	pager, err := NewPaginator(iter, opts, filter, IDTokenizer[*mockObject](""),
+	pager, err := NewPaginator(iter, opts, selector, IDTokenizer[*mockObject](""),
 		func(result *mockObject) (string, error) { return result.id, nil })
 
 	must.NoError(t, err)
@@ -80,7 +80,7 @@ func TestNamespaceFilter(t *testing.T) {
 			}
 
 			pager, err := NewPaginator(iter, opts,
-				NamespaceFilterFunc[*mockObject](tc.allowable),
+				NamespaceSelectorFunc[*mockObject](tc.allowable),
 				IDTokenizer[*mockObject](""),
 				func(result *mockObject) (string, error) { return result.namespace, nil })
 			must.NoError(t, err)

--- a/nomad/state/paginator/filter_test.go
+++ b/nomad/state/paginator/filter_test.go
@@ -26,7 +26,7 @@ func TestGenericFilter(t *testing.T) {
 		},
 	}}
 	iter := newTestIterator(ids)
-	tokenizer := testTokenizer{}
+	tokenizer := IDTokenizer[*mockObject]("")
 	opts := structs.QueryOptions{
 		PerPage: 3,
 	}
@@ -85,7 +85,7 @@ func TestNamespaceFilter(t *testing.T) {
 				AllowableNamespaces: tc.allowable,
 			}}
 			iter := newTestIteratorWithMocks(mocks)
-			tokenizer := testTokenizer{}
+			tokenizer := IDTokenizer[*mockObject]("")
 			opts := structs.QueryOptions{
 				PerPage: int32(len(mocks)),
 			}
@@ -174,8 +174,7 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.EvalsByNamespace(nil, structs.DefaultNamespace)
-			tokenizer := NewStructsTokenizer(iter, StructsTokenizerOptions{WithID: true})
-
+			tokenizer := IDTokenizer[*structs.Evaluation]("")
 			var evals []*structs.Evaluation
 			paginator, err := NewPaginator(iter, tokenizer, nil, opts, func(raw interface{}) error {
 				eval := raw.(*structs.Evaluation)
@@ -199,7 +198,7 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.Evals(nil, false)
-			tokenizer := NewStructsTokenizer(iter, StructsTokenizerOptions{WithID: true})
+			tokenizer := IDTokenizer[*structs.Evaluation]("")
 
 			var evals []*structs.Evaluation
 			paginator, err := NewPaginator(iter, tokenizer, nil, opts, func(raw interface{}) error {
@@ -237,7 +236,7 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.EvalsByNamespace(nil, structs.DefaultNamespace)
-			tokenizer := NewStructsTokenizer(iter, StructsTokenizerOptions{WithID: true})
+			tokenizer := IDTokenizer[*structs.Evaluation](opts.NextToken)
 
 			var evals []*structs.Evaluation
 			paginator, err := NewPaginator(iter, tokenizer, nil, opts, func(raw interface{}) error {
@@ -276,7 +275,7 @@ func BenchmarkEvalListFilter(b *testing.B) {
 
 		for i := 0; i < b.N; i++ {
 			iter, _ := state.Evals(nil, false)
-			tokenizer := NewStructsTokenizer(iter, StructsTokenizerOptions{WithID: true})
+			tokenizer := IDTokenizer[*structs.Evaluation](opts.NextToken)
 
 			var evals []*structs.Evaluation
 			paginator, err := NewPaginator(iter, tokenizer, nil, opts, func(raw interface{}) error {

--- a/nomad/state/paginator/paginator.go
+++ b/nomad/state/paginator/paginator.go
@@ -39,8 +39,8 @@ type Paginator[T, TStub any] struct {
 // error code along with an appropriate message.
 func NewPaginator[T, TStub any](
 	iter Iterator,
-	tokenizer Tokenizer[T],
 	opts structs.QueryOptions,
+	tokenizer Tokenizer[T],
 	stubFn func(T) (TStub, error),
 ) (*Paginator[T, TStub], error) {
 

--- a/nomad/state/paginator/paginator.go
+++ b/nomad/state/paginator/paginator.go
@@ -40,6 +40,7 @@ type Paginator[T, TStub any] struct {
 func NewPaginator[T, TStub any](
 	iter Iterator,
 	opts structs.QueryOptions,
+	filter FilterFunc[T],
 	tokenizer Tokenizer[T],
 	stubFn func(T) (TStub, error),
 ) (*Paginator[T, TStub], error) {
@@ -47,6 +48,7 @@ func NewPaginator[T, TStub any](
 	p := &Paginator[T, TStub]{
 		iter:           iter,
 		tokenizer:      tokenizer,
+		filter:         filter,
 		stubFn:         stubFn,
 		perPage:        opts.PerPage,
 		reverse:        opts.Reverse,
@@ -64,10 +66,10 @@ func NewPaginator[T, TStub any](
 	return p, nil
 }
 
-func (p *Paginator[T, TStub]) WithFilter(fn FilterFunc[T]) *Paginator[T, TStub] {
-	p.filter = fn
-	return p
-}
+// func (p *Paginator[T, TStub]) WithFilter(fn FilterFunc[T]) *Paginator[T, TStub] {
+// 	p.filter = fn
+// 	return p
+// }
 
 // Page populates a page by running the append function
 // over all results. Returns the next token.

--- a/nomad/state/paginator/paginator.go
+++ b/nomad/state/paginator/paginator.go
@@ -4,6 +4,7 @@
 package paginator
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/hashicorp/go-bexpr"
@@ -96,7 +97,8 @@ func (p *Paginator[T, TStub]) next() (TStub, paginatorState) {
 	}
 	obj, ok := raw.(T)
 	if !ok {
-		panic("paginator was instantiated with wrong type for table")
+		p.pageErr = errors.New("paginator was instantiated with wrong type for table")
+		return none, paginatorComplete
 	}
 
 	token, compared := p.tokenizer(obj)

--- a/nomad/state/paginator/paginator.go
+++ b/nomad/state/paginator/paginator.go
@@ -24,7 +24,7 @@ type Paginator[T, TStub any] struct {
 	iter           Iterator
 	tokenizer      Tokenizer[T]
 	bexpr          *bexpr.Evaluator
-	filter         FilterFunc[T]
+	selector       SelectorFunc[T]
 	stubFn         func(T) (TStub, error)
 	perPage        int32
 	itemCount      int32
@@ -40,7 +40,7 @@ type Paginator[T, TStub any] struct {
 func NewPaginator[T, TStub any](
 	iter Iterator,
 	opts structs.QueryOptions,
-	filter FilterFunc[T],
+	selector SelectorFunc[T],
 	tokenizer Tokenizer[T],
 	stubFn func(T) (TStub, error),
 ) (*Paginator[T, TStub], error) {
@@ -48,7 +48,7 @@ func NewPaginator[T, TStub any](
 	p := &Paginator[T, TStub]{
 		iter:           iter,
 		tokenizer:      tokenizer,
-		filter:         filter,
+		selector:       selector,
 		stubFn:         stubFn,
 		perPage:        opts.PerPage,
 		reverse:        opts.Reverse,
@@ -65,11 +65,6 @@ func NewPaginator[T, TStub any](
 
 	return p, nil
 }
-
-// func (p *Paginator[T, TStub]) WithFilter(fn FilterFunc[T]) *Paginator[T, TStub] {
-// 	p.filter = fn
-// 	return p
-// }
 
 // Page populates a page by running the append function
 // over all results. Returns the next token.
@@ -128,7 +123,7 @@ func (p *Paginator[T, TStub]) next() (TStub, paginatorState) {
 		}
 	}
 
-	if p.filter != nil && !p.filter(obj) {
+	if p.selector != nil && !p.selector(obj) {
 		return none, paginatorSkip
 	}
 

--- a/nomad/state/paginator/paginator_test.go
+++ b/nomad/state/paginator/paginator_test.go
@@ -20,7 +20,7 @@ func TestPaginator(t *testing.T) {
 		name              string
 		perPage           int32
 		nextToken         string
-		tokenizer         testTokenizer
+		tokenizer         Tokenizer[*mockObject]
 		expected          []string
 		expectedNextToken string
 		expectedError     string
@@ -28,12 +28,14 @@ func TestPaginator(t *testing.T) {
 		{
 			name:              "size-3 page-1",
 			perPage:           3,
+			tokenizer:         IDTokenizer[*mockObject](""),
 			expected:          []string{"0", "1", "2"},
 			expectedNextToken: "3",
 		},
 		{
 			name:              "size-5 page-2 stop before end",
 			perPage:           5,
+			tokenizer:         IDTokenizer[*mockObject]("3"),
 			nextToken:         "3",
 			expected:          []string{"3", "4", "5", "6", "7"},
 			expectedNextToken: "8",
@@ -41,6 +43,7 @@ func TestPaginator(t *testing.T) {
 		{
 			name:              "page-2 reading off the end",
 			perPage:           10,
+			tokenizer:         IDTokenizer[*mockObject]("5"),
 			nextToken:         "5",
 			expected:          []string{"5", "6", "7", "8", "9", "10", "11"},
 			expectedNextToken: "",
@@ -50,6 +53,7 @@ func TestPaginator(t *testing.T) {
 			perPage: 2,
 			// lexicographically, "10" < "2"
 			nextToken:         "10",
+			tokenizer:         IDTokenizer[*mockObject]("10"),
 			expected:          []string{"2", "3"},
 			expectedNextToken: "4",
 		},
@@ -58,7 +62,7 @@ func TestPaginator(t *testing.T) {
 			perPage: 2,
 			// "10" is converted to uint64(10) and compared with uint64 index
 			nextToken:         "10",
-			tokenizer:         testTokenizer{field: "index"},
+			tokenizer:         ModifyIndexTokenizer[*mockObject]("10"),
 			expected:          []string{"10", "11"},
 			expectedNextToken: "",
 		},
@@ -67,7 +71,7 @@ func TestPaginator(t *testing.T) {
 			perPage: 2,
 			// "" is converted to uint64(0) and compared with uint64 index
 			nextToken:         "",
-			tokenizer:         testTokenizer{field: "index"},
+			tokenizer:         ModifyIndexTokenizer[*mockObject](""),
 			expected:          []string{"0", "1"},
 			expectedNextToken: "2",
 		},
@@ -75,12 +79,14 @@ func TestPaginator(t *testing.T) {
 			name:              "starting off the end",
 			perPage:           5,
 			nextToken:         "a",
+			tokenizer:         IDTokenizer[*mockObject]("a"),
 			expected:          []string{},
 			expectedNextToken: "",
 		},
 		{
 			name:          "error during append",
 			expectedError: "failed to append",
+			tokenizer:     IDTokenizer[*mockObject](""),
 		},
 	}
 
@@ -152,6 +158,14 @@ func (m *mockObject) GetNamespace() string {
 	return m.namespace
 }
 
+func (m *mockObject) GetModifyIndex() uint64 {
+	return m.index
+}
+
+func (m *mockObject) GetID() string {
+	return m.id
+}
+
 func newTestIterator(ids []string) testResultIterator {
 	iter := testResultIterator{results: make(chan interface{}, 20)}
 	for x, id := range ids {
@@ -169,19 +183,4 @@ func newTestIteratorWithMocks(mocks []*mockObject) testResultIterator {
 		iter.results <- m
 	}
 	return iter
-}
-
-// implements Tokenizer interface
-type testTokenizer struct {
-	field string
-}
-
-func (t testTokenizer) GetToken(raw interface{}) any {
-	obj := raw.(*mockObject)
-	switch t.field {
-	case "index":
-		return obj.index
-	default:
-	}
-	return obj.id
 }

--- a/nomad/state/paginator/paginator_test.go
+++ b/nomad/state/paginator/paginator_test.go
@@ -99,7 +99,7 @@ func TestPaginator(t *testing.T) {
 				NextToken: tc.nextToken,
 			}
 
-			paginator, err := NewPaginator(iter, tc.tokenizer, opts,
+			paginator, err := NewPaginator(iter, opts, tc.tokenizer,
 				func(result *mockObject) (string, error) {
 					if tc.expectedError != "" {
 						return "", errors.New(tc.expectedError)

--- a/nomad/state/paginator/paginator_test.go
+++ b/nomad/state/paginator/paginator_test.go
@@ -100,7 +100,7 @@ func TestPaginator(t *testing.T) {
 			}
 
 			results := []string{}
-			paginator, err := NewPaginator(iter, tc.tokenizer, nil, opts,
+			paginator, err := NewPaginator(iter, tc.tokenizer, opts,
 				func(raw interface{}) error {
 					if tc.expectedError != "" {
 						return errors.New(tc.expectedError)

--- a/nomad/state/paginator/paginator_test.go
+++ b/nomad/state/paginator/paginator_test.go
@@ -99,21 +99,17 @@ func TestPaginator(t *testing.T) {
 				NextToken: tc.nextToken,
 			}
 
-			results := []string{}
 			paginator, err := NewPaginator(iter, tc.tokenizer, opts,
-				func(raw interface{}) error {
+				func(result *mockObject) (string, error) {
 					if tc.expectedError != "" {
-						return errors.New(tc.expectedError)
+						return "", errors.New(tc.expectedError)
 					}
-
-					result := raw.(*mockObject)
-					results = append(results, result.id)
-					return nil
+					return result.id, nil
 				},
 			)
 			must.NoError(t, err)
 
-			nextToken, err := paginator.Page()
+			results, nextToken, err := paginator.Page()
 			if tc.expectedError == "" {
 				must.NoError(t, err)
 				must.Eq(t, tc.expected, results)

--- a/nomad/state/paginator/paginator_test.go
+++ b/nomad/state/paginator/paginator_test.go
@@ -99,7 +99,7 @@ func TestPaginator(t *testing.T) {
 				NextToken: tc.nextToken,
 			}
 
-			paginator, err := NewPaginator(iter, opts, tc.tokenizer,
+			paginator, err := NewPaginator(iter, opts, nil, tc.tokenizer,
 				func(result *mockObject) (string, error) {
 					if tc.expectedError != "" {
 						return "", errors.New(tc.expectedError)

--- a/nomad/state/paginator/tokenizer.go
+++ b/nomad/state/paginator/tokenizer.go
@@ -4,124 +4,94 @@
 package paginator
 
 import (
+	"cmp"
 	"fmt"
-	"strings"
+	"strconv"
 )
 
 // Tokenizer is the interface that must be implemented to provide pagination
-// tokens to the Paginator.
-type Tokenizer interface {
-	// GetToken returns the pagination token for the given element.
-	GetToken(interface{}) any
+// tokens to the Paginator. It returns the token extracted from an object and
+// the results of a comparison against the target token the tokenizer is
+// seeking. Implementations should close over the token we're seeking.
+type Tokenizer[T any] func(item T) (string, int)
+
+// NamespaceIDTokenizer returns a tokenizer by Namespace and ID.
+func NamespaceIDTokenizer[T namespaceIDGetter](target string) Tokenizer[T] {
+	return func(item T) (string, int) {
+		ns := item.GetNamespace()
+		id := item.GetID()
+
+		// Use a character that is not part of validNamespaceName as separator to
+		// avoid accidentally generating collisions.
+		// For example, namespace `a` and job `b-c` would collide with namespace
+		// `a-b` and job `c` into the same token `a-b-c`, since `-` is an allowed
+		// character in namespace.
+		token := fmt.Sprintf("%s.%s", ns, id)
+		return token, cmp.Compare(token, target)
+	}
 }
 
-// IDGetter is the interface that must be implemented by structs that need to
-// have their ID as part of the pagination token.
-type IDGetter interface {
+// IDTokenizer returns a tokenizer by ID.
+func IDTokenizer[T idGetter](target string) Tokenizer[T] {
+	return func(item T) (string, int) {
+		id := item.GetID()
+		token := fmt.Sprintf("%s", id)
+		return token, cmp.Compare(token, target)
+	}
+}
+
+// CreateIndexAndIDTokenizer returns a tokenizer by CreateIndex and ID.
+func CreateIndexAndIDTokenizer[T idAndCreateIndexGetter](target string) Tokenizer[T] {
+	return func(item T) (string, int) {
+		index := item.GetCreateIndex()
+		id := item.GetID()
+		token := fmt.Sprintf("%d.%s", index, id)
+		return token, cmp.Compare(token, target)
+	}
+}
+
+// ModifyIndexTokenizer returns a tokenizer by ModifyIndex.
+func ModifyIndexTokenizer[T modifyIndexGetter](target string) Tokenizer[T] {
+	// attempt to convert token to uint for iterators ordered numerically.
+	// it's safe to ignore the error here because the `next` method ignores
+	// this field for string tokens and 0 is valid for an unset numeric token.
+	targetIndex, _ := strconv.ParseUint(target, 10, 64)
+
+	return func(item T) (string, int) {
+		index := item.GetModifyIndex()
+		token := fmt.Sprintf("%d", index)
+		return token, cmp.Compare(index, targetIndex)
+	}
+}
+
+// namespaceIDGetter must be implemented by structs that want to use
+// Namespace and ID as their pagination token.
+type namespaceIDGetter interface {
+	GetNamespace() string
 	GetID() string
 }
 
-// NamespaceGetter is the interface that must be implemented by structs that
-// need to have their Namespace as part of the pagination token.
-type NamespaceGetter interface {
+// idGetter must be implemented by structs that want to use their ID (without
+// namespace) as their pagination token.
+type idGetter interface {
+	GetID() string
+}
+
+// namespaceGetter must be implemented by structs that want to use Namespace
+// alone as their pagination token.
+type namespaceGetter interface {
 	GetNamespace() string
 }
 
-// CreateIndexGetter is the interface that must be implemented by structs that
-// need to have their CreateIndex as part of the pagination token.
-type CreateIndexGetter interface {
+// idAndCreateIndexGetter must be implemented by structs that want to use
+// CreateIndex and ID as their pagination token.
+type idAndCreateIndexGetter interface {
+	GetID() string
 	GetCreateIndex() uint64
 }
 
-// ModifyIndexGetter is the interface that must be implemented by structs that
-// need to have their ModifyIndex as part of the pagination token.
-type ModifyIndexGetter interface {
+// modifyIndexGetter must be implemented by structs that want to use ModifyIndex
+// as their pagination token.
+type modifyIndexGetter interface {
 	GetModifyIndex() uint64
-}
-
-// StructsTokenizerOptions is the configuration provided to a StructsTokenizer.
-//
-// These are some of the common use cases:
-//
-// Structs that can be uniquely identified with only its own ID:
-//
-//	StructsTokenizerOptions {
-//	    WithID: true,
-//	}
-//
-// Structs that are only unique within their namespace:
-//
-//	StructsTokenizerOptions {
-//	    WithID:        true,
-//	    WithNamespace: true,
-//	}
-//
-// Structs that can be sorted by their create index should also set
-// `WithCreateIndex` to `true` along with the other options:
-//
-//	StructsTokenizerOptions {
-//	    WithID:          true,
-//	    WithNamespace:   true,
-//	    WithCreateIndex: true,
-//	}
-//
-// For structs that can be sorted by the order they were modified, set
-// `OnlyModifyIndex` to `true` and exclude all other options:
-//
-//	StructsTokenizerOptions {
-//	    OnlyModifyIndex: true,
-//	}
-type StructsTokenizerOptions struct {
-	WithCreateIndex bool
-	WithNamespace   bool
-	WithID          bool
-	OnlyModifyIndex bool
-}
-
-// StructsTokenizer is an pagination token generator that can create different
-// formats of pagination tokens based on common fields found in the structs
-// package.
-type StructsTokenizer struct {
-	opts StructsTokenizerOptions
-}
-
-// NewStructsTokenizer returns a new StructsTokenizer.
-func NewStructsTokenizer(_ Iterator, opts StructsTokenizerOptions) StructsTokenizer {
-	return StructsTokenizer{
-		opts: opts,
-	}
-}
-
-func (it StructsTokenizer) GetToken(raw interface{}) any {
-	if raw == nil {
-		return ""
-	}
-
-	if it.opts.OnlyModifyIndex {
-		return raw.(ModifyIndexGetter).GetModifyIndex()
-	}
-
-	parts := []string{}
-
-	if it.opts.WithCreateIndex {
-		token := raw.(CreateIndexGetter).GetCreateIndex()
-		parts = append(parts, fmt.Sprintf("%v", token))
-	}
-
-	if it.opts.WithNamespace {
-		token := raw.(NamespaceGetter).GetNamespace()
-		parts = append(parts, token)
-	}
-
-	if it.opts.WithID {
-		token := raw.(IDGetter).GetID()
-		parts = append(parts, token)
-	}
-
-	// Use a character that is not part of validNamespaceName as separator to
-	// avoid accidentally generating collisions.
-	// For example, namespace `a` and job `b-c` would collide with namespace
-	// `a-b` and job `c` into the same token `a-b-c`, since `-` is an allowed
-	// character in namespace.
-	return strings.Join(parts, ".")
 }

--- a/nomad/state/paginator/tokenizer.go
+++ b/nomad/state/paginator/tokenizer.go
@@ -35,8 +35,7 @@ func NamespaceIDTokenizer[T namespaceIDGetter](target string) Tokenizer[T] {
 func IDTokenizer[T idGetter](target string) Tokenizer[T] {
 	return func(item T) (string, int) {
 		id := item.GetID()
-		token := fmt.Sprintf("%s", id)
-		return token, cmp.Compare(token, target)
+		return id, cmp.Compare(id, target)
 	}
 }
 

--- a/nomad/structs/host_volumes.go
+++ b/nomad/structs/host_volumes.go
@@ -107,9 +107,9 @@ func (hv *HostVolume) Copy() *HostVolume {
 	return &nhv
 }
 
-func (hv *HostVolume) Stub() *HostVolumeStub {
+func (hv *HostVolume) Stub() (*HostVolumeStub, error) {
 	if hv == nil {
-		return nil
+		return nil, nil
 	}
 
 	return &HostVolumeStub{
@@ -125,7 +125,7 @@ func (hv *HostVolume) Stub() *HostVolumeStub {
 		CreateTime:    hv.CreateTime,
 		ModifyIndex:   hv.ModifyIndex,
 		ModifyTime:    hv.ModifyTime,
-	}
+	}, nil
 }
 
 // Validate verifies that the submitted HostVolume spec has valid field values,
@@ -473,6 +473,11 @@ func (tgvc *TaskGroupHostVolumeClaim) GetNamespace() string {
 // GetID implements the paginator.IDGetter interface
 func (tgvc *TaskGroupHostVolumeClaim) GetID() string {
 	return tgvc.ID
+}
+
+// Stub implements support for pagination
+func (tgvc *TaskGroupHostVolumeClaim) Stub() (*TaskGroupHostVolumeClaim, error) {
+	return tgvc, nil
 }
 
 type TaskGroupVolumeClaimListRequest struct {

--- a/nomad/structs/node_pool.go
+++ b/nomad/structs/node_pool.go
@@ -135,6 +135,11 @@ func (n *NodePool) MemoryOversubscriptionEnabled(global *SchedulerConfiguration)
 	return memOversubEnabled
 }
 
+// Stub implements support for pagination
+func (n *NodePool) Stub() (*NodePool, error) {
+	return n, nil
+}
+
 // SetHash is used to compute and set the hash of node pool
 func (n *NodePool) SetHash() []byte {
 	// Initialize a 256bit Blake2 hash (32 bytes)

--- a/nomad/structs/service_registration.go
+++ b/nomad/structs/service_registration.go
@@ -177,6 +177,11 @@ func (s *ServiceRegistration) GetNamespace() string {
 	return s.Namespace
 }
 
+// Stub implements support for pagination
+func (s *ServiceRegistration) Stub() (*ServiceRegistration, error) {
+	return s, nil
+}
+
 // HashWith generates a unique value representative of s based on the contents of s.
 func (s *ServiceRegistration) HashWith(key string) string {
 	buf := make([]byte, 8)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10658,6 +10658,11 @@ func (d *Deployment) Copy() *Deployment {
 	return c
 }
 
+// Stub implements support for pagination
+func (d *Deployment) Stub() (*Deployment, error) {
+	return d, nil
+}
+
 // Active returns whether the deployment is active or terminal.
 func (d *Deployment) Active() bool {
 	switch d.Status {
@@ -13605,7 +13610,7 @@ func (a *ACLToken) SetHash() []byte {
 	return hashVal
 }
 
-func (a *ACLToken) Stub() *ACLTokenListStub {
+func (a *ACLToken) Stub() (*ACLTokenListStub, error) {
 	return &ACLTokenListStub{
 		AccessorID:     a.AccessorID,
 		Name:           a.Name,
@@ -13618,7 +13623,7 @@ func (a *ACLToken) Stub() *ACLTokenListStub {
 		ExpirationTime: a.ExpirationTime,
 		CreateIndex:    a.CreateIndex,
 		ModifyIndex:    a.ModifyIndex,
-	}
+	}, nil
 }
 
 // ACLTokenListRequest is used to request a list of tokens

--- a/nomad/task_group_host_volume_claim_endpoint.go
+++ b/nomad/task_group_host_volume_claim_endpoint.go
@@ -67,8 +67,7 @@ func (tgvc *TaskGroupHostVolumeClaim) List(args *structs.TaskGroupVolumeClaimLis
 			}
 
 			allowClaim := acl.NamespaceValidator(acl.NamespaceCapabilityHostVolumeRead)
-			filter := func(claim *structs.TaskGroupHostVolumeClaim) bool {
-				// empty prefix doesn't filter
+			selector := func(claim *structs.TaskGroupHostVolumeClaim) bool {
 				if !strings.HasPrefix(claim.ID, args.Prefix) {
 					return false
 				}
@@ -77,7 +76,7 @@ func (tgvc *TaskGroupHostVolumeClaim) List(args *structs.TaskGroupVolumeClaimLis
 			}
 
 			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
-				filter,
+				selector,
 				paginator.NamespaceIDTokenizer[*structs.TaskGroupHostVolumeClaim](args.NextToken),
 				(*structs.TaskGroupHostVolumeClaim).Stub)
 			if err != nil {

--- a/nomad/task_group_host_volume_claim_endpoint.go
+++ b/nomad/task_group_host_volume_claim_endpoint.go
@@ -68,8 +68,16 @@ func (tgvc *TaskGroupHostVolumeClaim) List(args *structs.TaskGroupVolumeClaimLis
 
 			tokenizer := paginator.NamespaceIDTokenizer[*structs.TaskGroupHostVolumeClaim](args.NextToken)
 
-			allowClaim := acl.NamespaceValidator(acl.NamespaceCapabilityHostVolumeRead)
+			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+				func(claim *structs.TaskGroupHostVolumeClaim) (*structs.TaskGroupHostVolumeClaim, error) {
+					return claim, nil
+				})
+			if err != nil {
+				return structs.NewErrRPCCodedf(
+					http.StatusBadRequest, "failed to create result paginator: %v", err)
+			}
 
+			allowClaim := acl.NamespaceValidator(acl.NamespaceCapabilityHostVolumeRead)
 			filter := func(claim *structs.TaskGroupHostVolumeClaim) bool {
 				// empty prefix doesn't filter
 				if !strings.HasPrefix(claim.ID, args.Prefix) {
@@ -78,25 +86,10 @@ func (tgvc *TaskGroupHostVolumeClaim) List(args *structs.TaskGroupVolumeClaimLis
 
 				return allowClaim(aclObj, claim.Namespace)
 			}
-
-			// Set up our output after we have checked the error.
-			var claims []*structs.TaskGroupHostVolumeClaim
-
-			// Build the paginator.
-			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-				func(raw any) error {
-					claim := raw.(*structs.TaskGroupHostVolumeClaim)
-					claims = append(claims, claim)
-					return nil
-				})
-			if err != nil {
-				return structs.NewErrRPCCodedf(
-					http.StatusBadRequest, "failed to create result paginator: %v", err)
-			}
 			pager = pager.WithFilter(filter)
 
 			// Calling page populates our output array as well as returns the next token.
-			nextToken, err := pager.Page()
+			claims, nextToken, err := pager.Page()
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to read result page: %v", err)

--- a/nomad/task_group_host_volume_claim_endpoint.go
+++ b/nomad/task_group_host_volume_claim_endpoint.go
@@ -66,12 +66,7 @@ func (tgvc *TaskGroupHostVolumeClaim) List(args *structs.TaskGroupVolumeClaimLis
 				return err
 			}
 
-			tokenizer := paginator.NewStructsTokenizer(iter,
-				paginator.StructsTokenizerOptions{
-					WithNamespace: true,
-					WithID:        true,
-				},
-			)
+			tokenizer := paginator.NamespaceIDTokenizer[*structs.TaskGroupHostVolumeClaim](args.NextToken)
 
 			allowClaim := acl.NamespaceValidator(acl.NamespaceCapabilityHostVolumeRead)
 			filters := []paginator.Filter{

--- a/nomad/task_group_host_volume_claim_endpoint.go
+++ b/nomad/task_group_host_volume_claim_endpoint.go
@@ -69,9 +69,7 @@ func (tgvc *TaskGroupHostVolumeClaim) List(args *structs.TaskGroupVolumeClaimLis
 			tokenizer := paginator.NamespaceIDTokenizer[*structs.TaskGroupHostVolumeClaim](args.NextToken)
 
 			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
-				func(claim *structs.TaskGroupHostVolumeClaim) (*structs.TaskGroupHostVolumeClaim, error) {
-					return claim, nil
-				})
+				(*structs.TaskGroupHostVolumeClaim).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)

--- a/nomad/task_group_host_volume_claim_endpoint.go
+++ b/nomad/task_group_host_volume_claim_endpoint.go
@@ -66,9 +66,8 @@ func (tgvc *TaskGroupHostVolumeClaim) List(args *structs.TaskGroupVolumeClaimLis
 				return err
 			}
 
-			tokenizer := paginator.NamespaceIDTokenizer[*structs.TaskGroupHostVolumeClaim](args.NextToken)
-
-			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				paginator.NamespaceIDTokenizer[*structs.TaskGroupHostVolumeClaim](args.NextToken),
 				(*structs.TaskGroupHostVolumeClaim).Stub)
 			if err != nil {
 				return structs.NewErrRPCCodedf(

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -424,12 +424,7 @@ func (sv *Variables) List(
 
 			// Generate the tokenizer to use for pagination using namespace and
 			// ID to ensure complete uniqueness.
-			tokenizer := paginator.NewStructsTokenizer(iter,
-				paginator.StructsTokenizerOptions{
-					WithNamespace: true,
-					WithID:        true,
-				},
-			)
+			tokenizer := paginator.NamespaceIDTokenizer[*structs.VariableEncrypted](args.NextToken)
 
 			filters := []paginator.Filter{
 				paginator.GenericFilter{
@@ -515,11 +510,7 @@ func (sv *Variables) listAllVariables(
 
 			// Generate the tokenizer to use for pagination using namespace and
 			// ID to ensure complete uniqueness.
-			tokenizer := paginator.NewStructsTokenizer(iter,
-				paginator.StructsTokenizerOptions{
-					WithNamespace: true,
-					WithID:        true,
-				})
+			tokenizer := paginator.NamespaceIDTokenizer[*structs.VariableEncrypted](args.NextToken)
 
 			filters := []paginator.Filter{
 				paginator.GenericFilter{

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -422,7 +422,17 @@ func (sv *Variables) List(
 				return err
 			}
 
-			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+			filter := func(v *structs.VariableEncrypted) bool {
+				if !strings.HasPrefix(v.Path, args.Prefix) {
+					return false
+				}
+
+				return aclObj.AllowVariableOperation(v.Namespace, v.Path,
+					acl.PolicyList,
+					auth.IdentityToACLClaim(args.GetIdentity(), sv.srv.State()))
+			}
+
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions, filter,
 				paginator.NamespaceIDTokenizer[*structs.VariableEncrypted](args.NextToken),
 				func(sv *structs.VariableEncrypted) (*structs.VariableMetadata, error) {
 					svStub := sv.VariableMetadata
@@ -436,17 +446,6 @@ func (sv *Variables) List(
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}
-
-			filter := func(v *structs.VariableEncrypted) bool {
-				if !strings.HasPrefix(v.Path, args.Prefix) {
-					return false
-				}
-
-				return aclObj.AllowVariableOperation(v.Namespace, v.Path,
-					acl.PolicyList,
-					auth.IdentityToACLClaim(args.GetIdentity(), sv.srv.State()))
-			}
-			pager = pager.WithFilter(filter)
 
 			// Calling page populates our output variable stub array as well as
 			// returns the next token.
@@ -490,7 +489,17 @@ func (sv *Variables) listAllVariables(
 				return err
 			}
 
-			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+			filter := func(v *structs.VariableEncrypted) bool {
+				if !strings.HasPrefix(v.Path, args.Prefix) {
+					return false
+				}
+
+				return aclObj.AllowVariableOperation(v.Namespace, v.Path,
+					acl.PolicyList,
+					auth.IdentityToACLClaim(args.GetIdentity(), sv.srv.State()))
+			}
+
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions, filter,
 				paginator.NamespaceIDTokenizer[*structs.VariableEncrypted](args.NextToken),
 				func(v *structs.VariableEncrypted) (*structs.VariableMetadata, error) {
 					svStub := v.VariableMetadata
@@ -504,17 +513,6 @@ func (sv *Variables) listAllVariables(
 				return structs.NewErrRPCCodedf(
 					http.StatusBadRequest, "failed to create result paginator: %v", err)
 			}
-
-			filter := func(v *structs.VariableEncrypted) bool {
-				if !strings.HasPrefix(v.Path, args.Prefix) {
-					return false
-				}
-
-				return aclObj.AllowVariableOperation(v.Namespace, v.Path,
-					acl.PolicyList,
-					auth.IdentityToACLClaim(args.GetIdentity(), sv.srv.State()))
-			}
-			pager = pager.WithFilter(filter)
 
 			// Calling page populates our output variable stubs array as well as
 			// returns the next token.

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -422,7 +422,7 @@ func (sv *Variables) List(
 				return err
 			}
 
-			filter := func(v *structs.VariableEncrypted) bool {
+			selector := func(v *structs.VariableEncrypted) bool {
 				if !strings.HasPrefix(v.Path, args.Prefix) {
 					return false
 				}
@@ -432,7 +432,7 @@ func (sv *Variables) List(
 					auth.IdentityToACLClaim(args.GetIdentity(), sv.srv.State()))
 			}
 
-			pager, err := paginator.NewPaginator(iter, args.QueryOptions, filter,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions, selector,
 				paginator.NamespaceIDTokenizer[*structs.VariableEncrypted](args.NextToken),
 				func(sv *structs.VariableEncrypted) (*structs.VariableMetadata, error) {
 					svStub := sv.VariableMetadata
@@ -489,7 +489,7 @@ func (sv *Variables) listAllVariables(
 				return err
 			}
 
-			filter := func(v *structs.VariableEncrypted) bool {
+			selector := func(v *structs.VariableEncrypted) bool {
 				if !strings.HasPrefix(v.Path, args.Prefix) {
 					return false
 				}
@@ -499,7 +499,7 @@ func (sv *Variables) listAllVariables(
 					auth.IdentityToACLClaim(args.GetIdentity(), sv.srv.State()))
 			}
 
-			pager, err := paginator.NewPaginator(iter, args.QueryOptions, filter,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions, selector,
 				paginator.NamespaceIDTokenizer[*structs.VariableEncrypted](args.NextToken),
 				func(v *structs.VariableEncrypted) (*structs.VariableMetadata, error) {
 					svStub := v.VariableMetadata

--- a/nomad/variables_endpoint.go
+++ b/nomad/variables_endpoint.go
@@ -422,9 +422,8 @@ func (sv *Variables) List(
 				return err
 			}
 
-			tokenizer := paginator.NamespaceIDTokenizer[*structs.VariableEncrypted](args.NextToken)
-
-			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				paginator.NamespaceIDTokenizer[*structs.VariableEncrypted](args.NextToken),
 				func(sv *structs.VariableEncrypted) (*structs.VariableMetadata, error) {
 					svStub := sv.VariableMetadata
 
@@ -491,9 +490,8 @@ func (sv *Variables) listAllVariables(
 				return err
 			}
 
-			tokenizer := paginator.NamespaceIDTokenizer[*structs.VariableEncrypted](args.NextToken)
-
-			pager, err := paginator.NewPaginator(iter, tokenizer, args.QueryOptions,
+			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
+				paginator.NamespaceIDTokenizer[*structs.VariableEncrypted](args.NextToken),
 				func(v *structs.VariableEncrypted) (*structs.VariableMetadata, error) {
 					svStub := v.VariableMetadata
 


### PR DESCRIPTION
The paginator was developed before generics were available, so we've had to work around a lack of compile-time safety by creating configuration objects at runtime that require a lot of branching and type casts. This results in a lot of added boilerplate in the RPC handlers.

Refactor the paginator to take advantage of generics. 
* Move all decision making around tokenization to compile-time by providing pre-built generic functions that close over target tokens. 
* Remove the `appendFunc` parameter in lieu of a `Stub` function parameter that will accept existing `Stub` functions in most cases (with the addition of an extra `error` return value).
* Generally remove boilerplate in the RPC handlers as a result, except where a given handler wants more complex filtering.

This doesn't reduce the boilerplate we need at the top of many blocking queries to define the iterator we want based on arguments, which we're typically doing to decide upon which memdb index we want. That's a query optimization problem and way beyond the scope of this PR.