### PR TITLE
update BPA to 0.5.6

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-22.04
-    container: hashicorpdev/backport-assistant:0.4.1
+    container: hashicorpdev/backport-assistant:0.5.6
     steps:
       - name: Backport changes to stable-website
         run: |


### PR DESCRIPTION
Fixes logging issues with the errors we've been getting for backport failures, which will help us further diagnose the problem.

Ref: https://hashicorp.atlassian.net/browse/NET-11804