### PR TITLE
docs: emphasize HOME and USER env vars for tasks that use custom `user` setting

### DIFF
--- a/website/content/docs/job-specification/task.mdx
+++ b/website/content/docs/job-specification/task.mdx
@@ -107,10 +107,11 @@ job "docs" {
 
 - `user` `(string: <varies>)` - Specifies the user that will run the task.
   Defaults to `nobody` for the [`exec`][exec] and [`java`][java] drivers.
-  [Docker][] images specify their own default users. This can only be set
-  on Linux platforms, and clients can restrict [which drivers][user_drivers]
-  are allowed to run tasks as [certain users][user_denylist].
-  On Windows, when Nomad is running as a [system service][service] for the
+  [Docker][] images specify their own default users. Clients can restrict
+  [which drivers][user_drivers] are allowed to run tasks as [certain
+  users][user_denylist]. On UNIX-like systems, setting `user` also affects
+  the environment variables `HOME` and `USER` available to the task.  On
+  Windows, when Nomad is running as a [system service][service] for the
   [`raw_exec`][raw_exec] driver, you may specify a less-privileged service user.
   For example, `NT AUTHORITY\LocalService`, `NT AUTHORITY\NetworkService`.
 

--- a/website/content/docs/runtime/environment.mdx
+++ b/website/content/docs/runtime/environment.mdx
@@ -7,7 +7,9 @@ description: Nomad provides runtime environment variables that you can use in yo
 # Runtime Environment Settings
 
 This page provides reference information for runtime environment settings in
-your Nomad job specification. Learn about task identifiers, CPU and memory resources, IP addresses, task directories, and host variables. Review job, network, and Consul variables. Supply arbitrary configuration to a job task.
+your Nomad job specification. Learn about task identifiers, CPU and memory
+resources, IP addresses, task directories, and host variables. Review job,
+network, and Consul variables. Supply arbitrary configuration to a job task.
 
 ## Introduction
 
@@ -108,10 +110,11 @@ behavior.
 
 ## Host environment variables
 
-Nomad passes the environment variables defined in the client host to tasks when
-using the `exec`, `raw_exec`, and `java` task drivers. The variables that are
-passed to the tasks can be controlled using the client configuration
-[`env.denylist`][].
+Nomad passes the environment variables defined in the client host to tasks
+when using the `exec`, `raw_exec`, and `java` task drivers. Nomad also modifies
+`HOME` and `USER` variables for tasks that have the `user` parameter set, to
+reflect the set username. The variables that are passed to the tasks can be
+controlled using the client configuration [`env.denylist`][].
 
 [jobspec]: /nomad/docs/job-specification 'Nomad Job Specification'
 [filesystem internals]: /nomad/docs/concepts/filesystem


### PR DESCRIPTION
In #25859 we fixed the task environment variables to account for `user` field
setting. This PR follows up with documentation adjustments.