### PR TITLE
upgrade testing: commit missing volume specification

### DIFF
--- a/enos/modules/run_workloads/scripts/nfs-volume.hcl
+++ b/enos/modules/run_workloads/scripts/nfs-volume.hcl
@@ -1,0 +1,28 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+type      = "csi"
+id        = "nfsTestVolume"
+name      = "nfsTestVolume"
+plugin_id = "rocketduck-nfs"
+
+capability {
+  access_mode     = "multi-node-multi-writer"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "multi-node-single-writer"
+  attachment_mode = "file-system"
+}
+
+capability {
+  access_mode     = "multi-node-reader-only"
+  attachment_mode = "file-system"
+}
+
+parameters {
+  uid  = "1000"
+  gid  = "1000"
+  mode = "770"
+}

--- a/enos/modules/run_workloads/scripts/wait_for_nfs_volume.sh
+++ b/enos/modules/run_workloads/scripts/wait_for_nfs_volume.sh
@@ -30,12 +30,13 @@ checkPlugin() {
         last_error="expected plugin to have at least 1 healthy nodes, found none"
         return 1
     fi
+    last_error=
     return 0
 }
 
 createVolume() {
     dir=$(dirname "${BASH_SOURCE[0]}")
-    nomad volume create "${dir}/volume.hcl" || {
+    nomad volume create "${dir}/nfs-volume.hcl" || {
         echo "Could not register volume"
         exit 1
     }


### PR DESCRIPTION
In #25285 we converted the CSI workload for upgrade testing to use a self-hosted NFS. But the volume spec name got changed to `volume.hcl` in the process, which is in our `.gitignore` file for the repo. We missed this during testing because the file existed locally, but it fails in nightly runs.

Ref: https://github.com/hashicorp/nomad/pull/25285
Ref: https://github.com/hashicorp/nomad-e2e/actions/runs/13703979647/job/38324786351