### PR TITLE
e2e: update consul task policy and add empty consul block to task groups

### DIFF
--- a/e2e/consul/input/namespaces/template_kv.nomad
+++ b/e2e/consul/input/namespaces/template_kv.nomad
@@ -33,7 +33,8 @@ job "template_kv" {
 
   group "group-z" {
 
-    # no consul namespace set
+    # no consul namespace set, but our task needs a consul token
+    consul {}
 
     task "task-z" {
       driver = "raw_exec"

--- a/e2e/consultemplate/input/update_triggers.nomad.hcl
+++ b/e2e/consultemplate/input/update_triggers.nomad.hcl
@@ -10,6 +10,9 @@ job "templating" {
 
   group "docker_downstream" {
 
+    // tasks in this group need a consul token
+    consul {}
+
     task "task" {
 
       driver = "docker"
@@ -49,6 +52,9 @@ EOT
   }
 
   group "exec_downstream" {
+
+    // tasks in this group need a consul token
+    consul {}
 
     task "task" {
 

--- a/e2e/terraform/provision-infra/scripts/consul-workload-identity/nomad-task-policy.hcl
+++ b/e2e/terraform/provision-infra/scripts/consul-workload-identity/nomad-task-policy.hcl
@@ -8,3 +8,7 @@ service_prefix "" {
 key_prefix "" {
   policy = "read"
 }
+
+node_prefix "" {
+  policy = "read"
+}


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Fixes currently failing E2E consul tests by giving the nomad task policy node read capabilities. Consul tasks needing access to consul also need to have an empty consul block to tell nomad to fetch and inject the token.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
