### PR TITLE
Manual backport of Docs: SEO front matter description for search: commands section

### DIFF
--- a/website/content/docs/commands/acl/auth-method/create.mdx
+++ b/website/content/docs/commands/acl/auth-method/create.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl auth-method create'
-description: The auth-method create command is used to create new ACL Auth Methods.
+page_title: 'nomad acl auth-method create command reference'
+description: |
+  The `nomad acl auth-method create` command creates new access control list (ACL) authentication methods. Set name, name format, description, OIDC or JWT type, local or global, and time to live (TTL).
 ---
 
-# Command: acl auth-method create
+# `nomad acl auth-method create` command reference
 
 The `acl auth-method create` command is used to create new ACL Auth Methods.
 
@@ -17,11 +18,11 @@ nomad acl auth-method create [options]
 The `acl auth-method create` command requires the correct setting of the create options
 via flags detailed below.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Create Options
+## Create options
 
 - `-name`: Sets the human readable name for the ACL auth method. The name must
   be between 1-128 characters and is a required parameter.

--- a/website/content/docs/commands/acl/auth-method/delete.mdx
+++ b/website/content/docs/commands/acl/auth-method/delete.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl auth-method delete'
-description: The auth-method delete command is used to delete existing ACL Auth Methods.
+page_title: 'nomad acl auth-method delete command reference'
+description: |
+  The `nomad auth-method delete command` deletes an existing access control list (ACL) authentication method.
 ---
 
-# Command: acl auth-method delete
+# `nomad`acl auth-method delete` command reference
 
 The `acl auth-method delete` command is used to delete existing ACL Auth Methods.
 
@@ -16,7 +17,7 @@ nomad acl auth-method delete [options] <auth-method_name>
 
 The `acl auth-method delete` command requires an existing method's name.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/acl/auth-method/info.mdx
+++ b/website/content/docs/commands/acl/auth-method/info.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl auth-method info'
+page_title: 'nomad acl auth-method info command reference'
 description: |
-  The auth-method info command is used to fetch information about an existing
-  ACL Auth Method.
+  The `nomad auth-method info` command fetches information about an existing access control list (ACL) authentication method. Review name, type, description, locality, time to live (TTL), token name format, and authentication method configuration.
 ---
 
-# Command: acl auth-method info
+# `nomad acl auth-method info` command reference
 
 The `acl auth-method info` command is used to fetch information about an existing ACL Auth Method.
 
@@ -18,11 +17,11 @@ nomad acl auth-method info [options] <auth-method_name>
 
 The `acl auth-method info` command requires an existing method's name.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Info Options
+## Info options
 
 - `-json`: Output the ACL auth method in a JSON format.
 

--- a/website/content/docs/commands/acl/auth-method/list.mdx
+++ b/website/content/docs/commands/acl/auth-method/list.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl auth-method list'
-description: The auth-method list command is used to list existing ACL Auth Methods.
+page_title: 'nomad acl auth-method list command reference'
+description: |
+  The `nomad acl auth-method list` command lists existing access control list (ACL) authentication methods.
 ---
 
-# Command: acl auth-method list
+# `nomad acl auth-method list` command reference
 
 The `acl auth-method list` command is used to list existing ACL Auth Methods.
 
@@ -14,11 +15,11 @@ The `acl auth-method list` command is used to list existing ACL Auth Methods.
 nomad acl auth-method list [options]
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## List Options
+## List options
 
 - `-json` : Output the ACL auth-methods in a JSON format.
 

--- a/website/content/docs/commands/acl/auth-method/update.mdx
+++ b/website/content/docs/commands/acl/auth-method/update.mdx
@@ -1,12 +1,14 @@
 ---
 layout: docs
-page_title: 'Commands: acl auth-method update'
-description: The auth-method update command is used to update existing ACL Auth Methods.
+page_title: 'nomad acl auth-method update command reference'
+description: |
+  The `nomad acl auth-method update` command updates an existing access control list (ACL) authentication method.  Modify name, name format, description, OIDC or JWT type, local or global, and time to live (TTL).
 ---
 
-# Command: acl auth-method update
+# `nomad acl auth-method update` command reference
 
-The `acl auth-method update` command is used to update existing ACL Auth Methods.
+The `acl auth-method update` command is used to update existing ACL Auth
+Methods.
 
 ## Usage
 
@@ -16,11 +18,11 @@ nomad acl auth-method update [options] <auth-method_name>
 
 The `acl auth-method update` command requires an existing method's name.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Update Options
+## Update options
 
 - `-name`: Sets the human-readable name for the ACL Role. It is required and
   can contain alphanumeric characters and dashes. This name must be unique and

--- a/website/content/docs/commands/acl/binding-rule/create.mdx
+++ b/website/content/docs/commands/acl/binding-rule/create.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl binding-rule create'
-description: The binding-rule create command is used to create new ACL Binding Rules.
+page_title: 'nomad acl binding-rule create command reference'
+description: |
+  The `nomad acl binding-rule create` command creates new access control list (ACL) binding rules. Set a description, associated authentication method, selector expression, or bind name. Configure role, policy, or management bind type.
 ---
 
-# Command: acl binding-rule create
+# `nomad acl binding-rule create` command reference
 
 The `acl binding-rule create` command is used to create new ACL Binding Rules.
 
@@ -17,11 +18,11 @@ nomad acl binding-rule create [options]
 The `acl binding-rule create` command requires the correct setting of the create options
 via flags detailed below.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Create Options
+## Create options
 
 - `-description`: A free form text description of the binding-rule that must not exceed
   256 characters.

--- a/website/content/docs/commands/acl/binding-rule/delete.mdx
+++ b/website/content/docs/commands/acl/binding-rule/delete.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl binding-rule delete'
-description: The binding-rule delete command is used to delete existing ACL Binding Rules.
+page_title: 'nomad acl binding-rule delete command reference'
+description: |
+  The `nomad acl binding-rule delete` command delete an existing access control list (ACL) binding rule.
 ---
 
-# Command: acl binding-rule delete
+# `nomad acl binding-rule delete` command reference
 
 The `acl binding-rule delete` command is used to delete existing ACL Binding Rules.
 

--- a/website/content/docs/commands/acl/binding-rule/info.mdx
+++ b/website/content/docs/commands/acl/binding-rule/info.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl binding-rule info'
+page_title: 'nomad acl binding-rule info command reference'
 description: |
-  The binding-rule info command is used to fetch information about an existing
-  ACL Binding Rule.
+  The `nomad acl binding-rule info` command fetches information about an existing access control list (ACL) binding rule. Review ID, description, authentication method, selector, bind type, bind name, and time to live (TTL).
 ---
 
-# Command: acl binding-rule info
+# `nomad acl binding-rule info` command reference
 
 The `acl binding-rule info` command is used to fetch information about an existing ACL Binding Rule.
 
@@ -18,11 +17,11 @@ nomad acl binding-rule info [options] <binding-rule_id>
 
 The `acl binding-rule info` command requires an existing rule's ID.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Info Options
+## Info options
 
 - `-json`: Output the ACL Binding Rule in a JSON format.
 

--- a/website/content/docs/commands/acl/binding-rule/list.mdx
+++ b/website/content/docs/commands/acl/binding-rule/list.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl binding-rule list'
-description: The binding-rule list command is used to list existing ACL Binding Rules.
+page_title: 'nomad acl binding-rule list command reference'
+description: |
+  The `nomad acl binding-rule list` command displays access control list (ACL) binding rules.
 ---
 
-# Command: acl binding-rule list
+# `nomad acl binding-rule list` command reference
 
 The `acl binding-rule list` command is used to list existing ACL Binding Rules.
 
@@ -14,11 +15,11 @@ The `acl binding-rule list` command is used to list existing ACL Binding Rules.
 nomad acl binding-rule list [options]
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## List Options
+## List options
 
 - `-json` : Output the ACL binding-rules in a JSON format.
 

--- a/website/content/docs/commands/acl/binding-rule/update.mdx
+++ b/website/content/docs/commands/acl/binding-rule/update.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl binding-rule update'
-description: The binding-rule update command is used to update existing ACL Binding Rules.
+page_title: 'nomad acl binding-rule update command reference'
+description: |
+    The `nomad acl binding-rule update` command modifies an existing access control list (ACL) binding rule. Update description, selector expression, bind name, and bind type.
 ---
 
-# Command: acl binding-rule update
+# `nomad acl binding-rule update` command reference
 
 The `acl binding-rule update` command is used to update existing ACL Binding Rules.
 
@@ -16,11 +17,11 @@ nomad acl binding-rule update [options] <binding-rule_ID>
 
 The `acl binding-rule update` command requires an existing rule's ID.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Update Options
+## Update options
 
 - `-description`: A free form text description of the binding-rule that must not exceed
   256 characters.

--- a/website/content/docs/commands/acl/bootstrap.mdx
+++ b/website/content/docs/commands/acl/bootstrap.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl bootstrap'
+page_title: 'nomad acl bootstrap command reference'
 description: |
-  The bootstrap command is used to create the initial ACL token.
+  The `nomad acl bootstrap` command creates the initial access control list (ACL) token. Nomad generates the token unless you provide a user-generated token.
 ---
 
-# Command: acl bootstrap
+# `nomad acl bootstrap` command reference
 
 The `acl bootstrap` command is used to bootstrap the initial ACL token.
 
@@ -15,17 +15,17 @@ The `acl bootstrap` command is used to bootstrap the initial ACL token.
 nomad acl bootstrap [options]
 ```
 
-The `acl bootstrap` command can be used in two ways: 
+The `acl bootstrap` command can be used in two ways:
 - If you provide no arguments it will return a system generated bootstrap token.
 - If you would like to provide an operator generated token it is possible to provide the token
-using a file `acl bootstrap [path]`. The Token can be read from stdin by setting the path to "-". 
+using a file `acl bootstrap [path]`. The Token can be read from stdin by setting the path to "-".
 Please make sure you secure this token in an appropriate manner as it could be written to your terminal history.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Bootstrap Options
+## Bootstrap options
 
 - `-json` : Output the bootstrap response in JSON format.
 - `-t` : Format and display the deployments using a Go template.
@@ -67,7 +67,7 @@ Create Index = 7
 Modify Index = 7
 ```
 
-Bootstrap the initial token with provided token using stdin 
+Bootstrap the initial token with provided token using stdin
 
 ```shell-session
 $ nomad acl bootstrap -

--- a/website/content/docs/commands/acl/index.mdx
+++ b/website/content/docs/commands/acl/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl'
+page_title: 'nomad acl command reference'
 description: |
-  The acl command is used to interact with ACL policies and tokens.
+  The `nomad acl` command interacts with access control list (ACL) policies, roles, tokens, binding rules, and authentication methods.
 ---
 
-# Command: acl
+# `nomad acl` command reference
 
 The `acl` command is used to interact with ACL policies and tokens. Learn more
 about using Nomad's ACL system in the [Secure Nomad with Access Control

--- a/website/content/docs/commands/acl/policy/apply.mdx
+++ b/website/content/docs/commands/acl/policy/apply.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl policy apply'
+page_title: 'nomad acl policy apply command reference'
 description: |
-  The policy apply command is used to create or update ACL policies.
+  The `nomad acl policy apply` command creates or updates an  access control list (ACL) policy. Set description, job, namespace, group, and task.
 ---
 
-# Command: acl policy apply
+# `nomad acl policy apply` command reference
 
 The `acl policy apply` command is used to create or update ACL policies.
 
@@ -20,11 +20,11 @@ to file. The policy can be read from stdin by setting the path to "-".
 
 This command requires a management ACL token.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Apply Options
+## Apply options
 
 - `-description`: Sets the human readable description for the ACL policy.
 

--- a/website/content/docs/commands/acl/policy/delete.mdx
+++ b/website/content/docs/commands/acl/policy/delete.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl policy delete'
+page_title: 'nomad acl policy delete command reference'
 description: |
-  The policy delete command is used to delete an existing ACL policies.
+  The `nomad acl policy delete` command deletes an access control list (ACL) policy.
 ---
 
-# Command: acl policy delete
+# `nomad acl policy delete` command reference
 
 The `acl policy delete` command is used to delete an existing ACL policies.
 
@@ -19,7 +19,7 @@ The `acl policy delete` command requires the policy name as an argument.
 
 This command requires a management ACL token.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/acl/policy/info.mdx
+++ b/website/content/docs/commands/acl/policy/info.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl policy info'
+page_title: 'nomad acl policy info command reference'
 description: >
-  The policy info command is used to fetch information on an existing ACL
-  policy.
+  The `nomad acl policy info` command fetches information on an access control list (ACL) policy. Review name, description, and workload, as well as access control list (ACL) policies and rules.
 ---
 
-# Command: acl policy info
+# `nomad acl policy info` command reference
 
 The `acl policy info` command is used to fetch information on an existing ACL
 policy.
@@ -22,7 +21,7 @@ The `acl policy info` command requires the policy name.
 This command requires a management ACL token or a token that has the
 associated policy.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/acl/policy/list.mdx
+++ b/website/content/docs/commands/acl/policy/list.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl policy list'
+page_title: 'nomad acl policy list command reference'
 description: |
-  The policy list command is used to list available ACL policies.
+  The `nomad acl policy list` command displays available access control list (ACL) policies.
 ---
 
-# Command: acl policy list
+# `nomad acl policy list` command reference
 
 The `acl policy list` command is used to list available ACL policies.
 
@@ -18,11 +18,11 @@ nomad acl policy list
 This command requires a management ACL token to view all policies. A
 non-management token can query its own policies.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## List Options
+## List options
 
 - `-json` : Output the policies in their JSON format.
 - `-t` : Format and display the policies using a Go template.

--- a/website/content/docs/commands/acl/role/create.mdx
+++ b/website/content/docs/commands/acl/role/create.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl role create'
-description: The role create command is used to create new ACL Roles.
+page_title: 'nomad acl role create command reference'
+description: |
+    The `nomad acl role create` command creates an access control list (ACL) role. Set name, description, and associated policy.
 ---
 
-# Command: acl role create
+# `nomad acl role create` command reference
 
 The `acl role create` command is used to create new ACL Roles.
 
@@ -17,11 +18,11 @@ nomad acl role create [options]
 The `acl role create` command requires the correct setting of the create options
 via flags detailed below.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Create Options
+## Create options
 
 - `-name`: Sets the human-readable name for the ACL Role. It is required and
   can contain alphanumeric characters and dashes. This name must be unique and

--- a/website/content/docs/commands/acl/role/delete.mdx
+++ b/website/content/docs/commands/acl/role/delete.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl role delete'
-description: The role delete command is used to delete existing ACL Roles.
+page_title: 'nomad acl role delete command reference'
+description: |
+  The `nomad acl role delete` command deletes an access control list (ACL) role.
 ---
 
-# Command: acl role delete
+# `nomad acl role delete` command reference
 
 The `acl role delete` command is used to delete existing ACL Roles.
 
@@ -16,7 +17,7 @@ nomad acl role delete [options] <role_id>
 
 The `acl role delete` command requires an existing role's ID.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/acl/role/info.mdx
+++ b/website/content/docs/commands/acl/role/info.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl role info'
+page_title: 'nomad acl role info command reference'
 description: |
-  The role info command is used to fetch information about an existing ACL
-  Role.
+  The `nomad acl role info` command fetches information about an access control list (ACL) role. Review ID, name, description, and policies.
 ---
 
-# Command: acl role info
+# `nomad acl role info` command reference
 
 The `acl role info` command is used to fetch information about an existing ACL Role.
 
@@ -18,11 +17,11 @@ nomad acl role info [options] <role_id> or <role_name>
 
 The `acl role info` command requires an existing role's ID or name.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Info Options
+## Info options
 
 - `-by-name`: Look up the ACL role using its name as the identifier. The
   command defaults to expecting the ACL ID as the argument.

--- a/website/content/docs/commands/acl/role/list.mdx
+++ b/website/content/docs/commands/acl/role/list.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl role list'
-description: The role list command is used to list existing ACL Roles.
+page_title: 'nomad acl role list command reference'
+description: |
+    The `nomad acl role list` displays access control list (ACL) roles.
 ---
 
-# Command: acl role list
+# `nomad acl role list` command reference
 
 The `acl role list` command is used to list existing ACL Roles.
 
@@ -14,11 +15,11 @@ The `acl role list` command is used to list existing ACL Roles.
 nomad acl role list [options]
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## List Options
+## List options
 
 - `-json` : Output the ACL roles in a JSON format.
 

--- a/website/content/docs/commands/acl/role/update.mdx
+++ b/website/content/docs/commands/acl/role/update.mdx
@@ -1,10 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl role update'
-description: The role update command is used to update existing ACL Roles.
+page_title: 'nomad acl role update command reference'
+description: |
+    The `nomad acl role update` command modifies an access control list (ACL) role. Modify name, description, and associated policy.
 ---
 
-# Command: acl role update
+# `nomad acl role update` command reference
 
 The `acl role update` command is used to update existing ACL Roles.
 
@@ -16,11 +17,11 @@ nomad acl role update [options] <role_id>
 
 The `acl role update` command requires an existing role's ID.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Update Options
+## Update options
 
 - `-name`: Sets the human-readable name for the ACL Role. It is required and
   can contain alphanumeric characters and dashes. This name must be unique and

--- a/website/content/docs/commands/acl/token/create.mdx
+++ b/website/content/docs/commands/acl/token/create.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl token create'
+page_title: 'nomad acl token create command reference'
 description: |
-  The token create command is used to create new ACL tokens.
+  The `nomad acl token create` command creates an access control list (ACL) token. Set name, client or management type, policy, role, time to live (TTL), and whether the policy should be global.
 ---
 
-# Command: acl token create
+# `nomad acl token create` command reference
 
 The `acl token create` command is used to create new ACL tokens.
 
@@ -17,11 +17,11 @@ nomad acl token create [options]
 
 The `acl token create` command requires no arguments.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Create Options
+## Create options
 
 - `-name`: Sets the human readable name for the ACL token.
 

--- a/website/content/docs/commands/acl/token/delete.mdx
+++ b/website/content/docs/commands/acl/token/delete.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl token delete'
+page_title: 'nomad acl token delete command reference'
 description: |
-  The token create command is used to delete existing ACL tokens.
+  The `nomad acl token delete` command deletes an access control list (ACL) token.
 ---
 
-# Command: acl token delete
+# `nomad acl token delete` command reference
 
 The `acl token delete` command is used to delete existing ACL tokens.
 
@@ -17,7 +17,7 @@ nomad acl token delete <token_accessor_id>
 
 The `acl token delete` command requires an existing token's AccessorID.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/acl/token/info.mdx
+++ b/website/content/docs/commands/acl/token/info.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl token info'
+page_title: 'nomad acl token info command reference'
 description: >
-  The token info command is used to fetch information about an existing ACL
-  token.
+  The `nomad acl token info` command fetches information about an access control list (ACL) token. Review accessor ID, secret ID, name, type, global scope, time to live (TTL), policies, and roles.
 ---
 
-# Command: acl token info
+# `nomad acl token info` command reference
 
 The `acl token info` command is used to fetch information about an existing ACL token.
 
@@ -18,7 +17,7 @@ nomad acl token info <token_accessor_id>
 
 The `acl token info` command requires an existing token's AccessorID.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/acl/token/list.mdx
+++ b/website/content/docs/commands/acl/token/list.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl token list'
+page_title: 'nomad acl token list command reference'
 description: |
-  The token list command is used to list existing ACL tokens.
+  The `nomad acl token list` command displays access control list (ACL) tokens.
 ---
 
-# Command: acl token list
+# `nomad acl token list` command reference
 
 The `acl token list` command is used to list existing ACL tokens.
 
@@ -15,11 +15,11 @@ The `acl token list` command is used to list existing ACL tokens.
 nomad acl token list
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## List Options
+## List options
 
 - `-json` : Output the tokens in their JSON format.
 - `-t` : Format and display the tokens using a Go template.

--- a/website/content/docs/commands/acl/token/self.mdx
+++ b/website/content/docs/commands/acl/token/self.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl token self'
+page_title: 'nomad acl token self command reference'
 description: >
-  The token self command is used to fetch information about the currently set
-  ACL token.
+  The `nomad acl token self` command fetches information about the currently set access control list (ACL) token. Review accessor ID, secret ID, name, type, global scope, time to live (TTL), policies, and roles.
 ---
 
-# Command: acl token self
+# `nomad acl token self` command reference
 
 The `acl token self` command is used to fetch information about the currently
 set ACL token.
@@ -17,7 +16,7 @@ set ACL token.
 nomad acl token self
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/acl/token/update.mdx
+++ b/website/content/docs/commands/acl/token/update.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: acl token update'
+page_title: 'nomad acl token update command reference'
 description: |
-  The token update command is used to update existing ACL tokens.
+  The `nomad acl token update` command modifies an access control list (ACL) token. Update name, client or management type, policy, and role.
 ---
 
-# Command: acl token update
+# `nomad acl token update` command reference
 
 The `acl token update` command is used to update existing ACL tokens.
 
@@ -17,11 +17,11 @@ nomad acl token update [options] <token_accessor_id>
 
 The `acl token update` command requires an existing token's accessor ID.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Update Options
+## Update options
 
 - `-name`: Sets the human readable name for the ACL token.
 

--- a/website/content/docs/commands/agent-info.mdx
+++ b/website/content/docs/commands/agent-info.mdx
@@ -1,14 +1,14 @@
 ---
 layout: docs
-page_title: 'Commands: agent-info'
+page_title: 'nomad agent-info command reference'
 description: |
-  Display information and status of a running agent.
+  The `nomad agent-info` command retrieves metrics and status information for a running agent. Use this command to review agent data from the client, nomad, serf, raft, and runtime subsystems.
 ---
 
-# Command: agent-info
+# `nomad agent-info` command reference
 
-The `agent-info` command dumps metrics and status information of a running
-agent. The information displayed pertains to the specific agent the CLI
+The `nomad agent-info` command retrieves metrics and status information for a
+running agent. The information returned pertains to the specific agent the CLI
 is connected to. This is useful for troubleshooting and performance monitoring.
 
 ## Usage
@@ -20,27 +20,27 @@ nomad agent-info [options]
 When ACLs are enabled, this command requires a token with the `agent:read`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Agent Info Options
+## `agent-info` options
 
 - `-json` : Output agent info in its JSON format.
 - `-t` : Format and display agent info using a Go template.
 
 ## Output
 
-Depending on the agent queried, information from different subsystems is
-returned. These subsystems are described below:
+Depending on the agent queried, the `nomad agent-info` command retrieves
+information from the following subsystems:
 
-- client - Status of the local Nomad client
-- nomad - Status of the local Nomad server
-- serf - Gossip protocol metrics and information
-- raft - Status information about the Raft consensus protocol
-- runtime - Various metrics from the runtime environment
+- Client: Status of the local Nomad client
+- Nomad: Status of the local Nomad server
+- Serf: Gossip protocol metrics and information
+- Raft: Status information about the Raft consensus protocol
+- Runtime: Various metrics from the runtime environment
 
-## Examples
+## Example
 
 ```shell-session
 $ nomad agent-info

