### PR TITLE
docker: `TestDockerDriver_OOMKilled` should run on cgroups v2

### DIFF
--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -2576,9 +2576,7 @@ func TestDockerDriver_OOMKilled(t *testing.T) {
 	ci.Parallel(t)
 	testutil.DockerCompatible(t)
 
-	// waiting on upstream fix for cgroups v2
-	// see https://github.com/hashicorp/nomad/issues/13119
-	testutil.CgroupsCompatibleV1(t)
+	testutil.CgroupsCompatibleV2(t)
 
 	taskCfg := newTaskConfig("", []string{"sh", "-c", `sleep 2 && x=a && while true; do x="$x$x"; done`})
 	task := &drivers.TaskConfig{


### PR DESCRIPTION
Docker driver's `TestDockerDriver_OOMKilled` should run on cgroups v2 now, since we're running [docker v27 client library](https://github.com/hashicorp/nomad/blob/release/1.10.0-beta.1/go.mod#L29) and our runners run docker v26 that contain containerd fix https://github.com/containerd/containerd/pull/6323. 

With cgroups v2:
```
$ go test -v -timeout 30s -count 10 -run ^TestDockerDriver_OOMKilled$ github.com/hashicorp/nomad/drivers/docker
🎬🎬🎬
    driver_test.go:2615: Successfully killed by OOM killer
2025-03-19T16:39:25.419+0100 [DEBUG] go-plugin@v1.6.2/grpc_stdio.go:142: docker.docker_logger.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
2025-03-19T16:39:25.421+0100 [INFO]  go-plugin@v1.6.2/client.go:780: docker.docker_logger: plugin process exited: plugin=/tmp/go-build2407037215/b001/docker.test id=51424
2025-03-19T16:39:25.421+0100 [DEBUG] go-plugin@v1.6.2/client.go:558: docker.docker_logger: plugin exited
2025-03-19T16:39:25.427+0100 [DEBUG] sending conn to default listener
2025-03-19T16:39:25.427+0100 [DEBUG] stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = error reading from server: EOF"
--- PASS: TestDockerDriver_OOMKilled (2.36s)
PASS
ok  	github.com/hashicorp/nomad/drivers/docker	23.384s
```
there appear to be no flakes. 

Related internal ticket: https://hashicorp.atlassian.net/browse/NET-12155