### PR TITLE
e2e: create consul policies and roles in respective namespaces

### DIFF
--- a/e2e/e2eutil/consul.go
+++ b/e2e/e2eutil/consul.go
@@ -11,6 +11,7 @@ import (
 	capi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/kr/pretty"
+	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -197,6 +198,25 @@ func DeleteConsulPolicies(t *testing.T, client *capi.Client, policies map[string
 			assert.NoError(t, err)
 		}
 	}
+}
+
+// CreateConsulRole is used to create a Consul ACL role with capabilities from the given policy
+// in the specified namespace.
+//
+// Requires Consul Enterprise.
+func CreateConsulRole(t *testing.T, client *capi.Client, name string, namespace string, policyID string) {
+	aclClient := client.ACL()
+
+	opts := &capi.WriteOptions{Namespace: namespace}
+	role := &capi.ACLRole{
+		Name:        name,
+		Description: "role for nomad tasks",
+		Policies: []*capi.ACLLink{{
+			ID: policyID,
+		}},
+	}
+	_, _, err := aclClient.RoleCreate(role, opts)
+	must.NoError(t, err)
 }
 
 // CreateConsulToken is used to create a Consul ACL token backed by the policy of


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
For the Consul E2E tests to function with workload identity, the nomad policy and associated role need to be present in the consul namespace that the nomad task is registering in.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
