### PR TITLE
docs: fix missing api version on acl path

### DIFF
--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -13,9 +13,9 @@ The `/acl/auth-methods` and `/acl/auth-method` endpoints are used to manage ACL 
 This endpoint creates an ACL auth method. The request is always forwarded to the
 authoritative region.
 
-| Method | Path               | Produces           |
-| ------ | ------------------ | ------------------ |
-| `POST` | `/acl/auth-method` | `application/json` |
+| Method | Path                  | Produces           |
+| ------ | --------------------- | ------------------ |
+| `POST` | `/v1/acl/auth-method` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -209,9 +209,9 @@ $ curl \
 This endpoint updates an existing ACL auth method. The request is always
 forwarded to the authoritative region.
 
-| Method | Path                            | Produces           |
-| ------ | ------------------------------- | ------------------ |
-| `POST` | `/acl/auth-method/:method_name` | `application/json` |
+| Method | Path                               | Produces           |
+| ------ | ---------------------------------- | ------------------ |
+| `POST` | `/v1/acl/auth-method/:method_name` | `application/json` |
 
 The table below shows this endpoint's support for [blocking
 queries](/nomad/api-docs#blocking-queries) and [required ACLs](/nomad/api-docs#acls).
@@ -377,9 +377,9 @@ $ curl \
 This endpoint lists all ACL auth methods. This lists the auth methods that have
 been replicated to the region, and may lag behind the authoritative region.
 
-| Method | Path                | Produces           |
-| ------ | ------------------- | ------------------ |
-| `GET`  | `/acl/auth-methods` | `application/json` |
+| Method | Path                   | Produces           |
+| ------ | ---------------------- | ------------------ |
+| `GET`  | `/v1/acl/auth-methods` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries),
@@ -418,9 +418,9 @@ This endpoint reads an ACL Auth Method with the given name. This queries the
 auth method that has been replicated to the region, and may lag behind the
 authoritative region.
 
-| Method | Path                            | Produces           |
-| ------ | ------------------------------- | ------------------ |
-| `GET`  | `/acl/auth-method/:method_name` | `application/json` |
+| Method | Path                               | Produces           |
+| ------ | ---------------------------------- | ------------------ |
+| `GET`  | `/v1/acl/auth-method/:method_name` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries),
@@ -487,9 +487,9 @@ $ curl \
 This endpoint deletes the ACL auth method as identified by its name. This
 request is always forwarded to the authoritative region.
 
-| Method   | Path                            | Produces       |
-| -------- | ------------------------------- | -------------- |
-| `DELETE` | `/acl/auth-method/:method_name` | `(empty body)` |
+| Method   | Path                               | Produces       |
+| -------- | ---------------------------------- | -------------- |
+| `DELETE` | `/v1/acl/auth-method/:method_name` | `(empty body)` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/website/content/api-docs/acl/binding-rules.mdx
+++ b/website/content/api-docs/acl/binding-rules.mdx
@@ -14,9 +14,9 @@ This endpoint reads an ACL Binding Rule with the given name. This queries the
 Binding Rule that has been replicated to the region, and may lag behind the
 authoritative region.
 
