### PR TITLE
ci: Compile on Ubuntu arm64 within core test workflow.

### DIFF
--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -49,13 +49,27 @@ env:
 jobs:
   checks:
     uses: ./.github/workflows/checks.yaml
+
+  # Compile on Windows amd64, macOS arm64, Linux amd64, and Linux arm64.
+  #
+  # GitHub hosted Linux arm64 runners are in preview and not available to
+  # private repositories, so we must use our self-hosted runners. This also has
+  # added security benefits.
+  #
+  # The runs-on conditional cannot be placed into the matrix.os array as GitHub
+  # breaks apart any nested array within it. It subsequently uses the elements
+  # as individual runners to call runs-on.
   compile:
     needs: [checks]
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-2019]
-    runs-on: ${{matrix.os}}
+        os:
+          - ubuntu-22.04
+          - ubuntu-22.04-arm
+          - macos-14
+          - windows-2019
+    runs-on: ${{ (endsWith(github.repository, '-enterprise')) && (matrix.os == 'ubuntu-22.04-arm') && fromJSON('["self-hosted", "ubuntu-22.04-arm64"]') || matrix.os }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -68,6 +82,7 @@ jobs:
         run: |
           make bootstrap
           make dev
+
   tests-api:
     needs: [checks]
     runs-on: custom-linux-xl-nomad-22.04


### PR DESCRIPTION
Nomad is released as a Linux arm64 binary, so having a compilation step on this OS/ARCH within our core test workflow will help ensure basic arm64 problems do not get into our release branches.

### Testing & Reproduction steps
I tested this change on Enterprise to ensure the conditional works as expected and the repository has access to the runners required. Ref: https://github.com/hashicorp/nomad-enterprise/actions/runs/14473962830/job/40594856618

### Links
Internal ref: NET-12466

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
