### PR TITLE
e2e: Ensure UI is enabled.

### DIFF
--- a/e2e/terraform/provision-infra/provision-nomad/etc/nomad.d/base.hcl
+++ b/e2e/terraform/provision-infra/provision-nomad/etc/nomad.d/base.hcl
@@ -30,5 +30,6 @@ telemetry {
 }
 
 ui {
+  enabled        = true
   show_cli_hints = false
 }


### PR DESCRIPTION
The `ui.enabled` parameter is a non-pointer bool which means the merge function is unable to differentiate between false and not set. When e2e introduced the `ui.show_cli_hints` configuration parameter, the way we merge meant the UI became disabled.

As a follow up, we should consider expanding our documentation to detail this, or change the `enabled` variable to a pointer, so we can differentiate between false and not set.

### Testing & Reproduction steps
Run a Nomad agent locally in development mode with the following config snippet:
```hcl
ui {
  show_cli_hints = true
}
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
