### PR TITLE
sec: Suppress GO-2025-3543 for github.com/opencontainers/runc

### DIFF
--- a/.github/scan.hcl
+++ b/.github/scan.hcl
@@ -44,6 +44,9 @@ repository {
   # periodically cleaned up to remove items that are no longer found by the scanner.
   triage {
     suppress {
+      vulnerabilities = [
+        "GO-2025-3543", // github.com/opencontainers/runc TODO(jrasell): remove once withdrawn from DBs.
+      ]
       paths = [
         "ui/tests/*",
         "internal/testing/*",

--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -30,6 +30,7 @@ binary {
     suppress {
       vulnerabilities = [
         "GO-2022-0635", // github.com/aws/aws-sdk-go@v1.55.6 TODO(jrasell): remove when dep updated.
+        "GO-2025-3543", // github.com/opencontainers/runc    TODO(jrasell): remove once withdrawn from DBs.
       ]
     }
   }


### PR DESCRIPTION
The vulnerability has been withdrawn but it may be a while until it is removed from the DB used by scanning. Suppressing this removes the false result in scanning processes. The change should be reverted once the DB is updated.

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
