### PR TITLE
Testing Revised Jira Fields

### DIFF
--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -37,8 +37,8 @@ jobs:
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve), customerfield_10091 is "Team (R&D)
           extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
-                          "labels": ["community", "GitHub"] }',
                           "Team[Team]": "72e166fb-d26c-4a61-b0de-7a290d91708f",
+                          "labels": ["community", "GitHub"] }'
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -37,7 +37,7 @@ jobs:
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve), customerfield_10091 is "Team (R&D)
           extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
-                          "labels": ["community", "GitHub"] }'
+                          "labels": ["community", "GitHub"] }',
                           "Team[Team]": "72e166fb-d26c-4a61-b0de-7a290d91708f",
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}

--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -37,9 +37,8 @@ jobs:
           description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created in GitHub by ${{ github.actor }}._"
           # customfield_10089 is "Issue Link", customfield_10371 is "Source" (use JIRA API to retrieve), customerfield_10091 is "Team (R&D)
           extraFields: '{ "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}",
-                          "customfield_10371": { "value": "GitHub" },
-                          "customfield_10091": ["NomadMinor"],
-                          "labels": ["community"] }'
+                          "labels": ["community", "GitHub"] }'
+                          "Team[Team]": "72e166fb-d26c-4a61-b0de-7a290d91708f",
         env:
           JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
           JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}


### PR DESCRIPTION
Removing custom fields no longer available, adding GitHub as a tag (in addition to community), and setting native Jira Team.