### PR TITLE
upgrade testing: temporarily disable CSI workload

### DIFF
--- a/enos/enos-scenario-upgrade.hcl
+++ b/enos/enos-scenario-upgrade.hcl
@@ -158,30 +158,33 @@ scenario "upgrade" {
         batch_raw_exec   = { job_spec = "jobs/raw-exec-batch.nomad.hcl", alloc_count = 3, type = "batch" }
         system_raw_exec  = { job_spec = "jobs/raw-exec-system.nomad.hcl", alloc_count = 0, type = "system" }
 
-        nfs = {
-          job_spec    = "jobs/nfs.nomad.hcl"
-          alloc_count = 1
-          type        = "service"
-        }
+        # TODO(tgross): temporarily disabled until we can get CSI plugins to
+        # come up reliably
 
-        csi_plugin_nfs_controllers = {
-          job_spec    = "jobs/plugin-nfs-controllers.nomad.hcl"
-          alloc_count = 1
-          type        = "service"
-        }
+        # nfs = {
+        #   job_spec    = "jobs/nfs.nomad.hcl"
+        #   alloc_count = 1
+        #   type        = "service"
+        # }
 
-        csi_plugin_nfs_nodes = {
-          job_spec    = "jobs/plugin-nfs-nodes.nomad.hcl"
-          alloc_count = 0
-          type        = "system"
-        }
+        # csi_plugin_nfs_controllers = {
+        #   job_spec    = "jobs/plugin-nfs-controllers.nomad.hcl"
+        #   alloc_count = 1
+        #   type        = "service"
+        # }
 
-        wants_csi = {
-          job_spec    = "jobs/wants-volume.nomad.hcl"
-          alloc_count = 1
-          type        = "service"
-          pre_script  = "scripts/wait_for_nfs_volume.sh"
-        }
+        # csi_plugin_nfs_nodes = {
+        #   job_spec    = "jobs/plugin-nfs-nodes.nomad.hcl"
+        #   alloc_count = 0
+        #   type        = "system"
+        # }
+
+        # wants_csi = {
+        #   job_spec    = "jobs/wants-volume.nomad.hcl"
+        #   alloc_count = 1
+        #   type        = "service"
+        #   pre_script  = "scripts/wait_for_nfs_volume.sh"
+        # }
 
         tproxy = {
           job_spec    = "jobs/tproxy.nomad.hcl"


### PR DESCRIPTION
The CSI workload we're using for upgrade testing seems to be flaky to come up. The plugin jobs don't launch in a timely fashion despite several attempts. In order to not block running the rest of the upgrade testing, let's disable this workload temporarily. We'll fix this in NET-12430.

Ref: https://hashicorp.atlassian.net/browse/NET-12430