### PR TITLE
upgrade testing: add missing dependency during client upgrades

### DIFF
--- a/enos/modules/upgrade_client/main.tf
+++ b/enos/modules/upgrade_client/main.tf
@@ -51,7 +51,7 @@ resource "enos_local_exec" "set_metadata" {
   scripts = [abspath("${path.module}/scripts/set_metadata.sh")]
 }
 
-module upgrade_client {
+module "upgrade_client" {
   depends_on = [enos_local_exec.set_metadata]
 
   source = "../upgrade_instance"
@@ -66,6 +66,7 @@ module upgrade_client {
 }
 
 resource "enos_local_exec" "wait_for_nomad_api_post_update" {
+  depends_on  = [module.upgrade_client]
   environment = local.nomad_env
 
   scripts = [abspath("${path.module}/scripts/wait_for_nomad_api.sh")]


### PR DESCRIPTION
The check to read back node metadata depends on a resource that waits for the Nomad API, but that resource doesn't wait for the metadata to be written in the first place (and the client subsequently upgraded). Add this dependency so that we're reading back the node metadata as the last step.

Ref: https://github.com/hashicorp/nomad-e2e/actions/runs/13690355150/job/38282457406