-| Method | Path                         | Produces           |
-| ------ | ---------------------------- | ------------------ |
-| `GET`  | `/acl/binding-rule/:rule_id` | `application/json` |
+| Method | Path                            | Produces           |
+| ------ | ------------------------------- | ------------------ |
+| `GET`  | `/v1/acl/binding-rule/:rule_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries),
@@ -62,9 +62,9 @@ $ curl \
 This endpoint lists all ACL Binding Rules. This lists the Binding Rules that have
 been replicated to the region, and may lag behind the authoritative region.
 
-| Method | Path                | Produces           |
-| ------ | ------------------- | ------------------ |
-| `GET`  | `/acl/binding-rules` | `application/json` |
+| Method | Path                    | Produces           |
+| ------ | ----------------------- | ------------------ |
+| `GET`  | `/v1/acl/binding-rules` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries),
@@ -103,9 +103,9 @@ $ curl \
 This endpoint creates an ACL Binding Rule. The request is always forwarded to the
 authoritative region.
 
-| Method | Path                | Produces           |
-| ------ | ------------------- | ------------------ |
-| `POST` | `/acl/binding-rule` | `application/json` |
+| Method | Path                   | Produces           |
+| ------ | ---------------------- | ------------------ |
+| `POST` | `/v1/acl/binding-rule` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -189,9 +189,9 @@ $ curl \
 This endpoint updates an existing ACL Binding Rule. The request is always
 forwarded to the authoritative region.
 
-| Method | Path                           | Produces           |
-| ------ | ------------------------------ | ------------------ |
-| `POST` | `/acl/binding-rule/:rule_id` | `application/json` |
+| Method | Path                            | Produces           |
+| ------ | ------------------------------- | ------------------ |
+| `POST` | `/v1/acl/binding-rule/:rule_id` | `application/json` |
 
 The table below shows this endpoint's support for [blocking
 queries](/nomad/api-docs#blocking-queries) and [required ACLs](/nomad/api-docs#acls).
@@ -260,9 +260,9 @@ $ curl \
 This endpoint deletes the ACL Binding Rule as identified by its ID. This request
 is always forwarded to the authoritative region.
 
-| Method   | Path                         | Produces       |
-| -------- | ---------------------------- | -------------- |
-| `DELETE` | `/acl/binding-rule/:rule_id` | `(empty body)` |
+| Method   | Path                            | Produces       |
+| -------- | ------------------------------- | -------------- |
+| `DELETE` | `/v1/acl/binding-rule/:rule_id` | `(empty body)` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/website/content/api-docs/acl/policies.mdx
+++ b/website/content/api-docs/acl/policies.mdx
@@ -14,9 +14,9 @@ For more details about ACLs, please see the [ACL Guide](/nomad/tutorials/access-
 This endpoint lists all ACL policies. This lists the policies that have been replicated
 to the region, and may lag behind the authoritative region.
 
-| Method | Path            | Produces           |
-| ------ | --------------- | ------------------ |
-| `GET`  | `/acl/policies` | `application/json` |
+| Method | Path               | Produces           |
+| ------ | -----   ---------- | ------------------ |
+| `GET`  | `/v1/acl/policies` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and
@@ -61,9 +61,9 @@ $ curl \
 This endpoint creates or updates an ACL Policy. This request is always forwarded to the
 authoritative region.
 
-| Method | Path                       | Produces       |
-| ------ | -------------------------- | -------------- |
-| `POST` | `/acl/policy/:policy_name` | `(empty body)` |
+| Method | Path                          | Produces       |
+| ------ | ----------------------------- | -------------- |
+| `POST` | `/v1/acl/policy/:policy_name` | `(empty body)` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -124,9 +124,9 @@ $ curl \
 This endpoint reads an ACL policy with the given name. This queries the policy that have been
 replicated to the region, and may lag behind the authoritative region.
 
-| Method | Path                       | Produces           |
-| ------ | -------------------------- | ------------------ |
-| `GET`  | `/acl/policy/:policy_name` | `application/json` |
+| Method | Path                          | Produces           |
+| ------ | ----------------------------- | ------------------ |
+| `GET`  | `/v1/acl/policy/:policy_name` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and
@@ -160,9 +160,9 @@ $ curl \
 This endpoint deletes the named ACL policy. This request is always forwarded to the
 authoritative region.
 
-| Method   | Path                       | Produces       |
-| -------- | -------------------------- | -------------- |
-| `DELETE` | `/acl/policy/:policy_name` | `(empty body)` |
+| Method   | Path                          | Produces       |
+| -------- | ----------------------------- | -------------- |
+| `DELETE` | `/v1/acl/policy/:policy_name` | `(empty body)` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/website/content/api-docs/acl/roles.mdx
+++ b/website/content/api-docs/acl/roles.mdx
@@ -13,9 +13,9 @@ The `/acl/roles` and `/acl/role/` endpoints are used to manage ACL Roles.
 This endpoint creates an ACL Role. The request is always forwarded to the
 authoritative region.
 
-| Method | Path        | Produces           |
-| ------ | ----------- | ------------------ |
-| `POST` | `/acl/role` | `application/json` |
+| Method | Path           | Produces           |
+| ------ | -------------- | ------------------ |
+| `POST` | `/v1/acl/role` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -84,9 +84,9 @@ $ curl \
 This endpoint updates an existing ACL Role. The request is always forwarded to the
 authoritative region.
 
-| Method | Path                 | Produces           |
-| ------ | -------------------- | ------------------ |
-| `POST` | `/acl/role/:role_id` | `application/json` |
+| Method | Path                    | Produces           |
+| ------ | ----------------------- | ------------------ |
+| `POST` | `/v1/acl/role/:role_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -159,9 +159,9 @@ $ curl \
 This endpoint lists all ACL Roles. This lists the roles that have been replicated
 to the region, and may lag behind the authoritative region.
 
-| Method | Path         | Produces           |
-| ------ | ------------ | ------------------ |
-| `GET`  | `/acl/roles` | `application/json` |
+| Method | Path            | Produces           |
+| ------ | --------------- | ------------------ |
+| `GET`  | `/v1/acl/roles` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries),
@@ -265,9 +265,9 @@ $ curl \
 This endpoint reads an ACL Role with the given name. This queries the role that
 has been replicated to the region, and may lag behind the authoritative region.
 
-| Method | Path                        | Produces           |
-| ------ | --------------------------- | ------------------ |
-| `GET`  | `/acl/role/name/:role_name` | `application/json` |
+| Method | Path                           | Produces           |
+| ------ | ------------------------------ | ------------------ |
+| `GET`  | `/v1/acl/role/name/:role_name` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries),
@@ -313,9 +313,9 @@ $ curl \
 This endpoint deletes the ACL role as identified by the ID. This request is
 always forwarded to the authoritative region.
 
