### PR TITLE
ci: windows 2022 runners (upcoming 2019 eol)

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -5,7 +5,7 @@ self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
     - custom-windows-medium
-    - windows-2019-16core
+    - windows-2022-16core
     - custom-linux-xxl-nomad-20.04
     - custom-linux-xl-nomad-22.04
     - custom-ubuntu-22.04-xl

--- a/.github/workflows/test-core.yaml
+++ b/.github/workflows/test-core.yaml
@@ -68,7 +68,7 @@ jobs:
           - ubuntu-22.04
           - ubuntu-22.04-arm
           - macos-14
-          - windows-2019
+          - windows-2022
     runs-on: ${{ (endsWith(github.repository, '-enterprise')) && (matrix.os == 'ubuntu-22.04-arm') && fromJSON('["self-hosted", "ubuntu-22.04-arm64"]') || matrix.os }}
     timeout-minutes: 20
     steps:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -43,7 +43,7 @@ env:
   VAULT_VERSION: 1.4.1
 jobs:
   test-windows:
-    runs-on: 'windows-2019-16core'
+    runs-on: 'windows-2022-16core'
     env:
       GOTESTSUM_PATH: c:\tmp\test-reports
     steps:
@@ -72,7 +72,7 @@ jobs:
       - name: Pre-download docker test image
         shell: bash
         run: |-
-          docker pull docker.mirror.hashicorp.services/hashicorpdev/busybox-windows:ltsc2019
+          docker pull docker.mirror.hashicorp.services/hashicorpdev/busybox-windows:ltsc2022
       - name: Build nomad
         shell: bash
         run: |-
@@ -80,7 +80,7 @@ jobs:
       - name: Run tests with gotestsum
         shell: bash
         env:
-          BUSYBOX_IMAGE: docker.mirror.hashicorp.services/hashicorpdev/busybox-windows:ltsc2019
+          BUSYBOX_IMAGE: docker.mirror.hashicorp.services/hashicorpdev/busybox-windows:ltsc2022
         run: |-
           # Only test docker driver tests for now
           export PATH=/c/go/bin:/c/gopath/bin:$PATH


### PR DESCRIPTION
~Naively optimistic~ fix for

> This is a scheduled Windows Server 2019 brownout. The Windows Server 2019 image will be removed on 2025-06-30. For more details, see https://github.com/actions/runner-images/issues/12045
