### PR TITLE
oidc: more tests for client assertions

### DIFF
--- a/api/acl.go
+++ b/api/acl.go
@@ -1023,14 +1023,14 @@ const (
 // PemCert, PemCertFile may contain an x509 certificate created with
 // the Key, used to derive the KeyID. Alternatively, KeyID may be set manually.
 //
-// PemKeyFile and PemCertFile, if set, must be present on disk on any Nomad
-// servers that may become cluster leaders.
+// PemKeyFile and PemCertFile, if set, must be an absolute path to a file
+// present on disk on any Nomad servers that may become cluster leaders.
 type OIDCClientAssertionKey struct {
 	// PemKey is the private key, in pem format. It is used to sign the JWT.
 	// Mutually exclusive with PemKeyFile.
 	PemKey string
-	// PemKeyFile is the path to a private key on server disk, in pem format.
-	// It is used to sign the JWT.
+	// PemKeyFile is an absolute path to a private key on Nomad servers' disk,
+	// in pem format. It is used to sign the JWT.
 	// Mutually exclusive with PemKey.
 	PemKeyFile string
 
@@ -1057,13 +1057,14 @@ type OIDCClientAssertionKey struct {
 	// Mutually exclusive with PemCert and PemCertFile.
 	// Allowed KeyIDHeader values: "kid" (the default)
 	KeyID string
-	// PemCert is a certificate, signed by the private key or a CA,
-	// in pem format. It is used to derive an x5t-style KeyID.
+	// PemCert is an x509 certificate, signed by the private key or a CA,
+	// in pem format. It is used to derive an x5t#S256 (or x5t) KeyID.
 	// Mutually exclusive with PemCertFile and KeyID.
 	// Allowed KeyIDHeader values: "x5t", "x5t#S256" (default "x5t#S256")
 	PemCert string
-	// PemCertFile is a certificate, signed by the private key or a CA,
-	// on server disk, in pem format. It is used to derive an x5t-style KeyID.
+	// PemCertFile is an absolute path to an x509 certificate on Nomad servers'
+	// disk, signed by the private key or a CA, in pem format.
+	// It is used to derive an x5t#S256 (or x5t) KeyID.
 	// Mutually exclusive with PemCert and KeyID.
 	// Allowed KeyIDHeader values: "x5t", "x5t#S256" (default "x5t#S256")
 	PemCertFile string

--- a/lib/auth/oidc/client_assertion.go
+++ b/lib/auth/oidc/client_assertion.go
@@ -153,7 +153,7 @@ func getCassCert(k *structs.OIDCClientAssertionKey) (*x509.Certificate, error) {
 	}
 	now := time.Now()
 	if now.Before(cert.NotBefore) || now.After(cert.NotAfter) {
-		return nil, errors.New("cert expired or not yet valid")
+		return nil, errors.New("certificate has expired or is not yet valid")
 	}
 	return cert, nil
 }

--- a/lib/auth/oidc/client_assertion_test.go
+++ b/lib/auth/oidc/client_assertion_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package oidc
 
 import (

--- a/lib/auth/oidc/client_assertion_test.go
+++ b/lib/auth/oidc/client_assertion_test.go
@@ -454,8 +454,7 @@ func TestBuildClientAssertionJWT_NomadKey(t *testing.T) {
 func TestBuildClientAssertionJWT_PrivateKeyExpiredCert(t *testing.T) {
 	nomadKey := generateTestPrivateKey(t)
 	nomadKID := generateTestKeyID(nomadKey)
-	nomadCert := generateExpiredTestCertificate(t, nomadKey)
-	nomadCertPath := writeTestCertToFile(t, nomadCert)
+	nomadExpiredCert := generateExpiredTestCertificate(t, nomadKey)
 
 	tests := []struct {
 		name        string
@@ -472,8 +471,8 @@ func TestBuildClientAssertionJWT_PrivateKeyExpiredCert(t *testing.T) {
 					Audience:     []string{"test-audience"},
 					KeyAlgorithm: "RS256",
 					PrivateKey: &structs.OIDCClientAssertionKey{
-						PemKeyBase64: encodeTestPrivateKeyBase64(t, nomadKey),
-						PemCertFile:  nomadCertPath,
+						PemKeyBase64:  encodeTestPrivateKeyBase64(t, nomadKey),
+						PemCertBase64: encodeTestCertBase64(t, nomadExpiredCert),
 					},
 				},
 			},

--- a/lib/auth/oidc/client_assertion_test.go
+++ b/lib/auth/oidc/client_assertion_test.go
@@ -1,0 +1,331 @@
+package oidc
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
+
+	tests := []struct {
+		name        string
+		config      *structs.ACLAuthMethodConfig
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name: "valid client secret",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID:     "test-client-id",
+				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
+				OIDCEnablePKCE:   true,
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourceClientSecret,
+					KeyAlgorithm: "HS256",
+					Audience:     []string{"test-audience"},
+					ExtraHeaders: map[string]string{
+						"test-header": "test-value",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid client secret no PKCE",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID:     "test-client-id",
+				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
+				OIDCEnablePKCE:   false, // Should we default this to true everywhere?
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourceClientSecret,
+					KeyAlgorithm: "HS256",
+					Audience:     []string{"test-audience"},
+					ExtraHeaders: map[string]string{
+						"test-header": "test-value",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil config",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID:        "test-client-id",
+				OIDCClientSecret:    "test-client-secret",
+				OIDCClientAssertion: nil,
+			},
+			wantErr:     true,
+			expectedErr: `no auth method config or client assertion`,
+		},
+		{
+			name: "invalid client secret length",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID:     "test-client-id",
+				OIDCClientSecret: "test-client-secret",
+				OIDCEnablePKCE:   true,
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourceClientSecret,
+					KeyAlgorithm: "HS256",
+					Audience:     []string{"test-audience"},
+					ExtraHeaders: map[string]string{
+						"test-header": "test-value",
+					},
+				},
+			},
+			wantErr:     true,
+			expectedErr: `invalid secret length for algorithm: "HS256" must be at least 32 bytes long`,
+		},
+		{
+			name: "invalid client secret kid in extra header",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID:     "test-client-id",
+				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
+				OIDCEnablePKCE:   true,
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourceClientSecret,
+					KeyAlgorithm: "HS256",
+					Audience:     []string{"test-audience"},
+					ExtraHeaders: map[string]string{
+						"kid": "test-kid",
+					},
+				},
+			},
+			wantErr:     true,
+			expectedErr: `WithHeaders: "kid" not allowed in WithHeaders; use WithKeyID instead`,
+		},
+		{
+			name: "invalid key algorithm none",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID:     "test-client-id",
+				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
+				OIDCEnablePKCE:   true,
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourceClientSecret,
+					KeyAlgorithm: "none",
+					Audience:     []string{"test-audience"},
+					ExtraHeaders: map[string]string{
+						"test-header": "test-value",
+					},
+				},
+			},
+			wantErr:     true,
+			expectedErr: `unsupported algorithm "none" for client secret`,
+		},
+		{
+			name: "invalid key algorithm None",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID:     "test-client-id",
+				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
+				OIDCEnablePKCE:   true,
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourceClientSecret,
+					KeyAlgorithm: "None",
+					Audience:     []string{"test-audience"},
+					ExtraHeaders: map[string]string{
+						"test-header": "test-value",
+					},
+				},
+			},
+			wantErr:     true,
+			expectedErr: `unsupported algorithm "None" for client secret`,
+		},
+		// expected non-nil error; got nil
+		{
+			name: "invalid missing issuer",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID:     "test-client-id",
+				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
+				OIDCEnablePKCE:   true,
+				BoundIssuer:      nil,
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourceClientSecret,
+					KeyAlgorithm: "HS256",
+					ExtraHeaders: map[string]string{
+						"test-header": "test-value",
+					},
+				},
+			},
+			wantErr:     true,
+			expectedErr: "missing issuer",
+		},
+		// expected non-nil error; got nil
+		{
+			name: "invalid missing audience with nil discovery url",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID:     "test-client-id",
+				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
+				OIDCEnablePKCE:   true,
+				OIDCDiscoveryURL: "",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourceClientSecret,
+					KeyAlgorithm: "HS256",
+					ExtraHeaders: map[string]string{
+						"test-header": "test-value",
+					},
+				},
+			},
+			wantErr:     true,
+			expectedErr: "missing audience with nil discovery URL",
+		},
+		// expected non-nil error; got nil
+		{
+			name: "invalid missing audience",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID:     "test-client-id",
+				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
+				OIDCEnablePKCE:   true,
+				OIDCDiscoveryURL: "https://test-discovery-url",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourceClientSecret,
+					KeyAlgorithm: "HS256",
+					ExtraHeaders: map[string]string{
+						"test-header": "test-value",
+					},
+				},
+			},
+			wantErr:     true,
+			expectedErr: "missing audience",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.config.Canonicalize() // inherits clientSecret from OIDCClientAssertion
+			jwt, err := BuildClientAssertionJWT(tt.config, nil, "")
+			if tt.wantErr {
+				must.Error(t, err)
+				must.StrContains(t, err.Error(), tt.expectedErr)
+			} else {
+				must.NoError(t, err)
+				must.NotNil(t, jwt)
+			}
+		})
+	}
+}
+
+func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
+	nomadKey := generateTestPrivateKey(t)
+	nomadKID := "test-kid"
+
+	tests := []struct {
+		name    string
+		config  *structs.ACLAuthMethodConfig
+		wantErr bool
+	}{
+		{
+			name: "nil config",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientAssertion: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "nomad key source",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID: "test-client-id",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourceNomad,
+					KeyAlgorithm: "RS256",
+					Audience:     []string{"test-audience"},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jwt, err := BuildClientAssertionJWT(tt.config, nomadKey, nomadKID)
+			if tt.wantErr {
+				must.Error(t, err)
+			} else {
+				must.NoError(t, err)
+				must.NotNil(t, jwt)
+			}
+		})
+	}
+}
+
+func TestBuildClientAssertionJWT_NomadKey(t *testing.T) {
+	nomadKey := generateTestPrivateKey(t)
+	nomadKID := "test-kid"
+
+	tests := []struct {
+		name    string
+		config  *structs.ACLAuthMethodConfig
+		wantErr bool
+	}{
+		{
+			name: "nil config",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientAssertion: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "private key source",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID: "test-client-id",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourcePrivateKey,
+					KeyAlgorithm: "RS256",
+					Audience:     []string{"test-audience"},
+					PrivateKey: &structs.OIDCClientAssertionKey{
+						PemKeyBase64: encodeTestPrivateKey(t, nomadKey),
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jwt, err := BuildClientAssertionJWT(tt.config, nomadKey, nomadKID)
+			if tt.wantErr {
+				must.Error(t, err)
+			} else {
+				must.NoError(t, err)
+				must.NotNil(t, jwt)
+			}
+		})
+	}
+}
+func generateTestPrivateKey(t *testing.T) *rsa.PrivateKey {
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	must.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "testkey.pem")
+
+	keyFile, err := os.Create(keyPath)
+	must.NoError(t, err)
+	defer keyFile.Close()
+
+	keyBytes := x509.MarshalPKCS1PrivateKey(key)
+	block := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: keyBytes,
+	}
+	err = pem.Encode(keyFile, block)
+	must.NoError(t, err)
+
+	return key
+}
+
+func encodeTestPrivateKey(t *testing.T, key *rsa.PrivateKey) string {
+	keyBytes := x509.MarshalPKCS1PrivateKey(key)
+	block := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: keyBytes,
+	}
+	return string(pem.EncodeToMemory(block))
+}

