### PR TITLE
update legacy Consul ACL doc to add a warning about Admin Partitions

### DIFF
--- a/website/content/docs/integrations/consul/acl.mdx
+++ b/website/content/docs/integrations/consul/acl.mdx
@@ -395,7 +395,7 @@ service_prefix "" {
 <Note title="Admin Partitions">
 
 This legacy workflow is not compatible with [Consul Admin
-Partitions](https://developer.hashicorp.com/consul/docs/enterprise/admin-partitions). If you
+Partitions](/consul/docs/enterprise/admin-partitions). If you
 are using Admin Partitions, you must use [Nomad Workload Identities](#nomad-workload-identities).
 
 </Note>

--- a/website/content/docs/integrations/consul/acl.mdx
+++ b/website/content/docs/integrations/consul/acl.mdx
@@ -392,9 +392,17 @@ service_prefix "" {
 }
 ```
 
+<Note title="Admin Partitions">
+
+This legacy workflow is not compatible with [Consul Admin
+Partitions](https://developer.hashicorp.com/consul/docs/enterprise/admin-partitions). If you
+are using Admin Partitions, you must use [Nomad Workload Identities](#nomad-workload-identities).
+
+</Note>
+
 <Note title="Deprecation Warning">
 
-This legacy workflow will be removed in Nomad 1.10. Before upgrading to Nomad 1.10,
+This legacy workflow was removed in Nomad 1.10. Before upgrading to Nomad 1.10,
 you need to configure authentication with Consul as described in
 [Nomad Workload Identities](#nomad-workload-identities).
 


### PR DESCRIPTION
### Description
Update the Consul ACL Docs, legacy (token) auth, to clarify that it doesn't support Consul Admin Partitions. While it was removed in 1.10, 1.8 and 1.9 are still supported so it's useful to have a clear warning about that in their versioned docs.

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
