### PR TITLE
e2e: require IMDSv2 for ec2 instances

### DIFF
--- a/e2e/terraform/provision-infra/compute.tf
+++ b/e2e/terraform/provision-infra/compute.tf
@@ -15,6 +15,10 @@ resource "aws_instance" "server" {
   count                  = var.server_count
   iam_instance_profile   = data.aws_iam_instance_profile.nomad_e2e_cluster.name
   availability_zone      = var.availability_zone
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
 
   # Instance tags
   tags = {
@@ -32,6 +36,10 @@ resource "aws_instance" "client_ubuntu_jammy" {
   count                  = var.client_count_linux
   iam_instance_profile   = data.aws_iam_instance_profile.nomad_e2e_cluster.name
   availability_zone      = var.availability_zone
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
 
   # Instance tags
   tags = {
@@ -52,6 +60,10 @@ resource "aws_instance" "client_windows_2016" {
   count                  = var.client_count_windows_2016
   iam_instance_profile   = data.aws_iam_instance_profile.nomad_e2e_cluster.name
   availability_zone      = var.availability_zone
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
 
   user_data = file("${path.module}/userdata/windows-2016.ps1")
 
@@ -71,6 +83,10 @@ resource "aws_instance" "consul_server" {
   vpc_security_group_ids = [aws_security_group.consul_server.id]
   iam_instance_profile   = data.aws_iam_instance_profile.nomad_e2e_cluster.name
   availability_zone      = var.availability_zone
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
 
   # Instance tags
   tags = {


### PR DESCRIPTION
Require Instance Metadata Service v2 to access EC2 instance metadata for all VMs that run our e2e suite. 

Internal ref: https://hashicorp.atlassian.net/browse/SECVULN-18860