### PR TITLE
e2e: Ignore UI link when parsing CLI column output.

### DIFF
--- a/e2e/e2eutil/cli.go
+++ b/e2e/e2eutil/cli.go
@@ -109,7 +109,7 @@ func ParseColumns(section string) ([]map[string]string, error) {
 	fieldNames := breakFields(rows[0])
 
 	for _, row := range rows[1:] {
-		if row == "" {
+		if row == "" || strings.HasPrefix(row, "==> View") {
 			continue
 		}
 		r := map[string]string{}


### PR DESCRIPTION
### Description
All other uses of the `ParseColumns` function pull out a section from the previous CLI command whereas the `NodeStatusListFiltered` passes the whole CLI output. This means the output includes the web UI link which is parsed by the function as its own nodeID entry in the return mapping and causes the test error.

This modifies the function, so any row that has the web ui starting prefix is ignored. This fixes the test but also means future use of this function is safer when passing the entire CLI output which includes the web ui footer.

### Links
Closes #25383 

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
