### PR TITLE
volumes: Version gate create/delete host volume RPCs.

### DIFF
--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -192,6 +192,10 @@ func (v *HostVolume) Create(args *structs.HostVolumeCreateRequest, reply *struct
 	}
 	defer metrics.MeasureSince([]string{"nomad", "host_volume", "create"}, time.Now())
 
+	if !ServersMeetMinimumVersion(v.srv.Members(), v.srv.Region(), minVersionDynamicHostVolumes, false) {
+		return fmt.Errorf("all servers should be running version %v or later to use dynamic host volumes", minVersionDynamicHostVolumes)
+	}
+
 	allowVolume := acl.NamespaceValidator(acl.NamespaceCapabilityHostVolumeCreate)
 	aclObj, err := v.srv.ResolveACL(args)
 	if err != nil {
@@ -612,6 +616,10 @@ func (v *HostVolume) Delete(args *structs.HostVolumeDeleteRequest, reply *struct
 		return structs.ErrPermissionDenied
 	}
 	defer metrics.MeasureSince([]string{"nomad", "host_volume", "delete"}, time.Now())
+
+	if !ServersMeetMinimumVersion(v.srv.Members(), v.srv.Region(), minVersionDynamicHostVolumes, false) {
+		return fmt.Errorf("all servers should be running version %v or later to use dynamic host volumes", minVersionDynamicHostVolumes)
+	}
 
 	// Note that all deleted volumes need to be in the same namespace
 	allowVolume := acl.NamespaceValidator(acl.NamespaceCapabilityHostVolumeDelete)

--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -294,6 +294,10 @@ func (v *HostVolume) Register(args *structs.HostVolumeRegisterRequest, reply *st
 	}
 	defer metrics.MeasureSince([]string{"nomad", "host_volume", "register"}, time.Now())
 
+	if !ServersMeetMinimumVersion(v.srv.Members(), v.srv.Region(), minVersionDynamicHostVolumes, false) {
+		return fmt.Errorf("all servers should be running version %v or later to use dynamic host volumes", minVersionDynamicHostVolumes)
+	}
+
 	allowVolume := acl.NamespaceValidator(acl.NamespaceCapabilityHostVolumeRegister)
 	aclObj, err := v.srv.ResolveACL(args)
 	if err != nil {

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -84,6 +84,11 @@ var minNodePoolsVersion = version.Must(version.NewVersion("1.6.0"))
 // automatically added to jobs that need access to Consul or Vault
 var minVersionMultiIdentities = version.Must(version.NewVersion("1.7.0"))
 
+// minVersionDynamicHostVolumes is the Nomad version at which the dynamic host
+// volumes feature was introduced. It forms the minimum version all local
+// servers must meet before the feature can be used.
+var minVersionDynamicHostVolumes = version.Must(version.NewVersion("1.10.0"))
+
 // monitorLeadership is used to monitor if we acquire or lose our role
 // as the leader in the Raft cluster. There is some work the leader is
 // expected to do, so we must react to changes


### PR DESCRIPTION
All Nomad servers should be running v1.10.0 before the DHV feature can be used. Without this, it is possible for a write to succeed and cause immediate loss and subsequant failure to establish leadership.

### Testing & Reproduction steps
I had the following setup:

- 1 Nomad client on 1.10.0-beta.1
- 1 Nomad server on 1.10.0-beta.1
- 2 Nomad servers on 1.9.7

I ran the following steps:
- Transferred leadership to the Nomad server running 1.10.0-beta.1
- Stopped the Nomad service running on the older servers to force the node connection to go to the leader
- Started the stopped services
- Ensured my CLI used the 1.10.0-beta.1 API address
- Ran the nomad volume create command which returned the monitor

The cluster lost leadership and cannot elect a new leader. The older version servers have the following interesting log lines:
```console
2025-04-01T12:56:15.167+0100 [WARN]  raft@v1.7.1/raft.go:1485: nomad.raft: failed to get previous log: previous-index=55 last-index=53 error="log not found"
2025-04-01T13:02:41.745+0100 [WARN]  raft@v1.7.1/replication.go:262: nomad.raft: appendEntries rejected, sending older logs: peer="{Voter 960a207b-854d-3ccd-1288-781314535953 192.168.136.91:4
647}" next=314
2025-04-01T13:02:41.746+0100 [INFO]  raft@v1.7.1/replication.go:450: nomad.raft: pipelining replication: peer="{Voter a5609647-594e-cc63-352b-2a650dbe26d3 192.168.136.90:4647}"
2025-04-01T13:02:41.746+0100 [WARN]  raft@v1.7.1/replication.go:262: nomad.raft: appendEntries rejected, sending older logs: peer="{Voter 960a207b-854d-3ccd-1288-781314535953 192.168.136.91:4
647}" next=313
```

The upgraded version:
```console
2025-04-01T13:03:31.205+0100 [ERROR] nomad/leader.go:240: nomad: failed to wait for barrier: error="leadership lost while committing log"
2025-04-01T13:03:31.205+0100 [INFO]  nomad/leader.go:122: nomad: cluster leadership lost
```

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
