### PR TITLE
Docs: fix broken links in 1.10 beta docs

### DIFF
--- a/website/content/api-docs/volumes.mdx
+++ b/website/content/api-docs/volumes.mdx
@@ -1219,6 +1219,6 @@ $ curl \
 [required ACLs]: /nomad/api-docs#acls
 [csi]: https://github.com/container-storage-interface/spec
 [csi_plugin]: /nomad/docs/job-specification/csi_plugin
-[csi_plugins_internals]: /nomad/docs/concepts/plugins/csi#csi-plugins
+[csi_plugins_internals]: /nomad/docs/concepts/plugins/storage/csi
 [Create CSI Volume]: #create-csi-volume
 [Volume Expansion]: /nomad/docs/other-specifications/volume/csi#volume-expansion

--- a/website/content/docs/commands/node/drain.mdx
+++ b/website/content/docs/commands/node/drain.mdx
@@ -162,4 +162,4 @@ $ nomad node drain -self -monitor
 [`reschedule`]: /nomad/docs/job-specification/reschedule
 [node status]: /nomad/docs/commands/node/status
 [workload migration guide]: /nomad/tutorials/manage-clusters/node-drain
-[internals-csi]: /nomad/docs/concepts/plugins/csi
+[internals-csi]: /nomad/docs/concepts/plugins/storage/csi

--- a/website/content/docs/commands/volume/create.mdx
+++ b/website/content/docs/commands/volume/create.mdx
@@ -89,7 +89,7 @@ the exact section.
 
 
 [csi]: https://github.com/container-storage-interface/spec
-[csi_plugins_internals]: /nomad/docs/concepts/plugins/csi#csi-plugins
+[csi_plugins_internals]: /nomad/docs/concepts/plugins/storage/csi
 [registers]: /nomad/docs/commands/volume/register
 [registered]: /nomad/docs/commands/volume/register
 [volume_specification]: /nomad/docs/other-specifications/volume

--- a/website/content/docs/commands/volume/delete.mdx
+++ b/website/content/docs/commands/volume/delete.mdx
@@ -47,6 +47,6 @@ volumes or `host-volume-delete` for dynamic host volumes.
   "csi".
 
 [csi]: https://github.com/container-storage-interface/spec
-[csi_plugins_internals]: /nomad/docs/concepts/plugins/csi#csi-plugins
+[csi_plugins_internals]: /nomad/docs/concepts/plugins/storage/csi
 [deregistered]: /nomad/docs/commands/volume/deregister
 [registered]: /nomad/docs/commands/volume/register

--- a/website/content/docs/commands/volume/register.mdx
+++ b/website/content/docs/commands/volume/register.mdx
@@ -110,6 +110,6 @@ the exact section.
 <span id="unused-fields" />
 
 [csi]: https://github.com/container-storage-interface/spec
-[csi_plugins_internals]: /nomad/docs/concepts/plugins/csi#csi-plugins
+[csi_plugins_internals]: /nomad/docs/concepts/plugins/storage/csi
 [volume_specification]: /nomad/docs/other-specifications/volume
 [`volume create`]: /nomad/docs/commands/volume/create

--- a/website/content/docs/commands/volume/snapshot-create.mdx
+++ b/website/content/docs/commands/volume/snapshot-create.mdx
@@ -65,4 +65,4 @@ Completed snapshot of volume ebs_prod_db1 with snapshot ID snap-12345.
 [csi]: https://github.com/container-storage-interface/spec
 [csi_plugin]: /nomad/docs/job-specification/csi_plugin
 [registered]: /nomad/docs/commands/volume/register
-[csi_plugins_internals]: /nomad/docs/concepts/plugins/csi#csi-plugins
+[csi_plugins_internals]: /nomad/docs/concepts/plugins/storage/csi

--- a/website/content/docs/commands/volume/snapshot-delete.mdx
+++ b/website/content/docs/commands/volume/snapshot-delete.mdx
@@ -46,4 +46,4 @@ Deleted snapshot snap-12345.
 [csi]: https://github.com/container-storage-interface/spec
 [csi_plugin]: /nomad/docs/job-specification/csi_plugin
 [registered]: /nomad/docs/commands/volume/register
-[csi_plugins_internals]: /nomad/docs/concepts/plugins/csi#csi-plugins
+[csi_plugins_internals]: /nomad/docs/concepts/plugins/storage/csi

--- a/website/content/docs/commands/volume/snapshot-list.mdx
+++ b/website/content/docs/commands/volume/snapshot-list.mdx
@@ -64,4 +64,4 @@ snap-12345   vol-abcdef   50GiB  2021-01-03T12:15:02Z  true
 [csi]: https://github.com/container-storage-interface/spec
 [csi_plugin]: /nomad/docs/job-specification/csi_plugin
 [registered]: /nomad/docs/commands/volume/register
