### PR TITLE
cli: operator debug: respect NOMAD_REGION env var

### DIFF
--- a/.changelog/25716.txt
+++ b/.changelog/25716.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: respect NOMAD_REGION and NOMAD_NAMESPACE in operator debug command
+```

--- a/.changelog/25716.txt
+++ b/.changelog/25716.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-cli: respect NOMAD_REGION and NOMAD_NAMESPACE in operator debug command
+cli: Respect NOMAD_REGION environment variable in operator debug command
 ```

--- a/command/meta.go
+++ b/command/meta.go
@@ -51,10 +51,12 @@ type Meta struct {
 	// Whether to force colorized output
 	forceColor bool
 
-	// The region to send API requests
+	// The value of the -region CLI flag to send with API requests
+	// note: does not reflect any environment variables
 	region string
 
-	// namespace to send API requests
+	// The value of the -namespace CLI flag to send with API requests
+	// note: does not reflect any environment variables
 	namespace string
 
 	// token is used for ACLs to access privileged information
@@ -201,6 +203,18 @@ func (m *Meta) clientConfig() *api.Config {
 
 func (m *Meta) Client() (*api.Client, error) {
 	return api.NewClient(m.clientConfig())
+}
+
+// Namespace returns the Nomad namespace used for API calls,
+// from either the -namespace flag, or the NOMAD_NAMESPACE env var.
+func (m *Meta) Namespace() string {
+	return m.clientConfig().Namespace
+}
+
+// Region returns the Nomad region used for API calls,
+// from either the -region flag, or the NOMAD_REGION env var.
+func (m *Meta) Region() string {
+	return m.clientConfig().Region
 }
 
 func (m *Meta) allNamespaces() bool {

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -512,7 +512,6 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	}
 
 	c.opts = &api.QueryOptions{
-		Region:     c.Meta.Region(),
 		AllowStale: allowStale,
 		AuthToken:  c.Meta.token,
 	}

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -512,7 +512,7 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	}
 
 	c.opts = &api.QueryOptions{
-		Region:     c.Meta.region,
+		Region:     c.Meta.Region(),
 		AllowStale: allowStale,
 		AuthToken:  c.Meta.token,
 	}
@@ -612,7 +612,7 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	}
 
 	// Filter for servers matching criteria
-	c.serverIDs, err = filterServerMembers(c.members, serverIDs, c.region)
+	c.serverIDs, err = filterServerMembers(c.members, serverIDs, c.Meta.Region())
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to parse server list; err: %v", err))
 		return 1
@@ -638,8 +638,8 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	c.Ui.Output("Starting debugger...")
 	c.Ui.Output("")
 	c.Ui.Output(fmt.Sprintf("Nomad CLI Version: %s", version.GetVersion().FullVersionNumber(true)))
-	c.Ui.Output(fmt.Sprintf("           Region: %s", c.region))
-	c.Ui.Output(fmt.Sprintf("        Namespace: %s", c.namespace))
+	c.Ui.Output(fmt.Sprintf("           Region: %s", c.Meta.Region()))
+	c.Ui.Output(fmt.Sprintf("        Namespace: %s", c.Meta.Namespace()))
 	c.Ui.Output(fmt.Sprintf("          Servers: (%d/%d) %v", serverCaptureCount, serversFound, c.serverIDs))
 	c.Ui.Output(fmt.Sprintf("          Clients: (%d/%d) %v", nodeCaptureCount, nodesFound, c.nodeIDs))
 	if nodeCaptureCount > 0 && nodeCaptureCount == c.maxNodes {


### PR DESCRIPTION
Fixes #25672 - tl;dr `NOMAD_REGION` and `NOMAD_NAMESPACE` are ignored by `nomad operator debug`

I thought about having `Meta.clientConfig()` _write_ `Meta.region` and `Meta.namespace`, but that felt off, so I opted for a couple of getters that can hopefully be easily discovered if needed for other cases.

Before:

```
$ NOMAD_REGION=global NOMAD_NAMESPACE=default nomad operator debug
Starting debugger...

Nomad CLI Version: Nomad v1.10.0
BuildDate 2025-04-09T16:40:54Z
Revision e26a2bd2acac2dcdcb623f4d293bac096beef478
           Region:
        Namespace:
          Servers: (1/1) ... etc etc ...
```

After:

```
$ NOMAD_REGION=global NOMAD_NAMESPACE=default nomad operator debug
Starting debugger...

Nomad CLI Version: Nomad v1.10.1-dev
BuildDate 2025-04-21T18:49:12Z
Revision c86d63da13145326ae69649fa9c51601dc16914a+CHANGES
           Region: global
        Namespace: default
          Servers: (1/1) ... etc etc ...
```