### PR TITLE
upgrade test: remove change mode from Vault workload

### DIFF
--- a/enos/modules/run_workloads/templates/vault-secrets.nomad.hcl.tpl
+++ b/enos/modules/run_workloads/templates/vault-secrets.nomad.hcl.tpl
@@ -51,8 +51,7 @@ job "get-secret" {
 
       template {
         destination = "local/config.json"
-        change_mode   = "signal"
-        change_signal = "SIGHUP"
+        change_mode   = "noop"
 
         data = <<EOT
 {{ with secret "${secret_path}" }}


### PR DESCRIPTION
During the upgrade test we can trigger a re-render of the Vault secret due to client restart before the allocrunner has marked the task as running, which triggers the change mode on the template and restarts the task. This results in a race where the alloc is still "pending" when we go to check it. We never change the value of this secret in upgrade testing, so paper over this race condition by setting a "noop" change mode.
