### PR TITLE
drivers: unflake TestExecutor_OOMKilled by increaseing memory

### DIFF
--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -287,7 +287,7 @@ func TestExecutor_OOMKilled(t *testing.T) {
 	execCmd.ResourceLimits = true
 	execCmd.ModePID = "private"
 	execCmd.ModeIPC = "private"
-	execCmd.Resources.LinuxResources.MemoryLimitBytes = 10 * 1024 * 1024
+	execCmd.Resources.LinuxResources.MemoryLimitBytes = 20 * 1024 * 1024
 	execCmd.Resources.NomadResources.Memory.MemoryMB = 10
 
 	executor := NewExecutorWithIsolation(testlog.HCLogger(t), compute)


### PR DESCRIPTION
Every now and then `TestExecutor_OOMKilled` would fail with:
```
executor_linux_test.go:297: 
        executor_linux_test.go:297: expected nil error
        ↪ error: unable to start container process: container init was OOM-killed (memory limit too low?)
```
which started happening since we [upgraded](https://github.com/hashicorp/nomad/pull/25138) libcontainer. Could it be that memfd-bind behavior changed in 1.2? (I can't figure this out from libcontainer changelogs) In any case, increasing the memory limit unflaked this test in my manual testing. 