### PR TITLE
Add AllocIPv6 option to allow IPv6 address being used for service registration

### DIFF
--- a/.changelog/25632.txt
+++ b/.changelog/25632.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul: Add AllocIPv6 option to allow IPv6 address being used for service registration
+```

--- a/client/serviceregistration/address.go
+++ b/client/serviceregistration/address.go
@@ -134,7 +134,7 @@ func GetAddress(
 
 		return driverNet.IP, port, nil
 
-	case structs.AddressModeAlloc, structs.AddressModeAllocAdvertiseIPv6:
+	case structs.AddressModeAlloc, structs.AddressModeAllocIPv6:
 		// Cannot use address mode alloc with custom advertise address.
 		if address != "" {
 			return "", 0, fmt.Errorf("cannot use custom advertise address with %q address mode", structs.AddressModeAlloc)
@@ -147,7 +147,7 @@ func GetAddress(
 
 		// If no port label is specified just return the IP
 		if portLabel == "" {
-			if addressMode == structs.AddressModeAllocAdvertiseIPv6 {
+			if addressMode == structs.AddressModeAllocIPv6 {
 				return netStatus.AddressIPv6, 0, nil
 			}
 			return netStatus.Address, 0, nil
@@ -157,12 +157,12 @@ func GetAddress(
 		if port, ok := ports.Get(portLabel); ok {
 			// Use port.To value unless not set
 			if port.To > 0 {
-				if addressMode == structs.AddressModeAllocAdvertiseIPv6 {
+				if addressMode == structs.AddressModeAllocIPv6 {
 					return netStatus.AddressIPv6, port.To, nil
 				}
 				return netStatus.Address, port.To, nil
 			}
-			if addressMode == structs.AddressModeAllocAdvertiseIPv6 {
+			if addressMode == structs.AddressModeAllocIPv6 {
 				return netStatus.AddressIPv6, port.Value, nil
 			}
 			return netStatus.Address, port.Value, nil
@@ -177,7 +177,7 @@ func GetAddress(
 		if port <= 0 {
 			return "", 0, fmt.Errorf("invalid port: %q: port must be >0", portLabel)
 		}
-		if addressMode == structs.AddressModeAllocAdvertiseIPv6 {
+		if addressMode == structs.AddressModeAllocIPv6 {
 			return netStatus.AddressIPv6, port, nil
 		}
 		return netStatus.Address, port, nil

--- a/client/serviceregistration/address.go
+++ b/client/serviceregistration/address.go
@@ -134,7 +134,7 @@ func GetAddress(
 
 		return driverNet.IP, port, nil
 
-	case structs.AddressModeAlloc:
+	case structs.AddressModeAlloc, structs.AddressModeAllocAdvertiseIPv6:
 		// Cannot use address mode alloc with custom advertise address.
 		if address != "" {
 			return "", 0, fmt.Errorf("cannot use custom advertise address with %q address mode", structs.AddressModeAlloc)
@@ -147,6 +147,9 @@ func GetAddress(
 
 		// If no port label is specified just return the IP
 		if portLabel == "" {
+			if addressMode == structs.AddressModeAllocAdvertiseIPv6 {
+				return netStatus.AddressIPv6, 0, nil
+			}
 			return netStatus.Address, 0, nil
 		}
 
@@ -154,7 +157,13 @@ func GetAddress(
 		if port, ok := ports.Get(portLabel); ok {
 			// Use port.To value unless not set
 			if port.To > 0 {
+				if addressMode == structs.AddressModeAllocAdvertiseIPv6 {
+					return netStatus.AddressIPv6, port.To, nil
+				}
 				return netStatus.Address, port.To, nil
+			}
+			if addressMode == structs.AddressModeAllocAdvertiseIPv6 {
+				return netStatus.AddressIPv6, port.Value, nil
 			}
 			return netStatus.Address, port.Value, nil
 		}
@@ -167,6 +176,9 @@ func GetAddress(
 		}
 		if port <= 0 {
 			return "", 0, fmt.Errorf("invalid port: %q: port must be >0", portLabel)
+		}
+		if addressMode == structs.AddressModeAllocAdvertiseIPv6 {
+			return netStatus.AddressIPv6, port, nil
 		}
 		return netStatus.Address, port, nil
 

--- a/client/serviceregistration/address_test.go
+++ b/client/serviceregistration/address_test.go
@@ -299,6 +299,26 @@ func Test_GetAddress(t *testing.T) {
 			expPort: 6379,
 		},
 		{
+			name:      "Alloc",
+			mode:      structs.AddressModeAllocIPv6,
+			portLabel: "db",
+			ports: []structs.AllocatedPortMapping{
+				{
+					Label:  "db",
+					Value:  12345,
+					To:     6379,
+					HostIP: HostIP,
+				},
+			},
+			status: &structs.AllocNetworkStatus{
+				InterfaceName: "eth0",
+				Address:       "172.26.0.1",
+				AddressIPv6:   "2001:db8::8a2e:370:7334",
+			},
+			expIP:   "2001:db8::8a2e:370:7334",
+			expPort: 6379,
+		},
+		{
 			name:      "Alloc no to value",
 			mode:      structs.AddressModeAlloc,
 			portLabel: "db",
@@ -380,6 +400,12 @@ func Test_GetAddress(t *testing.T) {
 		{
 			name:      "Address with alloc mode",
 			mode:      structs.AddressModeAlloc,
+			advertise: "example.com",
+			expErr:    `cannot use custom advertise address with "alloc" address mode`,
+		},
+		{
+			name:      "Address with alloc IPv6 mode",
+			mode:      structs.AddressModeAllocIPv6,
 			advertise: "example.com",
 			expErr:    `cannot use custom advertise address with "alloc" address mode`,
 		},

--- a/client/serviceregistration/checks/result.go
+++ b/client/serviceregistration/checks/result.go
@@ -40,7 +40,7 @@ type Query struct {
 
 	Timeout time.Duration // connection / request timeout
 
-	AddressMode string // host, driver, or alloc
+	AddressMode string // host, driver, alloc or alloc_advertise_ipv6
 	PortLabel   string // label or value
 
 	Protocol      string      // http checks only (http or https)

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -305,7 +305,7 @@ func (sc *ServiceCheck) validateCommon(allowableTypes []string) error {
 
 	// validate address_mode
 	switch sc.AddressMode {
-	case "", AddressModeHost, AddressModeDriver, AddressModeAlloc:
+	case "", AddressModeHost, AddressModeDriver, AddressModeAlloc, AddressModeAllocAdvertiseIPv6:
 		// Ok
 	case AddressModeAuto:
 		return fmt.Errorf("invalid address_mode %q - %s only valid for services", sc.AddressMode, AddressModeAuto)
@@ -562,10 +562,11 @@ func hashHeader(h hash.Hash, m map[string][]string) {
 }
 
 const (
-	AddressModeAuto   = "auto"
-	AddressModeHost   = "host"
-	AddressModeDriver = "driver"
-	AddressModeAlloc  = "alloc"
+	AddressModeAuto               = "auto"
+	AddressModeHost               = "host"
+	AddressModeDriver             = "driver"
+	AddressModeAlloc              = "alloc"
+	AddressModeAllocAdvertiseIPv6 = "alloc_advertise_ipv6"
 
 	// ServiceProviderConsul is the default service provider and the way Nomad
 	// worked before native service discovery.
@@ -597,7 +598,8 @@ type Service struct {
 	PortLabel string
 
 	// AddressMode specifies how the address in service registration is
-	// determined. Must be "auto" (default), "host", "driver", or "alloc".
+	// determined. Must be "auto" (default), "host", "driver", "alloc" or
+	// "alloc_advertise_ipv6".
 	AddressMode string
 
 	// Address enables explicitly setting a custom address to use in service
@@ -768,7 +770,7 @@ func (s *Service) Validate() error {
 
 	switch s.AddressMode {
 	case "", AddressModeAuto:
-	case AddressModeHost, AddressModeDriver, AddressModeAlloc:
+	case AddressModeHost, AddressModeDriver, AddressModeAlloc, AddressModeAllocAdvertiseIPv6:
 		if s.Address != "" {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Service address_mode must be %q if address is set", AddressModeAuto))
 		}

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -562,10 +562,10 @@ func hashHeader(h hash.Hash, m map[string][]string) {
 }
 
 const (
-	AddressModeAuto               = "auto"
-	AddressModeHost               = "host"
-	AddressModeDriver             = "driver"
-	AddressModeAlloc              = "alloc"
+	AddressModeAuto      = "auto"
+	AddressModeHost      = "host"
+	AddressModeDriver    = "driver"
+	AddressModeAlloc     = "alloc"
 	AddressModeAllocIPv6 = "alloc_ipv6"
 
 	// ServiceProviderConsul is the default service provider and the way Nomad

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -305,7 +305,7 @@ func (sc *ServiceCheck) validateCommon(allowableTypes []string) error {
 
 	// validate address_mode
 	switch sc.AddressMode {
-	case "", AddressModeHost, AddressModeDriver, AddressModeAlloc, AddressModeAllocAdvertiseIPv6:
+	case "", AddressModeHost, AddressModeDriver, AddressModeAlloc, AddressModeAllocIPv6:
 		// Ok
 	case AddressModeAuto:
 		return fmt.Errorf("invalid address_mode %q - %s only valid for services", sc.AddressMode, AddressModeAuto)
@@ -566,7 +566,7 @@ const (
 	AddressModeHost               = "host"
 	AddressModeDriver             = "driver"
 	AddressModeAlloc              = "alloc"
-	AddressModeAllocAdvertiseIPv6 = "alloc_advertise_ipv6"
+	AddressModeAllocIPv6 = "alloc_ipv6"
 
 	// ServiceProviderConsul is the default service provider and the way Nomad
 	// worked before native service discovery.
@@ -599,7 +599,7 @@ type Service struct {
 
 	// AddressMode specifies how the address in service registration is
 	// determined. Must be "auto" (default), "host", "driver", "alloc" or
-	// "alloc_advertise_ipv6".
+	// "alloc_ipv6".
 	AddressMode string
 
 	// Address enables explicitly setting a custom address to use in service
@@ -770,7 +770,7 @@ func (s *Service) Validate() error {
 
 	switch s.AddressMode {
 	case "", AddressModeAuto:
-	case AddressModeHost, AddressModeDriver, AddressModeAlloc, AddressModeAllocAdvertiseIPv6:
+	case AddressModeHost, AddressModeDriver, AddressModeAlloc, AddressModeAllocIPv6:
 		if s.Address != "" {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Service address_mode must be %q if address is set", AddressModeAuto))
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8313,8 +8313,8 @@ func validateServices(t *Task, tgNetworks Networks) error {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("service %q cannot use address_mode=\"alloc\", only services defined in a \"group\" block can use this mode", service.Name))
 		}
 
-		if service.AddressMode == AddressModeAllocAdvertiseIPv6 {
-			mErr.Errors = append(mErr.Errors, fmt.Errorf("service %q cannot use address_mode=\"alloc_advertise_ipv6\", only services defined in a \"group\" block can use this mode", service.Name))
+		if service.AddressMode == AddressModeAllocIPv6 {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("service %q cannot use address_mode=\"alloc_ipv6\", only services defined in a \"group\" block can use this mode", service.Name))
 		}
 
 		// Ensure that services with the same name are not being registered for
@@ -8354,8 +8354,8 @@ func validateServices(t *Task, tgNetworks Networks) error {
 				mErr.Errors = append(mErr.Errors, fmt.Errorf("check %q cannot use address_mode=\"alloc\", only checks defined in a \"group\" service block can use this mode", service.Name))
 			}
 
-			if check.AddressMode == AddressModeAllocAdvertiseIPv6 {
-				mErr.Errors = append(mErr.Errors, fmt.Errorf("check %q cannot use address_mode=\"alloc_advertise_ipv6\", only checks defined in a \"group\" service block can use this mode", service.Name))
+			if check.AddressMode == AddressModeAllocIPv6 {
+				mErr.Errors = append(mErr.Errors, fmt.Errorf("check %q cannot use address_mode=\"alloc_ipv6\", only checks defined in a \"group\" service block can use this mode", service.Name))
 			}
 
 			if !check.RequiresPort() {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8313,6 +8313,10 @@ func validateServices(t *Task, tgNetworks Networks) error {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("service %q cannot use address_mode=\"alloc\", only services defined in a \"group\" block can use this mode", service.Name))
 		}
 
+		if service.AddressMode == AddressModeAllocAdvertiseIPv6 {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("service %q cannot use address_mode=\"alloc_advertise_ipv6\", only services defined in a \"group\" block can use this mode", service.Name))
+		}
+
 		// Ensure that services with the same name are not being registered for
 		// the same port
 		if _, ok := knownServices[service.Name+service.PortLabel]; ok {
@@ -8348,6 +8352,10 @@ func validateServices(t *Task, tgNetworks Networks) error {
 
 			if check.AddressMode == AddressModeAlloc {
 				mErr.Errors = append(mErr.Errors, fmt.Errorf("check %q cannot use address_mode=\"alloc\", only checks defined in a \"group\" service block can use this mode", service.Name))
+			}
+
+			if check.AddressMode == AddressModeAllocAdvertiseIPv6 {
+				mErr.Errors = append(mErr.Errors, fmt.Errorf("check %q cannot use address_mode=\"alloc_advertise_ipv6\", only checks defined in a \"group\" service block can use this mode", service.Name))
 			}
 
 			if !check.RequiresPort() {

--- a/website/content/docs/job-specification/service.mdx
+++ b/website/content/docs/job-specification/service.mdx
@@ -150,6 +150,8 @@ service mesh][connect] integration.
     If a `to` value is not set, the port falls back to using the allocated host port. The `port`
     field may be a numeric port or a port label specified in the same group's network block.
 
+  - `alloc_ipv6` - Same as `alloc` but use the IPv6 address in case of dual-stack or IPv6-only.
+
   - `driver` - Advertise the port determined by the driver (e.g. Docker).
     The `port` may be a numeric port or a port label specified in the driver's
     `ports` field.
@@ -190,7 +192,7 @@ service mesh][connect] integration.
 - `tagged_addresses` `(map<string|string>` - Specifies custom [tagged addresses][tagged_addresses] to
   advertise in the Consul service registration. Only available where `provider = "consul"`.
 
-- `address_mode` `(string: "auto")` - Specifies which address (host, alloc or
+- `address_mode` `(string: "auto")` - Specifies which address (host, alloc, alloc_ipv6 or
   driver-specific) this service should advertise. See [below for
   examples.](#using-driver-address-mode) Valid options are:
 
@@ -199,6 +201,9 @@ service mesh][connect] integration.
     [networking modes][network_mode]. A numeric port may be specified for situations
     where no port mapping is necessary. This mode can only be set for services which
     are defined in a "group" block.
+
+  - `alloc_ipv6` - Identical as `alloc` but will pick the IPv6 address in case of
+    dual-stack or IPv6 only.
 
   - `auto` - Allows the driver to determine whether the host or driver address
     should be used. Defaults to `host` and only implemented by Docker. If you

--- a/website/content/docs/job-specification/service.mdx
+++ b/website/content/docs/job-specification/service.mdx
@@ -202,8 +202,7 @@ service mesh][connect] integration.
     where no port mapping is necessary. This mode can only be set for services which
     are defined in a "group" block.
 
-  - `alloc_ipv6` - Identical as `alloc` but will pick the IPv6 address in case of
-    dual-stack or IPv6 only.
+  - `alloc_ipv6` - Same as `alloc` but use the IPv6 address in case of dual-stack or IPv6-only.
 
   - `auto` - Allows the driver to determine whether the host or driver address
     should be used. Defaults to `host` and only implemented by Docker. If you


### PR DESCRIPTION
### Description

Fixes #25627 by adding an extra `alloc_advertise_ipv6` option similar to the `AdvertiseIPv6Addr` with the docker driver config. Seems the simplest way to fix this?

I'll finish the contributor checklist if I get a green light about this PR.

### Links

See #25627 

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
