### PR TITLE
Check for allocs running before checking for IDs after a client upgrade

### DIFF
--- a/enos/modules/upgrade_client/main.tf
+++ b/enos/modules/upgrade_client/main.tf
@@ -61,7 +61,7 @@ resource "enos_local_exec" "get_alloc_info" {
   )
 
   inline = [
-    "nomad alloc status -json | jq -r --arg NODE_ID \"$(nomad node status -allocs -address https://$CLIENT_IP:4646 -self -json | jq -r '.ID')\" '[ .[] | select(.NodeID == $NODE_ID) | {ID: .ID, Name: .Name, ClientStatus: .ClientStatus, TaskStates: .TaskStates}]'"  ]
+  "nomad alloc status -json | jq -r --arg NODE_ID \"$(nomad node status -allocs -address https://$CLIENT_IP:4646 -self -json | jq -r '.ID')\" '[ .[] | select(.NodeID == $NODE_ID) | {ID: .ID, Name: .Name, ClientStatus: .ClientStatus, TaskStates: .TaskStates}]'"]
 }
 
 module "upgrade_client" {

--- a/enos/modules/upgrade_client/main.tf
+++ b/enos/modules/upgrade_client/main.tf
@@ -61,8 +61,7 @@ resource "enos_local_exec" "get_alloc_info" {
   )
 
   inline = [
-    "nomad alloc status -json | jq -r --arg NODE_ID \"$(nomad node status -allocs -address https://$CLIENT_IP:4646 -self -json | jq -r '.ID')\" '[ .[] | select(.ClientStatus == \"running\" and .NodeID == $NODE_ID) | {ID: .ID, Name: .Name, ClientStatus: .ClientStatus}]'"
-  ]
+    "nomad alloc status -json | jq -r --arg NODE_ID \"$(nomad node status -allocs -address https://$CLIENT_IP:4646 -self -json | jq -r '.ID')\" '[ .[] | select(.NodeID == $NODE_ID) | {ID: .ID, Name: .Name, ClientStatus: .ClientStatus, TaskStates: .TaskStates}]'"  ]
 }
 
 module "upgrade_client" {

--- a/enos/modules/upgrade_client/scripts/verify_allocs.sh
+++ b/enos/modules/upgrade_client/scripts/verify_allocs.sh
@@ -48,17 +48,50 @@ done
 
 echo "Client $client_id at $CLIENT_IP is ready"
 
-# Quality: "nomad_alloc_reconect: A GET call to /v1/allocs will return the same IDs for running allocs before and after a client upgrade on each client"
-echo "Allocs found before upgrade $ALLOCS"
+allocs_count=$($ALLOCS |jq '[ .[] | select(.ClientStatus == "running")] | length')
+
+# Quality: "nomad_alloc_reconnect: A GET call to /v1/allocs will return the same IDs for running allocs before and after a client upgrade on each client"
+echo "$allocs_count allocs found before upgrade $ALLOCS"
+
+checkAllocsCount() {
+    local allocs
+    allocs=$(nomad alloc status -json) || error_exit "Failed to check alloc status"
+
+    running_allocs=$(echo "$allocs" | jq '[.[] | select(.ClientStatus == "running")]')
+    allocs_length=$(echo "$running_allocs" | jq 'length') \
+        || error_exit "Invalid alloc status -json output"
+
+    if [ "$allocs_length" -eq "$allocs_count" ]; then
+        return 0
+    fi
+
+    return 1
+}
 
 echo "Reading allocs for client at $CLIENT_IP"
+
+elapsed_time=0
+while true; do
+    checkAllocsCount && break
+
+    if [ "$elapsed_time" -ge "$MAX_WAIT_TIME" ]; then
+        error_exit "Some allocs are not running: $(nomad alloc status -json | jq -r '.[] | "\(.ID) \(.Name) \(.ClientStatus)"')"
+    fi
+
+    echo "Running allocs: $allocs_length, expected $allocs_count. Waiting for $elapsed_time  Retrying in $POLL_INTERVAL seconds..."
+    sleep $POLL_INTERVAL
+    elapsed_time=$((elapsed_time + POLL_INTERVAL))
+
+done
+
+echo "Correct number of allocs found running: $allocs_length"
 
 current_allocs=$(nomad alloc status -json | jq -r --arg client_id "$client_id" '[.[] | select(.ClientStatus == "running" and .NodeID == $client_id) | .ID] | join(" ")')
 if [ -z "$current_allocs" ]; then
     error_exit "Failed to read allocs for node: $client_id"
 fi
 
-IDs=$(echo $ALLOCS | jq -r '[.[].ID] | join(" ")')
+IDs=$($ALLOCS |jq '[ .[] | select(.ClientStatus == \"running\")] | [.[].ID] | join(" ")')
 
 IFS=' ' read -r -a INPUT_ARRAY <<< "${IDs[*]}"
 IFS=' ' read -r -a RUNNING_ARRAY <<< "$current_allocs"

--- a/enos/modules/upgrade_client/scripts/verify_allocs.sh
+++ b/enos/modules/upgrade_client/scripts/verify_allocs.sh
@@ -55,9 +55,8 @@ echo "$allocs_count allocs found before upgrade $ALLOCS"
 
 checkAllocsCount() {
     local allocs
-    allocs=$(nomad alloc status -json) || error_exit "Failed to check alloc status"
-
-    running_allocs=$(echo "$allocs" | jq '[.[] | select(.ClientStatus == "running")]')
+    running_allocs=$(nomad alloc status -json | jq -r --arg client_id "$client_id" '[.[] | select(.ClientStatus == "running" and .NodeID == $client_id)]') \
+        || error_exit "Failed to check alloc status"
     allocs_length=$(echo "$running_allocs" | jq 'length') \
         || error_exit "Invalid alloc status -json output"
 


### PR DESCRIPTION
The upgrade test is very flaky because checking the allocs running before and after un update on every client presents a lot of inconsistencies.  Sometimes there are more allocs after than before, sometimes it is the other way around. This PR introduces 2 things: It prints out the info of any alloc present on the client before upgrading, restarts the client, waits for the correct number of allocs to be running and then checks that they are the same that were running before.

### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
