### PR TITLE
Check for nil values when parsing HCL strings

### DIFF
--- a/.changelog/25294.txt
+++ b/.changelog/25294.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+hcl: Avoid panics by checking null values on durations
+```

--- a/jobspec2/hcl_conversions.go
+++ b/jobspec2/hcl_conversions.go
@@ -42,9 +42,20 @@ func newHCLDecoder() *gohcl.Decoder {
 
 func decodeDuration(expr hcl.Expression, ctx *hcl.EvalContext, val interface{}) hcl.Diagnostics {
 	srcVal, diags := expr.Value(ctx)
+	if srcVal.IsNull() {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagError,
+			Summary:  "Unsuitable value",
+			Detail:   fmt.Sprintf("Unsuitable duration value: nil"),
+			Subject:  expr.StartRange().Ptr(),
+			Context:  expr.Range().Ptr(),
+		})
+		return diags
+	}
 
 	if srcVal.Type() == cty.String {
 		dur, err := time.ParseDuration(srcVal.AsString())
+
 		if err != nil {
 			diags = append(diags, &hcl.Diagnostic{
 				Severity: hcl.DiagError,
@@ -68,7 +79,6 @@ func decodeDuration(expr hcl.Expression, ctx *hcl.EvalContext, val interface{}) 
 			Context:  expr.Range().Ptr(),
 		})
 		return diags
-
 	}
 
 	err := gocty.FromCtyValue(srcVal, val)
@@ -81,7 +91,6 @@ func decodeDuration(expr hcl.Expression, ctx *hcl.EvalContext, val interface{}) 
 			Context:  expr.Range().Ptr(),
 		})
 	}
-
 	return diags
 }
 

--- a/jobspec2/hcl_conversions.go
+++ b/jobspec2/hcl_conversions.go
@@ -46,7 +46,7 @@ func decodeDuration(expr hcl.Expression, ctx *hcl.EvalContext, val interface{}) 
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
 			Summary:  "Unsuitable value",
-			Detail:   fmt.Sprintf("Unsuitable duration value: nil"),
+			Detail:   "Unsuitable duration value: nil",
 			Subject:  expr.StartRange().Ptr(),
 			Context:  expr.Range().Ptr(),
 		})


### PR DESCRIPTION
Nomad panics when parsing a job specification which contains a kill_timeout that is null.
This is normally caught with a validation error, but if the null is provided via a ternary expression false ? "5s" : null Nomad panics instead.

It fixes [25292](https://github.com/hashicorp/nomad/issues/25292)

I couldn't find any other places where not checking the nil value could lead to a panic.

### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
