### PR TITLE
Add a test for re attaching allocs after client restart

### DIFF
--- a/enos/enos-quality.hcl
+++ b/enos/enos-quality.hcl
@@ -41,7 +41,7 @@ quality "nomad_allocs_status" {
   description = "A GET call to /v1/allocs returns the correct number of allocations and they are all running"
 }
 
-quality "nomad_alloc_reconect" {
-  description = "A GET call to /v1/alloc/:alloc_id will return the same alloc.CreateTime for each allocation before and after a client upgrade"
+quality "nomad_alloc_reconnect" {
+  description = "A GET call to /v1/allocs will return the same IDs for running allocs before and after a client upgrade on each client"
 }
 

--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -371,7 +371,8 @@ scenario "upgrade" {
     verifies = [
       quality.nomad_nodes_status,
       quality.nomad_job_status,
-      quality.nomad_node_metadata
+      quality.nomad_node_metadata,
+      quality.nomad_alloc_reconnect
     ]
 
     variables {
@@ -412,7 +413,8 @@ scenario "upgrade" {
     verifies = [
       quality.nomad_nodes_status,
       quality.nomad_job_status,
-      quality.nomad_node_metadata
+      quality.nomad_node_metadata,
+      quality.nomad_alloc_reconnect
     ]
 
     variables {
@@ -473,7 +475,8 @@ scenario "upgrade" {
     verifies = [
       quality.nomad_nodes_status,
       quality.nomad_job_status,
-      quality.nomad_node_metadata
+      quality.nomad_node_metadata,
+      quality.nomad_alloc_reconnect
     ]
 
     variables {
@@ -514,7 +517,8 @@ scenario "upgrade" {
     verifies = [
       quality.nomad_nodes_status,
       quality.nomad_job_status,
-      quality.nomad_node_metadata
+      quality.nomad_node_metadata,
+      quality.nomad_alloc_reconnect
     ]
 
     variables {

--- a/enos/modules/upgrade_client/main.tf
+++ b/enos/modules/upgrade_client/main.tf
@@ -108,7 +108,7 @@ resource "enos_local_exec" "verify_allocs" {
     local.nomad_env,
     {
       CLIENT_IP = var.client
-      ALLOCS = enos_local_exec.get_alloc_ids.stdout
+      ALLOCS    = enos_local_exec.get_alloc_ids.stdout
   })
 
   scripts = [abspath("${path.module}/scripts/verify_allocs.sh")]

--- a/enos/modules/upgrade_client/scripts/verify_allocs.sh
+++ b/enos/modules/upgrade_client/scripts/verify_allocs.sh
@@ -48,20 +48,22 @@ done
 
 echo "Client $client_id at $CLIENT_IP is ready"
 
-# Quality: "nomad_node_metadata: A GET call to /v1/node/:node-id returns the same  node.Meta for each node before and after a node upgrade"
-echo "Reading metadata for client at $CLIENT_IP"
-if ! client_meta=$(nomad node meta read -json -node-id "$client_id"); then
-    error_exit "Failed to read metadata for node: $client_id"
+# Quality: "nomad_alloc_reconect: A GET call to /v1/allocs will return the same IDs for running allocs before and after a client upgrade on each client"
+echo "Reading allocs for client at $CLIENT_IP"
+if ! current_allocs=$("nomad alloc status -json | jq -r --arg NODE_ID \"$(nomad node status -allocs -address https://$CLIENT_IP:4646 -self -json | jq -r '.ID')\" '[.[] | select(.ClientStatus == \"running\" and .NodeID == $NODE_ID) | .ID] | join(\" \")'"); then
+    error_exi "Failed to read allocs for node: $client_id"
 fi
 
-meta_node_ip=$(echo "$client_meta" | jq -r '.Dynamic.node_ip' )
-if [ "$meta_node_ip" != "$CLIENT_IP" ]; then
-  error_exit "Wrong value returned for node_ip: $meta_node_ip"
+RUNNING_ALLOCS=$(nomad alloc status -json | jq -r --arg NODE_ID "$NODE_ID" '[.[] | select(.ClientStatus == "running" and .NodeID == $NODE_ID) | .ID] | join(" ")')
+
+IFS=' ' read -r -a INPUT_ARRAY <<< "${ALLOCS[*]}"
+IFS=' ' read -r -a RUNNING_ARRAY <<< "$RUNNING_ALLOCS"
+
+sorted_input=($(printf "%s\n" "${INPUT_ARRAY[@]}" | sort))
+sorted_running=($(printf "%s\n" "${RUNNING_ARRAY[@]}" | sort))
+
+if [[ "${sorted_input[*]}" != "${sorted_running[*]}" ]]; then
+    error_exi "Different allocs found, expected: ${sorted_input[*]} found: ${sorted_running[*]}"
 fi
 
-meta_nomad_addr=$(echo "$client_meta" | jq -r '.Dynamic.nomad_addr' )
-if [ "$meta_nomad_addr" != "$NOMAD_ADDR" ]; then
-   error_exit "Wrong value returned for nomad_addr: $meta_nomad_addr"
-fi
-
-echo "Metadata correct in  $client_id at $CLIENT_IP"
+echo "All allocs reattached correctly for node at $CLIENT_IP"

--- a/enos/modules/upgrade_client/scripts/verify_allocs.sh
+++ b/enos/modules/upgrade_client/scripts/verify_allocs.sh
@@ -50,14 +50,14 @@ echo "Client $client_id at $CLIENT_IP is ready"
 
 # Quality: "nomad_alloc_reconect: A GET call to /v1/allocs will return the same IDs for running allocs before and after a client upgrade on each client"
 echo "Reading allocs for client at $CLIENT_IP"
-if ! current_allocs=$("nomad alloc status -json | jq -r --arg NODE_ID \"$(nomad node status -allocs -address https://$CLIENT_IP:4646 -self -json | jq -r '.ID')\" '[.[] | select(.ClientStatus == \"running\" and .NodeID == $NODE_ID) | .ID] | join(\" \")'"); then
-    error_exi "Failed to read allocs for node: $client_id"
+
+current_allocs=$(nomad alloc status -json | jq -r --arg client_id "$client_id" '[.[] | select(.ClientStatus == "running" and .NodeID == $client_id) | .ID] | join(" ")')
+if [ -z "$current_allocs" ]; then
+    error_exit "Failed to read allocs for node: $client_id"
 fi
 
-RUNNING_ALLOCS=$(nomad alloc status -json | jq -r --arg NODE_ID "$NODE_ID" '[.[] | select(.ClientStatus == "running" and .NodeID == $NODE_ID) | .ID] | join(" ")')
-
 IFS=' ' read -r -a INPUT_ARRAY <<< "${ALLOCS[*]}"
-IFS=' ' read -r -a RUNNING_ARRAY <<< "$RUNNING_ALLOCS"
+IFS=' ' read -r -a RUNNING_ARRAY <<< "$current_allocs"
 
 sorted_input=($(printf "%s\n" "${INPUT_ARRAY[@]}" | sort))
 sorted_running=($(printf "%s\n" "${RUNNING_ARRAY[@]}" | sort))


### PR DESCRIPTION
### Description
There was a quality in the upgrade scenario that was not being tested yet, we need to make sure the workloads are not stopped when the agent stops on a client and that they reattach when the agent comes back up.

This PR introduces a check that looks up any running alloc on a client before the upgrade and verifies that the same ones are running after the upgrade.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
