### PR TITLE
build: use nomad-builder docker image to build Nomad

### DIFF
--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -6,18 +6,39 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ARG ARCH="amd64"
 ARG GO_VERSION="1.24.1"
+ARG NODE_VERSION="20.9.0"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
  bash \
  build-essential \
  ca-certificates \
  curl \
+ # node 20 requires gcc 8.3+
+ g++-8 \
+ gcc-8 \
  git \
- xz-utils \
- zip
+ python3 \
+ xz-utils
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 1
 
 # Get Go and get Going ;)
 RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -C /opt -zxv
 ENV PATH="/opt/go/bin:$PATH"
+
+# Build node from source (node 20 and above binaries require newer glibc)
+RUN curl -fsSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz | tar -xJ && \
+    cd node-v$NODE_VERSION && \
+    ./configure --prefix=/opt/node && \
+    make -j$(($(nproc) / 2)) && \
+    make install && \
+    cd .. && rm -rf node-v$NODE_VERSION
+
+ENV PATH="/opt/node/bin:$PATH"
+
+# Install yarn
+RUN npm install -g yarn
 
 ENTRYPOINT /bin/bash

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -21,10 +21,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -C /opt -zxv
 
 # Best to map the internal user to host user
-ARG DOCKER_USER=default_user
-RUN addgroup $DOCKER_USER && useradd -m -g $DOCKER_USER $DOCKER_USER
-USER $DOCKER_USER
-ENV PATH="/home/${DOCKER_USER}/go/bin:/opt/go/bin:$PATH"
+# ARG DOCKER_USER=default_user
+# RUN addgroup $DOCKER_USER && useradd -m -g $DOCKER_USER $DOCKER_USER
+# USER $DOCKER_USER
+# ENV PATH="/home/${DOCKER_USER}/go/bin:/opt/go/bin:$PATH"
+
+# FIXME: should be owned by the $DOCKER_USER but for whatever reason we get
+# permission errors on the host system if we do that, even though it's the same s
+ENV PATH="/root/go/bin:/opt/go/bin:$PATH"
 
 RUN git config --global --add safe.directory /build
 

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -20,4 +20,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -C /opt -zxv
 ENV PATH="/root/go/bin:/opt/go/bin:$PATH"
 
+RUN git config --global --add safe.directory /build
+
 WORKDIR /build

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -17,6 +17,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Get Go and get Going ;)
 RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -C /opt -zxv
-ENV PATH="/opt/go/bin:$PATH"
+ENV PATH="/root/go/bin:/opt/go/bin:$PATH"
 
-ENTRYPOINT /bin/bash
+WORKDIR /build

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -5,29 +5,22 @@ FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG ARCH
 ARG GO_VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
  bash \
  build-essential \
  ca-certificates \
+ crossbuild-essential-arm64 \
  curl \
+ gcc-aarch64-linux-gnu \
  git \
  xz-utils \
  zip
 
 # Get Go and get Going ;)
-RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -C /opt -zxv
+RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -C /opt -zxv
 
-# Best to map the internal user to host user
-# ARG DOCKER_USER=default_user
-# RUN addgroup $DOCKER_USER && useradd -m -g $DOCKER_USER $DOCKER_USER
-# USER $DOCKER_USER
-# ENV PATH="/home/${DOCKER_USER}/go/bin:/opt/go/bin:$PATH"
-
-# FIXME: should be owned by the $DOCKER_USER but for whatever reason we get
-# permission errors on the host system if we do that, even though it's the same s
 ENV PATH="/root/go/bin:/opt/go/bin:$PATH"
 
 RUN git config --global --add safe.directory /build

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -8,10 +8,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG ARCH="amd64"
 ARG GO_VERSION="1.24.1"
 
-# Best to map the internal user to host user
-ARG DOCKER_USER=default_user
-RUN addgroup -S $DOCKER_USER && adduser -S $DOCKER_USER -G $DOCKER_USER
-
 RUN apt-get update && apt-get install -y --no-install-recommends \
  bash \
  build-essential \
@@ -23,7 +19,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Get Go and get Going ;)
 RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -C /opt -zxv
