### PR TITLE
job: Add migrate block detail when performing task group diff

### DIFF
--- a/.changelog/25528.txt
+++ b/.changelog/25528.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+job: Ensure migrate block difference is added to planning diff object
+```

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -293,6 +293,12 @@ func (tg *TaskGroup) Diff(other *TaskGroup, contextual bool) (*TaskGroupDiff, er
 		diff.Objects = append(diff.Objects, rDiff)
 	}
 
+	// Migrate block diff.
+	migrateDiff := primitiveObjectDiff(tg.Migrate, other.Migrate, nil, "Migrate", contextual)
+	if migrateDiff != nil {
+		diff.Objects = append(diff.Objects, migrateDiff)
+	}
+
 	// Reschedule policy diff
 	reschedDiff := primitiveObjectDiff(tg.ReschedulePolicy, other.ReschedulePolicy, nil, "ReschedulePolicy", contextual)
 	if reschedDiff != nil {

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -5271,6 +5271,61 @@ func TestTaskGroupDiff(t *testing.T) {
 				},
 			},
 		},
+		{
+			TestCase:   "edited migrate",
+			Contextual: false,
+			Old: &TaskGroup{
+				Migrate: &MigrateStrategy{
+					MaxParallel:     1,
+					HealthCheck:     "checks",
+					MinHealthyTime:  1 * time.Second,
+					HealthyDeadline: 1 * time.Minute,
+				},
+			},
+			New: &TaskGroup{
+				Migrate: &MigrateStrategy{
+					MaxParallel:     5,
+					HealthCheck:     "task_states",
+					MinHealthyTime:  5 * time.Second,
+					HealthyDeadline: 5 * time.Minute,
+				},
+			},
+			Expected: &TaskGroupDiff{
+				Type: DiffTypeEdited,
+				Objects: []*ObjectDiff{
+					{
+						Type: DiffTypeEdited,
+						Name: "Migrate",
+						Fields: []*FieldDiff{
+							{
+								Type: "Edited",
+								Name: "HealthCheck",
+								Old:  "checks",
+								New:  "task_states",
+							},
+							{
+								Type: "Edited",
+								Name: "HealthyDeadline",
+								Old:  "60000000000",
+								New:  "300000000000",
+							},
+							{
+								Type: "Edited",
+								Name: "MaxParallel",
+								Old:  "1",
+								New:  "5",
+							},
+							{
+								Type: "Edited",
+								Name: "MinHealthyTime",
+								Old:  "1000000000",
+								New:  "5000000000",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
### Description
Is it a bug or a feature, I could see either side of this but marking as a bug initially which allows backporting.

### Links
Closes #25522 

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
