### PR TITLE
[ui] Custom watchQuery equivalent on the storage index

### DIFF
--- a/ui/app/templates/storage/index.hbs
+++ b/ui/app/templates/storage/index.hbs
@@ -121,16 +121,14 @@
             </B.Tr>
           </:body>
         </Hds::Table>
-        {{#if (gt this.sortedCSIVolumes.length this.userSettings.pageSize)}}
-          <Hds::Pagination::Numbered
-            @totalItems={{this.filteredCSIVolumes.length}}
-            @currentPage={{this.csiPage}}
-            @pageSizes={{this.pageSizes}}
-            @currentPageSize={{this.userSettings.pageSize}}
-            @onPageChange={{action this.handlePageChange "csi"}}
-            @onPageSizeChange={{action (mut this.userSettings.pageSize)}}
-          />
-        {{/if}}
+        <Hds::Pagination::Numbered
+          @totalItems={{this.filteredCSIVolumes.length}}
+          @currentPage={{this.csiPage}}
+          @pageSizes={{this.pageSizes}}
+          @currentPageSize={{this.userSettings.pageSize}}
+          @onPageChange={{action this.handlePageChange "csi"}}
+          @onPageSizeChange={{action (mut this.userSettings.pageSize)}}
+        />
       {{else}}
         <div class="empty-message" data-test-empty-csi-volumes-list-headline>
           {{#if this.csiFilter}}
@@ -162,7 +160,7 @@
       </header>
       {{#if this.sortedDynamicHostVolumes.length}}
         <Hds::Table @caption="Dynamic Host Volumes"
-          @model={{this.sortedDynamicHostVolumes}}
+          @model={{this.paginatedDynamicHostVolumes}}
           @columns={{this.dhvColumns}}
           @sortBy={{this.dhvSortProperty}}
           @sortOrder={{if this.dhvSortDescending "desc" "asc"}}
@@ -202,16 +200,14 @@
             </B.Tr>
           </:body>
         </Hds::Table>
-        {{#if (gt this.sortedDynamicHostVolumes.length this.userSettings.pageSize)}}
-          <Hds::Pagination::Numbered
-            @totalItems={{this.filteredDynamicHostVolumes.length}}
-            @currentPage={{this.dhvPage}}
-            @pageSizes={{this.pageSizes}}
-            @currentPageSize={{this.userSettings.pageSize}}
-            @onPageChange={{action this.handlePageChange "dhv"}}
-            @onPageSizeChange={{action (mut this.userSettings.pageSize)}}
-          />
-        {{/if}}
+        <Hds::Pagination::Numbered
+          @totalItems={{this.filteredDynamicHostVolumes.length}}
+          @currentPage={{this.dhvPage}}
+          @pageSizes={{this.pageSizes}}
+          @currentPageSize={{this.userSettings.pageSize}}
+          @onPageChange={{action this.handlePageChange "dhv"}}
+          @onPageSizeChange={{action (mut this.userSettings.pageSize)}}
+        />
       {{else}}
         <div class="empty-message" data-test-empty-dhv-list-headline>
           {{#if this.dhvFilter}}

--- a/ui/app/templates/storage/index.hbs
+++ b/ui/app/templates/storage/index.hbs
@@ -213,7 +213,7 @@
           />
         {{/if}}
       {{else}}
-        <div class="empty-message">
+        <div class="empty-message" data-test-empty-dhv-list-headline>
           {{#if this.dhvFilter}}
             <p>No dynamic host volumes match your search for "{{this.dhvFilter}}"</p>
             <Hds::Button @text="Clear search" @color="secondary" {{on "click" (queue (action (mut this.dhvFilter) "") (action this.handlePageChange "dhv" 1))}} />

--- a/ui/app/templates/storage/index.hbs
+++ b/ui/app/templates/storage/index.hbs
@@ -32,7 +32,7 @@
   {{#if this.isForbidden}}
     <ForbiddenMessage />
   {{else}}
-    <Hds::Card::Container @level="base" @hasBorder={{false}} class="storage-index-table-card">
+    <Hds::Card::Container @level="base" @hasBorder={{false}} class="storage-index-table-card" data-test-csi-volumes-card>
       <header aria-label="CSI Volumes">
         <h3>CSI Volumes</h3>
         <p class="intro">
@@ -141,7 +141,7 @@
       {{/if}}
     </Hds::Card::Container>
 
-    <Hds::Card::Container @level="base" @hasBorder={{false}} class="storage-index-table-card">
+    <Hds::Card::Container @level="base" @hasBorder={{false}} class="storage-index-table-card" data-test-dynamic-host-volumes-card>
       <header aria-label="Dynamic Host Volumes">
         <h3>Dynamic Host Volumes</h3>
         <p class="intro">

--- a/ui/tests/acceptance/storage-list-test.js
+++ b/ui/tests/acceptance/storage-list-test.js
@@ -277,5 +277,166 @@ module('Acceptance | storage list', function (hooks) {
         'URL has the correct query param key and value'
       );
     });
+
+    module('Live updates are reflected in the list', function () {
+      test('When you visit the storage list page, the watch process is kicked off', async function (assert) {
+        await StorageList.visit();
+        const requests = server.pretender.handledRequests;
+        const dhvRequests = requests.filter((request) =>
+          request.url.startsWith('/v1/volumes?namespace=%2A&type=host')
+        );
+        const csiRequests = requests.filter((request) =>
+          request.url.startsWith('/v1/volumes?namespace=%2A&type=csi')
+        );
+        assert.equal(dhvRequests.length, 2, '2 DHV requests were made');
+        assert.equal(csiRequests.length, 2, '2 CSI requests were made');
+      });
+
+      test('When a new dynamic host volume is created, the page should reflect the changes', async function (assert) {
+        server.create('dynamic-host-volume', {
+          name: 'initial-volume',
+        });
+        const controller = this.owner.lookup('controller:storage.index');
+        await visit('/storage');
+
+        // Check pretender to see 2 requests related to DHV: the initial one, and another one with an index on it
+        const requests = server.pretender.handledRequests;
+
+        // Should be 2 DHV requests made: the initial one, and the watcher
+        let dhvRequests = requests.filter((request) =>
+          request.url.startsWith('/v1/volumes?namespace=%2A&type=host')
+        );
+        assert.equal(dhvRequests.length, 2, '2 DHV requests were made');
+
+        assert.dom('[data-test-dhv-row]').exists({ count: 1 });
+        assert.dom('[data-test-dhv-row]').containsText('initial-volume');
+
+        server.create('dynamic-host-volume', {
+          name: 'new-volume',
+        });
+
+        await controller.watchDHV.perform({
+          type: 'host',
+          namespace: controller.qpNamespace,
+        });
+
+        // Now there should be a third DHV request
+        dhvRequests = requests.filter((request) =>
+          request.url.startsWith('/v1/volumes?namespace=%2A&type=host')
+        );
+        assert.equal(dhvRequests.length, 3, '3 DHV requests were made');
+
+        // and a second row
+        assert.dom('[data-test-dhv-row]').exists({ count: 2 });
+      });
+
+      test('When a new csi volume is created, the page should reflect the changes', async function (assert) {
+        server.create('csi-volume', {
+          id: 'initial-volume',
+        });
+        const controller = this.owner.lookup('controller:storage.index');
+        await visit('/storage');
+
+        // Check pretender to see 2 requests related to DHV: the initial one, and another one with an index on it
+        const requests = server.pretender.handledRequests;
+
+        // Should be 2 DHV requests made: the initial one, and the watcher
+        let csiRequests = requests.filter((request) =>
+          request.url.startsWith('/v1/volumes?namespace=%2A&type=csi')
+        );
+        assert.equal(csiRequests.length, 2, '2 CSI requests were made');
+        assert.dom('[data-test-csi-volume-row]').exists({ count: 1 });
+        assert.dom('[data-test-csi-volume-row]').containsText('initial-volume');
+
+        server.create('csi-volume', {
+          id: 'new-volume',
+        });
+
+        await controller.watchCSI.perform({
+          type: 'csi',
+          namespace: controller.qpNamespace,
+        });
+
+        // Now there should be a third DHV request
+        csiRequests = requests.filter((request) =>
+          request.url.startsWith('/v1/volumes?namespace=%2A&type=csi')
+        );
+        assert.equal(csiRequests.length, 3, '3 CSI requests were made');
+
+        // and a second row
+        assert.dom('[data-test-csi-volume-row]').exists({ count: 2 });
+      });
+
+      test('When a dynamic host volume is updated, the page should reflect the changes', async function (assert) {
+        const dhv = server.create('dynamic-host-volume', {
+          name: 'initial-volume',
+        });
+        const controller = this.owner.lookup('controller:storage.index');
+        await visit('/storage');
+
+        // Check pretender to see 2 requests related to DHV: the initial one, and another one with an index on it
+        const requests = server.pretender.handledRequests;
+
+        // Should be 2 DHV requests made: the initial one, and the watcher
+        let dhvRequests = requests.filter((request) =>
+          request.url.startsWith('/v1/volumes?namespace=%2A&type=host')
+        );
+        assert.equal(dhvRequests.length, 2, '2 DHV requests were made');
+
+        assert.dom('[data-test-dhv-row]').exists({ count: 1 });
+        assert.dom('[data-test-dhv-row]').containsText('initial-volume');
+
+        dhv.update('name', 'updated-volume');
+
+        await controller.watchDHV.perform({
+          type: 'host',
+          namespace: controller.qpNamespace,
+        });
+
+        dhvRequests = requests.filter((request) =>
+          request.url.startsWith('/v1/volumes?namespace=%2A&type=host')
+        );
+        assert.equal(dhvRequests.length, 3, '3 DHV requests were made');
+
+        // Still just one row
+        assert.dom('[data-test-dhv-row]').exists({ count: 1 });
+        assert.dom('[data-test-dhv-row]').containsText('updated-volume');
+      });
+
+      test('When a dynamic host volume is deleted, the page should reflect the changes', async function (assert) {
+        const dhv = server.create('dynamic-host-volume', {
+          name: 'initial-volume',
+        });
+        const controller = this.owner.lookup('controller:storage.index');
+        await visit('/storage');
+
+        // Check pretender to see 2 requests related to DHV: the initial one, and another one with an index on it
+        const requests = server.pretender.handledRequests;
+
+        // Should be 2 DHV requests made: the initial one, and the watcher
+        let dhvRequests = requests.filter((request) =>
+          request.url.startsWith('/v1/volumes?namespace=%2A&type=host')
+        );
+        assert.equal(dhvRequests.length, 2, '2 DHV requests were made');
+
+        assert.dom('[data-test-dhv-row]').exists({ count: 1 });
+        assert.dom('[data-test-dhv-row]').containsText('initial-volume');
+
+        dhv.destroy();
+
+        await controller.watchDHV.perform({
+          type: 'host',
+          namespace: controller.qpNamespace,
+        });
+
+        dhvRequests = requests.filter((request) =>
+          request.url.startsWith('/v1/volumes?namespace=%2A&type=host')
+        );
+        assert.equal(dhvRequests.length, 3, '3 DHV requests were made');
+
+        assert.dom('[data-test-dhv-row]').exists({ count: 0 });
+        assert.ok(StorageList.dhvIsEmpty);
+      });
+    });
   }
 });

--- a/ui/tests/pages/storage/list.js
+++ b/ui/tests/pages/storage/list.js
@@ -51,8 +51,19 @@ export default create({
   dhvIsEmpty: isPresent('[data-test-empty-dhv-list-headline]'),
   dhvEmptyState: text('[data-test-empty-dhv-list-headline]'),
 
-  csiNextPage: clickable('.hds-pagination-nav__arrow--direction-next'),
-  csiPrevPage: clickable('.hds-pagination-nav__arrow--direction-prev'),
+  csiNextPage: clickable(
+    '[data-test-csi-volumes-card] .hds-pagination-nav__arrow--direction-next'
+  ),
+  csiPrevPage: clickable(
+    '[data-test-csi-volumes-card] .hds-pagination-nav__arrow--direction-prev'
+  ),
+
+  dhvNextPage: clickable(
+    '[data-test-dynamic-host-volumes-card] .hds-pagination-nav__arrow--direction-next'
+  ),
+  dhvPrevPage: clickable(
+    '[data-test-dynamic-host-volumes-card] .hds-pagination-nav__arrow--direction-prev'
+  ),
 
   error: error(),
   pageSizeSelect: pageSizeSelect(),

--- a/ui/tests/pages/storage/list.js
+++ b/ui/tests/pages/storage/list.js
@@ -48,6 +48,9 @@ export default create({
   csiIsEmpty: isPresent('[data-test-empty-csi-volumes-list-headline]'),
   csiEmptyState: text('[data-test-empty-csi-volumes-list-headline]'),
 
+  dhvIsEmpty: isPresent('[data-test-empty-dhv-list-headline]'),
+  dhvEmptyState: text('[data-test-empty-dhv-list-headline]'),
+
   csiNextPage: clickable('.hds-pagination-nav__arrow--direction-next'),
   csiPrevPage: clickable('.hds-pagination-nav__arrow--direction-prev'),
 


### PR DESCRIPTION
Adds live reload to Dynamic Host Volumes and CSI Volumes tables
Implements the watchQuery pattern in a bespoke way, kind of like what we do on the jobs index page.

(Note for reviewers: because Mirage doesn't have any kind of concept of "hold open this query until new data shows up on the server", we are manually triggering the JS functions that would run if one were observed)

## To test:
- Make a dynamic host volume, say with `nomad volume create`
- Head to the storage page. Check out your network requests; there should be a pending one with ?index=$notZero, for both type=host and type=csi
- If you make another dynamic host volume, the type=host query should `200`, and a new volume should show up on your page.
- The blocking query should kick back off a moment or two later
- When you leave the page, both the held-open queries (as well as a namespace query) should cancel.

## Why are these different than other live update mechanisms in the UI? Why can't you use `@watchQuery` like you use `@watchAll` or `@watchRelationship` etc.?
The short answer is that things like watchAll or watchRecord are deterministic as far as the store is concerned: if a record doesn't exist in one of those queries, it's safe for our watcher system to say "Oh! This record simply does not exist and we should forget about it."

This is not true of queries, though! The absence of a previously-existing record in a query might simply indicate that your query has changed in some way. Since we don't want to try to mimic the querying logic of our backend, we don't want to make deterministic assumptions here, either.

[Private slack reference for further details](https://hashicorp.enterprise.slack.com/docs/T024UT03C/F048092BG9X)