### PR TITLE
test: Only run and lint Linux network hook test on Linux.

### DIFF
--- a/client/allocrunner/network_hook_linux_test.go
+++ b/client/allocrunner/network_hook_linux_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build linux
+// +build linux
+
+package allocrunner
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/client/taskenv"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/nomad/plugins/drivers/testutils"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test"
+	"github.com/shoenig/test/must"
+)
+
+// TestNetworkHook_Prerun_Postrun_ExistingNetNS tests that the prerun and
+// postrun hooks call the Setup and Destroy with the expected behaviors when the
+// network namespace already exists (typical of agent restarts and host reboots)
+func TestNetworkHook_Prerun_Postrun_ExistingNetNS(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.Alloc()
+	alloc.Job.TaskGroups[0].Networks = []*structs.NetworkResource{
+		{Mode: "bridge"},
+	}
+
+	spec := &drivers.NetworkIsolationSpec{
+		Mode:   drivers.NetIsolationModeGroup,
+		Path:   "test",
+		Labels: map[string]string{"abc": "123"},
+	}
+	isolationSetter := &mockNetworkIsolationSetter{t: t, expectedSpec: spec}
+	statusSetter := &mockNetworkStatusSetter{t: t, expectedStatus: nil}
+
+	callCounts := testutil.NewCallCounter()
+
+	nm := &testutils.MockDriver{
+		MockNetworkManager: testutils.MockNetworkManager{
+			CreateNetworkF: func(allocID string, req *drivers.NetworkCreateRequest) (*drivers.NetworkIsolationSpec, bool, error) {
+				test.Eq(t, alloc.ID, allocID)
+				callCounts.Inc("CreateNetwork")
+				return spec, false, nil
+			},
+
+			DestroyNetworkF: func(allocID string, netSpec *drivers.NetworkIsolationSpec) error {
+				test.Eq(t, alloc.ID, allocID)
+				test.Eq(t, spec, netSpec)
+				callCounts.Inc("DestroyNetwork")
+				return nil
+			},
+		},
+	}
+
+	fakePlugin := newMockCNIPlugin()
+
+	configurator := &cniNetworkConfigurator{
+		nodeAttrs: map[string]string{
+			"plugins.cni.version.bridge": "1.6.1",
+		},
+		nodeMeta: map[string]string{},
+		logger:   testlog.HCLogger(t),
+		cni:      fakePlugin,
+		nsOpts:   &nsOpts{},
+	}
+	env := taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region).Build()
+
+	testCases := []struct {
+		name                             string
+		cniVersion                       string
+		checkErrs                        []error
+		setupErrs                        []string
+		expectPrerunCreateNetworkCalls   int
+		expectPrerunDestroyNetworkCalls  int
+		expectCheckCalls                 int
+		expectSetupCalls                 int
+		expectPostrunDestroyNetworkCalls int
+		expectPrerunError                string
+	}{
+		{
+			name:                             "good check",
+			cniVersion:                       "1.6.1",
+			expectPrerunCreateNetworkCalls:   1,
+			expectPrerunDestroyNetworkCalls:  0,
+			expectCheckCalls:                 1,
+			expectSetupCalls:                 0,
+			expectPostrunDestroyNetworkCalls: 1,
+		},
+		{
+			name:                             "initial check fails",
+			cniVersion:                       "1.6.1",
+			checkErrs:                        []error{fmt.Errorf("whatever")},
+			expectPrerunCreateNetworkCalls:   2,
+			expectPrerunDestroyNetworkCalls:  1,
+			expectCheckCalls:                 2,
+			expectSetupCalls:                 0,
+			expectPostrunDestroyNetworkCalls: 2,
+		},
+		{
+			name:       "check fails twice",
+			cniVersion: "1.6.1",
+			checkErrs: []error{
+				fmt.Errorf("whatever"),
+				fmt.Errorf("whatever"),
+			},
+			expectPrerunCreateNetworkCalls:   2,
+			expectPrerunDestroyNetworkCalls:  1,
+			expectCheckCalls:                 2,
+			expectSetupCalls:                 0,
+			expectPostrunDestroyNetworkCalls: 2,
+			expectPrerunError:                "failed to configure networking for alloc: network namespace already exists but was misconfigured: whatever",
+		},
+		{
+			name:                             "old CNI version skips check",
+			cniVersion:                       "1.2.0",
+			expectPrerunCreateNetworkCalls:   1,
+			expectPrerunDestroyNetworkCalls:  0,
+			expectCheckCalls:                 0,
+			expectSetupCalls:                 0,
+			expectPostrunDestroyNetworkCalls: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+
+		t.Run(tc.name, func(t *testing.T) {
+			callCounts.Reset()
+			fakePlugin.counter.Reset()
+			fakePlugin.checkErrors = tc.checkErrs
+			configurator.nodeAttrs["plugins.cni.version.bridge"] = tc.cniVersion
+			hook := newNetworkHook(testlog.HCLogger(t), isolationSetter,
+				alloc, nm, configurator, statusSetter)
+
+			err := hook.Prerun(env)
+			if tc.expectPrerunError == "" {
+				must.NoError(t, err)
+			} else {
+				must.EqError(t, err, tc.expectPrerunError)
+			}
+
+			test.Eq(t, tc.expectPrerunDestroyNetworkCalls,
+				callCounts.Get()["DestroyNetwork"], test.Sprint("DestroyNetwork calls after prerun"))
+			test.Eq(t, tc.expectPrerunCreateNetworkCalls,
+				callCounts.Get()["CreateNetwork"], test.Sprint("CreateNetwork calls after prerun"))
+
+			test.Eq(t, tc.expectCheckCalls, fakePlugin.counter.Get()["Check"], test.Sprint("Check calls"))
+			test.Eq(t, tc.expectSetupCalls, fakePlugin.counter.Get()["Setup"], test.Sprint("Setup calls"))
+
+			must.NoError(t, hook.Postrun())
+			test.Eq(t, tc.expectPostrunDestroyNetworkCalls,
+				callCounts.Get()["DestroyNetwork"], test.Sprint("DestroyNetwork calls after postrun"))
+
+		})
+	}
+}

