### PR TITLE
e2e: mention in the terraform readme that we require a local Consul binary

### DIFF
--- a/e2e/terraform/README.md
+++ b/e2e/terraform/README.md
@@ -56,14 +56,18 @@ client_count_linux               = "4"
 client_count_windows_2016        = "1"
 ```
 
-You will also need a Consul Enterprise license file and a Nomad Enterprise license file.
+You will also need a Consul Enterprise license file and a Nomad Enterprise
+license file, and a local Consul binary to provision Consul.
 
-Optionally, edit the `nomad_local_binary` variable in the
-`terraform.tfvars` file to change the path to the local binary of
-Nomad you'd like to upload, but keep in mind it has to match the OS and the CPU architecture of the nodes (amd64 linux). 
+Optionally, edit the `nomad_local_binary` variable in the `terraform.tfvars`
+file to change the path to the local binary of Nomad you'd like to upload, but
+keep in mind it has to match the OS and the CPU architecture of the nodes (amd64
+linux).
 
-NOTE: If you want to have a cluster with mixed CPU architectures, you need to specify the count and also provide the 
-corresponding binary using `var.nomad_local_binary_client_ubuntu_jammy` and or `var.nomad_local_binary_client_windows_2016`.
+NOTE: If you want to have a cluster with mixed CPU architectures,
+you need to specify the count and also provide the  corresponding
+binary using `var.nomad_local_binary_client_ubuntu_jammy` and or
+`var.nomad_local_binary_client_windows_2016`.
 
 Run Terraform apply to deploy the infrastructure:
 


### PR DESCRIPTION
Should be obvious, but it's not. 