### PR TITLE
Stream variable state change event

### DIFF
--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2304,17 +2304,17 @@ func (n *nomadFSM) applyVariableOperation(msgType structs.MessageType, buf []byt
 		[]metrics.Label{{Name: "op", Value: string(req.Op)}})
 	switch req.Op {
 	case structs.VarOpSet:
-		return n.state.VarSet(index, &req)
+		return n.state.VarSet(msgType, index, &req)
 	case structs.VarOpDelete:
-		return n.state.VarDelete(index, &req)
+		return n.state.VarDelete(msgType, index, &req)
 	case structs.VarOpDeleteCAS:
-		return n.state.VarDeleteCAS(index, &req)
+		return n.state.VarDeleteCAS(msgType, index, &req)
 	case structs.VarOpCAS:
-		return n.state.VarSetCAS(index, &req)
+		return n.state.VarSetCAS(msgType, index, &req)
 	case structs.VarOpLockAcquire:
-		return n.state.VarLockAcquire(index, &req)
+		return n.state.VarLockAcquire(msgType, index, &req)
 	case structs.VarOpLockRelease:
-		return n.state.VarLockRelease(index, &req)
+		return n.state.VarLockRelease(msgType, index, &req)
 	default:
 		err := fmt.Errorf("Invalid variable operation '%s'", req.Op)
 		n.logger.Warn("Invalid variable operation", "operation", req.Op)

--- a/nomad/state/state_store_variables.go
+++ b/nomad/state/state_store_variables.go
@@ -121,8 +121,8 @@ func (s *StateStore) GetVariable(
 }
 
 // VarSet is used to store a variable object.
-func (s *StateStore) VarSet(idx uint64, sv *structs.VarApplyStateRequest) *structs.VarApplyStateResponse {
-	tx := s.db.WriteTxn(idx)
+func (s *StateStore) VarSet(msgType structs.MessageType, idx uint64, sv *structs.VarApplyStateRequest) *structs.VarApplyStateResponse {
+	tx := s.db.WriteTxnMsgT(msgType, idx)
 	defer tx.Abort()
 
 	// Perform the actual set.
@@ -140,8 +140,8 @@ func (s *StateStore) VarSet(idx uint64, sv *structs.VarApplyStateRequest) *struc
 // VarSetCAS is used to do a check-and-set operation on a
 // variable. The ModifyIndex in the provided entry is used to determine if
 // we should write the entry to the state store or not.
-func (s *StateStore) VarSetCAS(idx uint64, sv *structs.VarApplyStateRequest) *structs.VarApplyStateResponse {
-	tx := s.db.WriteTxn(idx)
+func (s *StateStore) VarSetCAS(msgType structs.MessageType, idx uint64, sv *structs.VarApplyStateRequest) *structs.VarApplyStateResponse {
+	tx := s.db.WriteTxnMsgT(msgType, idx)
 	defer tx.Abort()
 
 	resp := s.varSetCASTxn(tx, idx, sv)
@@ -299,8 +299,8 @@ func (s *StateStore) varSetTxn(tx WriteTxn, idx uint64, req *structs.VarApplySta
 
 // VarDelete is used to delete a single variable in the
 // the state store.
-func (s *StateStore) VarDelete(idx uint64, req *structs.VarApplyStateRequest) *structs.VarApplyStateResponse {
-	tx := s.db.WriteTxn(idx)
+func (s *StateStore) VarDelete(msgType structs.MessageType, idx uint64, req *structs.VarApplyStateRequest) *structs.VarApplyStateResponse {
+	tx := s.db.WriteTxnMsgT(msgType, idx)
 	defer tx.Abort()
 
 	// Perform the actual delete
@@ -321,8 +321,8 @@ func (s *StateStore) VarDelete(idx uint64, req *structs.VarApplyStateRequest) *s
 // a given modify index. If the CAS index (cidx) specified is not equal to the
 // last observed index for the given variable, then the call is a noop,
 // otherwise a normal delete is invoked.
-func (s *StateStore) VarDeleteCAS(idx uint64, req *structs.VarApplyStateRequest) *structs.VarApplyStateResponse {
-	tx := s.db.WriteTxn(idx)
+func (s *StateStore) VarDeleteCAS(msgType structs.MessageType, idx uint64, req *structs.VarApplyStateRequest) *structs.VarApplyStateResponse {
+	tx := s.db.WriteTxnMsgT(msgType, idx)
 	defer tx.Abort()
 
 	resp := s.svDeleteCASTxn(tx, idx, req)
@@ -484,9 +484,9 @@ func (s *StateStore) VariablesQuotaByNamespace(ws memdb.WatchSet, namespace stri
 // VarLockAcquire is the method used to append a lock to a variable, if the
 // variable doesn't exists, it is created.
 // IMPORTANT: this method overwrites the variable, data included.
-func (s *StateStore) VarLockAcquire(idx uint64,
+func (s *StateStore) VarLockAcquire(msgType structs.MessageType, idx uint64,
 	req *structs.VarApplyStateRequest) *structs.VarApplyStateResponse {
-	tx := s.db.WriteTxn(idx)
+	tx := s.db.WriteTxnMsgT(msgType, idx)
 	defer tx.Abort()
 
 	// Try to fetch the variable.
@@ -521,9 +521,9 @@ func (s *StateStore) VarLockAcquire(idx uint64,
 	return resp
 }
 
-func (s *StateStore) VarLockRelease(idx uint64,
+func (s *StateStore) VarLockRelease(msgType structs.MessageType, idx uint64,
 	req *structs.VarApplyStateRequest) *structs.VarApplyStateResponse {
-	tx := s.db.WriteTxn(idx)
+	tx := s.db.WriteTxnMsgT(msgType, idx)
 	defer tx.Abort()
 
 	// Look up the entry in the state store.

--- a/nomad/structs/event.go
+++ b/nomad/structs/event.go
@@ -35,6 +35,7 @@ const (
 	TopicCSIVolume      Topic = "CSIVolume"
 	TopicCSIPlugin      Topic = "CSIPlugin"
 	TopicOperator       Topic = "Operator"
+	TopicVariable       Topic = "Variable"
 	TopicAll            Topic = "*"
 
 	TypeNodeRegistration              = "NodeRegistration"
@@ -73,6 +74,7 @@ const (
 	TypeCSIVolumeDeregistered         = "CSIVolumeDeregistered"
 	TypeCSIVolumeClaim                = "CSIVolumeClaim"
 	TypeUtilizationSnapshotUpserted   = "UtilizationSnapshotUpserted"
+	TypeVariableStateChanged          = "VariableStateChanged"
 )
 
 // Event represents a change in Nomads state.
@@ -215,4 +217,10 @@ type CSIVolumeEvent struct {
 // used as an event in the event stream
 type CSIPluginEvent struct {
 	Plugin *CSIPlugin
+}
+
+// VariableEvent holds state of variable to be
+// used as an event in the event stream
+type VariableEvent struct {
+	Variable *VariableEncrypted
 }


### PR DESCRIPTION
### Description
This is a suggestion pr for resolving issue https://github.com/hashicorp/nomad/issues/25899. It is draft and no testing change made yet demonstrate functionality I need. I did not change state of db purposefully to avoid any breaking change, and current state of streamed event is satisfactory for what I want to achieve. Change in variable will be reflected in events api, and the type of change I can infer from checking variables endpoint(update or delete)

Fixes: https://github.com/hashicorp/nomad/issues/25899
Fixes: https://hashicorp.atlassian.net/browse/NMD-773

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