--- a/client/allocrunner/network_hook_test.go
+++ b/client/allocrunner/network_hook_test.go
@@ -4,7 +4,6 @@
 package allocrunner
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
@@ -14,7 +13,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/drivers/testutils"
-	"github.com/hashicorp/nomad/testutil"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 )
@@ -135,145 +133,4 @@ func TestNetworkHook_Prerun_Postrun_host(t *testing.T) {
 	must.False(t, destroyCalled)
 	must.NoError(t, hook.Postrun())
 	must.True(t, destroyCalled)
-}
-
-// TestNetworkHook_Prerun_Postrun_ExistingNetNS tests that the prerun and
-// postrun hooks call the Setup and Destroy with the expected behaviors when the
-// network namespace already exists (typical of agent restarts and host reboots)
-func TestNetworkHook_Prerun_Postrun_ExistingNetNS(t *testing.T) {
-	ci.Parallel(t)
-
-	alloc := mock.Alloc()
-	alloc.Job.TaskGroups[0].Networks = []*structs.NetworkResource{
-		{Mode: "bridge"},
-	}
-
-	spec := &drivers.NetworkIsolationSpec{
-		Mode:   drivers.NetIsolationModeGroup,
-		Path:   "test",
-		Labels: map[string]string{"abc": "123"},
-	}
-	isolationSetter := &mockNetworkIsolationSetter{t: t, expectedSpec: spec}
-	statusSetter := &mockNetworkStatusSetter{t: t, expectedStatus: nil}
-
-	callCounts := testutil.NewCallCounter()
-
-	nm := &testutils.MockDriver{
-		MockNetworkManager: testutils.MockNetworkManager{
-			CreateNetworkF: func(allocID string, req *drivers.NetworkCreateRequest) (*drivers.NetworkIsolationSpec, bool, error) {
-				test.Eq(t, alloc.ID, allocID)
-				callCounts.Inc("CreateNetwork")
-				return spec, false, nil
-			},
-
-			DestroyNetworkF: func(allocID string, netSpec *drivers.NetworkIsolationSpec) error {
-				test.Eq(t, alloc.ID, allocID)
-				test.Eq(t, spec, netSpec)
-				callCounts.Inc("DestroyNetwork")
-				return nil
-			},
-		},
-	}
-
-	fakePlugin := newMockCNIPlugin()
-
-	configurator := &cniNetworkConfigurator{
-		nodeAttrs: map[string]string{
-			"plugins.cni.version.bridge": "1.6.1",
-		},
-		nodeMeta: map[string]string{},
-		logger:   testlog.HCLogger(t),
-		cni:      fakePlugin,
-		nsOpts:   &nsOpts{},
-	}
-	env := taskenv.NewBuilder(mock.Node(), alloc, nil, alloc.Job.Region).Build()
-
-	testCases := []struct {
-		name                             string
-		cniVersion                       string
-		checkErrs                        []error
-		setupErrs                        []string
-		expectPrerunCreateNetworkCalls   int
-		expectPrerunDestroyNetworkCalls  int
-		expectCheckCalls                 int
-		expectSetupCalls                 int
-		expectPostrunDestroyNetworkCalls int
-		expectPrerunError                string
-	}{
-		{
-			name:                             "good check",
-			cniVersion:                       "1.6.1",
-			expectPrerunCreateNetworkCalls:   1,
-			expectPrerunDestroyNetworkCalls:  0,
-			expectCheckCalls:                 1,
-			expectSetupCalls:                 0,
-			expectPostrunDestroyNetworkCalls: 1,
-		},
-		{
-			name:                             "initial check fails",
-			cniVersion:                       "1.6.1",
-			checkErrs:                        []error{fmt.Errorf("whatever")},
-			expectPrerunCreateNetworkCalls:   2,
-			expectPrerunDestroyNetworkCalls:  1,
-			expectCheckCalls:                 2,
-			expectSetupCalls:                 0,
-			expectPostrunDestroyNetworkCalls: 2,
-		},
-		{
-			name:       "check fails twice",
-			cniVersion: "1.6.1",
-			checkErrs: []error{
-				fmt.Errorf("whatever"),
-				fmt.Errorf("whatever"),
-			},
-			expectPrerunCreateNetworkCalls:   2,
-			expectPrerunDestroyNetworkCalls:  1,
-			expectCheckCalls:                 2,
-			expectSetupCalls:                 0,
-			expectPostrunDestroyNetworkCalls: 2,
-			expectPrerunError:                "failed to configure networking for alloc: network namespace already exists but was misconfigured: whatever",
-		},
-		{
-			name:                             "old CNI version skips check",
-			cniVersion:                       "1.2.0",
-			expectPrerunCreateNetworkCalls:   1,
-			expectPrerunDestroyNetworkCalls:  0,
-			expectCheckCalls:                 0,
-			expectSetupCalls:                 0,
-			expectPostrunDestroyNetworkCalls: 1,
-		},
-	}
-
-	for _, tc := range testCases {
-
-		t.Run(tc.name, func(t *testing.T) {
-			callCounts.Reset()
-			fakePlugin.counter.Reset()
-			fakePlugin.checkErrors = tc.checkErrs
-			configurator.nodeAttrs["plugins.cni.version.bridge"] = tc.cniVersion
-			hook := newNetworkHook(testlog.HCLogger(t), isolationSetter,
-				alloc, nm, configurator, statusSetter)
-
-			err := hook.Prerun(env)
-			if tc.expectPrerunError == "" {
-				must.NoError(t, err)
-			} else {
-				must.EqError(t, err, tc.expectPrerunError)
-			}
-
-			test.Eq(t, tc.expectPrerunDestroyNetworkCalls,
-				callCounts.Get()["DestroyNetwork"], test.Sprint("DestroyNetwork calls after prerun"))
-			test.Eq(t, tc.expectPrerunCreateNetworkCalls,
-				callCounts.Get()["CreateNetwork"], test.Sprint("CreateNetwork calls after prerun"))
-
-			test.Eq(t, tc.expectCheckCalls, fakePlugin.counter.Get()["Check"], test.Sprint("Check calls"))
-			test.Eq(t, tc.expectSetupCalls, fakePlugin.counter.Get()["Setup"], test.Sprint("Setup calls"))
-
-			must.NoError(t, hook.Postrun())
-			test.Eq(t, tc.expectPostrunDestroyNetworkCalls,
-				callCounts.Get()["DestroyNetwork"], test.Sprint("DestroyNetwork calls after postrun"))
-
-		})
-
-	}
 }


### PR DESCRIPTION
### Description
`cniNetworkConfigurator` is detailed within the Linux only CNI hook file. Before this change, running lint of tests which didn't ignore this file would result in an error:
```console
-: # github.com/hashicorp/nomad/client/allocrunner [github.com/hashicorp/nomad/client/allocrunner.test]
client/allocrunner/network_hook_test.go:180:19: undefined: cniNetworkConfigurator
client/allocrunner/network_hook_test.go:187:14: undefined: nsOpts
/Users/jrasell/Projects/go/nomad/client/allocrunner/network_hook_test.go:180:19: undefined: cniNetworkConfigurator
/Users/jrasell/Projects/go/nomad/client/allocrunner/network_hook_test.go:187:14: undefined: nsOpts
```

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
