### PR TITLE
e2e: Fix TestDocker/testRedis with increased timeout on deployment

### DIFF
--- a/e2e/docker/docker_test.go
+++ b/e2e/docker/docker_test.go
@@ -53,9 +53,9 @@ func runRegistry(t *testing.T) {
 
 	t.Logf("Setting up insecure private registry at %v", address)
 
-	// run the sed job to fixup the auth.json file with correct address and make
-	// sure the registry is marked as insecure for docker, otherwise pulls will
-	// fail
+	// run the sed job to fix the auth.json file with the correct address and
+	// make sure the registry is marked as insecure for docker, otherwise pulls
+	// will fail.
 	_, sedCleanup := jobs3.Submit(t,
 		"../docker_registry/registry-auths.hcl",
 		jobs3.Var("registry_address", address),
@@ -80,7 +80,7 @@ func runRegistry(t *testing.T) {
 }
 
 func testRedis(t *testing.T) {
-	job, cleanup := jobs3.Submit(t, "./input/redis.hcl")
+	job, cleanup := jobs3.Submit(t, "./input/redis.hcl", jobs3.Timeout(30*time.Second))
 	t.Cleanup(cleanup)
 
 	logs := job.TaskLogs("cache", "redis")


### PR DESCRIPTION
The fresh deployment of the Redis job took around 20s which is also the default context timeout on the e2e util that monitors and waits for a deployment to complete.

The tight timing meant the test often timed out but sometimes would complete successfully. Increasing the timeout for this deployment will remove the flakiness.

### Testing & Reproduction steps
Ran against an e2e cluster:
```console
$ go test -count 1 -v -run TestDocker ./...
=== RUN   TestDocker
    docker_test.go:54: Setting up insecure private registry at 172.31.93.113:23700
=== RUN   TestDocker/testRedis
=== RUN   TestDocker/testAuthBasic
    docker_test.go:91: test disabled until we have a local docker registry setup with tf
=== RUN   TestDocker/testAuthFileStatic
    docker_test.go:107: test disabled until we have a local docker registry setup with tf
=== RUN   TestDocker/testAuthHelper
    docker_test.go:123: test disabled until we have a local docker registry setup with tf
--- PASS: TestDocker (42.97s)
    --- PASS: TestDocker/testRedis (23.44s)
    --- SKIP: TestDocker/testAuthBasic (0.00s)
    --- SKIP: TestDocker/testAuthFileStatic (0.00s)
    --- SKIP: TestDocker/testAuthHelper (0.00s)
PASS
ok  	github.com/hashicorp/nomad/e2e/docker	43.289s
```

### Links
Closes #25738 

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
