### PR TITLE
docs: clarify Consul namespace default for Nomad CE

### DIFF
--- a/website/content/docs/configuration/consul.mdx
+++ b/website/content/docs/configuration/consul.mdx
@@ -108,7 +108,8 @@ agents.
   namespace](/consul/docs/enterprise/namespaces) used by the Consul
   integration. If non-empty, this namespace will be used on all Consul API calls
   and for Consul Connect configurations, unless overridden by the job's
-  [`consul.namespace`][] field.
+  [`consul.namespace`][] field. In Nomad Community Edition, only the `"default"`
+  namespace will be used, so this field should be omitted.
 
 - `ssl` `(bool: false)` - Specifies if the transport scheme should use HTTPS to
   communicate with the Consul agent. Will default to the `CONSUL_HTTP_SSL`

--- a/website/content/docs/job-specification/consul.mdx
+++ b/website/content/docs/job-specification/consul.mdx
@@ -96,7 +96,8 @@ The [`template`][template] block can use the Consul token as well.
   which group and task-level services within the group will be registered. Use
   of `template` to access Consul KV will read from the specified Consul
   namespace.  Specifying `namespace` takes precedence over the
-  [`-consul-namespace`][flag_consul_namespace] command line argument in `job run`.
+  [`-consul-namespace`][flag_consul_namespace] command line argument in `job
+  run`. In Nomad Community Edition, this field is ignored.
 
 - `partition` `(string: "")` - When this field is set, a constraint will be
   added to the group or task to ensure that the allocation is placed on a Nomad


### PR DESCRIPTION
In Nomad CE, the `consul.namespace` flag is always treated as having been set to `"default"`. That is, we ignore it and don't return an error even though it's a Nomad ENT-only feature. Clarify this in the documentation for the field the same way we've done for the `cluster` field.
