### PR TITLE
scheduler: account for affinity value of zero in score normalization

### DIFF
--- a/.changelog/25800.txt
+++ b/.changelog/25800.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fixed a bug where a node with no affinity could be selected over a node with low affinity
+```

--- a/scheduler/rank.go
+++ b/scheduler/rank.go
@@ -972,10 +972,8 @@ func (iter *NodeAffinityIterator) Next() *RankedNode {
 		}
 	}
 	normScore := totalAffinityScore / sumWeight
-	if totalAffinityScore != 0.0 {
-		option.Scores = append(option.Scores, normScore)
-		iter.ctx.Metrics().ScoreNode(option.Node, "node-affinity", normScore)
-	}
+	option.Scores = append(option.Scores, normScore)
+	iter.ctx.Metrics().ScoreNode(option.Node, "node-affinity", normScore)
 	return option
 }
 


### PR DESCRIPTION
If there are no affinities on a job, we don't want to count an affinity score of zero in the number of scores we divide the normalized score by. This is how we handle other scoring components like node reschedule penalties on nodes that weren't running the previous allocation.

But we also exclude counting the affinity in the case where we have affinity but the value is zero. In pathological cases, this can result in a node with a no affinity being picked over a node with low affinity, because the denominator is 1 larger. Include zero-value affinities in the count of scores if the job has affinities but the value just happens to be zero.

Fixes: https://github.com/hashicorp/nomad/issues/25621