### PR TITLE
metrics: emit cache and rss stats on cgroup v2

### DIFF
--- a/.changelog/25751.txt
+++ b/.changelog/25751.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+metrics: Fixed a bug where RSS and cache stats would not be reported for docker, exec, and java drivers under Linux cgroups v2
+```

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -3284,6 +3284,8 @@ DONE:
 			ticks := stats.ResourceUsage.CpuStats.TotalTicks
 			must.Greater(t, 0, ticks)
 			tickValues.Insert(ticks)
+			rss := stats.ResourceUsage.MemoryStats.RSS
+			must.Greater(t, 0, rss)
 			if statsReceived >= 3 {
 				cancel() // 3 is plenty
 			}

--- a/drivers/docker/stats_test.go
+++ b/drivers/docker/stats_test.go
@@ -168,6 +168,12 @@ func Test_taskHandle_collectDockerStats(t *testing.T) {
 
 		must.NonZero(t, dockerStats.MemoryStats.Usage)
 		must.MapContainsKey(t, dockerStats.MemoryStats.Stats, "file_mapped")
+
+		_, hasRSS := dockerStats.MemoryStats.Stats["rss"]
+		if !hasRSS {
+			_, hasRSS = dockerStats.MemoryStats.Stats["anon"]
+		}
+		must.True(t, hasRSS)
 	}
 
 	// Test Windows specific memory stats are collected as and when expected.

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -52,11 +52,13 @@ const (
 )
 
 var (
-	// ExecutorCgroupV1MeasuredMemStats is the list of memory stats captured by the executor with cgroup-v1
+	// ExecutorCgroupV1MeasuredMemStats is the list of memory stats captured by
+	// the executor with cgroup-v1
 	ExecutorCgroupV1MeasuredMemStats = []string{"RSS", "Cache", "Swap", "Usage", "Max Usage", "Kernel Usage", "Kernel Max Usage"}
 
-	// ExecutorCgroupV2MeasuredMemStats is the list of memory stats captured by the executor with cgroup-v2. cgroup-v2 exposes different memory stats and no longer reports rss or max usage.
-	ExecutorCgroupV2MeasuredMemStats = []string{"Cache", "Swap", "Usage"}
+	// ExecutorCgroupV2MeasuredMemStats is the list of memory stats captured by
+	// the executor with cgroup-v2. cgroup-v2 exposes different memory stats
+	ExecutorCgroupV2MeasuredMemStats = []string{"RSS", "Cache", "Swap", "Usage"}
 
 	// ExecutorCgroupMeasuredCpuStats is the list of CPU stats captures by the executor
 	ExecutorCgroupMeasuredCpuStats = []string{"System Mode", "User Mode", "Throttled Periods", "Throttled Time", "Percent"}
@@ -439,8 +441,19 @@ func (l *LibcontainerExecutor) handleStats(ch chan *cstructs.TaskResourceUsage, 
 		// Memory Related Stats
 		swap := stats.MemoryStats.SwapUsage
 		maxUsage := stats.MemoryStats.Usage.MaxUsage
-		rss := stats.MemoryStats.Stats["rss"]
+
 		cache := stats.MemoryStats.Stats["cache"]
+		if cache == 0 {
+			// This is the equivalent stat for cgroups v2, including filesystem
+			// cache and tmpfs
+			cache = stats.MemoryStats.Stats["file"]
+		}
+		rss := stats.MemoryStats.Stats["rss"]
+		if rss == 0 {
+			// This is the equivalent stat of anonymous mappings for cgroups v2.
+			rss = stats.MemoryStats.Stats["anon"]
+		}
+
 		mapped_file := stats.MemoryStats.Stats["mapped_file"]
 		ms := &cstructs.MemoryStats{
 			RSS:            rss,


### PR DESCRIPTION
In cgroups v2, a different map of memory stats is available from the kernel than in v1. The Docker API reflects this change. But there are equivalent values in the map for RSS (anonymously mapped memory) and cache (filesystem cache and tmpfs), which the Docker driver and shared executor are not currently emitting.

Fallback to these alternate values when the cgroups v1 values are not available. Include the anonymous mapping in the "measured" allocation stats as "RSS" so that they both show up in allocation metrics.  We can do this on both the `docker` driver and the Linux executor for `exec` and `java` drivers.

Fixes: https://github.com/hashicorp/nomad/issues/19185
Ref: https://hashicorp.atlassian.net/browse/NMD-437
Ref: https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html#memory-interface-files
Ref: https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt

### Testing & Reproduction steps

Run a Docker job (this job has no swap):

```
$ nomad operator api /v1/metrics | jq '.Gauges[] | select(.Name | startswith("nomad.client.allocs.memory")) | .Name, .Value'
"nomad.client.allocs.memory.allocated"
104857600.0
"nomad.client.allocs.memory.cache"
4096.0
"nomad.client.allocs.memory.rss"
3751936.0
"nomad.client.allocs.memory.swap"
0.0
"nomad.client.allocs.memory.usage"
4870144.0
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
