### PR TITLE
encrypter: Ignore wrapped key additions with zero wrapped keys.

### DIFF
--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -368,6 +368,18 @@ func (e *Encrypter) AddUnwrappedKey(rootKey *structs.UnwrappedRootKey, isUpgrade
 // but it returns an error for ease of testing.
 func (e *Encrypter) AddWrappedKey(ctx context.Context, wrappedKeys *structs.RootKey) error {
 
+	// If the passed root key does not contain any wrapped keys, it has no
+	// decryption tasks to perform and therefore should not supersede or impact
+	// tasks running for the same keyID.
+	//
+	// This conditional will only be hit when the FSM is taking action on
+	// fsm.RootKeyMetaSnapshot and structs.RootKeyMetaUpsertRequestType types
+	// which represent legacy style keys. When support is removed for these in
+	// 1.12.0, we should reconsider this conditional too.
+	if len(wrappedKeys.WrappedKeys) == 0 {
+		return nil
+	}
+
 	logger := e.log.With("key_id", wrappedKeys.KeyID)
 
 	e.lock.Lock()
@@ -387,7 +399,7 @@ func (e *Encrypter) AddWrappedKey(ctx context.Context, wrappedKeys *structs.Root
 
 	if cancel, ok := e.decryptTasks[wrappedKeys.KeyID]; ok {
 		// stop any previous tasks for this same key ID under the assumption
-		// they're broken or being superceded, but don't remove the CancelFunc
+		// they're broken or being superseded, but don't remove the CancelFunc
 		// from the map yet so that other callers don't think we can continue
 		cancel()
 	}


### PR DESCRIPTION
When a Nomad server restores its state via a snapshot and logs, it is possible a legacy wrapped key object/log is found. This key will not contain any wrapped keys and therefore should be ingored within the encrypter.

It is theoretically possible without this change that a key which generates zero decrypt tasks supersedes a running task and will place itself in the tracked decrypt task tracker. This decrypt task has no running work to remove its entry.

### Testing & Reproduction steps
The added test cover the steps needed.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
