### PR TITLE
modify rawexec TaskConfig and Config to accept envvar denylist

### DIFF
--- a/.changelog/25511.txt
+++ b/.changelog/25511.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+drivers/rawexec: adds denied_envvars to driver and task config options
+```

--- a/drivers/rawexec/driver_test.go
+++ b/drivers/rawexec/driver_test.go
@@ -754,12 +754,18 @@ func TestRawExecDriver_Env(t *testing.T) {
 	ci.Parallel(t)
 	ctestutil.RequireNotWindows(t)
 
-	require := require.New(t)
-
 	d := newEnabledRawExecDriver(t)
 	allocID := uuid.Generate()
 	taskName := "sleep"
 
+	task :=
+		&drivers.TaskConfig{
+			AllocID:   allocID,
+			ID:        uuid.Generate(),
+			Name:      taskName,
+			Env:       genEnv(),
+			Resources: testResources(allocID, taskName),
+		}
 	testCases := []struct {
 		name         string
 		driver       *Driver
@@ -888,14 +894,6 @@ func TestRawExecDriver_Env(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			task :=
-				&drivers.TaskConfig{
-					AllocID:   allocID,
-					ID:        uuid.Generate(),
-					Name:      taskName,
-					Env:       genEnv(),
-					Resources: testResources(allocID, taskName),
-				}
 			// if set, update driver config
 			if tc.driverConfig != nil {
 				tc.driver.config = tc.driverConfig

--- a/drivers/rawexec/driver_test.go
+++ b/drivers/rawexec/driver_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"slices"
 	"strconv"
 	"syscall"
 	"testing"
@@ -746,10 +745,7 @@ func TestRawExecDriver_buildEnvList(t *testing.T) {
 			d := newEnabledRawExecDriver(t)
 			d.config = tc.driverConfig
 			envList := d.buildEnvList(tc.taskConfig, tc.driverTaskConfig)
-
-			if !slices.Equal(envList, tc.expectedVars) {
-				t.Fatalf("fail and change to shoenig test")
-			}
+			must.SliceEqOp(t, envList, tc.expectedVars)
 		})
 	}
 }
@@ -915,24 +911,24 @@ func TestRawExecDriver_Env(t *testing.T) {
 
 			// set and encode task config
 			taskConfig := tc.taskConfig
-			require.NoError(task.EncodeConcreteDriverConfig(&taskConfig))
+			must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
 
-			// start task for non-windows runtimes
+			// start task
 			_, _, err := harness.StartTask(task)
-			require.NoError(err)
+			must.NoError(t, err)
 			// exec an env to standard out
 			res, err := harness.ExecTask(task.ID, []string{"env"}, 1*time.Second)
-			require.NoError(err)
-			require.True(res.ExitResult.Successful())
+			must.NoError(t, err)
+			must.True(t, res.ExitResult.Successful())
 
-			// confirm denied variables are not found in standardout
+			// confirm denied variables are not found in stdout
 			for _, v := range tc.deniedVars {
 				if tc.varsExpected {
-					require.NotContains(string(res.Stdout), v)
+					must.StrNotContains(t, string(res.Stdout), v)
 				}
 			}
 
-			require.NoError(harness.DestroyTask(task.ID, true))
+			must.NoError(t, harness.DestroyTask(task.ID, true))
 		})
 	}
 

--- a/website/content/docs/drivers/raw_exec.mdx
+++ b/website/content/docs/drivers/raw_exec.mdx
@@ -168,7 +168,7 @@ config {
 
 ```hcl
 config {
-  denied_envvars = "["AWS_SECRET_KEY", "*_TOKEN"]
+  denied_envvars = ["AWS_SECRET_KEY", "*_TOKEN"]
 }
 ```
 ## Client Options

--- a/website/content/docs/drivers/raw_exec.mdx
+++ b/website/content/docs/drivers/raw_exec.mdx
@@ -57,6 +57,9 @@ the Nomad client has been hardened according to the [production][hardening] guid
   must be an absolute path. This will also change the working directory when
   using `nomad alloc exec`.
 
+- `denied_envvars` - (Optional) Passes a list of environment variables to be
+scrubbed from the task environment. Supports simple globbing, "*" wildcard
+accepted as prefix and/or suffix.
 
 ## Examples
 
@@ -158,6 +161,14 @@ config {
   denied_host_gids = "2,4-8"
 }
 ```
