### PR TITLE
client: close namespace file handle and defensively lazy unmount

### DIFF
--- a/.changelog/25714.txt
+++ b/.changelog/25714.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: fix failure cleaning up namespace on batch jobs
+```

--- a/client/allocrunner/network_manager_linux.go
+++ b/client/allocrunner/network_manager_linux.go
@@ -141,6 +141,7 @@ func (*defaultNetworkManager) CreateNetwork(allocID string, _ *drivers.NetworkCr
 		}
 		return nil, false, err
 	}
+	defer netns.Close()
 
 	spec := &drivers.NetworkIsolationSpec{
 		Mode:   drivers.NetIsolationModeGroup,

--- a/client/lib/nsutil/netns_linux.go
+++ b/client/lib/nsutil/netns_linux.go
@@ -132,7 +132,7 @@ func NewNS(nsName string) (NetNS, error) {
 func UnmountNS(nsPath string) error {
 	// Only unmount if it's been bind-mounted (don't touch namespaces in /proc...)
 	if strings.HasPrefix(nsPath, NetNSRunDir) {
-		if err := unix.Unmount(nsPath, 0); err != nil {
+		if err := unix.Unmount(nsPath, unix.MNT_DETACH); err != nil {
 			return fmt.Errorf("failed to unmount NS: at %s: %w", nsPath, err)
 		}
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Nomad was holding open the namespace file handle, which would eventually get cleaned up by garbage collection. In batch jobs that ran very quickly, it was possible the leaked file handle was still open, and causing errors when attempting to unmount the namespace.

In addition to closing the file handle, we can use a `MNT_DETACH` flag when unmounting to ensure that in the event a namespace file handle is left open, the namespace is still unmounted eventually and no resources are leaked.

Fixes [GH#25610](https://github.com/hashicorp/nomad/issues/25610)

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
See [GH#25610](https://github.com/hashicorp/nomad/issues/25610) for reproduction steps.  In addition, you can see Nomad accessing the namespace file via shimming in an `exec.Command("fuser", -v, nsPath)` right before unmounting. This can be reproduced in Podman and exec2.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
