### PR TITLE
Manual backport of update legacy Consul ACL doc to add a warning about Admin Partitions …

### DIFF
--- a/website/content/docs/integrations/consul/acl.mdx
+++ b/website/content/docs/integrations/consul/acl.mdx
@@ -392,9 +392,17 @@ service_prefix "" {
 }
 ```
 
+<Note title="Admin Partitions">
+
+This legacy workflow is not compatible with [Consul Admin
+Partitions](/consul/docs/enterprise/admin-partitions). If you
+are using Admin Partitions, you must use [Nomad Workload Identities](#nomad-workload-identities).
+
+</Note>
+
 <Note title="Deprecation Warning">
 
-This legacy workflow will be removed in Nomad 1.10. Before upgrading to Nomad 1.10,
+This legacy workflow was removed in Nomad 1.10. Before upgrading to Nomad 1.10,
 you need to configure authentication with Consul as described in
 [Nomad Workload Identities](#nomad-workload-identities).
 


### PR DESCRIPTION
…(#25384)

* update legacy Consul ACL doc to add a warning about Admin Partitions

* Update website/content/docs/integrations/consul/acl.mdx


Manual backport of https://github.com/hashicorp/nomad/pull/25384/ because that PR only merged to release/1.9.x, not `main`. Automated backport didn't work.

