### PR TITLE
[ui] Case-insensitive jobs list filtering

### DIFF
--- a/.changelog/25378.txt
+++ b/.changelog/25378.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: Makes jobs list filtering case-insensitive
+```

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -653,7 +653,7 @@ export default class JobsIndexController extends Controller {
       this.searchText = newFilter;
     } else {
       // If it's a string without a filter operator, assume the user is trying to look up a job name
-      this.searchText = `Name contains "${newFilter}"`;
+      this.searchText = `Name matches "(?i)${newFilter}"`;
     }
   }
 

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -231,6 +231,12 @@ export default function () {
                   job[condition.field] &&
                   job[condition.field].includes(condition.value)
                 );
+              } else if (condition.operator === 'matches') {
+                // strip the (?i) bit out of the value; used for case-insensitive matching
+                // but JS doesn't support PCRE-style regex modifiers the way our backend does,
+                // so strip 'em out here.
+                const value = condition.value.replace('(?i)', '');
+                return new RegExp(value, 'i').test(job[condition.field]);
               } else if (condition.operator === '==') {
                 return job[condition.field] === condition.value;
               } else if (condition.operator === '!=') {


### PR DESCRIPTION
Currently, when you search (filter) the jobs list page by typing in a single word, we use a shortcut to translate that to `Name contains "$query"`.

This is a nice sprinkling of sugar but it comes at the cost of being case sensitive.

This PR changes the "contains" to a "matches" and uses an inline regex modifier (which our go backend is kind enough to play nice with; see mirage/js implementation note below) to make it case insensitive

![image](https://github.com/user-attachments/assets/a42bca31-49b5-4583-9e4f-06ccf3d3be89)

The above image does have the somewhat unsightly URL of `/ui/jobs?filter=Name%20matches%20%22(%3Fi)Fail%22` but the `(%3Fi)` is hardly the most egregious part of that.

Resolves #25316 