### PR TITLE
Add -group flag to `alloc exec`, `alloc logs` command

### DIFF
--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -53,6 +53,9 @@ Exec Specific Options:
   -job
     Use a random allocation from the specified job ID or prefix.
 
+  -group <group-name>
+    Specifies the task group with the task when a random allocation is selected.
+
   -i
     Pass stdin to the container, defaults to true.  Pass -i=false to disable.
 
@@ -78,6 +81,7 @@ func (l *AllocExecCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{
 			"--task": complete.PredictAnything,
 			"-job":   complete.PredictAnything,
+			"-group": complete.PredictAnything,
 			"-i":     complete.PredictNothing,
 			"-t":     complete.PredictNothing,
 			"-e":     complete.PredictSet("none", "~"),
@@ -103,7 +107,7 @@ func (l *AllocExecCommand) Name() string { return "alloc exec" }
 
 func (l *AllocExecCommand) Run(args []string) int {
 	var job, stdinOpt, ttyOpt bool
-	var task, escapeChar string
+	var task, group, escapeChar string
 
 	flags := l.Meta.FlagSet(l.Name(), FlagSetClient)
 	flags.Usage = func() { l.Ui.Output(l.Help()) }
@@ -112,6 +116,7 @@ func (l *AllocExecCommand) Run(args []string) int {
 	flags.BoolVar(&ttyOpt, "t", isTty(), "")
 	flags.StringVar(&escapeChar, "e", "~", "")
 	flags.StringVar(&task, "task", "", "")
+	flags.StringVar(&group, "group", "", "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -168,7 +173,7 @@ func (l *AllocExecCommand) Run(args []string) int {
 			return 1
 		}
 
-		allocStub, err = getRandomJobAlloc(client, jobID, "", ns)
+		allocStub, err = getRandomJobAlloc(client, jobID, group, ns)
 		if err != nil {
 			l.Ui.Error(fmt.Sprintf("Error fetching allocations: %v", err))
 			return 1

--- a/website/content/docs/commands/alloc/exec.mdx
+++ b/website/content/docs/commands/alloc/exec.mdx
@@ -44,6 +44,9 @@ capabilities for the allocation's namespace.
 - `-job`: Use a random allocation from the specified job or job ID prefix,
   preferring a running allocation.
 
+- `-group` <group-name>: Specifies the task group where the task is located 
+  when a random allocation is selected
+
 - `-i`: Pass stdin to the container, defaults to true. Pass `-i=false` to
   disable explicitly.
 

--- a/website/content/docs/commands/alloc/logs.mdx
+++ b/website/content/docs/commands/alloc/logs.mdx
@@ -48,6 +48,9 @@ When ACLs are enabled, this command requires a token with the `read-logs`,
 
 - `-task`: Specify the task to view the logs.
 
+- `-group` <group-name>: Specifies the task group where the task is located 
+  when a random allocation is selected
+
 - `-f`: Causes the output to not stop when the end of the logs are reached, but
   rather to wait for additional output. When supplied with no other flags except
   optionally `-job` and `-task`, both stdout and stderr logs will be followed.


### PR DESCRIPTION
### Description
Adds an optional `-group` flag to the `alloc logs` and `alloc exec` commands. Fixes an issue where if the `-task` and `-job` flags were provided, but the given task would only run on certain allocs, the `-group` can be used to specify where the task would be running. 

### Testing & Reproduction steps
I was able to reproduce the issue following the issue, and with the fix, observe that it could consistently find the correct alloc. 
```
for i in {1...100}; do ./bin/nomad alloc logs -task web -group api -job countdash; done
```

The logic to get a random job alloc by providing the `group` already existed, so this PR is just adding the flag and passing it to the function. 

### Links
Fixes https://github.com/hashicorp/nomad/issues/24938

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
