### PR TITLE
docker: add cgroupns task config

### DIFF
--- a/.changelog/25927.txt
+++ b/.changelog/25927.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-docker: add cgroupns task config
+docker: Added support for cgroup namespaces in the task config
 ```

--- a/.changelog/25927.txt
+++ b/.changelog/25927.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+docker: add cgroupns task config
+```

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -369,6 +369,7 @@ var (
 		"auth_soft_fail": hclspec.NewAttr("auth_soft_fail", "bool", false),
 		"cap_add":        hclspec.NewAttr("cap_add", "list(string)", false),
 		"cap_drop":       hclspec.NewAttr("cap_drop", "list(string)", false),
+		"cgroupns":       hclspec.NewAttr("cgroupns", "string", false),
 		"command":        hclspec.NewAttr("command", "string", false),
 		"cpuset_cpus":    hclspec.NewAttr("cpuset_cpus", "string", false),
 		"cpu_hard_limit": hclspec.NewAttr("cpu_hard_limit", "bool", false),
@@ -459,6 +460,7 @@ type TaskConfig struct {
 	AuthSoftFail            bool               `codec:"auth_soft_fail"`
 	CapAdd                  []string           `codec:"cap_add"`
 	CapDrop                 []string           `codec:"cap_drop"`
+	CgroupnsMode            string             `codec:"cgroupns"`
 	Command                 string             `codec:"command"`
 	ContainerExistsAttempts uint64             `codec:"container_exists_attempts"`
 	CPUCFSPeriod            int64              `codec:"cpu_cfs_period"`

--- a/drivers/docker/config_test.go
+++ b/drivers/docker/config_test.go
@@ -211,6 +211,7 @@ config {
   cap_drop = ["CAP_SYS_ADMIN", "CAP_SYS_TIME"]
   command = "/bin/bash"
   container_exists_attempts = 10
+  cgroupns = "host"
   cpu_hard_limit = true
   cpu_cfs_period = 20
   devices = [
@@ -361,6 +362,7 @@ config {
 		CapDrop:                 []string{"CAP_SYS_ADMIN", "CAP_SYS_TIME"},
 		Command:                 "/bin/bash",
 		ContainerExistsAttempts: 10,
+		CgroupnsMode:            "host",
 		CPUHardLimit:            true,
 		CPUCFSPeriod:            20,
 		Devices: []DockerDevice{

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1046,6 +1046,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 	cpuShares := d.cpuResources(task.Resources.LinuxResources.CPUShares)
 
 	hostConfig := &containerapi.HostConfig{
+		CgroupnsMode: containerapi.CgroupnsMode(driverConfig.CgroupnsMode),
 		// do not set cgroup parent anymore
 
 		OomScoreAdj: driverConfig.OOMScoreAdj, // ignored on platforms other than linux

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -84,8 +84,8 @@ The `docker` driver supports the following configuration in the job spec. Only
   }
   ```
 
-- `cgroupns` - (Optional) Cgroup namespace to use. Can be set to `host` or
-  `private`. If not specified Docker's default will be used.
+- `cgroupns` - (Optional) Cgroup namespace to use. Set to `host` or
+  `private`. If not specified, the driver uses Docker's default. Refer to Docker's [dockerd reference](https://docs.docker.com/reference/cli/dockerd/) for more information.
 
 - `container_exists_attempts` - (Optional) A number of attempts to be made to
   purge a container if during task creation Nomad encounters an existing one in

--- a/website/content/docs/drivers/docker.mdx
+++ b/website/content/docs/drivers/docker.mdx
@@ -84,6 +84,9 @@ The `docker` driver supports the following configuration in the job spec. Only
   }
   ```
 
+- `cgroupns` - (Optional) Cgroup namespace to use. Can be set to `host` or
+  `private`. If not specified Docker's default will be used.
+
 - `container_exists_attempts` - (Optional) A number of attempts to be made to
   purge a container if during task creation Nomad encounters an existing one in
   non-running state for the same task. Defaults to `5`.


### PR DESCRIPTION
### Description
This is a redo of https://github.com/hashicorp/nomad/pull/17702 

The Datadog Agent [docs](https://docs.datadoghq.com/containers/docker/?tab=standard) specifies that you should set `cgroupns=host`, but I can't do that via nomad.
```
docker run -d --cgroupns host \
    --pid host \
    --name dd-agent \
    -v /var/run/docker.sock:/var/run/docker.sock:ro \
    -v /proc/:/host/proc/:ro \
    -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
    -e DD_SITE=<DATADOG_SITE> \
    -e DD_API_KEY=<DATADOG_API_KEY> \
    gcr.io/datadoghq/agent:7
```

https://github.com/hashicorp/nomad/pull/17702#issuecomment-1749179725

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
