### PR TITLE
Backport ci: migrate runners to ubuntu-22.04 to 1.8.x. (#25651)

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 jobs:
   actionlint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: "Check workflow files"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   backport:
     if: github.event.pull_request.merged
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container: hashicorpdev/backport-assistant:0.4.1
     steps:
       - name: Backport changes to stable-website
@@ -34,7 +34,7 @@ jobs:
           ENABLE_VERSION_MANIFESTS: true
   backport-ent:
     if: github.event.pull_request.merged && contains(join(github.event.pull_request.labels.*.name), 'backport/ent')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Trigger backport for Enterprise
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
@@ -48,7 +48,7 @@ jobs:
       - backport
       - backport-ent
     if: always() && (needs.backport.result == 'failure' || needs.backport-ent.result == 'failure')
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-latest' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: ./.github/actions/vault-secrets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   get-go-version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
@@ -39,7 +39,7 @@ jobs:
           echo "Building with Go $(cat .go-version)"
           echo "go-version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
   get-product-version:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
@@ -53,7 +53,7 @@ jobs:
           echo "product-version=$(make version)" >> "$GITHUB_OUTPUT"
   generate-metadata-file:
     needs: get-product-version
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
@@ -76,7 +76,7 @@ jobs:
 
   build-other:
     needs: [get-go-version, get-product-version]
-    runs-on: custom-linux-xxl-nomad-20.04
+    runs-on: custom-linux-xl-nomad-22.04
     strategy:
       matrix:
         goos: [windows]
@@ -128,7 +128,7 @@ jobs:
 
   build-linux:
     needs: [get-go-version, get-product-version]
-    runs-on: custom-linux-xxl-nomad-20.04
+    runs-on: custom-linux-xl-nomad-22.04
     strategy:
       matrix:
         goos: [linux]
@@ -299,7 +299,7 @@ jobs:
     needs:
       - get-product-version
       - build-linux
-    runs-on: custom-linux-xxl-nomad-20.04
+    runs-on: custom-linux-xl-nomad-22.04
     strategy:
       matrix:
         arch: ["arm64", "amd64"]

--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   copywrite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   lock:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   prepare-release:
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-20.04' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-22.04' }}
     outputs:
       build-ref: ${{ steps.commit-change-push.outputs.build-ref }}
     steps:

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   semgrep:
     name: Semgrep Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: returntocorp/semgrep:1.36.0
     env:

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-14, windows-2019]
+        os: [ubuntu-22.04, macos-14, windows-2019]
     runs-on: ${{matrix.os}}
     timeout-minutes: 20
     steps:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   test-e2e-vault:
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-latest' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux"]') || 'ubuntu-22.04' }}
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: ./.github/actions/vault-secrets

--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   pre-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     defaults:
       run:
@@ -34,7 +34,7 @@ jobs:
   tests:
     needs:
       - pre-test
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-latest' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-22.04' }}
     timeout-minutes: 30
     continue-on-error: true
     defaults:
@@ -62,7 +62,7 @@ jobs:
     needs:
       - pre-test
       - tests
-    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-latest' }}
+    runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "linux", "type=m7a.2xlarge;m6a.2xlarge"]') || 'ubuntu-22.04' }}
     timeout-minutes: 30
     defaults:
       run:


### PR DESCRIPTION
Manual backport of #25651 because we need to be able to run CI on this branch when we backport PRs for documentation without it blowing up.

* ci: migrate runners to ubuntu-22.04
* find a supported build for custom-linux-xl