### PR TITLE
CSI: prevent loop in volumewatcher when node is GC'd

### DIFF
--- a/.changelog/25428.txt
+++ b/.changelog/25428.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where cleaning up volume claims on GC'd nodes would cause errors on the leader
+```

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -537,7 +537,7 @@ func (v *CSIVolume) controllerPublishVolume(req *structs.CSIVolumeClaimRequest, 
 		return err
 	}
 	if targetNode == nil {
-		return fmt.Errorf("%s: %s", structs.ErrUnknownNodePrefix, alloc.NodeID)
+		return fmt.Errorf("%w %s", structs.ErrUnknownNode, alloc.NodeID)
 	}
 
 	// if the RPC is sent by a client node, it may not know the claim's
@@ -925,6 +925,14 @@ func (v *CSIVolume) controllerUnpublishVolume(vol *structs.CSIVolume, claim *str
 	if claim.ExternalNodeID == "" {
 		externalNodeID, err := v.lookupExternalNodeID(vol, claim)
 		if err != nil {
+			// if the node has been GC'd, there's no path for us to ever send
+			// the controller detach, so assume the node is gone
+			if errors.Is(err, structs.ErrUnknownNode) {
+				v.logger.Trace("controller detach skipped for missing node", "vol", vol.ID)
+				claim.State = structs.CSIVolumeClaimStateReadyToFree
+				return v.checkpointClaim(vol, claim)
+			}
+
 			return fmt.Errorf("missing external node ID: %v", err)
 		}
 		claim.ExternalNodeID = externalNodeID
@@ -978,7 +986,7 @@ func (v *CSIVolume) lookupExternalNodeID(vol *structs.CSIVolume, claim *structs.
 		return "", err
 	}
 	if targetNode == nil {
-		return "", fmt.Errorf("%s: %s", structs.ErrUnknownNodePrefix, claim.NodeID)
+		return "", fmt.Errorf("%w %s", structs.ErrUnknownNode, claim.NodeID)
 	}
 
 	// get the storage provider's ID for the client node (not

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -615,20 +615,23 @@ func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {
 		endState       structs.CSIVolumeClaimState
 		nodeID         string
 		otherNodeID    string
+		externalNodeID string
 		expectedErrMsg string
 	}
 	testCases := []tc{
 		{
-			name:          "success",
-			startingState: structs.CSIVolumeClaimStateControllerDetached,
-			nodeID:        node.ID,
-			otherNodeID:   uuid.Generate(),
+			name:           "success",
+			startingState:  structs.CSIVolumeClaimStateControllerDetached,
+			nodeID:         node.ID,
+			otherNodeID:    uuid.Generate(),
+			externalNodeID: "i-example",
 		},
 		{
-			name:          "non-terminal allocation on same node",
-			startingState: structs.CSIVolumeClaimStateNodeDetached,
-			nodeID:        node.ID,
-			otherNodeID:   node.ID,
+			name:           "non-terminal allocation on same node",
+			startingState:  structs.CSIVolumeClaimStateNodeDetached,
+			nodeID:         node.ID,
+			otherNodeID:    node.ID,
+			externalNodeID: "i-example",
 		},
 		{
 			name:           "unpublish previously detached node",
@@ -637,6 +640,7 @@ func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {
 			expectedErrMsg: "could not detach from controller: controller detach volume: No path to node",
 			nodeID:         node.ID,
 			otherNodeID:    uuid.Generate(),
+			externalNodeID: "i-example",
 		},
 		{
 			name:           "unpublish claim on garbage collected node",
@@ -645,6 +649,15 @@ func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {
 			expectedErrMsg: "could not detach from controller: controller detach volume: No path to node",
 			nodeID:         uuid.Generate(),
 			otherNodeID:    uuid.Generate(),
+			externalNodeID: "i-example",
+		},
+		{
+			name:           "unpublish claim on garbage collected node missing external ID",
+			startingState:  structs.CSIVolumeClaimStateTaken,
+			endState:       structs.CSIVolumeClaimStateNodeDetached,
+			nodeID:         uuid.Generate(),
+			otherNodeID:    uuid.Generate(),
+			externalNodeID: "",
 		},
 		{
 			name:           "first unpublish",
@@ -653,6 +666,7 @@ func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {
 			expectedErrMsg: "could not detach from controller: controller detach volume: No path to node",
 			nodeID:         node.ID,
 			otherNodeID:    uuid.Generate(),
+			externalNodeID: "i-example",
 		},
 	}
 
@@ -693,7 +707,7 @@ func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {
 			claim := &structs.CSIVolumeClaim{
 				AllocationID:   alloc.ID,
 				NodeID:         tc.nodeID,
-				ExternalNodeID: "i-example",
+				ExternalNodeID: tc.externalNodeID,
 				Mode:           structs.CSIVolumeClaimRead,
 			}
 
@@ -708,7 +722,7 @@ func TestCSIVolumeEndpoint_Unpublish(t *testing.T) {
 			otherClaim := &structs.CSIVolumeClaim{
 				AllocationID:   otherAlloc.ID,
 				NodeID:         tc.otherNodeID,
-				ExternalNodeID: "i-example",
+				ExternalNodeID: tc.externalNodeID,
 				Mode:           structs.CSIVolumeClaimRead,
 			}
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -3021,6 +3021,7 @@ func (s *StateStore) csiVolumeDenormalizeTxn(txn Txn, ws memdb.WatchSet, vol *st
 				// so create one now
 				pastClaim = &structs.CSIVolumeClaim{
 					AllocationID:   id,
+					ExternalNodeID: currentClaim.ExternalNodeID,
 					NodeID:         currentClaim.NodeID,
 					Mode:           currentClaim.Mode,
 					State:          structs.CSIVolumeClaimStateUnpublishing,


### PR DESCRIPTION
If a CSI volume is has terminal allocations, the volumewatcher will submit an `Unpublish` RPC. But the "past claim" we create is missing the "external" node identifier (ex. the AWS EC2 instance ID). The unpublish RPC can tolerate this if the node still exists in the state store, but if the node has been GC'd the controller unpublish step will return an error. But at this point we've already checkpointed the unpublish workflow, which triggers a notification on the volumewatcher. This results in the volumewatcher getting into a tight loop of retries. Unfortunately even if we somehow break the loop (perhaps because we hit a different code path), we'll kick off this loop again after a leader election when we spin up the volumewatchers again.

This changeset includes the following:
* Fix the primary bug by including the external node ID when creating a "past claim" for a terminal allocation.
* If we can't lookup the external ID because there's no external node ID and the node no longer exists, abandon it in the same way that we do the node unpublish step.
* Rate limit the volumewatcher loop so that any future bugs of this type don't cause a tight loop.
* Remove some dead code found while working on this.

Fixes: https://github.com/hashicorp/nomad/issues/25349
Ref: https://hashicorp.atlassian.net/browse/NET-12298

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
  - unit test updates + manually tested with the NFS demo workload
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
