### PR TITLE
drivers: normalize CPU shares/weights to fit large hosts

### DIFF
--- a/.changelog/25963.txt
+++ b/.changelog/25963.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+driver: Allow resources.cpu values above the maximum cpu.share value on Linux
+```

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -948,6 +948,20 @@ func memoryLimits(driverHardLimitMB int64, taskMemory drivers.MemoryResources) (
 	return hard * 1024 * 1024, softBytes
 }
 
+const maxCPUShares = 262_144
+
+// cpuResources normalizes the requested CPU shares when the total compute
+// available on the node is larger than the largest share value allowed by the
+// kernel. On cgroups v2, Docker will re-normalize this to be within the
+// acceptable range for cpu.weight [1-10000].
+func (d *Driver) cpuResources(requested int64) int64 {
+	if d.compute.TotalCompute < maxCPUShares {
+		return requested
+	}
+
+	return int64(float64(requested) / float64(d.compute.TotalCompute) * maxCPUShares)
+}
+
 func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *TaskConfig,
 	imageID string) (createContainerOptions, error) {
 
@@ -1027,6 +1041,8 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		pidsLimit = driverConfig.PidsLimit
 	}
 
+	cpuShares := d.cpuResources(task.Resources.LinuxResources.CPUShares)
+
 	hostConfig := &containerapi.HostConfig{
 		// do not set cgroup parent anymore
 
@@ -1048,7 +1064,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 	hostConfig.Resources = containerapi.Resources{
 		Memory:            memory,            // hard limit
 		MemoryReservation: memoryReservation, // soft limit
-		CPUShares:         task.Resources.LinuxResources.CPUShares,
+		CPUShares:         cpuShares,
 		CpusetCpus:        task.Resources.LinuxResources.CpusetCpus,
 		PidsLimit:         &pidsLimit,
 	}

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -948,6 +948,8 @@ func memoryLimits(driverHardLimitMB int64, taskMemory drivers.MemoryResources) (
 	return hard * 1024 * 1024, softBytes
 }
 
+// maxCPUShares is the maximum value for cpu_shares in cgroups v1
+// https://github.com/torvalds/linux/blob/v6.15/kernel/sched/sched.h#L503
 const maxCPUShares = 262_144
 
 // cpuResources normalizes the requested CPU shares when the total compute

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -114,3 +114,16 @@ func TestDockerDriver_PidsLimit(t *testing.T) {
 		wait.Gap(50*time.Millisecond),
 	))
 }
+
+func TestDockerDriver_NormalizeCPUShares(t *testing.T) {
+	dh := dockerDriverHarness(t, nil)
+	driver := dh.Impl().(*Driver)
+	driver.compute.TotalCompute = 12000
+
+	must.Eq(t, maxCPUShares, driver.cpuResources(maxCPUShares))
+	must.Eq(t, 1000, driver.cpuResources(1000))
+
+	driver.compute.TotalCompute = maxCPUShares * 2
+	must.Eq(t, 500, driver.cpuResources(1000))
+	must.Eq(t, maxCPUShares/2, driver.cpuResources(maxCPUShares))
+}

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -123,6 +123,12 @@ func TestDockerDriver_NormalizeCPUShares(t *testing.T) {
 	must.Eq(t, maxCPUShares, driver.cpuResources(maxCPUShares))
 	must.Eq(t, 1000, driver.cpuResources(1000))
 
+	driver.compute.TotalCompute = maxCPUShares
+	must.Eq(t, maxCPUShares, driver.cpuResources(maxCPUShares))
+
+	driver.compute.TotalCompute = maxCPUShares + 1
+	must.Eq(t, 262143, driver.cpuResources(maxCPUShares))
+
 	driver.compute.TotalCompute = maxCPUShares * 2
 	must.Eq(t, 500, driver.cpuResources(1000))
 	must.Eq(t, maxCPUShares/2, driver.cpuResources(maxCPUShares))

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -1083,6 +1083,12 @@ func TestExecutor_clampCPUShares(t *testing.T) {
 	must.Eq(t, MaxCPUShares, le.clampCpuShares(MaxCPUShares))
 	must.Eq(t, 1000, le.clampCpuShares(1000))
 
+	le.compute.TotalCompute = MaxCPUShares
+	must.Eq(t, MaxCPUShares, le.clampCpuShares(MaxCPUShares))
+
+	le.compute.TotalCompute = MaxCPUShares + 1
+	must.Eq(t, 262143, le.clampCpuShares(MaxCPUShares))
+
 	le.compute = cpustats.Compute{TotalCompute: MaxCPUShares * 2}
 	must.Eq(t, 500, le.clampCpuShares(1000))
 	must.Eq(t, MaxCPUShares/2, le.clampCpuShares(MaxCPUShares))


### PR DESCRIPTION
The `resources.cpu` field is scheduled in MHz. On most Linux task drivers, this value is then mapped to a `cpu.share` (cgroups v1) or `cpu.weight` (cgroups v2). But this means on very large hosts where the total compute is greater than the Linux kernel defined maximum CPU shares, you can't set a `resources.cpu` value large enough to consume the entire host.

The `cpu.share`/`cpu.weight` value is relative within the parent cgroup's slice, which is owned by Nomad. So we can fix this by re-normalizing the weight on very large hosts such that the maximum `resources.cpu` matches up with largest possible CPU share. This happens in the task driver so that the rest of Nomad doesn't need to be aware of this implementation detail. Note that these functions will result in bad share config if the request is more than the available, but that's supposed to be caught in the scheduler so by not catching it here we intentionally hit the `runc` error.

Fixes: https://hashicorp.atlassian.net/browse/NMD-297
Fixes: https://github.com/hashicorp/nomad/issues/7731
Ref: https://go.hashi.co/rfc/nmd-211

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.

Running a node with `client.cpu.total_compute = 300000` and a task with `resources.cpu = 270000`:

```
$ nomad alloc status a8e34427
...
Task "task" is "running"
Task Resources:
CPU           Memory           Disk     Addresses
0/270000 MHz  136 KiB/100 MiB  300 MiB
...

$ nomad node status -verbose 4c4c4544
...
Allocated Resources
CPU                Memory          Disk             Alloc Count
270000/300000 MHz  100 MiB/31 GiB  300 MiB/6.2 GiB  1
...

$ sudo cat /sys/fs/cgroup/system.slice/docker-a4c924de12f5270b6c94eb0e3f3a2124be4d0eff2eb82c8516b2b85e679629bb.scope/cpu.weight
9000
```


- [x] ~**Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).~ Documentation improvements will be in a separate PR: https://github.com/hashicorp/nomad/pull/25964

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
