### PR TITLE
update backport assistant to 0.5.7

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-22.04
-    container: hashicorpdev/backport-assistant:v0.5.6
+    container: hashicorpdev/backport-assistant:v0.5.7
     steps:
       - name: Backport changes to stable-website
         run: |


### PR DESCRIPTION
Update BPA to avoid problems when requerying for reviewers.

Ref: https://github.com/hashicorp/backport-assistant/pull/152
Ref: https://hashicorp.atlassian.net/browse/NET-11804