### PR TITLE
ci: Run the build workflow on pushes to long-lived branches only.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,30 @@
+# The build workflow is responsible for building Nomad on all our supported
+# platforms. The compiled artifacts are then uploaded to GitHub. This upload
+# triggers the CRT prepare workflow, which downloads the artifacts and then
+# uploads them to our internal store.
+#
+# The workflow can be triggered in two ways:
+#  - pushes to main or long-lived release line branches (eg. 1.10.x)
+#  - dispatched via the release workflow (release.yml).
+#
+# The workflow should not be triggered from short-lived release branches;
+# branches that are cut from the long-lived ones in order to release Nomad. The
+# release workflow should be the only process responsible for triggering the
+# build workflow. This is because the release workflow performs a commit and
+# push of updated generated assets to the release branch. If this push triggers
+# a build, it will conflict with the release build process which shares the same
+# Git SHA and result in a last-write-wins to our internal store.
 name: build
 
 on:
   push:
     branches:
+      # 'main' is our forever branch where all changes get merged.
+      # 'release/[0-9].[0-9]+.x*' matches our long-lived release lines such as
+      # '1.10.x' and '1.10.x+ent' but excludes short-lived release branches such
+      # as '1.10.0' and '1.10.0+ent'.
       - main
-      - release/**
+      - 'release/[0-9].[0-9]+.x*'
   workflow_dispatch:
     inputs:
       build-ref:


### PR DESCRIPTION
### Description
The investigation is long, so I'll ask reviewers to use the linked Jira to gain addition context. This should resolve an issue identified in our build/release process that has resulted in release revisions including `+CHANGES`.

### Links
Jira: https://hashicorp.atlassian.net/browse/NET-12429

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