--- a/website/content/docs/commands/agent.mdx
+++ b/website/content/docs/commands/agent.mdx
@@ -1,29 +1,34 @@
 ---
 layout: docs
-page_title: 'Commands: agent'
+page_title: 'nomad agent command reference'
 description: |
-  The agent command is the main entrypoint to running a Nomad client or server.
+  The `nomad agent` command starts the Nomad agent, which handles client or server functionality, including exposing interfaces for client consumption and running jobs. The agent runs until it receives an interrupt signal.
 ---
 
-# Command: agent
+# `nomad agent` command reference
 
-The agent command is the heart of Nomad: it runs the agent that handles client
-or server functionality, including exposing interfaces for client consumption
-and running jobs.
+The `nomad agent` command starts the Nomad agent, which handles client or server
+functionality, including exposing interfaces for client consumption and running
+jobs. The agent runs until it receives an interrupt signal.
 
-Due to the power and flexibility of this command, the Nomad agent is documented
-in its own section. See the [Nomad Agent] guide and the [Configuration]
-documentation section for more information on how to use this command and the
-options it has.
+Refer to [Operating Nomad agents] and [Nomad agent configuration] for more
+information on how to use this command and the options it has.
 
--> **Note:** If you are running Nomad on Linux, you'll need to run client agents
-as root (or with `sudo`) so that cpuset accounting and network namespaces work
-correctly.
+## Usage
 
-## Command-line Options
+If you are running Nomad on Linux, you need to run client agents as root, or
+with `sudo`, so that cpuset accounting and network namespaces work correctly.
 
-A subset of the available Nomad agent configuration can optionally be passed in
-via CLI arguments. The `agent` command accepts the following arguments:
+```plaintext
+nomad agent [options]
+```
+
+## `nomad agent` options
+
+We recommend configuring a Nomad agent with configuration files. Refer to [Nomad
+agent configuration] for details.
+
+You may, however, may pass the following configuration options as CLI arguments:
 
 - `-alloc-dir=<path>`: Equivalent to the Client [alloc_dir][] config
   option.
@@ -222,7 +227,6 @@ via CLI arguments. The `agent` command accepts the following arguments:
 [server_failures_before_critical]: /nomad/docs/configuration/consul#server_failures_before_critical
 [server_failures_before_warning]: /nomad/docs/configuration/consul#server_failures_before_warning
 [client_service_name]: /nomad/docs/configuration/consul#client_service_name
-[configuration]: /nomad/docs/configuration
 [data_dir]: /nomad/docs/configuration#data_dir
 [datacenter]: /nomad/docs/configuration#datacenter
 [enabled]: /nomad/docs/configuration/acl#enabled
@@ -236,7 +240,8 @@ via CLI arguments. The `agent` command accepts the following arguments:
 [network_interface]: /nomad/docs/configuration/client#network_interface
 [node_class]: /nomad/docs/configuration/client#node_class
 [node_pool]: /nomad/docs/configuration/client#node_pool
-[nomad agent]: /nomad/docs/operations/nomad-agent
+[Operating Nomad agents]: /nomad/docs/operations/nomad-agent
+[Nomad agent configuration]: /nomad/docs/configuration
 [plugin_dir]: /nomad/docs/configuration#plugin_dir
 [region]: /nomad/docs/configuration#region
 [rejoin_after_leave]: /nomad/docs/configuration/server#rejoin_after_leave
@@ -253,3 +258,4 @@ via CLI arguments. The `agent` command accepts the following arguments:
 [state_dir]: /nomad/docs/configuration/client#state_dir
 [token]: /nomad/docs/configuration/consul#token
 [verify_ssl]: /nomad/docs/configuration/consul#verify_ssl
+

--- a/website/content/docs/commands/alloc/checks.mdx
+++ b/website/content/docs/commands/alloc/checks.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: alloc checks'
+page_title: 'nomad alloc checks command reference'
 description: |
-  Outputs service health check status information.
+  The `nomad alloc checks` command displays service health check status information for an allocation.
 ---
 
-# Command: alloc checks
+# `nomad alloc checks` command reference
 
 
 The `alloc checks` command outputs the latest health check status information for checks in the allocation.
@@ -20,15 +20,15 @@ Outputs the latest health check status information for services in the allocatio
 using the Nomad service discovery provider. This command accepts an allocation
 ID or prefix as the sole argument.
 
-When ACLs are enabled, this command requires a token with the 'read-job' capability 
-for the allocation's namespace. The 'list-jobs' capability is required to run the 
+When ACLs are enabled, this command requires a token with the 'read-job' capability
+for the allocation's namespace. The 'list-jobs' capability is required to run the
 command with an allocation ID prefix instead of the exact allocation ID.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Checks Options
+## Checks options
 
 - `-verbose`: Display verbose output.
 

--- a/website/content/docs/commands/alloc/exec.mdx
+++ b/website/content/docs/commands/alloc/exec.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: alloc exec'
+page_title: 'nomad alloc exec command reference'
 description: |
-  Runs a command in a container.
+  The `nomad alloc exec` runs a command inside a running task allocation, which is useful for debugging. Execute commands with or without an interactive shell inside the allocation.
 ---
 
-# Command: alloc exec
+# `nomad alloc exec` command reference
 
 **Alias: `nomad exec`**
 
@@ -33,11 +33,11 @@ the task driver does not have file system isolation (as with `raw_exec`),
 this command requires the `alloc-node-exec`, `read-job`, and `list-jobs`
 capabilities for the allocation's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Exec Options
+## Exec options
 
 - `-task`: Sets the task to exec command in.
 

--- a/website/content/docs/commands/alloc/fs.mdx
+++ b/website/content/docs/commands/alloc/fs.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: alloc fs'
+page_title: 'nomad alloc fs command reference'
 description: |
-  Introspect an allocation directory on a Nomad client
+  The `nomad alloc fs` lets you navigate an allocation working directory on a Nomad client.
 ---
 
-# Command: alloc fs
+# `nomad alloc fs` command reference
 
 **Alias: `nomad fs`**
 
@@ -38,11 +38,11 @@ directory].
 When ACLs are enabled, this command requires a token with the `read-fs`,
 `read-job`, and `list-jobs` capabilities for the allocation's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Fs Options
+## Fs options
 
 - `-H`: Machine friendly output.
 

--- a/website/content/docs/commands/alloc/index.mdx
+++ b/website/content/docs/commands/alloc/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: alloc'
+page_title: 'nomad alloc command reference'
 description: |
-  The alloc command is used to interact with allocations.
+  The `nomad alloc` commands interact with allocations. Access allocation directories, display status and health checks, stream task logs, run commands inside an allocation, and signal a running allocation. You can also stop, reschedule, and restart a running allocation.
 ---
 
-# Command: alloc
+# `nomad alloc` command reference
 
 The `alloc` command is used to interact with allocations.
 

--- a/website/content/docs/commands/alloc/logs.mdx
+++ b/website/content/docs/commands/alloc/logs.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: alloc logs'
+page_title: 'nomad alloc logs command reference'
 description: |
-  Stream the logs of a task.
+  The `nomad alloc logs` command streams the task logs from an allocation.
 ---
 
-# Command: alloc logs
+# `nomad alloc logs` command reference
 
 **Alias: `nomad logs`**
 
@@ -29,11 +29,11 @@ preference is given to the `-task` option.
 When ACLs are enabled, this command requires a token with the `read-logs`,
 `read-job`, and `list-jobs` capabilities for the allocation's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Logs Options
+## Logs options
 
 - `-stdout`: Display stdout logs. This is used as the default value in all
   commands except when using the `-f` flag where both stdout and stderr are

--- a/website/content/docs/commands/alloc/pause.mdx
+++ b/website/content/docs/commands/alloc/pause.mdx
@@ -1,19 +1,19 @@
 ---
 layout: docs
-page_title: 'Commands: alloc pause'
+page_title: 'nomad alloc pause command reference'
 description: |
-  Override the schedule for tasks using time based execution.
+  The `nomad alloc pause` command overrides the schedule for tasks using time-based execution, forcing the task to either stop or run.
 ---
 
-# Command: alloc pause
+# `nomad alloc pause` command reference
+
+Override the schedule for tasks using time based execution.
 
 <EnterpriseAlert />
 
 ~> **Note:** Time based task execution is an experimental feature and subject
 to change. This feature is supported for select customers. Please refer to the
-[Upgrade Guide][upgrade] to find breaking changes. 
-
-Override the schedule for tasks using time based execution.
+[Upgrade Guide][upgrade] to find breaking changes.
 
 ## Usage
 
@@ -29,11 +29,11 @@ ignored until a user resets the override.
 When ACLs are enabled, this command requires the `job-submit` capability for
 the allocation's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Pause Options
+## Pause options
 
 - `-state`: Override the current scheduled task state to be the specified state
   or reset to the scheduled state. Must be one of `pause`, `run`, or

--- a/website/content/docs/commands/alloc/restart.mdx
+++ b/website/content/docs/commands/alloc/restart.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: alloc restart'
+page_title: 'nomad alloc restart command reference'
 description: |
-  Restart a running allocation or task
+  The `nomad alloc restart` command restarts a running task or an entire allocation.
 ---
 
-# Command: alloc restart
+# `nomad alloc restart` command reference
 
 The `alloc restart` command allows a user to perform an in place restart of an
 an entire allocation or individual task.
@@ -32,11 +32,11 @@ When ACLs are enabled, this command requires a token with the
 `alloc-lifecycle`, `read-job`, and `list-jobs` capabilities for the
 allocation's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Restart Options
+## Restart options
 
 - `-all-tasks`: If set, all tasks in the allocation will be restarted, even the
   ones that already ran. This option cannot be used with `-task` or the

--- a/website/content/docs/commands/alloc/signal.mdx
+++ b/website/content/docs/commands/alloc/signal.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: alloc signal'
+page_title: 'nomad alloc signal command reference'
 description: |
-  Signal a running allocation or task
+  The `nomad alloc signal` command sends a signal to a running allocation or task.
 ---
 
-# Command: alloc signal
+# `nomad alloc signal` command reference
 
 The `alloc signal` command allows a user to perform an in place signal of an
 an entire allocation or individual task.
@@ -20,19 +20,19 @@ This command accepts a single allocation ID and a task name. The task name must
 be part of the allocation and the task must be currently running. The task name
 is optional and if omitted every task in the allocation will be signaled.
 
-Task name may also be specified using the `-task`  option rather than a command 
-argument. If task name is given with both an argument and the `-task` option, 
+Task name may also be specified using the `-task`  option rather than a command
+argument. If task name is given with both an argument and the `-task` option,
 preference is given to the `-task` option.
 
 When ACLs are enabled, this command requires a token with the
 `alloc-lifecycle`, `read-job`, and `list-jobs` capabilities for the
 allocation's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Signal Options
+## Signal options
 
 - `-s`: Signal to send to the tasks. Valid options depend on the driver.
 

--- a/website/content/docs/commands/alloc/status.mdx
+++ b/website/content/docs/commands/alloc/status.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: alloc status'
+page_title: 'nomad alloc status command reference'
 description: |
-  Display status and metadata about existing allocations and their tasks.
+  The `nomad alloc status` command display status and metadata about existing allocations and their tasks.
 ---
 
-# Command: alloc status
+# `nomad alloc status` command reference
 
 The `alloc status` command displays status information and metadata
 about an existing allocation and its tasks. It can be useful while
@@ -25,11 +25,11 @@ allocations and information will be displayed.
 When ACLs are enabled, this command requires a token with the `read-job` and
 `list-jobs` capabilities for the allocation's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Alloc Status Options
+## Alloc Status options
 
 - `-short`: Display short output. Shows only the most recent task event.
 - `-verbose`: Show full information.
@@ -89,7 +89,7 @@ CPU        Memory           Disk     Addresses
 1/500 MHz  6.3 MiB/256 MiB  300 MiB  db: 127.0.0.1:27908
 
 CSI Volumes:
-ID            Plugin  Provider  Schedulable  Mount Options
+ID            Plugin  Provider  Schedulable  Mount options
 vol-4150af42  ebs0    aws.ebs   true         <none>
 
 Task Events:

--- a/website/content/docs/commands/alloc/stop.mdx
+++ b/website/content/docs/commands/alloc/stop.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: alloc stop'
+page_title: 'nomad alloc stop command reference'
 description: |
-  Stop and reschedule a running allocation
+  The `nomad alloc stop` command perform an in-place restart of an entire allocation or an individual task.
 ---
 
-# Command: alloc stop
+# `nomad alloc stop` command reference
 
 The `alloc stop` command allows a user to perform an in-place restart of an
 entire allocation or individual task.
@@ -20,7 +20,7 @@ The `alloc stop` command requires a single argument, specifying the alloc ID or
 prefix to stop. If there is an exact match based on the provided alloc ID or
 prefix, then the alloc will be stopped, otherwise, a list of
 matching allocs and information will be displayed. If the stopped allocation
-belongs to a service or batch job they will rescheduled according to their 
+belongs to a service or batch job they will rescheduled according to their
 reschedule policy. [System allocs will not][] and will show up as completed.
 
 Stop will issue a request to stop and reschedule the allocation. An interactive
@@ -31,11 +31,11 @@ When ACLs are enabled, this command requires a token with the
 `alloc-lifecycle`, `read-job`, and `list-jobs` capabilities for the
 allocation's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Stop Options
+## Stop options
 
 - `-detach`: Return immediately instead of entering monitor mode. After the
   stop command is submitted, a new evaluation ID is printed to the

--- a/website/content/docs/commands/config/index.mdx
+++ b/website/content/docs/commands/config/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: config'
+page_title: 'nomad config command reference'
 description: |
-  The config command interacting with configurations.
+  The `nomad config` command interacts with configurations. Validate configuration files.
 ---
 
-# Command: config
+# `nomad config` command reference
 
 The `config` command is used to interact with configurations.
 

--- a/website/content/docs/commands/config/validate.mdx
+++ b/website/content/docs/commands/config/validate.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: config validate'
+page_title: 'nomad config validate command reference'
 description: |
-  The config validate command is used to validate Nomad configuration files.
+  The `nomad config validate` command validates Nomad configuration files so you can test Nomad configuration without starting the agent.
 ---
 
-# Command: config validate
+# `nomad config validate` command reference
 
 The `config validate` command performs validation on a set of Nomad
 configuration files. This is useful to test the Nomad configuration
@@ -30,7 +30,7 @@ require an ACL token.
 
 Returns 0 if the configuration is valid, or 1 if there are problems.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 

--- a/website/content/docs/commands/deployment/fail.mdx
+++ b/website/content/docs/commands/deployment/fail.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: deployment fail'
+page_title: 'nomad deployment fail command reference'
 description: |
-  The deployment fail command is used to manually fail a deployment.
+  The `nomad deployment fail` command manually fails a deployment, which stops the placement of new allocations.
 ---
 
-# Command: deployment fail
+# `nomad deployment fail` command reference
 
 The `deployment fail` command is used to mark a deployment as failed. Failing a
 deployment will stop the placement of new allocations as part of rolling
@@ -24,11 +24,11 @@ prefix.
 When ACLs are enabled, this command requires a token with the `submit-job`
 and `read-job` capabilities for the deployment's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Fail Options
+## Fail options
 
 - `-detach`: Return immediately instead of monitoring. A new evaluation ID
   will be output, which can be used to examine the evaluation using the

--- a/website/content/docs/commands/deployment/index.mdx
+++ b/website/content/docs/commands/deployment/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: deployment'
+page_title: 'nomad deployment command reference'
 description: |
-  The deployment command is used to interact with deployments.
+  The `nomad deployment` command interacts with deployments. List deployments, fetch status, and promote canaries. Pause, resume, and fail deployments.
 ---
 
-# Command: deployment
+# `nomad deployment` command reference
 
 The `deployment` command is used to interact with deployments.
 

--- a/website/content/docs/commands/deployment/list.mdx
+++ b/website/content/docs/commands/deployment/list.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: deployment list'
+page_title: 'nomad deployment list command reference'
 description: |
-  The deployment list command is used to list deployments.
+  The `nomad deployment list` command lists deployments.
 ---
 
-# Command: deployment list
+# `nomad deployment list` command reference
 
 The `deployment list` command is used list all deployments.
 
@@ -20,11 +20,11 @@ The `deployment list` command requires no arguments.
 When ACLs are enabled, this command requires a token with the 'read-job'
 capability for the deployment's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## List Options
+## List options
 
 - `-json` : Output the deployments in their JSON format.
 - `-filter`: Specifies an expression used to filter query results.

--- a/website/content/docs/commands/deployment/pause.mdx
+++ b/website/content/docs/commands/deployment/pause.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: deployment pause'
+page_title: 'nomad deployment pause command reference'
 description: >
-  The deployment pause command is used to pause a deployment and disallow new
-  placements.
+  The `nomad deployment pause` command pauses a deployment and does not allow new allocations.
 ---
 
-# Command: deployment pause
+# `nomad deployment pause` command reference
 
 The `deployment pause` command is used to pause a deployment. Pausing a
 deployment will pause the placement of new allocations as part of rolling
@@ -24,11 +23,11 @@ prefix.
 When ACLs are enabled, this command requires a token with the `submit-job`
 and `read-job` capabilities for the deployment's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Pause Options
+## Pause options
 
 - `-verbose`: Show full information.
 

--- a/website/content/docs/commands/deployment/promote.mdx
+++ b/website/content/docs/commands/deployment/promote.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: deployment promote'
+page_title: 'nomad deployment promote command reference'
 description: |
-  The deployment promote command is used to promote canaries in a deployment.
+  The `nomad deployment promote` command promotes healthy task group canaries in a deployment.
 ---
 
-# Command: deployment promote
+# `nomad deployment promote` command reference
 
 The `deployment promote` command is used to promote task groups in a deployment.
 Promotion should occur when the deployment has placed canaries for a task group
@@ -30,11 +30,11 @@ select particular groups to promote.
 When ACLs are enabled, this command requires a token with the `submit-job`
 and `read-job` capabilities for the deployment's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Promote Options
+## Promote options
 
 - `-group`: Group may be specified many times and is used to promote that
   particular group. If no specific groups are specified, all groups are

--- a/website/content/docs/commands/deployment/resume.mdx
+++ b/website/content/docs/commands/deployment/resume.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: deployment resume'
+page_title: 'nomad deployment resume command reference'
 description: |
-  The deployment resume command is used to resume a paused deployment.
+  The `nomad deployment resume` command resumes a paused deployment.
 ---
 
-# Command: deployment resume
+# `nomad deployment resume` command reference
 
 The `deployment resume` command is used to unpause a paused deployment.
 Resuming a deployment will resume the placement of new allocations as part of