-ENV PATH="/root/go/bin:/opt/go/bin:$PATH"
+
+# Best to map the internal user to host user
+ARG DOCKER_USER=default_user
+RUN addgroup $DOCKER_USER && useradd -m -g $DOCKER_USER $DOCKER_USER
+USER $DOCKER_USER
+ENV PATH="/home/${DOCKER_USER}/go/bin:/opt/go/bin:$PATH"
 
 RUN git config --global --add safe.directory /build
 

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG ARCH="amd64"
+ARG GO_VERSION="1.24.1"
+ARG NODE_VERSION="20.9.0"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ bash \
+ build-essential \
+ ca-certificates \
+ curl \
+ # node 20 requires gcc 8.3+
+ g++-8 \
+ gcc-8 \
+ git \
+ python3 \
+ xz-utils
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 1
+
+# Get Go and get Going ;)
+RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -C /opt -zxv
+ENV PATH="/opt/go/bin:$PATH"
+
+# Build node from source (node 20 and above binaries require newer glibc)
+RUN curl -fsSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz | tar -xJ && \
+    cd node-v$NODE_VERSION && \
+    ./configure --prefix=/opt/node && \
+    make -j$(($(nproc) / 2)) && \
+    make install && \
+    cd .. && rm -rf node-v$NODE_VERSION
+
+ENV PATH="/opt/node/bin:$PATH"
+
+# Install yarn
+RUN npm install -g yarn
+
+ENTRYPOINT /bin/bash

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -6,39 +6,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ARG ARCH="amd64"
 ARG GO_VERSION="1.24.1"
-ARG NODE_VERSION="20.9.0"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
  bash \
  build-essential \
  ca-certificates \
  curl \
- # node 20 requires gcc 8.3+
- g++-8 \
- gcc-8 \
  git \
- python3 \
  xz-utils
-
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 1
 
 # Get Go and get Going ;)
 RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -C /opt -zxv
 ENV PATH="/opt/go/bin:$PATH"
-
-# Build node from source (node 20 and above binaries require newer glibc)
-RUN curl -fsSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz | tar -xJ && \
-    cd node-v$NODE_VERSION && \
-    ./configure --prefix=/opt/node && \
-    make -j$(($(nproc) / 2)) && \
-    make install && \
-    cd .. && rm -rf node-v$NODE_VERSION
-
-ENV PATH="/opt/node/bin:$PATH"
-
-# Install yarn
-RUN npm install -g yarn
 
 ENTRYPOINT /bin/bash

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -6,39 +6,18 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 ARG ARCH="amd64"
 ARG GO_VERSION="1.24.1"
-ARG NODE_VERSION="20.9.0"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
  bash \
  build-essential \
  ca-certificates \
  curl \
- # node 20 requires gcc 8.3+
- g++-8 \
- gcc-8 \
  git \
- python3 \
- xz-utils
-
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 1
-RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 1
+ xz-utils \
+ zip
 
 # Get Go and get Going ;)
 RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -C /opt -zxv
 ENV PATH="/opt/go/bin:$PATH"
-
-# Build node from source (node 20 and above binaries require newer glibc)
-RUN curl -fsSL https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION.tar.xz | tar -xJ && \
-    cd node-v$NODE_VERSION && \
-    ./configure --prefix=/opt/node && \
-    make -j$(($(nproc) / 2)) && \
-    make install && \
-    cd .. && rm -rf node-v$NODE_VERSION
-
-ENV PATH="/opt/node/bin:$PATH"
-
-# Install yarn
-RUN npm install -g yarn
 
 ENTRYPOINT /bin/bash

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -8,6 +8,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 ARG ARCH="amd64"
 ARG GO_VERSION="1.24.1"
 
+# Best to map the internal user to host user
+ARG DOCKER_USER=default_user
+RUN addgroup -S $DOCKER_USER && adduser -S $DOCKER_USER -G $DOCKER_USER
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
  bash \
  build-essential \

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -1,4 +1,5 @@
-# syntax=docker/dockerfile:1
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
 
 FROM ubuntu:bionic
 

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -5,8 +5,8 @@ FROM ubuntu:bionic
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ARG ARCH="amd64"
-ARG GO_VERSION="1.24.1"
+ARG ARCH
+ARG GO_VERSION
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
  bash \

--- a/.github/nomad-builder/Dockerfile
+++ b/.github/nomad-builder/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
  ca-certificates \
  curl \
  git \
