### PR TITLE
Preserve core resources during inplace service alloc updates

### DIFF
--- a/.changelog/25705.txt
+++ b/.changelog/25705.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fixed a bug in accounting for resources.cores that could prevent placements on nodes with available cores
+```


### PR DESCRIPTION
### Description
When an alloc is running with the core resources specified, and the alloc is able to be updated in place, the cores it is running on should be preserved.

This fixes a bug where the allocation's task's core resources (CPU.ReservedCores) would be recomputed each time the reconciler checked that the allocation could continue to run on the given node. Under circumstances where a different core on the node became available before this check was made, the selection process could compute this new core as the core to run on, regardless of core the allocation was already running on. The check takes into account other allocations running on the node with reserved cores, but cannot check itself.

When this would happen for multiple allocations being evaluated in a single plan, the selection process would see the other cores being previously reserved but be unaware of the one it ran on, resulting in the same core being chosen over and over for each allocation that was being checked, and updated in the state store (but not on the node). Once those cores were chosen and committed for multiple allocs, the node appears to be exhausted on the cores dimension, and it would prevent any additional allocations from being started on the node.

The reconciler check/computation for allocations that are being updated in place and have resources.cores defined is effectively a check that the node has the available cores to run on, not a computation that should be changed. The fix still performs the check, but once it is successful any existing ReservedCores are preserved. Because any changes to this resource is considered a "destructive change", this can be confidently preserved during the inplace update.

### Testing & Reproduction steps
Added a scheduler test which models the bug scenario, where there are two existing running allocations on core `1` and `2`, while `0` is available. The test attempts to add a third allocation, which should result in the scheduler correctly assigning/keeping the same allocations remaining on cores `1` and `2` and the new job taking `0` (or whichever core it wants to take). 

### Links

Fixes: https://github.com/hashicorp/nomad/issues/25525
Fixes: https://github.com/hashicorp/nomad/issues/18549

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
