### PR TITLE
Manual backport of tests: fixes a few data races in tests (#25455)

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/armon/go-metrics"
+	hclog "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocrunner"
@@ -23,6 +24,7 @@ import (
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/fingerprint"
 	regMock "github.com/hashicorp/nomad/client/serviceregistration/mock"
+	"github.com/hashicorp/nomad/client/state"
 	cstate "github.com/hashicorp/nomad/client/state"
 	ctestutil "github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/command/agent/consul"
@@ -1033,8 +1035,10 @@ func TestClient_AddAllocError(t *testing.T) {
 	// Ensure the allocation has been marked as invalid and failed on the server
 	testutil.WaitForResult(func() (bool, error) {
 		c1.allocLock.RLock()
+		c1.invalidAllocsLock.Lock()
 		ar := c1.allocs[alloc1.ID]
 		_, isInvalid := c1.invalidAllocs[alloc1.ID]
+		c1.invalidAllocsLock.Unlock()
 		c1.allocLock.RUnlock()
 		if ar != nil {
 			return false, fmt.Errorf("expected nil alloc runner")
@@ -1927,10 +1931,14 @@ func TestClient_updateNodeFromDriverUpdatesAll(t *testing.T) {
 func TestClient_hasLocalState(t *testing.T) {
 	ci.Parallel(t)
 
-	c, cleanup := TestClient(t, nil)
-	defer cleanup()
+	newStateDB := func(logger hclog.Logger, _ string) (state.StateDB, error) {
+		return cstate.NewMemDB(logger), nil
+	}
 
-	c.stateDB = cstate.NewMemDB(c.logger)
+	c, cleanup := TestClient(t, func(c *config.Config) {
+		c.StateDBFactory = newStateDB
+	})
+	defer cleanup()
 
 	t.Run("nil Job", func(t *testing.T) {
 		alloc := mock.BatchAlloc()

--- a/client/heartbeatstop_test.go
+++ b/client/heartbeatstop_test.go
@@ -53,7 +53,9 @@ func TestHeartbeatStop_allocHook(t *testing.T) {
 	err := client.addAlloc(alloc, "")
 	must.NoError(t, err)
 	testutil.WaitForResult(func() (bool, error) {
+		client.heartbeatLock.Lock()
 		_, ok := client.heartbeatStop.allocInterval[alloc.ID]
+		client.heartbeatLock.Unlock()
 		return ok, nil
 	}, func(err error) {
 		must.NoError(t, err)

--- a/nomad/client_alloc_endpoint_test.go
+++ b/nomad/client_alloc_endpoint_test.go
@@ -279,7 +279,7 @@ func TestClientAllocations_GarbageCollect_OldNode(t *testing.T) {
 
 	// Test for a missing version error
 	delete(node.Attributes, "nomad.version")
-	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, 1007, node))
+	require.Nil(state.UpsertNode(nstructs.MsgTypeTestSetup, 1007, node.Copy()))
 
 	err = msgpackrpc.CallWithCodec(codec, "ClientAllocations.GarbageCollect", req, &resp)
 	require.True(nstructs.IsErrUnknownNomadVersion(err), err.Error())
@@ -496,10 +496,10 @@ func TestClientAllocations_GarbageCollect_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state1.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
-	require.Nil(state2.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state2.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a}))
+	require.Nil(state1.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state1.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a.Copy()}))
+	require.Nil(state2.UpsertJob(nstructs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state2.UpsertAllocs(nstructs.MsgTypeTestSetup, 1003, []*nstructs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/client_fs_endpoint_test.go
+++ b/nomad/client_fs_endpoint_test.go
@@ -68,8 +68,8 @@ func TestClientFS_List_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -128,8 +128,8 @@ func TestClientFS_List_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job.Copy()))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc.Copy()}))
 
 	cases := []struct {
 		Name          string
@@ -228,10 +228,10 @@ func TestClientFS_List_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -284,11 +284,11 @@ func TestClientFS_Stat_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1005, node))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1005, node.Copy()))
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
-	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1006, []*structs.Allocation{alloc}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1006, []*structs.Allocation{alloc.Copy()}))
 
 	req := &cstructs.FsStatRequest{
 		AllocID:      alloc.ID,
@@ -344,8 +344,8 @@ func TestClientFS_Stat_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -404,8 +404,8 @@ func TestClientFS_Stat_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job.Copy()))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc.Copy()}))
 
 	cases := []struct {
 		Name          string
@@ -504,10 +504,10 @@ func TestClientFS_Stat_Remote(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -636,8 +636,8 @@ func TestClientFS_Streaming_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job.Copy()))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc.Copy()}))
 
 	cases := []struct {
 		Name          string
@@ -777,8 +777,8 @@ func TestClientFS_Streaming_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -913,8 +913,8 @@ func TestClientFS_Streaming_Local_Follow(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -1056,10 +1056,10 @@ func TestClientFS_Streaming_Remote_Server(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -1202,8 +1202,8 @@ func TestClientFS_Streaming_Remote_Region(t *testing.T) {
 
 	// Upsert the allocation
 	state2 := s2.State()
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -1379,11 +1379,11 @@ func TestClientFS_Logs_OldNode(t *testing.T) {
 	// Test for an old version error
 	node := mock.Node()
 	node.Attributes["nomad.version"] = "0.7.1"
-	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1005, node))
+	require.Nil(state.UpsertNode(structs.MsgTypeTestSetup, 1005, node.Copy()))
 
 	alloc := mock.Alloc()
 	alloc.NodeID = node.ID
-	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1006, []*structs.Allocation{alloc}))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1006, []*structs.Allocation{alloc.Copy()}))
 
 	req := &cstructs.FsLogsRequest{
 		AllocID:      alloc.ID,
@@ -1465,8 +1465,8 @@ func TestClientFS_Logs_ACL(t *testing.T) {
 	// Upsert the allocation
 	state := s.State()
 	alloc := mock.Alloc()
-	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job))
-	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc}))
+	require.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 1010, nil, alloc.Job.Copy()))
+	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1011, []*structs.Allocation{alloc.Copy()}))
 
 	cases := []struct {
 		Name          string
@@ -1606,8 +1606,8 @@ func TestClientFS_Logs_Local(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -1743,8 +1743,8 @@ func TestClientFS_Logs_Local_Follow(t *testing.T) {
 
 	// Upsert the allocation
 	state := s.State()
-	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -1887,10 +1887,10 @@ func TestClientFS_Logs_Remote_Server(t *testing.T) {
 	// Upsert the allocation
 	state1 := s1.State()
 	state2 := s2.State()
-	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state1.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state1.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {
@@ -2034,8 +2034,8 @@ func TestClientFS_Logs_Remote_Region(t *testing.T) {
 
 	// Upsert the allocation
 	state2 := s2.State()
-	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job))
-	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a}))
+	require.Nil(state2.UpsertJob(structs.MsgTypeTestSetup, 999, nil, a.Job.Copy()))
+	require.Nil(state2.UpsertAllocs(structs.MsgTypeTestSetup, 1003, []*structs.Allocation{a.Copy()}))
 
 	// Wait for the client to run the allocation
 	testutil.WaitForResult(func() (bool, error) {

--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -388,7 +388,7 @@ func TestCSIVolumeEndpoint_Claim(t *testing.T) {
 		},
 	}
 	index++
-	err = state.UpsertNode(structs.MsgTypeTestSetup, index, node)
+	err = state.UpsertNode(structs.MsgTypeTestSetup, index, node.Copy())
 	require.NoError(t, err)
 
 	vols := []*structs.CSIVolume{{

--- a/nomad/eval_broker_test.go
+++ b/nomad/eval_broker_test.go
@@ -1153,7 +1153,9 @@ func TestEvalBroker_WaitUntil(t *testing.T) {
 	eval3.WaitUntil = now.Add(20 * time.Millisecond)
 	eval3.CreateIndex = 1
 	b.Enqueue(eval3)
+	b.l.Lock()
 	require.Equal(3, b.stats.TotalWaiting)
+	b.l.Unlock()
 	// sleep enough for two evals to be ready
 	time.Sleep(200 * time.Millisecond)
 
@@ -1171,7 +1173,9 @@ func TestEvalBroker_WaitUntil(t *testing.T) {
 	out, _, err = b.Dequeue(defaultSched, 2*time.Second)
 	require.Nil(err)
 	require.Equal(eval1, out)
+	b.l.Lock()
 	require.Equal(0, b.stats.TotalWaiting)
+	b.l.Unlock()
 }
 
 // Ensure that priority is taken into account when enqueueing many evaluations.

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -2543,7 +2543,7 @@ func TestJobEndpoint_Register_PortCollistion(t *testing.T) {
 			}
 			job.TaskGroups[0].Tasks[0].Services = nil
 
-			testutil.RegisterJob(t, s1.RPC, job)
+			testutil.RegisterJob(t, s1.RPC, job.Copy())
 			testutil.WaitForJobAllocStatus(t, s1.RPC, job, map[string]int{
 				structs.AllocClientStatusPending: 1,
 			})

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -1864,6 +1864,11 @@ func waitForStableLeadership(t *testing.T, servers []*Server) *Server {
 		require.NoError(t, err)
 	})
 
+	// wait for keyring to be initialized to ensure cluster is working
+	for _, s := range servers {
+		testutil.WaitForKeyring(t, s.RPC, leader.config.Region)
+	}
+
 	return leader
 }
 
@@ -1946,7 +1951,7 @@ func TestServer_handleEvalBrokerStateChange(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			// Create a new server and wait for leadership to be established.
-			testServer, cleanupFn := TestServer(t, nil)
+			testServer, cleanupFn := TestServer(t, tc.testServerCallBackConfig)
 			_ = waitForStableLeadership(t, []*Server{testServer})
 			defer cleanupFn()
 

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -1015,7 +1015,7 @@ func TestClientEndpoint_UpdateStatus_Reconnect(t *testing.T) {
 			}
 
 			jobReq := &structs.JobRegisterRequest{
-				Job: job,
+				Job: job.Copy(),
 				WriteRequest: structs.WriteRequest{
 					Region:    "global",
 					Namespace: job.Namespace,

--- a/nomad/serf_test.go
+++ b/nomad/serf_test.go
@@ -41,17 +41,26 @@ func TestNomad_JoinPeer(t *testing.T) {
 	})
 
 	testutil.WaitForResult(func() (bool, error) {
-		if len(s1.peers) != 2 {
-			return false, fmt.Errorf("bad: %#v", s1.peers)
+		s1.peerLock.Lock()
+		n1 := len(s1.peers)
+		local1 := len(s1.localPeers)
+		s1.peerLock.Unlock()
+		if n1 != 2 {
+			return false, fmt.Errorf("bad: %#v", n1)
 		}
-		if len(s2.peers) != 2 {
-			return false, fmt.Errorf("bad: %#v", s2.peers)
+		if local1 != 1 {
+			return false, fmt.Errorf("bad: %#v", local1)
 		}
-		if len(s1.localPeers) != 1 {
-			return false, fmt.Errorf("bad: %#v", s1.localPeers)
+
+		s2.peerLock.Lock()
+		n2 := len(s2.peers)
+		local2 := len(s2.localPeers)
+		s2.peerLock.Unlock()
+		if n2 != 2 {
+			return false, fmt.Errorf("bad: %#v", n2)
 		}
-		if len(s2.localPeers) != 1 {
-			return false, fmt.Errorf("bad: %#v", s2.localPeers)
+		if local2 != 1 {
+			return false, fmt.Errorf("bad: %#v", local2)
 		}
 		return true, nil
 	}, func(err error) {
@@ -167,8 +176,11 @@ func TestNomad_ReapPeer(t *testing.T) {
 	s3.reconcileCh <- s2mem
 
 	testutil.WaitForResult(func() (bool, error) {
-		if len(s1.peers["global"]) != 2 {
-			return false, fmt.Errorf("bad: %#v", s1.peers["global"])
+		s1.peerLock.Lock()
+		n1 := len(s1.peers["global"])
+		s1.peerLock.Unlock()
+		if n1 != 2 {
+			return false, fmt.Errorf("bad: %#v", n1)
 		}
 		peers, err := s1.numPeers()
 		if err != nil {
@@ -178,8 +190,11 @@ func TestNomad_ReapPeer(t *testing.T) {
 			return false, fmt.Errorf("bad: %#v", peers)
 		}
 
-		if len(s3.peers["global"]) != 2 {
-			return false, fmt.Errorf("bad: %#v", s1.peers["global"])
+		s3.peerLock.Lock()
+		n3 := len(s3.peers["global"])
+		s3.peerLock.Unlock()
+		if n3 != 2 {
+			return false, fmt.Errorf("bad: %#v", n3)
 		}
 		peers, err = s3.numPeers()
 		if err != nil {

--- a/nomad/stats_fetcher_test.go
+++ b/nomad/stats_fetcher_test.go
@@ -73,7 +73,9 @@ func TestStatsFetcher(t *testing.T) {
 	// Fake an in-flight request to server 3 and make sure we don't fetch
 	// from it.
 	func() {
+		s1.statsFetcher.inflightLock.Lock()
 		s1.statsFetcher.inflight[raft.ServerID(s3.config.NodeID)] = struct{}{}
+		s1.statsFetcher.inflightLock.Unlock()
 		defer func() {
 			s1.statsFetcher.inflightLock.Lock()
 			delete(s1.statsFetcher.inflight, raft.ServerID(s3.config.NodeID))


### PR DESCRIPTION
Manual backport of #25470 

Automatic backport failed due to conflict in `client/client_test.go` imports.

# Original Commit Description

* test: use statedb factory

Swapping fields on Client after it has been created is a race.

* test: lock before checking heartbeat state

Fixes races

* test: fix races by copying fsm objects

A common source of data races in tests is when they insert a fixture directly into memdb and then later mutate the object. Since objects in the state store are readonly, any later mutation is a data race.

* test: lock when peeking at eval stats

* test: lock when peeking at serf state

* test: lock when looking at stats

* test: fix default eval broker state test

The test was not applying the config callback. In addition the test raced against the configuration being applied. Waiting for the keyring to be initialized resolved the race in my testing, but given the high concurrency of the various leadership subsystems it's possible it may still flake.