### PR TITLE
test: fix go 1.24 test complaints

### DIFF
--- a/client/allocrunner/checks_hook_test.go
+++ b/client/allocrunner/checks_hook_test.go
@@ -206,7 +206,7 @@ func TestCheckHook_Checks_ResultsSet(t *testing.T) {
 				return true, nil
 			},
 			func(err error) {
-				t.Fatalf(err.Error())
+				t.Fatal(err)
 			},
 		)
 
@@ -271,7 +271,7 @@ func TestCheckHook_Checks_UpdateSet(t *testing.T) {
 			return true, nil
 		},
 		func(err error) {
-			t.Fatalf(err.Error())
+			t.Fatal(err)
 		},
 	)
 
@@ -308,7 +308,7 @@ func TestCheckHook_Checks_UpdateSet(t *testing.T) {
 			return true, nil
 		},
 		func(err error) {
-			t.Fatalf(err.Error())
+			t.Fatal(err)
 		},
 	)
 

--- a/client/allocrunner/taskrunner/task_runner_test.go
+++ b/client/allocrunner/taskrunner/task_runner_test.go
@@ -2047,10 +2047,10 @@ func TestTaskRunner_DriverNetwork(t *testing.T) {
 	}, func(err error) {
 		services, _ := consulAgent.ServicesWithFilterOpts("", nil)
 		for _, s := range services {
-			t.Logf(pretty.Sprint("Service: ", s))
+			t.Log(pretty.Sprint("Service: ", s))
 		}
 		for _, c := range consulAgent.CheckRegs() {
-			t.Logf(pretty.Sprint("Check:   ", c))
+			t.Log(pretty.Sprint("Check:   ", c))
 		}
 		require.NoError(t, err)
 	})

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -352,7 +352,7 @@ func TestClient_MixedTLS(t *testing.T) {
 			return true, nil
 		},
 		func(err error) {
-			t.Fatalf(err.Error())
+			t.Fatal(err)
 		},
 	)
 }
@@ -414,7 +414,7 @@ func TestClient_BadTLS(t *testing.T) {
 			return true, nil
 		},
 		func(err error) {
-			t.Fatalf(err.Error())
+			t.Fatal(err)
 		},
 	)
 }
@@ -1271,7 +1271,7 @@ func TestClient_ReloadTLS_UpgradePlaintextToTLS(t *testing.T) {
 			return true, nil
 		},
 			func(err error) {
-				t.Fatalf(err.Error())
+				t.Fatal(err)
 			},
 		)
 	}
@@ -1304,7 +1304,7 @@ func TestClient_ReloadTLS_UpgradePlaintextToTLS(t *testing.T) {
 			return true, nil
 		},
 			func(err error) {
-				t.Fatalf(err.Error())
+				t.Fatal(err)
 			},
 		)
 	}
@@ -1357,7 +1357,7 @@ func TestClient_ReloadTLS_DowngradeTLSToPlaintext(t *testing.T) {
 			}
 			return true, nil
 		}, func(err error) {
-			t.Fatalf(err.Error())
+			t.Fatal(err)
 		},
 		)
 	}
@@ -1382,7 +1382,7 @@ func TestClient_ReloadTLS_DowngradeTLSToPlaintext(t *testing.T) {
 			}
 			return true, nil
 		}, func(err error) {
-			t.Fatalf(err.Error())
+			t.Fatal(err)
 		},
 		)
 	}

--- a/client/consul/consul_test.go
+++ b/client/consul/consul_test.go
@@ -54,12 +54,12 @@ func newMockConsulServer() *mockConsulServer {
 				SecretID: secretID,
 			}
 			buf, _ := json.Marshal(token)
-			fmt.Fprintf(w, string(buf))
+			fmt.Fprint(w, string(buf))
 			return
 		}
 
 		w.WriteHeader(srv.errorCodeOnTokenSelf)
-		fmt.Fprintf(w, "{}")
+		fmt.Fprint(w, "{}")
 	})
 
 	srv.httpSrv = httptest.NewServer(mux)

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -6,6 +6,7 @@ package agent
 import (
 	"archive/tar"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -759,7 +760,7 @@ func TestHTTP_AllocSnapshot_Atomic(t *testing.T) {
 				return false, err
 			}
 
-			return serverAlloc.ClientStatus == structs.AllocClientStatusRunning, fmt.Errorf(serverAlloc.ClientStatus)
+			return serverAlloc.ClientStatus == structs.AllocClientStatusRunning, errors.New(serverAlloc.ClientStatus)
 		}, func(err error) {
 			t.Fatalf("client not running alloc: %v", err)
 		})

--- a/command/agent/retry_join_test.go
+++ b/command/agent/retry_join_test.go
@@ -92,7 +92,7 @@ func TestRetryJoin_Integration(t *testing.T) {
 		}
 		return true, nil
 	}, func(err error) {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	})
 }
 

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -411,9 +411,9 @@ func TestJobGetter_HTTPServer(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expectedApiJob, aj) {
 		for _, d := range pretty.Diff(expectedApiJob, aj) {
-			t.Logf(d)
+			t.Log(d)
 		}
-		t.Fatalf("Unexpected file")
+		t.Fatal("Unexpected file")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad
 
-go 1.23.6
+go 1.24
 
 // Pinned dependencies are noted in github.com/hashicorp/nomad/issues/11826.
 replace (

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -369,17 +369,17 @@ func TestLeader_PeriodicDispatcher_Restore_Adds(t *testing.T) {
 		leader.periodicDispatcher.l.Lock()
 		defer leader.periodicDispatcher.l.Unlock()
 		if _, tracked := leader.periodicDispatcher.tracked[tuplePeriodic]; !tracked {
-			return false, fmt.Errorf("periodic job not tracked")
+			return false, errors.New("periodic job not tracked")
 		}
 		if _, tracked := leader.periodicDispatcher.tracked[tupleNonPeriodic]; tracked {
-			return false, fmt.Errorf("non periodic job tracked")
+			return false, errors.New("non periodic job tracked")
 		}
 		if _, tracked := leader.periodicDispatcher.tracked[tupleParameterized]; tracked {
-			return false, fmt.Errorf("parameterized periodic job tracked")
+			return false, errors.New("parameterized periodic job tracked")
 		}
 		return true, nil
 	}, func(err error) {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	})
 }
 


### PR DESCRIPTION
I went to use a go 1.24 feature and found that my IDE didn't know what I was talking about, until I changed `go.mod` to `go 1.24` to align with #25249. That worked, but then running `go test` threw various complaints like

```
 Error: nomad/leader_test.go:382:12: non-constant format string in call to (*testing.common).Fatalf
```

I made a little test workflow over here to track them down: https://github.com/hashicorp/nomad/actions/runs/13773711997

Fortunately the only complaints are these formatting nitpicks.