### PR TITLE
semgrep: adjust forbidden package rule for regex matches

### DIFF
--- a/.semgrep/imports.yml
+++ b/.semgrep/imports.yml
@@ -3,20 +3,19 @@
 
 rules:
   - id: "disallow-imports"
-    patterns:
-      - pattern: '"github.com/boltdb/bolt"'
-      - pattern: '"github.com/pkg/errors"'
-      - pattern: '"github.com/hashicorp/consul"'
-      - pattern: '"github.com/hashicorp/consul/command/flags"'
-      - pattern: '"github.com/hashicorp/consul/sdk"'
-      - pattern: '"github.com/hashicorp/go-set"'
-      - pattern: '"github.com/mitchellh/cli"'
-      - pattern: '"golang.org/x/exp/slices"'
-      - pattern: '"golang.org/x/exp/maps"'
-      - pattern: '"golang.org/x/exp/constraints"'
+    pattern-either:
+      - pattern: import "github.com/boltdb/bolt"
+      - pattern: import "github.com/pkg/errors"
+      - pattern: import "=~/github.com\/hashicorp\/consul$/"
+      - pattern: import "github.com/hashicorp/consul/command/flags"
+      - pattern: import "=~/github.com\/hashicorp\/consul\/sdk$/"
+      - pattern: import "=~/github.com\/hashicorp\/go-set$/"
+      - pattern: import "github.com/mitchellh/cli"
+      - pattern: import "golang.org/x/exp/slices"
+      - pattern: import "golang.org/x/exp/maps"
+      - pattern: import "golang.org/x/exp/constraints"
     message: "Import of this package has been disallowed"
-    languages:
-      - "generic"
+    languages: [go]
     severity: "ERROR"
     paths:
       include:


### PR DESCRIPTION
We have several semgrep rules forbidding imports of packages we don't want. While testing out a new rule I discovered that the rule we have is completely ineffective. Update the rule to detect imports using the Go language plugin, including regex matching on some packages where it's forbidden to import the root but fine to import a subpackage or different version.

The go-set import rule is an example of one where our `go-set/v3` imports fails the re-written check unless we use the regex syntax. If you replace the pattern rule with `import "=~/github.com\/hashicorp\/go-set/v3$/"` it would fail.

---

Because the check won't actually run against all files without touching them:

<details><summary>semgrep run locally</summary>

```
$ semgrep scan --config .semgrep/imports.yml .

┌──── ○○○ ────┐
│ Semgrep CLI │
└─────────────┘


Scanning 6186 files (only git-tracked) with 1 Code rule:

  CODE RULES
  Scanning 2002 files.

  SUPPLY CHAIN RULES

  No rules to run.


  PROGRESS

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:02                                             


┌──────────────┐
│ Scan Summary │
└──────────────┘
✅ Scan completed successfully.
 • Findings: 0 (0 blocking)
 • Rules run: 1
 • Targets scanned: 2002
 • Parsed lines: ~99.9%
 • Scan skipped:
   ◦ Files larger than  files 1.0 MB: 9
   ◦ Files matching .semgrepignore patterns: 1
 • Scan was limited to files tracked by git
 • For a detailed list of skipped files and lines, run semgrep with the --verbose flag
Ran 1 rule on 2002 files: 0 findings.

✨ If Semgrep missed a finding, please send us feedback to let us know!
   See https://semgrep.dev/docs/reporting-false-negatives/
```

</details>


<details><summary>example run with go-set/v3 rule, showing what a failure looks like</summary>

