### PR TITLE
CI: run copywrite on PRs, not just after merges

### DIFF
--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -1,7 +1,11 @@
 name: Check Copywrite Headers
 
 on:
-  push: {}
+  pull_request:
+  push:
+    branches:
+      - 'main'
+      - 'release/**'
 
 jobs:
   copywrite:

--- a/scheduler/numa_ce_test.go
+++ b/scheduler/numa_ce_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
 package scheduler
 
 import (


### PR DESCRIPTION
This updates our copywrite CI check to run in all the same circumstances as our other checks, which will help this from falling through the cracks during reviews.