### PR TITLE
Force an agent return if there is an error on reload

### DIFF
--- a/.changelog/25721.txt
+++ b/.changelog/25721.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Errors encountered when reloading agent configuration will now cause agents to exit. Before configuration errors during reloads were only logged. This could lead to agents running but unable to communicate
+```

--- a/.changelog/25721.txt
+++ b/.changelog/25721.txt
@@ -1,3 +1,3 @@
-```release-note:bug
+```release-note:breaking-change
 core: Errors encountered when reloading agent configuration will now cause agents to exit. Before configuration errors during reloads were only logged. This could lead to agents running but unable to communicate
 ```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1010,7 +1010,7 @@ func (c *Command) terminateGracefully(signalCh chan os.Signal, sdSock io.Writer)
 // handleSignals blocks until we get an exit-causing signal
 func (c *Command) handleSignals() int {
 	signalCh := make(chan os.Signal, 4)
-	defer close(signalCh)
+	defer signal.Stop(signalCh)
 
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP, syscall.SIGPIPE)
 

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1038,7 +1038,7 @@ func (c *Command) handleSignals() int {
 				sdNotifyReloading(sdSock)
 				err := c.handleReload()
 				if err != nil {
-					c.Ui.Output("Terminal error found while reloading")
+					c.Ui.Error(fmt.Sprintf("Fatal error while reloading: %v", err)
 					return 1
 				}
 

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1032,7 +1032,7 @@ func (c *Command) handleSignals() int {
 
 			switch sig {
 			case syscall.SIGPIPE:
-				// Skip any SIGPIPE signal and don't try to log it (See issues #1798, #3554)
+				// Skip any SIGPIPE signal (see issues #1798, #3554)
 				continue
 			case syscall.SIGHUP:
 				sdNotifyReloading(sdSock)

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1039,9 +1039,16 @@ func (c *Command) handleSignals() int {
 					c.Ui.Output("Terminal error found while reloading")
 					return 1
 				}
+
 				sdNotify(sdSock, sdReady)
-			case os.Interrupt, syscall.SIGTERM:
+			case syscall.SIGTERM:
 				if !c.agent.GetConfig().LeaveOnTerm {
+					return 1
+				}
+
+				return c.terminateGracefully(signalCh, sdSock)
+			case os.Interrupt:
+				if !c.agent.GetConfig().LeaveOnInt {
 					return 1
 				}
 

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -987,7 +987,7 @@ func (c *Command) terminateGracefully(signalCh chan os.Signal, sdSock io.Writer)
 
 	timeout := gracefulTimeout
 
-	config := c.readConfig()
+	config := c.agent.config
 	if config == nil {
 		c.Ui.Output("Unable to read the agent configuration, using the default graceful timeout")
 	}

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -987,20 +987,13 @@ func (c *Command) terminateGracefully(signalCh chan os.Signal, sdSock io.Writer)
 
 	timeout := gracefulTimeout
 
-	config := c.agent.config
+	config := c.agent.client.GetConfig()
 	if config == nil {
 		c.Ui.Output("Unable to read the agent configuration, using the default graceful timeout")
 	}
 
-	if config.Client != nil && config.Client.Drain != nil && config.Client.Drain.Deadline != nil {
-		ddl, err := time.ParseDuration(*config.Client.Drain.Deadline)
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Unable to read the client's drain deadline, using the default graceful timeout: %s", err))
-		}
-
-		if ddl != 0 {
-			timeout += ddl
-		}
+	if config.Drain != nil && config.Drain.Deadline != 0 {
+		timeout += config.Drain.Deadline
 	}
 
 	c.Ui.Output("Gracefully shutting down agent...")

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1174,7 +1174,6 @@ func (c *Command) handleReload() error {
 		err := c.reloadHTTPServer()
 		if err != nil {
 			c.agent.httpLogger.Error("reloading config failed", "error", err)
-			return nil
 		}
 	}
 	return nil

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -993,11 +993,13 @@ func (c *Command) terminateGracefully(signalCh chan os.Signal, sdSock io.Writer)
 		close(gracefulCh)
 	}()
 
+	delay := time.NewTimer(gracefulTimeout)
+
 	// Wait for leave or another signal
 	select {
 	case <-signalCh:
 		return 1
-	case <-time.After(gracefulTimeout):
+	case <-delay.C:
 		return 1
 	case <-gracefulCh:
 	}

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -22,6 +22,13 @@ non-functional `-peer-address` option for the [`operator raft
 peer-remove`](/nomad/docs/commands/operator/raft/remove-peer) command, and the
 `address` parameter for the `DELETE /v1/operator/raft/peer` API.
 
+Errors encountered when reloading agent configuration will now cause agents to
+exit. Before configuration errors during reloads were only logged. This could 
+lead to agents running but unable to communicate. Any other errors when parsing
+the new configuration will be logged and the reload will be aborted, consistent
+with teh current behavior.
+
+
 ## Nomad 1.10.0
 
 @include 'release-notes/v1-10/deprecate-variable-limits.mdx'

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -26,7 +26,7 @@ Errors encountered when reloading agent configuration will now cause agents to
 exit. Before configuration errors during reloads were only logged. This could 
 lead to agents running but unable to communicate. Any other errors when parsing
 the new configuration will be logged and the reload will be aborted, consistent
-with teh current behavior.
+with the current behavior.
 
 
 ## Nomad 1.10.0

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -22,10 +22,10 @@ non-functional `-peer-address` option for the [`operator raft
 peer-remove`](/nomad/docs/commands/operator/raft/remove-peer) command, and the
 `address` parameter for the `DELETE /v1/operator/raft/peer` API.
 
-Errors encountered when reloading agent configuration will now cause agents to
-exit. Before configuration errors during reloads were only logged. This could 
-lead to agents running but unable to communicate. Any other errors when parsing
-the new configuration will be logged and the reload will be aborted, consistent
+Errors encountered when reloading agent configuration now cause agents to exit.
+In prior versions, Nomad only logged configuration errors during reloads. This
+could lead to agents running but unable to communicate. Any other errors when
+parsing the new configuration are logged and the reload is aborted, consistent
 with the current behavior.
 
 


### PR DESCRIPTION
### Description
Currently if an agent performs a system reload after a configuration update and encounters an error, it just logs it and continues, which can lead to agents running but unable to communicate. 
This PR changes that behaviour by forcing the agent to exit with an error code if it runs into a fatal error while reloading.

It also does a little refactor of the`handleSignals()` function for clarity and makes the graceful termination function aware of any drain configuration deadlines.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
Related issues:

-  [NMD-321](https://hashicorp.atlassian.net/browse/NMD-321)
- [GH-25199](https://github.com/hashicorp/nomad/issues/25199)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[NMD-321]: https://hashicorp.atlassian.net/browse/NMD-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