### PR TITLE
ci: pin docker/build-push-action to a TSCCR approved version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,7 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.make-prerelease == 'true' }}
 
       - name: Build nomad-builder image
-        uses: docker/build-push-action@548776e8d0d44ea63feed0c8a944e6235fc63eee # v6
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6
         with:
           platforms: linux/amd64 # we only ever build amd64 images because we always run on amd64 runners and cross-compile inside the container if needed
           context: .github/nomad-builder/


### PR DESCRIPTION
TSCCR checker has been complaining about this on enterprise repository. 