### PR TITLE
upgrade testing: make cluster name prefix a variable

### DIFF
--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -25,7 +25,7 @@ scenario "upgrade" {
   ]
 
   locals {
-    cluster_name           = "mcj-${matrix.os}-${matrix.arch}-${matrix.edition}-${var.product_version}"
+    cluster_name           = "${var.prefix}-${matrix.os}-${matrix.arch}-${matrix.edition}-${var.product_version}"
     linux_count            = matrix.os == "linux" ? "4" : "0"
     windows_count          = matrix.os == "windows" ? "4" : "0"
     arch                   = matrix.arch

--- a/enos/enos-vars.hcl
+++ b/enos/enos-vars.hcl
@@ -1,6 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+variable "prefix" {
+  type        = string
+  description = "Prefix for the cluster name"
+  default     = "upgrade"
+}
+
 # Variables for the fetch_artifactory module
 variable "artifactory_username" {
   type        = string

--- a/enos/enos.vars.example.hcl
+++ b/enos/enos.vars.example.hcl
@@ -1,6 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+prefix               = "<your initials or name>"
 artifactory_username = "<your email address>"
 artifactory_token    = "<your ARTIFACTORY_TOKEN from above>"
 product_version      = "1.8.9"                     # starting version


### PR DESCRIPTION
During initial development of upgrade testing, we had a hard-coded prefix to distinguish between clusters created for this vs those created by GHA runners. Update the prefix to be a variable so that developers can add their own prefix during test workload development.