### PR TITLE
template: Set any Consul token generated by workload identity.

### DIFF
--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -829,6 +829,11 @@ func newRunnerConfig(config *TaskTemplateManagerConfig,
 	if config.ConsulConfig != nil {
 		conf.Consul.Address = &config.ConsulConfig.Addr
 
+		// Populate the Consul configuration using any potential token that has
+		// been generated via workload identity. In the case no token has been
+		// generated, the empty string is safe to blindly add.
+		conf.Consul.Token = &config.ConsulToken
+
 		// Get the Consul namespace from agent config. This is the lower level
 		// of precedence (beyond default).
 		if config.ConsulConfig.Namespace != "" {

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -2525,6 +2525,65 @@ func TestTaskTemplateManager_Template_Wait_Set(t *testing.T) {
 	}
 }
 
+func Test_newRunnerConfig_consul(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name                 string
+		inputConfig          *TaskTemplateManagerConfig
+		expectedOutputConfig *ctconf.ConsulConfig
+	}{
+		{
+			name: "consul WI token",
+			inputConfig: &TaskTemplateManagerConfig{
+				ConsulConfig: sconfig.DefaultConsulConfig(),
+				ConsulToken:  "token",
+				ClientConfig: config.DefaultConfig(),
+			},
+			expectedOutputConfig: &ctconf.ConsulConfig{
+				Address:   pointer.Of("127.0.0.1:8500"),
+				Namespace: pointer.Of(""),
+				Auth:      ctconf.DefaultAuthConfig(),
+				Retry:     ctconf.DefaultRetryConfig(),
+				SSL:       ctconf.DefaultSSLConfig(),
+				Token:     pointer.Of("token"),
+				TokenFile: pointer.Of(""),
+				Transport: ctconf.DefaultTransportConfig(),
+			},
+		},
+		{
+			name: "no consul WI token",
+			inputConfig: &TaskTemplateManagerConfig{
+				ConsulConfig: sconfig.DefaultConsulConfig(),
+				ClientConfig: config.DefaultConfig(),
+			},
+			expectedOutputConfig: &ctconf.ConsulConfig{
+				Address:   pointer.Of("127.0.0.1:8500"),
+				Namespace: pointer.Of(""),
+				Auth:      ctconf.DefaultAuthConfig(),
+				Retry:     ctconf.DefaultRetryConfig(),
+				SSL:       ctconf.DefaultSSLConfig(),
+				Token:     pointer.Of(""),
+				TokenFile: pointer.Of(""),
+				Transport: ctconf.DefaultTransportConfig(),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// Finalize the expected configuration, so we don't have to set up
+			// all the pointers.
+			tc.expectedOutputConfig.Finalize()
+
+			actualOutputConfig, err := newRunnerConfig(tc.inputConfig, nil)
+			must.NoError(t, err)
+			must.Eq(t, tc.expectedOutputConfig, actualOutputConfig.Consul)
+		})
+	}
+}
+
 // TestTaskTemplateManager_Template_ErrMissingKey_Set asserts that all template level
 // configuration is accurately mapped from the template to the TaskTemplateManager's
 // template config.


### PR DESCRIPTION
### Description
In https://github.com/hashicorp/nomad/pull/25217 we removed legacy Consul token based task authentication. Unfortunately this change removed all the logic to configure consul-template with a token which meant Consul based templates would always get "ACL not found" errors. This change adds the correct configuration setup entry back.

Not released and caught by testing.
No backport.

### Links
https://hashicorp.atlassian.net/browse/NET-12253
https://hashicorp.atlassian.net/browse/NET-10260

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
