### PR TITLE
Update playwright to 1.51.0 for e2e ui tests

### DIFF
--- a/e2e/ui/package-lock.json
+++ b/e2e/ui/package-lock.json
@@ -5,16 +5,16 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@playwright/test": "^1.50.0"
+        "@playwright/test": "^1.51.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
-      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
+      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
       "dev": true,
       "dependencies": {
-        "playwright": "1.50.0"
+        "playwright": "1.51.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -38,12 +38,12 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
-      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
+      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.50.0"
+        "playwright-core": "1.51.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -56,9 +56,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
-      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
+      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
       "dev": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -70,12 +70,12 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
-      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.51.1.tgz",
+      "integrity": "sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==",
       "dev": true,
       "requires": {
-        "playwright": "1.50.0"
+        "playwright": "1.51.1"
       }
     },
     "fsevents": {
@@ -86,19 +86,19 @@
       "optional": true
     },
     "playwright": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
-      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.51.1.tgz",
+      "integrity": "sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.50.0"
+        "playwright-core": "1.51.1"
       }
     },
     "playwright-core": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
-      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
+      "version": "1.51.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.51.1.tgz",
+      "integrity": "sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==",
       "dev": true
     }
   }

--- a/e2e/ui/package.json
+++ b/e2e/ui/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "@playwright/test": "^1.50.0"
+    "@playwright/test": "^1.51.0"
   }
 }

--- a/e2e/ui/run.sh
+++ b/e2e/ui/run.sh
@@ -33,7 +33,7 @@ EOF
 }
 
 
-IMAGE="mcr.microsoft.com/playwright:v1.50.0-jammy"
+IMAGE="mcr.microsoft.com/playwright:v1.51.0-jammy"
 pushd $(dirname "${BASH_SOURCE[0]}") > /dev/null
 
 run_tests() {


### PR DESCRIPTION
Spiritual successor to #24956 
```
Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1161/chrome-linux/headless_shell
╔══════════════════════════════════════════════════════════════════════╗
║ Looks like Playwright Test or Playwright was just updated to 1.51.1. ║
║ Please update docker image as well.                                  ║
║ -  current: mcr.microsoft.com/playwright:v1.50.0-jammy               ║
║ - required: mcr.microsoft.com/playwright:v1.51.1-jammy               ║
║                                                                      ║
║ <3 Playwright Team                                                   ║
╚══════════════════════════════════════════════════════════════════════╝
```