- xz-utils
+ xz-utils \
+ zip
 
 # Get Go and get Going ;)
 RUN curl -L https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz | tar -C /opt -zxv

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,9 +191,6 @@ jobs:
         run: make prerelease
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.make-prerelease == 'true' }}
 
-      - name: Set up QEMU (for multiarch dockerx builds)
-        uses: docker/setup-qemu-action@fcd3152d8ad392d0e9c14d3f0de40f0a88b8ca0e # v3
-
       - name: Build nomad-builder image
         uses: docker/build-push-action@548776e8d0d44ea63feed0c8a944e6235fc63eee # v6
         with:
@@ -201,8 +198,6 @@ jobs:
           context: .github/nomad-builder/
           build-args: |
             GO_VERSION=${{ needs.get-go-version.outputs.go-version }}
-            ARCH=${{ matrix.goarch }}
-            DOCKER_USER=root  # FIXME: this should be set to the GH runner username, but if set to 'runner' we get permission errors on mkdir from within the container
           push: true
           tags: localhost:5000/nomad-builder:${{ github.sha }}
 
@@ -214,9 +209,8 @@ jobs:
           CGO_ENABLED: 1
         run: |
           go clean -cache
-          docker run -v "$(pwd)":/build localhost:5000/nomad-builder:${{ github.sha }} make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          # FIXME: we 'cp' instead of 'mv' below due to the zipfile being owned by root (it should be owned by the same uid:gid as the host system user)
-          cp pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          docker run --user "$(id --user):$(id --group)" -v "$(pwd)":/build localhost:5000/nomad-builder:${{ github.sha }} make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,7 @@ jobs:
           build-args: |
             GO_VERSION=${{ needs.get-go-version.outputs.go-version }}
             ARCH=${{ matrix.goarch }}
-            DOCKER_USER=$(whoami)
+            DOCKER_USER=runner
           push: true
           tags: localhost:5000/nomad-builder:${{ github.sha }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,6 +202,7 @@ jobs:
           build-args: |
             GO_VERSION=${{ needs.get-go-version.outputs.go-version }}
             ARCH=${{ matrix.goarch }}
+            DOCKER_USER=$(whoami)
           push: true
           tags: localhost:5000/nomad-builder:${{ github.sha }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,6 +100,11 @@ jobs:
       - get-product-version
       - get-go-version
     runs-on: ubuntu-24.04
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     strategy:
       matrix:
         arch: ["arm64", "amd64"]
@@ -112,6 +117,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@fcd3152d8ad392d0e9c14d3f0de40f0a88b8ca0e # v3
       - name: Docker Buildx (Action)
         uses: docker/build-push-action@548776e8d0d44ea63feed0c8a944e6235fc63eee # v6
         with:
@@ -119,7 +126,8 @@ jobs:
           build-args: |
             GO_VERSION=${{ env.go-version }}
             ARCH=${{ matrix.arch }}
-          tags: docker.io/hashicorppreview/nomad-builder:${{ github.sha }}
+          push: true
+          tags: localhost:5000/nomad-builder:${{ github.sha }}
 
   build-other:
     needs: [get-go-version, get-product-version]
@@ -176,6 +184,11 @@ jobs:
   build-linux:
     needs: [get-go-version, get-product-version, build-builder-image]
     runs-on: custom-linux-xxl-nomad-20.04
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     strategy:
       matrix:
         goos: [linux]
@@ -215,7 +228,7 @@ jobs:
         run: |
           go clean -cache
           # hacky hacks!
-          docker run -v "$(pwd)":/build hashicorppreview/nomad-builder:${{ github.sha }} make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          docker run -v "$(pwd)":/build localhost:5000/nomad-builder:${{ github.sha }} make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
           mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -177,8 +177,6 @@ jobs:
   build-linux:
     needs: [get-go-version, get-product-version, build-builder-image]
     runs-on: custom-linux-xxl-nomad-20.04
-    container:
-      image: hashicorppreview/nomad-builder:latest
     strategy:
       matrix:
         goos: [linux]
@@ -195,24 +193,34 @@ jobs:
       - name: Build dependencies
         run: make deps
 
+      - name: Setup node and yarn
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: "20"
+          cache-dependency-path: "ui/yarn.lock"
+
+      - name: Install Yarn
+        run: |
+          npm install -g yarn
+
       - name: Build prerelease
         run: make prerelease
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.make-prerelease == 'true' }}
 
