### PR TITLE
ui: Handle new token self response object when ACLs are disabled.

### DIFF
--- a/.changelog/25881.txt
+++ b/.changelog/25881.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fix incorrect calculation of permissions when ACLs are disabled which meant actions such as client drains were incorrectly blocked
+```

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -44,13 +44,14 @@ export default class TokenService extends Service {
     const TokenAdapter = getOwner(this).lookup('adapter:token');
     try {
       var token = yield TokenAdapter.findSelf();
+      if (token.accessor === 'acls-disabled') {
+        this.set('aclEnabled', false);
+        return null;
+      }
       this.secret = token.secret;
       return token;
     } catch (e) {
       const errors = e.errors ? e.errors.mapBy('detail') : [];
-      if (errors.find((error) => error === 'ACL support disabled')) {
-        this.set('aclEnabled', false);
-      }
       if (errors.find((error) => error === 'ACL token not found')) {
         this.set('tokenNotFound', true);
       }


### PR DESCRIPTION
### Description
The ACL self lookup now returns a spoof token when ACLs are
disabled, rather than an error. The UI needs to be updated to
handle this change, so permissions checks are not performed which
grey out buttons such as client drain incorrectly.

### Links
https://hashicorp.atlassian.net/browse/NMD-768

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
