### PR TITLE
fix URL for periodic jobs

### DIFF
--- a/website/content/docs/operations/metrics-reference.mdx
+++ b/website/content/docs/operations/metrics-reference.mdx
@@ -137,7 +137,7 @@ Please see the [agent configuration](/nomad/docs/configuration/telemetry)
 page for more details.
 
 Additional labels are emitted for [parameterized](/nomad/docs/job-specification/parameterized) and
-[periodic](/nomad/docs/job-specification/parameterized) jobs. Nomad
+[periodic](/nomad/docs/job-specification/periodic) jobs. Nomad
 emits the parent job id as a new label `parent_id`. Also, the labels `dispatch_id`
 and `periodic_id` are emitted, containing the ID of the specific invocation of the
 parameterized or periodic job respectively. For example, a dispatch job with the id


### PR DESCRIPTION
fix URL for periodic jobs

### Description
The original seems like a copy-pasta bug. Same url was being shown for `parameterized` and `periodic` jobs.

### Testing & Reproduction steps
N/A

### Links
N/A