-      - name: Install Linux build utilties
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y software-properties-common
-          sudo apt-get update
-          sudo apt-get install -y \
-            binutils-aarch64-linux-gnu \
-            gcc-aarch64-linux-gnu
+      # - name: Install Linux build utilties
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y software-properties-common
+      #     sudo apt-get update
+      #     sudo apt-get install -y \
+      #       binutils-aarch64-linux-gnu \
+      #       gcc-aarch64-linux-gnu
 
-      - name: Set gcc
-        run: |
-          if [ "${{ matrix.goarch }}" == "arm64" ]; then
-            echo "CC=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-          fi
+      # - name: Set gcc
+      #   run: |
+      #     if [ "${{ matrix.goarch }}" == "arm64" ]; then
+      #       echo "CC=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+      #     fi
 
       - name: Build
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,6 +174,9 @@ jobs:
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
 
+      - name: Build dependencies
+        run: make deps
+
       - name: Setup node and yarn
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,13 +167,12 @@ jobs:
         with:
           ref: ${{ github.event.inputs.build-ref }}
 
+      # even though we build inside the container, go tooling is still needed
+      # for make prerelease
       - name: Setup go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: ${{ needs.get-go-version.outputs.go-version }}
-
-      - name: Build dependencies
-        run: make deps
 
       - name: Setup node and yarn
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,8 +119,7 @@ jobs:
           build-args: |
             GO_VERSION=${{ env.go-version }}
             ARCH=${{ matrix.arch }}
-          dev_tags: |
-            docker.io/hashicorppreview/nomad-builder:${{ env.nomad-version }}-${{ github.sha }}
+          tags: docker.io/hashicorppreview/nomad-builder:${{ github.sha }}
 
   build-other:
     needs: [get-go-version, get-product-version]
@@ -216,7 +215,7 @@ jobs:
         run: |
           go clean -cache
           # hacky hacks!
-          docker run -v "$(pwd)":/build nomad-builder make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          docker run -v "$(pwd)":/build hashicorppreview/nomad-builder:${{ github.sha }} make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
           mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -202,7 +202,7 @@ jobs:
           build-args: |
             GO_VERSION=${{ needs.get-go-version.outputs.go-version }}
             ARCH=${{ matrix.goarch }}
-            DOCKER_USER=runner
+            DOCKER_USER=root  # FIXME: this should be set to the GH runner username, but if set to 'runner' we get permission errors on mkdir from within the container
           push: true
           tags: localhost:5000/nomad-builder:${{ github.sha }}
 
@@ -215,7 +215,8 @@ jobs:
         run: |
           go clean -cache
           docker run -v "$(pwd)":/build localhost:5000/nomad-builder:${{ github.sha }} make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
-          mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          # FIXME: we 'cp' instead of 'mv' below due to the zipfile being owned by root (it should be owned by the same uid:gid as the host system user)
+          cp pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,42 @@ jobs:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
 
+  # this builds the "nomad-builder" docker image that is used to build Nomad
+  build-docker-image:
+    needs:
+      - get-product-version
+      - get-go-version
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        arch: ["arm64", "amd64"]
+      fail-fast: true
+    env:
+      version: ${{ needs.get-product-version.outputs.product-version }}
+
+    name: Docker ${{ matrix.arch }} nomad-builder image build
+
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Docker Build (Action)
+        uses: hashicorp/actions-docker-build@11d43ef520c65f58683d048ce9b47d6617893c9a # v2.0.0
+        with:
+          smoke_test: |
+            TEST_VERSION="$(docker run "${IMAGE_NAME}" version | awk '/nomad/{print $3}')"
+            if [ "${TEST_VERSION#v}" != "${version}" ]; then
+              echo "Test FAILED"
+              exit 1
+            fi
+            echo "Test PASSED"
+          version: ${{ env.version }}
+          target: release
+          arch: ${{ matrix.arch }}
+          tags: |
+            docker.io/hashicorp/${{ env.PKG_NAME }}:${{ env.version }}
+          dev_tags: |
+            docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-dev
+            docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-${{ github.sha }}
+
   build-other:
     needs: [get-go-version, get-product-version]
     runs-on: custom-linux-xxl-nomad-20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,15 +113,15 @@ jobs:
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Docker Buildx (Action)
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@548776e8d0d44ea63feed0c8a944e6235fc63eee # v6
         with:
           version: ${{ env.nomad_version }}
           target: release
           arch: ${{ matrix.arch }}