-| Method   | Path                 | Produces       |
-| -------- | -------------------- | -------------- |
-| `DELETE` | `/acl/role/:role_id` | `(empty body)` |
+| Method   | Path                    | Produces       |
+| -------- | ----------------------- | -------------- |
+| `DELETE` | `/v1/acl/role/:role_id` | `(empty body)` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/website/content/api-docs/acl/tokens.mdx
+++ b/website/content/api-docs/acl/tokens.mdx
@@ -18,9 +18,9 @@ The provided token should be presented in a UUID format.
 This request is always forwarded to the authoritative region. It can only be invoked once
 until a [bootstrap reset](/nomad/tutorials/access-control/access-control-bootstrap#re-bootstrap-acl-system) is performed.
 
-| Method | Path             | Produces           |
-| ------ | ---------------- | ------------------ |
-| `POST` | `/acl/bootstrap` | `application/json` |
+| Method | Path                | Produces           |
+| ------ | ------------------- | ------------------ |
+| `POST` | `/v1/acl/bootstrap` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -92,9 +92,9 @@ $ curl \
 This endpoint lists all ACL tokens. This lists the local tokens and the global
 tokens which have been replicated to the region, and may lag behind the authoritative region.
 
-| Method | Path          | Produces           |
-| ------ | ------------- | ------------------ |
-| `GET`  | `/acl/tokens` | `application/json` |
+| Method | Path             | Produces           |
+| ------ | ---------------- | ------------------ |
+| `GET`  | `/v1/acl/tokens` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and
@@ -168,9 +168,9 @@ $ curl \
 This endpoint creates an ACL Token. If the token is a global token, the request
 is forwarded to the authoritative region.
 
-| Method | Path         | Produces           |
-| ------ | ------------ | ------------------ |
-| `POST` | `/acl/token` | `application/json` |
+| Method | Path            | Produces           |
+| ------ | --------------- | ------------------ |
+| `POST` | `/v1/acl/token` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -246,9 +246,9 @@ This endpoint updates an existing ACL Token. If the token is a global token, the
 is forwarded to the authoritative region. Note that a token cannot be switched from global
 to local or visa versa.
 
-| Method | Path                      | Produces           |
-| ------ | ------------------------- | ------------------ |
-| `POST` | `/acl/token/:accessor_id` | `application/json` |
+| Method | Path                         | Produces           |
+| ------ | ---------------------------- | ------------------ |
+| `POST` | `/v1/acl/token/:accessor_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -309,9 +309,9 @@ $ curl \
 This endpoint reads an ACL token with the given accessor. If the token is a global token
 which has been replicated to the region it may lag behind the authoritative region.
 
-| Method | Path                      | Produces           |
-| ------ | ------------------------- | ------------------ |
-| `GET`  | `/acl/token/:accessor_id` | `application/json` |
+| Method | Path                         | Produces           |
+| ------ | ---------------------------- | ------------------ |
+| `GET`  | `/v1/acl/token/:accessor_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and
@@ -349,9 +349,9 @@ $ curl \
 This endpoint reads the ACL token given by the passed SecretID. If the token is a global token
 which has been replicated to the region it may lag behind the authoritative region.
 
-| Method | Path              | Produces           |
-| ------ | ----------------- | ------------------ |
-| `GET`  | `/acl/token/self` | `application/json` |
+| Method | Path                 | Produces           |
+| ------ | -------------------- | ------------------ |
+| `GET`  | `/v1/acl/token/self` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and
@@ -390,9 +390,9 @@ $ curl \
 This endpoint deletes the ACL token by accessor. This request is forwarded to the
 authoritative region for global tokens.
 
-| Method   | Path                      | Produces       |
-| -------- | ------------------------- | -------------- |
-| `DELETE` | `/acl/token/:accessor_id` | `(empty body)` |
+| Method   | Path                         | Produces       |
+| -------- | ---------------------------- | -------------- |
+| `DELETE` | `/v1/acl/token/:accessor_id` | `(empty body)` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -419,9 +419,9 @@ $ curl \
 This endpoint creates a one-time token for the ACL token provided in the
 `X-Nomad-Token` header. Returns 403 if the token header is not set.
 
-| Method | Path                 | Produces           |
-| ------ | -------------------- | ------------------ |
-| `POST` | `/acl/token/onetime` | `application/json` |
+| Method | Path                    | Produces           |
+| ------ | ----------------------- | ------------------ |
+| `POST` | `/v1/acl/token/onetime` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -460,9 +460,9 @@ $ curl \
 This endpoint exchanges a one-time token for the original ACL token used to
 create it.
 
-| Method | Path                          | Produces           |
-| ------ | ----------------------------- | ------------------ |
-| `POST` | `/acl/token/onetime/exchange` | `application/json` |
+| Method | Path                             | Produces           |
+| ------ | -------------------------------- | ------------------ |
+| `POST` | `/v1/acl/token/onetime/exchange` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and


### PR DESCRIPTION
### Description
Just add api version prefix `/v1` in each path to be consistent with other api documentation and avoid confusion