### PR TITLE
Docs: Add "/v1" where missing so endpoint docs are consistent

### DIFF
--- a/website/content/api-docs/acl/roles.mdx
+++ b/website/content/api-docs/acl/roles.mdx
@@ -219,7 +219,7 @@ has been replicated to the region, and may lag behind the authoritative region.
 
 | Method | Path                 | Produces           |
 | ------ | -------------------- | ------------------ |
-| `GET`  | `/acl/role/:role_id` | `application/json` |
+| `GET`  | `/v1/acl/role/:role_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries),

--- a/website/content/api-docs/allocations.mdx
+++ b/website/content/api-docs/allocations.mdx
@@ -864,7 +864,7 @@ allocation ID.
 
 | Method | Path                             | Produces           |
 | ------ | -------------------------------- | ------------------ |
-| `GET`  | `/allocation/:alloc_id/services` | `application/json` |
+| `GET`  | `/v1/allocation/:alloc_id/services` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and
@@ -919,7 +919,7 @@ to the passed allocation ID.
 
 | Method | Path                           | Produces           |
 | ------ | ------------------------------ | ------------------ |
-| `GET`  | `/allocation/:alloc_id/checks` | `application/json` |
+| `GET`  | `/v1/allocation/:alloc_id/checks` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and

--- a/website/content/api-docs/jobs.mdx
+++ b/website/content/api-docs/jobs.mdx
@@ -2520,7 +2520,7 @@ The endpoint is used to read all services registered within Nomad belonging to t
 
 | Method | Path                    | Produces           |
 | ------ | ----------------------- | ------------------ |
-| `GET`  | `/job/:job_id/services` | `application/json` |
+| `GET`  | `/v1/job/:job_id/services` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and

--- a/website/content/api-docs/quotas.mdx
+++ b/website/content/api-docs/quotas.mdx
@@ -8,10 +8,7 @@ description: The /quota endpoints are used to query for and interact with quotas
 
 The `/quota` endpoints are used to query for and interact with quotas.
 
-<EnterpriseAlert>
-  This API endpoint and functionality only exists in Nomad Enterprise. This is
-  not present in the open source version of Nomad.
-</EnterpriseAlert>
+<EnterpriseAlert product="nomad"/>
 
 ## List Quota Specifications
 

--- a/website/content/api-docs/recommendations.mdx
+++ b/website/content/api-docs/recommendations.mdx
@@ -11,10 +11,7 @@ description: >-
 The `/recommendation` endpoints are used to query and interact with Dynamic
 Application Sizing recommendations.
 
-<EnterpriseAlert>
-  This API endpoint and functionality only exists in Nomad Enterprise. This is
-  not present in the open source version of Nomad.
-</EnterpriseAlert>
+<EnterpriseAlert product="nomad"/>
 
 ## List Recommendations
 

--- a/website/content/api-docs/scaling-policies.mdx
+++ b/website/content/api-docs/scaling-policies.mdx
@@ -14,7 +14,7 @@ This endpoint returns the scaling policies from all jobs.
 
 | Method | Path                | Produces           |
 | ------ | ------------------- | ------------------ |
-| `GET`  | `/scaling/policies` | `application/json` |
+| `GET`  | `/v1/scaling/policies` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and
@@ -102,7 +102,7 @@ This endpoint reads a specific scaling policy.
 
 | Method | Path                         | Produces           |
 | ------ | ---------------------------- | ------------------ |
-| `GET`  | `/scaling/policy/:policy_id` | `application/json` |
+| `GET`  | `/v1/scaling/policy/:policy_id` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and

--- a/website/content/api-docs/sentinel-policies.mdx
+++ b/website/content/api-docs/sentinel-policies.mdx
@@ -13,10 +13,7 @@ For more details about Sentinel policies, please see the [Sentinel Policy Guide]
 
 Sentinel endpoints are only available when ACLs are enabled. For more details about ACLs, please see the [ACL Guide](/nomad/tutorials/access-control).
 
-<EnterpriseAlert>
-  This API endpoint and functionality only exists in Nomad Enterprise. This is
-  not present in the open source version of Nomad.
-</EnterpriseAlert>
+<EnterpriseAlert product="nomad"/>
 
 ## List Policies
 
@@ -25,7 +22,7 @@ to the region, and may lag behind the authoritative region.
 
 | Method | Path                 | Produces           |
 | ------ | -------------------- | ------------------ |
-| `GET`  | `/sentinel/policies` | `application/json` |
+| `GET`  | `/v1/sentinel/policies` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and
@@ -65,7 +62,7 @@ authoritative region.
 
 | Method | Path                            | Produces       |
 | ------ | ------------------------------- | -------------- |
-| `POST` | `/sentinel/policy/:policy_name` | `(empty body)` |
+| `POST` | `/v1/sentinel/policy/:policy_name` | `(empty body)` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -117,7 +114,7 @@ replicated to the region, and may lag behind the authoritative region.
 
 | Method | Path                            | Produces           |
 | ------ | ------------------------------- | ------------------ |
-| `GET`  | `/sentinel/policy/:policy_name` | `application/json` |
+| `GET`  | `/v1/sentinel/policy/:policy_name` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and
@@ -156,7 +153,7 @@ authoritative region.
 
 | Method   | Path                            | Produces       |
 | -------- | ------------------------------- | -------------- |
-| `DELETE` | `/sentinel/policy/:policy_name` | `(empty body)` |
+| `DELETE` | `/v1/sentinel/policy/:policy_name` | `(empty body)` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/website/content/api-docs/services.mdx
+++ b/website/content/api-docs/services.mdx
@@ -62,7 +62,7 @@ This endpoint reads a specific service.
 
 | Method | Path                     | Produces           |
 | ------ | ------------------------ | ------------------ |
-| `GET`  | `/service/:service_name` | `application/json` |
+| `GET`  | `/v1/service/:service_name` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries), [consistency modes](/nomad/api-docs#consistency-modes) and

--- a/website/content/api-docs/status.mdx
+++ b/website/content/api-docs/status.mdx
@@ -14,7 +14,7 @@ This endpoint returns the address of the current leader in the region.
 
 | Method | Path             | Produces           |
 | ------ | ---------------- | ------------------ |
-| `GET`  | `/status/leader` | `application/json` |
+| `GET`  | `/v1/status/leader` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
@@ -43,7 +43,7 @@ This endpoint returns the set of raft peers in the region.
 
 | Method | Path            | Produces           |
 | ------ | --------------- | ------------------ |
-| `GET`  | `/status/peers` | `application/json` |
+| `GET`  | `/v1/status/peers` | `application/json` |
 
 The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and

--- a/website/content/api-docs/ui.mdx
+++ b/website/content/api-docs/ui.mdx
@@ -14,7 +14,7 @@ This page lists all known jobs in a paginated, searchable, and sortable table.
 
 | Path       | Produces    |
 | ---------- | ----------- |
-| `/ui/jobs` | `text/html` |
+| `/v1/ui/jobs` | `text/html` |
 
 ### Parameters
 
@@ -72,7 +72,7 @@ based on the type of job.
 
 | Path               | Produces    |
 | ------------------ | ----------- |
-| `/ui/jobs/:job_id` | `text/html` |
+| `/v1/ui/jobs/:job_id` | `text/html` |
 
 ### Parameters
 
@@ -91,7 +91,7 @@ This page shows the definition of a job as pretty-printed, syntax-highlighted, J
 
 | Path                          | Produces    |
 | ----------------------------- | ----------- |
-| `/ui/jobs/:job_id/definition` | `text/html` |
+| `/v1/ui/jobs/:job_id/definition` | `text/html` |
 
 ### Job Versions
 
@@ -101,7 +101,7 @@ job versions.
 
 | Path                        | Produces    |
 | --------------------------- | ----------- |
-| `/ui/jobs/:job_id/versions` | `text/html` |
+| `/v1/ui/jobs/:job_id/versions` | `text/html` |
 
 ### Job Deployments
 
@@ -116,7 +116,7 @@ in a table to drill into for task events.
 
 | Path                           | Produces    |
 | ------------------------------ | ----------- |
-| `/ui/jobs/:job_id/deployments` | `text/html` |
+| `/v1/ui/jobs/:job_id/deployments` | `text/html` |
 
 ### Job Allocations
 
@@ -124,7 +124,7 @@ This page lists all allocations for a job in a table view. Each allocation inclu
 
 | Path                           | Produces    |
 | ------------------------------ | ----------- |
-| `/ui/jobs/:job_id/allocations` | `text/html` |
+| `/v1/ui/jobs/:job_id/allocations` | `text/html` |
 
 ### Parameters
 
@@ -146,7 +146,7 @@ This page lists all evaluations for a job in a table view. Each evaluation inclu
 
 | Path                           | Produces    |
 | ------------------------------ | ----------- |
-| `/ui/jobs/:job_id/evaluations` | `text/html` |
+| `/v1/ui/jobs/:job_id/evaluations` | `text/html` |
 
 ### Parameters
 
@@ -165,7 +165,7 @@ allocations.
 
 | Path                                | Produces    |
 | ----------------------------------- | ----------- |
-| `/ui/jobs/:job_id/:task_group_name` | `text/html` |
+| `/v1/ui/jobs/:job_id/:task_group_name` | `text/html` |
 
 ### Parameters
 
@@ -191,7 +191,7 @@ description of the event.
 
 | Path                        | Produces    |
 | --------------------------- | ----------- |
-| `/ui/allocations/:alloc_id` | `text/html` |
+| `/v1/ui/allocations/:alloc_id` | `text/html` |
 
 ### Parameters
 
@@ -209,7 +209,7 @@ If the file is text based, the UI will render the text inline and the stream the
 
 | Path                                      | Produces    |
 | ----------------------------------------- | ----------- |
-| `/ui/allocations/:alloc_id/fs/:file_path` | `text/html` |
+| `/v1/ui/allocations/:alloc_id/fs/:file_path` | `text/html` |
 
 ### Parameters
 
@@ -226,7 +226,7 @@ and stopped, all static and dynamic addresses, and all recent events.
 
 | Path                                   | Produces    |
 | -------------------------------------- | ----------- |
-| `/ui/allocations/:alloc_id/:task_name` | `text/html` |
+| `/v1/ui/allocations/:alloc_id/:task_name` | `text/html` |
 
 ## Task Logs
 
@@ -236,7 +236,7 @@ to `stderr`.
 
 | Path                                        | Produces    |
 | ------------------------------------------- | ----------- |
-| `/ui/allocations/:alloc_id/:task_name/logs` | `text/html` |
+| `/v1/ui/allocations/:alloc_id/:task_name/logs` | `text/html` |
 
 ## Task File System
 
@@ -246,7 +246,7 @@ If the file is text based, the UI will render the text inline and the stream the
 
 | Path                                      | Produces    |
 | ----------------------------------------- | ----------- |
-| `/ui/allocations/:alloc_id/fs/:file_path` | `text/html` |
+| `/v1/ui/allocations/:alloc_id/fs/:file_path` | `text/html` |
 
 ### Parameters
 
@@ -264,7 +264,7 @@ This page is meant to be rendered in a popup window.
 
 | Path               | Produces    |
 | ------------------ | ----------- |
-| `/ui/exec/:job_id` | `text/html` |
+| `/v1/ui/exec/:job_id` | `text/html` |
 
 ### Parameters
 
@@ -278,7 +278,7 @@ This page is meant to be rendered in a popup window.
 
 | Path                           | Produces    |
 | ------------------------------ | ----------- |
-| `/ui/exec/:job_id/:task_group` | `text/html` |
+| `/v1/ui/exec/:job_id/:task_group` | `text/html` |
 
 ### Parameters
 
@@ -305,7 +305,7 @@ table.
 
 | Path          | Produces    |
 | ------------- | ----------- |
-| `/ui/clients` | `text/html` |
+| `/v1/ui/clients` | `text/html` |
 
 ### Parameters
 
@@ -336,7 +336,7 @@ address, port, datacenter, allocations, and attributes.
 
 | Path                     | Produces    |
 | ------------------------ | ----------- |
-| `/ui/clients/:client_id` | `text/html` |
+| `/v1/ui/clients/:client_id` | `text/html` |
 
 ### Parameters
 
@@ -358,7 +358,7 @@ This page streams log messages from a client's agent. It is the equivalent to th
 
 | Path                             | Produces    |
 | -------------------------------- | ----------- |
-| `/ui/clients/:client_id/monitor` | `text/html` |
+| `/v1/ui/clients/:client_id/monitor` | `text/html` |
 
 ### Parameters
 
@@ -372,7 +372,7 @@ the leader.
 
 | Path          | Produces    |
 | ------------- | ----------- |
-| `/ui/servers` | `text/html` |
+| `/v1/ui/servers` | `text/html` |
 
 ### Parameters
 
@@ -391,7 +391,7 @@ This page lists all tags associated with a server.
 
 | Path                     | Produces    |
 | ------------------------ | ----------- |
-| `/ui/servers/:server_id` | `text/html` |
+| `/v1/ui/servers/:server_id` | `text/html` |
 
 ## Server Monitor
 
@@ -399,7 +399,7 @@ This page streams log messages from a server's agent. It is the equivalent to th
 
 | Path                             | Produces    |
 | -------------------------------- | ----------- |
-| `/ui/servers/:server_id/monitor` | `text/html` |
+| `/v1/ui/servers/:server_id/monitor` | `text/html` |
 
 ### Parameters
 
@@ -411,7 +411,7 @@ This page lists all CSI volumes registered with the Nomad cluster by namespace. 
 
 | Path              | Produces    |
 | ----------------- | ----------- |
-| `/ui/csi/volumes` | `text/html` |
+| `/v1/ui/csi/volumes` | `text/html` |
 
 ### Parameters
 
@@ -436,7 +436,7 @@ This page shows information for a CSI volume. This includes whether or not the v
 
 | Path                         | Produces    |
 | ---------------------------- | ----------- |
-| `/ui/csi/volumes/:volume_id` | `text/html` |
+| `/v1/ui/csi/volumes/:volume_id` | `text/html` |
 
 ## CSI Plugins
 
@@ -444,7 +444,7 @@ This page lists all CSI plugins registered with the Nomad cluster. Each plugin i
 
 | Path              | Produces    |
 | ----------------- | ----------- |
-| `/ui/csi/plugins` | `text/html` |
+| `/v1/ui/csi/plugins` | `text/html` |
 
 ### Parameters
 
@@ -466,7 +466,7 @@ This page shows information for a CSI plugin. This includes the proportion of he
 
 | Path                         | Produces    |
 | ---------------------------- | ----------- |
-| `/ui/csi/plugins/:plugin_id` | `text/html` |
+| `/v1/ui/csi/plugins/:plugin_id` | `text/html` |
 
 ## CSI Plugin Allocations
 
@@ -474,7 +474,7 @@ This page lists all allocations for a CSI plugin. Each allocation includes the s
 
 | Path              | Produces    |
 | ----------------- | ----------- |
-| `/ui/csi/plugins` | `text/html` |
+| `/v1/ui/csi/plugins` | `text/html` |
 
 ### Parameters
 
@@ -504,7 +504,7 @@ Each recommendation in the list will contain information including the job and t
 
 | Path           | Produces    |
 | -------------- | ----------- |
-| `/ui/optimize` | `text/html` |
+| `/v1/ui/optimize` | `text/html` |
 
 ### Parameters
 
@@ -528,7 +528,7 @@ This page includes the same list of recommendations as the optimize route as wel
 
 | Path                                    | Produces    |
 | --------------------------------------- | ----------- |
-| `/ui/optimize/:job_id/:task_group_name` | `text/html` |
+| `/v1/ui/optimize/:job_id/:task_group_name` | `text/html` |
 
 ### Parameters
 
@@ -540,7 +540,7 @@ This page includes a visualization of all starting and running allocations group
 
 | Path           | Produces    |
 | -------------- | ----------- |
-| `/ui/topology` | `text/html` |
+| `/v1/ui/topology` | `text/html` |
 
 ## ACL Tokens
 
@@ -552,14 +552,14 @@ authenticate all future requests to allow read access to additional resources.
 
 | Path                  | Produces    |
 | --------------------- | ----------- |
-| `/ui/settings/tokens` | `text/html` |
+| `/v1/ui/settings/tokens` | `text/html` |
 
 
 ## Keyboard Shortcuts
 
 The Nomad UI supports several keyboard shortcuts in order to help users navigate and operate Nomad. You can use common key commands to dig into jobs, view logs, monitor evaluations, and more.
 
-Type `?` from anywhere in the UI to launch the Keyboard Shortcuts panel. 
+Type `?` from anywhere in the UI to launch the Keyboard Shortcuts panel.
 
 ### Default key commands:
 

--- a/website/content/api-docs/ui.mdx
+++ b/website/content/api-docs/ui.mdx
@@ -6,7 +6,8 @@ description: The /ui namespace is used to access the Nomad web user interface.
 
 # Nomad Web UI
 
-The Nomad UI is accessible at `/ui`. It is not namespaced by version. A request to `/` will also redirect to `/ui`.
+The Nomad UI is accessible at `/ui`. It is not namespaced by version, so do not
+prepend `/vi` to this endpoint. A request to `/` redirects to `/ui`.
 
 ## List Jobs
 
@@ -14,7 +15,7 @@ This page lists all known jobs in a paginated, searchable, and sortable table.
 
 | Path       | Produces    |
 | ---------- | ----------- |
-| `/v1/ui/jobs` | `text/html` |
+| `/ui/jobs` | `text/html` |
 
 ### Parameters
 
@@ -72,7 +73,7 @@ based on the type of job.
 
 | Path               | Produces    |
 | ------------------ | ----------- |
-| `/v1/ui/jobs/:job_id` | `text/html` |
+| `/ui/jobs/:job_id` | `text/html` |
 
 ### Parameters
 
@@ -91,7 +92,7 @@ This page shows the definition of a job as pretty-printed, syntax-highlighted, J
 
 | Path                          | Produces    |
 | ----------------------------- | ----------- |
-| `/v1/ui/jobs/:job_id/definition` | `text/html` |
+| `/ui/jobs/:job_id/definition` | `text/html` |
 
 ### Job Versions
 
@@ -101,7 +102,7 @@ job versions.
 
 | Path                        | Produces    |
 | --------------------------- | ----------- |
-| `/v1/ui/jobs/:job_id/versions` | `text/html` |
+| `/ui/jobs/:job_id/versions` | `text/html` |
 
 ### Job Deployments
 
@@ -116,7 +117,7 @@ in a table to drill into for task events.
 
 | Path                           | Produces    |
 | ------------------------------ | ----------- |
-| `/v1/ui/jobs/:job_id/deployments` | `text/html` |
+| `/ui/jobs/:job_id/deployments` | `text/html` |
 
 ### Job Allocations
 
@@ -124,7 +125,7 @@ This page lists all allocations for a job in a table view. Each allocation inclu
 
 | Path                           | Produces    |
 | ------------------------------ | ----------- |
-| `/v1/ui/jobs/:job_id/allocations` | `text/html` |
+| `/ui/jobs/:job_id/allocations` | `text/html` |
 
 ### Parameters
 
@@ -146,7 +147,7 @@ This page lists all evaluations for a job in a table view. Each evaluation inclu
 
 | Path                           | Produces    |
 | ------------------------------ | ----------- |
-| `/v1/ui/jobs/:job_id/evaluations` | `text/html` |
+| `/ui/jobs/:job_id/evaluations` | `text/html` |
 
 ### Parameters
 
@@ -165,7 +166,7 @@ allocations.
 
 | Path                                | Produces    |
 | ----------------------------------- | ----------- |
-| `/v1/ui/jobs/:job_id/:task_group_name` | `text/html` |
+| `/ui/jobs/:job_id/:task_group_name` | `text/html` |
 
 ### Parameters
 
@@ -191,7 +192,7 @@ description of the event.
 
 | Path                        | Produces    |
 | --------------------------- | ----------- |
-| `/v1/ui/allocations/:alloc_id` | `text/html` |
+| `/ui/allocations/:alloc_id` | `text/html` |
 
 ### Parameters
 
@@ -209,7 +210,7 @@ If the file is text based, the UI will render the text inline and the stream the
 
 | Path                                      | Produces    |
 | ----------------------------------------- | ----------- |
-| `/v1/ui/allocations/:alloc_id/fs/:file_path` | `text/html` |
+| `/ui/allocations/:alloc_id/fs/:file_path` | `text/html` |
 
 ### Parameters
 
@@ -226,7 +227,7 @@ and stopped, all static and dynamic addresses, and all recent events.
 
 | Path                                   | Produces    |
 | -------------------------------------- | ----------- |
-| `/v1/ui/allocations/:alloc_id/:task_name` | `text/html` |
+| `/ui/allocations/:alloc_id/:task_name` | `text/html` |
 
 ## Task Logs
 
@@ -236,7 +237,7 @@ to `stderr`.
 
 | Path                                        | Produces    |
 | ------------------------------------------- | ----------- |
-| `/v1/ui/allocations/:alloc_id/:task_name/logs` | `text/html` |
+| `/ui/allocations/:alloc_id/:task_name/logs` | `text/html` |
 
 ## Task File System
 
@@ -246,7 +247,7 @@ If the file is text based, the UI will render the text inline and the stream the
 
 | Path                                      | Produces    |
 | ----------------------------------------- | ----------- |
-| `/v1/ui/allocations/:alloc_id/fs/:file_path` | `text/html` |
+| `/ui/allocations/:alloc_id/fs/:file_path` | `text/html` |
 
 ### Parameters
 
@@ -264,7 +265,7 @@ This page is meant to be rendered in a popup window.
 
 | Path               | Produces    |
 | ------------------ | ----------- |
-| `/v1/ui/exec/:job_id` | `text/html` |
+| `/ui/exec/:job_id` | `text/html` |
 
 ### Parameters
 
@@ -278,7 +279,7 @@ This page is meant to be rendered in a popup window.
 
 | Path                           | Produces    |
 | ------------------------------ | ----------- |
-| `/v1/ui/exec/:job_id/:task_group` | `text/html` |
+| `/ui/exec/:job_id/:task_group` | `text/html` |
 
 ### Parameters
 
@@ -305,7 +306,7 @@ table.
 
 | Path          | Produces    |
 | ------------- | ----------- |
-| `/v1/ui/clients` | `text/html` |
+| `/ui/clients` | `text/html` |
 
 ### Parameters
 
@@ -336,7 +337,7 @@ address, port, datacenter, allocations, and attributes.
 
 | Path                     | Produces    |
 | ------------------------ | ----------- |
-| `/v1/ui/clients/:client_id` | `text/html` |
+| `/ui/clients/:client_id` | `text/html` |
 
 ### Parameters
 
@@ -358,7 +359,7 @@ This page streams log messages from a client's agent. It is the equivalent to th
 
 | Path                             | Produces    |
 | -------------------------------- | ----------- |
-| `/v1/ui/clients/:client_id/monitor` | `text/html` |
+| `/ui/clients/:client_id/monitor` | `text/html` |
 
 ### Parameters
 
@@ -372,7 +373,7 @@ the leader.
 
 | Path          | Produces    |
 | ------------- | ----------- |
-| `/v1/ui/servers` | `text/html` |
+| `/ui/servers` | `text/html` |
 
 ### Parameters
 
@@ -391,7 +392,7 @@ This page lists all tags associated with a server.
 
 | Path                     | Produces    |
 | ------------------------ | ----------- |
-| `/v1/ui/servers/:server_id` | `text/html` |
+| `/ui/servers/:server_id` | `text/html` |
 
 ## Server Monitor
 
@@ -399,7 +400,7 @@ This page streams log messages from a server's agent. It is the equivalent to th
 
 | Path                             | Produces    |
 | -------------------------------- | ----------- |
-| `/v1/ui/servers/:server_id/monitor` | `text/html` |
+| `/ui/servers/:server_id/monitor` | `text/html` |
 
 ### Parameters
 
@@ -411,7 +412,7 @@ This page lists all CSI volumes registered with the Nomad cluster by namespace. 
 
 | Path              | Produces    |
 | ----------------- | ----------- |
-| `/v1/ui/csi/volumes` | `text/html` |
+| `/ui/csi/volumes` | `text/html` |
 
 ### Parameters
 
@@ -436,7 +437,7 @@ This page shows information for a CSI volume. This includes whether or not the v
 
 | Path                         | Produces    |
 | ---------------------------- | ----------- |
-| `/v1/ui/csi/volumes/:volume_id` | `text/html` |
+| `/ui/csi/volumes/:volume_id` | `text/html` |
 
 ## CSI Plugins
 
@@ -444,7 +445,7 @@ This page lists all CSI plugins registered with the Nomad cluster. Each plugin i
 
 | Path              | Produces    |
 | ----------------- | ----------- |
-| `/v1/ui/csi/plugins` | `text/html` |
+| `/ui/csi/plugins` | `text/html` |
 
 ### Parameters
 
@@ -466,7 +467,7 @@ This page shows information for a CSI plugin. This includes the proportion of he
 
 | Path                         | Produces    |
 | ---------------------------- | ----------- |
-| `/v1/ui/csi/plugins/:plugin_id` | `text/html` |
+| `/ui/csi/plugins/:plugin_id` | `text/html` |
 
 ## CSI Plugin Allocations
 
@@ -474,7 +475,7 @@ This page lists all allocations for a CSI plugin. Each allocation includes the s
 
 | Path              | Produces    |
 | ----------------- | ----------- |
-| `/v1/ui/csi/plugins` | `text/html` |
+| `/ui/csi/plugins` | `text/html` |
 
 ### Parameters
 
@@ -504,7 +505,7 @@ Each recommendation in the list will contain information including the job and t
 
 | Path           | Produces    |
 | -------------- | ----------- |
-| `/v1/ui/optimize` | `text/html` |
+| `/ui/optimize` | `text/html` |
 
 ### Parameters
 
@@ -528,7 +529,7 @@ This page includes the same list of recommendations as the optimize route as wel
 
 | Path                                    | Produces    |
 | --------------------------------------- | ----------- |
-| `/v1/ui/optimize/:job_id/:task_group_name` | `text/html` |
+| `/ui/optimize/:job_id/:task_group_name` | `text/html` |
 
 ### Parameters
 
@@ -540,7 +541,7 @@ This page includes a visualization of all starting and running allocations group
 
 | Path           | Produces    |
 | -------------- | ----------- |
-| `/v1/ui/topology` | `text/html` |
+| `/ui/topology` | `text/html` |
 
 ## ACL Tokens
 
@@ -552,7 +553,7 @@ authenticate all future requests to allow read access to additional resources.
 
 | Path                  | Produces    |
 | --------------------- | ----------- |
-| `/v1/ui/settings/tokens` | `text/html` |
+| `/ui/settings/tokens` | `text/html` |
 
 
 ## Keyboard Shortcuts


### PR DESCRIPTION
### Description
This issue was raised for the ACL endpoints and fixed by an end user in https://github.com/hashicorp/nomad/pull/25356. This PR addresses the remaining API pages.


### Links

Jira: [CE-831]

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[CE-831]: https://hashicorp.atlassian.net/browse/CE-831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