### PR TITLE
upgrade testing: allow configurable artifactory repo

### DIFF
--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -48,6 +48,7 @@ scenario "upgrade" {
     variables {
       artifactory_username   = var.artifactory_username
       artifactory_token      = var.artifactory_token
+      artifactory_repo       = var.artifactory_repo_start
       arch                   = local.arch
       edition                = matrix.edition
       product_version        = var.product_version
@@ -242,6 +243,7 @@ scenario "upgrade" {
     variables {
       artifactory_username = var.artifactory_username
       artifactory_token    = var.artifactory_token
+      artifactory_repo     = var.artifactory_repo_upgrade
       arch                 = local.arch
       edition              = matrix.edition
       product_version      = var.upgrade_version

--- a/enos/enos-vars.hcl
+++ b/enos/enos-vars.hcl
@@ -27,10 +27,26 @@ variable "product_version" {
   default     = null
 }
 
+variable "artifactory_repo_start" {
+  description = "The Artifactory repository we'll download the starting binary from"
+  type        = string
+
+  # note: this default only works for released binaries
+  default = "hashicorp-crt-staging-local*"
+}
+
 variable "upgrade_version" {
   description = "The version of Nomad we want to upgrade the cluster to"
   type        = string
   default     = null
+}
+
+variable "artifactory_repo_upgrade" {
+  description = "The Artifactory repository we'll download the upgraded binary from"
+  type        = string
+
+  # note: this default only works for released binaries
+  default = "hashicorp-crt-staging-local*"
 }
 
 variable "download_binary_path" {


### PR DESCRIPTION
Prerelease builds are in a different Artifactory repository than release builds. Make this a variable option so we can test prerelease builds in the nightly/weekly runs.

Ref: https://github.com/hashicorp/nomad-e2e/pull/161
Ref: https://hashicorp.atlassian.net/browse/NET-12274