### PR TITLE
telemetry: fix excessive CPU consumption in executor

### DIFF
--- a/.changelog/25870.txt
+++ b/.changelog/25870.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+telemetry: Fix excess CPU consumption from alloc stats collection
+```
+
+```release-note:bug
+telemetry: Fixed a bug where alloc stats were still collected if telemetry.publish_allocation_metrics=false.
+```

--- a/.changelog/25870.txt
+++ b/.changelog/25870.txt
@@ -3,5 +3,5 @@ telemetry: Fix excess CPU consumption from alloc stats collection
 ```
 
 ```release-note:bug
-telemetry: Fixed a bug where alloc stats were still collected if telemetry.publish_allocation_metrics=false.
+telemetry: Fixed a bug where alloc stats were still collected (but not published) if telemetry.publish_allocation_metrics=false.
 ```

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -70,7 +70,7 @@ func (tr *TaskRunner) initHooks() {
 		newDispatchHook(alloc, hookLogger),
 		newVolumeHook(tr, hookLogger),
 		newArtifactHook(tr, tr.getter, hookLogger),
-		newStatsHook(tr, tr.clientConfig.StatsCollectionInterval, hookLogger),
+		newStatsHook(tr, tr.clientConfig.StatsCollectionInterval, tr.clientConfig.PublishAllocationMetrics, hookLogger),
 		newDeviceHook(tr.devicemanager, hookLogger),
 		newAPIHook(tr.shutdownCtx, tr.clientConfig.APIListenerRegistrar, hookLogger),
 		newWranglerHook(tr.wranglers, task.Name, alloc.ID, task.UsesCores(), hookLogger),

--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -717,7 +717,7 @@ func (e *UniversalExecutor) handleStats(ch chan *cstructs.TaskResourceUsage, ctx
 			timer.Reset(interval)
 		}
 
-		stats := e.processStats.StatProcesses()
+		stats := e.processStats.StatProcesses(time.Now())
 
 		select {
 		case <-ctx.Done():

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -445,7 +445,7 @@ func (l *LibcontainerExecutor) handleStats(ch chan *cstructs.TaskResourceUsage, 
 		stats := lstats.CgroupStats
 
 		// get the map of process pids in this container
-		pstats := l.processStats.StatProcesses()
+		pstats := l.processStats.StatProcesses(ts)
 
 		// Memory Related Stats
 		swap := stats.MemoryStats.SwapUsage

--- a/drivers/shared/executor/procstats/getstats.go
+++ b/drivers/shared/executor/procstats/getstats.go
@@ -131,5 +131,6 @@ func (lps *linuxProcStats) StatProcesses() ProcUsages {
 	}
 
 	lps.cache = result
+	lps.at = time.Now()
 	return result
 }

--- a/drivers/shared/executor/procstats/getstats_test.go
+++ b/drivers/shared/executor/procstats/getstats_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package procstats
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-set/v3"
+	"github.com/hashicorp/nomad/client/lib/cpustats"
+	"github.com/shoenig/test/must"
+	"oss.indeed.com/go/libtime"
+)
+
+type mockPL struct{}
+
+func (mockPL) ListProcesses() set.Collection[ProcessID] { return set.New[ProcessID](0) }
+
+func TestStatProcesses(t *testing.T) {
+	compute := cpustats.Compute{
+		TotalCompute: 1000,
+		NumCores:     1,
+	}
+	pl := mockPL{}
+
+	stats := &taskProcStats{
+		cacheTTL: 10 * time.Second,
+		procList: pl,
+		compute:  compute,
+		clock:    libtime.SystemClock(),
+		latest:   make(map[ProcessID]*stats),
+		cache:    make(ProcUsages),
+	}
+
+	stats.StatProcesses()
+	cachedAt := stats.at
+	must.NotEq(t, time.Time{}, cachedAt)
+	stats.StatProcesses()
+	must.Eq(t, cachedAt, stats.at, must.Sprint("cache should not have been updated"))
+}

--- a/drivers/shared/executor/procstats/getstats_test.go
+++ b/drivers/shared/executor/procstats/getstats_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/lib/cpustats"
 	"github.com/shoenig/test/must"
-	"oss.indeed.com/go/libtime"
 )
 
 type mockPL struct{}