-          tags: |
-            docker.io/hashicorp/nomad-builder:${{ env.nomad-version }}
+          build-args: |
+            GO_VERSION=${{ env.go-version }}
+            ARCH=${{ matrix.arch }}
           dev_tags: |
-            docker.io/hashicorppreview/nomad-builder:${{ env.nomad-version }}-dev
             docker.io/hashicorppreview/nomad-builder:${{ env.nomad-version }}-${{ github.sha }}
 
   build-other:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,6 @@ jobs:
       - name: Docker Buildx (Action)
         uses: docker/build-push-action@548776e8d0d44ea63feed0c8a944e6235fc63eee # v6
         with:
-          target: release
           context: .github/nomad-builder/
           build-args: |
             GO_VERSION=${{ env.go-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -197,6 +197,7 @@ jobs:
       - name: Build nomad-builder image
         uses: docker/build-push-action@548776e8d0d44ea63feed0c8a944e6235fc63eee # v6
         with:
+          platforms: linux/${{ matrix.goarch }}
           context: .github/nomad-builder/
           build-args: |
             GO_VERSION=${{ needs.get-go-version.outputs.go-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -207,21 +207,6 @@ jobs:
         run: make prerelease
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.make-prerelease == 'true' }}
 
-      # - name: Install Linux build utilties
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y software-properties-common
-      #     sudo apt-get update
-      #     sudo apt-get install -y \
-      #       binutils-aarch64-linux-gnu \
-      #       gcc-aarch64-linux-gnu
-
-      # - name: Set gcc
-      #   run: |
-      #     if [ "${{ matrix.goarch }}" == "arm64" ]; then
-      #       echo "CC=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
-      #     fi
-
       - name: Build
         env:
           GOOS: ${{ matrix.goos }}
@@ -230,7 +215,8 @@ jobs:
           CGO_ENABLED: 1
         run: |
           go clean -cache
-          make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          # hacky hacks!
+          docker run -v "$(pwd)":/build nomad-builder make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
           mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
 
   # this builds the "nomad-builder" docker image that is used to build Nomad
-  build-docker-image:
+  build-builder-image:
     needs:
       - get-product-version
       - get-go-version
@@ -105,30 +105,24 @@ jobs:
         arch: ["arm64", "amd64"]
       fail-fast: true
     env:
-      version: ${{ needs.get-product-version.outputs.product-version }}
+      nomad-version: ${{ needs.get-product-version.outputs.product-version }}
+      go-version: ${{ needs.get-go-version.outputs.go-version }}
 
     name: Docker ${{ matrix.arch }} nomad-builder image build
 
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - name: Docker Build (Action)
-        uses: hashicorp/actions-docker-build@11d43ef520c65f58683d048ce9b47d6617893c9a # v2.0.0
+      - name: Docker Buildx (Action)
+        uses: docker/build-push-action@v6
         with:
-          smoke_test: |
-            TEST_VERSION="$(docker run "${IMAGE_NAME}" version | awk '/nomad/{print $3}')"
-            if [ "${TEST_VERSION#v}" != "${version}" ]; then
-              echo "Test FAILED"
-              exit 1
-            fi
-            echo "Test PASSED"
-          version: ${{ env.version }}
+          version: ${{ env.nomad_version }}
           target: release
           arch: ${{ matrix.arch }}
           tags: |
-            docker.io/hashicorp/${{ env.PKG_NAME }}:${{ env.version }}
+            docker.io/hashicorp/nomad-builder:${{ env.nomad-version }}
           dev_tags: |
-            docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-dev
-            docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-${{ github.sha }}
+            docker.io/hashicorppreview/nomad-builder:${{ env.nomad-version }}-dev
+            docker.io/hashicorppreview/nomad-builder:${{ env.nomad-version }}-${{ github.sha }}
 
   build-other:
     needs: [get-go-version, get-product-version]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,41 +94,6 @@ jobs:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
 
-  # this builds the "nomad-builder" docker image that is used to build Nomad
-  build-builder-image:
-    needs:
-      - get-product-version
-      - get-go-version
-    runs-on: ubuntu-24.04
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    strategy:
-      matrix:
-        arch: ["arm64", "amd64"]
-      fail-fast: true
-    env:
-      nomad-version: ${{ needs.get-product-version.outputs.product-version }}
-      go-version: ${{ needs.get-go-version.outputs.go-version }}
-
-    name: Docker ${{ matrix.arch }} nomad-builder image build
-
-    steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@fcd3152d8ad392d0e9c14d3f0de40f0a88b8ca0e # v3
-      - name: Docker Buildx (Action)
-        uses: docker/build-push-action@548776e8d0d44ea63feed0c8a944e6235fc63eee # v6
-        with:
-          context: .github/nomad-builder/
-          build-args: |
-            GO_VERSION=${{ env.go-version }}
-            ARCH=${{ matrix.arch }}
-          push: true
-          tags: localhost:5000/nomad-builder:${{ github.sha }}
-
   build-other:
     needs: [get-go-version, get-product-version]
     runs-on: custom-linux-xxl-nomad-20.04
@@ -218,6 +183,19 @@ jobs:
       - name: Build prerelease
         run: make prerelease
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.make-prerelease == 'true' }}
+
+      - name: Set up QEMU (for multiarch dockerx builds)
+        uses: docker/setup-qemu-action@fcd3152d8ad392d0e9c14d3f0de40f0a88b8ca0e # v3
+
+      - name: Build nomad-builder image
+        uses: docker/build-push-action@548776e8d0d44ea63feed0c8a944e6235fc63eee # v6
+        with:
+          context: .github/nomad-builder/
+          build-args: |
+            GO_VERSION=${{ env.go-version }}
+            ARCH=${{ matrix.arch }}
+          push: true
+          tags: localhost:5000/nomad-builder:${{ github.sha }}
 
       - name: Build
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,7 @@ jobs:
           CGO_ENABLED: 1
         run: |
           go clean -cache
