### PR TITLE
Docs: Fix link rendering in server.default_scheduler_config

### DIFF
--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -130,12 +130,11 @@ server {
   expired ACL token before it is eligible for garbage collection. This is
   specified using a label suffix like "30s" or "1h".
 
-- `default_scheduler_config`
-  <code>([scheduler_configuration][update-scheduler-config]: nil)</code> -
-  Specifies the initial default scheduler config when bootstrapping cluster. The
-  parameter is ignored once the cluster is bootstrapped or value is updated
-  through the [API endpoint][update-scheduler-config]. Refer to [the example
-  section](#configuring-scheduler-config) for more details
+- `default_scheduler_config` <code>(<a href="/nomad/api-docs/operator/scheduler#update-scheduler-configuration">scheduler_configuration:</a></code>`nil`) - Specifies the initial default scheduler config when
+  bootstrapping cluster. The parameter is ignored once the cluster is
+  bootstrapped or value is updated through the [API
+  endpoint][update-scheduler-config]. Refer to [the example
+  section](#configuring-scheduler-config) for more details.
 
 - `heartbeat_grace` `(string: "10s")` - Specifies the additional time given
   beyond the heartbeat TTL of Clients to account for network and processing


### PR DESCRIPTION
### Description

Fix link rendering in /configuration/server#default_scheduler_config.

**Current**
![image](https://github.com/user-attachments/assets/131f65cf-afb4-446a-9a76-aad9bc7305bb)

**Fix**
![image](https://github.com/user-attachments/assets/f6a3b7e9-1c86-4048-8740-01f43d173fdb)

### Links

Jira: [CE-821]

https://nomad-git-ce821link-hashicorp.vercel.app/nomad/docs/configuration/server#default_scheduler_config

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[CE-821]: https://hashicorp.atlassian.net/browse/CE-821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