### PR TITLE
docs: document requirements for Consul tokens in admin partitions

### DIFF
--- a/website/content/docs/configuration/consul.mdx
+++ b/website/content/docs/configuration/consul.mdx
@@ -128,6 +128,10 @@ agents.
   environment variable if set. Nomad cannot refresh this token; if the token is
   deleted, Nomad is not able to communicate with Consul.
 
+  In Nomad Enterprise, if the Consul agent running alongside Nomad is in an
+  Consul Enterprise admin partition, you must create the Consul token provided
+  to the Nomad client in the same partition.
+
 - `verify_ssl` `(bool: true)`- Specifies if SSL peer verification should be used
   when communicating to the Consul API client over HTTPS. Will default to the
   `CONSUL_HTTP_SSL_VERIFY` environment variable if set.
@@ -416,6 +420,12 @@ namespace "nomad-ns" {
   }
 }
 ```
+
+### Consul Admin Partition <EnterpriseAlert inline/>
+
+In Nomad Enterprise, if the Consul agent running alongside Nomad is in an Consul
+Enterprise admin partition, you must create the Consul ACL token and ACL policy
+for Nomad clients in the same partition.
 
 
 [consul]: https://www.consul.io/ 'Consul by HashiCorp'

--- a/website/content/docs/configuration/consul.mdx
+++ b/website/content/docs/configuration/consul.mdx
@@ -128,7 +128,7 @@ agents.
   environment variable if set. Nomad cannot refresh this token; if the token is
   deleted, Nomad is not able to communicate with Consul.
 
-  In Nomad Enterprise, if the Consul agent running alongside Nomad is in an
+  In Nomad Enterprise, if the Consul agent running alongside Nomad is in a
   Consul Enterprise admin partition, you must create the Consul token provided
   to the Nomad client in the same partition.
 
@@ -423,7 +423,7 @@ namespace "nomad-ns" {
 
 ### Consul Admin Partition <EnterpriseAlert inline/>
 
-In Nomad Enterprise, if the Consul agent running alongside Nomad is in an Consul
+In Nomad Enterprise, if the Consul agent running alongside Nomad is in a Consul
 Enterprise admin partition, you must create the Consul ACL token and ACL policy
 for Nomad clients in the same partition.
 


### PR DESCRIPTION
When using Nomad with Consul, each Nomad agent is expected to have a Consul agent running alongside. When using Nomad Enterprise and Consul Enterprise together, the Consul agent may be in a Consul admin partition. In order for Nomad's "anti-entropy" sync to work with Consul, the Consul ACL token and ACL policy for the Nomad client must be in the same admin partition as the Consul agent. Otherwise, we can register services (via WI) but then won't be able to deregister them unless they're the default namespace.

Ref: https://hashicorp.atlassian.net/browse/NET-12361
Preview link: https://nomad-git-docs-consul-partitions-agents-hashicorp.vercel.app/nomad/docs/configuration/consul
