### PR TITLE
cancel waiting evals when allocs reconnect

### DIFF
--- a/.changelog/25923.txt
+++ b/.changelog/25923.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+disconnect: Fixed a bug where pending evals for reconnected allocs were not cancelled
+```

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1338,11 +1338,14 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 			taskGroup = job.LookupTaskGroup(alloc.TaskGroup)
 		}
 
-		// If we cannot find the task group for a failed alloc we cannot continue, unless it is an orphan.
+		// Add an evaluation if this is a failed alloc that is currently
+		// eligible for rescheduling
 		if evalTriggerBy != structs.EvalTriggerJobDeregister &&
 			allocToUpdate.ClientStatus == structs.AllocClientStatusFailed &&
 			alloc.FollowupEvalID == "" {
 
+			// If we cannot find the task group for a failed alloc we cannot
+			// continue, unless it is an orphan.
 			if taskGroup == nil {
 				n.logger.Debug("UpdateAlloc unable to find task group for job", "job", alloc.JobID, "alloc", alloc.ID, "task_group", alloc.TaskGroup)
 				continue

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -11701,6 +11701,22 @@ func (a *Allocation) NeedsToReconnect() bool {
 	return disconnected
 }
 
+// FollowupEvalForReconnect returns the ID of the allocation's follow-up eval if
+// the allocation is waiting to reconnect and the clientUpdate indicates that
+// the client has reconnected.
+func (a *Allocation) FollowupEvalForReconnect(clientUpdate *Allocation) (string, bool) {
+	if !a.NeedsToReconnect() || a.FollowupEvalID == "" {
+		return "", false
+	}
+
+	switch clientUpdate.ClientStatus {
+	case AllocClientStatusRunning, AllocClientStatusComplete, AllocClientStatusFailed:
+		return a.FollowupEvalID, true
+	}
+
+	return "", false
+}
+
 // LastStartOfTask returns the time of the last start event for the given task
 // using the allocations TaskStates. If the task has not started, the zero time
 // will be returned.


### PR DESCRIPTION
When a disconnected alloc reconnects, the follow-up evaluation is left pending and the followup eval ID field isn't cleared. If the allocation later fails, the followup eval ID prevents the server from creating a new eval for that event.

Update the state store so that updates from the client clear the followup eval ID if the allocation is reconnecting, and mark the eval as canceled. Update the FSM to remove those evals from the eval broker's delay heap.

Fixes: https://github.com/hashicorp/nomad/issues/12809
Fixes: https://hashicorp.atlassian.net/browse/NMD-291
Fixes: https://hashicorp.atlassian.net/browse/NMD-302

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
  * See also my comment below with end-to-end validation: https://github.com/hashicorp/nomad/pull/25923#issuecomment-2902370725
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
