### PR TITLE
ui: account for empty tokens returned from /acl/token/self

### DIFF
--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -862,7 +862,10 @@ export default function () {
 
     // Return the token if it exists
     if (tokenForSecret) {
-      return this.serialize(tokenForSecret);
+      // In some occassions the token can actually be empty, account for that
+      if (tokenForSecret.SecretID !== "") {
+        return this.serialize(tokenForSecret);
+      }
     }
 
     // Client error if it doesn't


### PR DESCRIPTION
[Recent change](https://github.com/hashicorp/nomad/pull/25547) to how we handle responses from `/acl/token/self` endpoint caused the UI to misbehave. Setting aside a discussion whether the API endpoint should return 200 when ACLs are disabled for a moment, the UI should always check not only that the `SecretID` field is present, but that it's also non-empty. 

Fixes https://github.com/hashicorp/nomad/issues/25862