+
+- `denied_envvars` - (Optional) Passes a list of environment variables to be
+scrubbed from all task environments. Supports simple globbing, "*" wildcard
+accepted as prefix and/or suffix. This will not be checked on Windows clients.
+```
+config {
+  denied_envvars = "["AWS_SECRET_KEY", "*_TOKEN]
+}
 
 ## Client Options
 

--- a/website/content/docs/drivers/raw_exec.mdx
+++ b/website/content/docs/drivers/raw_exec.mdx
@@ -58,8 +58,8 @@ the Nomad client has been hardened according to the [production][hardening] guid
   using `nomad alloc exec`.
 
 - `denied_envvars` - (Optional) Passes a list of environment variables to be
-scrubbed from the task environment. Supports simple globbing, "*" wildcard
-accepted as prefix and/or suffix.
+  scrubbed from the task environment. Supports simple globbing, "*" wildcard
+  accepted as prefix and/or suffix.
 
 ## Examples
 
@@ -163,8 +163,8 @@ config {
 ```
 
 - `denied_envvars` - (Optional) Passes a list of environment variables to be
-scrubbed from all task environments. Supports simple globbing, "*" wildcard
-accepted as prefix and/or suffix.
+  scrubbed from all task environments. Supports simple globbing, "*" wildcard
+  accepted as prefix and/or suffix.
 
 ```
 config {

--- a/website/content/docs/drivers/raw_exec.mdx
+++ b/website/content/docs/drivers/raw_exec.mdx
@@ -164,7 +164,8 @@ config {
 
 - `denied_envvars` - (Optional) Passes a list of environment variables to be
 scrubbed from all task environments. Supports simple globbing, "*" wildcard
-accepted as prefix and/or suffix. This will not be checked on Windows clients.
+accepted as prefix and/or suffix.
+
 ```
 config {
   denied_envvars = "["AWS_SECRET_KEY", "*_TOKEN]

--- a/website/content/docs/drivers/raw_exec.mdx
+++ b/website/content/docs/drivers/raw_exec.mdx
@@ -57,9 +57,9 @@ the Nomad client has been hardened according to the [production][hardening] guid
   must be an absolute path. This will also change the working directory when
   using `nomad alloc exec`.
 
-- `denied_envvars` - (Optional) Passes a list of environment variables to be
-  scrubbed from the task environment. Supports simple globbing, "*" wildcard
-  accepted as prefix and/or suffix.
+- `denied_envvars` - (Optional) Passes a list of environment variables that
+  the driver should scrub from the task environment. Supports globbing, with "*"
+  wildcard accepted as prefix and/or suffix.
 
 ## Examples
 
@@ -162,15 +162,15 @@ config {
 }
 ```
 
-- `denied_envvars` - (Optional) Passes a list of environment variables to be
-  scrubbed from all task environments. Supports simple globbing, "*" wildcard
-  accepted as prefix and/or suffix.
+- `denied_envvars` - (Optional) Passes a list of environment variables that
+  the driver should scrub from all task environments. Supports globbing with "*"
+  wildcard accepted as prefix and/or suffix.
 
-```
+```hcl
 config {
-  denied_envvars = "["AWS_SECRET_KEY", "*_TOKEN]
+  denied_envvars = "["AWS_SECRET_KEY", "*_TOKEN"]
 }
-
+```
 ## Client Options
 
 ~> Note: client configuration options will soon be deprecated. Please use


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Adds a raw exec plugin config option enabling users to define a list of environment variable names to be dropped from all or a single task's environment, as requested in [issue #17650](https://github.com/hashicorp/nomad/issues/17650). 

Configuration is accepted in the form of a `DeniedEnvars` option added to the rawexec driver and task config structs and rpcs and includes simple globbing support, defined as "prefix & suffix" in the documentation.


### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
[issue #17650](https://github.com/hashicorp/nomad/issues/17650)
### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
