### PR TITLE
e2e: allow consul access to nomad cluster

### DIFF
--- a/e2e/terraform/provision-infra/consul-servers.tf
+++ b/e2e/terraform/provision-infra/consul-servers.tf
@@ -187,7 +187,7 @@ resource "null_resource" "setup_consul_workload_identity" {
       CONSUL_CACERT      = "${local.keys_dir}/tls_ca.crt"
       CONSUL_HTTP_TOKEN  = "${random_uuid.consul_initial_management_token.result}"
       CONSUL_AGENT_TOKEN = "${random_uuid.consul_agent_token.result}"
-      NOMAD_SERVER_ADDR  = "https://${aws_instance.server[0].public_ip}:4646"
+      NOMAD_SERVER_ADDR  = "https://${aws_instance.server[0].private_ip}:4646"
     }
   }
 }

--- a/e2e/terraform/provision-infra/network.tf
+++ b/e2e/terraform/provision-infra/network.tf
@@ -89,6 +89,17 @@ resource "aws_security_group" "servers" {
   }
 }
 
+# Allows consul to make requests to Nomad, which is necessary when creating
+# auth methods. Must be done in an aws_security_group_rule to avoid cycles.
+resource "aws_security_group_rule" "consul_ingress" {
+  type = "ingress"
+  from_port = 0
+  to_port = 0
+  protocol = "-1"
+  security_group_id = aws_security_group.servers.id
+  source_security_group_id = aws_security_group.consul_server.id
+}
+
 # the secondary VPC security group is intended only for internal traffic
 # and so that we can exercise behaviors with multiple IPs
 resource "aws_security_group" "servers_secondary" {

--- a/e2e/terraform/provision-infra/network.tf
+++ b/e2e/terraform/provision-infra/network.tf
@@ -89,14 +89,14 @@ resource "aws_security_group" "servers" {
   }
 }
 
-# Allows consul to make requests to Nomad, which is necessary when creating
+# Allows Consul network access to Nomad, which is necessary when creating
 # auth methods. Must be done in an aws_security_group_rule to avoid cycles.
 resource "aws_security_group_rule" "consul_ingress" {
-  type = "ingress"
-  from_port = 0
-  to_port = 0
-  protocol = "-1"
-  security_group_id = aws_security_group.servers.id
+  type                     = "ingress"
+  from_port                = 0
+  to_port                  = 0
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.servers.id
   source_security_group_id = aws_security_group.consul_server.id
 }
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Allows the Consul server access to the Nomad cluster in E2E testing. This allows Consul to make the necessary JWKSUrl test call when creating an authentication method.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
