### PR TITLE
scheduler: fix state corruption from rescheduler tracker updates

### DIFF
--- a/.changelog/25698.txt
+++ b/.changelog/25698.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fixed a bug where updating the rescheduler tracker could corrupt the state store
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -12937,6 +12937,7 @@ func (p *Plan) NormalizeAllocations() {
 				DesiredDescription: alloc.DesiredDescription,
 				ClientStatus:       alloc.ClientStatus,
 				FollowupEvalID:     alloc.FollowupEvalID,
+				RescheduleTracker:  alloc.RescheduleTracker,
 			}
 		}
 	}

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -4718,8 +4718,7 @@ func TestServiceSched_BlockedReschedule(t *testing.T) {
 				must.Sprint("replacement alloc should have reschedule tracker"))
 			must.Len(t, 1, alloc.RescheduleTracker.Events)
 			replacementAllocID = alloc.ID
-		} else {
-			must.Eq(t, structs.AllocDesiredStatusStop, alloc.DesiredStatus)
+			break
 		}
 	}
 

--- a/scheduler/reconcile_util.go
+++ b/scheduler/reconcile_util.go
@@ -37,6 +37,9 @@ type placementResult interface {
 	// PreviousAllocation returns the previous allocation
 	PreviousAllocation() *structs.Allocation
 
+	// SetPreviousAllocation updates the reference to the previous allocation
+	SetPreviousAllocation(*structs.Allocation)
+
 	// IsRescheduling returns whether the placement was rescheduling a failed allocation
 	IsRescheduling() bool
 
@@ -80,11 +83,14 @@ func (a allocPlaceResult) TaskGroup() *structs.TaskGroup           { return a.ta
 func (a allocPlaceResult) Name() string                            { return a.name }
 func (a allocPlaceResult) Canary() bool                            { return a.canary }
 func (a allocPlaceResult) PreviousAllocation() *structs.Allocation { return a.previousAlloc }
-func (a allocPlaceResult) IsRescheduling() bool                    { return a.reschedule }
-func (a allocPlaceResult) StopPreviousAlloc() (bool, string)       { return false, "" }
-func (a allocPlaceResult) DowngradeNonCanary() bool                { return a.downgradeNonCanary }
-func (a allocPlaceResult) MinJobVersion() uint64                   { return a.minJobVersion }
-func (a allocPlaceResult) PreviousLost() bool                      { return a.lost }
+func (a allocPlaceResult) SetPreviousAllocation(alloc *structs.Allocation) {
+	a.previousAlloc = alloc
+}
+func (a allocPlaceResult) IsRescheduling() bool              { return a.reschedule }
+func (a allocPlaceResult) StopPreviousAlloc() (bool, string) { return false, "" }
+func (a allocPlaceResult) DowngradeNonCanary() bool          { return a.downgradeNonCanary }
+func (a allocPlaceResult) MinJobVersion() uint64             { return a.minJobVersion }
+func (a allocPlaceResult) PreviousLost() bool                { return a.lost }
 
 // allocDestructiveResult contains the information required to do a destructive
 // update. Destructive changes should be applied atomically, as in the old alloc
@@ -96,11 +102,12 @@ type allocDestructiveResult struct {
 	stopStatusDescription string
 }
 
-func (a allocDestructiveResult) TaskGroup() *structs.TaskGroup           { return a.placeTaskGroup }
-func (a allocDestructiveResult) Name() string                            { return a.placeName }
-func (a allocDestructiveResult) Canary() bool                            { return false }
-func (a allocDestructiveResult) PreviousAllocation() *structs.Allocation { return a.stopAlloc }
-func (a allocDestructiveResult) IsRescheduling() bool                    { return false }
+func (a allocDestructiveResult) TaskGroup() *structs.TaskGroup                   { return a.placeTaskGroup }
+func (a allocDestructiveResult) Name() string                                    { return a.placeName }
+func (a allocDestructiveResult) Canary() bool                                    { return false }
+func (a allocDestructiveResult) PreviousAllocation() *structs.Allocation         { return a.stopAlloc }
+func (a allocDestructiveResult) SetPreviousAllocation(alloc *structs.Allocation) {} // NOOP
+func (a allocDestructiveResult) IsRescheduling() bool                            { return false }
 func (a allocDestructiveResult) StopPreviousAlloc() (bool, string) {
 	return true, a.stopStatusDescription
 }


### PR DESCRIPTION
In #12319 we fixed a bug where updates to the reschedule tracker would be dropped if the follow-up allocation failed to be placed by the scheduler in the later evaluation. We did this by mutating the previous allocation's reschedule tracker. But we did this without copying the previous allocation first and then making sure the updated copy was in the plan. This is unfortunately unsafe and corrupts the state store on the server where the scheduler ran; it may cause a race condition in RPC handlers and it causes the server to be out of sync with the other servers. This was discovered while trying to make all our tests race-free, but likely impacts production users.

Copy the previous allocation before updating the reschedule tracker, and swap out the updated allocation in the plan. This also requires that we include the reschedule tracker in the "normalized" (stripped-down) allocations we send to the leader as part of a plan.

Ref: https://github.com/hashicorp/nomad/pull/12319
Fixes: https://hashicorp.atlassian.net/browse/NET-12357

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.

In addition to updated tests here, I deployed a job and broke it to trigger the reschedule tracking update for blocked evals. I then verified that I get the expected events in the event stream and did some comparison to the existing behavior and that looks as expected.

- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
