### PR TITLE
fix: consider volume_mounts in sidecarTaskDiff

### DIFF
--- a/.changelog/25878.txt
+++ b/.changelog/25878.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+task: consider volume_mounts in sidecarTaskDiff
+```

--- a/.changelog/25878.txt
+++ b/.changelog/25878.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-task: consider volume_mounts in sidecarTaskDiff
+job: Ensure sidecar task volume_mounts are added to planning diff object
 ```

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -1709,6 +1709,11 @@ func sidecarTaskDiff(old, new *SidecarTask, contextual bool) *ObjectDiff {
 		diff.Objects = append(diff.Objects, lDiff)
 	}
 
+	// volume_mount diff
+	if vDiffs := volumeMountsDiffs(old.VolumeMounts, new.VolumeMounts, contextual); vDiffs != nil {
+		diff.Objects = append(diff.Objects, vDiffs...)
+	}
+
 	return diff
 }
 

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -4085,6 +4085,17 @@ func TestTaskGroupDiff(t *testing.T) {
 													},
 												},
 											},
+											{
+												Type: DiffTypeDeleted,
+												Name: "VolumeMount",
+												Fields: []*FieldDiff{
+													{Type: DiffTypeDeleted, Name: "Destination", Old: "/path"},
+													{Type: DiffTypeDeleted, Name: "PropagationMode", Old: "private"},
+													{Type: DiffTypeDeleted, Name: "ReadOnly", Old: "false"},
+													{Type: DiffTypeDeleted, Name: "SELinuxLabel", Old: "Z"},
+													{Type: DiffTypeDeleted, Name: "Volume", Old: "vol0"},
+												},
+											},
 										},
 									},
 									{


### PR DESCRIPTION
### Description

volume_mounts are not regarded in `sidecarTaskDiff`, meaning two task which only differ in volume mounts will be considered equal. This addresses that.

### Testing & Reproduction steps


### Links

- #19786
- #20575

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
