### PR TITLE
drainer: Fix data race within test by correctly copying alloc.

### DIFF
--- a/nomad/drainer/watch_jobs_test.go
+++ b/nomad/drainer/watch_jobs_test.go
@@ -193,7 +193,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		replacement.NodeID = runningNode.ID
 		// start in pending state with no health status
 
-		updates = append(updates, a, replacement)
+		updates = append(updates, a.Copy(), replacement)
 		replacements[i] = replacement.Copy()
 	}
 	must.NoError(t, store.UpsertAllocs(structs.MsgTypeTestSetup, index, updates))
@@ -254,7 +254,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		a.ClientStatus = structs.AllocClientStatusComplete
 
 		replacement := newAlloc(runningNode, a.Job)
-		updates = append(updates, a, replacement)
+		updates = append(updates, a.Copy(), replacement)
 		replacements[i] = replacement.Copy()
 	}
 	must.NoError(t, store.UpsertAllocs(structs.MsgTypeTestSetup, index, updates))
@@ -298,7 +298,7 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		a.ClientStatus = structs.AllocClientStatusComplete
 
 		replacement := newAlloc(runningNode, a.Job)
-		updates = append(updates, a, replacement)
+		updates = append(updates, a.Copy(), replacement)
 		replacements[i] = replacement.Copy()
 	}
 	must.NoError(t, store.UpsertAllocs(structs.MsgTypeTestSetup, index, updates))


### PR DESCRIPTION
Some test cases were writing the same allocation object (memory pointer) to Nomad state in subsequant upsert calls. This causes a race condition with the drainer job watcher which reads the same object from Nomad state to perform conditional checks.

The data race is fixed by ensuring the allocation is copied between writes.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
