### PR TITLE
[ci/cd] Moves our default github action flows to use Node v20

### DIFF
--- a/.github/actions/setup-js/action.yml
+++ b/.github/actions/setup-js/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: 'node version'
     # https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md
     # package.json has ember-cli at version ~3.28.5 currently
-    default: '18'
+    default: '20'
 runs:
   using: composite
   steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Setup node and yarn
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: "18"
+          node-version: "20"
           cache-dependency-path: "ui/yarn.lock"
 
       - name: Install Yarn
@@ -152,7 +152,7 @@ jobs:
       - name: Setup node and yarn
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: "18"
+          node-version: "20"
           cache-dependency-path: "ui/yarn.lock"
 
       - name: Install Yarn
@@ -277,7 +277,7 @@ jobs:
       - name: Setup node and yarn
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: "18"
+          node-version: "20"
           cache-dependency-path: "ui/yarn.lock"
 
       - name: Install Yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Setup node and yarn
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
-          node-version: "18"
+          node-version: "20"
           cache-dependency-path: "ui/yarn.lock"
 
       - name: Install Yarn

--- a/ui/app/index.html
+++ b/ui/app/index.html
@@ -24,7 +24,6 @@
     {{content-for "body"}}
 
     <script src="{{rootURL}}assets/vendor.js"></script>
-
     <script src="{{rootURL}}assets/nomad-ui.js"></script>
 
     {{content-for "body-footer"}}


### PR DESCRIPTION
A note:
- Node v20 will be under [maintenance LTS mode until May 2026](https://nodejs.org/en/about/previous-releases), at which point it will fall out of support
- Node v22 is out and preferable, but comes with a few necessary internal upgrades. Notably:
  - An upgrade to Ember Data, which requires
    - A move away from Ember Data Model Fragments, which are used extensively throughout our codebase
    - Some node-sass related changes
    - Surely some other esm-related things

We have not prioritized these upgrades because the cost has seemed greater than the payoff. This might change under end-of-life node version scenarios next year, but the development cost is non-trivial.