### PR TITLE
nomad ui: 403 error handling

### DIFF
--- a/ui/app/adapters/application.js
+++ b/ui/app/adapters/application.js
@@ -10,6 +10,7 @@ import RESTAdapter from '@ember-data/adapter/rest';
 import codesForError from '../utils/codes-for-error';
 import removeRecord from '../utils/remove-record';
 import { default as NoLeaderError, NO_LEADER } from '../utils/no-leader-error';
+import { ForbiddenError } from '@ember-data/adapter/error';
 import classic from 'ember-classic-decorator';
 
 export const namespace = 'v1';
@@ -36,6 +37,17 @@ export default class ApplicationAdapter extends RESTAdapter {
   handleResponse(status, headers, payload) {
     if (status === 500 && payload === NO_LEADER) {
       return new NoLeaderError();
+    }
+    if (status === 403) {
+      const error = new ForbiddenError([
+        {
+          status: String(status),
+          title: 'The backend responded with an error',
+          detail: payload,
+        },
+      ]);
+      error.message = payload;
+      return error;
     }
     return super.handleResponse(...arguments);
   }

--- a/ui/app/utils/message-from-adapter-error.js
+++ b/ui/app/utils/message-from-adapter-error.js
@@ -8,6 +8,9 @@ import { ForbiddenError } from '@ember-data/adapter/error';
 // Returns a single string based on the response the adapter received
 export default function messageFromAdapterError(error, actionMessage) {
   if (error instanceof ForbiddenError) {
+    if (!error.message?.toLowerCase().endsWith('permission denied')) {
+      return error.message;
+    }
     return `Your ACL token does not grant permission to ${actionMessage}.`;
   }
 

--- a/ui/tests/unit/utils/message-from-adapter-error-test.js
+++ b/ui/tests/unit/utils/message-from-adapter-error-test.js
@@ -10,8 +10,13 @@ import messageFromAdapterError from 'nomad-ui/utils/message-from-adapter-error';
 const testCases = [
   {
     name: 'Forbidden Error',
-    in: [new ForbiddenError([], "Can't do that"), 'run tests'],
+    in: [new ForbiddenError([], 'Permission denied'), 'run tests'],
     out: 'Your ACL token does not grant permission to run tests.',
+  },
+  {
+    name: 'Forbidden Error with custom message',
+    in: [new ForbiddenError([], 'Custom message.'), 'run tests'],
+    out: 'Custom message.',
   },
   {
     name: 'Generic Error',


### PR DESCRIPTION
Currently the Nomad UI will always display an error without any body content. The Nomad CLI does handle this scenario nicely by outputting the body content coming from the API, see: https://github.com/hashicorp/nomad/blob/95c914624eaa5bc8f8942bbcbea0b54b207efe99/command/job_run.go#L299

The reason this is important for us is because we have a deployment approval handler in between clients and Nomad. Our policy API returns a 403 when approvals haven't been gathered with a descriptive message. Currently the Nomad UI unfortunately doesn't return any response content, it just raises a static error.

This change returns the ForbiddenError message if its set and doesn't end with string `permission denied`, which is the body content returned on Nomad API calls when ACL errors occur.