### PR TITLE
Docs: Add JSON format note to docker driver sysctl parameter

### DIFF
--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -165,14 +165,15 @@ The `docker` driver supports the following configuration in the job spec. Only
 
    <Warning>
 
-   If you are creating your job specification in JSON, you must use an array of
-   maps, not a single map as in HCL.
+   If you are creating your job specification in JSON, you must use wrap the map in an
+   array. Do not use a bare map as you would in HCL.
 
    ```json
    config {
      "sysctl": [
       {
-       "net.core.somaxconn": "16384"
+       "net.core.somaxconn": "16384",
+       "net.ipv4.tw_reuse": "1"
       }
     ]
    }

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -163,6 +163,23 @@ The `docker` driver supports the following configuration in the job spec. Only
   }
   ```
 
+   <Warning>
+
+   If you are creating your job specification in JSON, you must use an array of
+   maps, not a single map as in HCL.
+
+   ```json
+   config {
+     "sysctl": [
+      {
+       "net.core.somaxconn": "16384"
+      }
+    ]
+   }
+   ```
+
+   </Warning>
+
 - `ulimit` - (Optional) A key-value map of ulimit configurations to set to the
   containers on start.
 


### PR DESCRIPTION
### Description

From [NET-12322]

Docker task driver, `sysctl` parameter. HCL expects a key-value map, but JSON expects an array of maps. Add warning that JSON expects an array of maps.

### Links
Jira: [CE-837] [NET-12322]

Deploy preview: https://nomad-git-ce837sysctl-hashicorp.vercel.app/nomad/docs/drivers/docker#sysctl

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[NET-12322]: https://hashicorp.atlassian.net/browse/NET-12322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CE-837]: https://hashicorp.atlassian.net/browse/CE-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NET-12322]: https://hashicorp.atlassian.net/browse/NET-12322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