### PR TITLE
auth: oidc request lru cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/golang-lru/v2 v2.0.1
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/hcl v1.0.1-vault-3
 	github.com/hashicorp/hcl/v2 v2.20.2-0.20240517235513-55d9c02d147d
 	github.com/hashicorp/hil v0.0.0-20210521165536-27a72121fd40

--- a/go.sum
+++ b/go.sum
@@ -1269,8 +1269,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/golang-lru v1.0.2 h1:dV3g9Z/unq5DpblPpw+Oqcv4dU/1omnb4Ok8iPY6p1c=
 github.com/hashicorp/golang-lru v1.0.2/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
-github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
-github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.1-0.20201016140508-a07e7d50bbee h1:8B4HqvMUtYSjsGkYjiQGStc9pXffY2J+Z2SPQAj+wMY=
 github.com/hashicorp/hcl v1.0.1-0.20201016140508-a07e7d50bbee/go.mod h1:gwlu9+/P9MmKtYrMsHeFRZPXj2CTPm11TDnMeaRHS7g=
 github.com/hashicorp/hcl/v2 v2.20.2-0.20240517235513-55d9c02d147d h1:7abftkc86B+tlA/0cDy5f6C4LgWfFOCpsGg3RJZsfbw=

--- a/lib/auth/oidc/request.go
+++ b/lib/auth/oidc/request.go
@@ -4,12 +4,11 @@
 package oidc
 
 import (
-	"context"
 	"errors"
-	"sync"
 	"time"
 
 	"github.com/hashicorp/cap/oidc"
+	"github.com/hashicorp/golang-lru/v2/expirable"
 )
 
 var (
@@ -22,91 +21,47 @@ var (
 // to prevent a DOS from eating up server memory.
 const MaxRequests = 10000
 
-// expiringRequest ensures that OIDC requests that are only partially fulfilled
-// do not get stuck in memory forever.
-type expiringRequest struct {
-	// req is what we actually care about
-	req *oidc.Req
-
-	// cancel finishes the context so the cleanup goroutine can be cleaned up
-	cancel context.CancelFunc
-
-	// loadAndDeleted is set to true when LoadAndDelete deletes the request,
-	// so if by some terrible coincidence or mishandling, someone tries to
-	// Store() a request with the same nonce during a very narrow but
-	// not-impossible timeframe between LoadAndDelete and the delete()
-	// that follows the context being canceled.
-	loadAndDeleted bool
-}
-
 // NewRequestCache creates a cache for OIDC requests.
-func NewRequestCache() *RequestCache {
+// The JWT expiration time in the cap library is 5 minutes,
+// so timeout should be around that long.
+func NewRequestCache(timeout time.Duration) *RequestCache {
 	return &RequestCache{
-		m: make(map[string]*expiringRequest),
-		// the JWT expiration time in cap library is 5 minutes,
-		// so auto-delete from our request cache after 6.
-		timeout: 6 * time.Minute,
+		c: expirable.NewLRU[string, *oidc.Req](MaxRequests, nil, timeout),
 	}
 }
 
 type RequestCache struct {
-	l       sync.Mutex
-	m       map[string]*expiringRequest
-	timeout time.Duration
+	c *expirable.LRU[string, *oidc.Req]
 }
 
 // Store saves the request, to be Loaded later with its Nonce.
 // If LoadAndDelete is not called, the stale request will be auto-deleted.
-func (rc *RequestCache) Store(ctx context.Context, req *oidc.Req) error {
-	rc.l.Lock()
-	defer rc.l.Unlock()
+func (rc *RequestCache) Store(req *oidc.Req) error {
+	if rc.c.Len() >= MaxRequests {
+		return ErrTooManyRequests
+	}
 
-	if _, ok := rc.m[req.Nonce()]; ok {
+	if _, ok := rc.c.Get(req.Nonce()); ok {
 		// we already had a request for this nonce (should never happen)
 		return ErrNonceReuse
 	}
 
-	if len(rc.m) > MaxRequests {
-		return ErrTooManyRequests
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, rc.timeout)
-	rc.m[req.Nonce()] = &expiringRequest{
-		req:    req,
-		cancel: cancel,
-	}
-
-	// auto-delete after timeout or context canceled
-	go func() {
-		<-ctx.Done()
-		rc.l.Lock()
-		defer rc.l.Unlock()
-		// only delete if it was not already LoadAndDelete()d
-		if deleteMe, ok := rc.m[req.Nonce()]; ok && !deleteMe.loadAndDeleted {
-			delete(rc.m, req.Nonce())
-		}
-	}()
+	rc.c.Add(req.Nonce(), req)
 
 	return nil
 }
 
 func (rc *RequestCache) Load(nonce string) *oidc.Req {
-	rc.l.Lock()
-	defer rc.l.Unlock()
-	if er, ok := rc.m[nonce]; ok {
-		return er.req
+	if req, ok := rc.c.Get(nonce); ok {
+		return req
 	}
 	return nil
 }
 
 func (rc *RequestCache) LoadAndDelete(nonce string) *oidc.Req {
-	rc.l.Lock()
-	defer rc.l.Unlock()
-	if er, ok := rc.m[nonce]; ok {
-		delete(rc.m, nonce)
-		er.loadAndDeleted = true
-		er.cancel()
-		return er.req
+	if req, ok := rc.c.Get(nonce); ok {
+		rc.c.Remove(nonce)
+		return req
 	}
 	return nil
 }

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -2625,7 +2625,7 @@ func (a *ACL) OIDCAuthURL(args *structs.ACLOIDCAuthURLRequest, reply *structs.AC
 		if err != nil {
 			return err
 		}
-		if err = a.oidcRequestCache.Store(a.srv.shutdownCtx, oidcReq); err != nil {
+		if err = a.oidcRequestCache.Store(oidcReq); err != nil {
 			return fmt.Errorf("error storing OIDC request: %w", err)
 		}
 	}

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -5,7 +5,6 @@ package nomad
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net/url"
@@ -4218,9 +4217,7 @@ func cacheOIDCRequest(t *testing.T, cache *oidc.RequestCache, req structs.ACLOID
 		opts...,
 	)
 	must.NoError(t, err)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	t.Cleanup(cancel)
 	// make sure the cache is clean first
 	cache.LoadAndDelete(req.ClientNonce)
-	must.NoError(t, cache.Store(ctx, oidcReq))
+	must.NoError(t, cache.Store(oidcReq))
 }

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -440,7 +440,8 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigFunc
 	// ACL.OIDCAuthURL and ACL.OIDCCompleteAuth.
 	// It needs no special handling to handle agent shutdowns (its Store method
 	// handles this lifecycle).
-	s.oidcRequestCache = oidc.NewRequestCache()
+	// 6 minutes is 1 minute longer than the JWT expiration time in the cap lib.
+	s.oidcRequestCache = oidc.NewRequestCache(6 * time.Minute)
 
 	// Initialize the RPC layer
 	if err := s.setupRPC(tlsWrap); err != nil {


### PR DESCRIPTION
#25231 introduced a cache of OIDC requests to retain some state (mainly PKCE verifier) in between auth-url and complete-auth requests on the server.

This follows up on some useful comments that folks had about the cache:

* order-of-operations concerns, potential attack vectors, and mentions LRU cache:
   https://github.com/hashicorp/nomad/pull/25231#discussion_r1985550068
* limitations of my usage of `sync.Map`:
   https://github.com/hashicorp/nomad/pull/25231#discussion_r1985740444

Here we replace just about the whole thing (you may as well read the whole `requests.go` file instead of a diff) and instead wrap an auto-expiring, thread-safe LRU: https://github.com/hashicorp/golang-lru

I do still think the wrapper has some utility, so I kept it instead of using the LRU directly in the `*ACL` RPC.

There's a bit of meandering trial-and-error present in the 3 commits here, in case you're curious to see that. I will squash on merge.