### PR TITLE
state store: persist NextAllocation correctly when upserting allocations

### DIFF
--- a/.changelog/25799.txt
+++ b/.changelog/25799.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+reconnecting client: fix issue where reconcile strategy was sometimes ignored
+```

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4185,6 +4185,11 @@ func (s *StateStore) upsertAllocsImpl(index uint64, allocs []*structs.Allocation
 			alloc.ModifyIndex = index
 			alloc.AllocModifyIndex = index
 
+			// Carry over NextAllocation from existing
+			if exist.NextAllocation != "" {
+				alloc.NextAllocation = exist.NextAllocation
+			}
+
 			// Keep the clients task states
 			alloc.TaskStates = exist.TaskStates
 

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -6596,21 +6596,19 @@ func TestStateStore_UpsertAlloc_NextAllocation(t *testing.T) {
 	alloc2 := mock.Alloc()
 	alloc2.PreviousAllocation = alloc1.ID
 
-	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1})
-	require.NoError(t, err)
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1, alloc2})
+	must.NoError(t, err)
 
-	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc2})
-	require.NoError(t, err)
-
-	// upsertings alloc2 should update alloc1
+	// alloc1 should have the correct NextAllocation
 	actual, err := state.AllocByID(nil, alloc1.ID)
 	must.Eq(t, actual.NextAllocation, alloc2.ID)
 
-	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc1})
-	require.NoError(t, err)
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc2, alloc1})
+	must.NoError(t, err)
 
-	// upserting alloc1 again should carry over the NextAllocation
-	must.Eq(t, alloc1.NextAllocation, alloc2.ID)
+	// upsert in a different order, alloc1 should still have the correct NextAllocation
+	actual, err = state.AllocByID(nil, alloc1.ID)
+	must.Eq(t, actual.NextAllocation, alloc2.ID)
 }
 
 func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -6608,6 +6608,7 @@ func TestStateStore_UpsertAlloc_NextAllocation(t *testing.T) {
 
 	// upsert in a different order, alloc1 should still have the correct NextAllocation
 	actual, err = state.AllocByID(nil, alloc1.ID)
+	must.NoError(t, err)
 	must.Eq(t, actual.NextAllocation, alloc2.ID)
 }
 

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -6587,6 +6587,32 @@ func TestStateStore_UpsertAlloc_ChildJob(t *testing.T) {
 	require.False(t, watchFired(ws))
 }
 
+func TestStateStore_UpsertAlloc_NextAllocation(t *testing.T) {
+	ci.Parallel(t)
+
+	state := testStateStore(t)
+
+	alloc1 := mock.Alloc()
+	alloc2 := mock.Alloc()
+	alloc2.PreviousAllocation = alloc1.ID
+
+	err := state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc1})
+	require.NoError(t, err)
+
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc2})
+	require.NoError(t, err)
+
+	// upsertings alloc2 should update alloc1
+	actual, err := state.AllocByID(nil, alloc1.ID)
+	must.Eq(t, actual.NextAllocation, alloc2.ID)
+
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc1})
+	require.NoError(t, err)
+
+	// upserting alloc1 again should carry over the NextAllocation
+	must.Eq(t, alloc1.NextAllocation, alloc2.ID)
+}
+
 func TestStateStore_UpdateAlloc_Alloc(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
When allocations that already exists in the state store were upserted again, the `NextAllocation` field was being overwritten, causing issues with the reconnecting picker.  This change carries the `NextAllocation` field forward.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
