### PR TITLE
cni: add warning log for CNI check command failures

### DIFF
--- a/.changelog/25581.txt
+++ b/.changelog/25581.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cni: Add a warning log when CNI check commands fail
+```

--- a/client/allocrunner/network_hook.go
+++ b/client/allocrunner/network_hook.go
@@ -157,6 +157,7 @@ CREATE:
 			// ErrCNICheckFailed. We'll try to recover from this one time by
 			// recreating the netns from scratch before giving up
 			if errors.Is(err, ErrCNICheckFailed) && !checkedOnce {
+				h.logger.Warn("network configuration check failed", "error", err)
 				checkedOnce = true
 				destroyErr := h.manager.DestroyNetwork(h.alloc.ID, spec)
 				if destroyErr != nil {


### PR DESCRIPTION
In #24658 we fixed a bug around client restarts where we would not assert network namespaces existed and were properly configured when restoring allocations. We introduced a call to the CNI `Check` method so that the plugins could report correct config. But when we get an error from this call, we don't log it unless the error is fatal. This makes it challenging to debug the case where the initial check fails but we tear down the network and try again (as described in #25510). Add a noisy log line here.

Ref: https://github.com/hashicorp/nomad/pull/24658
Ref: https://github.com/hashicorp/nomad/issues/25510