### PR TITLE
dhv: mkdir plugin parameters: uid,guid,mode

### DIFF
--- a/client/fingerprint/dynamic_host_volumes.go
+++ b/client/fingerprint/dynamic_host_volumes.go
@@ -105,7 +105,7 @@ func GetHostVolumePluginVersions(log hclog.Logger, pluginDir, nodePool string) (
 
 			fprint, err := p.Fingerprint(ctx)
 			if err != nil {
-				log.Debug("failed to get version from plugin", "error", err)
+				// Fingerprint logs the error
 				return
 			}
 

--- a/client/host_volume_endpoint.go
+++ b/client/host_volume_endpoint.go
@@ -32,7 +32,6 @@ func (v *HostVolume) Create(
 
 	cresp, err := v.c.hostVolumeManager.Create(ctx, req)
 	if err != nil {
-		v.c.logger.Error("failed to create host volume", "name", req.Name, "error", err)
 		return err
 	}
 
@@ -53,7 +52,6 @@ func (v *HostVolume) Register(
 
 	err := v.c.hostVolumeManager.Register(ctx, req)
 	if err != nil {
-		v.c.logger.Error("failed to register host volume", "name", req.Name, "error", err)
 		return err
 	}
 
@@ -70,7 +68,6 @@ func (v *HostVolume) Delete(
 
 	_, err := v.c.hostVolumeManager.Delete(ctx, req)
 	if err != nil {
-		v.c.logger.Error("failed to delete host volume", "ID", req.ID, "error", err)
 		return err
 	}
 

--- a/client/hostvolumemanager/host_volume_plugin.go
+++ b/client/hostvolumemanager/host_volume_plugin.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	"github.com/hashicorp/go-hclog"

--- a/client/hostvolumemanager/host_volume_plugin_test.go
+++ b/client/hostvolumemanager/host_volume_plugin_test.go
@@ -159,25 +159,41 @@ func TestDecodeMkdirParams(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid mode",
+			name: "invalid mode: bad number",
+			params: map[string]string{
+				// this is what happens if you put mode=0700 instead of
+				// mode="0700" in the HCL spec.
+				"mode": "493",
+			},
+			err: `invalid value for "mode" ahh`,
+		},
+		{
+			name: "invalid mode: string",
 			params: map[string]string{
 				"mode": "consider the lobster",
 			},
-			err: "cannot parse 'mode' as uint",
+			err: `invalid value for "mode"`,
 		},
 		{
 			name: "invalid uid",
 			params: map[string]string{
 				"uid": "a supposedly fun thing i'll never do again",
 			},
-			err: "cannot parse 'uid' as int",
+			err: `invalid value for "uid"`,
 		},
 		{
 			name: "invalid gid",
 			params: map[string]string{
 				"gid": "surely you jest",
 			},
-			err: "cannot parse 'gid' as int",
+			err: `invalid value for "gid"`,
+		},
+		{
+			name: "unknown param",
+			params: map[string]string{
+				"what": "the hell is water?",
+			},
+			err: `unknown mkdir parameter: "what"`,
 		},
 	}
 

--- a/client/hostvolumemanager/host_volume_plugin_test.go
+++ b/client/hostvolumemanager/host_volume_plugin_test.go
@@ -122,7 +122,7 @@ func TestHostVolumePluginMkdir(t *testing.T) {
 					"mode": "invalid",
 				},
 			})
-		must.ErrorContains(t, err, "cannot parse")
+		must.ErrorContains(t, err, "invalid value")
 		must.Nil(t, resp)
 	})
 }
@@ -165,7 +165,7 @@ func TestDecodeMkdirParams(t *testing.T) {
 				// mode="0700" in the HCL spec.
 				"mode": "493",
 			},