```
$ semgrep scan --config .semgrep/imports.yml .

┌──── ○○○ ────┐
│ Semgrep CLI │
└─────────────┘


Scanning 6186 files (only git-tracked) with 1 Code rule:

  CODE RULES
  Scanning 2002 files.

  SUPPLY CHAIN RULES

  No rules to run.


  PROGRESS

  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:02                                             


┌──────────────────┐
│ 65 Code Findings │
└──────────────────┘

    client/acl.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "time"
            8┆
            9┆   metrics "github.com/hashicorp/go-metrics/compat"
           10┆   "github.com/hashicorp/go-set/v3"

    client/allocdir/task_dir.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "os"
            9┆   "path/filepath"
           10┆
           11┆   "github.com/hashicorp/go-hclog"
           12┆   "github.com/hashicorp/go-multierror"
           13┆   "github.com/hashicorp/go-set/v3"

    client/allocrunner/consul_grpc_sock_hook.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "errors"
            9┆   "fmt"
           10┆   "io"
           11┆   "net"
           12┆   "os"
           13┆   "path/filepath"
           14┆   "strings"
           15┆   "sync"
             [hid 6 additional lines, adjust with --max-lines-per-finding]

    client/allocrunner/consul_http_sock_hook.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "errors"
            9┆   "fmt"
           10┆   "net"
           11┆   "os"
           12┆   "path/filepath"
           13┆   "sync"
           14┆   "time"
           15┆
             [hid 3 additional lines, adjust with --max-lines-per-finding]

    client/allocrunner/networking_cni.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

           11┆ import (
           12┆   "context"
           13┆   "encoding/json"
           14┆   "errors"
           15┆   "fmt"
           16┆   "math/rand"
           17┆   "os"
           18┆   "path/filepath"
           19┆   "regexp"
           20┆   "slices"
             [hid 10 additional lines, adjust with --max-lines-per-finding]

    client/lib/cgroupslib/editor.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            8┆ import (
            9┆   "bytes"
           10┆   "fmt"
           11┆   "os"
           12┆   "path/filepath"
           13┆   "strconv"
           14┆   "strings"
           15┆
           16┆   "github.com/hashicorp/go-set/v3"

    client/lib/cgroupslib/mount.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            8┆ import (
            9┆   "bufio"
           10┆   "io"
           11┆   "os"
           12┆   "path/filepath"
           13┆   "strings"
           14┆   "syscall"
           15┆
           16┆   "github.com/hashicorp/go-set/v3"

    client/lib/idset/idset.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            8┆ import (
            9┆   "fmt"
           10┆   "regexp"
           11┆   "slices"
           12┆   "strconv"
           13┆   "strings"
           14┆
           15┆   "github.com/hashicorp/go-set/v3"

    client/serviceregistration/watcher.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "fmt"
            9┆   "time"
           10┆
           11┆   "github.com/hashicorp/go-hclog"
           12┆   "github.com/hashicorp/go-set/v3"

    command/acl_token_create.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "strings"
            9┆   "time"
           10┆
           11┆   "github.com/hashicorp/go-set/v3"

    command/agent/consul/service_client.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "errors"
            9┆   "fmt"
           10┆   "maps"
           11┆   "net"
           12┆   "net/url"
           13┆   "reflect"
           14┆   "regexp"
           15┆   "slices"
             [hid 11 additional lines, adjust with --max-lines-per-finding]

    command/agent/log_levels.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "github.com/hashicorp/go-set/v3"

    command/job_restart.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "errors"
            9┆   "fmt"
           10┆   "math"
           11┆   "os"
           12┆   "os/signal"
           13┆   "regexp"
           14┆   "strconv"
           15┆   "strings"
             [hid 6 additional lines, adjust with --max-lines-per-finding]

    command/job_restart_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "fmt"
            9┆   "net/http"
           10┆   "net/http/httptest"
           11┆   "net/http/httputil"
           12┆   neturl "net/url"
           13┆   "regexp"
           14┆   "sort"
           15┆   "strings"
             [hid 7 additional lines, adjust with --max-lines-per-finding]

    command/node_pool.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "strings"
            9┆
           10┆   "github.com/hashicorp/cli"
           11┆   "github.com/hashicorp/go-set/v3"

    command/node_pool_delete.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "strings"
            9┆
           10┆   "github.com/hashicorp/go-set/v3"

    command/node_pool_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "regexp"
            8┆   "testing"
            9┆
           10┆   "github.com/hashicorp/cli"
           11┆   "github.com/hashicorp/go-set/v3"

    command/node_status.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "math"
            9┆   "os"
           10┆   "sort"
           11┆   "strconv"
           12┆   "strings"
           13┆   "time"
           14┆
           15┆   humanize "github.com/dustin/go-humanize"
             [hid 1 additional lines, adjust with --max-lines-per-finding]

    command/var_put.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "encoding/json"
            8┆   "errors"
            9┆   "fmt"
           10┆   "io"
           11┆   "os"
           12┆   "path/filepath"
           13┆   "regexp"
           14┆   "slices"
           15┆   "strings"
             [hid 4 additional lines, adjust with --max-lines-per-finding]

    drivers/docker/driver.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "bytes"
            8┆   "context"
            9┆   "encoding/json"
           10┆   "errors"
           11┆   "fmt"
           12┆   "io"
           13┆   "net"
           14┆   "os"
           15┆   "path/filepath"
             [hid 21 additional lines, adjust with --max-lines-per-finding]

    drivers/docker/driver_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "fmt"
            9┆   "math/rand"
           10┆   "os"
           11┆   "path/filepath"
           12┆   "reflect"
           13┆   "runtime"
           14┆   "runtime/debug"
           15┆   "strings"
             [hid 18 additional lines, adjust with --max-lines-per-finding]

    drivers/docker/reconcile_dangling.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "fmt"
            9┆   "regexp"
           10┆   "sync"
           11┆   "time"
           12┆
           13┆   "github.com/docker/docker/api/types"
           14┆   containerapi "github.com/docker/docker/api/types/container"
           15┆   "github.com/docker/docker/client"
             [hid 2 additional lines, adjust with --max-lines-per-finding]

    drivers/docker/reconcile_dangling_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "encoding/json"
            9┆   "fmt"
           10┆   "os"
           11┆   "regexp"
           12┆   "testing"
           13┆   "time"
           14┆
           15┆   "github.com/docker/docker/api/types"
             [hid 2 additional lines, adjust with --max-lines-per-finding]

    drivers/docker/state.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "sync"
            8┆
            9┆   "github.com/hashicorp/go-set/v3"

    drivers/shared/executor/executor_basic.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            8┆ import (
            9┆   "os/exec"
           10┆
           11┆   "github.com/hashicorp/go-hclog"
           12┆   "github.com/hashicorp/go-set/v3"

    drivers/shared/executor/executor_linux.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            8┆ import (
            9┆   "context"
           10┆   "errors"
           11┆   "fmt"
           12┆   "io"
           13┆   "os"
           14┆   "os/exec"
           15┆   "os/signal"
           16┆   "path"
           17┆   "path/filepath"
             [hid 9 additional lines, adjust with --max-lines-per-finding]

    drivers/shared/executor/executor_universal_linux.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            8┆ import (
            9┆   "fmt"
           10┆   "os"
           11┆   "os/exec"
           12┆   "strconv"
           13┆   "syscall"
           14┆
           15┆   "github.com/hashicorp/go-set/v3"

    drivers/shared/executor/executor_windows.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            8┆ import (
            9┆   "errors"
           10┆   "fmt"
           11┆   "os"
           12┆   "os/exec"
           13┆   "runtime"
           14┆   "strings"
           15┆   "syscall"
           16┆   "unsafe"
           17┆
             [hid 2 additional lines, adjust with --max-lines-per-finding]

    drivers/shared/executor/procstats/getstats_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "testing"
            8┆   "time"
            9┆
           10┆   "github.com/hashicorp/go-set/v3"

    drivers/shared/executor/procstats/list_default.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            8┆ import (
            9┆   "context"
           10┆   "time"
           11┆
           12┆   "github.com/hashicorp/go-set/v3"

    drivers/shared/executor/procstats/list_linux.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            8┆ import (
            9┆   "github.com/hashicorp/go-set/v3"

    drivers/shared/executor/procstats/list_windows.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            8┆ import (
            9┆   "github.com/hashicorp/go-set/v3"

    drivers/shared/executor/procstats/procstats.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "time"
            8┆
            9┆   "github.com/hashicorp/go-set/v3"

    e2e/acl/helpers.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "testing"
            8┆
            9┆   "github.com/hashicorp/go-set/v3"

    e2e/consulcompat/shared_download_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "encoding/json"
            9┆   "os"
           10┆   "os/exec"
           11┆   "path/filepath"
           12┆   "runtime"
           13┆   "testing"
           14┆   "time"
           15┆
             [hid 2 additional lines, adjust with --max-lines-per-finding]

    e2e/nodedrain/node_drain_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "os"
            9┆   "strings"
           10┆   "testing"
           11┆   "time"
           12┆
           13┆   "github.com/hashicorp/go-set/v3"

    e2e/v3/jobs3/jobs3.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "fmt"
            9┆   "io"
           10┆   "math/rand"
           11┆   "os"
           12┆   "regexp"
           13┆   "strings"
           14┆   "testing"
           15┆   "time"
             [hid 2 additional lines, adjust with --max-lines-per-finding]

    e2e/v3/namespaces3/namespaces3.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "testing"
            8┆   "time"
            9┆
           10┆   "github.com/hashicorp/go-set/v3"

    e2e/vaultcompat/vaultcompat_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "encoding/json"
            9┆   "fmt"
           10┆   "os"
           11┆   "os/exec"
           12┆   "path/filepath"
           13┆   "runtime"
           14┆   "strings"
           15┆   "testing"
             [hid 4 additional lines, adjust with --max-lines-per-finding]

    helper/funcs.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "crypto/sha512"
            8┆   "fmt"
            9┆   "maps"
           10┆   "math"
           11┆   "net/http"
           12┆   "os"
           13┆   "path/filepath"
           14┆   "reflect"
           15┆   "regexp"
             [hid 7 additional lines, adjust with --max-lines-per-finding]

    helper/funcs_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "errors"
            8┆   "fmt"
            9┆   "maps"
           10┆   "reflect"
           11┆   "sort"
           12┆   "testing"
           13┆
           14┆   multierror "github.com/hashicorp/go-multierror"
           15┆   "github.com/hashicorp/go-set/v3"

    helper/users/dynamic/pool.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            8┆ import (
            9┆   "errors"
           10┆   "math/rand"
           11┆   "strconv"
           12┆   "sync"
           13┆
           14┆   "github.com/hashicorp/go-set/v3"

    nomad/acl_endpoint.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "encoding/json"
            9┆   "errors"
           10┆   "fmt"
           11┆   "net/http"
           12┆   "os"
           13┆   "path/filepath"
           14┆   "strings"
           15┆   "time"
             [hid 7 additional lines, adjust with --max-lines-per-finding]

    nomad/eval_endpoint_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "reflect"
            9┆   "strings"
           10┆   "testing"
           11┆   "time"
           12┆
           13┆   memdb "github.com/hashicorp/go-memdb"
           14┆   "github.com/hashicorp/go-set/v3"

    nomad/host_volume_endpoint_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "errors"
            9┆   "fmt"
           10┆   "sync"
           11┆   "testing"
           12┆   "time"
           13┆
           14┆   "github.com/hashicorp/go-multierror"
           15┆   "github.com/hashicorp/go-set/v3"

    nomad/job_endpoint.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "errors"
            9┆   "fmt"
           10┆   "net/http"
           11┆   "sort"
           12┆   "strings"
           13┆   "time"
           14┆
           15┆   "github.com/golang/snappy"
             [hid 5 additional lines, adjust with --max-lines-per-finding]

    nomad/job_endpoint_hook_connect.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "errors"
            8┆   "fmt"
            9┆   "net"
           10┆   "slices"
           11┆   "strconv"
           12┆   "strings"
           13┆   "time"
           14┆
           15┆   "github.com/hashicorp/go-set/v3"

    nomad/job_endpoint_statuses.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "errors"
            8┆   "net/http"
            9┆   "time"
           10┆
           11┆   "github.com/hashicorp/go-memdb"
           12┆   metrics "github.com/hashicorp/go-metrics/compat"
           13┆   "github.com/hashicorp/go-set/v3"

    nomad/node_pool_endpoint_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "testing"
            9┆   "time"
           10┆
           11┆   "github.com/google/go-cmp/cmp/cmpopts"
           12┆   "github.com/hashicorp/go-memdb"
           13┆   "github.com/hashicorp/go-set/v3"

    nomad/service_registration_endpoint.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "net/http"
            9┆   "sort"
           10┆   "strconv"
           11┆   "strings"
           12┆   "time"
           13┆
           14┆   "github.com/hashicorp/go-memdb"
           15┆   metrics "github.com/hashicorp/go-metrics/compat"
             [hid 2 additional lines, adjust with --max-lines-per-finding]

    nomad/state/state_store.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "context"
            8┆   "errors"
            9┆   "fmt"
           10┆   "reflect"
           11┆   "slices"
           12┆   "sort"
           13┆   "strings"
           14┆   "time"
           15┆
             [hid 5 additional lines, adjust with --max-lines-per-finding]

    nomad/structs/acl.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "bytes"
            8┆   "encoding/json"
            9┆   "errors"
           10┆   "fmt"
           11┆   "maps"
           12┆   "path"
           13┆   "regexp"
           14┆   "slices"
           15┆   "strconv"
             [hid 5 additional lines, adjust with --max-lines-per-finding]

    nomad/structs/config/workload_id.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "maps"
            8┆   "slices"
            9┆   "time"
           10┆
           11┆   "github.com/hashicorp/go-set/v3"

    nomad/structs/funcs.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "crypto/subtle"
            8┆   "encoding/base64"
            9┆   "encoding/binary"
           10┆   "fmt"
           11┆   "math"
           12┆   "sort"
           13┆   "strconv"
           14┆   "strings"
           15┆
             [hid 1 additional lines, adjust with --max-lines-per-finding]

    nomad/structs/job.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "github.com/hashicorp/go-set/v3"

    nomad/structs/job_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "testing"
            8┆
            9┆   "github.com/hashicorp/go-set/v3"

    nomad/structs/services.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "crypto/sha1"
            8┆   "encoding/binary"
            9┆   "errors"
           10┆   "fmt"
           11┆   "hash"
           12┆   "io"
           13┆   "maps"
           14┆   "net/url"
           15┆   "reflect"
             [hid 10 additional lines, adjust with --max-lines-per-finding]

    scheduler/device.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "strings"
            9┆
           10┆   "math"
           11┆
           12┆   "github.com/hashicorp/go-set/v3"

    scheduler/device_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "testing"
            8┆
            9┆   "github.com/hashicorp/go-set/v3"

    scheduler/propertyset.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "strconv"
            9┆
           10┆   log "github.com/hashicorp/go-hclog"
           11┆   memdb "github.com/hashicorp/go-memdb"
           12┆   "github.com/hashicorp/go-set/v3"

    scheduler/rank.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "math"
            9┆   "slices"
           10┆
           11┆   "github.com/hashicorp/go-set/v3"

    scheduler/reconcile_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "reflect"
            9┆   "regexp"
           10┆   "strconv"
           11┆   "testing"
           12┆   "time"
           13┆
           14┆   "github.com/hashicorp/go-set/v3"

    scheduler/spread_test.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "fmt"
            8┆   "math"
            9┆   "math/rand"
           10┆   "sort"
           11┆   "testing"
           12┆   "time"
           13┆
           14┆   "github.com/shoenig/test"
           15┆   "github.com/shoenig/test/must"
             [hid 3 additional lines, adjust with --max-lines-per-finding]

    scheduler/util.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "encoding/binary"
            8┆   "fmt"
            9┆   "maps"
           10┆   "math/rand"
           11┆   "slices"
           12┆
           13┆   log "github.com/hashicorp/go-hclog"
           14┆   memdb "github.com/hashicorp/go-memdb"
           15┆   "github.com/hashicorp/go-set/v3"

    tools/missing/main.go
   ❯❯❱ semgrep.disallow-imports
          Import of this package has been disallowed

            6┆ import (
            7┆   "cmp"
            8┆   "encoding/json"
            9┆   "errors"
           10┆   "fmt"
           11┆   "io"
           12┆   "io/fs"
           13┆   "os"
           14┆   "path/filepath"
           15┆   "sort"
             [hid 3 additional lines, adjust with --max-lines-per-finding]



┌──────────────┐
│ Scan Summary │
└──────────────┘
✅ Scan completed successfully.
 • Findings: 65 (65 blocking)
 • Rules run: 1
 • Targets scanned: 2002
 • Parsed lines: ~99.9%
 • Scan skipped:
   ◦ Files larger than  files 1.0 MB: 9
   ◦ Files matching .semgrepignore patterns: 1
 • Scan was limited to files tracked by git
 • For a detailed list of skipped files and lines, run semgrep with the --verbose flag
Ran 1 rule on 2002 files: 65 findings.

📢 Too many findings? Try Semgrep Pro for more powerful queries and less noise.
   See https://sg.run/false-positives.
```

</details>