### PR TITLE
docs: fix missing api version on agent path

### DIFF
--- a/website/content/api-docs/agent.mdx
+++ b/website/content/api-docs/agent.mdx
@@ -18,7 +18,7 @@ eventually consistent.
 
 | Method | Path             | Produces           |
 | ------ | ---------------- | ------------------ |
-| `GET`  | `/agent/members` | `application/json` |
+| `GET`  | `/v1/agent/members` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -79,7 +79,7 @@ are changes in the cluster.
 
 | Method | Path             | Produces           |
 | ------ | ---------------- | ------------------ |
-| `GET`  | `/agent/servers` | `application/json` |
+| `GET`  | `/v1/agent/servers` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -109,7 +109,7 @@ This endpoint updates the list of known servers to the provided list. This
 
 | Method | Path             | Produces       |
 | ------ | ---------------- | -------------- |
-| `POST` | `/agent/servers` | `(empty body)` |
+| `POST` | `/v1/agent/servers` | `(empty body)` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -138,7 +138,7 @@ This endpoint queries the state of the target agent (self).
 
 | Method | Path          | Produces           |
 | ------ | ------------- | ------------------ |
-| `GET`  | `/agent/self` | `application/json` |
+| `GET`  | `/v1/agent/self` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -387,7 +387,7 @@ eligible for servers.
 
 | Method | Path          | Produces           |
 | ------ | ------------- | ------------------ |
-| `POST` | `/agent/join` | `application/json` |
+| `POST` | `/v1/agent/join` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -428,7 +428,7 @@ stop attempting replication. This is only applicable for servers.
 
 | Method | Path                 | Produces           |
 | ------ | -------------------- | ------------------ |
-| `POST` | `/agent/force-leave` | `application/json` |
+| `POST` | `/v1/agent/force-leave` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -464,7 +464,7 @@ containing an error message.
 
 | Method | Path            | Produces           |
 | ------ | --------------- | ------------------ |
-| `GET`  | `/agent/health` | `application/json` |
+| `GET`  | `/v1/agent/health` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -506,7 +506,7 @@ information.
 
 | Method | Path          | Produces           |
 | ------ | ------------- | ------------------ |
-| `GET`  | `/agent/host` | `application/json` |
+| `GET`  | `/v1/agent/host` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -586,7 +586,7 @@ This endpoint streams logs from the local agent until the connection is closed
 
 | Method | Path             | Produces           |
 | ------ | ---------------- | ------------------ |
-| `GET`  | `/agent/monitor` | `application/json` |
+| `GET`  | `/v1/agent/monitor` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -659,10 +659,10 @@ of available profiles.
 
 | Method | Path                           | Produces                   |
 | ------ | ------------------------------ | -------------------------- |
-| `GET`  | `/agent/pprof/cmdline`         | `text/plain`               |
-| `GET`  | `/agent/pprof/profile`         | `application/octet-stream` |
-| `GET`  | `/agent/pprof/trace`           | `application/octet-stream` |
-| `GET`  | `/agent/pprof/<pprof profile>` | `application/octet-stream` |
+| `GET`  | `/v1/agent/pprof/cmdline`         | `text/plain`               |
+| `GET`  | `/v1/agent/pprof/profile`         | `application/octet-stream` |
+| `GET`  | `/v1/agent/pprof/trace`           | `application/octet-stream` |
+| `GET`  | `/v1/agent/pprof/<pprof profile>` | `application/octet-stream` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -682,15 +682,15 @@ unset and only use the ACL-protected endpoints.
 
 The following table explains when each endpoint is available:
 
-| Endpoint        | `enable_debug` | ACLs | **Available?** |
-| --------------- | -------------- | ---- | -------------- |
-| /v1/agent/pprof | unset          | n/a  | no             |
-| /v1/agent/pprof | `true`         | n/a  | yes            |
-| /v1/agent/pprof | `false`        | n/a  | no             |
-| /v1/agent/pprof | unset          | off  | no             |
-| /v1/agent/pprof | unset          | on   | **yes**        |
-| /v1/agent/pprof | `true`         | off  | yes            |
-| /v1/agent/pprof | `false`        | on   | **yes**        |
+| Endpoint          | `enable_debug` | ACLs | **Available?** |
+| ----------------- | -------------- | ---- | -------------- |
+| `/v1/agent/pprof` | unset          | n/a  | no             |
+| `/v1/agent/pprof` | `true`         | n/a  | yes            |
+| `/v1/agent/pprof` | `false`        | n/a  | no             |
+| `/v1/agent/pprof` | unset          | off  | no             |
+| `/v1/agent/pprof` | unset          | on   | **yes**        |
+| `/v1/agent/pprof` | `true`         | off  | yes            |
+| `/v1/agent/pprof` | `false`        | on   | **yes**        |
 
 ### Parameters
 
@@ -739,7 +739,7 @@ a Nomad server agent's scheduler workers.
 
 | Method | Path                | Produces           |
 | ------ | ------------------- | ------------------ |
-| `GET`  | `/agent/schedulers` | `application/json` |
+| `GET`  | `/v1/agent/schedulers` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -830,7 +830,7 @@ the perspective of the agent. This is only applicable for servers.
 
 | Method | Path                       | Produces           |
 | ------ | -------------------------- | ------------------ |
-| `GET`  | `/agent/schedulers/config` | `application/json` |
+| `GET`  | `/v1/agent/schedulers/config` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -878,7 +878,7 @@ to apply the provided values. This is only applicable for servers.
 
 | Method | Path                       | Produces           |
 | ------ | -------------------------- | ------------------ |
-| `PUT`  | `/agent/schedulers/config` | `application/json` |
+| `PUT`  | `/v1/agent/schedulers/config` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and


### PR DESCRIPTION
### Description
Just add api version prefix `/v1` in each path to be consistent with other api documentation and avoid confusion
