### PR TITLE
auth: oidc: disable pkce by default

### DIFF
--- a/api/acl.go
+++ b/api/acl.go
@@ -829,9 +829,8 @@ type ACLAuthMethodConfig struct {
 	// Optionally send a signed JWT ("private key jwt") as a client assertion
 	// to the OIDC provider
 	OIDCClientAssertion *OIDCClientAssertion
-	// Enable S256 PKCE challenge verification. If nil, the Nomad server sets
-	// this to true when creating an auth method. I.e. it is enabled by default.
-	OIDCEnablePKCE *bool
+	// Enable S256 PKCE challenge verification.
+	OIDCEnablePKCE bool
 	// Disable claims from the OIDC UserInfo endpoint
 	OIDCDisableUserInfo bool
 	// List of OIDC scopes

--- a/command/acl_auth_method.go
+++ b/command/acl_auth_method.go
@@ -96,7 +96,7 @@ func formatAuthMethodConfig(config *api.ACLAuthMethodConfig) string {
 	}
 	out = append(out, formatClientAssertion(config.OIDCClientAssertion)...)
 	out = append(out,
-		fmt.Sprintf("OIDC Enable PKCE|%t", config.OIDCEnablePKCE != nil && *config.OIDCEnablePKCE),
+		fmt.Sprintf("OIDC Enable PKCE|%t", config.OIDCEnablePKCE),
 		fmt.Sprintf("OIDC Disable UserInfo|%t", config.OIDCDisableUserInfo),
 		fmt.Sprintf("OIDC Scopes|%s", strings.Join(config.OIDCScopes, ",")),
 		fmt.Sprintf("Bound audiences|%s", strings.Join(config.BoundAudiences, ",")),

--- a/internal/testing/apitests/acl_test.go
+++ b/internal/testing/apitests/acl_test.go
@@ -11,7 +11,6 @@ import (
 	capOIDC "github.com/hashicorp/cap/oidc"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
-	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/shoenig/test/must"
 )
 
@@ -95,12 +94,10 @@ func TestACLOIDC_CompleteAuth(t *testing.T) {
 		MaxTokenTTL:   10 * time.Hour,
 		Default:       true,
 		Config: &api.ACLAuthMethodConfig{
-			OIDCDiscoveryURL: oidcTestProvider.Addr(),
-			OIDCClientID:     "mock",
-			OIDCClientSecret: "verysecretsecret",
-			// PKCE is hard to test at this level, because the verifier only
-			// exists on the server. this functionality is covered elsewhere.
-			OIDCEnablePKCE:      pointer.Of(false),
+			OIDCDiscoveryURL:    oidcTestProvider.Addr(),
+			OIDCClientID:        "mock",
+			OIDCClientSecret:    "verysecretsecret",
+			OIDCEnablePKCE:      false,
 			OIDCDisableUserInfo: false,
 			BoundAudiences:      []string{"mock"},
 			AllowedRedirectURIs: []string{"http://127.0.0.1:4649/oidc/callback"},

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -20,8 +20,6 @@ import (
 	"github.com/hashicorp/go-memdb"
 	metrics "github.com/hashicorp/go-metrics/compat"
 	"github.com/hashicorp/go-set/v3"
-	"github.com/hashicorp/nomad/helper/pointer"
-
 	policy "github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -1912,19 +1910,6 @@ func (a *ACL) UpsertAuthMethods(
 			}
 		}
 
-		// PKCE backcompat:
-		// * on new auth methods, if unset (nil) in the request, default enable
-		// * on existing auth methods, if unset, default to exististing value
-		// i.e. it must be explicitly disabled (Enable=false) on new methods,
-		// and explicitly enabled on existing methods.
-		if authMethod.Config.OIDCEnablePKCE == nil {
-			if existingMethod == nil {
-				authMethod.Config.OIDCEnablePKCE = pointer.Of(true)
-			} else {
-				authMethod.Config.OIDCEnablePKCE = existingMethod.Config.OIDCEnablePKCE
-			}
-		}
-
 		// if there is a client assertion, ensure it is valid.
 		if authMethod.Config.OIDCClientAssertion.IsSet() {
 			_, err := a.oidcClientAssertion(authMethod.Config)
@@ -3078,7 +3063,7 @@ func (a *ACL) oidcRequest(nonce, redirect string, config *structs.ACLAuthMethodC
 		opts = append(opts, capOIDC.WithAudiences(config.BoundAudiences...))
 	}
 
-	if config.OIDCEnablePKCE != nil && *config.OIDCEnablePKCE {
+	if config.OIDCEnablePKCE {
 		verifier, err := capOIDC.NewCodeVerifier()
 		if err != nil {
 			return nil, fmt.Errorf("failed to make pkce verifier: %w", err)

--- a/nomad/mock/acl.go
+++ b/nomad/mock/acl.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	"github.com/hashicorp/nomad/helper/pointer"
 	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/assert"
 
@@ -273,12 +272,10 @@ func ACLOIDCAuthMethod() *structs.ACLAuthMethod {
 		MaxTokenTTL:   maxTokenTTL,
 		Default:       false,
 		Config: &structs.ACLAuthMethodConfig{
-			OIDCDiscoveryURL: "http://example.com",
-			OIDCClientID:     "mock",
-			OIDCClientSecret: "very secret secret",
-			// PKCE is hard to test outside the server/RPC layer,
-			// because the verifier is only accessible there.
-			OIDCEnablePKCE:      pointer.Of(false),
+			OIDCDiscoveryURL:    "http://example.com",
+			OIDCClientID:        "mock",
+			OIDCClientSecret:    "very secret secret",
+			OIDCEnablePKCE:      false,
 			OIDCDisableUserInfo: false,
 			OIDCScopes:          []string{"groups"},
 			BoundAudiences:      []string{"sales", "engineering"},

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -796,9 +796,7 @@ func (a *ACLAuthMethod) SetHash() []byte {
 		_, _ = hash.Write([]byte(a.Config.OIDCDiscoveryURL))
 		_, _ = hash.Write([]byte(a.Config.OIDCClientID))
 		_, _ = hash.Write([]byte(a.Config.OIDCClientSecret))
-		if a.Config.OIDCEnablePKCE != nil {
-			_, _ = hash.Write([]byte(strconv.FormatBool(*a.Config.OIDCEnablePKCE)))
-		}
+		_, _ = hash.Write([]byte(strconv.FormatBool(a.Config.OIDCEnablePKCE)))
 		_, _ = hash.Write([]byte(strconv.FormatBool(a.Config.OIDCDisableUserInfo)))
 		_, _ = hash.Write([]byte(strconv.FormatBool(a.Config.VerboseLogging)))
 		_, _ = hash.Write([]byte(a.Config.ExpirationLeeway.String()))
@@ -1062,9 +1060,7 @@ type ACLAuthMethodConfig struct {
 	OIDCClientAssertion *OIDCClientAssertion
 
 	// Enable PKCE challenge verification
-	// If nil, the ACL Upsert RPC endpoint sets it to &true,
-	// if the auth method is brand new.
-	OIDCEnablePKCE *bool
+	OIDCEnablePKCE bool
 
 	// Disable claims from the OIDC UserInfo endpoint
 	OIDCDisableUserInfo bool

--- a/website/content/partials/api-docs/auth-method-params.mdx
+++ b/website/content/partials/api-docs/auth-method-params.mdx
@@ -98,10 +98,9 @@ for the auth method.
     alongside "kid" and "type". Setting the "kid" header here is not allowed;
     use `PrivateKey.KeyID`.
 
-  - `OIDCEnablePKCE` `(bool: true)` - When set to `true`, Nomad will include
+  - `OIDCEnablePKCE` `(bool: false)` - When set to `true`, Nomad will include
   [PKCE][] verification in the auth flow. Even with PKCE enabled in Nomad,
-  which is the default setting, you may still need to enable it in your OIDC
-  provider.
+  you may still need to enable it in your OIDC provider.
 
   - `OIDCDisableUserInfo` `(bool: false)` - When set to `true`, Nomad will not
   make a request to the identity provider to get OIDC UserInfo. You may wish to


### PR DESCRIPTION
~I introduced a bug in #25593: PKCE was properly enabled by default on new auth methods, but then create/update-ing the same auth method, it got set to `nil` and got stuck that way until being explicitly enabled.~

Even with this original bugfix in this PR, it would still leave unintuitive behavior, namely that removing the `OIDCEnablePKCE` field from an existing auth method that had it set to `*false` would not default-enable it as one might expect, but rather leave it at whatever its last value was: still disabled.

So instead, we'll do the safest and most straightforward implementation, and do a simple `bool` that must be explicitly enabled.