### PR TITLE
ui: Only show paused icon when allocs in pending state are paused.

### DIFF
--- a/.changelog/25742.txt
+++ b/.changelog/25742.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed a bug where the job list page incorrectly calculated if a job had paused tasks.
+```

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -316,15 +316,20 @@ export default class Job extends Model {
   @attr('boolean') isPack;
 
   /**
-   * A task with a schedule block can have execution paused at specific cron-based times.
-   * If one is currently paused, an allocation at /statuses will come back with hasPausedTask=true.
-   * We should represent this to the user in the job row.
+   * A task with a schedule block can have execution paused at specific
+   * cron-based times. If an allocation is currently paused and in a pending
+   * client state, we should represent this to the user in the job row.
+   *
+   * Use the allocations client status and the hasPausedTask allocation returned
+   * at /statuses to determine the correct information.
    */
   get hasPausedTask() {
     if (!this.allocations) {
       return false;
     }
-    return this.allocations.any((alloc) => alloc.hasPausedTask);
+    return this.allocations
+      .filter((alloc) => alloc.clientStatus === 'pending')
+      .any((alloc) => alloc.hasPausedTask);
   }
 
   // True when the job is the parent periodic or parameterized jobs

--- a/ui/mirage/factories/allocation.js
+++ b/ui/mirage/factories/allocation.js
@@ -229,8 +229,7 @@ export default Factory.extend({
       });
 
       allocation.update({
-        taskStateIds:
-          allocation.clientStatus === 'pending' ? [] : states.mapBy('id'),
+        taskStateIds: states.mapBy('id'),
         taskResourceIds: resources.mapBy('id'),
       });
 

--- a/ui/mirage/scenarios/default.js
+++ b/ui/mirage/scenarios/default.js
@@ -173,6 +173,23 @@ function smallCluster(server) {
       state: 'running',
     });
 
+  const pausedJobGroups = 2;
+  const pausedTasksPerGroup = 5;
+  server.create('job', {
+    name: 'paused-job',
+    id: 'paused-job',
+    namespaceId: 'default',
+    type: 'service',
+    withPausedTasks: true,
+    resourceSpec: Array(pausedJobGroups).fill('M: 256, C: 500'),
+    groupTaskCount: pausedTasksPerGroup,
+    shallow: false,
+    allocStatusDistribution: {
+      pending: 1,
+    },
+    noActiveDeployment: true,
+  });
+
   server.create('policy', {
     id: 'client-reader',
     name: 'client-reader',

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -289,9 +289,10 @@ module('Acceptance | allocation detail', function (hooks) {
   });
 
   test('when there are no tasks, an empty state is shown', async function (assert) {
-    // Make sure the allocation is pending in order to ensure there are no tasks
-    allocation = server.create('allocation', 'withTaskWithPorts', {
-      clientStatus: 'pending',
+    allocation = server.create('allocation');
+    allocation.update({
+      taskStateIds: [],
+      taskResourceIds: [],
     });
     await Allocation.visit({ id: allocation.id });
 

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -794,7 +794,6 @@ module('Acceptance | jobs list', function (hooks) {
 
     await JobsList.visit();
     console.log(pauseJob);
-    await this.pauseTest();
 
     assert.dom('[data-test-job-row="time-based-job"]').exists();
     assert

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -766,7 +766,8 @@ module('Acceptance | jobs list', function (hooks) {
       name: 'regular-job-2',
       createAllocations: true,
     });
-    server.create('job', {
+
+    let pauseJob = server.create('job', {
       name: 'time-based-job ',
       id: 'time-based-job',
       createAllocations: true,
@@ -777,10 +778,11 @@ module('Acceptance | jobs list', function (hooks) {
       groupAllocCount: 1,
       groupTaskCount: 1,
       allocStatusDistribution: {
-        running: 1,
+        pending: 1,
       },
       noActiveDeployment: true,
-      status: 'running',
+      status: 'pending',
+      clientStatus: 'pending',
       noFailedPlacements: true,
     });
 
@@ -791,6 +793,8 @@ module('Acceptance | jobs list', function (hooks) {
     const task = server.db.tasks.findBy({ taskGroupID: groupID });
 
     await JobsList.visit();
+    console.log(pauseJob);
+    await this.pauseTest();
 
     assert.dom('[data-test-job-row="time-based-job"]').exists();
     assert

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -766,9 +766,8 @@ module('Acceptance | jobs list', function (hooks) {
       name: 'regular-job-2',
       createAllocations: true,
     });
-
-    let pauseJob = server.create('job', {
-      name: 'time-based-job ',
+    server.create('job', {
+      name: 'time-based-job',
       id: 'time-based-job',
       createAllocations: true,
       type: 'service',
@@ -793,7 +792,6 @@ module('Acceptance | jobs list', function (hooks) {
     const task = server.db.tasks.findBy({ taskGroupID: groupID });
 
     await JobsList.visit();
-    console.log(pauseJob);
 
     assert.dom('[data-test-job-row="time-based-job"]').exists();
     assert


### PR DESCRIPTION
Jobs were being marked incorrectly as having paused allocations when terminal allocations were marked with the paused boolean. The UI should only mark a job as including paused allocations when these paused allocations are in the correct client state, which is pending.

In order to correctly handle the modified behaviour, mirage required an update, so that pending allocations had task states set.

### Testing & Reproduction steps
The linked Jira contains reproduction steps. The feature is Enterprise only, so you'll need to port this change into your ENT code and run `make dev-ui` to test locally.

### Links
[NMD-668](https://hashicorp.atlassian.net/browse/NMD-668)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[NMD-668]: https://hashicorp.atlassian.net/browse/NMD-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