### PR TITLE
client: statically assert hook interfaces in build

### DIFF
--- a/.changelog/25472.txt
+++ b/.changelog/25472.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where in-flight CSI RPCs would not be cancelled on client GC or dev agent shutdown
+```

--- a/client/allocrunner/allocdir_hook.go
+++ b/client/allocrunner/allocdir_hook.go
@@ -6,6 +6,7 @@ package allocrunner
 import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 )
 
 // allocDirHook creates and destroys the root directory and shared directories
@@ -22,6 +23,12 @@ func newAllocDirHook(logger hclog.Logger, allocDir allocdir.Interface) *allocDir
 	ad.logger = logger.Named(ad.Name())
 	return ad
 }
+
+// statically assert that the hook meets the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook  = (*allocDirHook)(nil)
+	_ interfaces.RunnerDestroyHook = (*allocDirHook)(nil)
+)
 
 func (h *allocDirHook) Name() string {
 	return "alloc_dir"

--- a/client/allocrunner/checks_hook.go
+++ b/client/allocrunner/checks_hook.go
@@ -113,6 +113,13 @@ func newChecksHook(
 	return h
 }
 
+// statically assert that the hook meets the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook  = (*checksHook)(nil)
+	_ interfaces.RunnerUpdateHook  = (*checksHook)(nil)
+	_ interfaces.RunnerPreKillHook = (*checksHook)(nil)
+)
+
 // initialize the dynamic fields of checksHook, which is to say setup all the
 // observers and query context things associated with the alloc.
 //

--- a/client/allocrunner/checks_hook_test.go
+++ b/client/allocrunner/checks_hook_test.go
@@ -25,12 +25,6 @@ import (
 	"github.com/shoenig/test/must"
 )
 
-var (
-	_ interfaces.RunnerPrerunHook  = (*checksHook)(nil)
-	_ interfaces.RunnerUpdateHook  = (*checksHook)(nil)
-	_ interfaces.RunnerPreKillHook = (*checksHook)(nil)
-)
-
 func makeCheckStore(logger hclog.Logger) checkstore.Shim {
 	db := state.NewMemDB(logger)
 	checkStore := checkstore.NewStore(logger, db)

--- a/client/allocrunner/consul_grpc_sock_hook.go
+++ b/client/allocrunner/consul_grpc_sock_hook.go
@@ -100,6 +100,13 @@ func newConsulGRPCSocketHook(
 	}
 }
 
+// statically assert that the hook meets the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook  = (*consulGRPCSocketHook)(nil)
+	_ interfaces.RunnerUpdateHook  = (*consulGRPCSocketHook)(nil)
+	_ interfaces.RunnerPostrunHook = (*consulGRPCSocketHook)(nil)
+)
+
 func (*consulGRPCSocketHook) Name() string {
 	return consulGRPCSockHookName
 }

--- a/client/allocrunner/consul_hook.go
+++ b/client/allocrunner/consul_hook.go
@@ -11,6 +11,7 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/consul"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/taskenv"
@@ -69,6 +70,14 @@ func newConsulHook(cfg consulHookConfig) *consulHook {
 	h.logger = cfg.logger.Named(h.Name())
 	return h
 }
+
+// statically assert the hook implements the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook  = (*consulHook)(nil)
+	_ interfaces.RunnerPostrunHook = (*consulHook)(nil)
+	_ interfaces.RunnerDestroyHook = (*consulHook)(nil)
+	_ interfaces.ShutdownHook      = (*consulHook)(nil)
+)
 
 func (*consulHook) Name() string {
 	return "consul"

--- a/client/allocrunner/consul_hook_test.go
+++ b/client/allocrunner/consul_hook_test.go
@@ -11,7 +11,6 @@ import (
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/nomad/ci"
-	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/consul"
 	cstate "github.com/hashicorp/nomad/client/state"
 	cstructs "github.com/hashicorp/nomad/client/structs"
@@ -23,9 +22,6 @@ import (
 	structsc "github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/shoenig/test/must"
 )
-
-// statically assert consul hook implements the expected interfaces
-var _ interfaces.RunnerPrerunHook = (*consulHook)(nil)
 
 func consulHookTestHarness(t *testing.T) *consulHook {
 	logger := testlog.HCLogger(t)

--- a/client/allocrunner/consul_http_sock_hook.go
+++ b/client/allocrunner/consul_http_sock_hook.go
@@ -74,6 +74,13 @@ func newConsulHTTPSocketHook(
 	}
 }
 
+// statically assert the hook implements the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook  = (*consulHTTPSockHook)(nil)
+	_ interfaces.RunnerPostrunHook = (*consulHTTPSockHook)(nil)
+	_ interfaces.RunnerUpdateHook  = (*consulHTTPSockHook)(nil)
+)
+
 func (*consulHTTPSockHook) Name() string {
 	return consulHTTPSocketHookName
 }

--- a/client/allocrunner/cpuparts_hook.go
+++ b/client/allocrunner/cpuparts_hook.go
@@ -5,6 +5,7 @@ package allocrunner
 
 import (
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/idset"
 	"github.com/hashicorp/nomad/client/lib/numalib/hw"
@@ -45,6 +46,12 @@ func newCPUPartsHook(
 func (h *cpuPartsHook) Name() string {
 	return cpuPartsHookName
 }
+
+// statically assert the hook implements the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook  = (*cpuPartsHook)(nil)
+	_ interfaces.RunnerPostrunHook = (*cpuPartsHook)(nil)
+)
 
 func (h *cpuPartsHook) Prerun() error {
 	return h.partitions.Reserve(h.reservations)

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -12,6 +12,7 @@ import (
 
 	hclog "github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/allocrunner/state"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/dynamicplugins"
@@ -75,6 +76,14 @@ func newCSIHook(alloc *structs.Allocation, logger hclog.Logger, csi csimanager.M
 		shutdownCancelFn:   shutdownCancelFn,
 	}
 }
+
+// statically assert the hook implements the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook  = (*csiHook)(nil)
+	_ interfaces.RunnerPostrunHook = (*csiHook)(nil)
+	_ interfaces.RunnerDestroyHook = (*csiHook)(nil)
+	_ interfaces.ShutdownHook      = (*csiHook)(nil)
+)
 
 func (c *csiHook) Name() string {
 	return "csi_hook"
@@ -549,7 +558,8 @@ func (c *csiHook) Shutdown() {
 // or when a -dev mode client is stopped. Cancel our shutdown context
 // so that we don't block client shutdown while in the CSI RPC retry
 // loop.
-func (c *csiHook) Destroy() {
+func (c *csiHook) Destroy() error {
 	c.logger.Trace("destroying hook")
 	c.shutdownCancelFn()
+	return nil
 }

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -550,7 +550,6 @@ func (c *csiHook) unmountImpl(result *volumePublishResult) error {
 // stopping. Cancel our shutdown context so that we don't block client
 // shutdown while in the CSI RPC retry loop.
 func (c *csiHook) Shutdown() {
-	c.logger.Trace("shutting down hook")
 	c.shutdownCancelFn()
 }
 
@@ -559,7 +558,6 @@ func (c *csiHook) Shutdown() {
 // so that we don't block client shutdown while in the CSI RPC retry
 // loop.
 func (c *csiHook) Destroy() error {
-	c.logger.Trace("destroying hook")
 	c.shutdownCancelFn()
 	return nil
 }

--- a/client/allocrunner/csi_hook_test.go
+++ b/client/allocrunner/csi_hook_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/ci"
-	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/allocrunner/state"
 	"github.com/hashicorp/nomad/client/pluginmanager/csimanager"
 	cstructs "github.com/hashicorp/nomad/client/structs"
@@ -23,9 +22,6 @@ import (
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/shoenig/test/must"
 )
-
-var _ interfaces.RunnerPrerunHook = (*csiHook)(nil)
-var _ interfaces.RunnerPostrunHook = (*csiHook)(nil)
 
 func TestCSIHook(t *testing.T) {
 	ci.Parallel(t)

--- a/client/allocrunner/fail_hook.go
+++ b/client/allocrunner/fail_hook.go
@@ -56,7 +56,16 @@ func (h *FailHook) LoadConfig(path string) *FailHook {
 	return h
 }
 
-var _ interfaces.RunnerPrerunHook = &FailHook{}
+// statically assert the hook implements the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook      = (*FailHook)(nil)
+	_ interfaces.RunnerPreKillHook     = (*FailHook)(nil)
+	_ interfaces.RunnerPostrunHook     = (*FailHook)(nil)
+	_ interfaces.RunnerDestroyHook     = (*FailHook)(nil)
+	_ interfaces.RunnerUpdateHook      = (*FailHook)(nil)
+	_ interfaces.RunnerTaskRestartHook = (*FailHook)(nil)
+	_ interfaces.ShutdownHook          = (*FailHook)(nil)
+)
 
 func (h *FailHook) Prerun() error {
 	if h.Fail.Prerun {
@@ -65,15 +74,11 @@ func (h *FailHook) Prerun() error {
 	return nil
 }
 
-var _ interfaces.RunnerPreKillHook = &FailHook{}
-
 func (h *FailHook) PreKill() {
 	if h.Fail.PreKill {
 		h.logger.Error("prekill", "error", ErrFailHookError)
 	}
 }
-
-var _ interfaces.RunnerPostrunHook = &FailHook{}
 
 func (h *FailHook) Postrun() error {
 	if h.Fail.Postrun {
@@ -82,16 +87,12 @@ func (h *FailHook) Postrun() error {
 	return nil
 }
 
-var _ interfaces.RunnerDestroyHook = &FailHook{}
-
 func (h *FailHook) Destroy() error {
 	if h.Fail.Destroy {
 		return fmt.Errorf("destroy %w", ErrFailHookError)
 	}
 	return nil
 }
-
-var _ interfaces.RunnerUpdateHook = &FailHook{}
 
 func (h *FailHook) Update(request *interfaces.RunnerUpdateRequest) error {
 	if h.Fail.Update {
@@ -100,16 +101,12 @@ func (h *FailHook) Update(request *interfaces.RunnerUpdateRequest) error {
 	return nil
 }
 
-var _ interfaces.RunnerTaskRestartHook = &FailHook{}
-
 func (h *FailHook) PreTaskRestart() error {
 	if h.Fail.PreTaskRestart {
 		return fmt.Errorf("destroy %w", ErrFailHookError)
 	}
 	return nil
 }
-
-var _ interfaces.ShutdownHook = &FailHook{}
 
 func (h *FailHook) Shutdown() {
 	if h.Fail.Shutdown {

--- a/client/allocrunner/group_service_hook.go
+++ b/client/allocrunner/group_service_hook.go
@@ -118,6 +118,15 @@ func newGroupServiceHook(cfg groupServiceHookConfig) *groupServiceHook {
 	return h
 }
 
+// statically assert the hook implements the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook      = (*groupServiceHook)(nil)
+	_ interfaces.RunnerPreKillHook     = (*groupServiceHook)(nil)
+	_ interfaces.RunnerPostrunHook     = (*groupServiceHook)(nil)
+	_ interfaces.RunnerUpdateHook      = (*groupServiceHook)(nil)
+	_ interfaces.RunnerTaskRestartHook = (*groupServiceHook)(nil)
+)
+
 func (*groupServiceHook) Name() string {
 	return groupServiceHookName
 }

--- a/client/allocrunner/group_service_hook_test.go
+++ b/client/allocrunner/group_service_hook_test.go
@@ -22,12 +22,6 @@ import (
 	"github.com/shoenig/test/must"
 )
 
-var _ interfaces.RunnerPrerunHook = (*groupServiceHook)(nil)
-var _ interfaces.RunnerUpdateHook = (*groupServiceHook)(nil)
-var _ interfaces.RunnerPostrunHook = (*groupServiceHook)(nil)
-var _ interfaces.RunnerPreKillHook = (*groupServiceHook)(nil)
-var _ interfaces.RunnerTaskRestartHook = (*groupServiceHook)(nil)
-
 // TestGroupServiceHook_NoGroupServices asserts calling group service hooks
 // without group services does not error.
 func TestGroupServiceHook_NoGroupServices(t *testing.T) {

--- a/client/allocrunner/health_hook.go
+++ b/client/allocrunner/health_hook.go
@@ -118,6 +118,14 @@ func newAllocHealthWatcherHook(
 	return h
 }
 
+// statically assert the hook implements the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook  = (*allocHealthWatcherHook)(nil)
+	_ interfaces.RunnerPostrunHook = (*allocHealthWatcherHook)(nil)
+	_ interfaces.RunnerUpdateHook  = (*allocHealthWatcherHook)(nil)
+	_ interfaces.ShutdownHook      = (*allocHealthWatcherHook)(nil)
+)
+
 func (h *allocHealthWatcherHook) Name() string {
 	return "alloc_health_watcher"
 }

--- a/client/allocrunner/health_hook_test.go
+++ b/client/allocrunner/health_hook_test.go
@@ -23,12 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// statically assert health hook implements the expected interfaces
-var _ interfaces.RunnerPrerunHook = (*allocHealthWatcherHook)(nil)
-var _ interfaces.RunnerUpdateHook = (*allocHealthWatcherHook)(nil)
-var _ interfaces.RunnerPostrunHook = (*allocHealthWatcherHook)(nil)
-var _ interfaces.ShutdownHook = (*allocHealthWatcherHook)(nil)
-
 // allocHealth is emitted to a chan whenever SetHealth is called
 type allocHealth struct {
 	healthy    bool

--- a/client/allocrunner/identity_hook.go
+++ b/client/allocrunner/identity_hook.go
@@ -5,6 +5,7 @@ package allocrunner
 
 import (
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/widmgr"
 )
 
@@ -20,6 +21,14 @@ func newIdentityHook(logger log.Logger, widmgr widmgr.IdentityManager) *identity
 	h.logger = logger.Named(h.Name())
 	return h
 }
+
+// statically assert the hook implements the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook  = (*identityHook)(nil)
+	_ interfaces.RunnerPreKillHook = (*identityHook)(nil)
+	_ interfaces.RunnerDestroyHook = (*identityHook)(nil)
+	_ interfaces.ShutdownHook      = (*identityHook)(nil)
+)
 
 func (*identityHook) Name() string {
 	return "identity"

--- a/client/allocrunner/identity_hook_test.go
+++ b/client/allocrunner/identity_hook_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/ci"
-	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	cstate "github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/client/widmgr"
@@ -17,12 +16,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/shoenig/test/must"
 )
-
-// statically assert network hook implements the expected interfaces
-var _ interfaces.RunnerPrerunHook = (*identityHook)(nil)
-var _ interfaces.ShutdownHook = (*identityHook)(nil)
-var _ interfaces.RunnerPreKillHook = (*identityHook)(nil)
-var _ interfaces.RunnerDestroyHook = (*identityHook)(nil)
 
 func TestIdentityHook_Prerun(t *testing.T) {
 	ci.Parallel(t)

--- a/client/allocrunner/migrate_hook.go
+++ b/client/allocrunner/migrate_hook.go
@@ -9,6 +9,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/config"
 )
 
@@ -32,6 +33,9 @@ func newDiskMigrationHook(
 	h.logger = logger.Named(h.Name())
 	return h
 }
+
+// statically assert the hook implements the expected interfaces
+var _ interfaces.RunnerPrerunHook = (*diskMigrationHook)(nil)
 
 func (h *diskMigrationHook) Name() string {
 	return "migrate_disk"

--- a/client/allocrunner/network_hook.go
+++ b/client/allocrunner/network_hook.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	hclog "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
@@ -102,6 +103,12 @@ func newNetworkHook(logger hclog.Logger,
 		logger:              logger,
 	}
 }
+
+// statically assert the hook implements the expected interfaces
+var (
+	_ interfaces.RunnerPrerunHook  = (*networkHook)(nil)
+	_ interfaces.RunnerPostrunHook = (*networkHook)(nil)
+)
 
 func (h *networkHook) Name() string {
 	return "network"

--- a/client/allocrunner/network_hook_test.go
+++ b/client/allocrunner/network_hook_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
-	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -19,10 +18,6 @@ import (
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 )
-
-// statically assert network hook implements the expected interfaces
-var _ interfaces.RunnerPrerunHook = (*networkHook)(nil)
-var _ interfaces.RunnerPostrunHook = (*networkHook)(nil)
 
 type mockNetworkIsolationSetter struct {
 	t            *testing.T

--- a/client/allocrunner/upstream_allocs_hook.go
+++ b/client/allocrunner/upstream_allocs_hook.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	"github.com/hashicorp/nomad/client/config"
 )
 
@@ -24,6 +25,9 @@ func newUpstreamAllocsHook(logger log.Logger, allocWatcher config.PrevAllocWatch
 	h.logger = logger.Named(h.Name())
 	return h
 }
+
+// statically assert the hook implements the expected interfaces
+var _ interfaces.RunnerPrerunHook = (*upstreamAllocsHook)(nil)
 
 func (h *upstreamAllocsHook) Name() string {
 	return "await_previous_allocations"


### PR DESCRIPTION
While working on #25373, I noticed that the CSI hook's `Destroy` method doesn't match the interface, which means it never gets called. Because this method only cancels any in-flight CSI requests, the only impact of this bug is that any CSI RPCs that are in-flight when an alloc is GC'd on the client or a dev agent is shut down won't be interrupted gracefully.

Fix the interface, but also make static assertions for all the allocrunner hooks in the production code, so that you can make changes to interfaces and have compile-time assistance in avoiding mistakes.

Ref: https://github.com/hashicorp/nomad/pull/25373

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
