### PR TITLE
rpc: copy all objects sent with inmem codec

### DIFF
--- a/client/acl_test.go
+++ b/client/acl_test.go
@@ -112,9 +112,7 @@ func TestClient_ACL_resolvePolicies(t *testing.T) {
 	test.Len(t, 2, out2)
 
 	// Check we get the same objects back (ignore ordering)
-	if out[0] != out2[0] && out[0] != out2[1] {
-		t.Fatalf("bad caching")
-	}
+	must.SliceContainsAll(t, out, out2)
 }
 
 func TestClient_resolveTokenACLRoles(t *testing.T) {

--- a/helper/codec/inmem.go
+++ b/helper/codec/inmem.go
@@ -5,8 +5,11 @@ package codec
 
 import (
 	"errors"
+	"fmt"
 	"net/rpc"
 	"reflect"
+
+	"github.com/mitchellh/copystructure"
 )
 
 // InmemCodec is used to do an RPC call without going over a network
@@ -26,7 +29,14 @@ func (i *InmemCodec) ReadRequestBody(args interface{}) error {
 	if args == nil {
 		return nil
 	}
-	sourceValue := reflect.Indirect(reflect.Indirect(reflect.ValueOf(i.Args)))
+
+	// Copy on read to avoid sharing pointers between callers and handlers
+	origArgs, err := copystructure.Copy(i.Args)
+	if err != nil {
+		return fmt.Errorf("error copying arguments to %s rpc: %w", i.Method, err)
+	}
+
+	sourceValue := reflect.Indirect(reflect.Indirect(reflect.ValueOf(origArgs)))
 	dst := reflect.Indirect(reflect.Indirect(reflect.ValueOf(args)))
 	dst.Set(sourceValue)
 	return nil
@@ -37,7 +47,13 @@ func (i *InmemCodec) WriteResponse(resp *rpc.Response, reply interface{}) error 
 		i.Err = errors.New(resp.Error)
 		return nil
 	}
-	sourceValue := reflect.Indirect(reflect.Indirect(reflect.ValueOf(reply)))
+
+	// Copy on write to avoid sharing pointers between callers and handlers
+	replyCopy, err := copystructure.Copy(reply)
+	if err != nil {
+		return fmt.Errorf("error copying reply from %s rpc: %w", i.Method, err)
+	}
+	sourceValue := reflect.Indirect(reflect.Indirect(reflect.ValueOf(replyCopy)))
 	dst := reflect.Indirect(reflect.Indirect(reflect.ValueOf(i.Reply)))
 	dst.Set(sourceValue)
 	return nil


### PR DESCRIPTION
### Description

This fixes data races in tests that use the InmemCodec. As there are cases where InmemCodec is used at runtime it's possible that this fixes "real" data races as well, but I can't find any evidence of that today.

A common source of data races in Nomad tests have been the use of the
InmemCodec. At runtime RPCs are made using a msgpack codec which
copies all objects during encoding and decoding. The InmemCodec does no
encoding or decoding and therefore shares pointers between callers and
RPC handlers. This makes it easy to cause data races in tests that
cannot occur at runtime.

This change uses copystructure to deep copy all objects sent through the
InmemCodec to mimic the behavior of runtime encoding/decoding.

While this creates more garbage and "wastes" CPU, this cost is mostly
incurred during testing, not runtime. This seems like a small price to
pay to make it easier to use Go's data race detector.

The alternative approach would be to carefully copy RPC arguments and replies before mutation.  Even if this approach were deemed more "correct", it incurs a higher runtime cost where we would be needlessly copying data that had just been decoded off the wire and therefore could never be shared and cause a race. Deep copying in InmemCodec allows most runtime RPCs to be simpler and more efficient by relying on the implicit "copying" done by msgpack.

### Testing & Reproduction steps
```
go test -race
```

Without this test the above in the `client` or `nomad` packages should fail.

### Links
Fixes at least one case in #12098

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
