### PR TITLE
Fix wording about delta priority needed to trigger preemption

### DIFF
--- a/website/content/docs/concepts/scheduling/preemption.mdx
+++ b/website/content/docs/concepts/scheduling/preemption.mdx
@@ -37,7 +37,7 @@ other job types.
 
 Nomad uses the [job priority](/nomad/docs/job-specification/job#priority) field to determine what running allocations can be preempted.
 In order to prevent a cascade of preemptions due to jobs close in priority being preempted, only allocations from jobs with a priority
-delta of more than 10 from the job needing placement are eligible for preemption.
+delta of 10 or greater compared to the job needing placement are eligible for preemption.
 
 For example, consider a node with the following distribution of allocations:
 


### PR DESCRIPTION
### Description
Hello 👋
Small fix about wording around delta priority needed to trigger preemption.

[Looking at the code ](https://github.com/hashicorp/nomad/blob/88ff5a7cae67152e4e6745100bff41af2efc05f6/scheduler/preemption.go#L339) delta priority needs to be greater or equal to 10 and not strictly greater.
