### PR TITLE
host volumes: -force flag for delete

### DIFF
--- a/.changelog/25902.txt
+++ b/.changelog/25902.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+host volumes: Add -force flag to volume delete command for removing volumes from GC'd nodes
+```

--- a/api/host_volumes.go
+++ b/api/host_volumes.go
@@ -174,7 +174,8 @@ type HostVolumeListRequest struct {
 }
 
 type HostVolumeDeleteRequest struct {
-	ID string
+	ID    string
+	Force bool
 }
 
 type HostVolumeDeleteResponse struct{}
@@ -243,6 +244,9 @@ func (hv *HostVolumes) Delete(req *HostVolumeDeleteRequest, opts *WriteOptions) 
 	path, err := url.JoinPath("/v1/volume/host/", url.PathEscape(req.ID))
 	if err != nil {
 		return nil, nil, err
+	}
+	if req.Force {
+		path = path + "?force=true"
 	}
 	wm, err := hv.client.delete(path, nil, resp, opts)
 	return resp, wm, err

--- a/nomad/structs/host_volumes.go
+++ b/nomad/structs/host_volumes.go
@@ -401,6 +401,7 @@ type HostVolumeRegisterResponse struct {
 
 type HostVolumeDeleteRequest struct {
 	VolumeID string
+	Force    bool
 	WriteRequest
 }
 

--- a/website/content/docs/commands/volume/delete.mdx
+++ b/website/content/docs/commands/volume/delete.mdx
@@ -39,6 +39,10 @@ volumes or `host-volume-delete` for dynamic host volumes.
 
 ## Delete options
 
+- `-force`: Delete the volume from the Nomad state store if the node has been
+  garbage collected. You should only use `-force` if the node will never rejoin
+  the cluster. Only available for dynamic host volumes.
+
 - `-secret`: Secrets to pass to the plugin to delete the snapshot. Accepts
   multiple flags in the form `-secret key=value`. Only available for CSI
   volumes.


### PR DESCRIPTION
When a node is garbage collected, we leave behind the dynamic host volume in the state store. We generally don't want to automatically garbage collect the volumes and risk data loss (see also #25903), but we should allow these to be removed via the API.

Fixes: https://github.com/hashicorp/nomad/issues/25762
Fixes: https://hashicorp.atlassian.net/browse/NMD-705
Ref: https://github.com/hashicorp/nomad/pull/25903

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
