### PR TITLE
test: Remove use of "mitchellh/go-testing-interface" for stdlib.

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-rootcerts v1.0.2
-	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/shoenig/test v1.12.1
 )

--- a/api/go.sum
+++ b/api/go.sum
@@ -21,8 +21,6 @@ github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5O
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
-github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
-github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/api/internal/testutil/server.go
+++ b/api/internal/testutil/server.go
@@ -22,11 +22,11 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"testing"
 	"time"
 
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/nomad/api/internal/testutil/discover"
-	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
 )
@@ -105,7 +105,7 @@ type ServerConfigCallback func(c *TestServerConfig)
 
 // defaultServerConfig returns a new TestServerConfig struct pre-populated with
 // usable config for running as server.
-func defaultServerConfig(t testing.T) *TestServerConfig {
+func defaultServerConfig() *TestServerConfig {
 	ports := PortAllocator.Grab(3)
 
 	logLevel := "ERROR"
@@ -142,7 +142,7 @@ func defaultServerConfig(t testing.T) *TestServerConfig {
 type TestServer struct {
 	cmd    *exec.Cmd
 	Config *TestServerConfig
-	t      testing.T
+	t      testing.TB
 
 	HTTPAddr   string
 	SerfAddr   string
@@ -151,7 +151,7 @@ type TestServer struct {
 
 // NewTestServer creates a new TestServer, and makes a call to
 // an optional callback function to modify the configuration.
-func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
+func NewTestServer(t testing.TB, cb ServerConfigCallback) *TestServer {
 	path, err := discover.NomadExecutable()
 	if err != nil {
 		t.Skipf("nomad not found, skipping: %v", err)
@@ -167,7 +167,7 @@ func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
 	configFile, err := os.CreateTemp(dataDir, "nomad")
 	must.NoError(t, err)
 
-	nomadConfig := defaultServerConfig(t)
+	nomadConfig := defaultServerConfig()
 	nomadConfig.DataDir = dataDir
 
 	if cb != nil {

--- a/client/allocdir/testing.go
+++ b/client/allocdir/testing.go
@@ -5,14 +5,14 @@ package allocdir
 
 import (
 	"os"
+	"testing"
 
 	hclog "github.com/hashicorp/go-hclog"
-	testing "github.com/mitchellh/go-testing-interface"
 )
 
 // TestAllocDir returns a built alloc dir in a temporary directory and cleanup
 // func.
-func TestAllocDir(t testing.T, l hclog.Logger, prefix, id string) (*AllocDir, func()) {
+func TestAllocDir(t testing.TB, l hclog.Logger, prefix, id string) (*AllocDir, func()) {
 	dir, err := os.MkdirTemp("", prefix)
 	if err != nil {
 		t.Fatalf("Couldn't create temp dir: %v", err)

--- a/client/allocrunner/tasklifecycle/testing.go
+++ b/client/allocrunner/tasklifecycle/testing.go
@@ -4,19 +4,19 @@
 package tasklifecycle
 
 import (
+	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
-	testing "github.com/mitchellh/go-testing-interface"
 )
 
-func RequireTaskBlocked(t testing.T, c *Coordinator, task *structs.Task) {
+func RequireTaskBlocked(t testing.TB, c *Coordinator, task *structs.Task) {
 	ch := c.StartConditionForTask(task)
 	requireChannelBlocking(t, ch, task.Name)
 }
 
-func RequireTaskAllowed(t testing.T, c *Coordinator, task *structs.Task) {
+func RequireTaskAllowed(t testing.TB, c *Coordinator, task *structs.Task) {
 	ch := c.StartConditionForTask(task)
 	requireChannelPassing(t, ch, task.Name)
 }
@@ -33,7 +33,7 @@ func WaitNotInitUntil(c *Coordinator, until time.Duration, errorFunc func()) {
 		})
 }
 
-func requireChannelPassing(t testing.T, ch <-chan struct{}, name string) {
+func requireChannelPassing(t testing.TB, ch <-chan struct{}, name string) {
 	testutil.WaitForResult(func() (bool, error) {
 		return !isChannelBlocking(ch), nil
 	}, func(_ error) {
@@ -41,7 +41,7 @@ func requireChannelPassing(t testing.T, ch <-chan struct{}, name string) {
 	})
 }
 
-func requireChannelBlocking(t testing.T, ch <-chan struct{}, name string) {
+func requireChannelBlocking(t testing.TB, ch <-chan struct{}, name string) {
 	testutil.WaitForResult(func() (bool, error) {
 		return isChannelBlocking(ch), nil
 	}, func(_ error) {

--- a/client/config/testing.go
+++ b/client/config/testing.go
@@ -8,18 +8,18 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
-	testing "github.com/mitchellh/go-testing-interface"
 )
 
 // TestClientConfig returns a default client configuration for test clients and
 // a cleanup func to remove the state and alloc dirs when finished.
-func TestClientConfig(t testing.T) (*Config, func()) {
+func TestClientConfig(t testing.TB) (*Config, func()) {
 	conf := DefaultConfig()
 	conf.Node = mock.Node()
 	conf.Logger = testlog.HCLogger(t)

--- a/client/lib/proclib/testing.go
+++ b/client/lib/proclib/testing.go
@@ -4,11 +4,12 @@
 package proclib
 
 import (
+	"testing"
+
 	"github.com/hashicorp/nomad/helper/testlog"
-	testing "github.com/mitchellh/go-testing-interface"
 )
 
-func MockWranglers(t testing.T) *Wranglers {
+func MockWranglers(t testing.TB) *Wranglers {
 	return &Wranglers{
 		configs: &Configs{
 			Logger: testlog.HCLogger(t),

--- a/client/testing.go
+++ b/client/testing.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/rpc"
+	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/client/config"
@@ -20,7 +21,6 @@ import (
 	"github.com/hashicorp/nomad/helper/pool"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/yamux"
-	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/shoenig/test/must"
 )
 
@@ -30,11 +30,11 @@ import (
 // There is no need to override the AllocDir or StateDir as they are randomized
 // and removed in the returned cleanup function. If they are overridden in the
 // callback then the caller still must run the returned cleanup func.
-func TestClient(t testing.T, cb func(c *config.Config)) (*Client, func() error) {
+func TestClient(t testing.TB, cb func(c *config.Config)) (*Client, func() error) {
 	return TestClientWithRPCs(t, cb, nil)
 }
 
-func TestClientWithRPCs(t testing.T, cb func(c *config.Config), rpcs map[string]interface{}) (*Client, func() error) {
+func TestClientWithRPCs(t testing.TB, cb func(c *config.Config), rpcs map[string]interface{}) (*Client, func() error) {
 	conf, cleanup := config.TestClientConfig(t)
 
 	// Tighten the fingerprinter timeouts (must be done in client package
@@ -94,7 +94,7 @@ func TestClientWithRPCs(t testing.T, cb func(c *config.Config), rpcs map[string]
 // with the server and then returns mock RPC responses for those interfaces
 // passed in the `rpcs` parameter. Useful for testing client RPCs from the
 // server. Returns the Client, a shutdown function, and any error.
-func TestRPCOnlyClient(t testing.T, cb func(c *config.Config), srvAddr net.Addr, rpcs map[string]any) (*Client, func()) {
+func TestRPCOnlyClient(t testing.TB, cb func(c *config.Config), srvAddr net.Addr, rpcs map[string]any) (*Client, func()) {
 	t.Helper()
 	conf, cleanup := config.TestClientConfig(t)
 	conf.StateDBFactory = state.GetStateDBFactory(true)

--- a/go.mod
+++ b/go.mod
@@ -99,7 +99,6 @@ require (
 	github.com/mitchellh/go-glint v0.0.0-20210722152315-6515ceb4a127
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-ps v1.0.0
-	github.com/mitchellh/go-testing-interface v1.14.2-0.20210821155943-2d9075ca8770
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/mitchellh/pointerstructure v1.2.1
@@ -271,6 +270,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.12 // indirect
+	github.com/mitchellh/go-testing-interface v1.14.2-0.20210821155943-2d9075ca8770 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/sys/user v0.3.0 // indirect

--- a/helper/pluginutils/catalog/testing.go
+++ b/helper/pluginutils/catalog/testing.go
@@ -4,7 +4,7 @@
 package catalog
 
 import (
-	testing "github.com/mitchellh/go-testing-interface"
+	"testing"
 
 	"github.com/hashicorp/nomad/helper/pluginutils/loader"
 	"github.com/hashicorp/nomad/helper/testlog"
@@ -12,7 +12,7 @@ import (
 )
 
 // TestPluginLoader returns a plugin loader populated only with internal plugins
-func TestPluginLoader(t testing.T) loader.PluginCatalog {
+func TestPluginLoader(t testing.TB) loader.PluginCatalog {
 	driverConfigs := []*config.PluginConfig{
 		{
 			Name: "raw_exec",
@@ -25,7 +25,7 @@ func TestPluginLoader(t testing.T) loader.PluginCatalog {
 }
 
 // TestPluginLoaderWithOptions allows configuring the plugin loader fully.
-func TestPluginLoaderWithOptions(t testing.T,
+func TestPluginLoaderWithOptions(t testing.TB,
 	pluginDir string,
 	options map[string]string,
 	configs []*config.PluginConfig) loader.PluginCatalog {

--- a/nomad/mock/acl.go
+++ b/nomad/mock/acl.go
@@ -12,11 +12,11 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"testing"
 	"text/template"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
-	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -165,7 +165,7 @@ func PluginPolicy(policy string) string {
 }
 
 // CreatePolicy creates a policy with the given name and rule.
-func CreatePolicy(t testing.T, state StateStore, index uint64, name, rule string) {
+func CreatePolicy(t testing.TB, state StateStore, index uint64, name, rule string) {
 	t.Helper()
 
 	// Create the ACLPolicy
@@ -178,7 +178,7 @@ func CreatePolicy(t testing.T, state StateStore, index uint64, name, rule string
 }
 
 // CreateToken creates a local, client token for the given policies
-func CreateToken(t testing.T, state StateStore, index uint64, policies []string) *structs.ACLToken {
+func CreateToken(t testing.TB, state StateStore, index uint64, policies []string) *structs.ACLToken {
 	t.Helper()
 
 	// Create the ACLToken
@@ -191,7 +191,7 @@ func CreateToken(t testing.T, state StateStore, index uint64, policies []string)
 
 // CreatePolicyAndToken creates a policy and then returns a token configured for
 // just that policy. CreatePolicyAndToken uses the given index and index+1.
-func CreatePolicyAndToken(t testing.T, state StateStore, index uint64, name, rule string) *structs.ACLToken {
+func CreatePolicyAndToken(t testing.TB, state StateStore, index uint64, name, rule string) *structs.ACLToken {
 	CreatePolicy(t, state, index, name, rule)
 	return CreateToken(t, state, index+1, []string{name})
 }

--- a/nomad/testing.go
+++ b/nomad/testing.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/hashicorp/nomad/ci"
@@ -17,7 +18,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	structsconfig "github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/version"
-	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/shoenig/test/must"
 )
 

--- a/testutil/file.go
+++ b/testutil/file.go
@@ -6,14 +6,14 @@ package testutil
 import (
 	"os"
 	"path/filepath"
+	"testing"
 
-	testing "github.com/mitchellh/go-testing-interface"
 	"github.com/shoenig/test/must"
 )
 
 // MustReadFile returns the contents of the specified file or fails the test.
 // Multiple arguments are joined with filepath.Join.
-func MustReadFile(t testing.T, path ...string) []byte {
+func MustReadFile(t testing.TB, path ...string) []byte {
 	contents, err := os.ReadFile(filepath.Join(path...))
 	must.NoError(t, err)
 	return contents

--- a/testutil/mock_calls.go
+++ b/testutil/mock_calls.go
@@ -6,8 +6,7 @@ package testutil
 import (
 	"maps"
 	"sync"
-
-	"github.com/mitchellh/go-testing-interface"
+	"testing"
 )
 
 func NewCallCounter() *CallCounter {
@@ -39,10 +38,10 @@ func (c *CallCounter) Reset() {
 	c.counts = make(map[string]int)
 }
 
-func (c *CallCounter) AssertCalled(t testing.T, name string) {
+func (c *CallCounter) AssertCalled(t testing.TB, name string) {
 	t.Helper()
 	counts := c.Get()
 	if _, ok := counts[name]; !ok {
-		t.Errorf("'%s' not called; all counts: %v", counts)
+		t.Errorf("'%s' not called; all counts: %v", name, counts)
 	}
 }

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -22,13 +22,13 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"testing"
 	"time"
 
 	cleanhttp "github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/discover"
 	"github.com/hashicorp/nomad/helper/pointer"
-	testing "github.com/mitchellh/go-testing-interface"
 )
 
 // TestServerConfig is the main server configuration struct.
@@ -154,7 +154,7 @@ func defaultServerConfig() *TestServerConfig {
 type TestServer struct {
 	cmd    *exec.Cmd
 	Config *TestServerConfig
-	t      testing.T
+	t      testing.TB
 
 	HTTPAddr   string
 	SerfAddr   string
@@ -163,7 +163,7 @@ type TestServer struct {
 
 // NewTestServer creates a new TestServer, and makes a call to
 // an optional callback function to modify the configuration.
-func NewTestServer(t testing.T, cb ServerConfigCallback) *TestServer {
+func NewTestServer(t testing.TB, cb ServerConfigCallback) *TestServer {
 	path, err := discover.NomadExecutable()
 	if err != nil {
 		t.Skipf("nomad not found, skipping: %v", err)

--- a/testutil/vault.go
+++ b/testutil/vault.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"testing"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -18,7 +19,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	vapi "github.com/hashicorp/vault/api"
-	testing "github.com/mitchellh/go-testing-interface"
 )
 
 // TestVault is a test helper. It uses a fork/exec model to create a test Vault
@@ -35,7 +35,7 @@ const (
 // testing.
 type TestVault struct {
 	cmd    *exec.Cmd
-	t      testing.T
+	t      testing.TB
 	waitCh chan error
 
 	Addr      string
@@ -45,7 +45,7 @@ type TestVault struct {
 	Client    *vapi.Client
 }
 
-func NewTestVaultFromPath(t testing.T, binary string) *TestVault {
+func NewTestVaultFromPath(t testing.TB, binary string) *TestVault {
 	t.Helper()
 
 	if _, err := exec.LookPath(binary); err != nil {
@@ -132,14 +132,14 @@ func NewTestVaultFromPath(t testing.T, binary string) *TestVault {
 }
 
 // NewTestVault returns a new TestVault instance that is ready for API calls
-func NewTestVault(t testing.T) *TestVault {
+func NewTestVault(t testing.TB) *TestVault {
 	t.Helper()
 
 	// Lookup vault from the path
 	return NewTestVaultFromPath(t, "vault")
 }
 
-func NewTestVaultDelayedFromPath(t testing.T, binary string) *TestVault {
+func NewTestVaultDelayedFromPath(t testing.TB, binary string) *TestVault {
 	t.Helper()
 
 	if _, err := exec.LookPath(binary); err != nil {
@@ -188,7 +188,7 @@ func NewTestVaultDelayedFromPath(t testing.T, binary string) *TestVault {
 // NewTestVaultDelayed returns a test Vault server that has not been started.
 // Start must be called and it is the callers responsibility to deal with any
 // port conflicts that may occur and retry accordingly.
-func NewTestVaultDelayed(t testing.T) *TestVault {
+func NewTestVaultDelayed(t testing.TB) *TestVault {
 	t.Helper()
 
 	return NewTestVaultDelayedFromPath(t, "vault")


### PR DESCRIPTION
The stdlib testing package now includes this interface, so we can remove our dependency on the external library.

Final uses are external to this repository:
```console
$ go mod why -m github.com/mitchellh/go-testing-interface
# github.com/mitchellh/go-testing-interface
github.com/hashicorp/nomad/client/allocrunner/taskrunner/getter
github.com/hashicorp/go-getter
github.com/mitchellh/go-testing-interface
```

### Links
Jira: https://hashicorp.atlassian.net/browse/NET-11447

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