@@ -23,11 +23,11 @@ prefix.
 When ACLs are enabled, this command requires a token with the `submit-job`
 and `read-job` capabilities for the deployment's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Resume Options
+## Resume options
 
 - `-detach`: Return immediately instead of monitoring. A new evaluation ID
   will be output, which can be used to examine the evaluation using the

--- a/website/content/docs/commands/deployment/status.mdx
+++ b/website/content/docs/commands/deployment/status.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: deployment status'
+page_title: 'nomad deployment status command reference'
 description: |
-  The deployment status command is used to display the status of a deployment.
+  The `nomad deployment status` command displays the status of a deployment.
 ---
 
-# Command: deployment status
+# `nomad deployment status` command reference
 
 The `deployment status` command is used to display the status of a deployment.
 The status will display the number of desired changes as well as the currently
@@ -28,11 +28,11 @@ the entire process, showing the failure and then monitoring the deployment of th
 When ACLs are enabled, this command requires a token with the 'read-job'
 capability for the deployment's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Status Options
+## Status options
 
 - `-json` : Output the deployment in its JSON format.
 - `-t` : Format and display the deployment using a Go template.

--- a/website/content/docs/commands/deployment/unblock.mdx
+++ b/website/content/docs/commands/deployment/unblock.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: deployment unblock'
+page_title: 'nomad deployment unblock command reference'
 description: |
-  The deployment unblock command is used to manually unblock a deployment.
+  The`nomad deployment unblock` command marks a blocked multi-region deployment as successful so you can force completion when there is a failed peer region.
 ---
 
-# Command: deployment unblock
+# `nomad deployment unblock` command reference
 
 The `deployment unblock` command is used to manually mark a blocked
 multiregion deployment as successful. A blocked deployment is a multiregion
@@ -26,11 +26,11 @@ prefix.
 When ACLs are enabled, this command requires a token with the `submit-job`
 and `read-job` capabilities for the deployment's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Unblock Options
+## Unblock options
 
 - `-detach`: Return immediately instead of monitoring. A new evaluation ID
   will be output, which can be used to examine the evaluation using the

--- a/website/content/docs/commands/eval/delete.mdx
+++ b/website/content/docs/commands/eval/delete.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: eval delete'
+page_title: 'nomad eval delete command reference'
 description: |
-  The eval delete command is used to delete evaluations.
+  The `nomad eval delete` command deletes an evaluation by ID or a group of evaluations that match a filter.
 ---
 
-# Command: eval delete
+# `nomad eval delete` command reference
 
 The `eval delete` command is used to delete evaluations. It should be used
 cautiously and only in outage situations where there is a large backlog of
@@ -29,11 +29,11 @@ and delete a set of evaluations.
 
 When ACLs are enabled, this command requires a `management` token.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Delete Options
+## Delete options
 
 - `-filter`: Specifies an expression used to filter evaluations by for
   deletion. When using this flag, it is advisable to ensure the syntax is

--- a/website/content/docs/commands/eval/index.mdx
+++ b/website/content/docs/commands/eval/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: eval'
+page_title: 'nomad eval command reference'
 description: |
-  The eval command is used to interact with evals.
+  The `nomad eval` command interact with evaluations. Fetch status, delete an evaluation, and list all evaluations.
 ---
 
-# Command: eval
+# `nomad eval` command reference
 
 The `eval` command is used to interact with evals.
 

--- a/website/content/docs/commands/eval/list.mdx
+++ b/website/content/docs/commands/eval/list.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: eval list'
+page_title: 'nomad eval list command reference'
 description: |
-  The eval list command is used to list evaluations.
+  The `nomad eval list` command displays a list of all evaluations or evaluations that match a filter.
 ---
 
-# Command: eval list
+# `nomad eval list` command reference
 
 The `eval list` command is used list all evaluations.
 
@@ -20,11 +20,11 @@ The `eval list` command requires no arguments.
 When ACLs are enabled, this command requires a token with the `read-job`
 capability for the requested namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## List Options
+## List options
 
 - `-verbose`: Show full information.
 - `-per-page`: How many results to show per page.

--- a/website/content/docs/commands/eval/status.mdx
+++ b/website/content/docs/commands/eval/status.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: 'Commands: eval status'
+page_title: 'nomad eval status command reference'
 description: >
-  The eval status command is used to see the status and potential failed
-  allocations of an evaluation.
+  The `nomad eval status` command displays the status and potential failed
+  allocations of an evaluation. Use with the `monitor` flag to start an interactive monitoring session.
 ---
 
-# Command: eval status
+# `nomad eval status` command reference
 
 The `eval status` command is used to display information about an existing
 evaluation. In the case an evaluation could not place all the requested
@@ -37,11 +37,11 @@ resource exhaustion, etc), then the exit code will be 2. Any other
 errors, including client connection issues or internal errors, are
 indicated by exit code 1.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Eval Status Options
+## Eval status options
 
 - `-monitor`: Monitor an outstanding evaluation
 - `-verbose`: Show full information.

--- a/website/content/docs/commands/fmt.mdx
+++ b/website/content/docs/commands/fmt.mdx
@@ -1,35 +1,34 @@
 ---
 layout: docs
-page_title: 'Commands: fmt'
+page_title: 'nomad fmt command reference'
 description: |
-  Rewrite Nomad config and job files to canonical format
+  The `nomad fmt` commands rewrites Nomad configuration and job specification
+   files to canonical format. Use this command to improve readability and enforce consistency of style in Nomad files.
 ---
 
-# Command: fmt
+# `nomad fmt` command reference
 
-The `fmt` commands check the syntax and rewrites Nomad configuration and jobspec
-files to canonical format. It can be used to improve readability and enforce
+The `nomad fmt` command rewrites Nomad configuration and job specification files
+to canonical format. Use this command to improve readability and enforce
 consistency of style in Nomad files.
 
 ## Usage
 
 ```plaintext
-nomad fmt [flags] paths ...
+nomad fmt [options] paths ...
 ```
 
-Formats Nomad agent configuration and job file to a canonical format. If a path
-is a directory, it will recursively format all files with .nomad and .hcl
-extensions in the directory.
+If a path is a directory, the command recursively formats all files with
+`.nomad` and `.hcl` extensions in the directory. If you provide a single dash
+(-) as an argument, the `nomad fmt` command reads from standard input and
+writes the processed text to standard output.
 
