### PR TITLE
testing: fix a panic in docker stats collection test

### DIFF
--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -3280,6 +3280,10 @@ DONE:
 	for {
 		select {
 		case stats := <-recv:
+			if stats == nil {
+				// prevent NPE when channel close races with context close
+				continue
+			}
 			statsReceived++
 			ticks := stats.ResourceUsage.CpuStats.TotalTicks
 			must.Greater(t, 0, ticks)


### PR DESCRIPTION
When the context closes, the stats emitter closes its channel. It's possible for the channel to be closed in the stats emitter goroutine before the `select` in the test sees that the context has closed, which can result in a panic in the test when we try to read the empty value off the channel.

Example test run https://github.com/hashicorp/nomad-enterprise/actions/runs/14643472774/job/41091737592?pr=2654