-[csi_plugins_internals]: /nomad/docs/concepts/plugins/csi#csi-plugins
+[csi_plugins_internals]: /nomad/docs/concepts/plugins/storage/csi

--- a/website/content/docs/concepts/filesystem.mdx
+++ b/website/content/docs/concepts/filesystem.mdx
@@ -481,7 +481,7 @@ the volume, it is not possible to have `artifact`, `template`, or
 `dispatch_payload` blocks write to a volume.
 
 [artifacts]: /nomad/docs/job-specification/artifact
-[csi volumes]: /nomad/docs/concepts/plugins/csi
+[csi volumes]: /nomad/docs/concepts/plugins/storage/csi
 [dispatch payloads]: /nomad/docs/job-specification/dispatch_payload
 [templates]: /nomad/docs/job-specification/template
 [`data_dir`]: /nomad/docs/configuration#data_dir

--- a/website/content/docs/ecosystem.mdx
+++ b/website/content/docs/ecosystem.mdx
@@ -73,7 +73,7 @@ description: Learn about the Nomad ecosystem, which includes CI/CD, task drivers
 
 ## Storage
 
-- [CSI](/nomad/docs/concepts/plugins/csi)
+- [CSI](/nomad/docs/concepts/plugins/storage/csi)
 - [Portworx](/nomad/tutorials/stateful-workloads/stateful-workloads-portworx)
 
 ## GPUs

--- a/website/content/docs/operations/stateful-workloads.mdx
+++ b/website/content/docs/operations/stateful-workloads.mdx
@@ -108,8 +108,9 @@ There are three CSI plugin subtypes:
 - **Monolithic**: Combines both the above roles.
 
 All types can and should be run as Nomad jobs - `system` jobs for Node and
-Monolithic, `service` for Controllers. More information can be found on the CSI
-concepts [documentation page](/nomad/docs/concepts/plugins/csi).
+Monolithic, `service` for Controllers. Refer to the [Container Storage Interface
+(CSI) plugins page][csi-concepts] for more information.
+
 
 CSI plugins are useful when storage requirements are quickly and constantly
 evolving. For example, an environment that sees new workloads with persistent
@@ -169,7 +170,7 @@ volumes or distributed storage with GlusterFS or Ceph, host volumes provide a qu
 option to consume highly available and reliable storage.
 
 Refer to the [Stateful workloads with Nomad host
-volumes](/nomad/tutorials/stateful-workloads/stateful-workloads-host-volumes)
+volumes][csi-tutorial]
 tutorial to learn more about using host volumes with Nomad.
 
 #### NFS caveats
@@ -234,9 +235,9 @@ following resources:
 
 ### CSI
 
-- [Nomad CSI plugin concepts](/nomad/docs/concepts/plugins/storage/csi)
+- [Nomad CSI plugin concepts][csi-concepts]
 - [Nomad CSI
-  tutorial](/nomad/tutorials/stateful-workloads/stateful-workloads-csi-volumes)
+  tutorial][csi-tutorial]
 - [Nomad CSI examples](https://github.com/hashicorp/nomad/tree/main/demo/csi)
 - [Ceph RBD CSI with Nomad](https://docs.ceph.com/en/latest/rbd/rbd-nomad/)
 - [Democratic CSI with
@@ -249,3 +250,6 @@ following resources:
 
 - [Dynamic host volume plugins](/nomad/docs/concepts/plugins/storage/host-volumes)
 - [Dynamic host volume tutorial](/nomad/tutorial/stateful-workloads/stateful-workloads-dynamic-host-volumes)
+
+[csi-concepts]: /nomad/docs/concepts/plugins/storage/csi
+[csi-tutorial]: /nomad/tutorials/stateful-workloads/stateful-workloads-csi-volumes

--- a/website/content/docs/partnerships.mdx
+++ b/website/content/docs/partnerships.mdx
@@ -90,7 +90,7 @@ Autoscaling
 
 Storage
 
-- [CSI plugins documentation](/nomad/docs/concepts/plugins/csi)
+- [CSI plugins documentation](/nomad/docs/concepts/plugins/storage/csi)
 
 Observability & Analysis
 


### PR DESCRIPTION
### Description
1.10 beta docs

Fix broken links to CSI concepts page, which changed location. The redirect is in `redirects.js`: 

```js
  // CSI plugins moved under new storage path alongside new host volume plugins
  {
    source: '/nomad/docs/concepts/plugins/csi',
    destination: '/nomad/docs/concepts/plugins/storage/csi',
    permanent: true,
  },
```

But that isn't working for the 1.10 beta docs due to `v1.10.x` in the beta URL. So update the pages with the broken link rather than add a version-based redirect for the 1.10 beta URL.

**Merge into `main` only.**

### Links
Jira: [CE-839]

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[CE-839]: https://hashicorp.atlassian.net/browse/CE-839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