### PR TITLE
cli: acl auth-method info: add client assertion / pkce

### DIFF
--- a/command/acl_auth_method.go
+++ b/command/acl_auth_method.go
@@ -93,6 +93,10 @@ func formatAuthMethodConfig(config *api.ACLAuthMethodConfig) string {
 		fmt.Sprintf("OIDC Discovery URL|%s", config.OIDCDiscoveryURL),
 		fmt.Sprintf("OIDC Client ID|%s", config.OIDCClientID),
 		fmt.Sprintf("OIDC Client Secret|%s", config.OIDCClientSecret),
+	}
+	out = append(out, formatClientAssertion(config.OIDCClientAssertion)...)
+	out = append(out,
+		fmt.Sprintf("OIDC Disable PKCE|%t", config.OIDCDisablePKCE != nil && *config.OIDCDisablePKCE),
 		fmt.Sprintf("OIDC Disable UserInfo|%t", config.OIDCDisableUserInfo),
 		fmt.Sprintf("OIDC Scopes|%s", strings.Join(config.OIDCScopes, ",")),
 		fmt.Sprintf("Bound audiences|%s", strings.Join(config.BoundAudiences, ",")),
@@ -106,7 +110,7 @@ func formatAuthMethodConfig(config *api.ACLAuthMethodConfig) string {
 		fmt.Sprintf("ClockSkew Leeway|%s", config.ClockSkewLeeway.String()),
 		fmt.Sprintf("Claim mappings|%s", strings.Join(formatMap(config.ClaimMappings), "; ")),
 		fmt.Sprintf("List claim mappings|%s", strings.Join(formatMap(config.ListClaimMappings), "; ")),
-	}
+	)
 	return formatKV(out)
 }
 
@@ -114,6 +118,23 @@ func formatMap(m map[string]string) []string {
 	out := []string{}
 	for k, v := range m {
 		out = append(out, fmt.Sprintf("{%s: %s}", k, v))
+	}
+	return out
+}
+
+func formatClientAssertion(cass *api.OIDCClientAssertion) []string {
+	var out []string
+	if cass == nil {
+		return out
+	}
+	prefix := "OIDC Client Assertion"
+	out = []string{
+		fmt.Sprintf("%s KeySource|%s", prefix, cass.KeySource),
+		fmt.Sprintf("%s Algorithm|%s", prefix, cass.KeyAlgorithm),
+		fmt.Sprintf("%s Audience|%s", prefix, strings.Join(cass.Audience, ",")),
+	}
+	if len(cass.ExtraHeaders) > 0 {
+		out = append(out, fmt.Sprintf("%s Headers|%s", prefix, strings.Join(formatMap(cass.ExtraHeaders), "; ")))
 	}
 	return out
 }


### PR DESCRIPTION
I opted to leave off the `PrivateKey` field, because a) it makes the left column huge, b) a `PemCert` value would be even huger, c) it's pretty advanced information, and d) it's easily accessible with `-json`

Example output:

```
$ nomad acl auth-method info my-auth-method
... existing stuff ...
Auth Method Config

JWT Validation Public Keys      = <none>
JWKS URL                        = <none>
OIDC Discovery URL              = http://localhost:8080/realms/Nomad
OIDC Client ID                  = nomad
OIDC Client Secret              = <none>
OIDC Client Assertion KeySource = nomad
OIDC Client Assertion Algorithm = RS256
OIDC Client Assertion Audience  = one,two
OIDC Client Assertion Headers   = {one: uno}; {two: dos}
OIDC Disable PKCE               = false
OIDC Disable UserInfo           = false
OIDC Scopes                     = openid,kc-groups
Bound audiences                 = nomad,another-nomad
... etc etc ...
```

Note that even with `-json`, `OIDCClientSecret` and `PemKey` are `redacted`.  They are not accessible via API.