### PR TITLE
docs: add note about Consul Enterprise role bindings

### DIFF
--- a/website/content/docs/integrations/consul/acl.mdx
+++ b/website/content/docs/integrations/consul/acl.mdx
@@ -285,6 +285,12 @@ Similarly to binding rules, namespace rules have a [`Selector`][] expression to
 determine when the rule should be applied and a [`BindNamespace`][] value that
 defines the namespace used.
 
+Auth methods with a namespace rule create Consul tokens in that Consul
+namespace. Binding rules with `-bind-type role` will also target a role (and
+associated policies) in that same Consul namespace. So you should create the
+auth method and binding rules in the default namespace, and the role and
+policies in the target namespaces.
+
 In Nomad Enterprise, workload identities for tasks and services placed within
 the scope of a `consul` block with a `namespace` value, have an additional
 claim called `consul_namespace` that represents the Consul namespace defined


### PR DESCRIPTION
When configuring Consul to use Nomad workload identities, you create the Consul auth method in the default namespace. If you're using Consul Enterprise namespaces, there are two available approaches: one is to create the tokens in the default namespace and give them policies that define cross-namespace access, and the other is to use binding rules that map the login to a particular namespace. The latter is what we show in our docs, but this was missing a note that any roles (and their associated policies) targetted by `-bind-type role` need to exist in the Consul namespace we're logging into.
