### PR TITLE
auth: sanitize auth method in create/update reply

### DIFF
--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -1947,7 +1947,7 @@ func (a *ACL) UpsertAuthMethods(
 			return structs.NewErrRPCCodedf(400, "ACL auth method lookup failed: %v", err)
 		}
 		if lookupAuthMethod != nil {
-			reply.AuthMethods = append(reply.AuthMethods, lookupAuthMethod)
+			reply.AuthMethods = append(reply.AuthMethods, lookupAuthMethod.Sanitize())
 		}
 	}
 


### PR DESCRIPTION
Auth method create/update APIs only work for someone who has the OIDC client's secret(s) in hand, but that could be a CI system, which might log output in the clear.

Attn: @dduzgun-security 

Follow-up to PR #25328 which includes doc changes and a changelog.