### PR TITLE
dependabot: update reviewer for website directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
       day: "sunday"
       time: "09:00"
     assignees:
-      - "@hashicorp/web-platform"
+      - "@hashicorp/web-presence"
     labels:
       - "theme/dependencies"
       - "theme/website"


### PR DESCRIPTION
When we updated the codeowner for the website directory to include the "web presence" group, we didn't also update the dependabot reviewer. This results in errors in dependabot PRs.

Ref: https://github.com/hashicorp/nomad/pull/25492#issuecomment-2746105976