### PR TITLE
Add note to root keyring remove command

### DIFF
--- a/website/content/docs/commands/operator/root/keyring-remove.mdx
+++ b/website/content/docs/commands/operator/root/keyring-remove.mdx
@@ -13,6 +13,10 @@ key.
 
 If ACLs are enabled, this command requires a management token.
 
+<Note>
+  This command requires the full key ID (UUID) of the keys to be provided. Use the <code>-verbose</code> option with the <code>list</code> command to fetch the full key ID.
+</Note>
+
 ## Usage
 
 ```plaintext


### PR DESCRIPTION
### Description

This PR updates the documentation for the root keyring remove command to note that the full key ID must be provided for the command to function correctly.
