### PR TITLE
docs: oidc client assertions and pkce

### DIFF
--- a/lib/auth/oidc/client_assertion.go
+++ b/lib/auth/oidc/client_assertion.go
@@ -29,6 +29,23 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
+// BuildClientAssertionJWT makes a JWT to be included in an OIDC auth request.
+// Reference: https://oauth.net/private-key-jwt/
+//
+// There are three input variations depending on OIDCClientAssertion.KeySource:
+//   - "client_secret": uses the config's ClientSecret as an HMAC key to sign
+//     the JWT. This is marginally more secure than a bare ClientSecret.
+//   - "nomad": uses the RS256 nomadKey (Nomad's private key) to sign the JWT,
+//     and the nomadKID as the JWT's "kid" header, which the OIDC provider uses
+//     to find the public key at Nomad's JWKS endpoint (/.well-known/jwks.json)
+//     to verify the JWT signature. This is arguably the most secure option,
+//     because only Nomad has the private key.
+//   - "private_key": uses an RSA private key provided by the user. They may
+//     provide a KeyID to use as the JWT's "kid" header, or an x509 public
+//     certificate to derive an x5t#S256 (or x5t) header, which the OIDC
+//     provider uses to find the cert on their end to verify the JWT signature.
+//     This is the most flexible option, allowing users to manage their own
+//     keys however they like.
 func BuildClientAssertionJWT(config *structs.ACLAuthMethodConfig, nomadKey *rsa.PrivateKey, nomadKID string) (*cass.JWT, error) {
 	// should already be validated by caller, but just in case.
 	if config == nil || config.OIDCClientAssertion == nil {

--- a/website/content/api-docs/acl/auth-methods.mdx
+++ b/website/content/api-docs/acl/auth-methods.mdx
@@ -50,9 +50,8 @@ The table below shows this endpoint's support for
 - `Default` `(bool: false)` - Defines whether this ACL Auth Method is to be
   set as default when running `nomad login` command.
 
-- `Config` `(ACLAuthMethodConfig: <required>)` - The raw configuration to use for
-  the auth method. This parameter is part of the auth method configuration, not
-  specific to Nomad.
+- `Config` `(ACLAuthMethodConfig: <required>)` - The raw configuration to use
+  for the auth method.
 
   - `OIDCDiscoveryURL` `(string: <required>)` - The OIDC discovery URL, without
     any `.well-known` component (base path). Required for `OIDC` method type.
@@ -64,6 +63,65 @@ The table below shows this endpoint's support for
 
   - `OIDCClientSecret` `(string: <required>)` - The OAuth client secret
     configured with your OIDC provider. Required for `OIDC` method type.
+
+  - `OIDCClientAssertion` `(OIDCClientAssertion)` - Optionally send a signed JWT
+    ("[private key jwt][]") as a client assertion to the OIDC provider.
+    Browse to the [OIDC concepts][concepts-assertions] page to learn more.
+
+    - `Audience` `(array<string>)` - Who will be processing the assertion.
+      Defaults to the parent `ACLAuthMethodConfig`'s `OIDCDiscoveryURL`
+
+    - `KeySource` `(string: <required>)` - Specifies where to get the private
+      key to sign the JWT.
+      Available sources:
+        - "nomad": Use current active key in Nomad's keyring
+        - "private_key": Use key material in the `PrivateKey` field
+        - "client_secret": Use the `OIDCClientSecret` inherited from the parent
+          `ACLAuthMethodConfig` as an HMAC key
+
+    - `KeyAlgorithm` `(string)` is the key's algorithm. Its default values are
+      based on the `KeySource`:
+        - "nomad": "RS256" (from Nomad's keyring, must not be changed)
+        - "private_key": "RS256" (must be RS256, RS384, or RS512)
+        - "client_secret": "HS256" (must be HS256, HS384, or HS512)
+
+    - `PrivateKey` `(OIDCClientAssertionKey)` - External key material to sign
+      the JWT. `KeySource` must be "private_key" to enable this.
+
+      - `PemKey` `(string)` - An RSA private key, in pem format. It is used to
+        sign the JWT. Mutually exclusive with `PemKeyFile`.
+
+      - `PemKeyFile` `(string)` - An absolute path to a private key on Nomad
+        servers' disk, in pem format. It is used to sign the JWT.
+        Mutually exclusive with `PemKey`.
+
+      - `KeyIDHeader` `(string)` - Which header the provider will use to find
+        the public key to verify the signed JWT.
+        Allowed values are: "kid", "x5t", or "x5t#S256".
+        The default depends on which of the following options is set.
+
+      - `KeyID` `(string)` - Becomes the JWT's "kid" header.
+        Mutually exclusive with `PemCert` and `PemCertFile`.
+        Allowed `KeyIDHeader` values: "kid" (the default)
+
+      - `PemCert` `(string)` - An x509 certificate, signed by the private key
+        or a CA, in pem format. It is used to derive an [x5t#S256][]
+        (or [x5t][]) KeyID.
+        Mutually exclusive with `PemCertFile` and `KeyID`.
+        Allowed `KeyIDHeader` values: "x5t", "x5t#S256" (default "x5t#S256")
+
+      - `PemCertFile` `(string)` - An absolute path to an x509 certificate on
+        Nomad servers' disk, signed by the private key or a CA, in pem format.
+        It is used to derive an [x5t#S256][] (or [x5t][]) KeyID.
+        Mutually exclusive with `PemCert` and KeyID.
+        Allowed `KeyIDHeader` values: "x5t", "x5t#S256" (default "x5t#S256")
+
+    - `ExtraHeaders` `(map[string]string)` - Added to the JWT headers,
+      alongside "kid" and "type". Setting the "kid" header here is not allowed;
+      use `PrivateKey.KeyID`.
+
+  - `OIDCDisablePKCE` `(bool: false)` - When set to `true`, Nomad will not
+    include [PKCE][] verification in the auth flow.
 
   - `OIDCDisableUserInfo` `(bool: false)` - When set to `true`, Nomad will not make
     a request to the identity provider to get OIDC UserInfo. You may wish to set this
@@ -82,6 +140,9 @@ The table below shows this endpoint's support for
 
   - `BoundAudiences` `(array<string>)` - List of aud claims that are valid for
     login; any match is sufficient.
+
+  - `BoundIssuer` `(array<string>)` - The value against which to match the iss
+    claim in a JWT.
 
   - `AllowedRedirectURIs` `(array<string>)` - A list of allowed values for
     redirect_uri. Must be non-empty.
@@ -246,9 +307,8 @@ queries](/nomad/api-docs#blocking-queries) and [required ACLs](/nomad/api-docs#a
 - `Default` `(bool: false)` - Defines whether this ACL auth method is to be
   set as default when running `nomad login` command.
 
-- `Config` `(ACLAuthMethodConfig: nil)` - The raw configuration to use for
-  the auth method. This parameter is part of the auth method configuration, not
-  specific to Nomad.
+- `Config` `(ACLAuthMethodConfig: <reqiured>)` - The raw configuration to use for
+  the auth method.
 
   - `OIDCDiscoveryURL` `(string: "")` - The OIDC discovery URL, without
     any .well-known component (base path).
@@ -259,6 +319,65 @@ queries](/nomad/api-docs#blocking-queries) and [required ACLs](/nomad/api-docs#a
   - `OIDCClientSecret` `(string: "")` - The OAuth client secret
     configured with your OIDC provider.
 
+  - `OIDCClientAssertion` `(OIDCClientAssertion)` - Optionally send a signed JWT
+    ("[private key jwt][]") as a client assertion to the OIDC provider.
+    Browse to the [OIDC concepts][concepts-assertions] page to learn more.
+
+    - `Audience` `(array<string>)` - Who will be processing the assertion.
+      Defaults to the parent `ACLAuthMethodConfig`'s `OIDCDiscoveryURL`
+
+    - `KeySource` `(string: <required>)` - Specifies where to get the private
+      key to sign the JWT.
+      Available sources:
+        - "nomad": Use current active key in Nomad's keyring
+        - "private_key": Use key material in the `PrivateKey` field
+        - "client_secret": Use the `OIDCClientSecret` inherited from the parent
+          `ACLAuthMethodConfig` as an HMAC key
+
+    - `KeyAlgorithm` `(string)` is the key's algorithm. Its default values are
+      based on the `KeySource`:
+        - "nomad": "RS256" (from Nomad's keyring, must not be changed)
+        - "private_key": "RS256" (must be RS256, RS384, or RS512)
+        - "client_secret": "HS256" (must be HS256, HS384, or HS512)
+
+    - `PrivateKey` `(OIDCClientAssertionKey)` - External key material to sign
+      the JWT. `KeySource` must be "private_key" to enable this.
+
+      - `PemKey` `(string)` - An RSA private key, in pem format. It is used to
+        sign the JWT. Mutually exclusive with `PemKeyFile`.
+
+      - `PemKeyFile` `(string)` - An absolute path to a private key on Nomad
+        servers' disk, in pem format. It is used to sign the JWT.
+        Mutually exclusive with `PemKey`.
+
+      - `KeyIDHeader` `(string)` - Which header the provider will use to find
+        the public key to verify the signed JWT.
+        Allowed values are: "kid", "x5t", or "x5t#S256".
+        The default depends on which of the following options is set.
+
+      - `KeyID` `(string)` - Becomes the JWT's "kid" header.
+        Mutually exclusive with `PemCert` and `PemCertFile`.
+        Allowed `KeyIDHeader` values: "kid" (the default)
+
+      - `PemCert` `(string)` - An x509 certificate, signed by the private key
+        or a CA, in pem format. It is used to derive an [x5t#S256][]
+        (or [x5t][]) KeyID.
+        Mutually exclusive with `PemCertFile` and `KeyID`.
+        Allowed `KeyIDHeader` values: "x5t", "x5t#S256" (default "x5t#S256")
+
+      - `PemCertFile` `(string)` - An absolute path to an x509 certificate on
+        Nomad servers' disk, signed by the private key or a CA, in pem format.
+        It is used to derive an [x5t#S256][] (or [x5t][]) KeyID.
+        Mutually exclusive with `PemCert` and KeyID.
+        Allowed `KeyIDHeader` values: "x5t", "x5t#S256" (default "x5t#S256")
+
+    - `ExtraHeaders` `(map[string]string)` - Added to the JWT headers,
+      alongside "kid" and "type". Setting the "kid" header here is not allowed;
+      use `PrivateKey.KeyID`.
+
+  - `OIDCDisablePKCE` `(bool: false)` - When set to `true`, Nomad will not
+    include [PKCE][] verification in the auth flow.
+
   - `OIDCDisableUserInfo` `(bool: false)` - When set to `true`, Nomad will not make
     a request to the identity provider to get OIDC UserInfo. You may wish to set this
     if your identity provider doesn't send any additional claims from the UserInfo
@@ -268,6 +387,9 @@ queries](/nomad/api-docs#blocking-queries) and [required ACLs](/nomad/api-docs#a
 
   - `BoundAudiences` `(array<string>)` - List of aud claims that are valid for
     login; any match is sufficient.
+
+  - `BoundIssuer` `(array<string>)` - The value against which to match the iss
+    claim in a JWT.
 
   - `AllowedRedirectURIs` `(array<string>)` - A list of allowed values for
     redirect_uri. Must be non-empty.
@@ -512,3 +634,9 @@ $ curl \
     --header "X-Nomad-Token: <NOMAD_TOKEN_SECRET_ID>" \
     https://localhost:4646/v1/acl/auth-method/example-acl-auth-method
 ```
+
+[private key jwt]: https://oauth.net/private-key-jwt/
+[concepts-assertions]: /nomad/docs/concepts/acl/auth-methods/oidc#client-assertions
+[x5t]: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.7
+[x5t#S256]: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.8
+[pkce]: https://oauth.net/2/pkce/

--- a/website/content/docs/commands/acl/auth-method/create.mdx
+++ b/website/content/docs/commands/acl/auth-method/create.mdx
@@ -103,4 +103,27 @@ Example config file:
 }
 ```
 
+Example config with private key JWT [client assertion][]
+instead of a client secret:
+
+```json
+{
+  "OIDCDiscoveryURL": "https://my-keycloak-instance.com/realms/nomad",
+  "OIDCClientID": "my-great-client-id",
+  "OIDCClientAssertion": {
+    "KeySource": "nomad"
+  },
+  "BoundAudiences": [
+    "my-great-client-id"
+  ],
+  "AllowedRedirectURIs": [
+    "http://localhost:4646/oidc/callback"
+  ],
+  "ListClaimMappings": {
+    "groups": "groups"
+  }
+}
+```
+
 [configuration]: /nomad/api-docs/acl/auth-methods#config
+[client assertion]: /nomad/api-docs/acl/auth-methods#oidcclientassertion

--- a/website/content/docs/concepts/acl/auth-methods/oidc.mdx
+++ b/website/content/docs/concepts/acl/auth-methods/oidc.mdx
@@ -74,6 +74,107 @@ Complete the login via your OIDC provider. Launching browser to:
 Your browser opens to the generated URL to complete the provider's login.
 Enter the URL manually if the browser does not automatically open.
 
+### Client assertions
+
+Also known as "[private key JWT][]", client assertions offer a more secure
+authentication mechanism compared to client secrets. The OIDC client (in this
+case, Nomad) signs a JWT with an RSA private key (or HMAC key) that the OIDC
+provider verifies with an associated public key (or the same HMAC key).
+
+Here are some partial [auth method configuration][] examples. They focus only
+on the client assertion feature; they are not complete, functional examples.
+
+#### Nomad keyring
+
+```json
+{
+  "OIDCDiscoveryURL": "https://your-keycloak-instance.com/realms/nomad",
+  "OIDCClientID": "{your-client-id}",
+  "BoundAudiences": ["{your-client-id}"],
+  "OIDCClientAssertion": {
+    "Audience": ["https://your-keycloak-instance.com/realms/nomad"],
+    "KeySource": "nomad"
+  }
+}
+```
+
+In this example for Keycloak, Nomad signs the JWT with its own internal private
+key. It sets the JWT's "kid" header as the key ID, as presented by Nomad's
+[jwks.json][] endpoint.
+
+This is arguably the most secure option, because only Nomad has the private key.
+
+Notice the distinction between the two "audience" fields:
+* `BoundAudiences` is often the application client ID (Nomad being the client),
+  which Nomad will verify against what the OIDC provider sends to Nomad. Nomad
+  uses this to make sure that requests are for Nomad, and not some other client.
+  This applies to all OIDC configuration, not only client assertions.
+* `OIDCClientAssertion.Audience` is the OIDC provider, because that is the
+  target audience of the client assertion JWT. The provider uses this to make
+  sure that requests are for it and not some other provider. This is often the
+  same as the `OIDCDiscoveryURL`, so defaults to that.
+
+This option requires that the OIDC provider have network access to Nomad's JWKS,
+either directly or via proxy, but otherwise requires no extra management of key
+material beyond Nomad's built-in [keyring][key-management].
+
+#### User provided key
+
+```json
+{
+  "OIDCDiscoveryURL": "https://login.microsoftonline.com/{tenant}/v2.0",
+  "OIDCClientID": "{app-client-id}",
+  "BoundAudiences": ["{app-client-id}"],
+  "OIDCClientAssertion": {
+    "KeySource": "private_key",
+    "KeyAlgorithm": "RS256",
+    "PrivateKey": {
+      "PemKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...the-rest-of-the-key...uJ8fR\n-----END RSA PRIVATE KEY-----",
+      "PemCert": "-----BEGIN CERTIFICATE-----\nMIID...the-rest-of-the-cert...GUCk=\n-----END CERTIFICATE-----"
+    }
+  }
+}
+```
+
+In this example for Microsoft Entra ID (formerly Azure Active Directory),
+we use a private RSA key that we generated separate from Nomad to sign the JWT.
+We also provide an x509 certificate created from the key (or a CA), which Nomad
+uses to derive an [x5t#S256][] thumbprint header. The certificate also must be
+uploaded to the Entra ID app, so that when you try to log in, Entra ID can use
+the "x5t#S256" header to look up the public key that it has stored.
+
+The key and/or certificate may also be configured as filenames on disk on Nomad
+servers with the `PemKeyFile` and `PemCertFile` options, respectively. These
+allow you to rotate your key/cert without needing to update the auth method,
+but they must be present on the disk of any server that may become Nomad leader.
+
+Or, the `KeyID` may be provided directly, instead of a certificate, depending on
+your OIDC provider's requirements.
+
+This allows you to bring your own RSA key for OIDC providers that do not
+support JWKS, network topologies that do not allow connectivity between the
+provider and Nomad JWKS, or if you want a signing key that is specifically
+and only for this purpose.
+
+#### Client secret HMAC
+
+```json
+{
+  "OIDCDiscoveryURL": "https://your-oidc-provider.com/oidc-discovery-url",
+  "OIDCClientID": "your-client-id",
+  "OIDCClientSecret": "long-secret-id-has-to-be-at-least-32-bytes",
+  "OIDCClientAssertion": {
+    "KeySource": "client_secret"
+  }
+}
+```
+
+This example uses the `OIDCClientSecret` as an HMAC key to sign the JWT.
+This is marginally more secure than a bare client secret, as the JWT is
+time-bound, and signed by the secret, rather than sending the secret itself
+over the network. As with a normal client secret, both Nomad and the OIDC
+provider need to have the same secret.
+
 ## OIDC Configuration Troubleshooting
 
 The amount of configuration required for OIDC is relatively small, but it can
@@ -110,8 +211,19 @@ port numbers, and whether trailing slashes are present.
   what you expect. Since claims data is logged verbatim and may contain
   sensitive information, do not use this option in production.
 
+- For client assertions, if `VerboseLogging` is enabled, then the Nomad leader
+  server will log a JWT when the auth method is created, and when someone makes
+  a login attempt. These JWTs are not 100% identical to what gets sent to the
+  OIDC provider (due to being time-bounded), but you can check the JWT headers
+  and claims to compare with your OIDC provider's requirements.
+
 @include 'jwt_claim_mapping_details.mdx'
 
 [ACL Overview]: /nomad/docs/concepts/acl
 [auth-method create]: /nomad/docs/commands/acl/auth-method/create
+[private key jwt]: https://oauth.net/private-key-jwt/
+[auth method configuration]: /nomad/api-docs/acl/auth-methods
+[key-management]: /nomad/docs/operations/key-management
+[x5t#S256]: https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.8
+[jwks.json]: /nomad/api-docs/operator/keyring#list-active-public-keys
 [VerboseLogging]: /nomad/api-docs/acl/auth-methods#verboselogging

--- a/website/content/docs/operations/key-management.mdx
+++ b/website/content/docs/operations/key-management.mdx
@@ -6,9 +6,10 @@ description: Learn about the key management in Nomad.
 
 # Key Management
 
-Nomad servers maintain an encryption keyring used to encrypt [Variables][] and
-sign task [workload identities][]. The servers encrypt these data encryption
-keys (DEK) and store the wrapped keys in Raft.
+Nomad servers maintain an encryption keyring used to encrypt [Variables][],
+sign task [workload identities][], and sign OIDC [client assertion JWTs][].
+The servers encrypt these data encryption keys (DEK) and store the wrapped keys
+in Raft.
 
 The key encryption key (KEK) used to encrypt the DEK is controlled by the
 [`keyring`][] provider. When using an external KMS or Vault transit encryption
@@ -89,6 +90,7 @@ keyring rotate`][] once the servers have joined.
 
 [variables]: /nomad/docs/concepts/variables
 [workload identities]: /nomad/docs/concepts/workload-identity
+[client assertion JWTs]: /nomad/docs/concepts/acl/auth-methods/oidc#client-assertions
 [data directory]: /nomad/docs/configuration#data_dir
 [`keyring`]: /nomad/docs/configuration/keyring
 [`nomad operator root keyring rotate -full`]: /nomad/docs/commands/operator/root/keyring-rotate

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -87,6 +87,12 @@ Nomad no longer creates an implicit Consul identity for workloads that don't
 register services with Consul. Tasks that require Consul tokens for template
 rendering must include a [`consul` block][] or specify an [`identity`][].
 
+#### OIDC login with PKCE
+Nomad now enables [PKCE](https://oauth.net/2/pkce/) by default for new or
+updated auth methods. The
+[`OIDCDisablePKCE`](/nomad/api-docs/acl/auth-methods#oidcdisablepkce)
+option may be set to turn off this extra security.
+
 ## Nomad 1.9.5
 
 #### CNI plugins


### PR DESCRIPTION
Documentation for #25231 

* Changed some go doc comments to be an easier copy/paste into mdx
* Updated api-docs, auth-method create cli, concepts
* Called out default-enabled PKCE in upgrade guide
* Add config for BoundIssuer, which was missing from api-docs

Also made some light functional changes that I hit along the way.
* Do not send client secret normally, if it's being used as a client assertion HMAC
* Only run new validation on "OIDC" auth method types, not "JWT"