### PR TITLE
Only error on constraints if no allocs are running

### DIFF
--- a/.changelog/25850.txt
+++ b/.changelog/25850.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fixed a bug whenre planning or running a system job with constraints & rpreviously running allocations would return a failed allocation error
+```

--- a/.changelog/25850.txt
+++ b/.changelog/25850.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-scheduler: Fixed a bug whenre planning or running a system job with constraints & rpreviously running allocations would return a failed allocation error
+scheduler: Fixed a bug where planning or running a system job with constraints & previously running allocations would return a failed allocation error
 ```

--- a/scheduler/scheduler_sysbatch_test.go
+++ b/scheduler/scheduler_sysbatch_test.go
@@ -1013,11 +1013,6 @@ func TestSysBatch_JobConstraint_AddNode(t *testing.T) {
 	require.Nil(t, h.Process(NewSysBatchScheduler, eval3))
 	require.Equal(t, "complete", h.Evals[2].Status)
 
-	// Ensure `groupA` fails to be placed due to its constraint, but `groupB` doesn't
-	require.Len(t, h.Evals[2].FailedTGAllocs, 1)
-	require.Contains(t, h.Evals[2].FailedTGAllocs, "groupA")
-	require.NotContains(t, h.Evals[2].FailedTGAllocs, "groupB")
-
 	require.Len(t, h.Plans, 2)
 	require.Len(t, h.Plans[1].NodeAllocation, 1)
 	// Ensure all NodeAllocations are from first Eval
@@ -1039,6 +1034,120 @@ func TestSysBatch_JobConstraint_AddNode(t *testing.T) {
 	allocsNodeThree, err := h.State.AllocsByNode(ws, nodeBTwo.ID)
 	require.NoError(t, err)
 	require.Len(t, allocsNodeThree, 1)
+}
+
+func TestSysBatch_JobConstraint_AllFiltered(t *testing.T) {
+	ci.Parallel(t)
+	h := NewHarness(t)
+
+	// Create two nodes, one with a custom class
+	node := mock.Node()
+	must.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
+	node2 := mock.Node()
+	must.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node2))
+
+	// Create a job with a constraint
+	job := mock.SystemBatchJob()
+	job.Priority = structs.JobDefaultPriority
+	fooConstraint := &structs.Constraint{
+		LTarget: "${node.unique.name}",
+		RTarget: "something-else",
+		Operand: "==",
+	}
+	job.Constraints = []*structs.Constraint{fooConstraint}
+	must.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
+
+	// Create a mock evaluation to start the job, which will run on the foo node
+	eval := &structs.Evaluation{
+		Namespace:   structs.DefaultNamespace,
+		ID:          uuid.Generate(),
+		Priority:    job.Priority,
+		TriggeredBy: structs.EvalTriggerJobRegister,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+	must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
+
+	// Process the evaluation
+	err := h.Process(NewSystemScheduler, eval)
+	must.NoError(t, err)
+
+	// Ensure a single eval
+	must.Len(t, 1, h.Evals)
+	eval = h.Evals[0]
+
+	// Ensure that the eval reports failed allocation
+	must.Eq(t, len(eval.FailedTGAllocs), 1)
+	// Ensure that the failed allocation is due to constraint on both nodes
+	must.Eq(t, eval.FailedTGAllocs[job.TaskGroups[0].Name].ConstraintFiltered[fooConstraint.String()], 2)
+}
+
+func TestSysBatch_JobConstraint_RunMultiple(t *testing.T) {
+	ci.Parallel(t)
+	h := NewHarness(t)
+
+	// Create two nodes, one with a custom class
+	fooNode := mock.Node()
+	fooNode.Name = "foo"
+	must.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), fooNode))
+
+	barNode := mock.Node()
+	must.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), barNode))
+
+	// Create a job with a constraint
+	job := mock.SystemBatchJob()
+	job.Priority = structs.JobDefaultPriority
+	fooConstraint := &structs.Constraint{
+		LTarget: "${node.unique.name}",
+		RTarget: fooNode.Name,
+		Operand: "==",
+	}
+	job.Constraints = []*structs.Constraint{fooConstraint}
+	must.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
+
+	// Create a mock evaluation to start the job, which will run on the foo node
+	eval := &structs.Evaluation{
+		Namespace:   structs.DefaultNamespace,
+		ID:          uuid.Generate(),
+		Priority:    job.Priority,
+		TriggeredBy: structs.EvalTriggerJobRegister,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+	must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
+
+	// Process the evaluation
+	err := h.Process(NewSystemScheduler, eval)
+	must.NoError(t, err)
+
+	// Create a mock evaluation to run the job again, which will not place any
+	// new allocations (fooNode is already running, barNode is constrained), but
+	// will not report failed allocations
+	eval2 := &structs.Evaluation{
+		Namespace:   structs.DefaultNamespace,
+		ID:          uuid.Generate(),
+		Priority:    job.Priority,
+		TriggeredBy: structs.EvalTriggerJobRegister,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+	must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval2}))
+
+	err = h.Process(NewSystemScheduler, eval2)
+	must.NoError(t, err)
+
+	// Ensure a single plan
+	must.Len(t, 1, h.Plans)
+
+	// Ensure that no evals report a failed allocation
+	for _, eval := range h.Evals {
+		must.Eq(t, 0, len(eval.FailedTGAllocs))
+	}
+
+	// Ensure that plan includes allocation running on fooNode
+	must.Len(t, 1, h.Plans[0].NodeAllocation[fooNode.ID])
+	// Ensure that plan does not include allocation running on barNode
+	must.Len(t, 0, h.Plans[0].NodeAllocation[barNode.ID])
 }
 
 // No errors reported when no available nodes prevent placement

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -290,9 +290,7 @@ func (s *SystemScheduler) computeJobAllocs() error {
 	diff.update = destructiveUpdates
 
 	for _, inplaceUpdate := range inplaceUpdates {
-		if !allocExistsForTaskGroup[inplaceUpdate.TaskGroup.Name] {
-			allocExistsForTaskGroup[inplaceUpdate.TaskGroup.Name] = true
-		}
+		allocExistsForTaskGroup[inplaceUpdate.TaskGroup.Name] = true
 	}
 
 	if s.eval.AnnotatePlan {
@@ -326,9 +324,7 @@ func (s *SystemScheduler) computeJobAllocs() error {
 	}
 
 	for _, ignoredAlloc := range diff.ignore {
-		if !allocExistsForTaskGroup[ignoredAlloc.TaskGroup.Name] {
-			allocExistsForTaskGroup[ignoredAlloc.TaskGroup.Name] = true
-		}
+		allocExistsForTaskGroup[ignoredAlloc.TaskGroup.Name] = true
 	}
 
 	// Compute the placements


### PR DESCRIPTION
### Description
When running a system job with a constraint, any run after an initial startup returns an exit(2) and a warning about unplaced allocations due to constraints. An error that is not encountered on the initial run, though the constraint stays the same. This is because the node that satisfies the condition is already running the allocation, and the placement is ignored. Another placement is attempted, but the only node(s) left are the ones that do not satisfy the constraint. Nomad views this case (no allocations that were attempted to placed could be placed successfully) as an error, and reports it as such. In reality, no allocations should be placed or updated in this case, but it should not be treated as an error.

This change uses the `ignored` & in-place `updated` placements from diffSystemAlloc to attempt to determine if the case encountered is an error (no ignored/in-place updates placements means that nothing is already running, and is an error), or is not one (an ignored placement means that the task is already running somewhere on a node). It does this at the point where `failedTGAlloc` is populated, so placement functionality isn't changed, just the field that populates the error.

There is functionality that should be preserved which (correctly) notifies a user if a job is attempted that cannot be run on any node due to the constraints filtering out all available nodes. This should still behave as expected, and an explicit test has been added for it.

### Testing & Reproduction steps
Define a system jobspec with a constraint on a node in the node pool, and run it. Once an allocation is running on an available node, run (or plan) the job again. In the below example, there are 3 nodes and the constraint on the job is defined as
```
constraint {
    attribute = "${attr.unique.hostname}"
    operator  = "="
    value     = "nomad-client01"
 }
```

Previous behavior (on second run):
```
 $ nomad job run job.nomad.hcl
==> 2025-05-14T11:04:05-07:00: Monitoring evaluation "da38faeb"
    2025-05-14T11:04:05-07:00: Evaluation triggered by job "example"
    2025-05-14T11:04:06-07:00: Evaluation status changed: "pending" -> "complete"
==> 2025-05-14T11:04:06-07:00: Evaluation "da38faeb" finished with status "complete" but failed to place all allocations:
    2025-05-14T11:04:06-07:00: Task Group "cache" (failed to place 1 allocation):
      * Constraint "${attr.unique.hostname} = nomad-client01": 2 nodes excluded by filter
```
Reports a failure to place an allocation due to the constraint filtering out the node

New behavior (on second run):
```
$ nomad job run job.nomad.hcl
==> 2025-05-14T11:08:27-07:00: Monitoring evaluation "446123ac"
    2025-05-14T11:08:27-07:00: Evaluation triggered by job "example"
    2025-05-14T11:08:28-07:00: Evaluation status changed: "pending" -> "complete"
==> 2025-05-14T11:08:28-07:00: Evaluation "446123ac" finished with status "complete"
```

### Links
Fixes #12748 #12016 #19413 #12366 

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
