### PR TITLE
network: Support IPv6 only interfaces in CNI

### DIFF
--- a/client/allocrunner/networking_cni_test.go
+++ b/client/allocrunner/networking_cni_test.go
@@ -465,6 +465,31 @@ func TestCNI_cniToAllocNet_Invalid(t *testing.T) {
 	require.Nil(t, allocNet)
 }
 
+func TestCNI_cniToAllocNet_IPv6(t *testing.T) {
+	ci.Parallel(t)
+
+	cniResult := &cni.Result{
+		Interfaces: map[string]*cni.Config{
+			"eth0": {
+				Sandbox: "at-the-park",
+				IPConfigs: []*cni.IPConfig{
+					{IP: net.IPv6zero}, // ::
+				},
+			},
+		},
+	}
+
+	c := &cniNetworkConfigurator{
+		logger: testlog.HCLogger(t),
+	}
+	allocNet, err := c.cniToAllocNet(cniResult)
+	must.NoError(t, err)
+	must.NotNil(t, allocNet)
+	test.Eq(t, "::", allocNet.Address)
+	test.Eq(t, "::", allocNet.AddressIPv6)
+	test.Eq(t, "eth0", allocNet.InterfaceName)
+}
+
 func TestCNI_cniToAllocNet_Dualstack(t *testing.T) {
 	ci.Parallel(t)
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -12096,15 +12096,20 @@ func (s *NodeScoreMeta) Data() interface{} {
 // systems in Nomad such as service registration.
 type AllocNetworkStatus struct {
 	InterfaceName string
-	Address       string
-	AddressIPv6   string
-	DNS           *DNSConfig
+	// Address is the IP allocation of the address.
+	// If the interface is IPv6 only, this value will be V6 too.
+	Address string
+	// AddressIPv6 is the IP allocation of the address. If the iface is IPv4 only,
+	// this will be empty.
+	AddressIPv6 string
+	DNS         *DNSConfig
 }
 
 func (a *AllocNetworkStatus) Copy() *AllocNetworkStatus {
 	if a == nil {
 		return nil
 	}
+
 	return &AllocNetworkStatus{
 		InterfaceName: a.InterfaceName,
 		Address:       a.Address,


### PR DESCRIPTION
### Description
In previous versions, Nomad supported IPv6 only interfaces by simply setting the V6 value in `Address`. This worked until the move to `AddressV6` in the networking CNI code, making interfaces that only use IPv6 unable to be used.

This commit tries to come back to that behaviour, where Address could also be a V6.

The reason we are not renaming to AddressIPv4 is to be retrocompatible with stored allocation networks on places like BoltDB.


### Testing & Reproduction steps
Try to setup a CNI allocation on an IPv6 only iface. Easy to repro on the unit test.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
