### PR TITLE
Docs: Job spec artifact - move environment section

### DIFF
--- a/website/content/docs/job-specification/artifact.mdx
+++ b/website/content/docs/job-specification/artifact.mdx
@@ -63,7 +63,15 @@ automatically unarchived before the starting the task.
   See [`go-getter`][go-getter] for details.
 
 - `chown` `(bool: false)` - Specifies whether Nomad should recursively `chown`
-  the downloaded artifact to be owned by the [`task.user`][task_user] uid and gid.
+  the downloaded artifact to be owned by the [`task.user`][task_user] uid and
+  gid.
+
+## Environment
+
+The `artifact` downloader by default does not have access to the environment
+variables set for the Nomad client. Manage inheritance of environment variables
+with the [`artifact.set_environment_variables`][client_artifact] client
+configuration.
 
 ## Operation Limits
 
@@ -268,11 +276,6 @@ artifact {
 }
 ```
 
-## Environment
-
-The `artifact` downloader by default does not have access to the environment variables
-set for the Nomad client. Inheritance of environment variables can be managed through the [`artifact.set_environment_variables`][client_artifact]
-client configuration.
 
 [client_artifact]: /nomad/docs/configuration/client#artifact-parameters
 [go-getter]: https://github.com/hashicorp/go-getter 'HashiCorp go-getter Library'


### PR DESCRIPTION
### Description

Support requested that we move the Environment section further up the page because users don't see the section when it's at the bottom.

### Links
Jira: [CE-712]
[Deploy preview](https://nomad-git-ce712-hashicorp.vercel.app/nomad/docs/job-specification/artifact)

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[CE-712]: https://hashicorp.atlassian.net/browse/CE-712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