### PR TITLE
cli: Add node_prefix read policy to Consul setup task policy.

### DIFF
--- a/.changelog/25310.txt
+++ b/.changelog/25310.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Add node_prefix read when setting up the task workload identity Consul policy
+```

--- a/command/asset/consul-wi-default-policy.hcl
+++ b/command/asset/consul-wi-default-policy.hcl
@@ -1,3 +1,7 @@
+node_prefix "" {
+  policy = "read"
+}
+
 service_prefix "" {
   policy = "read"
 }


### PR DESCRIPTION
When Nomad registers a service within Consul it is regarded as a node service. In order for Nomad workloads to read these services, it must have an ACL policy which includes node_prefix read. If it does not, the service is filtered out from the result.

This change adds the required permission to the Consul setup command.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
