### PR TITLE
dynamic host volumes: don't wait for fingerprint to reserve node

### DIFF
--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -550,9 +550,9 @@ func (v *HostVolume) placeHostVolume(snap *state.StateSnapshot, vol *structs.Hos
 
 		// note: this is a race if multiple users create volumes of the same
 		// name concurrently, but we can't completely solve it on the server
-		// because we haven't yet written to state. The client will reject
-		// requests to create/register a volume with the same name with a
-		// different ID.
+		// because we haven't yet written to state. The client single-threads
+		// requests by volume name, so will reject requests to create/register a
+		// volume with the same name but a different ID.
 		if snap.NodeHasHostVolume(candidate.ID, vol.Name) {
 			filteredByExisting++
 			continue

--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -549,10 +549,11 @@ func (v *HostVolume) placeHostVolume(snap *state.StateSnapshot, vol *structs.Hos
 		candidate := raw.(*structs.Node)
 
 		// note: this is a race if multiple users create volumes of the same
-		// name concurrently, but we can't solve it on the server because we
-		// haven't yet written to state. The client will reject requests to
-		// create/register a volume with the same name with a different ID.
-		if _, hasVol := candidate.HostVolumes[vol.Name]; hasVol {
+		// name concurrently, but we can't completely solve it on the server
+		// because we haven't yet written to state. The client will reject
+		// requests to create/register a volume with the same name with a
+		// different ID.
+		if snap.NodeHasHostVolume(candidate.ID, vol.Name) {
 			filteredByExisting++
 			continue
 		}

--- a/nomad/host_volume_endpoint_test.go
+++ b/nomad/host_volume_endpoint_test.go
@@ -697,6 +697,10 @@ func TestHostVolumeEndpoint_placeVolume(t *testing.T) {
 	must.NoError(t, store.UpsertNode(structs.MsgTypeTestSetup, 1000, node2))
 	must.NoError(t, store.UpsertNode(structs.MsgTypeTestSetup, 1000, node3))
 
+	vol := mock.HostVolume()
+	vol.NodeID = node3.ID
+	must.NoError(t, store.UpsertHostVolume(1000, vol))
+
 	testCases := []struct {
 		name      string
 		vol       *structs.HostVolume

--- a/nomad/state/state_store_host_volumes.go
+++ b/nomad/state/state_store_host_volumes.go
@@ -294,7 +294,7 @@ func upsertHostVolumeForNode(txn *txn, node *structs.Node, index uint64) error {
 func (s *StateStore) NodeHasHostVolume(nodeID, volName string) bool {
 	iter, err := s.HostVolumesByNodeID(nil, nodeID, SortDefault)
 	if err != nil {
-		return false
+		return true
 	}
 	for {
 		raw := iter.Next()

--- a/nomad/state/state_store_host_volumes.go
+++ b/nomad/state/state_store_host_volumes.go
@@ -290,3 +290,21 @@ func upsertHostVolumeForNode(txn *txn, node *structs.Node, index uint64) error {
 
 	return nil
 }
+
+func (s *StateStore) NodeHasHostVolume(nodeID, volName string) bool {
+	iter, err := s.HostVolumesByNodeID(nil, nodeID, SortDefault)
+	if err != nil {
+		return false
+	}
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		match := raw.(*structs.HostVolume)
+		if match.Name == volName {
+			return true
+		}
+	}
+	return false
+}

--- a/nomad/state/state_store_host_volumes_test.go
+++ b/nomad/state/state_store_host_volumes_test.go
@@ -234,12 +234,22 @@ func TestStateStore_UpdateHostVolumesFromFingerprint(t *testing.T) {
 	vols[3].Name = "dhv-two"
 	vols[3].NodeID = node.ID
 
+	must.False(t, store.NodeHasHostVolume(node.ID, "dhv-zero"))
+	must.False(t, store.NodeHasHostVolume(node.ID, "dhv-one"))
+	must.False(t, store.NodeHasHostVolume(node.ID, "dhv-two"))
+	must.False(t, store.NodeHasHostVolume(otherNode.ID, "dhv-one"))
+
 	index++
 	oldIndex := index
 	must.NoError(t, store.UpsertHostVolume(index, vols[0]))
 	must.NoError(t, store.UpsertHostVolume(index, vols[1]))
 	must.NoError(t, store.UpsertHostVolume(index, vols[2]))
 	must.NoError(t, store.UpsertHostVolume(index, vols[3]))
+
+	must.True(t, store.NodeHasHostVolume(node.ID, "dhv-zero"))
+	must.True(t, store.NodeHasHostVolume(node.ID, "dhv-one"))
+	must.True(t, store.NodeHasHostVolume(node.ID, "dhv-two"))
+	must.True(t, store.NodeHasHostVolume(otherNode.ID, "dhv-one"))
 
 	vol0, err := store.HostVolumeByID(nil, ns, vols[0].ID, false)
 	must.NoError(t, err)


### PR DESCRIPTION
If multiple dynamic host volumes are created in quick succession, it's possible for the server to attempt placement on a host where another volume has been placed but not yet fingerprinted as ready (which returns an error from the client). Once a `VolumeCreate` RPC returns a response, we've already invoked the plugin successfully and written to state, so we're just waiting on the fingerprint for scheduling purposes. Change the placement selection so that we skip a node if it has a volume, regardless of whether that volume is ready yet.
