### PR TITLE
docker: correct stat response for rss, cache and swap memory in cgroups v1

### DIFF
--- a/.changelog/25741.txt
+++ b/.changelog/25741.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fix missing stats for rss, cache and swap memory for cgroups v1
+```

--- a/drivers/docker/stats.go
+++ b/drivers/docker/stats.go
@@ -128,9 +128,9 @@ func (h *taskHandle) collectStats(ctx context.Context, destCh *usageSender, inte
 
 // collectDockerStats performs the stats collection from the Docker API. It is
 // split into its own function for the purpose of aiding testing.
-func (h *taskHandle) collectDockerStats(ctx context.Context) (*containerapi.Stats, error) {
+func (h *taskHandle) collectDockerStats(ctx context.Context) (*containerapi.StatsResponse, error) {
 
-	var stats *containerapi.Stats
+	var stats *containerapi.StatsResponse
 
 	statsReader, err := h.dockerClient.ContainerStats(ctx, h.containerID, false)
 	if err != nil && err != io.EOF {

--- a/drivers/docker/stats_test.go
+++ b/drivers/docker/stats_test.go
@@ -22,12 +22,15 @@ import (
 func TestDriver_DockerStatsCollector(t *testing.T) {
 	ci.Parallel(t)
 
-	stats := &containerapi.Stats{}
+	stats := &containerapi.StatsResponse{}
 	stats.CPUStats.ThrottlingData.Periods = 10
 	stats.CPUStats.ThrottlingData.ThrottledPeriods = 10
 	stats.CPUStats.ThrottlingData.ThrottledTime = 10
 
 	stats.MemoryStats.Stats = map[string]uint64{}
+	stats.MemoryStats.Stats["rss"] = 6537216
+	stats.MemoryStats.Stats["cache"] = 1234
+	stats.MemoryStats.Stats["swap"] = 0
 	stats.MemoryStats.Stats["file_mapped"] = 1024
 	stats.MemoryStats.Usage = 5651904
 	stats.MemoryStats.MaxUsage = 6651904
@@ -39,6 +42,9 @@ func TestDriver_DockerStatsCollector(t *testing.T) {
 
 	if runtime.GOOS != "windows" {
 		must.Eq(t, stats.MemoryStats.Stats["file_mapped"], ru.ResourceUsage.MemoryStats.MappedFile)
+		must.Eq(t, stats.MemoryStats.Stats["rss"], ru.ResourceUsage.MemoryStats.RSS)
+		must.Eq(t, stats.MemoryStats.Stats["cache"], ru.ResourceUsage.MemoryStats.Cache)
+		must.Eq(t, stats.MemoryStats.Stats["swap"], ru.ResourceUsage.MemoryStats.Swap)
 		must.Eq(t, stats.MemoryStats.Usage, ru.ResourceUsage.MemoryStats.Usage)
 		must.Eq(t, stats.MemoryStats.MaxUsage, ru.ResourceUsage.MemoryStats.MaxUsage)
 		must.Eq(t, stats.CPUStats.ThrottlingData.ThrottledPeriods, ru.ResourceUsage.CpuStats.ThrottledPeriods)

--- a/drivers/docker/util/stats_posix.go
+++ b/drivers/docker/util/stats_posix.go
@@ -19,7 +19,7 @@ var (
 	DockerCgroupV2MeasuredMemStats = []string{"Cache", "Swap", "Usage"}
 )
 
-func DockerStatsToTaskResourceUsage(s *containerapi.Stats, compute cpustats.Compute) *cstructs.TaskResourceUsage {
+func DockerStatsToTaskResourceUsage(s *containerapi.StatsResponse, compute cpustats.Compute) *cstructs.TaskResourceUsage {
 	var (
 		totalCompute = compute.TotalCompute
 		totalCores   = compute.NumCores
@@ -34,7 +34,12 @@ func DockerStatsToTaskResourceUsage(s *containerapi.Stats, compute cpustats.Comp
 	}
 
 	ms := &cstructs.MemoryStats{
+		// containerapi exposes memory stat file as a map, consult
+		// https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
 		MappedFile: s.MemoryStats.Stats["file_mapped"],
+		Cache:      s.MemoryStats.Stats["cache"],
+		RSS:        s.MemoryStats.Stats["rss"],
+		Swap:       s.MemoryStats.Stats["swap"],
 		Usage:      s.MemoryStats.Usage,
 		MaxUsage:   s.MemoryStats.MaxUsage,
 		Measured:   measuredMems,


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/25138 refactoring accidentally removed
some of the memory stats that weren't available as concrete types in
containerapi. 

Fixes https://github.com/hashicorp/nomad/issues/24920
Internal ref: https://hashicorp.atlassian.net/browse/NMD-437