@@ -28,14 +27,19 @@ func TestStatProcesses(t *testing.T) {
 		cacheTTL: 10 * time.Second,
 		procList: pl,
 		compute:  compute,
-		clock:    libtime.SystemClock(),
 		latest:   make(map[ProcessID]*stats),
 		cache:    make(ProcUsages),
 	}
 
-	stats.StatProcesses()
+	now := time.Now()
+	stats.StatProcesses(now)
 	cachedAt := stats.at
 	must.NotEq(t, time.Time{}, cachedAt)
-	stats.StatProcesses()
+
+	stats.StatProcesses(now)
 	must.Eq(t, cachedAt, stats.at, must.Sprint("cache should not have been updated"))
+
+	later := now.Add(30 * time.Second)
+	stats.StatProcesses(later)
+	must.Eq(t, later, stats.at, must.Sprint("cache should have been updated"))
 }

--- a/drivers/shared/executor/procstats/list_test.go
+++ b/drivers/shared/executor/procstats/list_test.go
@@ -38,14 +38,14 @@ func genMockProcs(needles, haystack int) ([]ps.Process, []ProcessID) {
 	expect := []ProcessID{42}
 
 	// TODO: make this into a tree structure, not just a linear tree
-	for i := 0; i < needles; i++ {
+	for i := range needles {
 		parent := 42 + i
 		pid := parent + 1
 		procs = append(procs, mockProc(pid, parent))
 		expect = append(expect, pid)
 	}
 
-	for i := 0; i < haystack; i++ {
+	for i := range haystack {
 		parent := 200 + i
 		pid := parent + 1
 		procs = append(procs, mockProc(pid, parent))

--- a/drivers/shared/executor/procstats/list_windows.go
+++ b/drivers/shared/executor/procstats/list_windows.go
@@ -12,19 +12,6 @@ import (
 
 // ListByPid will scan the process table and return a set of the process family
 // tree starting with executorPID as the root.
-//
-// The implementation here specifically avoids using more than one system
-// call. Unlike on Linux where we just read a cgroup, on Windows we must build
-// the tree manually. We do so knowing only the child->parent relationships.
-//
-// So this turns into a fun leet code problem, where we invert the tree using
-// only a bucket of edges pointing in the wrong direction. Basically we just
-// iterate every process, recursively follow its parent, and determine whether
-// executorPID is an ancestor.
-//
-// See https://github.com/hashicorp/nomad/issues/20042 as an example of what
-// happens when you use syscalls to work your way from the root down to its
-// descendants.
 func ListByPid(executorPID int) set.Collection[ProcessID] {
 	procs := list(executorPID, ps.Processes)
 	return procs

--- a/drivers/shared/executor/procstats/procstats.go
+++ b/drivers/shared/executor/procstats/procstats.go
@@ -31,7 +31,7 @@ type ProcUsages map[string]*drivers.ResourceUsage
 // for gathering CPU and memory process stats for all processes associated with
 // a task.
 type ProcessStats interface {
-	StatProcesses() ProcUsages
+	StatProcesses(time.Time) ProcUsages
 }
 
 // A ProcessList is anything (i.e. a task driver) that implements ListProcesses


### PR DESCRIPTION
Collecting metrics from processes is expensive, especially on platforms like
Windows. The executor code has a 5s cache of stats to ensure that we don't
thrash syscalls on nodes running many allocations. But the timestamp used to
calculate TTL of this cache was never being set, so we were always treating it
as expired. This causes excess CPU utilization on client nodes.

Ensure that when we fill the cache, we set the timestamp. In testing on Windows,
this reduces exector CPU overhead by roughly 75%.

This changeset includes two other related items:

* The `telemetry.publish_allocation_metrics` field correctly prevents a node
  from publishing metrics, but the stats hook on the taskrunner still collects
  the metrics, which can be expensive. Thread the configuration value into the
  stats hook so that we don't collect if `telemetry.publish_allocation_metrics =
  false`.

* The `linuxProcStats` type in the executor's `procstats` package is misnamed as
  a result of a couple rounds of refactoring. It's used by all task executors,
  not just Linux. Rename this and move a comment about how Windows processes are
  listed so that the comment is closer to where the logic is implemented.

Fixes: https://github.com/hashicorp/nomad/issues/23323
Fixes: https://hashicorp.atlassian.net/browse/NMD-455

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
