### PR TITLE
paginator: fix tokenizer comparison of composite index and ID

### DIFF
--- a/.changelog/25792.txt
+++ b/.changelog/25792.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+paginator: fix tokenizer comparison of composite index and ID
+```

--- a/.changelog/25792.txt
+++ b/.changelog/25792.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-paginator: fix tokenizer comparison of composite index and ID
+api: Fixed pagination bug which could result in duplicate results
 ```

--- a/nomad/state/paginator/tokenizer_test.go
+++ b/nomad/state/paginator/tokenizer_test.go
@@ -52,3 +52,94 @@ func TestTokenizer(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateIndexAndIDTokenizer(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name          string
+		obj           *mockCreateIndexObject
+		target        string
+		expectedToken string
+		expectedCmp   int
+	}{
+		{
+			name:          "common index (less)",
+			obj:           newMockCreateIndexObject(12, "aaa-bbb-ccc"),
+			target:        "12.bbb-ccc-ddd",
+			expectedToken: "12.aaa-bbb-ccc",
+			expectedCmp:   -1,
+		},
+		{
+			name:          "common index (greater)",
+			obj:           newMockCreateIndexObject(12, "bbb-ccc-ddd"),
+			target:        "12.aaa-bbb-ccc",
+			expectedToken: "12.bbb-ccc-ddd",
+			expectedCmp:   1,
+		},
+		{
+			name:          "common index (equal)",
+			obj:           newMockCreateIndexObject(12, "bbb-ccc-ddd"),
+			target:        "12.bbb-ccc-ddd",
+			expectedToken: "12.bbb-ccc-ddd",
+			expectedCmp:   0,
+		},
+		{
+			name:          "less index",
+			obj:           newMockCreateIndexObject(12, "aaa-bbb-ccc"),
+			target:        "89.aaa-bbb-ccc",
+			expectedToken: "12.aaa-bbb-ccc",
+			expectedCmp:   -1,
+		},
+		{
+			name:          "greater index",
+			obj:           newMockCreateIndexObject(89, "aaa-bbb-ccc"),
+			target:        "12.aaa-bbb-ccc",
+			expectedToken: "89.aaa-bbb-ccc",
+			expectedCmp:   1,
+		},
+		{
+			name:          "common index start (less)",
+			obj:           newMockCreateIndexObject(12, "aaa-bbb-ccc"),
+			target:        "102.aaa-bbb-ccc",
+			expectedToken: "12.aaa-bbb-ccc",
+			expectedCmp:   -1,
+		},
+		{
+			name:          "common index start (greater)",
+			obj:           newMockCreateIndexObject(102, "aaa-bbb-ccc"),
+			target:        "12.aaa-bbb-ccc",
+			expectedToken: "102.aaa-bbb-ccc",
+			expectedCmp:   1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := CreateIndexAndIDTokenizer[*mockCreateIndexObject](tc.target)
+			actualToken, actualCmp := fn(tc.obj)
+			must.Eq(t, tc.expectedToken, actualToken)
+			must.Eq(t, tc.expectedCmp, actualCmp)
+		})
+	}
+}
+
+func newMockCreateIndexObject(createIndex uint64, id string) *mockCreateIndexObject {
+	return &mockCreateIndexObject{
+		createIndex: createIndex,
+		id:          id,
+	}
+}
+
+type mockCreateIndexObject struct {
+	createIndex uint64
+	id          string
+}
+
+func (m *mockCreateIndexObject) GetCreateIndex() uint64 {
+	return m.createIndex
+}
+
+func (m *mockCreateIndexObject) GetID() string {
+	return m.id
+}


### PR DESCRIPTION
### Description

The `CreateIndexAndIDTokenizer` creates a composite token by
combining the create index value and ID from the object with
a `.`. Tokens are then compared lexicographically. The comparison
is appropriate for the ID segment of the token, but it is not for
the create index segement. Since the create index values are stored
with numeric ordering, using a lexicographical comparison can cause
unexpected results.

For example, when comparing the token `12.object-id` to `102.object-id`
the result will show `12.object-id` being greater. This is the
correct comparison but it is incorrect for the intention of the token.
With the knowledge of the composition of the token, the response
should be that `12.object-id` is less.

The unexpected behavior can be seen when performing lists (like listing
allocations). The behavior is encountered inconsistently due to
two requirements which must be met:

1. Create index values with a large enough span (ex: 12 and 102)
2. Correct per page value to get a "bad" next token (ex: prefix with 102)

To prevent the unexpected behavior, the target token is split
and the components are used individually to compare against the
object.

### Testing & Reproduction steps

1. Create a pageable number of allocations and space creation over a long enough timespan for the CreateIndex to reach three digits 
2. List allocations and paginate the response such that the NextToken value is at the start of the three digit CreateIndex values 
3. Request next page of results and view entries from start of list

### Example 

A simple script was used to cycle through page sizes, listing allocations and checking for duplicate objects. It displays where the comparison results in unexpected behavior:

```
Completed loop 138 (size: 3 next_token: "88.aef58062-8cd8-e5ba-33e2-f3ebe0054b0b")
  -> Item ID: 88.aef58062-8cd8-e5ba-33e2-f3ebe0054b0b
  -> Item ID: 101.96f23439-8921-572e-70fd-71a724a56b85
  -> Item ID: 117.5eb20d56-59eb-91e4-c92e-fc17bd714f3b
Completed loop 139 (size: 3 next_token: "117.d0ae8856-7863-80f1-abaa-52c05172449f")
  -> Item ID: 12.00438448-6b52-024d-1efd-ed1ace4147b4
ERROR - Item ID (12.00438448-6b52-024d-1efd-ed1ace4147b4) already seen on loop number 1, current index: 0
```

### Links

#25435

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