-          docker run --user "$(id --user):$(id --group)" -v "$(pwd)":/build localhost:5000/nomad-builder:${{ github.sha }} make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          docker run --user "$(id --user):$(id --group)" --env HOME=/tmp -v "$(pwd)":/build localhost:5000/nomad-builder:${{ github.sha }} make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
           mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,6 +167,11 @@ jobs:
         with:
           ref: ${{ github.event.inputs.build-ref }}
 
+      - name: Setup go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version: ${{ needs.get-go-version.outputs.go-version }}
+
       - name: Build dependencies
         run: make deps
 
@@ -193,7 +198,7 @@ jobs:
           context: .github/nomad-builder/
           build-args: |
             GO_VERSION=${{ needs.get-go-version.outputs.go-version }}
-            ARCH=${{ matrix.arch }}
+            ARCH=${{ matrix.goarch }}
           push: true
           tags: localhost:5000/nomad-builder:${{ github.sha }}
 
@@ -205,7 +210,6 @@ jobs:
           CGO_ENABLED: 1
         run: |
           go clean -cache
-          # hacky hacks!
           docker run -v "$(pwd)":/build localhost:5000/nomad-builder:${{ github.sha }} make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
           mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
           path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
   build-linux:
-    needs: [get-go-version, get-product-version, build-builder-image]
+    needs: [get-go-version, get-product-version]
     runs-on: custom-linux-xxl-nomad-20.04
     services:
       registry:
@@ -192,7 +192,7 @@ jobs:
         with:
           context: .github/nomad-builder/
           build-args: |
