### PR TITLE
Fix CSI ExpandVolume stagingPath

### DIFF
--- a/.changelog/25253.txt
+++ b/.changelog/25253.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a CSI ExpandVolume bug where the namespace was left out of the staging path
+```

--- a/client/pluginmanager/csimanager/volume.go
+++ b/client/pluginmanager/csimanager/volume.go
@@ -293,7 +293,7 @@ func (v *volumeManager) unstageVolume(ctx context.Context, volNS, volID, remoteI
 	// plugin to perform unstaging
 	stagingPath := v.stagingDirForVolume(v.containerMountPoint, volNS, volID, usage)
 
-	// This it the path from the host, which we need to use to verify whether
+	// This is the path from the host, which we need to use to verify whether
 	// the path is the right one to pass to the plugin container
 	hostStagingPath := v.stagingDirForVolume(v.mountRoot, volNS, volID, usage)
 	_, err := os.Stat(hostStagingPath)
@@ -416,8 +416,14 @@ func (v *volumeManager) ExpandVolume(ctx context.Context, volNS, volID, remoteID
 			"volume_id", volID, "alloc_id", allocID, "error", err)
 	}
 
+	// This is the staging path inside the container, which we pass to the
+	// plugin to perform expansion
 	stagingPath := v.stagingDirForVolume(v.containerMountPoint, volNS, volID, usage)
-	_, err = os.Stat(stagingPath)
+
+	// This is the path from the host, which we need to use to verify whether
+	// the path is the right one to pass to the plugin container
+	hostStagingPath := v.stagingDirForVolume(v.mountRoot, volNS, volID, usage)
+	_, err = os.Stat(hostStagingPath)
 	if err != nil && errors.Is(err, fs.ErrNotExist) {
 		// COMPAT: it's possible to get an unmount request that includes the
 		// namespace even for volumes that were mounted before the path included


### PR DESCRIPTION
### Description
Fix the checking of the staging path against the mountRoot on the host rather then checking against the containerMountPoint which (probably) never exists on the host causing it to default back the the legacy behaviour.

### Testing & Reproduction steps
Should be easily reproducible on any csi driver supporting ExpandVolume and has nomad namespaces enabled. Tested with nomad enterprise 1.8.5

### Links
https://github.com/hashicorp/nomad/issues/24465

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