-			err: `invalid value for "mode" ahh`,
+			err: `invalid value for "mode"`,
 		},
 		{
 			name: "invalid mode: string",
@@ -311,7 +311,7 @@ func TestHostVolumePluginExternal(t *testing.T) {
 		must.NoError(t, err)
 
 		v, err := plug.Fingerprint(timeout(t))
-		must.EqError(t, err, `error getting version from plugin "test_plugin_sad.sh": exit status 1`)
+		must.EqError(t, err, `error fingerprinting plugin "test_plugin_sad.sh": exit status 1`)
 		must.Nil(t, v)
 		logged := getLogs()
 		must.StrContains(t, logged, "fingerprint: sad plugin is sad")

--- a/command/volume_create_host_test.go
+++ b/command/volume_create_host_test.go
@@ -57,7 +57,7 @@ capability {
 }
 
 parameters {
-  foo = "bar"
+  mode = "0700"
 }
 `
 

--- a/nomad/mock/host_volumes.go
+++ b/nomad/mock/host_volumes.go
@@ -23,7 +23,7 @@ func HostVolumeRequest(ns string) *structs.HostVolume {
 		},
 		RequestedCapacityMinBytes: 100000,
 		RequestedCapacityMaxBytes: 200000,
-		Parameters:                map[string]string{"foo": "bar"},
+		Parameters:                map[string]string{"mode": "0700"},
 		State:                     structs.HostVolumeStatePending,
 	}
 	return vol

--- a/website/content/docs/concepts/plugins/storage/host-volumes.mdx
+++ b/website/content/docs/concepts/plugins/storage/host-volumes.mdx
@@ -13,12 +13,12 @@ This page describes the plugin specification for
 your own plugin to dynamically configure persistent storage on your Nomad
 client nodes.
 
-Nomad has one built-in plugin called `mkdir`, which creates a directory on the
-host in the Nomad agent's [host_volumes_dir][]. The `mkdir` plugin does not
-support the `capacity_min` or `capacity_max` fields.
+If you do not need to write your own plugin, consider Nomad's built-in
+[`mkdir` plugin][mkdir_plugin], which creates a directory on the host.
 
-Review the examples first to get a sense of the specification in action.
-A plugin can be as basic as a short shell script.
+If you have more complex needs than that, review the examples here to get a
+sense of the specification in action. A plugin can be as basic as a short shell
+script.
 
 The full [specification](#specification) is after the examples,
 followed by a list of [general considerations](#considerations).
@@ -425,4 +425,5 @@ Plugin authors should consider these details when writing plugins.
 [api-create]: /nomad/api-docs/volumes#create-dynamic-host-volume
 [cli-delete]: /nomad/docs/commands/volume/delete
 [api-delete]: /nomad/api-docs/volumes#delete-dynamic-host-volume
+[mkdir_plugin]: /nomad/docs/other-specifications/volume/host#mkdir-plugin
 [host_volumes_dir]: /nomad/docs/configuration/client#host_volumes_dir

--- a/website/content/docs/other-specifications/volume/host.mdx
+++ b/website/content/docs/other-specifications/volume/host.mdx
@@ -48,7 +48,7 @@ the API.
   behavior is up to the plugin. If you want to specify an exact size, set
   `capacity_min` and `capacity_max` to the same value. Accepts human-friendly
   suffixes such as `"100GiB"`. Plugins that cannot restrict the size of volumes,
-  such as the built-in `mkdir` plugin, may ignore this field.
+  such as the built-in [`mkdir`][mkdir_plugin] plugin, may ignore this field.
 
 - `capacity_max` `(string: <optional>)` - Option for requesting a maximum
   capacity, in bytes. The capacity of a volume may be the physical size of a
@@ -57,7 +57,7 @@ the API.
   behavior is up to the plugin. If you want to specify an exact size, set
   `capacity_min` and `capacity_max` to the same value. Accepts human-friendly
   suffixes such as `"100GiB"`. Plugins that cannot restrict the size of volumes,
-  such as the built-in `mkdir` plugin, may ignore this field.
+  such as the built-in [`mkdir`][mkdir_plugin] plugin, may ignore this field.
 
 - `capability` <code>([Capability][capability]: &lt;required&gt;)</code> -
   Option for validating the capability of a volume.
@@ -101,11 +101,49 @@ the API.
 
 - `plugin_id` `(string)` - The ID of the [dynamic host volume
   plugin][dhv_plugin] that manages this volume. Required for volume
-  creation. Nomad has one built-in plugin called `mkdir`, which creates a
-  directory on the host in the Nomad agent's [host_volumes_dir][].
+  creation. Nomad has one built-in plugin called [`mkdir`][mkdir_plugin].
 
 - `type` `(string: <required>)` - The type of volume. Must be `"host"` for
   dynamic host volumes.
+
+## mkdir plugin
+
+Nomad has one built-in plugin called `mkdir`, which creates a directory on the
+host in the Nomad agent's [host_volumes_dir][]. The directory name is the
+volume's ID.
+
+`mkdir` ignores `capacity_min` and `capacity_max` volume configuration,
+since it has no way of enforcing them.
+
+### mkdir parameters
+
+- `mode` `(string: <optional>)` - [Numeric
+notation](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation)
+to apply to the created directory. Defaults to "0700", so only the owner can
+access it.
+- `uid` `(string: <optional>)` - User ID to own the directory. Defaults to the
+user running the Nomad client agent, which is commonly root ("0").
+- `gid` `(string: <optional>)` - Group ID to own the directory. Defaults to the
+user running the Nomad client agent, which is commonly root ("0").
+
+The user and group IDs must be present on any node that may receive the volume.
+
+### mkdir example
+
+<CodeBlockConfig filename="mkdir.volume.hcl">
+
+```hcl
+type      = "host"
+name      = "cool-host-vol"
+plugin_id = "mkdir"
+parameters = {
+  mode = "0755"
+  uid  = "1000"
+  gid  = "1000"
+}
+```
+
+</CodeBlockConfig>
 
 ## Differences Between Create and Register
 
@@ -307,4 +345,5 @@ registered.
 [`volume register`]: /nomad/docs/commands/volume/register
 [`volume status`]: /nomad/docs/commands/volume/status
 [dhv_plugin]: /nomad/docs/concepts/plugins/storage/host-volumes
+[mkdir_plugin]: #mkdir-plugin
 [host_volumes_dir]: /nomad/docs/configuration/client#host_volumes_dir

--- a/website/content/docs/other-specifications/volume/host.mdx
+++ b/website/content/docs/other-specifications/volume/host.mdx
@@ -120,11 +120,11 @@ since it has no way of enforcing them.
 - `mode` `(string: <optional>)` - [Numeric
 notation](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation)
 to apply to the created directory. Defaults to "0700", so only the owner can
-access it.
-- `uid` `(string: <optional>)` - User ID to own the directory. Defaults to the
-user running the Nomad client agent, which is commonly root ("0").
-- `gid` `(string: <optional>)` - Group ID to own the directory. Defaults to the
-user running the Nomad client agent, which is commonly root ("0").
+access it. Must be a string, or you may get unexpected results.
+- `uid` `(int: <optional>)` - User ID to own the directory. Defaults to the
+user running the Nomad client agent, which is commonly `0` (root).
+- `gid` `(int: <optional>)` - Group ID to own the directory. Defaults to the
+user running the Nomad client agent, which is commonly `0` (root).
 
 The user and group IDs must be present on any node that may receive the volume.
 
@@ -138,8 +138,8 @@ name      = "cool-host-vol"
 plugin_id = "mkdir"
 parameters = {
   mode = "0755"
-  uid  = "1000"
-  gid  = "1000"
+  uid  = 1000
+  gid  = 1000
 }
 ```
 


### PR DESCRIPTION
Our friend @ygersie [requested an option](https://github.com/hashicorp/nomad/pull/24479#issuecomment-2754239594) to change perms/ownership on the directory that our built-in `mkdir` plugin creates, which is a nice idea, so let's do it!