### PR TITLE
build: pin actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: "Check workflow files"
-        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest
+        uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint@sha256:887a259a5a534f3c4f36cb02dca341673c6089431057242cdc931e9f133147e9


### PR DESCRIPTION
We're required to pin Docker images for Actions to a specific SHA now and this is tripping scans in the Enterprise repo. Update the actionlint image.

Ref: https://go.hashi.co/memo/sec-032