-            GO_VERSION=${{ env.go-version }}
+            GO_VERSION=${{ needs.get-go-version.outputs.go-version }}
             ARCH=${{ matrix.arch }}
           push: true
           tags: localhost:5000/nomad-builder:${{ github.sha }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,7 +194,7 @@ jobs:
       - name: Build nomad-builder image
         uses: docker/build-push-action@548776e8d0d44ea63feed0c8a944e6235fc63eee # v6
         with:
-          platforms: linux/${{ matrix.goarch }}
+          platforms: linux/amd64 # we only ever build amd64 images because we always run on amd64 runners and cross-compile inside the container if needed
           context: .github/nomad-builder/
           build-args: |
             GO_VERSION=${{ needs.get-go-version.outputs.go-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,9 +115,8 @@ jobs:
       - name: Docker Buildx (Action)
         uses: docker/build-push-action@548776e8d0d44ea63feed0c8a944e6235fc63eee # v6
         with:
-          version: ${{ env.nomad_version }}
           target: release
-          arch: ${{ matrix.arch }}
+          context: .github/nomad-builder/
           build-args: |
             GO_VERSION=${{ env.go-version }}
             ARCH=${{ matrix.arch }}
@@ -177,8 +176,10 @@ jobs:
           path: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
 
   build-linux:
-    needs: [get-go-version, get-product-version]
+    needs: [get-go-version, get-product-version, build-builder-image]
     runs-on: custom-linux-xxl-nomad-20.04
+    container:
+      image: hashicorppreview/nomad-builder:latest
     strategy:
       matrix:
         goos: [linux]
@@ -191,23 +192,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.inputs.build-ref }}
-      - name: Setup go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: ${{ needs.get-go-version.outputs.go-version }}
 
       - name: Build dependencies
         run: make deps
-
-      - name: Setup node and yarn
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version: "20"
-          cache-dependency-path: "ui/yarn.lock"
-
-      - name: Install Yarn
-        run: |
-          npm install -g yarn
 
       - name: Build prerelease
         run: make prerelease


### PR DESCRIPTION
This introduces a docker image based off of `ubuntu:bionic` that can be used to compile Nomad binary against glibc 2.27.

The image cannot build JS assets, which must be created before we compile the Go binary. 

Demonstration:

```
$ docker run -ti -v $(pwd)/build:/tmp/build nomad-builder
root@700996484f70:/# cd /tmp/build
root@700996484f70:/tmp/build# git clone https://github.com/hashicorp/nomad.git
Cloning into 'nomad'...
remote: Enumerating objects: 310410, done.
remote: Counting objects: 100% (274/274), done.
remote: Compressing objects: 100% (157/157), done.
remote: Total 310410 (delta 186), reused 117 (delta 117), pack-reused 310136 (from 4)
Receiving objects: 100% (310410/310410), 560.45 MiB | 38.19 MiB/s, done.
Resolving deltas: 100% (221073/221073), done.
root@700996484f70:/tmp/build# cd nomad
root@700996484f70:/tmp/build/nomad# make bootstrap
...
root@700996484f70:/tmp/build/nomad# PATH=/root/go/bin:$PATH make dev
==> Formatting HCL
==> Removing old development build...
==> Building pkg/linux_amd64/nomad with tags ui hashicorpmetrics  ...
...
root@700996484f70:/tmp/build/nomad# ./bin/nomad version
Nomad v1.10.0-dev
BuildDate 2025-04-08T12:57:29Z
Revision 311a83d706f4ac8b781ee48ba0b95f6c825bd9b6+CHANGES
root@700996484f70:/tmp/build/nomad# ldd ./bin/nomad
	linux-vdso.so.1 (0x00007ffdabd97000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x0000746d99cca000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x0000746d99aab000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x0000746d996ba000)
	/lib64/ld-linux-x86-64.so.2 (0x0000746d99ee4000)
root@700996484f70:/tmp/build/nomad# ldd --version
ldd (Ubuntu GLIBC 2.27-3ubuntu1.6) 2.27
Copyright (C) 2018 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
root@700996484f70:/tmp/build/nomad# exit
$ ldd --version
ldd (Ubuntu GLIBC 2.35-0ubuntu3.8) 2.35
Copyright (C) 2022 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
Written by Roland McGrath and Ulrich Drepper.
$ ./build/nomad/bin/nomad version
Nomad v1.10.0-dev
BuildDate 2025-04-08T12:57:29Z
Revision 311a83d706f4ac8b781ee48ba0b95f6c825bd9b6+CHANGES
$ ldd ./build/nomad/bin/nomad
	linux-vdso.so.1 (0x00007ffc822ac000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x000078e086e21000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x000078e086e1c000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000078e086a00000)
	/lib64/ld-linux-x86-64.so.2 (0x000078e086e3d000)
```

These changes add approximately a minute to the linux build step. An example of a successful `build` CI run that uses this image: https://github.com/hashicorp/nomad/actions/runs/14384938384

Fixes https://github.com/hashicorp/nomad-enterprise/issues/1109
Internal ref: https://hashicorp.atlassian.net/browse/NET-12422