### PR TITLE
Docs: Manual backport of Add note to root keyring remove command (#25637) to release/1.8.x

### DIFF
--- a/website/content/docs/commands/operator/root/keyring-remove.mdx
+++ b/website/content/docs/commands/operator/root/keyring-remove.mdx
@@ -19,6 +19,11 @@ If ACLs are enabled, this command requires a management token.
 nomad operator root keyring remove [options] <key ID>
 ```
 
+The `key ID` must be the UUID. Use the `-verbose` option with the
+[`nomad operator root keyring list`
+command](/nomad/docs/commands/operator/root/keyring-list) to fetch the key
+UUID.
+
 ## General Options
 
 @include 'general_options.mdx'


### PR DESCRIPTION
Replaces failed automatic backport https://github.com/hashicorp/nomad/pull/25645

* Add note to root keyring remove command

This PR updates the documentation for the root keyring remove command to note that the full key ID must be provided for the command to function correctly.

* Move keyID explanation to usage section

---------
