### PR TITLE
ci: disable docker build summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,6 +193,8 @@ jobs:
 
       - name: Build nomad-builder image
         uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6
+        env:
+          DOCKER_BUILD_SUMMARY: false
         with:
           platforms: linux/amd64 # we only ever build amd64 images because we always run on amd64 runners and cross-compile inside the container if needed
           context: .github/nomad-builder/


### PR DESCRIPTION
Having `.dockerbuild` as one of the artifacts messes with our release tooling. 

example `build` run with this change: https://github.com/hashicorp/nomad/actions/runs/14472045048