--- a/lib/auth/oidc/client_assertion_test.go
+++ b/lib/auth/oidc/client_assertion_test.go
@@ -367,7 +367,24 @@ func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 					},
 				},
 			},
-			wantErr:     false,
+			wantErr:     true,
+			expectedErr: "invalid path for private key file",
+		},
+		{
+			name: "invalid private key source with invalid kid ID",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID: "test-client-id",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourcePrivateKey,
+					Audience:     []string{"test-audience"},
+					KeyAlgorithm: "RS256",
+					PrivateKey: &structs.OIDCClientAssertionKey{
+						PemKeyBase64: encodeTestPrivateKeyBase64(t, nomadKey),
+						KeyID:        "invalid-kid",
+					},
+				},
+			},
+			wantErr:     true,
 			expectedErr: "invalid path for private key file",
 		},
 	}

--- a/lib/auth/oidc/client_assertion_test.go
+++ b/lib/auth/oidc/client_assertion_test.go
@@ -44,22 +44,6 @@ func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "valid client secret no PKCE",
-			config: &structs.ACLAuthMethodConfig{
-				OIDCClientID:     "test-client-id",
-				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
-				OIDCClientAssertion: &structs.OIDCClientAssertion{
-					KeySource:    structs.OIDCKeySourceClientSecret,
-					KeyAlgorithm: "HS256",
-					Audience:     []string{"test-audience"},
-					ExtraHeaders: map[string]string{
-						"test-header": "test-value",
-					},
-				},
-			},
-			wantErr: false,
-		},
-		{
 			name: "nil config",
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID:        "test-client-id",
@@ -385,7 +369,7 @@ func TestBuildClientAssertionJWT_PrivateKeyExpiredCert(t *testing.T) {
 		expectedErr string
 	}{
 		{
-			name: "invalid PemKeyBase64",
+			name: "invalid PemKey",
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID: "test-client-id",
 				OIDCClientAssertion: &structs.OIDCClientAssertion{
@@ -402,7 +386,7 @@ func TestBuildClientAssertionJWT_PrivateKeyExpiredCert(t *testing.T) {
 			expectedErr: "failed to parse private key",
 		},
 		{
-			name: "expired certificate PemCertBase64",
+			name: "expired certificate PemCert",
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID: "test-client-id",
 				OIDCClientAssertion: &structs.OIDCClientAssertion{

--- a/lib/auth/oidc/client_assertion_test.go
+++ b/lib/auth/oidc/client_assertion_test.go
@@ -3,9 +3,7 @@ package oidc
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/sha256"
 	"crypto/x509"
-	"encoding/base64"
 	"encoding/pem"
 	"math/big"
 	"os"
@@ -172,7 +170,7 @@ func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
 func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 	nomadKey := generateTestPrivateKey(t)
 	nomadKeyPath := writeTestPrivateKeyToFile(t, nomadKey)
-	nomadKID := generateTestKeyID(nomadKey)
+	nomadKID := "anything"
 	nomadCert := generateTestCertificate(t, nomadKey)
 	nomadCertPath := writeTestCertToFile(t, nomadCert)
 
@@ -325,7 +323,7 @@ func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 
 func TestBuildClientAssertionJWT_NomadKey(t *testing.T) {
 	nomadKey := generateTestPrivateKey(t)
-	nomadKID := generateTestKeyID(nomadKey)
+	nomadKID := "anything"
 
 	tests := []struct {
 		name    string
@@ -370,7 +368,7 @@ func TestBuildClientAssertionJWT_NomadKey(t *testing.T) {
 func TestBuildClientAssertionJWT_PrivateKeyExpiredCert(t *testing.T) {
 	nomadKey := generateTestPrivateKey(t)
 	nomadInvalidKey := generateInvalidTestPrivateKey(t)
-	nomadKID := generateTestKeyID(nomadKey)
+	nomadKID := "anything"
 	nomadCert := generateTestCertificate(t, nomadKey)
 	nomadExpiredCert := generateExpiredTestCertificate(t, nomadKey)
 
@@ -431,31 +429,9 @@ func TestBuildClientAssertionJWT_PrivateKeyExpiredCert(t *testing.T) {
 	}
 }
 
-func generateTestKeyID(key *rsa.PrivateKey) string {
-	keyBytes := x509.MarshalPKCS1PublicKey(&key.PublicKey)
-	thumbprint := sha256.Sum256(keyBytes)
-	return base64.URLEncoding.EncodeToString(thumbprint[:])
-}
-
 func generateTestPrivateKey(t *testing.T) *rsa.PrivateKey {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	must.NoError(t, err)
-
-	tmpDir := t.TempDir()
-	keyPath := filepath.Join(tmpDir, "testkey.pem")
-
-	keyFile, err := os.Create(keyPath)
-	must.NoError(t, err)
-	defer keyFile.Close()
-
-	keyBytes := x509.MarshalPKCS1PrivateKey(key)
-	block := &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: keyBytes,
-	}
-	err = pem.Encode(keyFile, block)
-	must.NoError(t, err)
-
 	return key
 }
 

--- a/lib/auth/oidc/client_assertion_test.go
+++ b/lib/auth/oidc/client_assertion_test.go
@@ -3,8 +3,11 @@ package oidc
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
@@ -232,7 +235,160 @@ func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
 
 func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 	nomadKey := generateTestPrivateKey(t)
-	nomadKID := "test-kid"
+	nomadKeyPath := writeTestPrivateKeyToFile(t, nomadKey)
+	nomadKID := generateTestKeyID(nomadKey)
+	nomadCert := generateTestCertificate(t, nomadKey)
+	nomadCertPath := writeTestCertToFile(t, nomadCert)
+
+	tests := []struct {
+		name        string
+		config      *structs.ACLAuthMethodConfig
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name: "nil config",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientAssertion: nil,
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid private key source with pem key base64",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID: "test-client-id",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourcePrivateKey,
+					Audience:     []string{"test-audience"},
+					KeyAlgorithm: "RS256",
+					PrivateKey: &structs.OIDCClientAssertionKey{
+						PemKeyBase64: encodeTestPrivateKeyBase64(t, nomadKey),
+						KeyID:        nomadKID,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid private key source with pem key base64 with pem cert base64",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID: "test-client-id",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourcePrivateKey,
+					Audience:     []string{"test-audience"},
+					KeyAlgorithm: "RS256",
+					PrivateKey: &structs.OIDCClientAssertionKey{
+						PemKeyBase64:  encodeTestPrivateKeyBase64(t, nomadKey),
+						PemCertBase64: encodeTestCertBase64(t, nomadCert),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid private key source with pem cert file",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID: "test-client-id",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourcePrivateKey,
+					Audience:     []string{"test-audience"},
+					KeyAlgorithm: "RS256",
+					PrivateKey: &structs.OIDCClientAssertionKey{
+						PemKeyBase64: encodeTestPrivateKeyBase64(t, nomadKey),
+						PemCertFile:  nomadCertPath,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid private key source with pem key file with Key ID",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID: "test-client-id",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourcePrivateKey,
+					Audience:     []string{"test-audience"},
+					KeyAlgorithm: "RS256",
+					PrivateKey: &structs.OIDCClientAssertionKey{
+						PemKeyFile: nomadKeyPath,
+						KeyID:      nomadKID,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		// invalid pem key file location
+		{
+			name: "invalid private key source with pem key file",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID: "test-client-id",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourcePrivateKey,
+					Audience:     []string{"test-audience"},
+					KeyAlgorithm: "RS256",
+					PrivateKey: &structs.OIDCClientAssertionKey{
+						PemKeyFile: nomadKeyPath + "/invalid",
+						KeyID:      nomadKID,
+					},
+				},
+			},
+			wantErr:     true,
+			expectedErr: "invalid path for private key file",
+		},
+		// path traversal in pem key file
+		{
+			name: "invalid private key source with pem key file path traversal",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID: "test-client-id",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourcePrivateKey,
+					Audience:     []string{"test-audience"},
+					KeyAlgorithm: "RS256",
+					PrivateKey: &structs.OIDCClientAssertionKey{
+						PemKeyFile: "../../../../../../../../../../../../etc/passwd",
+						KeyID:      nomadKID,
+					},
+				},
+			},
+			wantErr:     true,
+			expectedErr: "invalid path for private key file",
+		},
+		{
+			name: "invalid private key source with pem cert file path traversal",
+			config: &structs.ACLAuthMethodConfig{
+				OIDCClientID: "test-client-id",
+				OIDCClientAssertion: &structs.OIDCClientAssertion{
+					KeySource:    structs.OIDCKeySourcePrivateKey,
+					Audience:     []string{"test-audience"},
+					KeyAlgorithm: "RS256",
+					PrivateKey: &structs.OIDCClientAssertionKey{
+						PemKeyBase64: encodeTestPrivateKeyBase64(t, nomadKey),
+						PemCertFile:  "../../../../../../../../../../../../etc/passwd",
+					},
+				},
+			},
+			wantErr:     false,
+			expectedErr: "invalid path for private key file",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jwt, err := BuildClientAssertionJWT(tt.config, nomadKey, nomadKID)
+			if tt.wantErr {
+				must.Error(t, err)
+				must.StrContains(t, err.Error(), tt.expectedErr)
+			} else {
+				must.NoError(t, err)
+				must.NotNil(t, jwt)
+			}
+		})
+	}
+}
+
+func TestBuildClientAssertionJWT_NomadKey(t *testing.T) {
+	nomadKey := generateTestPrivateKey(t)
+	nomadKID := generateTestKeyID(nomadKey)
 
 	tests := []struct {
 		name    string
@@ -262,6 +418,8 @@ func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			tt.config.Canonicalize() // inherits clientSecret from OIDCClientAssertion
+			tt.config.Validate()     // validates clientSecret length
 			jwt, err := BuildClientAssertionJWT(tt.config, nomadKey, nomadKID)
 			if tt.wantErr {
 				must.Error(t, err)
@@ -273,51 +431,12 @@ func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 	}
 }
 
-func TestBuildClientAssertionJWT_NomadKey(t *testing.T) {
-	nomadKey := generateTestPrivateKey(t)
-	nomadKID := "test-kid"
-
-	tests := []struct {
-		name    string
-		config  *structs.ACLAuthMethodConfig
-		wantErr bool
-	}{
-		{
-			name: "nil config",
-			config: &structs.ACLAuthMethodConfig{
-				OIDCClientAssertion: nil,
-			},
-			wantErr: true,
-		},
-		{
-			name: "private key source",
-			config: &structs.ACLAuthMethodConfig{
-				OIDCClientID: "test-client-id",
-				OIDCClientAssertion: &structs.OIDCClientAssertion{
-					KeySource:    structs.OIDCKeySourcePrivateKey,
-					KeyAlgorithm: "RS256",
-					Audience:     []string{"test-audience"},
-					PrivateKey: &structs.OIDCClientAssertionKey{
-						PemKeyBase64: encodeTestPrivateKey(t, nomadKey),
-					},
-				},
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			jwt, err := BuildClientAssertionJWT(tt.config, nomadKey, nomadKID)
-			if tt.wantErr {
-				must.Error(t, err)
-			} else {
-				must.NoError(t, err)
-				must.NotNil(t, jwt)
-			}
-		})
-	}
+func generateTestKeyID(key *rsa.PrivateKey) string {
+	keyBytes := x509.MarshalPKCS1PublicKey(&key.PublicKey)
+	thumbprint := sha256.Sum256(keyBytes)
+	return base64.URLEncoding.EncodeToString(thumbprint[:])
 }
+
 func generateTestPrivateKey(t *testing.T) *rsa.PrivateKey {
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
 	must.NoError(t, err)
@@ -340,11 +459,69 @@ func generateTestPrivateKey(t *testing.T) *rsa.PrivateKey {
 	return key
 }
 
-func encodeTestPrivateKey(t *testing.T, key *rsa.PrivateKey) string {
+func writeTestPrivateKeyToFile(t *testing.T, key *rsa.PrivateKey) string {
+	tmpDir := t.TempDir()
+	keyPath := filepath.Join(tmpDir, "testkey.pem")
+
+	keyFile, err := os.Create(keyPath)
+	must.NoError(t, err)
+	defer keyFile.Close()
+
 	keyBytes := x509.MarshalPKCS1PrivateKey(key)
 	block := &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: keyBytes,
 	}
-	return string(pem.EncodeToMemory(block))
+	err = pem.Encode(keyFile, block)
+	must.NoError(t, err)
+
+	return keyPath
+}
+
+func encodeTestPrivateKeyBase64(t *testing.T, key *rsa.PrivateKey) string {
+	keyBytes := x509.MarshalPKCS1PrivateKey(key)
+	block := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: keyBytes,
+	}
+	return base64.StdEncoding.EncodeToString(pem.EncodeToMemory(block))
+}
+
+func generateTestCertificate(t *testing.T, key *rsa.PrivateKey) *x509.Certificate {
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	must.NoError(t, err)
+
+	cert, err := x509.ParseCertificate(certDER)
+	must.NoError(t, err)
+
+	return cert
+}
+
+func encodeTestCertBase64(t *testing.T, cert *x509.Certificate) string {
+	block := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	}
+	return base64.StdEncoding.EncodeToString(pem.EncodeToMemory(block))
+}
+
+func writeTestCertToFile(t *testing.T, cert *x509.Certificate) string {
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, "testcert.pem")
+
+	certFile, err := os.Create(certPath)
+	must.NoError(t, err)
+	defer certFile.Close()
+
+	block := &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: cert.Raw,
+	}
+	err = pem.Encode(certFile, block)
+	must.NoError(t, err)
+
+	return certPath
 }

--- a/lib/auth/oidc/client_assertion_test.go
+++ b/lib/auth/oidc/client_assertion_test.go
@@ -30,7 +30,6 @@ func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID:     "test-client-id",
 				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
-				OIDCEnablePKCE:   true,
 				OIDCClientAssertion: &structs.OIDCClientAssertion{
 					KeySource:    structs.OIDCKeySourceClientSecret,
 					KeyAlgorithm: "HS256",
@@ -47,7 +46,6 @@ func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID:     "test-client-id",
 				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
-				OIDCEnablePKCE:   false, // Should we default this to true everywhere?
 				OIDCClientAssertion: &structs.OIDCClientAssertion{
 					KeySource:    structs.OIDCKeySourceClientSecret,
 					KeyAlgorithm: "HS256",
@@ -74,7 +72,6 @@ func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID:     "test-client-id",
 				OIDCClientSecret: "test-client-secret",
-				OIDCEnablePKCE:   true,
 				OIDCClientAssertion: &structs.OIDCClientAssertion{
 					KeySource:    structs.OIDCKeySourceClientSecret,
 					KeyAlgorithm: "HS256",
@@ -92,7 +89,6 @@ func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID:     "test-client-id",
 				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
-				OIDCEnablePKCE:   true,
 				OIDCClientAssertion: &structs.OIDCClientAssertion{
 					KeySource:    structs.OIDCKeySourceClientSecret,
 					KeyAlgorithm: "HS256",
@@ -110,7 +106,6 @@ func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID:     "test-client-id",
 				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
-				OIDCEnablePKCE:   true,
 				OIDCClientAssertion: &structs.OIDCClientAssertion{
 					KeySource:    structs.OIDCKeySourceClientSecret,
 					KeyAlgorithm: "none",
@@ -128,7 +123,6 @@ func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID:     "test-client-id",
 				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
-				OIDCEnablePKCE:   true,
 				OIDCClientAssertion: &structs.OIDCClientAssertion{
 					KeySource:    structs.OIDCKeySourceClientSecret,
 					KeyAlgorithm: "None",
@@ -143,49 +137,10 @@ func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
 		},
 		// expected non-nil error; got nil
 		{
-			name: "invalid missing issuer",
-			config: &structs.ACLAuthMethodConfig{
-				OIDCClientID:     "test-client-id",
-				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
-				OIDCEnablePKCE:   true,
-				BoundIssuer:      nil,
-				OIDCClientAssertion: &structs.OIDCClientAssertion{
-					KeySource:    structs.OIDCKeySourceClientSecret,
-					KeyAlgorithm: "HS256",
-					ExtraHeaders: map[string]string{
-						"test-header": "test-value",
-					},
-				},
-			},
-			wantErr:     true,
-			expectedErr: "missing issuer",
-		},
-		// expected non-nil error; got nil
-		{
-			name: "invalid missing audience with empty discovery url",
-			config: &structs.ACLAuthMethodConfig{
-				OIDCClientID:     "test-client-id",
-				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
-				OIDCEnablePKCE:   true,
-				OIDCDiscoveryURL: "",
-				OIDCClientAssertion: &structs.OIDCClientAssertion{
-					KeySource:    structs.OIDCKeySourceClientSecret,
-					KeyAlgorithm: "HS256",
-					ExtraHeaders: map[string]string{
-						"test-header": "test-value",
-					},
-				},
-			},
-			wantErr:     true,
-			expectedErr: "missing audience with empty discovery URL",
-		},
-		// expected non-nil error; got nil
-		{
 			name: "invalid missing audience",
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID:     "test-client-id",
 				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
-				OIDCEnablePKCE:   true,
 				OIDCClientAssertion: &structs.OIDCClientAssertion{
 					KeySource:    structs.OIDCKeySourceClientSecret,
 					KeyAlgorithm: "HS256",
@@ -195,33 +150,13 @@ func TestBuildClientAssertionJWT_ClientSecret(t *testing.T) {
 				},
 			},
 			wantErr:     true,
-			expectedErr: "missing audience",
-		},
-		// expected non-nil error; got nil
-		{
-			name: "inexistent discovery URL",
-			config: &structs.ACLAuthMethodConfig{
-				OIDCClientID:     "test-client-id",
-				OIDCClientSecret: "1234567890abcdefghijklmnopqrstuvwxyz",
-				OIDCEnablePKCE:   true,
-				OIDCDiscoveryURL: "https://test-discovery-url",
-				OIDCClientAssertion: &structs.OIDCClientAssertion{
-					KeySource:    structs.OIDCKeySourceClientSecret,
-					KeyAlgorithm: "HS256",
-					ExtraHeaders: map[string]string{
-						"test-header": "test-value",
-					},
-				},
-			},
-			wantErr:     true,
-			expectedErr: "inexistent discovery URL",
+			expectedErr: "missing Audience",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.config.Canonicalize() // inherits clientSecret from OIDCClientAssertion
-			tt.config.Validate()     // validates clientSecret length
+			tt.config.Canonicalize() // inherits ClientSecret from OIDCClientAssertion
 			jwt, err := BuildClientAssertionJWT(tt.config, nil, "")
 			if tt.wantErr {
 				must.Error(t, err)
@@ -255,7 +190,7 @@ func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "valid private key source with pem key base64",
+			name: "valid private key source with pem key",
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID: "test-client-id",
 				OIDCClientAssertion: &structs.OIDCClientAssertion{
@@ -263,15 +198,15 @@ func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 					Audience:     []string{"test-audience"},
 					KeyAlgorithm: "RS256",
 					PrivateKey: &structs.OIDCClientAssertionKey{
-						PemKeyBase64: encodeTestPrivateKeyBase64(t, nomadKey),
-						KeyID:        nomadKID,
+						PemKey: encodeTestPrivateKey(nomadKey),
+						KeyID:  nomadKID,
 					},
 				},
 			},
 			wantErr: false,
 		},
 		{
-			name: "valid private key source with pem key base64 with pem cert base64",
+			name: "valid private key source with pem key with pem cert",
 			config: &structs.ACLAuthMethodConfig{
 				OIDCClientID: "test-client-id",
 				OIDCClientAssertion: &structs.OIDCClientAssertion{
@@ -279,8 +214,8 @@ func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 					Audience:     []string{"test-audience"},
 					KeyAlgorithm: "RS256",
 					PrivateKey: &structs.OIDCClientAssertionKey{
-						PemKeyBase64:  encodeTestPrivateKeyBase64(t, nomadKey),
-						PemCertBase64: encodeTestCertBase64(t, nomadCert),
+						PemKey:  encodeTestPrivateKey(nomadKey),
+						PemCert: encodeTestCert(nomadCert),
 					},
 				},
 			},
@@ -295,8 +230,8 @@ func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 					Audience:     []string{"test-audience"},
 					KeyAlgorithm: "RS256",
 					PrivateKey: &structs.OIDCClientAssertionKey{
-						PemKeyBase64: encodeTestPrivateKeyBase64(t, nomadKey),
-						PemCertFile:  nomadCertPath,
+						PemKey:      encodeTestPrivateKey(nomadKey),
+						PemCertFile: nomadCertPath,
 					},
 				},
 			},
@@ -334,7 +269,7 @@ func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 				},
 			},
 			wantErr:     true,
-			expectedErr: "invalid path for private key file",
+			expectedErr: "error reading PemKeyFile",
 		},
 		// path traversal in pem key file
 		{
@@ -346,13 +281,13 @@ func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 					Audience:     []string{"test-audience"},
 					KeyAlgorithm: "RS256",
 					PrivateKey: &structs.OIDCClientAssertionKey{
-						PemKeyFile: "../../../../../../../../../../../../etc/passwd",
+						PemKeyFile: "../../../../../../../../../../../../etc/passwd", // TODO: this gets read, but errors as "invalid key"
 						KeyID:      nomadKID,
 					},
 				},
 			},
 			wantErr:     true,
-			expectedErr: "invalid path for private key file",
+			expectedErr: "error parsing PemKeyFile: invalid key:",
 		},
 		{
 			name: "invalid private key source with pem cert file path traversal",
@@ -363,37 +298,19 @@ func TestBuildClientAssertionJWT_PrivateKey(t *testing.T) {
 					Audience:     []string{"test-audience"},
 					KeyAlgorithm: "RS256",
 					PrivateKey: &structs.OIDCClientAssertionKey{
-						PemKeyBase64: encodeTestPrivateKeyBase64(t, nomadKey),
-						PemCertFile:  "../../../../../../../../../../../../etc/passwd",
+						PemKey:      encodeTestPrivateKey(nomadKey),
+						PemCertFile: "../../../../../../../../../../../../etc/passwd", // TODO: this gets read, but "failed to decode"
 					},
 				},
 			},
 			wantErr:     true,
-			expectedErr: "invalid path for private key file",
-		},
-		{
-			name: "invalid private key source with invalid kid ID",
-			config: &structs.ACLAuthMethodConfig{
-				OIDCClientID: "test-client-id",
-				OIDCClientAssertion: &structs.OIDCClientAssertion{
-					KeySource:    structs.OIDCKeySourcePrivateKey,
-					Audience:     []string{"test-audience"},
-					KeyAlgorithm: "RS256",
-					PrivateKey: &structs.OIDCClientAssertionKey{
-						PemKeyBase64: encodeTestPrivateKeyBase64(t, nomadKey),
-						KeyID:        "invalid-kid",
-					},
-				},
-			},
-			wantErr:     true,
-			expectedErr: "invalid path for private key file",
+			expectedErr: "failed to decode PemCertFile PEM block",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.config.Canonicalize() // inherits clientSecret from OIDCClientAssertion
-			tt.config.Validate()     // validates clientSecret length
 			jwt, err := BuildClientAssertionJWT(tt.config, nomadKey, nomadKID)
 			if tt.wantErr {
 				must.Error(t, err)
@@ -439,7 +356,6 @@ func TestBuildClientAssertionJWT_NomadKey(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.config.Canonicalize() // inherits clientSecret from OIDCClientAssertion
-			tt.config.Validate()     // validates clientSecret length
 			jwt, err := BuildClientAssertionJWT(tt.config, nomadKey, nomadKID)
 			if tt.wantErr {
 				must.Error(t, err)
@@ -473,8 +389,8 @@ func TestBuildClientAssertionJWT_PrivateKeyExpiredCert(t *testing.T) {
 					Audience:     []string{"test-audience"},
 					KeyAlgorithm: "RS256",
 					PrivateKey: &structs.OIDCClientAssertionKey{
-						PemKeyBase64:  encodeTestPrivateKeyBase64(t, nomadInvalidKey),
-						PemCertBase64: encodeTestCertBase64(t, nomadCert),
+						PemKey:  encodeTestPrivateKey(nomadInvalidKey),
+						PemCert: encodeTestCert(nomadCert),
 					},
 				},
 			},
@@ -490,8 +406,8 @@ func TestBuildClientAssertionJWT_PrivateKeyExpiredCert(t *testing.T) {
 					Audience:     []string{"test-audience"},
 					KeyAlgorithm: "RS256",
 					PrivateKey: &structs.OIDCClientAssertionKey{
-						PemKeyBase64:  encodeTestPrivateKeyBase64(t, nomadKey),
-						PemCertBase64: encodeTestCertBase64(t, nomadExpiredCert),
+						PemKey:  encodeTestPrivateKey(nomadKey),
+						PemCert: encodeTestCert(nomadExpiredCert),
 					},
 				},
 			},
@@ -503,7 +419,6 @@ func TestBuildClientAssertionJWT_PrivateKeyExpiredCert(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.config.Canonicalize() // inherits clientSecret from OIDCClientAssertion
-			tt.config.Validate()     // validates clientSecret length
 			jwt, err := BuildClientAssertionJWT(tt.config, nomadKey, nomadKID)
 			if tt.wantErr {
 				must.Error(t, err)
@@ -563,18 +478,20 @@ func writeTestPrivateKeyToFile(t *testing.T, key *rsa.PrivateKey) string {
 	return keyPath
 }
 
-func encodeTestPrivateKeyBase64(t *testing.T, key *rsa.PrivateKey) string {
+func encodeTestPrivateKey(key *rsa.PrivateKey) string {
 	keyBytes := x509.MarshalPKCS1PrivateKey(key)
 	block := &pem.Block{
 		Type:  "RSA PRIVATE KEY",
 		Bytes: keyBytes,
 	}
-	return base64.StdEncoding.EncodeToString(pem.EncodeToMemory(block))
+	return string(pem.EncodeToMemory(block))
 }
 
 func generateTestCertificate(t *testing.T, key *rsa.PrivateKey) *x509.Certificate {
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
 	}
 	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
 	must.NoError(t, err)
@@ -585,12 +502,12 @@ func generateTestCertificate(t *testing.T, key *rsa.PrivateKey) *x509.Certificat
 	return cert
 }
 
-func encodeTestCertBase64(t *testing.T, cert *x509.Certificate) string {
+func encodeTestCert(cert *x509.Certificate) string {
 	block := &pem.Block{
 		Type:  "CERTIFICATE",
 		Bytes: cert.Raw,
 	}
-	return base64.StdEncoding.EncodeToString(pem.EncodeToMemory(block))
+	return string(pem.EncodeToMemory(block))
 }
 
 func writeTestCertToFile(t *testing.T, cert *x509.Certificate) string {

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -1634,19 +1634,19 @@ func TestOIDCClientAssertionKey_Validate(t *testing.T) {
 			err: ErrMissingClientAssertionKey,
 		},
 		{
-			name: "missing kid or cert",
-			key: &OIDCClientAssertionKey{
-				PemKeyFile: "/any.key",
-			},
-			err: ErrMissingClientAssertionKeyID,
-		},
-		{
 			name: "ambiguous key",
 			key: &OIDCClientAssertionKey{
 				PemKeyFile: "/any.key",
 				PemKey:     "anykey",
 			},
 			err: ErrAmbiguousClientAssertionKey,
+		},
+		{
+			name: "missing keyid or cert",
+			key: &OIDCClientAssertionKey{
+				PemKeyFile: "/any.key",
+			},
+			err: ErrMissingClientAssertionKeyID,
 		},
 		{
 			name: "ambiguous keyid - cert file and pem",
@@ -1674,6 +1674,22 @@ func TestOIDCClientAssertionKey_Validate(t *testing.T) {
 				KeyID:   "key-id",
 			},
 			err: ErrAmbiguousClientAssertionKeyID,
+		},
+		{
+			name: "non-absolute key path",
+			key: &OIDCClientAssertionKey{
+				PemKeyFile: "./who-knows-where-this-might-be.key",
+				KeyID:      "key-id",
+			},
+			err: ErrInvalidClientAssertionKeyPath,
+		},
+		{
+			name: "non-absolute cert path",
+			key: &OIDCClientAssertionKey{
+				PemKey:      "anykey",
+				PemCertFile: "./who-knows-where-this-might-be.cert",
+			},
+			err: ErrInvalidClientAssertionCertPath,
 		},
 		{
 			name: "bad key header for keyid",

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -1392,6 +1392,22 @@ func TestACLAuthMethod_Merge(t *testing.T) {
 	must.Eq(t, am1.Config.OIDCClientAssertion.PrivateKey.KeyID, "test-key-id")
 }
 
+func TestACLAuthMethodConfig_Validate(t *testing.T) {
+	ci.Parallel(t)
+
+	// fail everything
+	am := &ACLAuthMethodConfig{}
+	am.Canonicalize() // there is insufficient info for this to help
+	err := am.Validate()
+	must.ErrorContains(t, err, "missing OIDCDiscoveryURL")
+	must.ErrorContains(t, err, "missing OIDCClientID")
+	must.ErrorContains(t, err, "missing BoundAudiences") // TODO: BoundIssuer? it's not even documented...
+	am.OIDCClientAssertion = &OIDCClientAssertion{}
+	am.Canonicalize()
+	err = am.Validate()
+	must.ErrorContains(t, err, "invalid client assertion config:")
+}
+
 func TestACLAuthMethodConfig_Copy(t *testing.T) {
 	ci.Parallel(t)
 

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -2121,7 +2121,7 @@ func validClientAssertion() *OIDCClientAssertion {
 		KeySource: OIDCKeySourcePrivateKey,
 		Audience:  []string{"test-audience"},
 		PrivateKey: &OIDCClientAssertionKey{
-			PemKeyFile:  "test-key-file",
+			PemKeyFile:  "/test.key",
 			KeyIDHeader: OIDCClientAssertionHeaderKid,
 			KeyID:       "test-key-id",
 		},


### PR DESCRIPTION
@dduzgun-security was nice enough to write a bunch of tests for us for #25231 :)

I changed some of em, and moved some logic into structs/

The main functional change here is that `Pem(Key|Cert)File` fields must be absolute paths.