### PR TITLE
auth: oidc client assertion tweaks

### DIFF
--- a/lib/auth/oidc/client_assertion.go
+++ b/lib/auth/oidc/client_assertion.go
@@ -6,6 +6,8 @@ package oidc
 import (
 	"bytes"
 	"crypto/rsa"
+
+	// sha1 is used to derive an "x5t" jwt header from an x509 certificate
 	// sha1 is used to derive an "x5t" jwt header from an x509 certificate,
 	// per the OIDC JWS spec:
 	// https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.7

--- a/lib/auth/oidc/client_assertion_test.go
+++ b/lib/auth/oidc/client_assertion_test.go
@@ -518,3 +518,34 @@ func generateInvalidTestPrivateKey(t *testing.T) *rsa.PrivateKey {
 
 	return key
 }
+
+func TestWrapBeginEnd(t *testing.T) {
+	// strings instead of []byte for easier diff output on test failure
+	begin := "BEGIN"
+	end := "END"
+	expect := "BEGIN\nstuff\nEND"
+	cases := []struct {
+		name    string
+		content string
+		expect  string
+	}{
+		{
+			name:    "complete",
+			content: "BEGIN\nstuff\nEND",
+		},
+		{
+			name:    "missing",
+			content: "stuff",
+		},
+		{
+			name:    "no newlines",
+			content: "BEGINstuffEND",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := wrapBeginEnd([]byte(tc.content), []byte(begin), []byte(end))
+			must.Eq(t, expect, string(got))
+		})
+	}
+}

--- a/lib/auth/oidc/provider.go
+++ b/lib/auth/oidc/provider.go
@@ -25,6 +25,13 @@ func providerConfig(authMethod *structs.ACLAuthMethod) (*oidc.Config, error) {
 		algs = []oidc.Alg{oidc.RS256}
 	}
 
+	// if client assertion is enabled, do not send a client secret normally;
+	// if it is set to anything, it will be used as an HMAC to sign the client
+	// assertion JWT, instead.
+	if authMethod.Config.OIDCClientAssertion != nil {
+		authMethod.Config.OIDCClientSecret = ""
+	}
+
 	return oidc.NewConfig(
 		authMethod.Config.OIDCDiscoveryURL,
 		authMethod.Config.OIDCClientID,

--- a/lib/auth/oidc/provider.go
+++ b/lib/auth/oidc/provider.go
@@ -28,14 +28,15 @@ func providerConfig(authMethod *structs.ACLAuthMethod) (*oidc.Config, error) {
 	// if client assertion is enabled, do not send a client secret normally;
 	// if it is set to anything, it will be used as an HMAC to sign the client
 	// assertion JWT, instead.
+	clientSecret := authMethod.Config.OIDCClientSecret
 	if authMethod.Config.OIDCClientAssertion != nil {
-		authMethod.Config.OIDCClientSecret = ""
+		clientSecret = ""
 	}
 
 	return oidc.NewConfig(
 		authMethod.Config.OIDCDiscoveryURL,
 		authMethod.Config.OIDCClientID,
-		oidc.ClientSecret(authMethod.Config.OIDCClientSecret),
+		oidc.ClientSecret(clientSecret),
 		algs,
 		authMethod.Config.AllowedRedirectURIs,
 		oidc.WithAudiences(authMethod.Config.BoundAudiences...),

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -1121,10 +1121,9 @@ func (a *ACLAuthMethodConfig) Canonicalize() {
 		if len(a.OIDCClientAssertion.Audience) == 0 {
 			a.OIDCClientAssertion.Audience = []string{a.OIDCDiscoveryURL}
 		}
-		// move the client secret into the client assertion
+		// the client assertion inherits the client secret,
+		// in case KeySource = "client_secret"
 		a.OIDCClientAssertion.ClientSecret = a.OIDCClientSecret
-		// do not also send the client secret normally
-		a.OIDCClientSecret = ""
 		a.OIDCClientAssertion.Canonicalize()
 	}
 }

--- a/nomad/structs/acl_test.go
+++ b/nomad/structs/acl_test.go
@@ -1403,7 +1403,6 @@ func TestACLAuthMethodConfig_Canonicalize(t *testing.T) {
 	am.Canonicalize()
 	must.Eq(t, []string{"test-disco-url"}, cass.Audience, must.Sprint("should inherit audience"))
 	must.Eq(t, "super secret", cass.ClientSecret, must.Sprint("should inherit secret"))
-	must.Eq(t, "", am.OIDCClientSecret, must.Sprint("secret should move to assertion"))
 }
 
 func TestACLAuthMethodConfig_Validate(t *testing.T) {


### PR DESCRIPTION
Couple small things, neither strictly necessary, but "fit and finish":

1. Modify how we skip sending an OIDC client secret the non-client-assertion way if `PrivateKey.KeySource = "client_secret"`, mainly so that it still shows up as `redacted` instead of `<none>` in the output of `nomad acl auth-method info`
2. Allow some flexibility in how users provide custom key/cert. It can be fiddly to get newlines in the exact right places (required after the header, and before the footer), so adding ~~header/footer and~~ newlines in the right spots makes it easier to configure.