### PR TITLE
server: Validate config num schedulers is between 0 and num CPUs.

### DIFF
--- a/.changelog/25441.txt
+++ b/.changelog/25441.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+server: Validate `num_schedulers` configuration parameter is between 0 and the number of CPUs available on the machine
+```

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -616,6 +616,15 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 
 	conf.KEKProviderConfigs = agentConfig.KEKProviders
 
+	// Ensure the passed number of scheduler is between the bounds of zero and
+	// the number of CPU cores on the machine. The runtime CPU count object is
+	// populated at process start time, so there is no overhead in calling the
+	// function compared to saving the value.
+	if conf.NumSchedulers < 0 || conf.NumSchedulers > runtime.NumCPU() {
+		return nil, fmt.Errorf("number of schedulers should be between 0 and %d",
+			runtime.NumCPU())
+	}
+
 	return conf, nil
 }
 

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -1702,6 +1703,14 @@ type schedulerWorkerConfigTest_testExpect struct {
 // These test cases are run for both the ACL and Non-ACL enabled servers. When
 // ACLS are not enabled, the request.aclTokens are ignored.
 func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequestTest {
+
+	numCPU := runtime.NumCPU()
+
+	halfCPU := numCPU / 2
+	if halfCPU == 0 {
+		halfCPU = 1
+	}
+
 	forbidden := schedulerWorkerConfigTest_testExpect{
 		expectedResponseCode: http.StatusForbidden,
 		expectedResponse:     structs.ErrPermissionDenied.Error(),
@@ -1716,12 +1725,11 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 	}
 	success1 := schedulerWorkerConfigTest_testExpect{
 		expectedResponseCode: http.StatusOK,
-		expectedResponse:     &api.AgentSchedulerWorkerConfigResponse{EnabledSchedulers: []string{"_core", "batch"}, NumSchedulers: 8},
+		expectedResponse:     &api.AgentSchedulerWorkerConfigResponse{EnabledSchedulers: []string{"_core", "batch"}, NumSchedulers: numCPU},
 	}
-
 	success2 := schedulerWorkerConfigTest_testExpect{
 		expectedResponseCode: http.StatusOK,
-		expectedResponse:     &api.AgentSchedulerWorkerConfigResponse{EnabledSchedulers: []string{"_core", "batch"}, NumSchedulers: 9},
+		expectedResponse:     &api.AgentSchedulerWorkerConfigResponse{EnabledSchedulers: []string{"_core", "batch"}, NumSchedulers: halfCPU},
 	}
 
 	return []scheduleWorkerConfigTest_workerRequestTest{
@@ -1780,7 +1788,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 			request: schedulerWorkerConfigTest_testRequest{
 				verb:        http.MethodPost,
 				aclToken:    "",
-				requestBody: `{"num_schedulers":9,"enabled_schedulers":["_core", "batch"]}`,
+				requestBody: fmt.Sprintf(`{"num_schedulers":%d,"enabled_schedulers":["_core", "batch"]}`, halfCPU),
 			},
 			whenACLNotEnabled: success2,
 			whenACLEnabled:    forbidden,
@@ -1790,7 +1798,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 			request: schedulerWorkerConfigTest_testRequest{
 				verb:        http.MethodPut,
 				aclToken:    "",
-				requestBody: `{"num_schedulers":8,"enabled_schedulers":["_core", "batch"]}`,
+				requestBody: fmt.Sprintf(`{"num_schedulers":%d,"enabled_schedulers":["_core", "batch"]}`, numCPU),
 			},
 			whenACLNotEnabled: success1,
 			whenACLEnabled:    forbidden,
@@ -1800,7 +1808,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 			request: schedulerWorkerConfigTest_testRequest{
 				verb:        http.MethodPost,
 				aclToken:    "node_write",
-				requestBody: `{"num_schedulers":9,"enabled_schedulers":["_core", "batch"]}`,
+				requestBody: fmt.Sprintf(`{"num_schedulers":%d,"enabled_schedulers":["_core", "batch"]}`, halfCPU),
 			},
 			whenACLNotEnabled: success2,
 			whenACLEnabled:    forbidden,
@@ -1810,7 +1818,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 			request: schedulerWorkerConfigTest_testRequest{
 				verb:        http.MethodPut,
 				aclToken:    "node_write",
-				requestBody: `{"num_schedulers":8,"enabled_schedulers":["_core", "batch"]}`,
+				requestBody: fmt.Sprintf(`{"num_schedulers":%d,"enabled_schedulers":["_core", "batch"]}`, numCPU),
 			},
 			whenACLNotEnabled: success1,
 			whenACLEnabled:    forbidden,
@@ -1820,7 +1828,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 			request: schedulerWorkerConfigTest_testRequest{
 				verb:        http.MethodPost,
 				aclToken:    "agent_write",
-				requestBody: `{"num_schedulers":9,"enabled_schedulers":["_core", "batch"]}`,
+				requestBody: fmt.Sprintf(`{"num_schedulers":%d,"enabled_schedulers":["_core", "batch"]}`, halfCPU),
 			},
 			whenACLNotEnabled: success2,
 			whenACLEnabled:    success2,
@@ -1830,7 +1838,7 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 			request: schedulerWorkerConfigTest_testRequest{
 				verb:        http.MethodPut,
 				aclToken:    "agent_write",
-				requestBody: `{"num_schedulers":8,"enabled_schedulers":["_core", "batch"]}`,
+				requestBody: fmt.Sprintf(`{"num_schedulers":%d,"enabled_schedulers":["_core", "batch"]}`, numCPU),
 			},
 			whenACLNotEnabled: success1,
 			whenACLEnabled:    success1,
@@ -1895,6 +1903,26 @@ func schedulerWorkerConfigTest_testCases() []scheduleWorkerConfigTest_workerRequ
 			whenACLNotEnabled: invalidRequest,
 			whenACLEnabled:    invalidRequest,
 		},
+		{
+			name: "post with too many schedulers",
+			request: schedulerWorkerConfigTest_testRequest{
+				verb:        http.MethodPost,
+				aclToken:    "agent_write",
+				requestBody: `{"num_schedulers":9223372036854775807,"enabled_schedulers":["_core", "batch"]}`,
+			},
+			whenACLNotEnabled: invalidRequest,
+			whenACLEnabled:    invalidRequest,
+		},
+		{
+			name: "put with too many schedulers",
+			request: schedulerWorkerConfigTest_testRequest{
+				verb:        http.MethodPut,
+				aclToken:    "agent_write",
+				requestBody: `{"num_schedulers":9223372036854775807,"enabled_schedulers":["_core", "batch"]}`,
+			},
+			whenACLNotEnabled: invalidRequest,
+			whenACLEnabled:    invalidRequest,
+		},
 	}
 }
 
@@ -1902,8 +1930,7 @@ func TestHTTP_AgentSchedulerWorkerConfigRequest_NoACL(t *testing.T) {
 	ci.Parallel(t)
 
 	configFn := func(c *Config) {
-		var numSchedulers = 8
-		c.Server.NumSchedulers = &numSchedulers
+		c.Server.NumSchedulers = pointer.Of(runtime.NumCPU())
 		c.Server.EnabledSchedulers = []string{"_core", "batch"}
 		c.Client.Enabled = false
 	}
@@ -1935,8 +1962,7 @@ func TestHTTP_AgentSchedulerWorkerConfigRequest_ACL(t *testing.T) {
 	ci.Parallel(t)
 
 	configFn := func(c *Config) {
-		var numSchedulers = 8
-		c.Server.NumSchedulers = &numSchedulers
+		c.Server.NumSchedulers = pointer.Of(runtime.NumCPU())
 		c.Server.EnabledSchedulers = []string{"_core", "batch"}
 		c.Client.Enabled = false
 	}

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -14,6 +14,7 @@ import (
 	"net/rpc"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -1642,12 +1643,12 @@ func (swpa SchedulerWorkerPoolArgs) IsInvalid() bool {
 	return !swpa.IsValid()
 }
 
-// IsValid verifies that the pool arguments are valid. That is, they have a non-negative
-// numSchedulers value and the enabledSchedulers list has _core and only refers to known
+// IsValid verifies that the pool arguments are valid. That is, they have a
+// non-negative numSchedulers value which is less than the number of CPUs on the
+// machine and the enabledSchedulers list has _core and only refers to known
 // schedulers.
 func (swpa SchedulerWorkerPoolArgs) IsValid() bool {
-	if swpa.NumSchedulers < 0 {
-		// the pool has to be non-negative
+	if swpa.NumSchedulers < 0 || swpa.NumSchedulers > runtime.NumCPU() {
 		return false
 	}
 
@@ -1686,7 +1687,7 @@ func getSchedulerWorkerPoolArgsFromConfigLocked(c *Config) *SchedulerWorkerPoolA
 	}
 }
 
-// GetSchedulerWorkerInfo returns a slice of WorkerInfos from all of
+// GetSchedulerWorkersInfo returns a slice of WorkerInfos from all of
 // the running scheduler workers.
 func (s *Server) GetSchedulerWorkersInfo() []WorkerInfo {
 	s.workerLock.RLock()

--- a/nomad/server_test.go
+++ b/nomad/server_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -566,14 +567,14 @@ func TestServer_ReloadSchedulers_NumSchedulers(t *testing.T) {
 	ci.Parallel(t)
 
 	s1, cleanupS1 := TestServer(t, func(c *Config) {
-		c.NumSchedulers = 8
+		c.NumSchedulers = runtime.NumCPU()
 	})
 	defer cleanupS1()
 
 	require.Equal(t, s1.config.NumSchedulers, len(s1.workers))
 
 	config := DefaultConfig()
-	config.NumSchedulers = 4
+	config.NumSchedulers = runtime.NumCPU() / 2
 	require.NoError(t, s1.Reload(config))
 
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
The `server.num_scheduler` configuration value should be a value between 0 and the number of CPUs on the machine. The Nomad agent was not validating the configuration parameter which meant you could use a negative value or a value much larger than the available machine CPUs. This change enforces validation of the configuration value both on server startup and when the agent is reloaded.

The Nomad API was only performing negative value validation when updating the scheduler number via this method. This change adds to the validation to ensure the number is not greater than the CPUs on the machine.

Out documentation currently correctly states the expected value bounds: https://developer.hashicorp.com/nomad/docs/configuration/server#num_schedulers

### Testing & Reproduction steps
Using the configuration example below, try starting a Nomad dev agent with various values using this change and before. In tests with the agent started, you can alter the value and send a SIGHUP signal to the agent to test reload validation.
```hcl
server {
  num_schedulers = 10
}
```

To test the API change you can start a Nomad agent in dev mode then attempt to write the following data via the curl command `curl --request PUT --data @payload.json http://localhost:4646/v1/agent/schedulers/config`:
```json
{
  "enabled_schedulers": [
    "service",
    "batch",
    "system",
    "sysbatch",
    "_core"
  ],
  "num_schedulers": 1000
}
```

I went back and forth on the idea of just updating the `SchedulerWorkerPoolArgs.IsValid` function only to get the validation we want. It would work, but the server has to be started before this check is triggered. I therefore decided to have both the config validation and the backend validation with the idea to expand the configuration validation to cover more cases and eventually plug this into the `config validate` command.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
