### PR TITLE
acl: use WhoAmI RPC endpoint in /acl/token/self

### DIFF
--- a/api/util_test.go
+++ b/api/util_test.go
@@ -14,7 +14,7 @@ import (
 func assertQueryMeta(t *testing.T, qm *QueryMeta) {
 	t.Helper()
 
-	must.NotEq(t, 0, qm.LastIndex, must.Sprint("bad index"))
+	must.NotEq(t, 0, qm.LastIndex, must.Sprint("expected QueryMeta.LastIndex to be != 0"))
 	must.True(t, qm.KnownLeader, must.Sprint("expected a known leader but gone none"))
 }
 

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -219,27 +219,25 @@ func (s *HTTPServer) aclTokenQuery(resp http.ResponseWriter, req *http.Request,
 	return out.Token, nil
 }
 
-func (s *HTTPServer) aclTokenSelf(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
+func (s *HTTPServer) aclTokenSelf(resp http.ResponseWriter, req *http.Request) (any, error) {
 	if req.Method != http.MethodGet {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
-	args := structs.ResolveACLTokenRequest{}
+	args := structs.GenericRequest{}
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
 		return nil, nil
 	}
 
-	args.SecretID = args.AuthToken
-
-	var out structs.ResolveACLTokenResponse
-	if err := s.agent.RPC("ACL.ResolveToken", &args, &out); err != nil {
+	var out structs.ACLWhoAmIResponse
+	if err := s.agent.RPC("ACL.WhoAmI", &args, &out); err != nil {
 		return nil, err
 	}
 
 	setMeta(resp, &out.QueryMeta)
-	if out.Token == nil {
+	if out.Identity.ACLToken == nil {
 		return nil, CodedError(404, "ACL token not found")
 	}
-	return out.Token, nil
+	return out.Identity.ACLToken, nil
 }
 
 func (s *HTTPServer) aclTokenUpdate(resp http.ResponseWriter, req *http.Request,

--- a/command/agent/acl_endpoint.go
+++ b/command/agent/acl_endpoint.go
@@ -234,7 +234,7 @@ func (s *HTTPServer) aclTokenSelf(resp http.ResponseWriter, req *http.Request) (
 	}
 
 	setMeta(resp, &out.QueryMeta)
-	if out.Identity.ACLToken == nil {
+	if out.Identity == nil || out.Identity.ACLToken == nil {
 		return nil, CodedError(404, "ACL token not found")
 	}
 	return out.Identity.ACLToken, nil

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -1055,52 +1055,6 @@ func (a *ACL) GetTokens(args *structs.ACLTokenSetRequest, reply *structs.ACLToke
 	return a.srv.blockingRPC(&opts)
 }
 
-// ResolveToken is used to lookup a specific token by a secret ID.
-//
-// Deprecated: Prior to Nomad 1.5 this RPC was used by clients for
-// authenticating local RPCs. Since Nomad 1.5 added workload identity support,
-// clients now use the more flexible ACL.WhoAmI RPC. The /v1/acl/token/self API
-// is the only remaining caller and should be switched to ACL.WhoAmI.
-func (a *ACL) ResolveToken(args *structs.ResolveACLTokenRequest, reply *structs.ResolveACLTokenResponse) error {
-	if !a.srv.config.ACLEnabled {
-		return aclDisabled
-	}
-	if done, err := a.srv.forward("ACL.ResolveToken", args, args, reply); done {
-		return err
-	}
-	a.srv.MeasureRPCRate("acl", structs.RateMetricRead, args)
-	defer metrics.MeasureSince([]string{"nomad", "acl", "resolve_token"}, time.Now())
-
-	// Setup the query meta
-	a.srv.setQueryMeta(&reply.QueryMeta)
-
-	// Snapshot the state
-	state, err := a.srv.State().Snapshot()
-	if err != nil {
-		return err
-	}
-
-	// Look for the token
-	out, err := state.ACLTokenBySecretID(nil, args.SecretID)
-	if err != nil {
-		return err
-	}
-
-	// Setup the output
-	reply.Token = out
-	if out != nil {
-		reply.Index = out.ModifyIndex
-	} else {
-		// Use the last index that affected the token table
-		index, err := state.Index("acl_token")
-		if err != nil {
-			return err
-		}
-		reply.Index = index
-	}
-	return nil
-}
-
 func (a *ACL) UpsertOneTimeToken(args *structs.OneTimeTokenUpsertRequest, reply *structs.OneTimeTokenUpsertResponse) error {
 	if !a.srv.config.ACLEnabled {
 		return aclDisabled

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -1055,6 +1055,50 @@ func (a *ACL) GetTokens(args *structs.ACLTokenSetRequest, reply *structs.ACLToke
 	return a.srv.blockingRPC(&opts)
 }
 
+// ResolveToken is used to lookup a specific token by a secret ID.
+//
+// Deprecated: This RPC has been deprecated since Nomad 1.5 and is only kept for
+// compatibility purposes.
+func (a *ACL) ResolveToken(args *structs.ResolveACLTokenRequest, reply *structs.ResolveACLTokenResponse) error {
+	if !a.srv.config.ACLEnabled {
+		return aclDisabled
+	}
+	if done, err := a.srv.forward("ACL.ResolveToken", args, args, reply); done {
+		return err
+	}
+	a.srv.MeasureRPCRate("acl", structs.RateMetricRead, args)
+	defer metrics.MeasureSince([]string{"nomad", "acl", "resolve_token"}, time.Now())
+
+	// Setup the query meta
+	a.srv.setQueryMeta(&reply.QueryMeta)
+
+	// Snapshot the state
+	state, err := a.srv.State().Snapshot()
+	if err != nil {
+		return err
+	}
+
+	// Look for the token
+	out, err := state.ACLTokenBySecretID(nil, args.SecretID)
+	if err != nil {
+		return err
+	}
+
+	// Setup the output
+	reply.Token = out
+	if out != nil {
+		reply.Index = out.ModifyIndex
+	} else {
+		// Use the last index that affected the token table
+		index, err := state.Index("acl_token")
+		if err != nil {
+			return err
+		}
+		reply.Index = index
+	}
+	return nil
+}
+
 func (a *ACL) UpsertOneTimeToken(args *structs.OneTimeTokenUpsertRequest, reply *structs.OneTimeTokenUpsertResponse) error {
 	if !a.srv.config.ACLEnabled {
 		return aclDisabled

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -2194,6 +2194,9 @@ func (a *ACL) WhoAmI(args *structs.GenericRequest, reply *structs.ACLWhoAmIRespo
 		}
 	}
 
+	// Setup the query meta
+	a.srv.setQueryMeta(&reply.QueryMeta)
+
 	reply.Identity = args.GetIdentity()
 
 	// COMPAT: originally these were time.Time objects but switching to go-jose

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -2208,6 +2208,10 @@ func (a *ACL) WhoAmI(args *structs.GenericRequest, reply *structs.ACLWhoAmIRespo
 		reply.Identity.Claims.NotBefore = nil
 	}
 
+	if reply.Identity.ACLToken != nil {
+		reply.Index = reply.Identity.ACLToken.ModifyIndex
+	}
+
 	return nil
 }
 

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -1887,38 +1887,6 @@ func TestACLEndpoint_UpsertTokens(t *testing.T) {
 	}
 }
 
-func TestACLEndpoint_ResolveToken(t *testing.T) {
-	ci.Parallel(t)
-	s1, _, cleanupS1 := TestACLServer(t, nil)
-	defer cleanupS1()
-	codec := rpcClient(t, s1)
-	testutil.WaitForLeader(t, s1.RPC)
-
-	// Create the register request
-	token := mock.ACLToken()
-	s1.fsm.State().UpsertACLTokens(structs.MsgTypeTestSetup, 1000, []*structs.ACLToken{token})
-
-	// Lookup the token
-	get := &structs.ResolveACLTokenRequest{
-		SecretID:     token.SecretID,
-		QueryOptions: structs.QueryOptions{Region: "global"},
-	}
-	var resp structs.ResolveACLTokenResponse
-	if err := msgpackrpc.CallWithCodec(codec, "ACL.ResolveToken", get, &resp); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	assert.Equal(t, uint64(1000), resp.Index)
-	assert.Equal(t, token, resp.Token)
-
-	// Lookup non-existing token
-	get.SecretID = uuid.Generate()
-	if err := msgpackrpc.CallWithCodec(codec, "ACL.ResolveToken", get, &resp); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	assert.Equal(t, uint64(1000), resp.Index)
-	assert.Nil(t, resp.Token)
-}
-
 func TestACLEndpoint_WhoAmI(t *testing.T) {
 	ci.Parallel(t)
 

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -1887,6 +1887,38 @@ func TestACLEndpoint_UpsertTokens(t *testing.T) {
 	}
 }
 
+func TestACLEndpoint_ResolveToken(t *testing.T) {
+	ci.Parallel(t)
+	s1, _, cleanupS1 := TestACLServer(t, nil)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	token := mock.ACLToken()
+	s1.fsm.State().UpsertACLTokens(structs.MsgTypeTestSetup, 1000, []*structs.ACLToken{token})
+
+	// Lookup the token
+	get := &structs.ResolveACLTokenRequest{
+		SecretID:     token.SecretID,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var resp structs.ResolveACLTokenResponse
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.ResolveToken", get, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp.Index)
+	assert.Equal(t, token, resp.Token)
+
+	// Lookup non-existing token
+	get.SecretID = uuid.Generate()
+	if err := msgpackrpc.CallWithCodec(codec, "ACL.ResolveToken", get, &resp); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	assert.Equal(t, uint64(1000), resp.Index)
+	assert.Nil(t, resp.Token)
+}
+
 func TestACLEndpoint_WhoAmI(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
`ResolveToken` RPC endpoint was only used by the `/acl/token/self` API. We should migrate to the WI-aware `WhoAmI` instead. 

Related to https://github.com/hashicorp/nomad/issues/24663
Internal ref: https://hashicorp.atlassian.net/browse/NET-11867