### PR TITLE
agent: Fix misaligned contextual k/v logging arguments.

### DIFF
--- a/client/allocrunner/taskrunner/api_hook.go
+++ b/client/allocrunner/taskrunner/api_hook.go
@@ -97,7 +97,7 @@ func (h *apiHook) Stop(ctx context.Context, req *interfaces.TaskStopRequest, res
 	if h.ln != nil {
 		if err := h.ln.Close(); err != nil {
 			if !errors.Is(err, net.ErrClosed) {
-				h.logger.Debug("error closing task listener: %v", err)
+				h.logger.Debug("error closing task listener", "error", err)
 			}
 		}
 		h.ln = nil

--- a/client/allocrunner/taskrunner/dynamic_users_hook.go
+++ b/client/allocrunner/taskrunner/dynamic_users_hook.go
@@ -77,7 +77,7 @@ func (h *dynamicUsersHook) Prestart(_ context.Context, request *interfaces.TaskP
 	// allocate an unused UID/GID from the pool
 	ugid, err := h.pool.Acquire()
 	if err != nil {
-		h.logger.Error("unable to acquire anonymous UID/GID: %v", err)
+		h.logger.Error("unable to acquire anonymous UID/GID", "error", err)
 		return err
 	}
 

--- a/client/allocrunner/taskrunner/identity_hook.go
+++ b/client/allocrunner/taskrunner/identity_hook.go
@@ -134,12 +134,13 @@ func (h *identityHook) watchIdentity(wid *structs.WorkloadIdentity, runCh chan s
 			if signedWID == nil {
 				// The only way to hit this should be a bug as it indicates the server
 				// did not sign an identity for a task on this alloc.
-				h.logger.Error("missing workload identity %q", wid.Name)
+				h.logger.Error("missing workload identity", "identity", wid.Name)
 				return
 			}
 
 			if err := h.setAltToken(wid, signedWID.JWT); err != nil {
-				h.logger.Error(err.Error())
+				h.logger.Error("failed to set workload identity token",
+					"identity", wid.Name, "error", err)
 			}
 
 			// Skip ChangeMode on firstRun and notify caller it can proceed
@@ -148,7 +149,8 @@ func (h *identityHook) watchIdentity(wid *structs.WorkloadIdentity, runCh chan s
 				case runCh <- struct{}{}:
 				default:
 					// Not great but not necessarily fatal
-					h.logger.Warn("task started before identity %q was fetched", wid.Name)
+					h.logger.Warn("task started before identity was fetched",
+						"identity", wid.Name)
 				}
 
 				firstRun = false

--- a/client/client.go
+++ b/client/client.go
@@ -1333,7 +1333,7 @@ func (c *Client) restoreState() error {
 		allocState, err := c.stateDB.GetAcknowledgedState(alloc.ID)
 		if err != nil {
 			c.logger.Error("error restoring last acknowledged alloc state, will update again",
-				err, "alloc_id", alloc.ID)
+				"error", err, "alloc_id", alloc.ID)
 		} else {
 			ar.AcknowledgeState(allocState)
 		}

--- a/client/widmgr/widmgr.go
+++ b/client/widmgr/widmgr.go
@@ -121,7 +121,8 @@ func (m *WIDMgr) Run() error {
 
 	hasExpired, err := m.restoreStoredIdentities()
 	if err != nil {
-		m.logger.Warn("failed to get signed identities from state DB, refreshing from server: %w", err)
+		m.logger.Warn("failed to get signed identities from state DB, refreshing from server",
+			"error", err)
 	}
 	if hasExpired {
 		if err := m.getInitialIdentities(); err != nil {

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -2107,7 +2107,7 @@ func (j *Job) Dispatch(args *structs.JobDispatchRequest, reply *structs.JobDispa
 	// Commit this update via Raft
 	_, jobCreateIndex, err := j.srv.raftApply(structs.JobRegisterRequestType, regReq)
 	if err != nil {
-		j.logger.Error("dispatched job register failed", "error")
+		j.logger.Error("dispatched job register failed", "error", err)
 		return err
 	}
 

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -2624,7 +2624,7 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) {
 	store := s.fsm.State()
 	key, err := store.GetActiveRootKey(nil)
 	if err != nil {
-		logger.Error("failed to get active key: %v", err)
+		logger.Error("failed to get active key", "error", err)
 		return
 	}
 	if key != nil {
@@ -2653,7 +2653,7 @@ func (s *Server) initializeKeyring(stopCh <-chan struct{}) {
 	rootKey, err := structs.NewUnwrappedRootKey(structs.EncryptionAlgorithmAES256GCM)
 	rootKey = rootKey.MakeActive()
 	if err != nil {
-		logger.Error("could not initialize keyring: %v", err)
+		logger.Error("could not initialize keyring", "error", err)
 		return
 	}
 

--- a/nomad/locks.go
+++ b/nomad/locks.go
@@ -57,7 +57,7 @@ func (s *Server) CreateVariableLockTTLTimer(variable structs.VariableEncrypted) 
 	lock := s.lockTTLTimer.Get(lockID)
 	if lock != nil {
 		// If this was to happen, there is a sync issue somewhere else
-		s.logger.Error("attempting to recreate existing lock: %s", lockID)
+		s.logger.Error("attempting to recreate existing lock", "lock", lockID)
 		return
 	}
 
@@ -146,7 +146,7 @@ func (s *Server) RemoveVariableLockTTLTimer(variable structs.VariableEncrypted) 
 	lock := s.lockTTLTimer.Get(lockID)
 	if lock == nil {
 		// If this was to happen, there is a sync issue somewhere else.
-		s.logger.Error("attempting to removed missing lock: %s", lockID)
+		s.logger.Error("attempting to removed missing lock", "lock", lockID)
 		return
 	}
 

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -362,7 +362,7 @@ func (s *SystemScheduler) computePlacements(place []allocTuple) error {
 
 		node, ok := nodeByID[missing.Alloc.NodeID]
 		if !ok {
-			s.logger.Debug("could not find node %q", missing.Alloc.NodeID)
+			s.logger.Debug("could not find node", "node", missing.Alloc.NodeID)
 			continue
 		}
 


### PR DESCRIPTION
Arguments passed to hclog log lines should always have an even number to provide the expected k/v output.


### Links
Related #25628 

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
