### PR TITLE
e2e: Ensure test resources are cleaned.

### DIFF
--- a/e2e/dynamic_host_volumes/dynamic_host_volumes_test.go
+++ b/e2e/dynamic_host_volumes/dynamic_host_volumes_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad/e2e/e2eutil"
 	"github.com/hashicorp/nomad/e2e/v3/jobs3"
 	"github.com/hashicorp/nomad/e2e/v3/volumes3"
+	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
 )
@@ -59,6 +60,11 @@ func TestDynamicHostVolumes_RegisterWorkflow(t *testing.T) {
 		"register-volumes-policy", "./input/register-volumes.policy.hcl")
 	must.NoError(t, err)
 	t.Logf("[%v] ACL policy for job %q created", time.Since(start), submitted.JobID())
+
+	t.Cleanup(func() {
+		_, err := nomad.ACLPolicies().Delete("register-volumes-policy", nil)
+		test.NoError(t, err)
+	})
 
 	must.NoError(t, e2eutil.Dispatch(submitted.JobID(),
 		map[string]string{

--- a/e2e/exec2/exec2_test.go
+++ b/e2e/exec2/exec2_test.go
@@ -81,15 +81,11 @@ func testCountdash(t *testing.T) {
 }
 
 func testHTTP(t *testing.T) {
-	job, _ := jobs3.Submit(t,
-		"./input/http.hcl",
-		jobs3.DisableCleanup(),
-	)
+	job, httpCleanup := jobs3.Submit(t, "./input/http.hcl")
+	t.Cleanup(httpCleanup)
 
-	job2, _ := jobs3.Submit(t,
-		"./input/http_curl.hcl",
-		jobs3.DisableCleanup(),
-	)
+	job2, httpCurlCleanup := jobs3.Submit(t, "./input/http_curl.hcl")
+	t.Cleanup(httpCurlCleanup)
 
 	logs := job.TaskLogs("backend", "http")
 	must.StrContains(t, logs.Stderr, `"GET / HTTP/1.1" 200 -`)        // healthcheck


### PR DESCRIPTION
I couldn't find any reason the exec2 HTTP jobs were not being run with a generated cleanup function, so I added this.

The deletion of the DHV ACL policy does not seem like it would have any negative impact.

### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
