### PR TITLE
testing: fix vault setup test's reliance on specific Raft index

### DIFF
--- a/command/setup_vault_test.go
+++ b/command/setup_vault_test.go
@@ -87,7 +87,7 @@ test  default    batch  pending
 			expectedOut: fmt.Sprintf(`{
     "JobsWithoutVaultIdentity": [
         {
-            "CreateIndex": 10,
+            "CreateIndex": %d,
             "Datacenters": [
                 "dc1"
             ],
@@ -111,7 +111,7 @@ test  default    batch  pending
     "OutdatedNodes": [],
     "VaultTokens": null
 }
-`, *job.CreateIndex, *job.ModifyIndex, *job.SubmitTime),
+`, *job.CreateIndex, *job.CreateIndex, *job.ModifyIndex, *job.SubmitTime),
 		},
 		{
 			name: "-check with -t",


### PR DESCRIPTION
The test for `nomad setup vault` command expects a specific `CreateIndex` for the job it creates. Any change in Raft writes when a server comes up or establishes leadership can cause this test to break. Interpolate the expected index as we've done for other indexes on the job to make this test less brittle.

Ref: https://github.com/hashicorp/nomad-enterprise/pull/2673#issuecomment-2847619747