### PR TITLE
release: update backport versions for 1.10.0

### DIFF
--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -6,14 +6,15 @@
 
 schema = 1
 active_versions {
-  version "1.9.x" {
-    ce_active = true
-  }
-  version "1.8.x" {
+  version "1.10.x" {
     ce_active = true
     lts       = true
   }
-  version "1.7.x" {
-    ce_active = true
+  version "1.9.x" {
+    ce_active = true # needed for docs
+  }
+  version "1.8.x" {
+    ce_active = true # needed for docs
+    lts       = true
   }
 }


### PR DESCRIPTION
With the release of Nomad 1.10.0-rc.1, we'll start backporting to the 1.10.x release series. Add this to the supported versions and remove 1.7.x.

(This step appears to be missing from https://github.com/hashicorp/nomad-releases/issues/432; I'll update that checklist)
