### PR TITLE
docs: add missing podman task config options

### DIFF
--- a/website/content/plugins/drivers/podman.mdx
+++ b/website/content/plugins/drivers/podman.mdx
@@ -459,7 +459,7 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   }
   ```
 
-- `shm_size` - (Optional) Set the size of `/dev/shm`. Refer to `podman run
+- `shm_size` - (Optional) Set the size of `/dev/shm`. Refer to [`podman run
   --shm-size](https://docs.podman.io/en/latest/markdown/podman-run.1.html#shm-size-number-unit)
   for more details.
 

--- a/website/content/plugins/drivers/podman.mdx
+++ b/website/content/plugins/drivers/podman.mdx
@@ -134,8 +134,8 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
 
 ## Task Configuration
 
-- `apparmor_profile` - (Optional) Name of a apparmor profile to be used instead of
-  the default profile. The special value unconfined disables apparmor for this container.
+- `apparmor_profile` - (Optional) Name of an AppArmor profile to use instead of
+  the default profile. The special value `unconfined` disables AppArmor for this container.
 
   ```hcl
   config {
@@ -170,8 +170,7 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   }
   ```
 
-- `auth_soft_fail` - (Optional) Ignores errors returned from auth backend so
-  fallbacks can be tried.
+- `auth_soft_fail` - (Optional) Ignore errors returned from auth backend so Podman can fall back to a different auth method.
 
   ```hcl
   config {
@@ -209,12 +208,16 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   }
   ```
 
-- `cpu_hard_limit` (Optional) `true` or `false`. Use hard CPU limiting instead of
-  soft limiting. By default this is `false` which means soft limiting is used and
-  containers are able to burst above their CPU limit when there is idle capacity.
+- `cpu_hard_limit` (Optional) `true` or `false`. Use hard CPU limiting instead
+  of soft limiting. By default this is `false`, which means Podman uses soft
+  limiting so that containers are able to burst above their CPU limit when there
+  is idle capacity.
 
-- `cpu_cfs_period` - (Optional) Set the CPU persiod for the Completely Fair Scheduler (CFS),
-  which is a duration in microseconds. See podman --cpu-period for details.
+- `cpu_cfs_period` - (Optional) Set the CPU period for the [Completely Fair
+  Scheduler (CFS)](https://docs.kernel.org/scheduler/sched-design-CFS.html),
+  which is a duration in microseconds. Refer to [`podman run
+  --cpu-period`](https://docs.podman.io/en/latest/markdown/podman-run.1.html#cpu-period-limit)
+  for details.
 
 - `devices` - (Optional) A list of `host-device[:container-device][:permissions]`
   definitions. Each entry adds a host device to the container. Optional
@@ -408,7 +411,7 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   }
   ```
 
-- `pids_limit` - (Optional) An integer value that specified the pid limit for
+- `pids_limit` - (Optional) An integer value that specified the PID limit for
   the container.
 
   ```hcl
@@ -434,7 +437,7 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   }
   ```
 
-- `security_opt` - (Optional) A list of security-related options that are set
+- `security_opt` - (Optional) A list of security-related options that Podman sets
   in the container.
 
   ```hcl
@@ -446,7 +449,7 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   }
   ```
 
-- `selinux_opts` - (Optional) A list of prciess labels the container will use.
+- `selinux_opts` - (Optional) A list of process labels that the container uses.
 
   ```hcl
   config {
@@ -456,7 +459,8 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   }
   ```
 
-- `shm_size` - (Optional) Set the size of `/dev/shm`. See Podman --shm-size
+- `shm_size` - (Optional) Set the size of `/dev/shm`. Refer to `podman run
+  --shm-size](https://docs.podman.io/en/latest/markdown/podman-run.1.html#shm-size-number-unit)
   for more details.
 
 - `socket` - (Optional) The name of the socket as defined in the socket block in

--- a/website/content/plugins/drivers/podman.mdx
+++ b/website/content/plugins/drivers/podman.mdx
@@ -134,6 +134,15 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
 
 ## Task Configuration
 
+- `apparmor_profile` - (Optional) Name of a apparmor profile to be used instead of
+  the default profile. The special value unconfined disables apparmor for this container.
+
+  ```hcl
+  config {
+    apparmor_profile = "your-profile"
+  }
+  ```
+
 - `args` - (Optional) A list of arguments to the optional command. If no
   [`command`] is specified, the arguments are passed directly to the container.
 
@@ -158,6 +167,15 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
       password = "sup3rs3creT"
       tlsVerify = false
     }
+  }
+  ```
+
+- `auth_soft_fail` - (Optional) Ignores errors returned from auth backend so
+  fallbacks can be tried.
+
+  ```hcl
+  config {
+    auth_soft_fail = true
   }
   ```
 
@@ -191,6 +209,13 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   }
   ```
 
+- `cpu_hard_limit` (Optional) `true` or `false`. Use hard CPU limiting instead of
+  soft limiting. By default this is `false` which means soft limiting is used and
+  containers are able to burst above their CPU limit when there is idle capacity.
+
+- `cpu_cfs_period` - (Optional) Set the CPU persiod for the Completely Fair Scheduler (CFS),
+  which is a duration in microseconds. See podman --cpu-period for details.
+
 - `devices` - (Optional) A list of `host-device[:container-device][:permissions]`
   definitions. Each entry adds a host device to the container. Optional
   permissions can be used to specify device permissions, it is a combination of
@@ -214,6 +239,14 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   }
   ```
 
