### PR TITLE
agent: Improve retry joiner code with small refactor.

### DIFF
--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -910,13 +910,8 @@ func (c *Command) handleRetryJoin(config *Config) error {
 	c.retryJoinErrCh = make(chan struct{})
 
 	if config.Server.Enabled && len(config.Server.RetryJoin) != 0 {
-		joiner := retryJoiner{
-			autoDiscover:  autoDiscover{goDiscover: &discover.Discover{}, netAddrs: &netAddrs{}},
-			errCh:         c.retryJoinErrCh,
-			logger:        c.agent.logger.Named("joiner"),
-			serverJoin:    c.agent.server.Join,
-			serverEnabled: true,
-		}
+
+		joiner := retryJoiner{}
 
 		if err := joiner.Validate(config); err != nil {
 			return err
@@ -944,36 +939,36 @@ func (c *Command) handleRetryJoin(config *Config) error {
 		len(config.Server.ServerJoin.RetryJoin) != 0 {
 
 		joiner := retryJoiner{
-			autoDiscover:  autoDiscover{goDiscover: &discover.Discover{}, netAddrs: &netAddrs{}},
-			errCh:         c.retryJoinErrCh,
-			logger:        c.agent.logger.Named("joiner"),
-			serverJoin:    c.agent.server.Join,
-			serverEnabled: true,
+			autoDiscover: autoDiscover{goDiscover: &discover.Discover{}, netAddrs: &netAddrs{}},
+			errCh:        c.retryJoinErrCh,
+			joinCfg:      config.Server.ServerJoin,
+			joinFunc:     c.agent.server.Join,
+			logger:       c.agent.logger.Named("joiner").With("agent_mode", "server"),
 		}
 
 		if err := joiner.Validate(config); err != nil {
 			return err
 		}
 
-		go joiner.RetryJoin(config.Server.ServerJoin)
+		go joiner.RetryJoin()
 	}
 
 	if config.Client.Enabled &&
 		config.Client.ServerJoin != nil &&
 		len(config.Client.ServerJoin.RetryJoin) != 0 {
 		joiner := retryJoiner{
-			autoDiscover:  autoDiscover{goDiscover: &discover.Discover{}, netAddrs: &netAddrs{}},
-			errCh:         c.retryJoinErrCh,
-			logger:        c.agent.logger.Named("joiner"),
-			clientJoin:    c.agent.client.SetServers,
-			clientEnabled: true,
+			autoDiscover: autoDiscover{goDiscover: &discover.Discover{}, netAddrs: &netAddrs{}},
+			errCh:        c.retryJoinErrCh,
+			joinCfg:      config.Client.ServerJoin,
+			joinFunc:     c.agent.client.SetServers,
+			logger:       c.agent.logger.Named("joiner").With("agent_mode", "client"),
 		}
 
 		if err := joiner.Validate(config); err != nil {
 			return err
 		}
 
-		go joiner.RetryJoin(config.Client.ServerJoin)
+		go joiner.RetryJoin()
 	}
 
 	return nil


### PR DESCRIPTION
The agent retry joiner implementation had different parameters to control its execution for agents running in server and client mode. The agent would set up individual joiners depending on the agent mode, making the object parameter overhead un-required.

This change removes the excess configuration options for the joiner, reducing code complexity slightly and hopefully making future modifications in this area easier to make.

Notes:
- no user facing changes, so PR doesn't require a changelog entry
- should backport to make future work and backports easier

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
