### PR TITLE
rpc: Fix data race in yamux config modification for conn handling.

### DIFF
--- a/helper/pool/pool_test.go
+++ b/helper/pool/pool_test.go
@@ -5,10 +5,12 @@ package pool
 
 import (
 	"fmt"
+	"math"
 	"net"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/yamux"
@@ -19,6 +21,19 @@ func newTestPool(t *testing.T) *ConnPool {
 	l := testlog.HCLogger(t)
 	p := NewPool(l, 1*time.Minute, 10, nil, yamux.DefaultConfig())
 	return p
+}
+
+func Test_NewPool(t *testing.T) {
+
+	// Generate a custom yamux configuration, so we can ensure this gets stored
+	// as expected.
+	yamuxConfig := yamux.DefaultConfig()
+	yamuxConfig.AcceptBacklog = math.MaxInt
+
+	testPool := NewPool(hclog.NewNullLogger(), 10*time.Second, 10, nil, yamuxConfig)
+	must.NotNil(t, testPool)
+	must.NotNil(t, testPool.yamuxCfg)
+	must.Eq(t, yamuxConfig.AcceptBacklog, testPool.yamuxCfg.AcceptBacklog)
 }
 
 func TestConnPool_ConnListener(t *testing.T) {


### PR DESCRIPTION
The server RPC handler and RPC connection pool both use a shared configuration object for custom yamux configuration. Both sub-systems were modifying the shared object which could cause a data race. The passed object is now cloned before being modified.

This changes also moves where the yamux configuration is cloned and modified to the relevant constructor function. This avoids performing a clone per connection handle or per new connection generated in the RPC pool.

<details>

<summary>data race</summary>

```console
WARNING: DATA RACE
Write at 0x00c0003745d8 by goroutine 235:
  github.com/hashicorp/nomad/nomad.(*rpcHandler).handleMultiplexV2()
      github.com/hashicorp/nomad/nomad/rpc.go:522 +0xd4
  github.com/hashicorp/nomad/nomad.(*rpcHandler).handleConn()
      github.com/hashicorp/nomad/nomad/rpc.go:393 +0x7a4
  github.com/hashicorp/nomad/nomad.(*rpcHandler).listen.gowrap2()
      github.com/hashicorp/nomad/nomad/rpc.go:224 +0x70

Previous write at 0x00c0003745d8 by goroutine 233:
  github.com/hashicorp/nomad/helper/pool.(*ConnPool).getNewConn()
      github.com/hashicorp/nomad/helper/pool/pool.go:399 +0x1ac
  github.com/hashicorp/nomad/helper/pool.(*ConnPool).acquire()
      github.com/hashicorp/nomad/helper/pool/pool.go:317 +0x32c
  github.com/hashicorp/nomad/helper/pool.(*ConnPool).getRPCClient()
      github.com/hashicorp/nomad/helper/pool/pool.go:448 +0x58
  github.com/hashicorp/nomad/helper/pool.(*ConnPool).RPC()
      github.com/hashicorp/nomad/helper/pool/pool.go:493 +0x68
  github.com/hashicorp/nomad/nomad.(*StatsFetcher).fetch()
      github.com/hashicorp/nomad/nomad/stats_fetcher.go:68 +0x370
  github.com/hashicorp/nomad/nomad.(*StatsFetcher).Fetch.gowrap1()
      github.com/hashicorp/nomad/nomad/stats_fetcher.go:97 +0x4c

Goroutine 235 (running) created at:
  github.com/hashicorp/nomad/nomad.(*rpcHandler).listen()
      github.com/hashicorp/nomad/nomad/rpc.go:224 +0x5f0
  github.com/hashicorp/nomad/nomad.(*Server).startRPCListener.gowrap1()
      github.com/hashicorp/nomad/nomad/server.go:576 +0x4c

Goroutine 233 (running) created at:
  github.com/hashicorp/nomad/nomad.(*StatsFetcher).Fetch()
      github.com/hashicorp/nomad/nomad/stats_fetcher.go:97 +0x498
  github.com/hashicorp/nomad/nomad.(*AutopilotDelegate).FetchServerStats()
      github.com/hashicorp/nomad/nomad/autopilot.go:60 +0x68
  github.com/hashicorp/raft-autopilot.(*Autopilot).gatherNextStateInputs()
      github.com/hashicorp/raft-autopilot@v0.1.6/state.go:160 +0xc08
  github.com/hashicorp/raft-autopilot.(*Autopilot).nextState()
      github.com/hashicorp/raft-autopilot@v0.1.6/state.go:171 +0x38
  github.com/hashicorp/raft-autopilot.(*Autopilot).updateState()
      github.com/hashicorp/raft-autopilot@v0.1.6/state.go:384 +0x3c
  github.com/hashicorp/raft-autopilot.(*Autopilot).Start()
      github.com/hashicorp/raft-autopilot@v0.1.6/run.go:37 +0x77c
  github.com/hashicorp/nomad/nomad.(*Server).establishLeadership()
      github.com/hashicorp/nomad/nomad/leader.go:375 +0xf8
  github.com/hashicorp/nomad/nomad.(*Server).leaderLoop()
      github.com/hashicorp/nomad/nomad/leader.go:252 +0x2ac
  github.com/hashicorp/nomad/nomad.(*Server).monitorLeadership.func1.1()
      github.com/hashicorp/nomad/nomad/leader.go:112 +0x7c
  github.com/hashicorp/nomad/nomad.(*Server).monitorLeadership.func1.gowrap1()
      github.com/hashicorp/nomad/nomad/leader.go:113 +0x44
```

</details>

### Testing & Reproduction steps
Build Nomad locally with the `-race` flag and run a dev agent with and without this change.

I think the race in this form originates due to https://github.com/hashicorp/nomad/issues/25032. That being said, I still think the change is worthwhile and makes sense.

### Links
Related: #25466

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
