### PR TITLE
refactor alloc drain to make intent more clear

### DIFF
--- a/nomad/drainer/drainer.go
+++ b/nomad/drainer/drainer.go
@@ -395,25 +395,25 @@ func (n *NodeDrainer) batchDrainAllocs(allocs []*structs.Allocation) (uint64, er
 // affected jobs.
 func (n *NodeDrainer) drainAllocs(future *structs.BatchFuture, allocs []*structs.Allocation) {
 	// Compute the effected jobs and make the transition map
-	jobs := make(map[structs.NamespacedID]*structs.Allocation, 4)
+	jobs := make(map[structs.NamespacedID]*structs.Job, 4)
 	transitions := make(map[string]*structs.DesiredTransition, len(allocs))
 	for _, alloc := range allocs {
 		transitions[alloc.ID] = &structs.DesiredTransition{
 			Migrate: pointer.Of(true),
 		}
-		jobs[alloc.JobNamespacedID()] = alloc
+		jobs[alloc.JobNamespacedID()] = alloc.Job
 	}
 
 	evals := make([]*structs.Evaluation, 0, len(jobs))
 	now := time.Now().UTC().UnixNano()
-	for _, alloc := range jobs {
+	for _, job := range jobs {
 		evals = append(evals, &structs.Evaluation{
 			ID:          uuid.Generate(),
-			Namespace:   alloc.Namespace,
-			Priority:    alloc.Job.Priority,
-			Type:        alloc.Job.Type,
+			Namespace:   job.Namespace,
+			Priority:    job.Priority,
+			Type:        job.Type,
 			TriggeredBy: structs.EvalTriggerNodeDrain,
-			JobID:       alloc.JobID,
+			JobID:       job.ID,
 			Status:      structs.EvalStatusPending,
 			CreateTime:  now,
 			ModifyTime:  now,

--- a/nomad/drainer/watch_jobs.go
+++ b/nomad/drainer/watch_jobs.go
@@ -368,7 +368,7 @@ func handleTaskGroup(snap *state.StateSnapshot, batch bool, tg *structs.TaskGrou
 
 		// Check if the alloc should be considered migrated. A migrated
 		// allocation is one that is terminal on the client, is on a draining
-		// allocation, and has been updated since our last handled index to
+		// node, and has been updated since our last handled index to
 		// avoid emitting many duplicate migrate events.
 		if alloc.ClientTerminalStatus() &&
 			onDrainingNode &&


### PR DESCRIPTION
While working on #25726, I found a method in the drainer code that records creates a map of job IDs to allocations.

At first glance this looks like a bug because it effectively de-duplicates the allocations per job. But the consumer of the map is only concerned with jobs, not allocations, and simply reads the job off the allocation. Refactor this to make it obvious we're looking at the job.

Ref: https://github.com/hashicorp/nomad/pull/25726