### PR TITLE
auth: decrease size of oidc request cache

### DIFF
--- a/lib/auth/oidc/request.go
+++ b/lib/auth/oidc/request.go
@@ -12,14 +12,17 @@ import (
 )
 
 var (
-	ErrNonceReuse      = errors.New("nonce reuse detected")
+	ErrNonceReuse = errors.New("nonce reuse detected")
+	// ErrTooManyRequests is returned if the request cache is full.
+	// Realistically, we expect this only to happen if the auth-url
+	// API endpoint is being DOS'd.
 	ErrTooManyRequests = errors.New("too many auth requests")
 )
 
 // MaxRequests is how many requests are allowed to be stored at a time.
 // It needs to be large enough for legitimate user traffic, but small enough
 // to prevent a DOS from eating up server memory.
-const MaxRequests = 10000
+const MaxRequests = 1000
 
 // NewRequestCache creates a cache for OIDC requests.
 // The JWT expiration time in the cap library is 5 minutes,


### PR DESCRIPTION
If the auth-url api is getting DOS'd, then we do not expect it to still function; we only protect the rest of the system.

Users will need to use a break-glass ACL token if they need Nomad UI/API access during such a denial of service.