### PR TITLE
ci: migrate runners to ubuntu-22.04

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: "Check workflow files"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   backport:
     if: github.event.pull_request.merged
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: hashicorpdev/backport-assistant:0.4.1
     steps:
       - name: Backport changes to stable-website
@@ -34,7 +34,7 @@ jobs:
           ENABLE_VERSION_MANIFESTS: true
   backport-ent:
     if: github.event.pull_request.merged && contains(join(github.event.pull_request.labels.*.name), 'backport/ent')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Trigger backport for Enterprise
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
@@ -48,7 +48,7 @@ jobs:
       - backport
       - backport-ent
     if: always() && (needs.backport.result == 'failure' || needs.backport-ent.result == 'failure')
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-latest' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Retrieve Vault-hosted Secrets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ env:
 
 jobs:
   get-go-version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
@@ -59,7 +59,7 @@ jobs:
           echo "Building with Go $(cat .go-version)"
           echo "go-version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
   get-product-version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
@@ -73,7 +73,7 @@ jobs:
           echo "product-version=$(make version)" >> "$GITHUB_OUTPUT"
   generate-metadata-file:
     needs: get-product-version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
@@ -148,7 +148,7 @@ jobs:
 
   build-linux:
     needs: [get-go-version, get-product-version]
-    runs-on: custom-linux-xxl-nomad-20.04
+    runs-on: custom-linux-xxl-nomad-22.04
     services:
       registry:
         image: registry:2
@@ -331,7 +331,7 @@ jobs:
     needs:
       - get-product-version
       - build-linux
-    runs-on: custom-linux-xxl-nomad-20.04
+    runs-on: custom-linux-xxl-nomad-22.04
     strategy:
       matrix:
         arch: ["arm64", "amd64"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
 
   build-other:
     needs: [get-go-version, get-product-version]
-    runs-on: custom-linux-xxl-nomad-20.04
+    runs-on: custom-linux-xl-nomad-22.04
     strategy:
       matrix:
         goos: [windows]
@@ -148,7 +148,7 @@ jobs:
 
   build-linux:
     needs: [get-go-version, get-product-version]
-    runs-on: custom-linux-xxl-nomad-22.04
+    runs-on: custom-linux-xl-nomad-22.04
     services:
       registry:
         image: registry:2
@@ -331,7 +331,7 @@ jobs:
     needs:
       - get-product-version
       - build-linux
-    runs-on: custom-linux-xxl-nomad-22.04
+    runs-on: custom-linux-xl-nomad-22.04
     strategy:
       matrix:
         arch: ["arm64", "amd64"]

--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   copywrite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3

--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -12,9 +12,9 @@ name: Jira Issue Sync
 
 jobs:
   sync:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Jira Issue sync
-    steps:    
+    steps:
       - name: Login
         uses: atlassian/gajira-login@45fd029b9f1d6d8926c6f04175aa80c0e42c9026 # v3.0.1
         env:
@@ -26,7 +26,7 @@ jobs:
         id: set-ticket-type
         run: |
           echo "TYPE=GH Issue" >> "$GITHUB_OUTPUT"
-          
+
       - name: Create ticket if an issue is labeled with hcc/jira
         if: github.event.action == 'labeled' && github.event.label.name == 'hcc/jira'
         uses: tomhjp/gh-action-jira-create@3ed1789cad3521292e591a7cfa703215ec1348bf # v0.2.1
@@ -35,7 +35,7 @@ jobs:
           issuetype: "${{ steps.set-ticket-type.outputs.TYPE }}"
           summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.TYPE }} #${{ github.event.issue.number }}]: ${{ github.event.issue.title }}"
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
-          # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve), customerfield_10091 is "Team (R&D) 
+          # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve), customerfield_10091 is "Team (R&D)
           extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
                           "customfield_10371": { "value": "GitHub" },
                           "customfield_10091": ["NomadMinor"],

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lock:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   prepare-release:
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-20.04' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-22.04' }}
     outputs:
       build-ref: ${{ steps.commit-change-push.outputs.build-ref }}
     steps:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,7 +9,7 @@ jobs:
   semgrep-validate:
     name: Semgrep Validate
     if: (github.actor != 'dependabot[bot]')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: returntocorp/semgrep:1.107.0
     steps:
@@ -19,7 +19,7 @@ jobs:
   semgrep:
     name: Semgrep Scan
     needs: [semgrep-validate]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: returntocorp/semgrep:1.107.0
     env:

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2019]
+        os: [ubuntu-22.04, macos-14, windows-2019]
     runs-on: ${{matrix.os}}
     timeout-minutes: 20
     steps:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   test-e2e-vault:
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-latest' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Retrieve Vault-hosted Secrets

--- a/.github/workflows/test-failure-notification.yml
+++ b/.github/workflows/test-failure-notification.yml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   send-notification:
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-latest' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-22.04' }}
     steps:
       - name: Retrieve Vault-hosted Secrets
         if: endsWith(github.repository, '-enterprise')
@@ -69,7 +69,7 @@ jobs:
                 }
               ]
             }
-        
+
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   pre-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     defaults:
       run:
@@ -34,7 +34,7 @@ jobs:
   tests:
     needs:
       - pre-test
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-latest' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-22.04' }}
     timeout-minutes: 30
     defaults:
       run:
@@ -93,7 +93,7 @@ jobs:
     needs:
       - pre-test
       - tests
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-latest' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-22.04' }}
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
Our runners are a mixture of `ubuntu-latest`, `ubuntu-22.04` and `ubuntu-20.04`. Seeing as 20.04 is reaching end of support and becoming a security vulnerability, we should unify our CI infrastructure and pin it to the latest LTS. 

_caution:_ Do not merge this before https://github.com/hashicorp/nomad/pull/25626 lands. 