+- `extra_hosts` - (Optional) Set additional hosts in the container.
+
+  ```hcl
+  config {
+    extra_hosts = ["test4.localhost:127.0.0.2", "test6.localhost:[::1]"]
+  }
+  ```
+
 - `force_pull` - (Optional) `true` or `false` (default). Always pull the latest
   image on container start.
 
@@ -234,14 +267,6 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   ```hcl
   config {
     image = "docker://redis"
-  }
-  ```
-
-- `extra_hosts` - (Optional) Set additional hosts in the container
-
-  ```hcl
-  config {
-    extra_hosts = ["test4.localhost:127.0.0.2", "test6.localhost:[::1]"]
   }
   ```
 
@@ -383,6 +408,15 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   }
   ```
 
+- `pids_limit` - (Optional) An integer value that specified the pid limit for
+  the container.
+
+  ```hcl
+  config {
+    pids_limit = 64
+  }
+  ```
+
 - `ports` - (Optional) Forward and expose ports. Refer to
   [Docker driver configuration][nomad_driver_ports] for details.
 
@@ -397,6 +431,40 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
   ```hcl
   config {
     readonly_rootfs = true
+  }
+  ```
+
+- `security_opt` - (Optional) A list of security-related options that are set
+  in the container.
+
+  ```hcl
+  config {
+    security_opt = [
+      "no-new-privileges"
+    ]
+
+  }
+  ```
+
+- `selinux_opts` - (Optional) A list of prciess labels the container will use.
+
+  ```hcl
+  config {
+    selinux_opts = [
+      "type:my_container.process"
+    ]
+  }
+  ```
+
+- `shm_size` - (Optional) Set the size of `/dev/shm`. See Podman --shm-size
+  for more details.
+
+- `socket` - (Optional) The name of the socket as defined in the socket block in
+  the client agent's plugin configuration. Defaults to the socket named "default".
+
+  ```hcl
+  config {
+    socket = "app1"
   }
   ```
 
@@ -454,6 +522,14 @@ The `podman` driver implements the following [capabilities](/nomad/docs/concepts
       nproc  = "4242"
       nofile = "2048:4096"
     }
+  }
+  ```
+
+- `userns` - (Optional) Ser the user namespace mode for the container.
+
+  ```hcl
+  config {
+    userns = "keep-id:uid=200,gid=210"
   }
   ```
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Adds missing Podman task config options to the Podman driver docs.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
