### PR TITLE
e2e: disable IMDSv2 in tests

### DIFF
--- a/e2e/terraform/provision-infra/compute.tf
+++ b/e2e/terraform/provision-infra/compute.tf
@@ -15,10 +15,6 @@ resource "aws_instance" "server" {
   count                  = var.server_count
   iam_instance_profile   = data.aws_iam_instance_profile.nomad_e2e_cluster.name
   availability_zone      = var.availability_zone
-  metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
-  }
 
   # Instance tags
   tags = {
@@ -36,10 +32,6 @@ resource "aws_instance" "client_ubuntu_jammy" {
   count                  = var.client_count_linux
   iam_instance_profile   = data.aws_iam_instance_profile.nomad_e2e_cluster.name
   availability_zone      = var.availability_zone
-  metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
-  }
 
   # Instance tags
   tags = {
@@ -60,10 +52,6 @@ resource "aws_instance" "client_windows_2016" {
   count                  = var.client_count_windows_2016
   iam_instance_profile   = data.aws_iam_instance_profile.nomad_e2e_cluster.name
   availability_zone      = var.availability_zone
-  metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
-  }
 
   user_data = file("${path.module}/userdata/windows-2016.ps1")
 
@@ -83,10 +71,6 @@ resource "aws_instance" "consul_server" {
   vpc_security_group_ids = [aws_security_group.consul_server.id]
   iam_instance_profile   = data.aws_iam_instance_profile.nomad_e2e_cluster.name
   availability_zone      = var.availability_zone
-  metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
-  }
 
   # Instance tags
   tags = {


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Consul needs to use a newer version of go-discover that can query IMDSv2 in order for our test infrastructure to be enabled with it.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