-If you provide a single dash (-) as argument, fmt will read from standard input
-(STDIN) and output the processed output to standard output (STDOUT).
-
-Note that, this command will check the syntax against
+The `nomad fmt` command checks the syntax against
 [HCL2](https://github.com/hashicorp/hcl/blob/hcl2/README.md), the second
 generation of Hashicorp Configuration Language. Running this command with
-deprecated HCL1 jobspec will result in errors.
+deprecated HCL1 job specification results in errors.
 
-## Format Options:
+## `nomad fmt` options
 
 - `-check`: Check if the files are valid HCL files. If not, exit status of the
   command will be 1 and the incorrect files will not be formatted. This flag

--- a/website/content/docs/commands/index.mdx
+++ b/website/content/docs/commands/index.mdx
@@ -1,54 +1,48 @@
 ---
 layout: docs
-page_title: Commands (CLI)
+page_title: Nomad command-line interface (CLI) reference
 description: >
-  Nomad can be controlled via a command-line interface. This page documents all
-  the commands Nomad accepts.
+  The Nomad command-line interface (CLI) interacts with a Nomad cluster. This page contains reference information on how to install CLI autocomplete, configure remote usage, and specify CLI options. Review connection, access control list (ACL), mutual TLS (mTLS), and license environment variables.
 ---
 
-# Nomad Commands (CLI)
+# Nomad command-line interface (CLI) reference
 
-Nomad is controlled via a very easy to use command-line interface (CLI).
-Nomad is only a single command-line application: `nomad`, which
-takes a subcommand such as "agent" or "status". The complete list of
-subcommands is in the navigation to the left.
-
-The Nomad CLI is a well-behaved command line application. In erroneous cases,
-a non-zero exit status will be returned. It also responds to `-h` and `--help`
-as you would most likely expect.
-
-To view a list of the available commands at any time, just run Nomad
-with no arguments. To get help for any specific subcommand, run the subcommand
-with the `-h` argument.
-
-Each command has been conveniently documented on this website. Links to each
-command can be found on the left.
+The Nomad CLI is a well-behaved command-line application. In erroneous cases,
+the CLI returns a non-zero exit status. To view a list of available commands,
+run the `nomad` command with no arguments, `-h`, or `--help`. To access help for
+any specific subcommand, run the subcommand with the `-h` argument.
 
 ## Autocomplete
 
-Nomad's CLI supports command autocomplete. Autocomplete can be installed or
-uninstalled by running the following on bash, zsh or fish shells:
+Nomad's CLI supports command autocomplete.
+
+To install autocomplete, run the `nomad` command with the
+`-autocomplete-install` option.
 
 ```shell-session
 $ nomad -autocomplete-install
+```
+
+To uninstall autocomplete, run the `nomad` command with the
+`-autocomplete-uninstall` option.
+
+```shell-session
 $ nomad -autocomplete-uninstall
 ```
 
-## Command Contexts
+## Command contexts
 
 Nomad's CLI commands have implied contexts in their naming convention. Because
 the CLI is most commonly used to manipulate or query jobs, you can assume that
 any given command is working in that context unless the command name implies
-otherwise.
-
-For example, the `nomad job run` command is used to run a new job, the `nomad status` command queries information about existing jobs, etc. Conversely,
+otherwise. For example, the `nomad job run` command runs a new job and the `nomad status` command queries information about existing jobs. Conversely,
 commands with a prefix in their name likely operate in a different context.
 Examples include the `nomad agent-info` or `nomad node drain` commands,
 which operate in the agent or node contexts respectively.
 
-### Remote Usage
+### Remote usage
 
-The Nomad CLI may be used to interact with a remote Nomad cluster, even when the
+You may use the Nomad CLI to interact with a remote Nomad cluster, even when the
 local machine does not have a running Nomad agent. To do so, set the
 `NOMAD_ADDR` environment variable or use the `-address=<addr>` flag when running
 commands.
@@ -58,17 +52,16 @@ $ NOMAD_ADDR=https://remote-address:4646 nomad status
 $ nomad status -address=https://remote-address:4646
 ```
 
-The provided address must be reachable from your local machine. There are a
-variety of ways to accomplish this (VPN, SSH Tunnel, etc). If the port is
-exposed to the public internet it is highly recommended to configure TLS.
+The Nomad address must be reachable from your local machine. If the Nomad
+port is exposed to the public internet, we recommend configuring TLS. Refer to
+the [`tls` block in agent configuration] for details.
 
-### Environment Variables
+### Environment variables
 
-Nomad can use environment variables to configure command-line tool options.
-These environment variables can be overridden as needed using individual
-flags.
+Nomad can use environment variables to configure command-line tool options. You
+may override these environment variables with individual flags.
 
-#### Connection Environment Variables
+#### Connection environment variables
 
 - `NOMAD_ADDR` - The address of the Nomad server. Defaults to
   `http://127.0.0.1:4646`.
@@ -85,16 +78,18 @@ flags.
   information in environments where the Nomad API is behind an authenticating
   proxy server.
 
-#### ACL Environment Variables
+#### Access control list (ACL) environment variables
 
 - `NOMAD_TOKEN` - The SecretID of an ACL token to use to authenticate API
   requests with.
 
-#### CLI Environment Variables
+#### CLI environment variables
 
 - `NOMAD_CLI_NO_COLOR` - Disables colored command output.
 
-#### mTLS Environment Variables
+#### Mutual TLS (mTLS) environment variables
+
+- `NOMAD_CLI_SHOW_HINTS` - Enables ui-hints in common CLI command output.
 
 - `NOMAD_CLIENT_CERT` - Path to a PEM encoded client certificate for TLS
   authentication to the Nomad server. Must also specify `NOMAD_CLIENT_KEY`.
@@ -115,9 +110,12 @@ flags.
 - `NOMAD_TLS_SERVER_NAME` - The server name to use as the SNI host when
   connecting via TLS.
 
-#### Nomad Enterprise Licensing Environment Variables
+#### Nomad Enterprise license environment variables
 
 - `NOMAD_LICENSE_PATH` - An absolute path to a Nomad Enterprise license file,
   for example `/etc/nomad.d/license.hclic`.
 
 - `NOMAD_LICENSE` - The Nomad Enterprise license file contents as a string.
+
+
+[`tls` block in agent configuration]: /nomad/docs/configuration/tls

--- a/website/content/docs/commands/job/action.mdx
+++ b/website/content/docs/commands/job/action.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: 'Commands: job action'
+page_title: 'nomad job action command reference'
 description: |
-  The job action command is used to execute predefined actions from a job
-  specification in a running task context
+  The `nomad job action` command executes predefined actions from a job
+  specification in a running task context.
 ---
 
-# Command: job action
+# `nomad job action` command reference
 
 **Alias: `nomad action`**
 
@@ -45,11 +45,11 @@ the defined action command will be run. No further input is possible, save for
 the escape character to terminate execution, so interactive commands are not
 supported.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Action Options
+## Action options
 
 - `-job`: (Required) Specifies the job containing the predefined action.
 

--- a/website/content/docs/commands/job/allocs.mdx
+++ b/website/content/docs/commands/job/allocs.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job allocs'
+page_title: 'nomad job allocs command reference'
 description: |
-  The allocs command is used to list allocations for a job.
+  The `nomad job allocs`  command lists allocations for a job.
 ---
 
-# Command: job allocs
+# `nomad job allocs` command reference
 
 The `job allocs` command is used to display the allocations for a
 particular job.
@@ -23,11 +23,11 @@ When ACLs are enabled, this command requires a token with the `read-job`
 capability for the job's namespace. The `list-jobs` capability is required to
 run the command with a job prefix instead of the exact job ID.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Allocs Options
+## Allocs options
 
 - `-all`: Display all allocations matching the job ID, even those from an
   older instance of the job.

--- a/website/content/docs/commands/job/deployments.mdx
+++ b/website/content/docs/commands/job/deployments.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job deployments'
+page_title: 'nomad job deployments command reference'
 description: |
-  The deployments command is used to list deployments for a job.
+  The `nomad job deployments` command lists deployments for a job.
 ---
 
-# Command: job deployments
+# `nomad job deployments` command reference
 
 The `job deployments` command is used to display the deployments for a
 particular job.
@@ -23,11 +23,11 @@ When ACLs are enabled, this command requires a token with the `read-job`
 capability for the job's namespace. The `list-jobs` capability is required to
 run the command with a job prefix instead of the exact job ID.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Deployment Options
+## Deployment options
 
 - `-latest`: Display the latest deployment only.
 

--- a/website/content/docs/commands/job/dispatch.mdx
+++ b/website/content/docs/commands/job/dispatch.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job dispatch'
+page_title: 'nomad job dispatch command reference'
 description: |
-  The dispatch command is used to create an instance of a parameterized job.
+  The `nomad job dispatch` creates an instance of a parameterized job.
 ---
 
-# Command: job dispatch
+# `nomad job dispatch` command reference
 
 The `job dispatch` command is used to create new instances of a [parameterized
 job]. The parameterized job captures a job's configuration and runtime
@@ -53,11 +53,11 @@ not used.
 See the [multiregion] documentation for additional considerations when
 dispatching parameterized jobs.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Dispatch Options
+## Dispatch options
 
 - `-meta`: Meta takes a key/value pair separated by "=". The metadata key will
   be merged into the job's metadata. The job may define a default value for the

--- a/website/content/docs/commands/job/eval.mdx
+++ b/website/content/docs/commands/job/eval.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job eval'
+page_title: 'nomad job eval command reference'
 description: |
-  The job eval command is used to force an evaluation of a job
+  The `nomad job eval` command forces an evaluation of a job. Optionally, force placement of failed allocations.
 ---
 
-# Command: job eval
+# `nomad job eval` command reference
 
 The `job eval` command is used to force an evaluation of a job, given the job
 ID.
@@ -26,11 +26,11 @@ run the command with a job prefix instead of the exact job ID. The `read-job`
 capability is required to monitor the resulting evaluation when `-detach` is
 not used.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Eval Options
+## Eval options
 
 - `-force-reschedule`: `force-reschedule` is used to force placement of failed
   allocations. If this is set, failed allocations that are past their reschedule

--- a/website/content/docs/commands/job/history.mdx
+++ b/website/content/docs/commands/job/history.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job history'
+page_title: 'nomad job history command reference'
 description: |
-  The history command is used to display all tracked versions of a job.
+  The `nomad job history` command displays the history of a single version or all tracked versions of a job. Optionally display the difference between two versions or tags or differences between each job and its predecessor.
 ---
 
-# Command: job history
+# `nomad job history` command reference
 
 The `job history` command is used to display the known versions of a particular
 job. The command can display the diff between job versions and can be useful for
@@ -25,11 +25,11 @@ When ACLs are enabled, this command requires a token with the `read-job`
 capability for the job's namespace. The `list-jobs` capability is required to
 run the command with a job prefix instead of the exact job ID.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## History Options
+## History options
 
 - `-p`: Display the differences between each job and its predecessor.
 - `-full`: Display the full job definition for each version.

--- a/website/content/docs/commands/job/index.mdx
+++ b/website/content/docs/commands/job/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job'
+page_title: 'nomad job command reference'
 description: |
-  The job command is used to interact with jobs.
+  The `nomad job` command interacts with jobs. Create, validate, and plan a job specification. Display allocations, deployments, history, and status. Execute predefined actions, dispatch parameterized jobs, inspect a job, force the evaluation of a periodic job, scale allocations, and promote canaries. Run, restart, revert, and stop a job.
 ---
 
-# Command: job
+# `nomad job` command reference
 
 The `job` command is used to interact with jobs.
 
@@ -57,4 +57,4 @@ subcommands are available:
 [stop]: /nomad/docs/commands/job/stop 'Stop a running job and cancel its allocations'
 [tag]: /nomad/docs/commands/job/tag 'Tag a job with a version'
 [validate]: /nomad/docs/commands/job/validate 'Check a job specification for syntax errors'
-[promote]: /nomad/docs/commands/job/promote 
+[promote]: /nomad/docs/commands/job/promote

--- a/website/content/docs/commands/job/init.mdx
+++ b/website/content/docs/commands/job/init.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job init'
+page_title: 'nomad job init command reference'
 description: |
-  The job init command is used to generate a skeleton jobspec template.
+  The `nomad job init` command generates a job specification with example configurations for tasks, task groups, runtime constraints, and resource allocation.
 ---
 
-# Command: job init
+# `nomad job init` command reference
 
 **Alias: `nomad init`**
 
@@ -25,7 +25,7 @@ default filename for the generated file is "example.nomad.hcl".
 Please refer to the [jobspec] and [drivers] pages to learn how to customize the
 template.
 
-## Init Options
+## Init options
 
 - `-short`: If set, a minimal jobspec without comments is emitted.
 - `-connect`: If set, the jobspec includes Consul Connect integration.

--- a/website/content/docs/commands/job/inspect.mdx
+++ b/website/content/docs/commands/job/inspect.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job inspect'
+page_title: 'nomad job inspect command reference'
 description: |
-  The job inspect command is used to inspect a submitted job.
+  The `nomad job inspect` command displays a complete job definition so you can inspect contents.
 ---
 
-# Command: job inspect
+# `nomad job inspect` command reference
 
 **Alias: `nomad inspect`**
 
@@ -26,11 +26,11 @@ When ACLs are enabled, this command requires a token with the `read-job`
 capability for the job's namespace. The `list-jobs` capability is required to
 run the command with a job prefix instead of the exact job ID.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Inspect Options
+## Inspect options
 
 - `-version`: Display only the job at the given job version.
 - `-json` : Output the job in its JSON format. Cannot be used with `-hcl`.

--- a/website/content/docs/commands/job/periodic-force.mdx
+++ b/website/content/docs/commands/job/periodic-force.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: 'Commands: job periodic force'
+page_title: 'nomad job periodic force command reference'
 description: >
-  The job periodic force command is used to force the evaluation of a periodic
-  job.
+  The `nomad job periodic force` command forces the evaluation of a periodic
+  job. Use this command to immediately run a periodic job, even if it violates the job's `prohibit_overlap` setting.
 ---
 
-# Command: job periodic force
+# `nomad job periodic force` command reference
 
 The `job periodic force` command is used to [force the evaluation] of a
 [periodic job].
@@ -32,11 +32,11 @@ run the command with a job prefix instead of the exact job ID. The `read-job`
 capability is required to monitor the resulting evaluation when `-detach` is
 not used.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Run Options
+## Run options
 
 - `-detach`: Return immediately instead of monitoring. A new evaluation ID
   will be output, which can be used to examine the evaluation using the

--- a/website/content/docs/commands/job/plan.mdx
+++ b/website/content/docs/commands/job/plan.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job plan'
+page_title: 'nomad job plan command reference'
 description: |
-  The job plan command is used to dry-run a job update to determine its effects.
+  The `nomad job plan` command executes a dry run of a job to determine its effects.
 ---
 
-# Command: job plan
+# `nomad job plan` command reference
 
 **Alias: `nomad plan`**
 
@@ -55,11 +55,11 @@ precedence, going from highest to lowest: the `-vault-token` flag, the
 When ACLs are enabled, this command requires a token with the `submit-job`
 capability for the job's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Plan Options
+## Plan options
 
 - `-diff`: Determines whether the diff between the remote job and planned job is
   shown. Defaults to true.

--- a/website/content/docs/commands/job/promote.mdx
+++ b/website/content/docs/commands/job/promote.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job promote'
+page_title: 'nomad job promote command reference'
 description: |
-  The promote command is used to promote a job's canaries.
+  The `nomad job promote` command promotes healthy task group canaries in a deployment.
 ---
 
-# Command: job promote
+# `nomad job promote` command reference
 
 The `job promote` command is used to promote task groups in the most recent
 deployment for the given job. Promotion should occur when the deployment has
@@ -32,11 +32,11 @@ and `read-job` capabilities for the job's namespace. The `list-jobs`
 capability is required to run the command with a job prefix instead of the
 exact job ID.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Promote Options
+## Promote options
 
 - `-group`: Group may be specified many times and is used to promote that
   particular group. If no specific groups are specified, all groups are

--- a/website/content/docs/commands/job/restart.mdx
+++ b/website/content/docs/commands/job/restart.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job restart'
+page_title: 'nomad job restart command reference'
 description: |
-  The job restart command is used to restart allocations for a job.
+  The `nomad job restart` command restarts or reschedules allocations for a job.
 ---
 
-# Command: job restart
+# `nomad job restart` command reference
 
 The `job restart` command is used to restart or reschedule allocations for a
 particular job.
@@ -52,11 +52,11 @@ When ACLs are enabled, this command requires a token with the
 `list-jobs` capability is required to run the command with a job prefix instead
 of the exact job ID.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Restart Options
+## Restart options
 
 - `-all-tasks`: If set, all tasks in the allocations are restarted, even the
   ones that have already run, such as non-sidecar tasks. Tasks will restart

--- a/website/content/docs/commands/job/revert.mdx
+++ b/website/content/docs/commands/job/revert.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job revert'
+page_title: 'nomad job revert command reference'
 description: |
-  The revert command is used to revert to a prior version of the job.
+  The `nomad job revert` command reverts the current job to a prior version.
 ---
 
-# Command: job revert
+# `nomad job revert` command reference
 
 The `job revert` command is used to revert a job to a prior version of the
 job. The available versions to revert to can be found using [`job history`]
@@ -43,11 +43,11 @@ run the command with a job prefix instead of the exact job ID. The `read-job`
 capability is required to monitor the resulting evaluation when `-detach` is
 not used.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Revert Options
+## Revert options
 
 - `-detach`: Return immediately instead of monitoring. A new evaluation ID
   will be output, which can be used to examine the evaluation using the

--- a/website/content/docs/commands/job/run.mdx
+++ b/website/content/docs/commands/job/run.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job run'
+page_title: 'nomad job run command reference'
 description: |
-  The job run command is used to run a new job.
+  The `nomad job run` command submits a job to Nomad for scheduling, which then runs the job.
 ---
 
-# Command: job run
+# `nomad job run` command reference
 
 **Alias: `nomad run`**
 
@@ -54,11 +54,11 @@ token with the `csi-mount-volume` capability for the volume's namespace. Jobs
 that mount host volumes require a token with the `host_volume` capability for
 that volume.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Run Options
+## Run options
 
 - `-check-index`: If set, the job is only registered or
   updated if the passed job modify index matches the server side version.

--- a/website/content/docs/commands/job/scale.mdx
+++ b/website/content/docs/commands/job/scale.mdx
@@ -1,11 +1,12 @@
 ---
 layout: docs
-page_title: 'Commands: job scale'
+page_title: 'nomad job scale command reference'
 description: |
-  The job scale command is used to change the count of a Nomad job group.
+  The `nomad job scale` command changes the number of running allocations within
+  a Nomad task group.
 ---
 
-# Command: job scale
+# `nomad job scale` command reference
 
 The `job scale` command is used to alter the number of running allocations within
 a Nomad task group.
@@ -35,11 +36,11 @@ command with a job prefix instead of the exact job ID. The `read-job`
 capability is required to monitor the resulting evaluation when `-detach` is
 not used.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Scale Options
+## Scale options
 
 - `-check-index`: If set, the job is only scaled if the passed job modify index
   matches the server side version. Ignored if value of zero is passed. If a

--- a/website/content/docs/commands/job/scaling-events.mdx
+++ b/website/content/docs/commands/job/scaling-events.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job scaling-events'
+page_title: 'nomad job scaling-events command reference'
 description: |
-  The job scaling-events command details scaling events for a given job.
+  The `nomad job scaling-events` command displays scaling events for the specified job.
 ---
 
-# Command: job scaling-events
+# `nomad job scaling-events` command reference
 
 The `job scaling-events` command is used display the recent scaling events for
 a given job.
@@ -24,11 +24,11 @@ When ACLs are enabled, this command requires a token with either the
 `list-jobs` capability is required to run the command with a job prefix
 instead of the exact job ID.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Scaling-Events Options
+## Scaling-Events options
 
 - `-verbose`: Show full information.
 

--- a/website/content/docs/commands/job/status.mdx
+++ b/website/content/docs/commands/job/status.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: job status'
+page_title: 'nomad job status command reference'
 description: |
-  Display information and status of jobs.
+  The `nomad job status` command displays information and status for the specified job.
 ---
 
-# Command: job status
+# `nomad job status` command reference
 
 The `job status` command displays status information for a job.
 
@@ -32,11 +32,11 @@ run the command with a job prefix instead of the exact job ID.
 
 @include 'job-status-map.mdx'
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Status Options
+## Status options
 
 - `-all-allocs`: Display all allocations matching the job ID, even those from an
   older instance of the job.

--- a/website/content/docs/commands/job/stop.mdx
+++ b/website/content/docs/commands/job/stop.mdx
@@ -1,11 +1,12 @@
 ---
 layout: docs
-page_title: 'Commands: job stop'
+page_title: 'nomad job stop command reference'
 description: |
-  The job stop command is used to stop a running job.
+  The `nomad job stop` command stops a running job and signals the scheduler
+  to cancel all of the job's running allocations.
 ---
 
-# Command: job stop
+# `nomad job stop` command reference
 
 **Alias: `nomad stop`**
 
@@ -32,11 +33,11 @@ and `read-job` capabilities for the job's namespace. The `list-jobs`
 capability is required to run the command with job prefixes instead of exact
 job IDs.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Stop Options
+## Stop options
 
 - `-detach`: Return immediately instead of entering monitor mode. After the
   deregister command is submitted, a new evaluation ID is printed to the screen,

--- a/website/content/docs/commands/job/tag.mdx
+++ b/website/content/docs/commands/job/tag.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: 'Commands: job tag'
+page_title: 'nomad job tag command reference'
 description: |
-  Use the job tag commands to manage versions. The job tag apply command saves a job version tag, and the job tag unset command removes a job version tag.
+  The `nomad job tag` command manages versions. The `nomad job tag apply` command saves a job version tag, and the `nomad job tag unset` command removes a job version tag.
 ---
 
 
-# Command: job tag
+# `nomad job tag` command reference
 
 @include 'version/tag-reason.mdx'
 

--- a/website/content/docs/commands/job/validate.mdx
+++ b/website/content/docs/commands/job/validate.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: 'Commands: job validate'
+page_title: 'nomad job validate command reference'
 description: >
-  The job validate command is used to check a job specification for syntax
+  The `nomad job validate` command checks a job specification for syntax
   errors and validation problems.
 ---
 
-# Command: job validate
+# `nomad job validate` command reference
 
 **Alias: `nomad validate`**
 
@@ -36,11 +36,11 @@ precedence, going from highest to lowest: the `-vault-token` flag, the
 When ACLs are enabled, this command requires a token with the `read-job`
 capability for the job's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Validate Options
+## Validate options
 
 - `-json`: Parses the job file as JSON. If the outer object has a Job field,
   such as from "nomad job inspect" or "nomad run -output", the value of the

--- a/website/content/docs/commands/license/get.mdx
+++ b/website/content/docs/commands/license/get.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: license get'
+page_title: 'nomad license get command reference'
 description: |
-  The license get command is used to get the current license.
+  The `nomad license get` command fetches the Nomad Enterprise license from the Nomad server.
 ---
 
-# Command: license get
+# `nomad license get` command reference
 
 The `license get` command is used to retrieve the current Nomad Enterprise
 license. The command is not forwarded to the Nomad leader, and will return
@@ -22,7 +22,7 @@ nomad license get [options]
 When ACLs are enabled, this command requires a token with the 'operator:read'
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/license/index.mdx
+++ b/website/content/docs/commands/license/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: license'
+page_title: 'nomad license command reference'
 description: |
-  The license command is used to interact with an enterprise license.
+  The `nomad license` command gets or inspects a Nomad Enterprise license.
 ---
 
-# Command: license
+# `nomad license` command reference
 
 ~> License commands are only available with Nomad Enterprise.
 

--- a/website/content/docs/commands/license/inspect.mdx
+++ b/website/content/docs/commands/license/inspect.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: license inspect'
+page_title: 'nomad license inspect command reference'
 description: |
-  The license inspect command is used to inspect and validate an enterprise license.
+  The `nomad license inspect` command inspects a Nomad Enterprise license to see if it is valid with the installed Nomad binary.
 ---
 
-# Command: license inspect
+# `nomad license inspect` command reference
 
 <EnterpriseAlert>
   This command is only present in Nomad Enterprise.

--- a/website/content/docs/commands/login.mdx
+++ b/website/content/docs/commands/login.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: login'
+page_title: 'nomad login command reference'
 description: |
-  Login to Nomad using an authentication method
+  The `nomad login` command uses OpenID Connect (OIDC) to authenticate a user with a single sign-on (SSO) provider. Nomad creates an access control list (ACL) token after successful authentication.
 ---
 
-# Command: login
+# `nomad login` command reference
 
 The `login` command is used to log in to an SSO provider and exchange the third
 party credentials for a newly minted Nomad ACL token.
@@ -19,11 +19,11 @@ nomad login [options]
 The login command will exchange the provided third party credentials with the
 requested auth method for a newly minted Nomad ACL token.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Login Options
+## Login options
 
 - `-method`: The name of the ACL auth method to log in via. If the cluster
   administrator has configured a default, this flag is optional.

--- a/website/content/docs/commands/monitor.mdx
+++ b/website/content/docs/commands/monitor.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: monitor'
+page_title: 'nomad monitor command reference'
 description: |
-  Stream the logs of a running nomad agent.
+  The `nomad monitor` command streams log messages for a given agent. Configure log level, log output, node ID, and server ID.
 ---
 
-# Command: monitor
+# `nomad monitor` command reference
 
 The `nomad monitor` command streams log messages for a given agent.
 
@@ -27,11 +27,11 @@ The monitor command also allows you to specify a single client node id to follow
 When ACLs are enabled, this command requires a token with the `agent:read`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Monitor Options
+## Monitor options
 
 - `-log-level`: The log level to use for log streaming. Defaults to `info`.
   Possible values include `trace`, `debug`, `info`, `warn`, `error`

--- a/website/content/docs/commands/namespace/apply.mdx
+++ b/website/content/docs/commands/namespace/apply.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: namespace apply'
+page_title: 'nomad namespace apply command reference'
 description: |
-  The namespace apply command is used create or update a namespace.
+  The `nomad namespace apply` command creates or updates a Nomad namespace.
 ---
 
-# Command: namespace apply
+# `nomad namespace apply` command reference
 
 The `namespace apply` command is used create or update a namespace.
 
@@ -32,11 +32,11 @@ If ACLs are enabled, this command requires a management ACL token. In federated
 clusters, the namespace will be created in the authoritative region and will be
 replicated to all federated regions.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Apply Options
+## Apply options
 
 - `-quota` : An optional quota to apply to the namespace.
 

--- a/website/content/docs/commands/namespace/delete.mdx
+++ b/website/content/docs/commands/namespace/delete.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: namespace delete'
+page_title: 'nomad namespace delete command reference'
 description: |
-  The namespace delete command is used to delete a namespace.
+  The `nomad namespace delete` command deletes a namespace.
 ---
 
-# Command: namespace delete
+# `nomad namespace delete` command reference
 
 The `namespace delete` command is used delete a namespace.
 
@@ -30,7 +30,7 @@ existing CSI volumes or variables attached to it, or quotas associated with it.
 In federated clusters, you cannot delete a namespace that has any of the above
 in any of the federated regions.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/namespace/index.mdx
+++ b/website/content/docs/commands/namespace/index.mdx
@@ -1,8 +1,8 @@
 ---
 layout: docs
-page_title: 'Commands: namespace'
+page_title: 'nomad namespace command reference'
 description: |
-  The namespace command is used to interact with namespaces.
+  The nomad namespace reference command interact with namespaces. Create, inspect, and delete a namespace. Display status information and list namespaces.
 ---
 
 # Command: namespace

--- a/website/content/docs/commands/namespace/inspect.mdx
+++ b/website/content/docs/commands/namespace/inspect.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: 'Commands: namespace inspect'
+page_title: 'nomad namespace inspect command reference'
 description: >
-  The namespace inspect command is used to view raw information about a
+  The `nomad namespace inspect` command displays raw information about a
   particular namespace.
 ---
 
-# Command: namespace inspect
+# `nomad namespace inspect` command reference
 
 The `namespace inspect` command is used to view raw information about a particular
 namespace.
@@ -26,11 +26,11 @@ nomad namespace inspect [options] <namespace_name>
 If ACLs are enabled, this command requires a management ACL token or a token
 that has a capability associated with the namespace.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Inspect Options
+## Inspect options
 
 - `-t` : Format and display the namespace using a Go template.
 

--- a/website/content/docs/commands/namespace/list.mdx
+++ b/website/content/docs/commands/namespace/list.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: namespace list'
+page_title: 'nomad namespace list command reference'
 description: |
-  The namespace list command is used to list namespaces.
+  The `nomad namespace list` command displays a list of namespaces.
 ---
 
-# Command: namespace list
+# `nomad namespace list` command reference
 
 The `namespace list` command is used list available namespaces.
 
@@ -27,11 +27,11 @@ If ACLs are enabled, this command requires a management ACL token to view all
 namespaces. A non-management token can be used to list namespaces for which it
 has an associated capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## List Options
+## List options
 
 - `-json` : Output the namespaces in their JSON format.
 

--- a/website/content/docs/commands/namespace/status.mdx
+++ b/website/content/docs/commands/namespace/status.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: namespace status'
+page_title: 'nomad namespace status command reference'
 description: >
-  The namespace status command is used to view the status of a particular
-  namespace.
+  The `nomad namespace status` command displays status information for the specified namespace.
 ---
 
-# Command: namespace status
+# `nomad namespace status` command reference
 
 The `namespace status` command is used to view the status of a particular
 namespace.
@@ -26,11 +25,11 @@ nomad namespace status [options] <namespace_name>
 If ACLs are enabled, this command requires a management ACL token or a token
 that has a capability associated with the namespace.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Status Options
+## Status options
 
 - `-json` : Output the namespace status in its JSON format.
 - `-t` : Format and display the namespace status using a Go template.

--- a/website/content/docs/commands/node-pool/apply.mdx
+++ b/website/content/docs/commands/node-pool/apply.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node pool apply'
+page_title: 'nomad node pool apply command reference'
 description: |
-  The node pool apply command is used to create or update a node pool.
+  The `nomad node pool apply` command creates or updates a node pool.
 ---
 
-# Command: node pool apply
+# `nomad node pool apply` command reference
 
 The `node pool apply` command is used to create or update a node pool.
 
@@ -23,11 +23,11 @@ in a `node_pool` policy that matches the node pool being targeted. In federated
 clusters, the node pool will be created in the authoritative region and will be
 replicated to all federated regions.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Apply Options
+## Apply options
 
 - `-json`: Parse the input as a JSON node pool specification.
 

--- a/website/content/docs/commands/node-pool/delete.mdx
+++ b/website/content/docs/commands/node-pool/delete.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node pool delete'
+page_title: 'nomad node pool delete command reference'
 description: |
-  The node pool delete command is used to delete a node pool.
+  The `nomad node pool delete` command deletes the specified node pool.
 ---
 
-# Command: node pool delete
+# `nomad node pool delete` command reference
 
 The `node pool delete` command is used delete a node pool.
 
@@ -22,7 +22,7 @@ You cannot delete a node pool that has nodes or non-terminal jobs. In federated
 clusters, you cannot delete a node pool that has nodes or non-terminal jobs in
 any of the federated regions.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/node-pool/index.mdx
+++ b/website/content/docs/commands/node-pool/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node pool'
+page_title: 'nomad node pool command reference'
 description: |
-  The node pool command is used to interact with node pools.
+  The `nomad node pool` command interact with node pools. Generate an example node pool specification. Create, update, and delete a node pool. Display a list of node pools and information about a specific node pool. Display jobs and nodes in a node pool.
 ---
 
-# Command: node pool
+# `nomad node pool` command reference
 
 The `node pool` command is used to interact with node pools.
 
@@ -22,6 +22,8 @@ following subcommands are available:
 
 - [`node pool info`][info] - Fetch information on an existing node pool.
 
+- [`node pool init`][init] - Generate an example node pool specification.
+
 - [`node pool jobs`][jobs] - Retrieve a list of jobs in a node pool.
 
 - [`node pool list`][list] - Retrieve a list of node pools.
@@ -31,6 +33,7 @@ following subcommands are available:
 [apply]: /nomad/docs/commands/node-pool/apply
 [delete]: /nomad/docs/commands/node-pool/delete
 [info]: /nomad/docs/commands/node-pool/info
+[init]: /nomad/docs/commands/node-pool/init
 [jobs]: /nomad/docs/commands/node-pool/jobs
 [list]: /nomad/docs/commands/node-pool/list
 [nodes]: /nomad/docs/commands/node-pool/nodes

--- a/website/content/docs/commands/node-pool/info.mdx
+++ b/website/content/docs/commands/node-pool/info.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node pool info'
+page_title: 'nomad node pool info command reference'
 description: |
-  The node pool info command is used to fetch information about a node pool.
+  The `nomad node pool info` command displays information about a node pool.
 ---
 
-# Command: node pool info
+# `nomad node pool info` command reference
 
 The `node pool info` command is used to fetch information about an existing
 node pool.
@@ -19,11 +19,11 @@ nomad node pool info [options] <node-pool>
 If ACLs are enabled, this command requires a token with the `read` capability
 in a `node_pool` policy that matches the node pool being targeted.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Info Options
+## Info options
 
 - `-json`: Output the node pool in its JSON format.
 

--- a/website/content/docs/commands/node-pool/init.mdx
+++ b/website/content/docs/commands/node-pool/init.mdx
@@ -1,14 +1,14 @@
 ---
 layout: docs
-page_title: 'Commands: node pool init'
+page_title: 'nomad node pool init command reference'
 description: |
-  Generate an example node pool specification.
+  The `nomad node pool init` command generates an example node pool specification.
 ---
 
-# Command: node pool init
+# `nomad node pool init` command reference
 
-The `node pool init` creates an example node pool specification file that can be
-used as a starting point to customize further.
+The `nomad node pool init` command creates an example node pool specification
+file that you can use as a starting point to customize further.
 
 ## Usage
 
@@ -19,7 +19,7 @@ nomad node pool init <filename>
 When no filename is supplied, a default filename of "pool.nomad.hcl" or
 "pool.nomad.json" will be used depending on the output format.
 
-## Init Options
+## Init options
 
 - `-out` `(enum: hcl | json)`: Format of generated node pool
   specification. Defaults to `hcl`.

--- a/website/content/docs/commands/node-pool/jobs.mdx
+++ b/website/content/docs/commands/node-pool/jobs.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node pool jobs'
+page_title: 'nomad node pool jobs command reference'
 description: |
-  The node pool jobs command is used to list jobs in node pool.
+  The `nomad node pool jobs` command displays jobs in the specified node pool.
 ---
 
-# Command: node pool jobs
+# `nomad node pool jobs` command reference
 
 The `node pool jobs` command is used to list jobs in a node pool.
 
@@ -19,11 +19,11 @@ If ACLs are enabled, this command requires a token with the `read` capability in
 a `node_pool` policy that matches the node pool being targeted. The results will
 be filtered by the namespaces where the token has `read-job` capability.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Jobs Options
+## Jobs options
 
 - `-filter`: Specifies an expression used to [filter results][api_filtering].
 

--- a/website/content/docs/commands/node-pool/list.mdx
+++ b/website/content/docs/commands/node-pool/list.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node pool list'
+page_title: 'nomad node pool list command reference'
 description: |
-  The node pool list command is used to list node pools.
+  The `nomad node pool list` command displays all node pools or those matching a filter expression.
 ---
 
-# Command: node pool list
+# `nomad node pool list` command reference
 
 The `node pool list` command is used to list existing node pools.
 
@@ -19,11 +19,11 @@ If ACLs are enabled, this command requires a management token to view all node
 pools. A non-management token can be used to list node pools for which the
 token has the 'read' capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## List Options
+## List options
 
 - `-filter`: Specifies an expression used to [filter results][api_filtering].
 

--- a/website/content/docs/commands/node-pool/nodes.mdx
+++ b/website/content/docs/commands/node-pool/nodes.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node pool nodes'
+page_title: 'nomad node pool nodes command reference'
 description: |
-  The node pool nodes command is used to list nodes in node pool.
+  The `nomad node pool nodes` command displays nodes in the specified node pool.
 ---
 
-# Command: node pool nodes
+# `nomad node pool nodes` command reference
 
 The `node pool nodes` command is used to list nodes in a node pool.
 
@@ -19,11 +19,11 @@ If ACLs are enabled, this command requires a token with the `node:read`
 capability and the `read` capability in a `node_pool` policy that matches the
 node pool being targeted.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Nodes Options
+## Nodes options
 
 - `-filter`: Specifies an expression used to [filter results][api_filtering].
 

--- a/website/content/docs/commands/node/config.mdx
+++ b/website/content/docs/commands/node/config.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node config'
+page_title: 'nomad node config command reference'
 description: |
-  The node config command is used to view or modify client configuration.
+  The `nomad node config` command displays configuration details for the specified client. You can also update the client's server list with this command.
 ---
 
-# Command: node config
+# `nomad node config` command reference
 
 The `node config` command is used to view or modify client configuration
 details. This command only works on client nodes, and can be used to update
@@ -20,11 +20,11 @@ nomad node config [options]
 The arguments behave differently depending on the flags given. See each flag's
 description below for specific usage information and requirements.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Node Config Options
+## Node Config options
 
 - `-servers`: List the client's known servers. Client nodes do not participate
   in the gossip pool, and instead register with these servers periodically over

--- a/website/content/docs/commands/node/drain.mdx
+++ b/website/content/docs/commands/node/drain.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node drain'
+page_title: 'nomad node drain command reference'
 description: |
-  The node drain command is used to configure a node's drain strategy.
+  The `nomad node drain` command turns on or turns off a node's drain mode. Drain mode prevents any new tasks from being allocated to the node and beings migrating all existing allocations to other nodes.
 ---
 
-# Command: node drain
+# `nomad node drain` command reference
 
 The `node drain` command is used to toggle drain mode on a given node. Drain
 mode prevents any new tasks from being allocated to the node, and begins
@@ -56,11 +56,11 @@ operation is desired.
 If ACLs are enabled, this option requires a token with the 'node:write'
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Drain Options
+## Drain options
 
 - `-enable`: Enable node drain mode.
 

--- a/website/content/docs/commands/node/eligibility.mdx
+++ b/website/content/docs/commands/node/eligibility.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node eligibility'
+page_title: 'nomad node eligibility command reference'
 description: >
-  The node eligibility command is used to configure a node's scheduling
-  eligibility.
+  The `nomad node eligibility` command turns on or turns off a node's eligibility to receive placements and run new allocations.
 ---
 
-# Command: node eligibility
+# `nomad node eligibility` command reference
 
 The `node eligibility` command is used to toggle scheduling eligibility for a
 given node. By default nodes are eligible for scheduling meaning they can
@@ -42,11 +41,11 @@ operation is desired.
 If ACLs are enabled, this option requires a token with the 'node:write'
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Eligibility Options
+## Eligibility options
 
 - `-enable`: Enable scheduling eligibility.
 - `-disable`: Disable scheduling eligibility.

--- a/website/content/docs/commands/node/index.mdx
+++ b/website/content/docs/commands/node/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node'
+page_title: 'nomad node command reference'
 description: |
-  The node command is used to interact with nodes.
+  The nomad node reference command interacts with nodes. View or modify client configuration. Toggle scheduling eligibility and node drain mode. Display metadata and status information.
 ---
 
-# Command: node
+# `nomad node` command reference
 
 The `node` command is used to interact with nodes.
 

--- a/website/content/docs/commands/node/meta/apply.mdx
+++ b/website/content/docs/commands/node/meta/apply.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node meta apply'
+page_title: 'nomad node meta apply command reference'
 description: |
-  The node meta apply command updates node metadata.
+  The `nomad node meta apply` command updates node metadata on client agents.
 ---
 
-# Command: node meta apply
+# `nomad node meta apply` command reference
 
 Modify a node's metadata. This command only applies to client agents, and can
 be used to update the scheduling metadata the node registers.
@@ -21,11 +21,11 @@ This command uses the [`/v1/client/metadata` HTTP API][api].
 nomad node meta apply [-node-id ...] [-unset ...] key1=value1 ... kN=vN
 ```
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Node Meta Apply Options
+## Node Meta Apply options
 
 - `-node-id` - Updates metadata on the specified node. If not specified the
   node receiving the request will be used by default.

--- a/website/content/docs/commands/node/meta/index.mdx
+++ b/website/content/docs/commands/node/meta/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node meta'
+page_title: 'nomad node meta command reference'
 description: |
-  The node meta commands are used to read and update node metadata.
+  The nomad node meta commands read and update node metadata.
 ---
 
-# Command: node meta
+# nomad node meta reference
 
 The `meta` command is used to read and update node metadata. This metadata is
 available for [interpolation using the `${meta.<key>}` syntax in jobs][interp].

--- a/website/content/docs/commands/node/meta/read.mdx
+++ b/website/content/docs/commands/node/meta/read.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node meta read'
+page_title: 'nomad node meta read command reference'
 description: |
-  The node meta read command reads node metadata.
+  The nomad node meta read command displays metadata on the specified node.
 ---
 
-# Command: node meta read
+# nomad node meta read reference
 
 Read a node's metadata. This command only works on client agents. The node
 status command can be used to retrieve node metadata from any agent.
@@ -24,11 +24,11 @@ This command uses the [`/v1/client/metadata` HTTP API][api].
 nomad node meta read [-json] [-node-id ...]
 ```
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Node Meta Read Options
+## Node Meta Read options
 
 - `-node-id` - Reads metadata on the specified node. If not specified the
   node receiving the request will be used by default.

--- a/website/content/docs/commands/node/status.mdx
+++ b/website/content/docs/commands/node/status.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: node status'
+page_title: 'nomad node status command reference'
 description: |
-  The node status command is used to display information about nodes.
+  The `nomad node status` command displays status information about registered client nodes.
 ---
 
-# Command: node status
+# `nomad node status` command reference
 
 The `node status` command is used to display information about client nodes. A
 node must first be registered with the servers before it will be visible in this
@@ -30,11 +30,11 @@ information will be displayed. If running the command on a Nomad Client, the
 If ACLs are enabled, this option requires a token with the 'node:read'
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Status Options
+## Status options
 
 - `-self`: Query the status of the local node.
 
@@ -334,7 +334,7 @@ Host Volumes
 Name  ReadOnly  Source
 
 CSI Volumes
-ID        Name  Namespace  Plugin ID  Schedulable  Access Mode         Mount Options
+ID        Name  Namespace  Plugin ID  Schedulable  Access Mode         Mount options
 402f2c83  vol   default    plug       true         single-node-writer  <none>
 
 Drivers

--- a/website/content/docs/commands/operator/api.mdx
+++ b/website/content/docs/commands/operator/api.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator api'
+page_title: 'nomad operator api command reference'
 description: |
-  operator api is a utility command for accessing Nomad's HTTP API similar to
-  the popular open source program curl.
+  The `nomad operator api` command is a cURL-like utility command for accessing Nomad's HTTP API.
 ---
 
-# Command: operator api
+# `nomad operator api` command reference
 
 The `operator api` command allows easy access to Nomad's HTTP API similar to
 the popular [curl] program. Nomad's `operator api` command reads [environment
@@ -43,11 +42,11 @@ curl \
   https://client.global.nomad:4646/v1/jobs
 ```
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Operator API Options
+## Operator API options
 
 - `-dryrun`: output a curl command instead of performing the HTTP request
   immediately. Note that you do *not* need the 3rd party `curl` command

--- a/website/content/docs/commands/operator/autopilot/get-config.mdx
+++ b/website/content/docs/commands/operator/autopilot/get-config.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator autopilot get-config'
+page_title: 'nomad operator autopilot get-config command reference'
 description: |
-  Display the current Autopilot configuration.
+  The `nomad operator autopilot get-config` command displays the current Autopilot configuration.
 ---
 
-# Command: operator autopilot get-config
+# `nomad operator autopilot get-config` command reference
 
 The Autopilot operator command is used to view the current Autopilot
 configuration. See the [Autopilot Guide] for more information about Autopilot.
@@ -19,7 +19,7 @@ nomad operator autopilot get-config [options]
 If ACLs are enabled, this command requires a token with the `operator:read`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/operator/autopilot/health.mdx
+++ b/website/content/docs/commands/operator/autopilot/health.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator autopilot health'
+page_title: 'nomad operator autopilot health command reference'
 description: |
-  Display the current Autopilot internal health.
+  The `nomad operator autopilot health` command displays the current Autopilot internal health.
 ---
 
-# Command: operator autopilot state
+# `nomad operator autopilot health` command reference
 
 The Autopilot operator command is used to view the current Autopilot
 state. See the [Autopilot Guide][] for more information about Autopilot.
@@ -19,11 +19,11 @@ nomad operator autopilot health [options]
 If ACLs are enabled, this command requires a token with the `operator:read`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Output Options
+## Output options
 
 - `-json`: Output the Autopilot health in unformatted JSON.
 
@@ -34,9 +34,9 @@ $ nomad operator autopilot health
 Healthy: true
 FailureTolerance: 0
 Leader: e349749b-3303-3ddf-959c-b5885a0e1f6e
-Voters:  
+Voters:
         e349749b-3303-3ddf-959c-b5885a0e1f6e
-Servers: 
+Servers:
 ID                                    Name      Address         SerfStatus  Version   Leader  Voter  Healthy  LastContact  LastTerm  LastIndex  StableSince
 e349749b-3303-3ddf-959c-b5885a0e1f6e  node1     127.0.0.1:4647  alive       1.7.5     true    true   true     0s           2         14         2024-02-20 16:40:55 +0000 UTC
 ```

--- a/website/content/docs/commands/operator/autopilot/set-config.mdx
+++ b/website/content/docs/commands/operator/autopilot/set-config.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator autopilot set-config'
+page_title: 'nomad operator autopilot set-config command reference'
 description: |
-  Modify the current Autopilot configuration.
+  The `nomad operator autopilot set-config` command modifies the current Autopilot configuration.
 ---
 
-# Command: operator autopilot set-config
+# `nomad operator autopilot set-config` command reference
 
 The Autopilot operator command is used to set the current Autopilot
 configuration. See the [Autopilot Guide] for more information about Autopilot.
@@ -19,11 +19,11 @@ nomad operator autopilot set-config [options]
 If ACLs are enabled, this command requires a token with the `operator:write`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Set Config Options
+## Set Config options
 
 - `-cleanup-dead-servers` - Specifies whether to enable automatic removal of
   dead servers upon the successful joining of new servers to the cluster. Must be

--- a/website/content/docs/commands/operator/client-state.mdx
+++ b/website/content/docs/commands/operator/client-state.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: 'Commands: operator client-state'
+page_title: 'nomad operator client-state command reference'
 description: >
-  The `operator client-state` command generates a representation of the
+  The `nomad operator client-state` command generates a representation of the
   stored client state in JSON format.
 ---
 
-# Command: operator client-state
+# `nomad operator client-state` command reference
 
 The `operator client-state` command generates a representation of the
 stored client state in JSON format.

--- a/website/content/docs/commands/operator/debug.mdx
+++ b/website/content/docs/commands/operator/debug.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator debug'
+page_title: 'nomad operator debug command reference'
 description: |
-  Build an archive of debug data.
+  The `nomad operator debug` command builds an archive containing Nomad cluster configuration and state information, Nomad server and client node logs, and pprof profiles from the selected servers and client nodes.
 ---
 
-# Command: operator debug
+# `nomad operator debug` command reference
 
 The `operator debug` command builds an archive containing Nomad cluster
 configuration and state information, Nomad server and client node
@@ -41,11 +41,11 @@ require the 'agent:read' and 'operator:read' capabilities, as well as the
 token will also require 'agent:write', or enable_debug configuration set to
 true.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Debug Options
+## Debug options
 
 - `-duration=5m`: Set the duration of the debug capture. Logs will be captured from
   specified servers and nodes at `log-level`. Defaults to `5m`.

--- a/website/content/docs/commands/operator/gossip/keyring-generate.mdx
+++ b/website/content/docs/commands/operator/gossip/keyring-generate.mdx
@@ -1,13 +1,13 @@
 ---
 layout: docs
-page_title: 'Commands: operator gossip keyring generate'
+page_title: 'nomad operator gossip keyring generate command reference'
 description: >
-  The `operator gossip keyring generate` command generates an encryption key that can be used for
+  The `nomad operator gossip keyring generate` command generates an encryption key that can be used for
   Nomad server's gossip traffic encryption. The keygen command uses a
   cryptographically strong pseudo-random number generator to generate the key.
 ---
 
-# Command: operator gossip keyring generate
+# nomad operator gossip keyring generate reference
 
 The `operator gossip keyring generate` command generates an encryption
 key that can be used for Nomad server's gossip traffic encryption. The

--- a/website/content/docs/commands/operator/gossip/keyring-install.mdx
+++ b/website/content/docs/commands/operator/gossip/keyring-install.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator gossip keyring install'
+page_title: 'nomad operator gossip keyring install command reference'
 description: |
-  Install a new gossip encryption key
+  The `nomad operator gossip keyring install` command installs a new gossip encryption key.
 ---
 
-# Command: operator gossip keyring install
+# `nomad operator gossip keyring install` command reference
 
 The `operator gossip keyring install` command is used to install a new
 encryption key used for gossip. This will broadcast the new key to all
@@ -24,7 +24,7 @@ capability.
 nomad operator gossip keyring install [options] <key>
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/operator/gossip/keyring-list.mdx
+++ b/website/content/docs/commands/operator/gossip/keyring-list.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator gossip keyring list'
+page_title: 'nomad operator gossip keyring list command reference'
 description: |
-  List gossip keys
+  The `nomad operator gossip keyring list` command displays all gossip keys currently in use within the cluster.
 ---
 
-# Command: operator gossip keyring list
+# `nomad operator gossip keyring list` command reference
 
 The `operator gossip keyring list` command lists all gossip keys
 currently in use within the cluster.
@@ -23,7 +23,7 @@ If ACLs are enabled, this command requires a token with the
 nomad operator gossip keyring list [options]
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/operator/gossip/keyring-remove.mdx
+++ b/website/content/docs/commands/operator/gossip/keyring-remove.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator gossip keyring remove'
+page_title: 'nomad operator gossip keyring remove command reference'
 description: |
-  Remove a new gossip encryption key
+  The `nomad operator gossip keyring remove` command removes the specified, non-primary gossip encryption key from the cluster.
 ---
 
-# Command: operator gossip keyring remove
+# `nomad operator gossip keyring remove` command reference
 
 The `operator gossip keyring remove` command removes the given key
 from the cluster. This operation may only be performed on keys which
@@ -24,7 +24,7 @@ capability.
 nomad operator gossip keyring remove [options] <key>
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/operator/gossip/keyring-use.mdx
+++ b/website/content/docs/commands/operator/gossip/keyring-use.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator gossip keyring use'
+page_title: 'nomad operator gossip keyring use command reference'
 description: |
-  Use a new gossip encryption key
+  The `nomad operator gossip keyring use` command changes the encryption key that Nomad uses for gossip.
 ---
 
-# Command: operator gossip keyring use
+# `nomad operator gossip keyring use` command reference
 
 The `operator gossip keyring use` command changes the encryption key
 used for gossip. The key must already be installed before this
@@ -24,7 +24,7 @@ capability.
 nomad operator gossip keyring use [options] <key>
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/operator/index.mdx
+++ b/website/content/docs/commands/operator/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator'
+page_title: 'nomad operator command reference'
 description: |
-  The operator command provides cluster-level tools for Nomad operators.
+  The `nomad operator` command provides cluster-level tools for Nomad operators.
 ---
 
-# Command: operator
+# `nomad operator` command reference
 
 The `operator` command provides cluster-level tools for Nomad operators, such
 as interacting with the Raft subsystem.

--- a/website/content/docs/commands/operator/metrics.mdx
+++ b/website/content/docs/commands/operator/metrics.mdx
@@ -1,13 +1,13 @@
 ---
 layout: docs
-page_title: 'Commands: operator metrics'
+page_title: 'nomad operator metrics command reference'
 description: |-
-  The `operator metrics` command queries the metrics API
+  The `nomad operator metrics` command queries the metrics API
   endpoint for metrics data related to the current Nomad
   process.
 ---
 
-# Command: operator metrics
+# `nomad operator metrics` command reference
 
 The `operator metrics` command queries the [metrics API endpoint](/nomad/api-docs/metrics).
 
@@ -17,11 +17,11 @@ The `operator metrics` command queries the [metrics API endpoint](/nomad/api-doc
 nomad operator metrics [options]
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Metrics Specific Options
+## Metrics Specific options
 
 - `-pretty`: Pretty prints the JSON output
 - `-format <format>`: Specify output format (`prometheus`)

--- a/website/content/docs/commands/operator/raft/info.mdx
+++ b/website/content/docs/commands/operator/raft/info.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator raft info'
+page_title: 'nomad operator raft info command reference'
 description: |
-  Display Raft server state.
+  The `nomad operator raft info` command displays summary information about the Raft logs persisted in the Nomad data directory.
 ---
 
-# Command: operator raft info
+# `nomad operator raft info` command reference
 
 The `raft info` command is used to display summary information about the
 raft logs persisted in the Nomad [data directory].

--- a/website/content/docs/commands/operator/raft/list-peers.mdx
+++ b/website/content/docs/commands/operator/raft/list-peers.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator raft list-peers'
+page_title: 'nomad operator raft list-peers command reference'
 description: |
-  Display the current Raft peer configuration.
+  The `nomad operator raft list-peers` command displays the current Raft peer configuration.
 ---
 
-# Command: operator raft list-peers
+# `nomad operator raft list-peers` command reference
 
 The `raft list-peers` command is used to display the current Raft peer
 configuration.
@@ -22,11 +22,11 @@ nomad operator raft list-peers [options]
 
 If ACLs are enabled, this command requires a management token.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## List Peers Options
+## List Peers options
 
 - `-stale`: The stale argument defaults to "false" which means the leader
   provides the result. If the cluster is in an outage state without a leader, you

--- a/website/content/docs/commands/operator/raft/logs.mdx
+++ b/website/content/docs/commands/operator/raft/logs.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator raft logs'
+page_title: 'nomad operator raft logs command reference'
 description: |
-  Display Raft server state.
+  The `nomad operator raft logs` command displays the log entries persisted in the Nomad data directory.
 ---
 
-# Command: operator raft logs
+# `nomad operator raft logs` command reference
 
 The `raft logs` command is used to display the log entries persisted in
 the Nomad [data directory] in JSON format.

--- a/website/content/docs/commands/operator/raft/remove-peer.mdx
+++ b/website/content/docs/commands/operator/raft/remove-peer.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator raft remove-peer'
+page_title: 'nomad operator raft remove-peer command reference'
 description: |
-  Remove a Nomad server from the Raft configuration.
+  The `nomad operator raft remove-peer` command removes a Nomad server from the Raft configuration.
 ---
 
-# Command: operator raft remove-peer
+# `nomad operator raft remove-peer` command reference
 
 Remove the Nomad server with given address from the Raft configuration.
 
@@ -28,11 +28,11 @@ nomad operator raft remove-peer [options]
 
 If ACLs are enabled, this command requires a management token.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Remove Peer Options
+## Remove Peer options
 
 - `-peer-address`: Remove a Nomad server with given address from the Raft
   configuration. The format is "IP:port"

--- a/website/content/docs/commands/operator/raft/state.mdx
+++ b/website/content/docs/commands/operator/raft/state.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator raft state'
+page_title: 'nomad operator raft state command reference'
 description: |
-  Display Raft server state.
+  The `nomad operator raft state` command displays Raft server state obtained by replaying Raft log entries persisted in the Nomad data directory.
 ---
 
-# Command: operator raft state
+# `nomad operator raft state` command reference
 
 The `raft state` command is used to display the server state obtained by
 replaying raft log entries persisted in the Nomad [data directory] in
@@ -25,7 +25,7 @@ being used by a running Nomad server.
 nomad operator raft state [options] <path to data dir>
 ```
 
-## Raft State Options
+## Raft State options
 
 - `-last-index=<last_index>`: Set the last log index to be applied, to
   drop spurious log entries not properly committed. If the

--- a/website/content/docs/commands/operator/raft/transfer-leadership.mdx
+++ b/website/content/docs/commands/operator/raft/transfer-leadership.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator raft transfer-leadership'
+page_title: 'nomad operator raft transfer-leadership command reference'
 description: |
-  Transfer leadership to a specific a Nomad server.
+  The `nomad operator raft transfer-leadership` command transfers leadership to a specific Nomad server.
 ---
 
-# Command: operator raft transfer-leadership
+# `nomad operator raft transfer-leadership` command reference
 
 Transfer leadership from the current leader to the given server member.
 
@@ -31,11 +31,11 @@ nomad operator raft transfer-leadership [options]
 If ACLs are enabled, this command requires a management token.
 </Tip>
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Transfer Leadership Options
+## Transfer Leadership options
 
 - `-peer-address`: Specifies the Raft **Address** of the target server as
   provided in the output of the [`nomad operator raft list-peers`][] command or

--- a/website/content/docs/commands/operator/root/keyring-list.mdx
+++ b/website/content/docs/commands/operator/root/keyring-list.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator root keyring list'
+page_title: 'nomad operator root keyring list command reference'
 description: |
-  List encryption key metadata
+  The `nomad operator root keyring list` command displays encryption key metadata for installed keys. This command does not display sensitive key material.
 ---
 
-# Command: operator root keyring list
+# `nomad operator root keyring list` command reference
 
 The `operator root keyring list` command lists the currently installed
 keys. This list returns key metadata and not sensitive key material.
@@ -18,11 +18,11 @@ If ACLs are enabled, this command requires a management token.
 nomad operator root keyring list [options]
 ```
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## List Options
+## List options
 
 - `-verbose`: Enable verbose output
 

--- a/website/content/docs/commands/operator/root/keyring-remove.mdx
+++ b/website/content/docs/commands/operator/root/keyring-remove.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator root keyring remove'
+page_title: 'nomad operator root keyring remove command reference'
 description: |
-  Remove an unused encryption key
+  The `nomad operator root keyring remove` command removes an unused encryption key from the cluster.
 ---
 
-# Command: operator root keyring remove
+# `nomad operator root keyring remove` command reference
 
 The `operator root keyring remove` command removes an encryption key from the
 cluster. This operation may only be performed on keys that are not the active
@@ -19,11 +19,11 @@ If ACLs are enabled, this command requires a management token.
 nomad operator root keyring remove [options] <key ID>
 ```
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Remove Options
+## Remove options
 
 - `-force`: Remove the key even if it was used to sign an existing variable
 or workload identity.

--- a/website/content/docs/commands/operator/root/keyring-rotate.mdx
+++ b/website/content/docs/commands/operator/root/keyring-rotate.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator root keyring rotate'
+page_title: 'nomad operator root keyring rotate command reference'
 description: |
-  Rotate encryption key
+  The `nomad operator root keyring rotate` command rotates the encryption key by generating a new encryption key for all future variables.
 ---
 
-# Command: operator root keyring rotate
+# `nomad operator root keyring rotate` command reference
 
 The `operator root keyring rotate` command generates a new encryption key for
 all future variables.
@@ -18,11 +18,11 @@ If ACLs are enabled, this command requires a management token.
 nomad operator root keyring rotate [options]
 ```
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Rotate Options
+## Rotate options
 
 - `-full`: Decrypt all existing variables and re-encrypt with the new key. This
   command will immediately return and the re-encryption process will run

--- a/website/content/docs/commands/operator/scheduler/get-config.mdx
+++ b/website/content/docs/commands/operator/scheduler/get-config.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator scheduler get-config'
+page_title: 'nomad operator scheduler get-config command reference'
 description: |
-  Display the current scheduler configuration.
+  The `nomad operator scheduler get-config` command displays the current scheduler configuration.
 ---
 
-# Command: operator scheduler get-config
+# `nomad operator scheduler get-config` command reference
 
 The scheduler operator get-config command is used to view the current scheduler
 configuration.
@@ -19,11 +19,11 @@ nomad operator scheduler get-config [options]
 If ACLs are enabled, this command requires a token with the `operator:read`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Get Config Options
+## Get Config options
 
 - `-json`: Output the scheduler config in its JSON format.
 

--- a/website/content/docs/commands/operator/scheduler/set-config.mdx
+++ b/website/content/docs/commands/operator/scheduler/set-config.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator scheduler set-config'
+page_title: 'nomad operator scheduler set-config command reference'
 description: |
-  Modify the scheduler configuration.
+  The `nomad operator scheduler set-config` command modifies the scheduler configuration. Set binpack or spread allocation. Enable or disable preemption for batch, service, sysbatch, and system jobs.
 ---
 
-# Command: operator scheduler set-config
+# `nomad operator scheduler set-config` command reference
 
 The scheduler operator set-config command is used to modify the scheduler
 configuration.
@@ -19,11 +19,11 @@ nomad operator scheduler set-config [options]
 If ACLs are enabled, this command requires a token with the `operator:write`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Set Config Options
+## Set config options
 
 - `-check-index` - If set, the scheduler config is only updated if the passed
   modify index matches the current server side version. If a non-zero value is

--- a/website/content/docs/commands/operator/snapshot/agent.mdx
+++ b/website/content/docs/commands/operator/snapshot/agent.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator snapshot agent'
+page_title: 'nomad operator snapshot agent command reference'
 description: |
-  Periodically saves snapshots of Nomad server state
+  The `nomad operator snapshot agent` command takes snapshots of the state of the Nomad servers and saves them locally or pushes them to an optional remote storage service.
 ---
 
-# Command: operator snapshot agent
+# `nomad operator snapshot agent` command reference
 
 <EnterpriseAlert />
 
@@ -107,20 +107,20 @@ google_storage {
 nomad operator snapshot agent [options] <config_file>
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Snapshot agent Options
+## Snapshot agent options
 
-### Snapshot Options
+### Snapshot options
 
 - `-interval`: Interval at which to perform snapshots as a time with a unit suffix, which can be "s", "m", "h" for seconds, minutes, or hours. If 0 is provided, the agent will take a single snapshot and then exit, which is useful for running snapshots via batch jobs. Defaults to "1h".
 - `-lock-key`: A prefix in Consul's key-value store used to coordinate between different instances of the snapshot agent in order to only have one active instance at a time. For highly available operation of the snapshot agent, simply run multiple instances. All instances must be configured with the same lock key in order to properly coordinate. Defaults to "nomad-snapshot/lock".
 - `-max-failures`: Number of snapshot failures after which the snapshot agent will give up leadership. In a highly available operation with multiple snapshot agents available, this gives another agent a chance to take over if an agent is experiencing issues, such as running out of disk space for snapshots. Defaults to 3.
 - `-retain`: Number of snapshots to retain. After each snapshot is taken, the oldest snapshots will start to be deleted in order to retain at most this many snapshots. If this is set to 0, the agent will not perform this and snapshots will accumulate forever. Defaults to 30.
 
-### Agent Options
+### Agent options
 
 - `-deregister-after`: An interval, after which if the agent is unhealthy it will be automatically deregistered from Consul service. discovery. This is a time with a unit suffix, which can be "s", "m", "h" for seconds, minutes, or hours. If 0 is provided, this will be disabled. Defaults to "72h".
 - `-log-level`: Controls verbosity of snapshot agent logs. Valid options are "TRACE", "DEBUG", "INFO", "WARN", "ERR". Defaults to "INFO".
@@ -129,11 +129,11 @@ nomad operator snapshot agent [options] <config_file>
 - `-syslog`: This enables forwarding logs to syslog. Defaults to false.
 - `-syslog-facility`: Sets the facility to use for forwarding logs to syslog. Defaults to "LOCAL0".
 
-### Local Storage Options
+### Local Storage options
 
 - `-local-path`: Location to store snapshots locally. The default behavior of the snapshot agent is to store snapshots locally in this directory. Defaults to "." to use the current working directory. If an alternate storage option is configured, then local storage will be disabled and this option will be ignored.
 
-### S3 Storage Options:
+### S3 Storage options:
 
 Note that despite the AWS references, any S3-compatible endpoint can be specified with '-aws-s3-endpoint'.
 
@@ -152,7 +152,7 @@ Note that despite the AWS references, any S3-compatible endpoint can be specifie
 - `-aws-s3-enable-kms`: Enables using Amazon KMS for encrypting snapshots
 - `-aws-s3-kms-key`: Optional KMS key to use, if this is not set the default KMS key will be used.
 
-### Azure Blob Storage Options
+### Azure Blob Storage options
 
 (Note: Non-Solaris platforms only)
 
@@ -161,7 +161,7 @@ Note that despite the AWS references, any S3-compatible endpoint can be specifie
 - `-azure-blob-container-name`: Container to use. Required for Azure blob storage, and setting this disables local storage.
 - `-azure-blob-environment`: Environment to use. Defaults to AZUREPUBLICCLOUD. Other valid environments are AZURECHINACLOUD, AZUREGERMANCLOUD and AZUREUSGOVERNMENTCLOUD.
 
-### Google Storage Options
+### Google Storage options
 
 - `-google-bucket`: The bucket to use.
 

--- a/website/content/docs/commands/operator/snapshot/inspect.mdx
+++ b/website/content/docs/commands/operator/snapshot/inspect.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator snapshot inspect'
+page_title: 'nomad operator snapshot inspect command reference'
 description: |
-  Displays information about a snapshot file stored on local disk.
+  The `nomad operator snapshot inspect` command displays information about a snapshot file stored on local disk.
 ---
 
-# Command: operator snapshot inspect
+# `nomad operator snapshot inspect` command reference
 
 Displays information about a snapshot file stored on local disk.
 
@@ -15,7 +15,7 @@ Displays information about a snapshot file stored on local disk.
 nomad operator snapshot inspect [options] [file]
 ```
 
-## Inspect Options
+## Inspect options
 
 - `-json` : Output information about the snapshot file in JSON format.
 

--- a/website/content/docs/commands/operator/snapshot/redact.mdx
+++ b/website/content/docs/commands/operator/snapshot/redact.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator snapshot redact'
+page_title: 'nomad operator snapshot redact command reference'
 description: |
-  Redacts snapshot of Nomad server state
+ The `nomad operator snapshot redact` command removes key material from an existing snapshot file created by the `operator snapshot save` command so you can transmit a snapshot without exposing key material.
 ---
 
-# Command: operator snapshot redact
+# `nomad operator snapshot redact` command reference
 
 
 The `operator snapshot redact` command removes key material from an existing

--- a/website/content/docs/commands/operator/snapshot/restore.mdx
+++ b/website/content/docs/commands/operator/snapshot/restore.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator snapshot restore'
+page_title: 'nomad operator snapshot restore command reference'
 description: |
-  Restore snapshot of Nomad server state
+  The `nomad operator snapshot restore` command restores the specified Nomad snapshot.
 ---
 
-# Command: operator snapshot restore
+# `nomad operator snapshot restore` command reference
 
 The `operator snapshot restore` command restores an atomic, point-in-time
 snapshot of the state of the Nomad servers, which includes jobs, nodes,
@@ -41,7 +41,7 @@ $ nomad operator snapshot restore backup.snap
 nomad operator snapshot restore [options] <file>
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/operator/snapshot/save.mdx
+++ b/website/content/docs/commands/operator/snapshot/save.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator snapshot save'
+page_title: 'nomad operator snapshot save command reference'
 description: |
-  Saves snapshot of Nomad server state
+  The `nomad operator snapshot save` command saves an atomic, point-in-time snapshot of state of the Nomad servers, including jobs, nodes, allocations,periodic jobs, ACLs for outage recovery, and the keyring.
 ---
 
-# Command: operator snapshot save
+# `nomad operator snapshot save` command reference
 
 The `operator snapshot save` command retrieves an atomic, point-in-time
 snapshot of the state of the Nomad servers, which includes jobs, nodes,
@@ -50,11 +50,11 @@ $ nomad operator snapshot save -stale backup.snap
 nomad operator snapshot save [options] <file>
 ```
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Snapshot Save Options
+## Snapshot save options
 
 - `-redact`: The redact option will locally edit the snapshot to remove any
   cleartext key material from the root keyring. Only the AEAD keyring provider

--- a/website/content/docs/commands/operator/snapshot/state.mdx
+++ b/website/content/docs/commands/operator/snapshot/state.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: operator snapshot state'
+page_title: 'nomad operator snapshot state command reference'
 description: |
-  Displays a JSON representation of a Raft snapshot.
+  The `nomad operator snapshot state` command displays a JSON representation of a Raft snapshot.
 ---
 
-# Command: operator snapshot state
+# `nomad operator snapshot state` command reference
 
 Displays a JSON representation of state in a raft snapshot on disk.
 

--- a/website/content/docs/commands/plugin/index.mdx
+++ b/website/content/docs/commands/plugin/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: plugin'
+page_title: 'nomad plugin command reference'
 description: |
-  The plugin command is used to interact with plugins.
+  The `nomad plugin` command interacts with external plugins that a job can use, such as Container Storage Interface (CSI) plugins.
 ---
 
-# Command: plugin
+# `nomad plugin` command reference
 
 The `plugin` command is used to interact with external plugins that
 can be registered by Nomad jobs. Currently Nomad supports [Container

--- a/website/content/docs/commands/plugin/status.mdx
+++ b/website/content/docs/commands/plugin/status.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: plugin status'
+page_title: 'nomad plugin status command reference'
 description: |
-  Display information and status of plugins.
+  The `nomad plugin status` displays information and status for a specific plugin, plugins by type, or all plugins.
 ---
 
-# Command: plugin status
+# `nomad plugin status` command reference
 
 The `plugin status` command displays status information for [Container
 Storage Interface (CSI)][csi] plugins.
@@ -27,11 +27,11 @@ of the most useful status fields for each.
 If ACLs are enabled, this command requires a token with the `plugin:read`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Status Options
+## Status options
 
 - `-type`: Display only plugins of a particular type. Currently only
   the `csi` type is supported, so this option can be omitted when

--- a/website/content/docs/commands/quota/apply.mdx
+++ b/website/content/docs/commands/quota/apply.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: quota apply'
+page_title: 'nomad quota apply command reference'
 description: |
-  The quota apply command is used to create or update quota specifications.
+  The `nomad quota apply` command creates or updates a Nomad Enterprise quota specification.
 ---
 
-# Command: quota apply
+# `nomad quota apply` command reference
 
 The `quota apply` command is used to create or update [quota specifications][].
 
-~> Quota commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -23,11 +23,11 @@ specification can be read from stdin by setting the path to "-".
 If ACLs are enabled, this command requires a token with the `quota:write`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Apply Options
+## Apply options
 
 - `-json`: Parse the input as a JSON quota specification.
 

--- a/website/content/docs/commands/quota/delete.mdx
+++ b/website/content/docs/commands/quota/delete.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: quota delete'
+page_title: 'nomad quota delete command reference'
 description: |
-  The quota delete command is used to delete an existing quota specification.
+  The `nomad quota delete` command deletes an existing quota specification in Nomad Enterprise.
 ---
 
-# Command: quota delete
+# `nomad quota delete` command reference
 
 The `quota delete` command is used to delete an existing quota specification.
 
-~> Quota commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -22,7 +22,7 @@ The `quota delete` command requires the quota specification name as an argument.
 If ACLs are enabled, this command requires a token with the `quota:write`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 

--- a/website/content/docs/commands/quota/index.mdx
+++ b/website/content/docs/commands/quota/index.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: quota'
+page_title: 'nomad quota command reference'
 description: |
-  The quota command is used to interact with quota specifications.
+  The `nomad quota` command interacts with Nomad Enterprise quota specifications. Generate an example specification. Create, update, delete, and inspect a quota specification. Display quota status and current usage. Retrieve a list of all quota specifications.
 ---
 
-# Command: quota
+# `nomad quota` command reference
 
 The `quota` command is used to interact with quota specifications.
 
-~> Quota commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 

--- a/website/content/docs/commands/quota/init.mdx
+++ b/website/content/docs/commands/quota/init.mdx
@@ -1,16 +1,16 @@
 ---
 layout: docs
-page_title: 'Commands: quota init'
+page_title: 'nomad quota init command reference'
 description: |
-  Generate an example quota specification.
+  The `nomad quota init` command generates an example quota specification that you can customize for your Nomad Enterprise quota specification.
 ---
 
-# Command: quota init
+# `nomad quota init` command reference
 
 The `quota init` command is used to create an example [quota specification][]
 file that can be used as a starting point to customize further.
 
-~> Quota commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -18,7 +18,7 @@ file that can be used as a starting point to customize further.
 nomad quota init
 ```
 
-## Init Options
+## Init options
 
 - `-json`: Create an example JSON quota specification.
 

--- a/website/content/docs/commands/quota/inspect.mdx
+++ b/website/content/docs/commands/quota/inspect.mdx
@@ -1,17 +1,17 @@
 ---
 layout: docs
-page_title: 'Commands: quota inspect'
+page_title: 'nomad quota inspect command reference'
 description: >
-  The quota inspect command is used to view raw information about a particular
-  quota specification.
+  The `nomad quota inspect` command displays raw information about a particular
+  quota specification in Nomad Enterprise.
 ---
 
-# Command: quota inspect
+# `nomad quota inspect` command reference
 
 The `quota inspect` command is used to view raw information about a particular
 quota. The default output is in JSON format.
 
-~> Quota commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -22,11 +22,11 @@ nomad quota inspect [options] <quota_name>
 If ACLs are enabled, this command requires a token with the `quota:read`
 capability and access to any namespaces that the quota is applied to.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Inspect Options
+## Inspect options
 
 - `-json`: Output the quota specifications in a JSON format.
 

--- a/website/content/docs/commands/quota/list.mdx
+++ b/website/content/docs/commands/quota/list.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: quota list'
+page_title: 'nomad quota list command reference'
 description: |
-  The quota list command is used to list available quota specifications.
+  The `nomad quota list` command displays a list of available quota specifications in Nomad Enterprise.
 ---
 
-# Command: quota list
+# `nomad quota list` command reference
 
 The `quota list` command is used to list available quota specifications.
 
-~> Quota commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -21,11 +21,11 @@ If ACLs are enabled, this command requires a token with the `quota:read`
 capability. Any quotas applied to namespaces that the token does not have
 access to will be filtered from the results.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## List Options
+## List options
 
 - `-json`: Output the quota specifications in a JSON format.
 

--- a/website/content/docs/commands/quota/status.mdx
+++ b/website/content/docs/commands/quota/status.mdx
@@ -1,17 +1,16 @@
 ---
 layout: docs
-page_title: 'Commands: quota status'
+page_title: 'nomad quota status command reference'
 description: >
-  The quota status command is used to view the status of a particular quota
-  specification.
+  The `nomad quota status` command displays status information for a particular quota specification in Nomad Enterprise.
 ---
 
-# Command: quota status
+# `nomad quota status` command reference
 
 The `quota status` command is used to view the status of a particular quota
 specification.
 
-~> Quota commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -22,11 +21,11 @@ nomad quota status [options] <quota_name>
 If ACLs are enabled, this command requires a token with the `quota:read`
 capability and access to any namespaces that the quota is applied to.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Inspect Options
+## Inspect options
 
 - `-json`: Output the quota specifications in a JSON format.
 

--- a/website/content/docs/commands/recommendation/apply.mdx
+++ b/website/content/docs/commands/recommendation/apply.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: recommendation apply'
+page_title: 'nomad recommendation apply command reference'
 description: |
-  The recommendation apply command is used to apply recommendations.
+  The `nomad recommendation apply` command applies one or more recommendations in Nomad Enterprise.
 ---
 
-# Command: recommendation apply
+# `nomad recommendation apply` command reference
 
 The `recommendation apply` command is used to apply recommendations.
 
-~> Recommendation commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -25,11 +25,11 @@ When ACLs are enabled, this command requires a token with the `submit-job`,
 `read-job`, and `submit-recommendation` capabilities for the recommendation's
 namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Apply Options
+## Apply options
 
 - `-detach`: Return immediately instead of entering monitor mode. After applying
   a recommendation, the evaluation ID will be printed to the screen, which can

--- a/website/content/docs/commands/recommendation/dismiss.mdx
+++ b/website/content/docs/commands/recommendation/dismiss.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: recommendation dismiss'
+page_title: 'nomad recommendation dismiss command reference'
 description: |
-  The recommendation dismiss command is used to dismiss recommendations.
+  The `nomad recommendation dismiss` command dismisses one or more recommendations in Nomad Enterprise.
 ---
 
-# Command: recommendation dismiss
+# `nomad recommendation dismiss` command reference
 
 The `recommendation dismiss` command is used to dismiss recommendations.
 
-~> Recommendation commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -25,7 +25,7 @@ When ACLs are enabled, this command requires a token with the `submit-job`,
 `read-job`, and `submit-recommendation` capabilities for the recommendation's
 namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 

--- a/website/content/docs/commands/recommendation/index.mdx
+++ b/website/content/docs/commands/recommendation/index.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: recommendation'
+page_title: 'nomad recommendation command reference'
 description: |
-  The recommendation command is used to interact with recommendations.
+  The `nomad recommendation` command interacts with recommendations in Nomad Enterprise. Display a specific recommendation or a list of recommendations. Apply or dismiss recommendations.
 ---
 
-# Command: recommendation
+# `nomad recommendation` command reference
 
 The `recommendation` command is used to interact with recommendations.
 
-~> Recommendation commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 

--- a/website/content/docs/commands/recommendation/info.mdx
+++ b/website/content/docs/commands/recommendation/info.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: recommendation info'
+page_title: 'nomad recommendation info command reference'
 description: |
-  The recommendation info command is used to read the specified recommendation.
+  The `nomad recommendation info` command displays information about the specified recommendation in Nomad Enterprise.
 ---
 
-# Command: recommendation info
+# `nomad recommendation info` command reference
 
 The `recommendation info` command is used to read the specified recommendation.
 
-~> Recommendation commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -22,11 +22,11 @@ The `recommendation info` command requires a single argument, a recommendation I
 When ACLs are enabled, this command requires a token with the `read-job`
 capability for the recommendation's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Info Options
+## Info options
 
 - `-json` : Output the recommendation in its JSON format.
 

--- a/website/content/docs/commands/recommendation/list.mdx
+++ b/website/content/docs/commands/recommendation/list.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: recommendation list'
+page_title: 'nomad recommendation list command reference'
 description: |
-  The recommendation list command is used to list the available recommendations.
+  The `nomad recommendation list` command displays a list of available recommendations in Nomad Enterprise. Filter options include job, group, and task.
 ---
 
-# Command: recommendation list
+# `nomad recommendation list` command reference
 
 The `recommendation list` command is used to list the available recommendations.
 
-~> Recommendation commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -23,11 +23,11 @@ When ACLs are enabled, this command requires a token with the `submit-job`,
 `read-job`, and `submit-recommendation` capabilities for the namespace being
 queried.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## List Options
+## List options
 
 - `-job`: Specifies the job ID to filter the recommendations list by.
 

--- a/website/content/docs/commands/scaling/index.mdx
+++ b/website/content/docs/commands/scaling/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: scaling'
+page_title: 'nomad scaling command reference'
 description: |
-  The scaling command is used to interact with the scaling API.
+  The `nomad scaling` command interacts with scaling policies.
 ---
 
-# Command: scaling
+# `nomad scaling` command reference
 
 The `scaling` command is used to interact with the scaling API.
 

--- a/website/content/docs/commands/scaling/policy-info.mdx
+++ b/website/content/docs/commands/scaling/policy-info.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: scaling policy info'
+page_title: 'nomad scaling policy info command reference'
 description: |
-  Display an individual Nomad scaling policy.
+  The `nomad scaling policy info` command displays detailed information for the specified scaling policy.
 ---
 
-# Command: scaling policy info
+# `nomad scaling policy info` command reference
 
 Info is used to return detailed information on the specified scaling policy.
 
@@ -18,11 +18,11 @@ nomad scaling policy info [options] <policy_id>
 If ACLs are enabled, this command requires a token with the `read-job` and
 `list-jobs` capabilities for the policy's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Policy Info Options
+## Policy Info options
 
 - `-json` : Output the scaling policy in its JSON format.
 - `-t` : Format and display the scaling policy using a Go template.

--- a/website/content/docs/commands/scaling/policy-list.mdx
+++ b/website/content/docs/commands/scaling/policy-list.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: scaling policy list'
+page_title: 'nomad scaling policy list command reference'
 description: |
-  Display all Nomad scaling policies.
+  The `nomad scaling policy list` command displays all Nomad scaling policies. Filter options include job and policy type.
 ---
 
-# Command: scaling policy list
+# `nomad scaling policy list` command reference
 
 List is used to list all scaling policies stored in Nomad.
 
@@ -20,11 +20,11 @@ If ACLs are enabled, this command requires a token with the `read-job` and
 that the token does not have access to will have its policies filtered from
 the results.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Policy List Options
+## Policy List options
 
 - `-job` : Specifies the job ID to filter the scaling policies list by.
 - `-type` : Filter scaling policies by type.

--- a/website/content/docs/commands/sentinel/apply.mdx
+++ b/website/content/docs/commands/sentinel/apply.mdx
@@ -1,17 +1,16 @@
 ---
 layout: docs
-page_title: 'Commands: sentinel apply'
+page_title: 'nomad sentinel apply command reference'
 description: >
-  The sentinel apply command is used to write a new, or update an existing,
-  Sentinel policy.
+  The `nomad sentinel apply` command creates or updates a Sentinel policy in Nomad Enterprise.
 ---
 
-# Command: sentinel apply
+# `nomad sentinel apply` command reference
 
 The `sentinel apply` command is used to write a new, or update an existing,
 Sentinel policy.
 
-~> Sentinel commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -26,11 +25,11 @@ file name.
 Sentinel commands are only available when ACLs are enabled. This command
 requires a management token.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Apply Options
+## Apply options
 
 - `-description` : Sets a human readable description for the policy
 

--- a/website/content/docs/commands/sentinel/delete.mdx
+++ b/website/content/docs/commands/sentinel/delete.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: sentinel delete'
+page_title: 'nomad sentinel delete command reference'
 description: |
-  The sentinel delete command is used to delete a Sentinel policy.
+  The `nomad sentinel delete` command deletes the specified Sentinel policy in Nomad Enterprise.
 ---
 
-# Command: sentinel delete
+# `nomad sentinel delete` command reference
 
 The `sentinel delete` command is used to delete a Sentinel policy.
 
-~> Sentinel commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>.
 
 ## Usage
 
@@ -22,7 +22,7 @@ The `sentinel delete` command requires a single argument, the policy name.
 Sentinel commands are only available when ACLs are enabled. This command
 requires a management token.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/sentinel/index.mdx
+++ b/website/content/docs/commands/sentinel/index.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: sentinel'
+page_title: 'nomad sentinel command reference'
 description: |
-  The sentinel command is used to interact with Sentinel policies.
+  The `nomad sentinel` command interacts with Sentinel policies in Nomad Enterprise. Create, update, and delete a policy. Inspect and list policies.
 ---
 
-# Command: sentinel
+# `nomad sentinel` command reference
 
 The `sentinel` command is used to interact with Sentinel policies.
 
-~> Sentinel commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 

--- a/website/content/docs/commands/sentinel/list.mdx
+++ b/website/content/docs/commands/sentinel/list.mdx
@@ -1,16 +1,16 @@
 ---
 layout: docs
-page_title: 'Commands: sentinel list'
+page_title: 'nomad sentinel list command reference'
 description: |
-  The sentinel list command is used to list all installed Sentinel policies.
+  The `nomad sentinel list` command displays a list all Sentinel policies installed in Nomad Enterprise.
 ---
 
-# Command: sentinel list
+# `nomad sentinel list` command reference
 
 The `sentinel list` command is used to display all the installed Sentinel
 policies.
 
-~> Sentinel commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -23,7 +23,7 @@ The `sentinel list` command requires no arguments.
 Sentinel commands are only available when ACLs are enabled. This command
 requires a management token.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/sentinel/read.mdx
+++ b/website/content/docs/commands/sentinel/read.mdx
@@ -1,15 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: sentinel read'
+page_title: 'nomad sentinel read command reference'
 description: |
-  The sentinel read command is used to inspect a Sentinel policies.
+  The `nomad sentinel read` command displays detailed information about the specified Sentinel policy in Nomad Enterprise.
 ---
 
-# Command: sentinel read
+# `nomad sentinel read` command reference
 
 The `sentinel read` command is used to inspect a Sentinel policy.
 
-~> Sentinel commands are only available with Nomad Enterprise.
+<EnterpriseAlert product="nomad"/>
 
 ## Usage
 
@@ -22,11 +22,11 @@ The `sentinel read` command requires a single argument, the policy name.
 Sentinel commands are only available when ACLs are enabled. This command
 requires a management token.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Read Options
+## Read options
 
 - `-raw` : Output the raw policy only.
 

--- a/website/content/docs/commands/server/force-leave.mdx
+++ b/website/content/docs/commands/server/force-leave.mdx
@@ -1,16 +1,15 @@
 ---
 layout: docs
-page_title: 'Commands: server force-leave'
+page_title: 'nomad server force-leave command reference'
 description: >
-  The server force-leave command is used to force a server into the "left"
-  state.
+  The `nomad server force-leave` command forces a server into the left state so that you can eject server nodes that have failed.
 ---
 
-# Command: server force-leave
+# `nomad server force-leave` command reference
 
 The `server force-leave` command forces a server to enter the "left" state.
 This can be used to eject server nodes which have failed and will not rejoin
-the cluster. The failed or left server will be garbage collected after `24h`. 
+the cluster. The failed or left server will be garbage collected after `24h`.
 
 ~> Note that if the server is actually still alive, it will
 eventually rejoin the cluster again.
@@ -30,11 +29,11 @@ from the list of members immediately.
 If ACLs are enabled, this option requires a token with the `agent:write`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Server Force-Leave Options
+## Server force-leave options
 
 - `-prune`: Removes failed or left server from the Serf member list immediately.
 	If member is actually still alive, it will eventually rejoin the cluster again.

--- a/website/content/docs/commands/server/index.mdx
+++ b/website/content/docs/commands/server/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: server'
+page_title: 'nomad server command reference'
 description: |
-  The server command is used to interact with Nomad servers.
+  The `nomad server` command interacts with Nomad servers. Display a list of servers, join server nodes together, and force a server into the left state.
 ---
 
-# Command: server
+# `nomad server` command reference
 
 Command: `nomad server`
 

--- a/website/content/docs/commands/server/join.mdx
+++ b/website/content/docs/commands/server/join.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: 'Commands: server join'
+page_title: 'nomad server join command reference'
 description: >
-  The server join command is used to join the local server to one or more Nomad
+  The `nomad server join` command joins the local server to one or more Nomad
   servers.
 ---
 
-# Command: server join
+# `nomad server join` command reference
 
 The `server join` command joins the local server to one or more Nomad servers.
 Joining is only required for server nodes, and only needs to succeed against
@@ -28,7 +28,7 @@ Joining servers in different regions will [federate][] the regions. This assumes
 that ACLs have been bootstrapped in the authoritative region. See [Configure for
 multiple regions][] in the ACLs tutorial.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/server/members.mdx
+++ b/website/content/docs/commands/server/members.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: server members'
+page_title: 'nomad server members command reference'
 description: >
-  The server members command is used to display a list of the known server
-  members and their status.
+  The `nomad server members` command displays a list of servers in the cluster. Review name, address, port, region, datacenter, Raft version, build version, status, tags, and whether the server is the leader.
 ---
 
-# Command: server members
+# `nomad server members` command reference
 
 The `server members` command displays a list of the known servers in the cluster
 and their current status. Member information is provided by the gossip protocol,
@@ -21,11 +20,11 @@ nomad server members [options]
 If ACLs are enabled, this option requires a token with the `node:read`
 capability.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 
-## Server Members Options
+## Server Members options
 
 - `-detailed` (<code>_deprecated_</code> use `-verbose` instead): Dump the
   basic member information as well as the raw set of tags for each member. This
@@ -36,9 +35,9 @@ capability.
   for each member. This mode reveals additional information not displayed in
   the standard output format.
 
-- `-json`: Output the server memebers in its JSON format.
+- `-json`: Output the server members in its JSON format.
 
-- `-t`: Format and display the server memebers using a Go template.
+- `-t`: Format and display the server members using a Go template.
 
 ## Examples
 

--- a/website/content/docs/commands/service/delete.mdx
+++ b/website/content/docs/commands/service/delete.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: service delete'
+page_title: 'nomad service delete command reference'
 description: |
-  The service delete command is used to delete Nomad service registrations.
+  The `nomad service delete` command deletes a Nomad service by name and ID.
 ---
 
-# Command: service delete
+# `nomad service delete` command reference
 
 The `service delete` command is used to delete an individual service
 registration. <em>This command is not expected to be used during normal
@@ -23,7 +23,7 @@ and the ID of the individual registration to delete.
 When ACLs are enabled, this command requires a token with the `submit-job`
 capability for the service registration namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 

--- a/website/content/docs/commands/service/index.mdx
+++ b/website/content/docs/commands/service/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: service'
+page_title: 'nomad service command reference'
 description: |
-  The service command is used to interact with the service API.
+  The `nomad service` command interacts with Nomad services. Display service  information and delete a registered service.
 ---
 
-# Command: service
+# `nomad service` command reference
 
 The `service` command is used to interact with the service API.
 

--- a/website/content/docs/commands/service/info.mdx
+++ b/website/content/docs/commands/service/info.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: service info'
+page_title: 'nomad service info command reference'
 description: |
-  The service info command is used to read the specified Nomad registered
-  service by name.
+  The `nomad service info` command displays information about the specified registered service. Search by service name to review namespace, job, allocation, node, datacenter, address, and tags.
 ---
 
-# Command: service info
+# `nomad service info` command reference
 
 The `service info` command is used to read the specified Nomad registered
 service by name.
@@ -22,11 +21,11 @@ The `service info` command requires a single argument, a service name.
 When ACLs are enabled, this command requires a token with the `read-job`
 capability for the service's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Info Options
+## Info options
 
 - `-per-page`: How many results to show per page.
 

--- a/website/content/docs/commands/service/list.mdx
+++ b/website/content/docs/commands/service/list.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: service list'
+page_title: 'nomad service list command reference'
 description: |
-  The service list command is used to list the registered Nomad services.
+  The `nomad service list` command displays a list of registered Nomad services.
 ---
 
-# Command: service list
+# `nomad service list` command reference
 
 The `service list` command is used to list the registered Nomad services.
 
@@ -24,11 +24,11 @@ The command supports the wildcard namespace identifier. Any namespaces that
 the token does not have access to will have its services filtered from the
 results.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## List Options
+## List options
 
 - `-json`: Output the services in its JSON format.
 

--- a/website/content/docs/commands/setup/consul.mdx
+++ b/website/content/docs/commands/setup/consul.mdx
@@ -1,14 +1,13 @@
 ---
 layout: docs
-page_title: 'Commands: setup consul'
+page_title: 'nomad setup consul command reference'
 description: |
-  Setup a Consul cluster for Nomad integration.
+  The `nomad setup consul` command configures a Consul cluster to allow Nomad workloads to authenticate themselves with workload identity.
 ---
 
-# Command: setup consul
+# `nomad setup consul` command reference
 
-This command sets up Consul for allowing Nomad workloads to authenticate
-themselves using Workload Identity.
+The `nomad setup consul` command configures a Consul cluster to allow Nomad workloads to authenticate themselves with workload identity.
 
 This command requires `acl:write` permissions for Consul and respects
 `CONSUL_HTTP_TOKEN`, `CONSUL_HTTP_ADDR`, and other [Consul-related environment
@@ -27,7 +26,7 @@ versions of Nomad.
 nomad setup consul [options]
 ```
 
-## Setup Consul Options
+## Options
 
 - `-jwks-url`: URL of Nomad's JWKS endpoint contacted by Consul to verify JWT
   signatures. Defaults to `http://localhost:4646/.well-known/jwks.json`.

--- a/website/content/docs/commands/setup/index.mdx
+++ b/website/content/docs/commands/setup/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: setup'
+page_title: 'nomad setup command reference'
 description: |
-  The setup command is used to interact with interactive setup helpers.
+  The `nomad setup` command sets up Consul and Vault integration.
 ---
 
-# Command: setup
+# `nomad setup` command reference
 
 The `setup` command groups helper subcommands used for setting up external
 tools.

--- a/website/content/docs/commands/setup/vault.mdx
+++ b/website/content/docs/commands/setup/vault.mdx
@@ -1,14 +1,13 @@
 ---
 layout: docs
-page_title: 'Commands: setup vault'
+page_title: 'nomad setup vault command reference'
 description: |
-  Setup a Vault cluster for Nomad integration.
+  The `nomad setup vault` command configures a Vault installation to allow Nomad workloads to authenticate themselves with workload identity.
 ---
 
-# Command: setup vault
+# `nomad setup vault` command reference
 
-This command sets up Vault for allowing Nomad workloads to authenticate
-themselves using Workload Identity.
+The `nomad setup vault` command configures a Vault installation to allow Nomad workloads to authenticate themselves with workload identity.
 
 This command requires `acl:write` permissions for Vault and respects
 `VAULT_TOKEN`, `VAULT_ADDR`, and other [Vault-related environment
@@ -34,7 +33,7 @@ versions of Nomad.
 nomad setup vault [options]
 ```
 
-## Setup Vault Options
+## Options
 
 - `-jwks-url`: URL of Nomad's JWKS endpoint contacted by Consul to verify JWT
   signatures. Defaults to `http://localhost:4646/.well-known/jwks.json`.
@@ -51,7 +50,7 @@ nomad setup vault [options]
 - `-check`: Verify if the Nomad cluster is ready to migrate to Workload
   Identities.
 
-### Setup Vault Options When Using `-check`:
+### Options when using `-check`
 
 - `-json`: Output migration status information in its JSON format.
 

--- a/website/content/docs/commands/status.mdx
+++ b/website/content/docs/commands/status.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: status'
+page_title: 'nomad status command reference'
 description: |
-  Display the status output for any Nomad resource.
+  The `nomad status` command display the status output for any Nomad resource.
 ---
 
-# Command: status
+# `nomad status` command reference
 
 The `status` command displays the status output for any Nomad resource.
 
@@ -22,7 +22,7 @@ appropriate status command to display more detailed output.
 If the ID is omitted, the command lists out all of the existing jobs. This is
 for backwards compatibility and should not be relied on.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 

--- a/website/content/docs/commands/system/gc.mdx
+++ b/website/content/docs/commands/system/gc.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: system gc'
+page_title: 'nomad system gc command reference'
 description: |
-  Run the system garbage collection process.
+  The `nomad system gc` command runs the system garbage collection process on jobs, evaluations, allocations, and nodes.
 ---
 
-# Command: system gc
+# `nomad system gc` command reference
 
 Initializes a garbage collection of jobs, evaluations, allocations, and nodes.
 This is an asynchronous operation.
@@ -32,7 +32,7 @@ nomad system gc [options]
 
 If ACLs are enabled, this option requires a management token.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/system/index.mdx
+++ b/website/content/docs/commands/system/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: system'
+page_title: 'nomad system command reference'
 description: |
-  The system command is used to interact with the system API.
+  The `nomad system` commands run garbage collection and reconcile job summaries.
 ---
 
-# Command: system
+# `nomad system` command reference
 
 The `system` command is used to interact with the system API. These calls are
 used for system maintenance and should not be necessary for most users.

--- a/website/content/docs/commands/system/reconcile-summaries.mdx
+++ b/website/content/docs/commands/system/reconcile-summaries.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: system reconcile summaries'
+page_title: 'nomad system reconcile summaries command reference'
 description: |
-  Reconciles the summaries of all registered jobs.
+  The `nomad system reconcile summaries` command reconciles the summaries of all registered jobs.
 ---
 
-# Command: system reconcile summaries
+# `nomad system reconcile summaries` command reference
 
 Reconciles the summaries of all registered jobs.
 
@@ -17,7 +17,7 @@ nomad system reconcile summaries [options]
 
 If ACLs are enabled, this option requires a management token.
 
-## General Options
+## General options
 
 @include 'general_options_no_namespace.mdx'
 

--- a/website/content/docs/commands/tls/ca-create.mdx
+++ b/website/content/docs/commands/tls/ca-create.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: tls ca create'
+page_title: 'nomad tls ca create command reference'
 description: |
-  This command creates a Certificate Authority that can be used to create
-  self signed certificates to be used for Nomad TLS setup.
+  The `nomad tls ca create` command creates a certificate authority that you then use to create a self-signed certificate for Nomad Transport Layer Security (TLS) configuration.
 ---
 
-# Command: nomad tls ca create
+# `nomad tls ca create` command reference
 
 Create is used to create a self signed Certificate Authority to be used for
 Nomad TLS setup.
@@ -17,7 +16,7 @@ Nomad TLS setup.
 nomad tls ca create [options]
 ```
 
-## CA Create Options
+## Options
 
 - `-additional-domain=<value>`: Add name constraints for the CA. The server will
   reject certificates for DNS names other than those specified in `-domain` and

--- a/website/content/docs/commands/tls/ca-info.mdx
+++ b/website/content/docs/commands/tls/ca-info.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: tls ca info'
+page_title: 'nomad tls ca info command reference'
 description: |
-  This command displays relevant information that is contained within a
-  Certificate Authority certificate.
+  The `nomad tls ca info` command displays serial number, issuer, name, expiration date, and permitted DNS domains for the provided certificate authority (CA) file.
 ---
 
-# Command: nomad tls ca info
+# `nomad tls ca info` command reference
 
 Info is used to display relevant information that is contained within the
 provided certificate file.

--- a/website/content/docs/commands/tls/cert-create.mdx
+++ b/website/content/docs/commands/tls/cert-create.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: TLS Cert Create'
+page_title: 'nomad tls cert create command reference'
 description: |
-  This command creates a Certificate that can be used for Nomad TLS setup.
+  The `nomad tls cert create` command creates a server, client, or command-line interface (CLI) certificate for Transport Layer Security (TLS) configuration in your Nomad cluster.
 ---
 
-# Command: nomad tls cert create
+# `nomad tls cert create` command reference
 
 The `tls cert create` command is used to create certificates to be used for
 [TLS encryption][] for your Nomad cluster. You can then copy these to your
@@ -16,7 +16,7 @@ configuration of the agents.
 
 Usage: `nomad tls cert create [options]`
 
-#### Command Options
+#### Options
 
 - `-additional-dnsname=<string>`: Provide an additional dnsname for Subject
   Alternative Names. `localhost` is always included. This flag may be provided

--- a/website/content/docs/commands/tls/cert-info.mdx
+++ b/website/content/docs/commands/tls/cert-info.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: TLS Cert Info'
+page_title: 'nomad tls cert info command reference'
 description: |
-  This command displays relevant information that is contained within a
-  certificate.
+  The `nomad tls cert info` command displays serial number, issuer, name, expiration date, DNS names, and IP address from a specified certificate file.
 ---
 
-# Command: nomad tls cert info
+# `nomad tls cert info` command reference
 
 Info is used to display relevant information that is contained within a provided
 certificate file.

--- a/website/content/docs/commands/tls/index.mdx
+++ b/website/content/docs/commands/tls/index.mdx
@@ -1,12 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: tls'
+page_title: 'nomad tls command reference'
 description: |
-  The tls command is used to help with creating a Certificate Authority 
-  and up self signed certificates for Nomad TLS configuration.
+  The `nomad tls` command creates and displays information about a certificate authority and self-signed certificate for Nomad's Transport Security Layer (TLS).
 ---
 
-# Command: tls
+# `nomad tls` command reference
 
 The `tls` command is used to help with setting up a self signed CA and certificates for Nomad TLS.
 

--- a/website/content/docs/commands/ui.mdx
+++ b/website/content/docs/commands/ui.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: ui'
+page_title: 'nomad ui command reference'
 description: |
-  The ui command is used to open the Nomad Web UI.
+  The `nomad ui` command opens the Nomad Web UI. Provide a node, job, or allocation identifier to open that object's UI page in your browser. Authenticate with an access control list (ACL) token. Use the `show-url` flag to return the UI's URL.
 ---
 
-# Command: ui
+# `nomad ui` command reference
 
 The `ui` command is used to open the Nomad Web UI.
 
@@ -27,11 +27,11 @@ token for a one-time token, which is passed to the web UI. That one-time token
 will be exchanged for your Nomad ACL token and stored in the browser's local
 storage for authentication.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## UI Options
+## UI options
 
 - `-authenticate`: Exchange your Nomad ACL token for a one-time token in the
   web UI.

--- a/website/content/docs/commands/var/get.mdx
+++ b/website/content/docs/commands/var/get.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: "Command: var get"
+page_title: nomad var get reference
 description: |-
-  The "var get" command retrieves the variable at the given path from
-  Nomad. If no variable exists at that path, an error is returned.
+  The `nomad var get` command retrieves the variable at the given path from
+  Nomad.
 ---
 
-# Command: var get
+# `nomad var get` command reference
 
 The `var get` command is used to get the contents of an existing [variable][].
 
@@ -20,11 +20,11 @@ If ACLs are enabled, this command requires a token with the `variables:read`
 capability for the target variable's namespace and path. See the [ACL policy][]
 documentation for details.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Output Options
+## Output options
 
 - `-item` `(string: "")`: Print only the value of the given item. Specifying
    this option will take precedence over other formatting directives. The result

--- a/website/content/docs/commands/var/index.mdx
+++ b/website/content/docs/commands/var/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: "Commands: var"
+page_title: nomad var reference
 description: |-
-  The "var" command groups subcommands for interacting with Nomad variables.
+  The `nomad var` commands interact with Nomad variables. Create a variable specification file. Insert, update, delete, or acquire a lock over a variable. Fetch and list variables.
 ---
 
-# Command: var
+# `nomad var` command reference
 
 The `var` command is used to interact with Nomad [variables].
 

--- a/website/content/docs/commands/var/init.mdx
+++ b/website/content/docs/commands/var/init.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: var init'
+page_title: 'nomad var init command reference'
 description: |
-  Generate an example variable specification.
+  The `nomad var init` command generates an example variable specification that you can customize for your Nomad variables.
 ---
 
-# Command: var init
+# `nomad var init` command reference
 
 The `var init` creates an example variable specification file that can be used
 as a starting point to customize further.
@@ -19,7 +19,7 @@ nomad var init <filename>
 When no filename is supplied, a default filename of "spec.nv.hcl" or
 "spec.nv.json" will be used depending on the output format.
 
-## Init Options
+## Init options
 
 - `-out` `(enum: hcl | json)`: Format of generated variable
   specification. Defaults to `hcl`.

--- a/website/content/docs/commands/var/list.mdx
+++ b/website/content/docs/commands/var/list.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: "Command: var list"
+page_title: nomad var list reference
 description: |-
-  The "var list" command lists data from Nomad's variables datastore at
+  The `nomad var list` command displays data from Nomad's variables datastore at
   or beginning with the given prefix.
 ---
 
-# Command: var list
+# `nomad var list` command reference
 
 The `var list` command returns a list of [variable][] paths accessible to the
 current user, optionally filtered to paths containing a provided prefix. Do not
@@ -30,11 +30,11 @@ If ACLs are enabled, this command requires the `variables:list` capability for
 the namespaces and paths containing the variables to list. See the [ACL policy][]
 documentation for details.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## List Options
+## List options
 
 - `-per-page` `(int: <unset>)`: How many results to show per page.
 

--- a/website/content/docs/commands/var/lock.mdx
+++ b/website/content/docs/commands/var/lock.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: "Command: var lock"
+page_title: nomad var lock reference
 description: |-
-  The "var lock" command locks a variable, only allowing the lock owner to modify it.
+  The `nomad var lock` command locks a variable, only allowing the lock owner to modify it.
 ---
 
-# Command: var lock
+# `nomad var lock` command reference
 
 The `var lock` command holds a lock on a [variable][].
 
@@ -21,17 +21,17 @@ is created in the given variable, and only when held, is a child process invoked
 
 The lock command can be called on an existing variable or an entire new variable
 specification can be provided to the command from a file by using an
-@-prefixed path to a variable specification file. Items to be stored in the 
-variable can be supplied using the specification file as well. 
+@-prefixed path to a variable specification file. Items to be stored in the
+variable can be supplied using the specification file as well.
 
 Nomad lock launches its children in a shell. By default, Nomad will use the
-shell defined in the environment variable SHELL. If SHELL is not defined, 
+shell defined in the environment variable SHELL. If SHELL is not defined,
 it will default to /bin/sh. It should be noted that not all shells terminate
-child processes when they receive SIGTERM. Under Ubuntu, /bin/sh is linked 
-to dash, which does not terminate its children. In order to ensure that 
+child processes when they receive SIGTERM. Under Ubuntu, /bin/sh is linked
+to dash, which does not terminate its children. In order to ensure that
 child processes are killed when the lock is lost, be sure to set the SHELL
-environment variable appropriately, or run without a shell by setting -shell=false. 
- 
+environment variable appropriately, or run without a shell by setting -shell=false.
+
 If [ACLs][] are enabled, this command requires the 'variables:write' capability
 for the destination namespace and path.
 
@@ -53,17 +53,17 @@ values are read using the `range` function.
 Variable items are restricted to 64KiB in size. This limit is calculated by
 taking the sum of the length in bytes of all of the unencrypted keys and values.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Lock Options
+## Lock options
 - `-verbose`: Provides additional information via standard error to preserve
   standard output (stdout) for redirected output.
 
 - `ttl`: Optional, TTL for the lock, time the variable will be locked. Defaults to 15s.
 
-- `delay`: Optional, time the variable is blocked from locking when a lease is not renewed.	
+- `delay`: Optional, time the variable is blocked from locking when a lease is not renewed.
 	Defaults to 15s.
 
 - `max-retry`:Optional, max-retry up to this number of times if Nomad returns a 500 error
@@ -72,12 +72,12 @@ taking the sum of the length in bytes of all of the unencrypted keys and values.
 	time required to detect a lost lock in some cases. Defaults to 5. Set to 0 to
 	disable.
 
-- `shell`: Optional, use a shell to run the command (can set a custom shell via		
+- `shell`: Optional, use a shell to run the command (can set a custom shell via
 	the SHELL environment variable). The default value is true.
 
 ## Examples
 
-Attempts to acquire a lock over the variable at path "secret/creds" for a time of 
+Attempts to acquire a lock over the variable at path "secret/creds" for a time of
 15s and executes  `nomad job run webapp.nomad.hcl` if it succeeds:
 
 ```shell-session

--- a/website/content/docs/commands/var/purge.mdx
+++ b/website/content/docs/commands/var/purge.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
-page_title: "Command: var purge"
+page_title: nomad var purge reference
 description: |-
-  The "var purge" command permanently removes the specified variable
+  The `nomad var purge` command permanently removes the specified variable
   from Nomad.
 ---
 
-# Command: var purge
+# `nomad var purge` command reference
 
 The `var purge` command permanently deletes an existing [variable][] from Nomad's
 variable storage.
@@ -23,11 +23,11 @@ If ACLs are enabled, this command requires a token with the `variables:destroy`
 capability for the target variable's namespace and path. See the [ACL policy][]
 documentation for details.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Command Options
+## Command options
 
 - `-check-index` `(int: <unset>)`: If set, the variable is only acted upon if
   the server-side version's index matches the provided value. When a variable

--- a/website/content/docs/commands/var/put.mdx
+++ b/website/content/docs/commands/var/put.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: "Command: var put"
+page_title: nomad var put reference
 description: |-
-  The "var put" command writes a variable to the given path in Nomad.
+  The `nomad var put` command creates or updates a Nomad variable.
 ---
 
-# Command: var put
+# `nomad var put` command reference
 
 The `var put` command creates or updates an existing [variable][].
 
@@ -54,11 +54,11 @@ values are read using the `range` function.
 Variable items are restricted to 64KiB in size. This limit is calculated by
 taking the sum of the length in bytes of all of the unencrypted keys and values.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Put Options
+## Put options
 
 - `-check-index` `(int: <unset>)`: If set, the variable is only acted upon if
   the server-side version's index matches the provided value. When a variable

--- a/website/content/docs/commands/version.mdx
+++ b/website/content/docs/commands/version.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: version'
+page_title: 'nomad version command reference'
 description: |
-  Display the version and build data of Nomad
+  The `nomad version` command displays the version, build date, and revision information for a Nomad installation.
 ---
 
-# Command: version
+# `nomad version` command reference
 
 The `version` command displays build information about the running binary,
 including the release version, build date, and the exact revision.

--- a/website/content/docs/commands/volume/create.mdx
+++ b/website/content/docs/commands/volume/create.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: volume create'
+page_title: 'nomad volume create command reference'
 description: |
   Create volumes with CSI plugins.
 ---
 
-# Command: volume create
+# `nomad volume create` command reference
 
 The `volume create` command creates external storage volumes with Nomad's
 [Container Storage Interface (CSI)][csi] support. Only CSI plugins that
@@ -27,7 +27,7 @@ read from the file at the supplied path.
 When ACLs are enabled, this command requires a token with the
 `csi-write-volume` capability for the volume's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 

--- a/website/content/docs/commands/volume/delete.mdx
+++ b/website/content/docs/commands/volume/delete.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: volume delete'
+page_title: 'nomad volume delete command reference'
 description: |
   Delete volumes with CSI plugins.
 ---
 
-# Command: volume delete
+# `nomad volume delete` command reference
 
 The `volume delete` command deletes external storage volumes with Nomad's
 [Container Storage Interface (CSI)][csi] support. Only CSI plugins that
@@ -28,7 +28,7 @@ exists, this command will silently return without an error.
 When ACLs are enabled, this command requires a token with the
 `csi-write-volume` capability for the volume's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 

--- a/website/content/docs/commands/volume/deregister.mdx
+++ b/website/content/docs/commands/volume/deregister.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: volume deregister'
+page_title: 'nomad volume deregister command reference'
 description: |
   Deregister volumes with CSI plugins.
 ---
 
-# Command: volume deregister
+# `nomad volume deregister` command reference
 
 The `volume deregister` command deregisters external storage volumes with
 Nomad's [Container Storage Interface (CSI)][csi] support. The volume will be
@@ -27,11 +27,11 @@ unpublished.
 When ACLs are enabled, this command requires a token with the
 `csi-write-volume` capability for the volume's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Deregister Options
+## Deregister options
 
 - `-force`: Force deregistration of the volume and immediately drop claims for
   terminal allocations. Returns an error if the volume has running

--- a/website/content/docs/commands/volume/detach.mdx
+++ b/website/content/docs/commands/volume/detach.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: volume detach'
+page_title: 'nomad volume detach command reference'
 description: |
-  Detach volumes with CSI plugins.
+  The `nomad volume detach` command detaches external storage volumes with Container Storage Interface (CSI) plugins.
 ---
 
-# Command: volume detach
+# `nomad volume detach` command reference
 
 The `volume detach` command detaches external storage volumes with Nomad's
 [Container Storage Interface (CSI)][csi] support.
@@ -28,7 +28,7 @@ When ACLs are enabled, this command requires a token with the
 `csi-write-volume` and `csi-read-volume` capabilities for the volume's
 namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 

--- a/website/content/docs/commands/volume/index.mdx
+++ b/website/content/docs/commands/volume/index.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: volume'
+page_title: 'nomad volume command reference'
 description: |
-  The volume command is used to interact with volumes.
+  The `nomad volume` command interacts with volumes. Generate an example volume specification. Create, delete, register, and deregister a volume. Create and delete a volume snapshot. Display a list of volumes and status information for a single volume.
 ---
 
-# Command: volume
+# `nomad volume` command reference
 
 The `volume` command is used to interact with volumes.
 

--- a/website/content/docs/commands/volume/init.mdx
+++ b/website/content/docs/commands/volume/init.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: volume init'
+page_title: 'nomad volume init command reference'
 description: |
   Generate an example volume specification.
 ---
 
-# Command: volume init
+# `nomad volume init` command reference
 
 The `volume init` command is used to create an example volume specification
 file that can be used as a starting point to customize further.
@@ -16,7 +16,7 @@ file that can be used as a starting point to customize further.
 nomad volume init
 ```
 
-## Init Options
+## Init options
 
 - `-json`: Create an example JSON volume specification.
 

--- a/website/content/docs/commands/volume/register.mdx
+++ b/website/content/docs/commands/volume/register.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: volume register'
+page_title: 'nomad volume register command reference'
 description: |
   Register volumes with CSI plugins.
 ---
 
-# Command: volume register
+# `nomad volume register` command reference
 
 The `volume register` command registers external storage volumes with Nomad's
 [Container Storage Interface (CSI)][csi] support. The volume must exist on the
@@ -30,7 +30,7 @@ from the file at the supplied path.
 When ACLs are enabled, this command requires a token with the
 `csi-write-volume` capability for the volume's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 

--- a/website/content/docs/commands/volume/snapshot-create.mdx
+++ b/website/content/docs/commands/volume/snapshot-create.mdx
@@ -1,12 +1,12 @@
 ---
 layout: docs
 
-page_title: 'Commands: volume snapshot create'
+page_title: 'nomad volume snapshot create command reference'
 description: |
-  Create external volume snapshots.
+  The `nomad volume snapshot create` command creates a snapshot of an existing Container Storage Interface (CSI) volume.
 ---
 
-# Command: volume snapshot create
+# `nomad volume snapshot create` command reference
 
 The `volume snapshot create` command creates a snapshot of an existing
 [Container Storage Interface (CSI)][csi] volume. Only CSI plugins that
@@ -32,11 +32,11 @@ accept this name and it may be ignored.
 When ACLs are enabled, this command requires a token with the
 `csi-write-volume` capability for the volume's namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Snapshot Create Options
+## Snapshot create options
 
 - `-parameter`: Parameters to pass to the plugin to create a
   snapshot. Accepts multiple flags in the form `-parameter key=value`

--- a/website/content/docs/commands/volume/snapshot-delete.mdx
+++ b/website/content/docs/commands/volume/snapshot-delete.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: volume snapshot delete'
+page_title: 'nomad volume snapshot delete command reference'
 description: |
-  Delete external volume snapshots.
+  The `nomad volume snapshot delete` command deletes a snapshot of an existing Container Storage Interface (CSI) volume.
 ---
 
-# Command: volume snapshot delete
+# `nomad volume snapshot delete` command reference
 
 The `volume snapshot delete` command deletes a snapshot of an existing
 [Container Storage Interface (CSI)][csi] volume. Only CSI plugins that
@@ -25,11 +25,11 @@ need to be [registered] with Nomad in order to be deleted.
 When ACLs are enabled, this command requires a token with the `csi-write-
 volume` and `plugin:read` capabilities.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Snapshot Delete Options
+## Snapshot delete options
 
 - `-secret`: Secrets to pass to the plugin to delete the
   snapshot. Accepts multiple flags in the form `-secret key=value`

--- a/website/content/docs/commands/volume/snapshot-list.mdx
+++ b/website/content/docs/commands/volume/snapshot-list.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: volume snapshot list'
+page_title: 'nomad volume snapshot list command reference'
 description: |
-  List external volume snapshots.
+  The `nomad volume snapshot list` command displays a list external Container Storage Interface (CSI) volume snapshots along with the source volume ID as known to the external storage provider.
 ---
 
-# Command: volume snapshot list
+# `nomad volume snapshot list` command reference
 
 The `volume snapshot list` command lists volume snapshots known to a
 [Container Storage Interface (CSI)][csi] storage provider. Only CSI plugins
@@ -23,11 +23,11 @@ source volume ID as known to the external storage provider. This is not the
 same as the Nomad volume ID, as the source volume may not be [registered] with
 Nomad.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Snapshot List Options
+## Snapshot list options
 
 - `-page-token`: Where to start pagination.
 - `-per-page`: How many results to show per page.

--- a/website/content/docs/commands/volume/status.mdx
+++ b/website/content/docs/commands/volume/status.mdx
@@ -1,11 +1,11 @@
 ---
 layout: docs
-page_title: 'Commands: volume status'
+page_title: 'nomad volume status command reference'
 description: |
-  Display information and status of volumes.
+  The `nomad volume status` command displays volume information and status for a single volume or a list of volumes.
 ---
 
-# Command: volume status
+# `nomad volume status` command reference
 
 The `volume status` command displays status information for [Container
 Storage Interface (CSI)][csi] volumes.
@@ -28,11 +28,11 @@ When ACLs are enabled, this command requires a token with the
 `csi-read-volume` and `csi-list-volumes` capability for the volume's
 namespace.
 
-## General Options
+## General options
 
 @include 'general_options.mdx'
 
-## Status Options
+## Status options
 
 - `-type`: Display only volumes of a particular type. Currently only
   the `csi` type is supported, so this option can be omitted when
@@ -93,7 +93,7 @@ Nodes Healthy        = 1
 Nodes Expected       = 1
 Access Mode          = single-node-writer
 Attachment Mode      = file-system
-Mount Options        = fs_type: ext4 flags: ro
+Mount options        = fs_type: ext4 flags: ro
 Namespace            = default
 ```
 
@@ -116,7 +116,7 @@ Nodes Healthy        = 1
 Nodes Expected       = 1
 Access Mode          = single-node-writer
 Attachment Mode      = file-system
-Mount Options        = fs_type: ext4 flags: ro
+Mount options        = fs_type: ext4 flags: ro
 Namespace            = default
 
 Allocations


### PR DESCRIPTION
Original https://github.com/hashicorp/nomad/pull/25175

Manual backport because main contains 1.10 content not in stable-website, so removed 1.10 from backport.
