### PR TITLE
cli: Use meta response index to start monitoring volume create.

### DIFF
--- a/command/volume_create_host.go
+++ b/command/volume_create_host.go
@@ -52,7 +52,7 @@ func (c *VolumeCreateCommand) hostVolumeCreate(
 		Volume:         vol,
 		PolicyOverride: override,
 	}
-	resp, _, err := client.HostVolumes().Create(req, nil)
+	resp, meta, err := client.HostVolumes().Create(req, nil)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error creating volume: %s", err))
 		return 1
@@ -75,7 +75,7 @@ func (c *VolumeCreateCommand) hostVolumeCreate(
 		c.Ui.Output(fmt.Sprintf(
 			"==> Created host volume %s with ID %s", vol.Name, vol.ID))
 		volID = vol.ID
-		lastIndex = vol.ModifyIndex
+		lastIndex = meta.LastIndex
 	}
 
 	if vol.Namespace != "" {


### PR DESCRIPTION
### Description
The volume object does not have the indexes set which is a symptom of the FSM and RPC workings. If the create CLI runs against a follower, the subsequent monitor command might error with a 404 code because the follower does not have the object in state and the wait index is set to zero.

No changelog or backport needed.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
