### PR TITLE
scheduler: isolate reconciliation code

### DIFF
--- a/ci/test-core.json
+++ b/ci/test-core.json
@@ -46,6 +46,7 @@
     "nomad/volumewatcher/...",
     "plugins/...",
     "scheduler/...",
+    "scheduler/reconcile/...",
     "testutil/..."
   ]
 }

--- a/scheduler/README.md
+++ b/scheduler/README.md
@@ -33,8 +33,9 @@ in more detail:
 ## Reconciliation
 
 The first step for the service and bach job scheduler is called
-"reconciliation," and its logic lies in the `scheduler/reconciler` package. There are two reconcilers: 
-`AllocReconciler` object for service and batch jobs, and `Node` reconciler used by system and sysbatch jobs. 
+"reconciliation," and its logic lies in the `scheduler/reconciler` package.
+There are two reconcilers: `AllocReconciler` object for service and batch jobs,
+and `Node` reconciler used by system and sysbatch jobs.
 
 Both reconciler's task is to tell the scheduler about desired allocations or
 deployments to be updated or created, which should be updated destructively or
@@ -177,7 +178,7 @@ feasibility iterators that live in `scheduler/feasible.go` to filter by:
 
 - node eligibiligy,
 - data center,
-- and node pool. 
+- and node pool.
 
 Once nodes are filtered, the `Stack` implementations (`GenericStack` and
 `SystemStack`) check for:

--- a/scheduler/README.md
+++ b/scheduler/README.md
@@ -30,19 +30,20 @@ in more detail:
                                  +--------------+        +-----------+       +-------------+                           +----------+
 ```
 
-## Cluster reconciliation
+## Reconciliation
 
 The first step for the service and bach job scheduler is called
-"reconciliation," and its logic lies in `scheduler/reconcile.go` file. The
-`allocReconciler` object has one public method: `Compute`, which takes no
-arguments and returns `reconcileResults` object. This results object tells the
-scheduler about desired deployment to be updated or created, which allocations
-to place, which should be updated destructively or in-place, which should be
-stopped, and which are disconnected or are reconnecting. The reconciler works
-in terms of "buckets," that is, it processes allocations by putting them into
-different sets, and that's how its whole logic is implemented.
+"reconciliation," and its logic lies in the `scheduler/reconciler` package. There are two reconcilers: 
+`AllocReconciler` object for service and batch jobs, and `Node` reconciler used by system and sysbatch jobs. 
 
-The following vocabulary is used by the reconciler:
+Both reconciler's task is to tell the scheduler about desired allocations or
+deployments to be updated or created, which should be updated destructively or
+in-place, which should be stopped, and which are disconnected or are
+reconnecting. The reconciler works in terms of "buckets," that is, it processes
+allocations by putting them into different sets, and that's how its whole logic
+is implemented.
+
+The following vocabulary is used by the reconcilers:
 
 - "tainted node:" a node is considered "tainted" if allocations must be migrated
 off of it. These are nodes that are draining or have been drained, but also
@@ -73,6 +74,8 @@ status, but also when it's pending or initializing.
 
   - "expiring allocations:" allocations which are not possible to reschedule, due
      to lost configurations of their disconnected clients.
+
+### Cluster Reconciler
 
 The following diagram illustrates the logic flow of the cluster reconciler:
 
@@ -160,6 +163,10 @@ The following diagram illustrates the logic flow of the cluster reconciler:
         |return a.result|
         +---------------+
 ```
+
+### Node Reconciler
+
+TODO
 
 ## Feasibility checking
 

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler/reconcile"
-	"github.com/hashicorp/nomad/scheduler/status"
+	sstructs "github.com/hashicorp/nomad/scheduler/structs"
 )
 
 const (
@@ -191,9 +191,9 @@ func (s *GenericScheduler) createBlockedEval(planFailure bool) error {
 	s.blocked = s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs)
 	if planFailure {
 		s.blocked.TriggeredBy = structs.EvalTriggerMaxPlans
-		s.blocked.StatusDescription = status.BlockedEvalMaxPlanDesc
+		s.blocked.StatusDescription = sstructs.BlockedEvalMaxPlanDesc
 	} else {
-		s.blocked.StatusDescription = status.BlockedEvalFailedPlacements
+		s.blocked.StatusDescription = sstructs.BlockedEvalFailedPlacements
 	}
 
 	return s.planner.CreateEval(s.blocked)

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -191,9 +191,9 @@ func (s *GenericScheduler) createBlockedEval(planFailure bool) error {
 	s.blocked = s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs)
 	if planFailure {
 		s.blocked.TriggeredBy = structs.EvalTriggerMaxPlans
-		s.blocked.StatusDescription = sstructs.BlockedEvalMaxPlanDesc
+		s.blocked.StatusDescription = sstructs.DescBlockedEvalMaxPlan
 	} else {
-		s.blocked.StatusDescription = sstructs.BlockedEvalFailedPlacements
+		s.blocked.StatusDescription = sstructs.DescBlockedEvalFailedPlacements
 	}
 
 	return s.planner.CreateEval(s.blocked)

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -16,6 +16,8 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/scheduler/reconcile"
+	"github.com/hashicorp/nomad/scheduler/status"
 )
 
 const (
@@ -26,52 +28,6 @@ const (
 	// maxBatchScheduleAttempts is used to limit the number of times
 	// we will attempt to schedule if we continue to hit conflicts for batch.
 	maxBatchScheduleAttempts = 2
-
-	// allocNotNeeded is the status used when a job no longer requires an allocation
-	allocNotNeeded = "alloc not needed due to job update"
-
-	// allocReconnected is the status to use when a replacement allocation is stopped
-	// because a disconnected node reconnects.
-	allocReconnected = "alloc not needed due to disconnected client reconnect"
-
-	// allocMigrating is the status used when we must migrate an allocation
-	allocMigrating = "alloc is being migrated"
-
-	// allocUpdating is the status used when a job requires an update
-	allocUpdating = "alloc is being updated due to job update"
-
-	// allocLost is the status used when an allocation is lost
-	allocLost = "alloc is lost since its node is down"
-
-	// allocUnknown is the status used when an allocation is unknown
-	allocUnknown = "alloc is unknown since its node is disconnected"
-
-	// allocInPlace is the status used when speculating on an in-place update
-	allocInPlace = "alloc updating in-place"
-
-	// allocNodeTainted is the status used when stopping an alloc because its
-	// node is tainted.
-	allocNodeTainted = "alloc not needed as node is tainted"
-
-	// allocRescheduled is the status used when an allocation failed and was rescheduled
-	allocRescheduled = "alloc was rescheduled because it failed"
-
-	// blockedEvalMaxPlanDesc is the description used for blocked evals that are
-	// a result of hitting the max number of plan attempts
-	blockedEvalMaxPlanDesc = "created due to placement conflicts"
-
-	// blockedEvalFailedPlacements is the description used for blocked evals
-	// that are a result of failing to place all allocations.
-	blockedEvalFailedPlacements = "created to place remaining allocations"
-
-	// reschedulingFollowupEvalDesc is the description used when creating follow
-	// up evals for delayed rescheduling
-	reschedulingFollowupEvalDesc = "created for delayed rescheduling"
-
-	// disconnectTimeoutFollowupEvalDesc is the description used when creating follow
-	// up evals for allocations that be should be stopped after its disconnect
-	// timeout has passed.
-	disconnectTimeoutFollowupEvalDesc = "created for delayed disconnect timeout"
 
 	// maxPastRescheduleEvents is the maximum number of past reschedule event
 	// that we track when unlimited rescheduling is enabled
@@ -235,9 +191,9 @@ func (s *GenericScheduler) createBlockedEval(planFailure bool) error {
 	s.blocked = s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs)
 	if planFailure {
 		s.blocked.TriggeredBy = structs.EvalTriggerMaxPlans
-		s.blocked.StatusDescription = blockedEvalMaxPlanDesc
+		s.blocked.StatusDescription = status.BlockedEvalMaxPlanDesc
 	} else {
-		s.blocked.StatusDescription = blockedEvalFailedPlacements
+		s.blocked.StatusDescription = status.BlockedEvalFailedPlacements
 	}
 
 	return s.planner.CreateEval(s.blocked)
@@ -381,54 +337,53 @@ func (s *GenericScheduler) computeJobAllocs() error {
 	// nodes to lost, but only if the scheduler has already marked them
 	updateNonTerminalAllocsToLost(s.plan, tainted, allocs)
 
-	reconciler := NewAllocReconciler(s.logger,
+	r := reconcile.NewAllocReconciler(s.logger,
 		genericAllocUpdateFn(s.ctx, s.stack, s.eval.ID),
 		s.batch, s.eval.JobID, s.job, s.deployment, allocs, tainted, s.eval.ID,
 		s.eval.Priority, s.planner.ServersMeetMinimumVersion(minVersionMaxClientDisconnect, true))
-
-	results := reconciler.Compute()
-	s.logger.Debug("reconciled current state with desired state", "results", log.Fmt("%#v", results))
+	r.Compute()
+	s.logger.Debug("reconciled current state with desired state", "results", log.Fmt("%#v", r.Result))
 
 	if s.eval.AnnotatePlan {
 		s.plan.Annotations = &structs.PlanAnnotations{
-			DesiredTGUpdates: results.desiredTGUpdates,
+			DesiredTGUpdates: r.Result.DesiredTGUpdates,
 		}
 	}
 
 	// Add the deployment changes to the plan
-	s.plan.Deployment = results.deployment
-	s.plan.DeploymentUpdates = results.deploymentUpdates
+	s.plan.Deployment = r.Result.Deployment
+	s.plan.DeploymentUpdates = r.Result.DeploymentUpdates
 
 	// Store all the follow up evaluations from rescheduled allocations
-	if len(results.desiredFollowupEvals) > 0 {
-		for _, evals := range results.desiredFollowupEvals {
+	if len(r.Result.DesiredFollowupEvals) > 0 {
+		for _, evals := range r.Result.DesiredFollowupEvals {
 			s.followUpEvals = append(s.followUpEvals, evals...)
 		}
 	}
 
 	// Update the stored deployment
-	if results.deployment != nil {
-		s.deployment = results.deployment
+	if r.Result.Deployment != nil {
+		s.deployment = r.Result.Deployment
 	}
 
 	// Handle the stop
-	for _, stop := range results.stop {
-		s.plan.AppendStoppedAlloc(stop.alloc, stop.statusDescription, stop.clientStatus, stop.followupEvalID)
+	for _, stop := range r.Result.Stop {
+		s.plan.AppendStoppedAlloc(stop.Alloc, stop.StatusDescription, stop.ClientStatus, stop.FollowupEvalID)
 	}
 
 	// Handle disconnect updates
-	for _, update := range results.disconnectUpdates {
+	for _, update := range r.Result.DisconnectUpdates {
 		s.plan.AppendUnknownAlloc(update)
 	}
 
 	// Handle reconnect updates.
 	// Reconnected allocs have a new AllocState entry.
-	for _, update := range results.reconnectUpdates {
+	for _, update := range r.Result.ReconnectUpdates {
 		s.ctx.Plan().AppendAlloc(update, nil)
 	}
 
 	// Handle the in-place updates
-	for _, update := range results.inplaceUpdate {
+	for _, update := range r.Result.InplaceUpdate {
 		if update.DeploymentID != s.deployment.GetID() {
 			update.DeploymentID = s.deployment.GetID()
 			update.DeploymentStatus = nil
@@ -437,12 +392,12 @@ func (s *GenericScheduler) computeJobAllocs() error {
 	}
 
 	// Handle the annotation updates
-	for _, update := range results.attributeUpdates {
+	for _, update := range r.Result.AttributeUpdates {
 		s.ctx.Plan().AppendAlloc(update, nil)
 	}
 
 	// Nothing remaining to do if placement is not required
-	if len(results.place)+len(results.destructiveUpdate) == 0 {
+	if len(r.Result.Place)+len(r.Result.DestructiveUpdate) == 0 {
 		// If the job has been purged we don't have access to the job. Otherwise
 		// set the queued allocs to zero. This is true if the job is being
 		// stopped as well.
@@ -455,23 +410,23 @@ func (s *GenericScheduler) computeJobAllocs() error {
 	}
 
 	// Compute the placements
-	place := make([]placementResult, 0, len(results.place))
-	for _, p := range results.place {
-		s.queuedAllocs[p.taskGroup.Name] += 1
+	place := make([]reconcile.PlacementResult, 0, len(r.Result.Place))
+	for _, p := range r.Result.Place {
+		s.queuedAllocs[p.TaskGroup().Name] += 1
 		place = append(place, p)
 	}
 
-	destructive := make([]placementResult, 0, len(results.destructiveUpdate))
-	for _, p := range results.destructiveUpdate {
-		s.queuedAllocs[p.placeTaskGroup.Name] += 1
+	destructive := make([]reconcile.PlacementResult, 0, len(r.Result.DestructiveUpdate))
+	for _, p := range r.Result.DestructiveUpdate {
+		s.queuedAllocs[p.TaskGroup().Name] += 1
 		destructive = append(destructive, p)
 	}
-	return s.computePlacements(destructive, place, results.taskGroupAllocNameIndexes)
+	return s.computePlacements(destructive, place, r.Result.TaskGroupAllocNameIndexes)
 }
 
 // downgradedJobForPlacement returns the previous stable version of the job for
 // downgrading a placement for non-canaries
-func (s *GenericScheduler) downgradedJobForPlacement(p placementResult) (string, *structs.Job, error) {
+func (s *GenericScheduler) downgradedJobForPlacement(p reconcile.PlacementResult) (string, *structs.Job, error) {
 	ns, jobID := s.job.Namespace, s.job.ID
 	tgName := p.TaskGroup().Name
 
@@ -509,7 +464,9 @@ func (s *GenericScheduler) downgradedJobForPlacement(p placementResult) (string,
 
 // computePlacements computes placements for allocations. It is given the set of
 // destructive updates to place and the set of new placements to place.
-func (s *GenericScheduler) computePlacements(destructive, place []placementResult, nameIndex map[string]*allocNameIndex) error {
+func (s *GenericScheduler) computePlacements(
+	destructive, place []reconcile.PlacementResult, nameIndex map[string]*reconcile.AllocNameIndex,
+) error {
 
 	// Get the base nodes
 	nodes, byDC, err := s.setNodes(s.job)
@@ -528,7 +485,7 @@ func (s *GenericScheduler) computePlacements(destructive, place []placementResul
 	// Have to handle destructive changes first as we need to discount their
 	// resources. To understand this imagine the resources were reduced and the
 	// count was scaled up.
-	for _, results := range [][]placementResult{destructive, place} {
+	for _, results := range [][]reconcile.PlacementResult{destructive, place} {
 		for _, missing := range results {
 			// Get the task group
 			tg := missing.TaskGroup()
@@ -880,7 +837,7 @@ func updateRescheduleTracker(alloc *structs.Allocation, prev *structs.Allocation
 }
 
 // findPreferredNode finds the preferred node for an allocation
-func (s *GenericScheduler) findPreferredNode(place placementResult) (*structs.Node, error) {
+func (s *GenericScheduler) findPreferredNode(place reconcile.PlacementResult) (*structs.Node, error) {
 	prev := place.PreviousAllocation()
 	if prev == nil {
 		return nil, nil
@@ -929,7 +886,7 @@ func (s *GenericScheduler) selectNextOption(tg *structs.TaskGroup, selectOptions
 }
 
 // handlePreemptions sets relevant preeemption related fields.
-func (s *GenericScheduler) handlePreemptions(option *RankedNode, alloc *structs.Allocation, missing placementResult) {
+func (s *GenericScheduler) handlePreemptions(option *RankedNode, alloc *structs.Allocation, missing reconcile.PlacementResult) {
 	if option.PreemptedAllocs == nil {
 		return
 	}

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/scheduler/reconcile"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 )
@@ -7048,9 +7049,8 @@ func TestDowngradedJobForPlacement_PicksTheLatest(t *testing.T) {
 
 			sched.job = nj
 			sched.deployment = deployment
-			placement := &allocPlaceResult{
-				taskGroup: nj.TaskGroups[0],
-			}
+			placement := &reconcile.AllocPlaceResult{}
+			placement.SetTaskGroup(nj.TaskGroups[0])
 
 			// Here, assert the downgraded job version
 			foundDeploymentID, foundJob, err := sched.downgradedJobForPlacement(placement)

--- a/scheduler/reconcile/allocs.go
+++ b/scheduler/reconcile/allocs.go
@@ -84,12 +84,12 @@ func (a AllocPlaceResult) PreviousAllocation() *structs.Allocation { return a.pr
 func (a AllocPlaceResult) SetPreviousAllocation(alloc *structs.Allocation) {
 	a.previousAlloc = alloc
 }
-func (a AllocPlaceResult) IsRescheduling() bool               { return a.reschedule }
-func (a AllocPlaceResult) StopPreviousAlloc() (bool, string)  { return false, "" }
-func (a AllocPlaceResult) DowngradeNonCanary() bool           { return a.downgradeNonCanary }
-func (a AllocPlaceResult) MinJobVersion() uint64              { return a.minJobVersion }
-func (a AllocPlaceResult) PreviousLost() bool                 { return a.lost }
-func (a AllocPlaceResult) SetTaskGroup(tg *structs.TaskGroup) { a.taskGroup = tg }
+func (a AllocPlaceResult) IsRescheduling() bool                { return a.reschedule }
+func (a AllocPlaceResult) StopPreviousAlloc() (bool, string)   { return false, "" }
+func (a AllocPlaceResult) DowngradeNonCanary() bool            { return a.downgradeNonCanary }
+func (a AllocPlaceResult) MinJobVersion() uint64               { return a.minJobVersion }
+func (a AllocPlaceResult) PreviousLost() bool                  { return a.lost }
+func (a *AllocPlaceResult) SetTaskGroup(tg *structs.TaskGroup) { a.taskGroup = tg }
 
 // allocDestructiveResult contains the information required to do a destructive
 // update. Destructive changes should be applied atomically, as in the old alloc

--- a/scheduler/reconcile/allocs_test.go
+++ b/scheduler/reconcile/allocs_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package scheduler
+package reconcile
 
 import (
 	"testing"
@@ -1554,7 +1554,7 @@ func Test_allocNameIndex_Highest(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		inputAllocNameIndex *allocNameIndex
+		inputAllocNameIndex *AllocNameIndex
 		inputN              uint
 		expectedOutput      map[string]struct{}
 	}{
@@ -1651,7 +1651,7 @@ func Test_allocNameIndex_NextCanaries(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		inputAllocNameIndex *allocNameIndex
+		inputAllocNameIndex *AllocNameIndex
 		inputN              uint
 		inputExisting       allocSet
 		inputDestructive    allocSet
@@ -1716,7 +1716,7 @@ func Test_allocNameIndex_Next(t *testing.T) {
 
 	testCases := []struct {
 		name                string
-		inputAllocNameIndex *allocNameIndex
+		inputAllocNameIndex *AllocNameIndex
 		inputN              uint
 		expectedOutput      []string
 	}{

--- a/scheduler/reconcile/reconcile_cluster.go
+++ b/scheduler/reconcile/reconcile_cluster.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/hashicorp/nomad/scheduler/status"
+	sstructs "github.com/hashicorp/nomad/scheduler/structs"
 )
 
 const (
@@ -383,13 +383,13 @@ func (a *AllocReconciler) handleStop(m allocMatrix) {
 // stopping an entire job or task group.
 func (a *AllocReconciler) filterAndStopAll(set allocSet) uint64 {
 	untainted, migrate, lost, disconnecting, reconnecting, ignore, expiring := set.filterByTainted(a.taintedNodes, a.supportsDisconnectedClients, a.now)
-	a.markStop(untainted, "", status.AllocNotNeeded)
-	a.markStop(migrate, "", status.AllocNotNeeded)
-	a.markStop(lost, structs.AllocClientStatusLost, status.AllocLost)
-	a.markStop(disconnecting, "", status.AllocNotNeeded)
-	a.markStop(reconnecting, "", status.AllocNotNeeded)
-	a.markStop(ignore.filterByClientStatus(structs.AllocClientStatusUnknown), "", status.AllocNotNeeded)
-	a.markStop(expiring.filterByClientStatus(structs.AllocClientStatusUnknown), "", status.AllocNotNeeded)
+	a.markStop(untainted, "", sstructs.AllocNotNeeded)
+	a.markStop(migrate, "", sstructs.AllocNotNeeded)
+	a.markStop(lost, structs.AllocClientStatusLost, sstructs.AllocLost)
+	a.markStop(disconnecting, "", sstructs.AllocNotNeeded)
+	a.markStop(reconnecting, "", sstructs.AllocNotNeeded)
+	a.markStop(ignore.filterByClientStatus(structs.AllocClientStatusUnknown), "", sstructs.AllocNotNeeded)
+	a.markStop(expiring.filterByClientStatus(structs.AllocClientStatusUnknown), "", sstructs.AllocNotNeeded)
 	return uint64(len(set))
 }
 
@@ -703,7 +703,7 @@ func (a *AllocReconciler) cancelUnneededCanaries(original allocSet, desiredChang
 	// stopSet is the allocSet that contains the canaries we desire to stop from
 	// above.
 	stopSet := all.fromKeys(stop)
-	a.markStop(stopSet, "", status.AllocNotNeeded)
+	a.markStop(stopSet, "", sstructs.AllocNotNeeded)
 	desiredChanges.Stop += uint64(len(stopSet))
 	all = all.difference(stopSet)
 
@@ -720,8 +720,8 @@ func (a *AllocReconciler) cancelUnneededCanaries(original allocSet, desiredChang
 		// We don't add these stops to desiredChanges because the deployment is
 		// still active. DesiredChanges is used to report deployment progress/final
 		// state. These transient failures aren't meaningful.
-		a.markStop(migrate, "", status.AllocMigrating)
-		a.markStop(lost, structs.AllocClientStatusLost, status.AllocLost)
+		a.markStop(migrate, "", sstructs.AllocMigrating)
+		a.markStop(lost, structs.AllocClientStatusLost, sstructs.AllocLost)
 
 		canaries = untainted
 		all = all.difference(migrate, lost)
@@ -862,7 +862,7 @@ func (a *AllocReconciler) computeReplacements(deploymentPlaceReady bool, desired
 		// turn relies on len(lostLater) == 0.
 		a.Result.Place = append(a.Result.Place, place...)
 
-		a.markStop(failed, "", status.AllocRescheduled)
+		a.markStop(failed, "", sstructs.AllocRescheduled)
 		desiredChanges.Stop += uint64(len(failed))
 
 		minimum := min(len(place), underProvisionedBy)
@@ -905,7 +905,7 @@ func (a *AllocReconciler) computeReplacements(deploymentPlaceReady bool, desired
 
 			a.Result.Stop = append(a.Result.Stop, AllocStopResult{
 				Alloc:             prev,
-				StatusDescription: status.AllocRescheduled,
+				StatusDescription: sstructs.AllocRescheduled,
 			})
 			desiredChanges.Stop++
 		}
@@ -926,7 +926,7 @@ func (a *AllocReconciler) computeDestructiveUpdates(destructive allocSet, underP
 			placeName:             alloc.Name,
 			placeTaskGroup:        tg,
 			stopAlloc:             alloc,
-			stopStatusDescription: status.AllocUpdating,
+			stopStatusDescription: sstructs.AllocUpdating,
 		})
 	}
 }
@@ -936,7 +936,7 @@ func (a *AllocReconciler) computeMigrations(desiredChanges *structs.DesiredUpdat
 	for _, alloc := range migrate.nameOrder() {
 		a.Result.Stop = append(a.Result.Stop, AllocStopResult{
 			Alloc:             alloc,
-			StatusDescription: status.AllocMigrating,
+			StatusDescription: sstructs.AllocMigrating,
 		})
 		a.Result.Place = append(a.Result.Place, AllocPlaceResult{
 			name:          alloc.Name,
@@ -1016,7 +1016,7 @@ func (a *AllocReconciler) computeStop(group *structs.TaskGroup, nameIndex *Alloc
 	var stop allocSet
 	stop = stop.union(lost)
 
-	a.markDelayed(lost, structs.AllocClientStatusLost, status.AllocLost, followupEvals)
+	a.markDelayed(lost, structs.AllocClientStatusLost, sstructs.AllocLost, followupEvals)
 
 	// If we are still deploying or creating canaries, don't stop them
 	if isCanarying {
@@ -1052,7 +1052,7 @@ func (a *AllocReconciler) computeStop(group *structs.TaskGroup, nameIndex *Alloc
 				stop[id] = alloc
 				a.Result.Stop = append(a.Result.Stop, AllocStopResult{
 					Alloc:             alloc,
-					StatusDescription: status.AllocNotNeeded,
+					StatusDescription: sstructs.AllocNotNeeded,
 				})
 				delete(untainted, id)
 
@@ -1074,7 +1074,7 @@ func (a *AllocReconciler) computeStop(group *structs.TaskGroup, nameIndex *Alloc
 			}
 			a.Result.Stop = append(a.Result.Stop, AllocStopResult{
 				Alloc:             alloc,
-				StatusDescription: status.AllocNotNeeded,
+				StatusDescription: sstructs.AllocNotNeeded,
 			})
 			delete(migrate, id)
 			stop[id] = alloc
@@ -1094,7 +1094,7 @@ func (a *AllocReconciler) computeStop(group *structs.TaskGroup, nameIndex *Alloc
 			stop[id] = alloc
 			a.Result.Stop = append(a.Result.Stop, AllocStopResult{
 				Alloc:             alloc,
-				StatusDescription: status.AllocNotNeeded,
+				StatusDescription: sstructs.AllocNotNeeded,
 			})
 			delete(untainted, id)
 
@@ -1111,7 +1111,7 @@ func (a *AllocReconciler) computeStop(group *structs.TaskGroup, nameIndex *Alloc
 		stop[id] = alloc
 		a.Result.Stop = append(a.Result.Stop, AllocStopResult{
 			Alloc:             alloc,
-			StatusDescription: status.AllocNotNeeded,
+			StatusDescription: sstructs.AllocNotNeeded,
 		})
 		delete(untainted, id)
 
@@ -1152,7 +1152,7 @@ func (a *AllocReconciler) reconcileReconnecting(reconnecting allocSet, all alloc
 			a.Result.Stop = append(a.Result.Stop, AllocStopResult{
 				Alloc:             reconnectingAlloc,
 				ClientStatus:      structs.AllocClientStatusFailed,
-				StatusDescription: status.AllocRescheduled,
+				StatusDescription: sstructs.AllocRescheduled,
 			})
 			continue
 		}
@@ -1170,7 +1170,7 @@ func (a *AllocReconciler) reconcileReconnecting(reconnecting allocSet, all alloc
 			stop[reconnectingAlloc.ID] = reconnectingAlloc
 			a.Result.Stop = append(a.Result.Stop, AllocStopResult{
 				Alloc:             reconnectingAlloc,
-				StatusDescription: status.AllocNotNeeded,
+				StatusDescription: sstructs.AllocNotNeeded,
 			})
 			continue
 		}
@@ -1214,7 +1214,7 @@ func (a *AllocReconciler) reconcileReconnecting(reconnecting allocSet, all alloc
 					stop[reconnectingAlloc.ID] = reconnectingAlloc
 					a.Result.Stop = append(a.Result.Stop, AllocStopResult{
 						Alloc:             reconnectingAlloc,
-						StatusDescription: status.AllocNotNeeded,
+						StatusDescription: sstructs.AllocNotNeeded,
 					})
 				}
 			} else {
@@ -1224,7 +1224,7 @@ func (a *AllocReconciler) reconcileReconnecting(reconnecting allocSet, all alloc
 					stop[replacementAlloc.ID] = replacementAlloc
 					a.Result.Stop = append(a.Result.Stop, AllocStopResult{
 						Alloc:             replacementAlloc,
-						StatusDescription: status.AllocReconnected,
+						StatusDescription: sstructs.AllocReconnected,
 					})
 				}
 			}
@@ -1354,7 +1354,7 @@ func (a *AllocReconciler) createLostLaterEvals(rescheduleLater []*delayedResched
 		JobID:             a.job.ID,
 		JobModifyIndex:    a.job.ModifyIndex,
 		Status:            structs.EvalStatusPending,
-		StatusDescription: status.ReschedulingFollowupEvalDesc,
+		StatusDescription: sstructs.ReschedulingFollowupEvalDesc,
 		WaitUntil:         nextReschedTime,
 	}
 	evals = append(evals, eval)
@@ -1422,7 +1422,7 @@ func (a *AllocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName
 		JobID:             a.job.ID,
 		JobModifyIndex:    a.job.ModifyIndex,
 		Status:            structs.EvalStatusPending,
-		StatusDescription: status.DisconnectTimeoutFollowupEvalDesc,
+		StatusDescription: sstructs.DisconnectTimeoutFollowupEvalDesc,
 		WaitUntil:         nextReschedTime,
 	}
 	evals = append(evals, eval)
@@ -1446,7 +1446,7 @@ func (a *AllocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName
 				JobID:             a.job.ID,
 				JobModifyIndex:    a.job.ModifyIndex,
 				Status:            structs.EvalStatusPending,
-				StatusDescription: status.DisconnectTimeoutFollowupEvalDesc,
+				StatusDescription: sstructs.DisconnectTimeoutFollowupEvalDesc,
 				WaitUntil:         timeoutInfo.rescheduleTime,
 			}
 			evals = append(evals, eval)
@@ -1469,7 +1469,7 @@ func (a *AllocReconciler) appendUnknownDisconnectingUpdates(disconnecting allocS
 		updatedAlloc := alloc.Copy()
 		updatedAlloc.ClientStatus = structs.AllocClientStatusUnknown
 		updatedAlloc.AppendState(structs.AllocStateFieldClientStatus, structs.AllocClientStatusUnknown)
-		updatedAlloc.ClientDescription = status.AllocUnknown
+		updatedAlloc.ClientDescription = sstructs.AllocUnknown
 		updatedAlloc.FollowupEvalID = allocIDToFollowupEvalID[id]
 		a.Result.DisconnectUpdates[updatedAlloc.ID] = updatedAlloc
 

--- a/scheduler/reconcile/reconcile_cluster.go
+++ b/scheduler/reconcile/reconcile_cluster.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package scheduler
+package reconcile
 
 // The reconciler is the first stage in the scheduler for service and batch
 // jobs. It compares the existing state to the desired state to determine the
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
-	reconnectingpicker "github.com/hashicorp/nomad/scheduler/reconnecting_picker"
+	"github.com/hashicorp/nomad/scheduler/status"
 )
 
 const (
@@ -34,37 +34,27 @@ const (
 	rescheduleWindowSize = 1 * time.Second
 )
 
-type ReconnectingPicker interface {
-	PickReconnectingAlloc(disconnect *structs.DisconnectStrategy, original *structs.Allocation, replacement *structs.Allocation) *structs.Allocation
-}
-
-// allocUpdateType takes an existing allocation and a new job definition and
+// AllocUpdateType takes an existing allocation and a new job definition and
 // returns whether the allocation can ignore the change, requires a destructive
 // update, or can be inplace updated. If it can be inplace updated, an updated
 // allocation that has the new resources and alloc metrics attached will be
 // returned.
-type allocUpdateType func(existing *structs.Allocation, newJob *structs.Job,
+type AllocUpdateType func(existing *structs.Allocation, newJob *structs.Job,
 	newTG *structs.TaskGroup) (ignore, destructive bool, updated *structs.Allocation)
 
-type AllocReconcilerOption func(*allocReconciler)
+type AllocReconcilerOption func(*AllocReconciler)
 
-func AllocRenconcilerWithNow(now time.Time) AllocReconcilerOption {
-	return func(ar *allocReconciler) {
-		ar.now = now
-	}
-}
-
-// allocReconciler is used to determine the set of allocations that require
+// AllocReconciler is used to determine the set of allocations that require
 // placement, inplace updating or stopping given the job specification and
 // existing cluster state. The reconciler should only be used for batch and
 // service jobs.
-type allocReconciler struct {
+type AllocReconciler struct {
 	// logger is used to log debug information. Logging should be kept at a
 	// minimal here
 	logger log.Logger
 
 	// canInplace is used to check if the allocation can be inplace upgraded
-	allocUpdateFn allocUpdateType
+	allocUpdateFn AllocUpdateType
 
 	// batch marks whether the job is a batch job
 	batch bool
@@ -108,62 +98,62 @@ type allocReconciler struct {
 	// defaults to time.Now, and overridden in unit tests
 	now time.Time
 
-	reconnectingPicker ReconnectingPicker
+	reconnectingPicker reconnectingPickerInterface
 
-	// result is the results of the reconcile. During computation it can be
+	// Result is the results of the reconcile. During computation it can be
 	// used to store intermediate state
-	result *reconcileResults
+	Result *ReconcileResults
 }
 
-// reconcileResults contains the results of the reconciliation and should be
+// ReconcileResults contains the results of the reconciliation and should be
 // applied by the scheduler.
-type reconcileResults struct {
-	// deployment is the deployment that should be created or updated as a
+type ReconcileResults struct {
+	// Deployment is the Deployment that should be created or updated as a
 	// result of scheduling
-	deployment *structs.Deployment
+	Deployment *structs.Deployment
 
-	// deploymentUpdates contains a set of deployment updates that should be
+	// DeploymentUpdates contains a set of deployment updates that should be
 	// applied as a result of scheduling
-	deploymentUpdates []*structs.DeploymentStatusUpdate
+	DeploymentUpdates []*structs.DeploymentStatusUpdate
 
-	// place is the set of allocations to place by the scheduler
-	place []allocPlaceResult
+	// Place is the set of allocations to Place by the scheduler
+	Place []AllocPlaceResult
 
-	// destructiveUpdate is the set of allocations to apply a destructive update to
-	destructiveUpdate []allocDestructiveResult
+	// DestructiveUpdate is the set of allocations to apply a destructive update to
+	DestructiveUpdate []allocDestructiveResult
 
-	// inplaceUpdate is the set of allocations to apply an inplace update to
-	inplaceUpdate []*structs.Allocation
+	// InplaceUpdate is the set of allocations to apply an inplace update to
+	InplaceUpdate []*structs.Allocation
 
-	// stop is the set of allocations to stop
-	stop []allocStopResult
+	// Stop is the set of allocations to Stop
+	Stop []AllocStopResult
 
-	// attributeUpdates are updates to the allocation that are not from a
+	// AttributeUpdates are updates to the allocation that are not from a
 	// jobspec change.
-	attributeUpdates map[string]*structs.Allocation
+	AttributeUpdates map[string]*structs.Allocation
 
-	// disconnectUpdates is the set of allocations are on disconnected nodes, but
+	// DisconnectUpdates is the set of allocations are on disconnected nodes, but
 	// have not yet had their ClientStatus set to AllocClientStatusUnknown.
-	disconnectUpdates map[string]*structs.Allocation
+	DisconnectUpdates map[string]*structs.Allocation
 
-	// reconnectUpdates is the set of allocations that have ClientStatus set to
+	// ReconnectUpdates is the set of allocations that have ClientStatus set to
 	// AllocClientStatusUnknown, but the associated Node has reconnected.
-	reconnectUpdates map[string]*structs.Allocation
+	ReconnectUpdates map[string]*structs.Allocation
 
-	// desiredTGUpdates captures the desired set of changes to make for each
+	// DesiredTGUpdates captures the desired set of changes to make for each
 	// task group.
-	desiredTGUpdates map[string]*structs.DesiredUpdates
+	DesiredTGUpdates map[string]*structs.DesiredUpdates
 
-	// desiredFollowupEvals is the map of follow up evaluations to create per task group
+	// DesiredFollowupEvals is the map of follow up evaluations to create per task group
 	// This is used to create a delayed evaluation for rescheduling failed allocations.
-	desiredFollowupEvals map[string][]*structs.Evaluation
+	DesiredFollowupEvals map[string][]*structs.Evaluation
 
-	// taskGroupAllocNameIndexes is a tracking of the allocation name index,
+	// TaskGroupAllocNameIndexes is a tracking of the allocation name index,
 	// keyed by the task group name. This is stored within the results, so the
 	// generic scheduler can use this to perform duplicate alloc index checks
 	// before submitting the plan. This is always non-nil and is handled within
 	// a single routine, so does not require a mutex.
-	taskGroupAllocNameIndexes map[string]*allocNameIndex
+	TaskGroupAllocNameIndexes map[string]*AllocNameIndex
 }
 
 // delayedRescheduleInfo contains the allocation id and a time when its eligible to be rescheduled.
@@ -179,18 +169,18 @@ type delayedRescheduleInfo struct {
 	rescheduleTime time.Time
 }
 
-func (r *reconcileResults) GoString() string {
+func (r *ReconcileResults) GoString() string {
 	base := fmt.Sprintf("Total changes: (place %d) (destructive %d) (inplace %d) (stop %d) (disconnect %d) (reconnect %d)",
-		len(r.place), len(r.destructiveUpdate), len(r.inplaceUpdate), len(r.stop), len(r.disconnectUpdates), len(r.reconnectUpdates))
+		len(r.Place), len(r.DestructiveUpdate), len(r.InplaceUpdate), len(r.Stop), len(r.DisconnectUpdates), len(r.ReconnectUpdates))
 
-	if r.deployment != nil {
-		base += fmt.Sprintf("\nCreated Deployment: %q", r.deployment.ID)
+	if r.Deployment != nil {
+		base += fmt.Sprintf("\nCreated Deployment: %q", r.Deployment.ID)
 	}
-	for _, u := range r.deploymentUpdates {
+	for _, u := range r.DeploymentUpdates {
 		base += fmt.Sprintf("\nDeployment Update for ID %q: Status %q; Description %q",
 			u.DeploymentID, u.Status, u.StatusDescription)
 	}
-	for tg, u := range r.desiredTGUpdates {
+	for tg, u := range r.DesiredTGUpdates {
 		base += fmt.Sprintf("\nDesired Changes for %q: %#v", tg, u)
 	}
 
@@ -199,12 +189,12 @@ func (r *reconcileResults) GoString() string {
 
 // NewAllocReconciler creates a new reconciler that should be used to determine
 // the changes required to bring the cluster state inline with the declared jobspec
-func NewAllocReconciler(logger log.Logger, allocUpdateFn allocUpdateType, batch bool,
+func NewAllocReconciler(logger log.Logger, allocUpdateFn AllocUpdateType, batch bool,
 	jobID string, job *structs.Job, deployment *structs.Deployment,
 	existingAllocs []*structs.Allocation, taintedNodes map[string]*structs.Node, evalID string,
-	evalPriority int, supportsDisconnectedClients bool, opts ...AllocReconcilerOption) *allocReconciler {
+	evalPriority int, supportsDisconnectedClients bool, opts ...AllocReconcilerOption) *AllocReconciler {
 
-	ar := &allocReconciler{
+	ar := &AllocReconciler{
 		logger:                      logger.Named("reconciler"),
 		allocUpdateFn:               allocUpdateFn,
 		batch:                       batch,
@@ -217,15 +207,15 @@ func NewAllocReconciler(logger log.Logger, allocUpdateFn allocUpdateType, batch 
 		evalPriority:                evalPriority,
 		supportsDisconnectedClients: supportsDisconnectedClients,
 		now:                         time.Now().UTC(),
-		result: &reconcileResults{
-			attributeUpdates:          make(map[string]*structs.Allocation),
-			disconnectUpdates:         make(map[string]*structs.Allocation),
-			reconnectUpdates:          make(map[string]*structs.Allocation),
-			desiredTGUpdates:          make(map[string]*structs.DesiredUpdates),
-			desiredFollowupEvals:      make(map[string][]*structs.Evaluation),
-			taskGroupAllocNameIndexes: make(map[string]*allocNameIndex),
+		Result: &ReconcileResults{
+			AttributeUpdates:          make(map[string]*structs.Allocation),
+			DisconnectUpdates:         make(map[string]*structs.Allocation),
+			ReconnectUpdates:          make(map[string]*structs.Allocation),
+			DesiredTGUpdates:          make(map[string]*structs.DesiredUpdates),
+			DesiredFollowupEvals:      make(map[string][]*structs.Evaluation),
+			TaskGroupAllocNameIndexes: make(map[string]*AllocNameIndex),
 		},
-		reconnectingPicker: reconnectingpicker.New(logger),
+		reconnectingPicker: newReconnectingPicker(logger),
 	}
 
 	for _, op := range opts {
@@ -237,7 +227,7 @@ func NewAllocReconciler(logger log.Logger, allocUpdateFn allocUpdateType, batch 
 
 // Compute reconciles the existing cluster state and returns the set of changes
 // required to converge the job spec and state
-func (a *allocReconciler) Compute() *reconcileResults {
+func (a *AllocReconciler) Compute() {
 	// Create the allocation matrix
 	m := newAllocMatrix(a.job, a.existingAllocs)
 
@@ -247,17 +237,15 @@ func (a *allocReconciler) Compute() *reconcileResults {
 	// stopping all running allocs
 	if a.job.Stopped() {
 		a.handleStop(m)
-		return a.result
+		return
 	}
 
 	a.computeDeploymentPaused()
 	deploymentComplete := a.computeDeploymentComplete(m)
 	a.computeDeploymentUpdates(deploymentComplete)
-
-	return a.result
 }
 
-func (a *allocReconciler) computeDeploymentComplete(m allocMatrix) bool {
+func (a *AllocReconciler) computeDeploymentComplete(m allocMatrix) bool {
 	complete := true
 	for group, as := range m {
 		groupComplete := a.computeGroup(group, as)
@@ -267,7 +255,7 @@ func (a *allocReconciler) computeDeploymentComplete(m allocMatrix) bool {
 	return complete
 }
 
-func (a *allocReconciler) computeDeploymentUpdates(deploymentComplete bool) {
+func (a *AllocReconciler) computeDeploymentUpdates(deploymentComplete bool) {
 	if a.deployment != nil {
 		// Mark the deployment as complete if possible
 		if deploymentComplete {
@@ -276,14 +264,14 @@ func (a *allocReconciler) computeDeploymentUpdates(deploymentComplete bool) {
 				// need to make sure we don't revert those states
 				if a.deployment.Status != structs.DeploymentStatusUnblocking &&
 					a.deployment.Status != structs.DeploymentStatusSuccessful {
-					a.result.deploymentUpdates = append(a.result.deploymentUpdates, &structs.DeploymentStatusUpdate{
+					a.Result.DeploymentUpdates = append(a.Result.DeploymentUpdates, &structs.DeploymentStatusUpdate{
 						DeploymentID:      a.deployment.ID,
 						Status:            structs.DeploymentStatusBlocked,
 						StatusDescription: structs.DeploymentStatusDescriptionBlocked,
 					})
 				}
 			} else {
-				a.result.deploymentUpdates = append(a.result.deploymentUpdates, &structs.DeploymentStatusUpdate{
+				a.Result.DeploymentUpdates = append(a.Result.DeploymentUpdates, &structs.DeploymentStatusUpdate{
 					DeploymentID:      a.deployment.ID,
 					Status:            structs.DeploymentStatusSuccessful,
 					StatusDescription: structs.DeploymentStatusDescriptionSuccessful,
@@ -293,7 +281,7 @@ func (a *allocReconciler) computeDeploymentUpdates(deploymentComplete bool) {
 
 		// Mark the deployment as pending since its state is now computed.
 		if a.deployment.Status == structs.DeploymentStatusInitializing {
-			a.result.deploymentUpdates = append(a.result.deploymentUpdates, &structs.DeploymentStatusUpdate{
+			a.Result.DeploymentUpdates = append(a.Result.DeploymentUpdates, &structs.DeploymentStatusUpdate{
 				DeploymentID:      a.deployment.ID,
 				Status:            structs.DeploymentStatusPending,
 				StatusDescription: structs.DeploymentStatusDescriptionPendingForPeer,
@@ -302,7 +290,7 @@ func (a *allocReconciler) computeDeploymentUpdates(deploymentComplete bool) {
 	}
 
 	// Set the description of a created deployment
-	if d := a.result.deployment; d != nil {
+	if d := a.Result.Deployment; d != nil {
 		if d.RequiresPromotion() {
 			if d.HasAutoPromote() {
 				d.StatusDescription = structs.DeploymentStatusDescriptionRunningAutoPromotion
@@ -322,7 +310,7 @@ func (a *allocReconciler) computeDeploymentUpdates(deploymentComplete bool) {
 //     pending or initializing, which are the initial states for multi-region
 //     job deployments. This flag tells Compute that we should not make
 //     placements on the deployment.
-func (a *allocReconciler) computeDeploymentPaused() {
+func (a *AllocReconciler) computeDeploymentPaused() {
 	if a.deployment != nil {
 		a.deploymentPaused = a.deployment.Status == structs.DeploymentStatusPaused ||
 			a.deployment.Status == structs.DeploymentStatusPending ||
@@ -338,11 +326,11 @@ func (a *allocReconciler) computeDeploymentPaused() {
 // 1. Jobs that are marked for stop, but there is a non-terminal deployment.
 // 2. Deployments that are active, but referencing a different job version.
 // 3. Deployments that are already successful.
-func (a *allocReconciler) cancelUnneededDeployments() {
+func (a *AllocReconciler) cancelUnneededDeployments() {
 	// If the job is stopped and there is a non-terminal deployment, cancel it
 	if a.job.Stopped() {
 		if a.deployment != nil && a.deployment.Active() {
-			a.result.deploymentUpdates = append(a.result.deploymentUpdates, &structs.DeploymentStatusUpdate{
+			a.Result.DeploymentUpdates = append(a.Result.DeploymentUpdates, &structs.DeploymentStatusUpdate{
 				DeploymentID:      a.deployment.ID,
 				Status:            structs.DeploymentStatusCancelled,
 				StatusDescription: structs.DeploymentStatusDescriptionStoppedJob,
@@ -363,7 +351,7 @@ func (a *allocReconciler) cancelUnneededDeployments() {
 	// Check if the deployment is active and referencing an older job and cancel it
 	if d.JobCreateIndex != a.job.CreateIndex || d.JobVersion != a.job.Version {
 		if d.Active() {
-			a.result.deploymentUpdates = append(a.result.deploymentUpdates, &structs.DeploymentStatusUpdate{
+			a.Result.DeploymentUpdates = append(a.Result.DeploymentUpdates, &structs.DeploymentStatusUpdate{
 				DeploymentID:      a.deployment.ID,
 				Status:            structs.DeploymentStatusCancelled,
 				StatusDescription: structs.DeploymentStatusDescriptionNewerJob,
@@ -382,61 +370,61 @@ func (a *allocReconciler) cancelUnneededDeployments() {
 }
 
 // handleStop marks all allocations to be stopped, handling the lost case
-func (a *allocReconciler) handleStop(m allocMatrix) {
+func (a *AllocReconciler) handleStop(m allocMatrix) {
 	for group, as := range m {
 		as = filterByTerminal(as)
 		desiredChanges := new(structs.DesiredUpdates)
 		desiredChanges.Stop = a.filterAndStopAll(as)
-		a.result.desiredTGUpdates[group] = desiredChanges
+		a.Result.DesiredTGUpdates[group] = desiredChanges
 	}
 }
 
 // filterAndStopAll stops all allocations in an allocSet. This is useful in when
 // stopping an entire job or task group.
-func (a *allocReconciler) filterAndStopAll(set allocSet) uint64 {
+func (a *AllocReconciler) filterAndStopAll(set allocSet) uint64 {
 	untainted, migrate, lost, disconnecting, reconnecting, ignore, expiring := set.filterByTainted(a.taintedNodes, a.supportsDisconnectedClients, a.now)
-	a.markStop(untainted, "", allocNotNeeded)
-	a.markStop(migrate, "", allocNotNeeded)
-	a.markStop(lost, structs.AllocClientStatusLost, allocLost)
-	a.markStop(disconnecting, "", allocNotNeeded)
-	a.markStop(reconnecting, "", allocNotNeeded)
-	a.markStop(ignore.filterByClientStatus(structs.AllocClientStatusUnknown), "", allocNotNeeded)
-	a.markStop(expiring.filterByClientStatus(structs.AllocClientStatusUnknown), "", allocNotNeeded)
+	a.markStop(untainted, "", status.AllocNotNeeded)
+	a.markStop(migrate, "", status.AllocNotNeeded)
+	a.markStop(lost, structs.AllocClientStatusLost, status.AllocLost)
+	a.markStop(disconnecting, "", status.AllocNotNeeded)
+	a.markStop(reconnecting, "", status.AllocNotNeeded)
+	a.markStop(ignore.filterByClientStatus(structs.AllocClientStatusUnknown), "", status.AllocNotNeeded)
+	a.markStop(expiring.filterByClientStatus(structs.AllocClientStatusUnknown), "", status.AllocNotNeeded)
 	return uint64(len(set))
 }
 
 // markStop is a helper for marking a set of allocation for stop with a
 // particular client status and description.
-func (a *allocReconciler) markStop(allocs allocSet, clientStatus, statusDescription string) {
+func (a *AllocReconciler) markStop(allocs allocSet, clientStatus, statusDescription string) {
 	for _, alloc := range allocs {
-		a.result.stop = append(a.result.stop, allocStopResult{
-			alloc:             alloc,
-			clientStatus:      clientStatus,
-			statusDescription: statusDescription,
+		a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+			Alloc:             alloc,
+			ClientStatus:      clientStatus,
+			StatusDescription: statusDescription,
 		})
 	}
 }
 
 // markDelayed does markStop, but optionally includes a FollowupEvalID so that we can update
 // the stopped alloc with its delayed rescheduling evalID
-func (a *allocReconciler) markDelayed(allocs allocSet, clientStatus, statusDescription string, followupEvals map[string]string) {
+func (a *AllocReconciler) markDelayed(allocs allocSet, clientStatus, statusDescription string, followupEvals map[string]string) {
 	for _, alloc := range allocs {
-		a.result.stop = append(a.result.stop, allocStopResult{
-			alloc:             alloc,
-			clientStatus:      clientStatus,
-			statusDescription: statusDescription,
-			followupEvalID:    followupEvals[alloc.ID],
+		a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+			Alloc:             alloc,
+			ClientStatus:      clientStatus,
+			StatusDescription: statusDescription,
+			FollowupEvalID:    followupEvals[alloc.ID],
 		})
 	}
 }
 
 // computeGroup reconciles state for a particular task group. It returns whether
 // the deployment it is for is complete with regards to the task group.
-func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
+func (a *AllocReconciler) computeGroup(groupName string, all allocSet) bool {
 
 	// Create the desired update object for the group
 	desiredChanges := new(structs.DesiredUpdates)
-	a.result.desiredTGUpdates[groupName] = desiredChanges
+	a.Result.DesiredTGUpdates[groupName] = desiredChanges
 
 	// Get the task group. The task group may be nil if the job was updates such
 	// that the task group no longer exists
@@ -542,7 +530,7 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 	// which is the union of untainted, rescheduled, allocs on migrating
 	// nodes, and allocs on down nodes (includes canaries)
 	nameIndex := newAllocNameIndex(a.jobID, groupName, tg.Count, untainted.union(migrate, rescheduleNow, lost))
-	a.result.taskGroupAllocNameIndexes[groupName] = nameIndex
+	a.Result.TaskGroupAllocNameIndexes[groupName] = nameIndex
 
 	// Stop any unneeded allocations and update the untainted set to not
 	// include stopped allocations.
@@ -583,7 +571,7 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 	// * If there are any canaries that they have been promoted
 	// * There is no delayed stop_after_client_disconnect alloc, which delays scheduling for the whole group
 	// * An alloc was lost
-	var place []allocPlaceResult
+	var place []AllocPlaceResult
 	if len(lostLater) == 0 {
 		place = a.computePlacements(tg, nameIndex, untainted, migrate, rescheduleNow, lost, isCanarying)
 		if !existingDeployment {
@@ -609,7 +597,7 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 	// Deployments that are still initializing need to be sent in full in the
 	// plan so its internal state can be persisted by the plan applier.
 	if a.deployment != nil && a.deployment.Status == structs.DeploymentStatusInitializing {
-		a.result.deployment = a.deployment
+		a.Result.Deployment = a.deployment
 	}
 
 	deploymentComplete := a.isDeploymentComplete(groupName, destructive, inplace,
@@ -618,7 +606,7 @@ func (a *allocReconciler) computeGroup(groupName string, all allocSet) bool {
 	return deploymentComplete
 }
 
-func (a *allocReconciler) initializeDeploymentState(group string, tg *structs.TaskGroup) (*structs.DeploymentState, bool) {
+func (a *AllocReconciler) initializeDeploymentState(group string, tg *structs.TaskGroup) (*structs.DeploymentState, bool) {
 	var dstate *structs.DeploymentState
 	existingDeployment := false
 
@@ -639,7 +627,7 @@ func (a *allocReconciler) initializeDeploymentState(group string, tg *structs.Ta
 }
 
 // If we have destructive updates, and have fewer canaries than is desired, we need to create canaries.
-func (a *allocReconciler) requiresCanaries(tg *structs.TaskGroup, dstate *structs.DeploymentState, destructive, canaries allocSet) bool {
+func (a *AllocReconciler) requiresCanaries(tg *structs.TaskGroup, dstate *structs.DeploymentState, destructive, canaries allocSet) bool {
 	canariesPromoted := dstate != nil && dstate.Promoted
 	return tg.Update != nil &&
 		len(destructive) != 0 &&
@@ -647,14 +635,14 @@ func (a *allocReconciler) requiresCanaries(tg *structs.TaskGroup, dstate *struct
 		!canariesPromoted
 }
 
-func (a *allocReconciler) computeCanaries(tg *structs.TaskGroup, dstate *structs.DeploymentState,
-	destructive, canaries allocSet, desiredChanges *structs.DesiredUpdates, nameIndex *allocNameIndex) {
+func (a *AllocReconciler) computeCanaries(tg *structs.TaskGroup, dstate *structs.DeploymentState,
+	destructive, canaries allocSet, desiredChanges *structs.DesiredUpdates, nameIndex *AllocNameIndex) {
 	dstate.DesiredCanaries = tg.Update.Canary
 
 	if !a.deploymentPaused && !a.deploymentFailed {
 		desiredChanges.Canary += uint64(tg.Update.Canary - len(canaries))
 		for _, name := range nameIndex.NextCanaries(uint(desiredChanges.Canary), canaries, destructive) {
-			a.result.place = append(a.result.place, allocPlaceResult{
+			a.Result.Place = append(a.Result.Place, AllocPlaceResult{
 				name:      name,
 				canary:    true,
 				taskGroup: tg,
@@ -665,7 +653,7 @@ func (a *allocReconciler) computeCanaries(tg *structs.TaskGroup, dstate *structs
 
 // filterOldTerminalAllocs filters allocations that should be ignored since they
 // are allocations that are terminal from a previous job version.
-func (a *allocReconciler) filterOldTerminalAllocs(all allocSet) (filtered, ignore allocSet) {
+func (a *AllocReconciler) filterOldTerminalAllocs(all allocSet) (filtered, ignore allocSet) {
 	if !a.batch {
 		return all, nil
 	}
@@ -688,7 +676,7 @@ func (a *allocReconciler) filterOldTerminalAllocs(all allocSet) (filtered, ignor
 // cancelUnneededCanaries handles the canaries for the group by stopping the
 // unneeded ones and returning the current set of canaries and the updated total
 // set of allocs for the group
-func (a *allocReconciler) cancelUnneededCanaries(original allocSet, desiredChanges *structs.DesiredUpdates) (canaries, all allocSet) {
+func (a *AllocReconciler) cancelUnneededCanaries(original allocSet, desiredChanges *structs.DesiredUpdates) (canaries, all allocSet) {
 	// Stop any canary from an older deployment or from a failed one
 	var stop []string
 
@@ -715,7 +703,7 @@ func (a *allocReconciler) cancelUnneededCanaries(original allocSet, desiredChang
 	// stopSet is the allocSet that contains the canaries we desire to stop from
 	// above.
 	stopSet := all.fromKeys(stop)
-	a.markStop(stopSet, "", allocNotNeeded)
+	a.markStop(stopSet, "", status.AllocNotNeeded)
 	desiredChanges.Stop += uint64(len(stopSet))
 	all = all.difference(stopSet)
 
@@ -732,8 +720,8 @@ func (a *allocReconciler) cancelUnneededCanaries(original allocSet, desiredChang
 		// We don't add these stops to desiredChanges because the deployment is
 		// still active. DesiredChanges is used to report deployment progress/final
 		// state. These transient failures aren't meaningful.
-		a.markStop(migrate, "", allocMigrating)
-		a.markStop(lost, structs.AllocClientStatusLost, allocLost)
+		a.markStop(migrate, "", status.AllocMigrating)
+		a.markStop(lost, structs.AllocClientStatusLost, status.AllocLost)
 
 		canaries = untainted
 		all = all.difference(migrate, lost)
@@ -745,7 +733,7 @@ func (a *allocReconciler) cancelUnneededCanaries(original allocSet, desiredChang
 // computeUnderProvisionedBy returns the number of allocs that still need to be
 // placed for a particular group. The inputs are the group definition, the untainted,
 // destructive, and migrate allocation sets, and whether we are in a canary state.
-func (a *allocReconciler) computeUnderProvisionedBy(group *structs.TaskGroup, untainted, destructive, migrate allocSet, isCanarying bool) int {
+func (a *AllocReconciler) computeUnderProvisionedBy(group *structs.TaskGroup, untainted, destructive, migrate allocSet, isCanarying bool) int {
 	// If no update strategy, nothing is migrating, and nothing is being replaced,
 	// allow as many as defined in group.Count
 	if group.Update.IsEmpty() || len(destructive)+len(migrate) == 0 {
@@ -790,14 +778,14 @@ func (a *allocReconciler) computeUnderProvisionedBy(group *structs.TaskGroup, un
 // definition, the set of untainted, migrating and reschedule allocations for the group.
 //
 // Placements will meet or exceed group count.
-func (a *allocReconciler) computePlacements(group *structs.TaskGroup,
-	nameIndex *allocNameIndex, untainted, migrate, reschedule, lost allocSet,
-	isCanarying bool) []allocPlaceResult {
+func (a *AllocReconciler) computePlacements(group *structs.TaskGroup,
+	nameIndex *AllocNameIndex, untainted, migrate, reschedule, lost allocSet,
+	isCanarying bool) []AllocPlaceResult {
 
 	// Add rescheduled placement results
-	var place []allocPlaceResult
+	var place []AllocPlaceResult
 	for _, alloc := range reschedule {
-		place = append(place, allocPlaceResult{
+		place = append(place, AllocPlaceResult{
 			name:          alloc.Name,
 			taskGroup:     group,
 			previousAlloc: alloc,
@@ -822,7 +810,7 @@ func (a *allocReconciler) computePlacements(group *structs.TaskGroup,
 		}
 
 		existing++
-		place = append(place, allocPlaceResult{
+		place = append(place, AllocPlaceResult{
 			name:               alloc.Name,
 			taskGroup:          group,
 			previousAlloc:      alloc,
@@ -837,7 +825,7 @@ func (a *allocReconciler) computePlacements(group *structs.TaskGroup,
 	// Add remaining placement results
 	if existing < group.Count {
 		for _, name := range nameIndex.Next(uint(group.Count - existing)) {
-			place = append(place, allocPlaceResult{
+			place = append(place, AllocPlaceResult{
 				name:               name,
 				taskGroup:          group,
 				downgradeNonCanary: isCanarying,
@@ -853,15 +841,15 @@ func (a *allocReconciler) computePlacements(group *structs.TaskGroup,
 // and if the placement is already rescheduling or part of a failed deployment.
 // The input deploymentPlaceReady is calculated as the deployment is not paused, failed, or canarying.
 // It returns the number of allocs still needed.
-func (a *allocReconciler) computeReplacements(deploymentPlaceReady bool, desiredChanges *structs.DesiredUpdates,
-	place []allocPlaceResult, rescheduleNow, lost allocSet, underProvisionedBy int) int {
+func (a *AllocReconciler) computeReplacements(deploymentPlaceReady bool, desiredChanges *structs.DesiredUpdates,
+	place []AllocPlaceResult, rescheduleNow, lost allocSet, underProvisionedBy int) int {
 
 	// Disconnecting allocs are not failing, but are included in rescheduleNow.
 	// Create a new set that only includes the actual failures and compute
 	// replacements based off that.
 	failed := make(allocSet)
 	for id, alloc := range rescheduleNow {
-		_, ok := a.result.disconnectUpdates[id]
+		_, ok := a.Result.DisconnectUpdates[id]
 		if !ok && alloc.ClientStatus != structs.AllocClientStatusUnknown {
 			failed[id] = alloc
 		}
@@ -872,9 +860,9 @@ func (a *allocReconciler) computeReplacements(deploymentPlaceReady bool, desired
 		desiredChanges.Place += uint64(len(place))
 		// This relies on the computePlacements having built this set, which in
 		// turn relies on len(lostLater) == 0.
-		a.result.place = append(a.result.place, place...)
+		a.Result.Place = append(a.Result.Place, place...)
 
-		a.markStop(failed, "", allocRescheduled)
+		a.markStop(failed, "", status.AllocRescheduled)
 		desiredChanges.Stop += uint64(len(failed))
 
 		minimum := min(len(place), underProvisionedBy)
@@ -891,7 +879,7 @@ func (a *allocReconciler) computeReplacements(deploymentPlaceReady bool, desired
 	if len(lost) != 0 {
 		allowed := min(len(lost), len(place))
 		desiredChanges.Place += uint64(allowed)
-		a.result.place = append(a.result.place, place[:allowed]...)
+		a.Result.Place = append(a.Result.Place, place[:allowed]...)
 	}
 
 	// if no failures or there are no pending placements return.
@@ -907,17 +895,17 @@ func (a *allocReconciler) computeReplacements(deploymentPlaceReady bool, desired
 		partOfFailedDeployment := a.deploymentFailed && prev != nil && a.deployment.ID == prev.DeploymentID
 
 		if !partOfFailedDeployment && p.IsRescheduling() {
-			a.result.place = append(a.result.place, p)
+			a.Result.Place = append(a.Result.Place, p)
 			desiredChanges.Place++
 
-			_, prevIsDisconnecting := a.result.disconnectUpdates[prev.ID]
+			_, prevIsDisconnecting := a.Result.DisconnectUpdates[prev.ID]
 			if prevIsDisconnecting {
 				continue
 			}
 
-			a.result.stop = append(a.result.stop, allocStopResult{
-				alloc:             prev,
-				statusDescription: allocRescheduled,
+			a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+				Alloc:             prev,
+				StatusDescription: status.AllocRescheduled,
 			})
 			desiredChanges.Stop++
 		}
@@ -926,7 +914,7 @@ func (a *allocReconciler) computeReplacements(deploymentPlaceReady bool, desired
 	return underProvisionedBy
 }
 
-func (a *allocReconciler) computeDestructiveUpdates(destructive allocSet, underProvisionedBy int,
+func (a *AllocReconciler) computeDestructiveUpdates(destructive allocSet, underProvisionedBy int,
 	desiredChanges *structs.DesiredUpdates, tg *structs.TaskGroup) {
 
 	// Do all destructive updates
@@ -934,23 +922,23 @@ func (a *allocReconciler) computeDestructiveUpdates(destructive allocSet, underP
 	desiredChanges.DestructiveUpdate += uint64(minimum)
 	desiredChanges.Ignore += uint64(len(destructive) - minimum)
 	for _, alloc := range destructive.nameOrder()[:minimum] {
-		a.result.destructiveUpdate = append(a.result.destructiveUpdate, allocDestructiveResult{
+		a.Result.DestructiveUpdate = append(a.Result.DestructiveUpdate, allocDestructiveResult{
 			placeName:             alloc.Name,
 			placeTaskGroup:        tg,
 			stopAlloc:             alloc,
-			stopStatusDescription: allocUpdating,
+			stopStatusDescription: status.AllocUpdating,
 		})
 	}
 }
 
-func (a *allocReconciler) computeMigrations(desiredChanges *structs.DesiredUpdates, migrate allocSet, tg *structs.TaskGroup, isCanarying bool) {
+func (a *AllocReconciler) computeMigrations(desiredChanges *structs.DesiredUpdates, migrate allocSet, tg *structs.TaskGroup, isCanarying bool) {
 	desiredChanges.Migrate += uint64(len(migrate))
 	for _, alloc := range migrate.nameOrder() {
-		a.result.stop = append(a.result.stop, allocStopResult{
-			alloc:             alloc,
-			statusDescription: allocMigrating,
+		a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+			Alloc:             alloc,
+			StatusDescription: status.AllocMigrating,
 		})
-		a.result.place = append(a.result.place, allocPlaceResult{
+		a.Result.Place = append(a.Result.Place, AllocPlaceResult{
 			name:          alloc.Name,
 			canary:        alloc.DeploymentStatus.IsCanary(),
 			taskGroup:     tg,
@@ -962,7 +950,7 @@ func (a *allocReconciler) computeMigrations(desiredChanges *structs.DesiredUpdat
 	}
 }
 
-func (a *allocReconciler) createDeployment(groupName string, strategy *structs.UpdateStrategy,
+func (a *AllocReconciler) createDeployment(groupName string, strategy *structs.UpdateStrategy,
 	existingDeployment bool, dstate *structs.DeploymentState, all, destructive allocSet) {
 	// Guard the simple cases that require no computation first.
 	if existingDeployment ||
@@ -971,7 +959,7 @@ func (a *allocReconciler) createDeployment(groupName string, strategy *structs.U
 		return
 	}
 
-	updatingSpec := len(destructive) != 0 || len(a.result.inplaceUpdate) != 0
+	updatingSpec := len(destructive) != 0 || len(a.Result.InplaceUpdate) != 0
 
 	hadRunning := false
 	for _, alloc := range all {
@@ -990,15 +978,15 @@ func (a *allocReconciler) createDeployment(groupName string, strategy *structs.U
 	// A previous group may have made the deployment already. If not create one.
 	if a.deployment == nil {
 		a.deployment = structs.NewDeployment(a.job, a.evalPriority, a.now.UnixNano())
-		a.result.deployment = a.deployment
+		a.Result.Deployment = a.deployment
 	}
 
 	// Attach the groups deployment state to the deployment
 	a.deployment.TaskGroups[groupName] = dstate
 }
 
-func (a *allocReconciler) isDeploymentComplete(groupName string, destructive, inplace, migrate, rescheduleNow allocSet,
-	place []allocPlaceResult, rescheduleLater []*delayedRescheduleInfo, requiresCanaries bool) bool {
+func (a *AllocReconciler) isDeploymentComplete(groupName string, destructive, inplace, migrate, rescheduleNow allocSet,
+	place []AllocPlaceResult, rescheduleLater []*delayedRescheduleInfo, requiresCanaries bool) bool {
 
 	complete := len(destructive)+len(inplace)+len(place)+len(migrate)+len(rescheduleNow)+len(rescheduleLater) == 0 &&
 		!requiresCanaries
@@ -1021,14 +1009,14 @@ func (a *allocReconciler) isDeploymentComplete(groupName string, destructive, in
 // computeStop returns the set of allocations that are marked for stopping given
 // the group definition, the set of allocations in various states and whether we
 // are canarying.
-func (a *allocReconciler) computeStop(group *structs.TaskGroup, nameIndex *allocNameIndex,
+func (a *AllocReconciler) computeStop(group *structs.TaskGroup, nameIndex *AllocNameIndex,
 	untainted, migrate, lost, canaries allocSet, isCanarying bool, followupEvals map[string]string) allocSet {
 
 	// Mark all lost allocations for stop.
 	var stop allocSet
 	stop = stop.union(lost)
 
-	a.markDelayed(lost, structs.AllocClientStatusLost, allocLost, followupEvals)
+	a.markDelayed(lost, structs.AllocClientStatusLost, status.AllocLost, followupEvals)
 
 	// If we are still deploying or creating canaries, don't stop them
 	if isCanarying {
@@ -1062,9 +1050,9 @@ func (a *allocReconciler) computeStop(group *structs.TaskGroup, nameIndex *alloc
 		for id, alloc := range untainted.difference(canaries) {
 			if _, match := canaryNames[alloc.Name]; match {
 				stop[id] = alloc
-				a.result.stop = append(a.result.stop, allocStopResult{
-					alloc:             alloc,
-					statusDescription: allocNotNeeded,
+				a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+					Alloc:             alloc,
+					StatusDescription: status.AllocNotNeeded,
 				})
 				delete(untainted, id)
 
@@ -1084,9 +1072,9 @@ func (a *allocReconciler) computeStop(group *structs.TaskGroup, nameIndex *alloc
 			if _, match := removeNames[alloc.Name]; !match {
 				continue
 			}
-			a.result.stop = append(a.result.stop, allocStopResult{
-				alloc:             alloc,
-				statusDescription: allocNotNeeded,
+			a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+				Alloc:             alloc,
+				StatusDescription: status.AllocNotNeeded,
 			})
 			delete(migrate, id)
 			stop[id] = alloc
@@ -1104,9 +1092,9 @@ func (a *allocReconciler) computeStop(group *structs.TaskGroup, nameIndex *alloc
 	for id, alloc := range untainted {
 		if _, ok := removeNames[alloc.Name]; ok {
 			stop[id] = alloc
-			a.result.stop = append(a.result.stop, allocStopResult{
-				alloc:             alloc,
-				statusDescription: allocNotNeeded,
+			a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+				Alloc:             alloc,
+				StatusDescription: status.AllocNotNeeded,
 			})
 			delete(untainted, id)
 
@@ -1121,9 +1109,9 @@ func (a *allocReconciler) computeStop(group *structs.TaskGroup, nameIndex *alloc
 	// were allocations with duplicate names.
 	for id, alloc := range untainted {
 		stop[id] = alloc
-		a.result.stop = append(a.result.stop, allocStopResult{
-			alloc:             alloc,
-			statusDescription: allocNotNeeded,
+		a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+			Alloc:             alloc,
+			StatusDescription: status.AllocNotNeeded,
 		})
 		delete(untainted, id)
 
@@ -1149,7 +1137,7 @@ func (a *allocReconciler) computeStop(group *structs.TaskGroup, nameIndex *alloc
 //   - If the reconnecting allocation is to be stopped, its replacements may
 //     not be present in any of the returned sets. The rest of the reconciler
 //     logic will handle them.
-func (a *allocReconciler) reconcileReconnecting(reconnecting allocSet, all allocSet, tg *structs.TaskGroup) (allocSet, allocSet) {
+func (a *AllocReconciler) reconcileReconnecting(reconnecting allocSet, all allocSet, tg *structs.TaskGroup) (allocSet, allocSet) {
 	stop := make(allocSet)
 	reconnect := make(allocSet)
 
@@ -1161,10 +1149,10 @@ func (a *allocReconciler) reconcileReconnecting(reconnecting allocSet, all alloc
 
 		if reconnectFailed {
 			stop[reconnectingAlloc.ID] = reconnectingAlloc
-			a.result.stop = append(a.result.stop, allocStopResult{
-				alloc:             reconnectingAlloc,
-				clientStatus:      structs.AllocClientStatusFailed,
-				statusDescription: allocRescheduled,
+			a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+				Alloc:             reconnectingAlloc,
+				ClientStatus:      structs.AllocClientStatusFailed,
+				StatusDescription: status.AllocRescheduled,
 			})
 			continue
 		}
@@ -1180,9 +1168,9 @@ func (a *allocReconciler) reconcileReconnecting(reconnecting allocSet, all alloc
 
 		if stopReconnecting {
 			stop[reconnectingAlloc.ID] = reconnectingAlloc
-			a.result.stop = append(a.result.stop, allocStopResult{
-				alloc:             reconnectingAlloc,
-				statusDescription: allocNotNeeded,
+			a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+				Alloc:             reconnectingAlloc,
+				StatusDescription: status.AllocNotNeeded,
 			})
 			continue
 		}
@@ -1218,15 +1206,15 @@ func (a *allocReconciler) reconcileReconnecting(reconnecting allocSet, all alloc
 			}
 
 			// Pick which allocation we want to keep using the disconnect reconcile strategy
-			keepAlloc := a.reconnectingPicker.PickReconnectingAlloc(tg.Disconnect, reconnectingAlloc, replacementAlloc)
+			keepAlloc := a.reconnectingPicker.pickReconnectingAlloc(tg.Disconnect, reconnectingAlloc, replacementAlloc)
 			if keepAlloc == replacementAlloc {
 				// The replacement allocation is preferred, so stop the one
 				// reconnecting if not stopped yet.
 				if _, ok := stop[reconnectingAlloc.ID]; !ok {
 					stop[reconnectingAlloc.ID] = reconnectingAlloc
-					a.result.stop = append(a.result.stop, allocStopResult{
-						alloc:             reconnectingAlloc,
-						statusDescription: allocNotNeeded,
+					a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+						Alloc:             reconnectingAlloc,
+						StatusDescription: status.AllocNotNeeded,
 					})
 				}
 			} else {
@@ -1234,9 +1222,9 @@ func (a *allocReconciler) reconcileReconnecting(reconnecting allocSet, all alloc
 				// that are not in server terminal status or stopped already.
 				if _, ok := stop[replacementAlloc.ID]; !ok {
 					stop[replacementAlloc.ID] = replacementAlloc
-					a.result.stop = append(a.result.stop, allocStopResult{
-						alloc:             replacementAlloc,
-						statusDescription: allocReconnected,
+					a.Result.Stop = append(a.Result.Stop, AllocStopResult{
+						Alloc:             replacementAlloc,
+						StatusDescription: status.AllocReconnected,
 					})
 				}
 			}
@@ -1259,7 +1247,7 @@ func (a *allocReconciler) reconcileReconnecting(reconnecting allocSet, all alloc
 // 2. Those that can be upgraded in-place. These are added to the results
 // automatically since the function contains the correct state to do so,
 // 3. Those that require destructive updates
-func (a *allocReconciler) computeUpdates(group *structs.TaskGroup, untainted allocSet) (ignore, inplace, destructive allocSet) {
+func (a *AllocReconciler) computeUpdates(group *structs.TaskGroup, untainted allocSet) (ignore, inplace, destructive allocSet) {
 	// Determine the set of allocations that need to be updated
 	ignore = make(map[string]*structs.Allocation)
 	inplace = make(map[string]*structs.Allocation)
@@ -1273,7 +1261,7 @@ func (a *allocReconciler) computeUpdates(group *structs.TaskGroup, untainted all
 			destructive[alloc.ID] = alloc
 		} else {
 			inplace[alloc.ID] = alloc
-			a.result.inplaceUpdate = append(a.result.inplaceUpdate, inplaceAlloc)
+			a.Result.InplaceUpdate = append(a.Result.InplaceUpdate, inplaceAlloc)
 		}
 	}
 
@@ -1283,7 +1271,7 @@ func (a *allocReconciler) computeUpdates(group *structs.TaskGroup, untainted all
 // createRescheduleLaterEvals creates batched followup evaluations with the WaitUntil field
 // set for allocations that are eligible to be rescheduled later, and marks the alloc with
 // the followupEvalID
-func (a *allocReconciler) createRescheduleLaterEvals(rescheduleLater []*delayedRescheduleInfo, all allocSet, tgName string) {
+func (a *AllocReconciler) createRescheduleLaterEvals(rescheduleLater []*delayedRescheduleInfo, all allocSet, tgName string) {
 	// followupEvals are created in the same way as for delayed lost allocs
 	allocIDToFollowupEvalID := a.createLostLaterEvals(rescheduleLater, tgName)
 
@@ -1294,10 +1282,10 @@ func (a *allocReconciler) createRescheduleLaterEvals(rescheduleLater []*delayedR
 		updatedAlloc.FollowupEvalID = allocIDToFollowupEvalID[laterAlloc.alloc.ID]
 
 		// Can't updated an allocation that is disconnected
-		if _, ok := a.result.disconnectUpdates[laterAlloc.allocID]; !ok {
-			a.result.attributeUpdates[laterAlloc.allocID] = updatedAlloc
+		if _, ok := a.Result.DisconnectUpdates[laterAlloc.allocID]; !ok {
+			a.Result.AttributeUpdates[laterAlloc.allocID] = updatedAlloc
 		} else {
-			a.result.disconnectUpdates[laterAlloc.allocID].FollowupEvalID = allocIDToFollowupEvalID[laterAlloc.alloc.ID]
+			a.Result.DisconnectUpdates[laterAlloc.allocID].FollowupEvalID = allocIDToFollowupEvalID[laterAlloc.alloc.ID]
 		}
 	}
 }
@@ -1307,7 +1295,7 @@ func (a *allocReconciler) createRescheduleLaterEvals(rescheduleLater []*delayedR
 // set to running, and these allocs are appended to the Plan as non-destructive
 // updates. Clients are responsible for reconciling the DesiredState with the
 // actual state as the node comes back online.
-func (a *allocReconciler) computeReconnecting(reconnecting allocSet) {
+func (a *AllocReconciler) computeReconnecting(reconnecting allocSet) {
 
 	// Create updates that will be appended to the plan.
 	for _, alloc := range reconnecting {
@@ -1335,14 +1323,14 @@ func (a *allocReconciler) computeReconnecting(reconnecting allocSet) {
 		// Use a copy to prevent mutating the object from statestore.
 		reconnectedAlloc := alloc.Copy()
 		reconnectedAlloc.AppendState(structs.AllocStateFieldClientStatus, alloc.ClientStatus)
-		a.result.reconnectUpdates[reconnectedAlloc.ID] = reconnectedAlloc
+		a.Result.ReconnectUpdates[reconnectedAlloc.ID] = reconnectedAlloc
 	}
 }
 
 // handleDelayedLost creates batched followup evaluations with the WaitUntil field set for
 // lost allocations. followupEvals are appended to a.result as a side effect, we return a
 // map of alloc IDs to their followupEval IDs.
-func (a *allocReconciler) createLostLaterEvals(rescheduleLater []*delayedRescheduleInfo, tgName string) map[string]string {
+func (a *AllocReconciler) createLostLaterEvals(rescheduleLater []*delayedRescheduleInfo, tgName string) map[string]string {
 	if len(rescheduleLater) == 0 {
 		return map[string]string{}
 	}
@@ -1366,7 +1354,7 @@ func (a *allocReconciler) createLostLaterEvals(rescheduleLater []*delayedResched
 		JobID:             a.job.ID,
 		JobModifyIndex:    a.job.ModifyIndex,
 		Status:            structs.EvalStatusPending,
-		StatusDescription: reschedulingFollowupEvalDesc,
+		StatusDescription: status.ReschedulingFollowupEvalDesc,
 		WaitUntil:         nextReschedTime,
 	}
 	evals = append(evals, eval)
@@ -1404,7 +1392,7 @@ func (a *allocReconciler) createLostLaterEvals(rescheduleLater []*delayedResched
 // createTimeoutLaterEvals creates followup evaluations with the
 // WaitUntil field set for allocations in an unknown state on disconnected nodes.
 // It returns a map of allocIDs to their associated followUpEvalIDs.
-func (a *allocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName string) map[string]string {
+func (a *AllocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName string) map[string]string {
 	if len(disconnecting) == 0 {
 		return map[string]string{}
 	}
@@ -1434,7 +1422,7 @@ func (a *allocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName
 		JobID:             a.job.ID,
 		JobModifyIndex:    a.job.ModifyIndex,
 		Status:            structs.EvalStatusPending,
-		StatusDescription: disconnectTimeoutFollowupEvalDesc,
+		StatusDescription: status.DisconnectTimeoutFollowupEvalDesc,
 		WaitUntil:         nextReschedTime,
 	}
 	evals = append(evals, eval)
@@ -1458,7 +1446,7 @@ func (a *allocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName
 				JobID:             a.job.ID,
 				JobModifyIndex:    a.job.ModifyIndex,
 				Status:            structs.EvalStatusPending,
-				StatusDescription: disconnectTimeoutFollowupEvalDesc,
+				StatusDescription: status.DisconnectTimeoutFollowupEvalDesc,
 				WaitUntil:         timeoutInfo.rescheduleTime,
 			}
 			evals = append(evals, eval)
@@ -1476,14 +1464,14 @@ func (a *allocReconciler) createTimeoutLaterEvals(disconnecting allocSet, tgName
 
 // Create updates that will be applied to the allocs to mark the FollowupEvalID
 // and the unknown ClientStatus and AllocState.
-func (a *allocReconciler) appendUnknownDisconnectingUpdates(disconnecting allocSet, allocIDToFollowupEvalID map[string]string, rescheduleNow allocSet) {
+func (a *AllocReconciler) appendUnknownDisconnectingUpdates(disconnecting allocSet, allocIDToFollowupEvalID map[string]string, rescheduleNow allocSet) {
 	for id, alloc := range disconnecting {
 		updatedAlloc := alloc.Copy()
 		updatedAlloc.ClientStatus = structs.AllocClientStatusUnknown
 		updatedAlloc.AppendState(structs.AllocStateFieldClientStatus, structs.AllocClientStatusUnknown)
-		updatedAlloc.ClientDescription = allocUnknown
+		updatedAlloc.ClientDescription = status.AllocUnknown
 		updatedAlloc.FollowupEvalID = allocIDToFollowupEvalID[id]
-		a.result.disconnectUpdates[updatedAlloc.ID] = updatedAlloc
+		a.Result.DisconnectUpdates[updatedAlloc.ID] = updatedAlloc
 
 		// update the reschedule set so that any placements holding onto this
 		// pointer are using the right pointer for PreviousAllocation()
@@ -1497,13 +1485,13 @@ func (a *allocReconciler) appendUnknownDisconnectingUpdates(disconnecting allocS
 
 // appendFollowupEvals appends a set of followup evals for a task group to the
 // desiredFollowupEvals map which is later added to the scheduler's followUpEvals set.
-func (a *allocReconciler) appendFollowupEvals(tgName string, evals []*structs.Evaluation) {
+func (a *AllocReconciler) appendFollowupEvals(tgName string, evals []*structs.Evaluation) {
 	// Merge with
-	if existingFollowUpEvals, ok := a.result.desiredFollowupEvals[tgName]; ok {
+	if existingFollowUpEvals, ok := a.Result.DesiredFollowupEvals[tgName]; ok {
 		evals = append(existingFollowUpEvals, evals...)
 	}
 
-	a.result.desiredFollowupEvals[tgName] = evals
+	a.Result.DesiredFollowupEvals[tgName] = evals
 }
 
 // emitRescheduleInfo emits metrics about the rescheduling decision of an evaluation. If a followup evaluation is

--- a/scheduler/reconcile/reconcile_node.go
+++ b/scheduler/reconcile/reconcile_node.go
@@ -189,7 +189,7 @@ func diffSystemAllocsForNode(
 				disconnect := exist.Copy()
 				disconnect.ClientStatus = structs.AllocClientStatusUnknown
 				disconnect.AppendState(structs.AllocStateFieldClientStatus, structs.AllocClientStatusUnknown)
-				disconnect.ClientDescription = sstructs.AllocUnknown
+				disconnect.ClientDescription = sstructs.StatusAllocUnknown
 				result.Disconnecting = append(result.Disconnecting, AllocTuple{
 					Name:      name,
 					TaskGroup: tg,

--- a/scheduler/reconcile/reconcile_node.go
+++ b/scheduler/reconcile/reconcile_node.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/hashicorp/nomad/scheduler/status"
+	sstructs "github.com/hashicorp/nomad/scheduler/structs"
 )
 
 // Node is like diffSystemAllocsForNode however, the allocations in the
@@ -189,7 +189,7 @@ func diffSystemAllocsForNode(
 				disconnect := exist.Copy()
 				disconnect.ClientStatus = structs.AllocClientStatusUnknown
 				disconnect.AppendState(structs.AllocStateFieldClientStatus, structs.AllocClientStatusUnknown)
-				disconnect.ClientDescription = status.AllocUnknown
+				disconnect.ClientDescription = sstructs.AllocUnknown
 				result.Disconnecting = append(result.Disconnecting, AllocTuple{
 					Name:      name,
 					TaskGroup: tg,

--- a/scheduler/reconcile/reconnecting_picker_test.go
+++ b/scheduler/reconcile/reconnecting_picker_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package reconnectingpicker
+package reconcile
 
 import (
 	"testing"
@@ -13,7 +13,7 @@ import (
 )
 
 func TestPickReconnectingAlloc_NewerVersion(t *testing.T) {
-	rp := New(hclog.NewNullLogger())
+	rp := newReconnectingPicker(hclog.NewNullLogger())
 	ds := &structs.DisconnectStrategy{
 		Reconcile: "best-score",
 	}
@@ -59,14 +59,14 @@ func TestPickReconnectingAlloc_NewerVersion(t *testing.T) {
 			},
 		}
 
-		result := rp.PickReconnectingAlloc(ds, original, replacement)
+		result := rp.pickReconnectingAlloc(ds, original, replacement)
 
 		must.Eq(t, tc.expected, result)
 	}
 }
 
 func TestPickReconnectingAlloc_DifferentStrategies(t *testing.T) {
-	rp := New(hclog.NewNullLogger())
+	rp := newReconnectingPicker(hclog.NewNullLogger())
 	now := time.Now()
 
 	original := &structs.Allocation{
@@ -164,7 +164,7 @@ func TestPickReconnectingAlloc_DifferentStrategies(t *testing.T) {
 				Reconcile: tc.strategy,
 			}
 
-			result := rp.PickReconnectingAlloc(ds, original, replacement)
+			result := rp.pickReconnectingAlloc(ds, original, replacement)
 			must.Eq(t, tc.expected, result)
 
 		})
@@ -172,7 +172,7 @@ func TestPickReconnectingAlloc_DifferentStrategies(t *testing.T) {
 }
 
 func TestPickReconnectingAlloc_BestScore(t *testing.T) {
-	rp := New(hclog.NewNullLogger())
+	rp := newReconnectingPicker(hclog.NewNullLogger())
 
 	original := &structs.Allocation{
 		Job: &structs.Job{
@@ -249,7 +249,7 @@ func TestPickReconnectingAlloc_BestScore(t *testing.T) {
 			replacement.ClientStatus = tc.replacementClientStatus
 			replacement.Metrics.ScoreMetaData[0].NormScore = tc.replacementScore
 
-			result := rp.PickReconnectingAlloc(&structs.DisconnectStrategy{
+			result := rp.pickReconnectingAlloc(&structs.DisconnectStrategy{
 				Reconcile: structs.ReconcileOptionBestScore,
 			}, original, replacement)
 
@@ -259,7 +259,7 @@ func TestPickReconnectingAlloc_BestScore(t *testing.T) {
 }
 
 func TestPickReconnectingAlloc_LongestRunning(t *testing.T) {
-	rp := New(hclog.NewNullLogger())
+	rp := newReconnectingPicker(hclog.NewNullLogger())
 	now := time.Now()
 	taskGroupNoLeader := &structs.TaskGroup{
 		Name: "taskGroupNoLeader",
@@ -465,7 +465,7 @@ func TestPickReconnectingAlloc_LongestRunning(t *testing.T) {
 			original.TaskStates["task2"] = &tc.originalState
 			replacement.TaskStates["task2"] = &tc.replacementState
 
-			result := rp.PickReconnectingAlloc(&structs.DisconnectStrategy{
+			result := rp.pickReconnectingAlloc(&structs.DisconnectStrategy{
 				Reconcile: structs.ReconcileOptionLongestRunning,
 			}, original, replacement)
 

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler/reconcile"
-	"github.com/hashicorp/nomad/scheduler/status"
+	sstructs "github.com/hashicorp/nomad/scheduler/structs"
 )
 
 const (
@@ -263,18 +263,18 @@ func (s *SystemScheduler) computeJobAllocs() error {
 
 	// Add all the allocs to stop
 	for _, e := range r.Stop {
-		s.plan.AppendStoppedAlloc(e.Alloc, status.AllocNotNeeded, "", "")
+		s.plan.AppendStoppedAlloc(e.Alloc, sstructs.AllocNotNeeded, "", "")
 	}
 
 	// Add all the allocs to migrate
 	for _, e := range r.Migrate {
-		s.plan.AppendStoppedAlloc(e.Alloc, status.AllocNodeTainted, "", "")
+		s.plan.AppendStoppedAlloc(e.Alloc, sstructs.AllocNodeTainted, "", "")
 	}
 
 	// Lost allocations should be transitioned to desired status stop and client
 	// status lost.
 	for _, e := range r.Lost {
-		s.plan.AppendStoppedAlloc(e.Alloc, status.AllocLost, structs.AllocClientStatusLost, "")
+		s.plan.AppendStoppedAlloc(e.Alloc, sstructs.AllocLost, structs.AllocClientStatusLost, "")
 	}
 
 	for _, e := range r.Disconnecting {
@@ -308,7 +308,7 @@ func (s *SystemScheduler) computeJobAllocs() error {
 	}
 
 	// Treat non in-place updates as an eviction and new placement.
-	s.limitReached = evictAndPlace(s.ctx, r, r.Update, status.AllocUpdating, &limit)
+	s.limitReached = evictAndPlace(s.ctx, r, r.Update, sstructs.AllocUpdating, &limit)
 
 	// Nothing remaining to do if placement is not required
 	if len(r.Place) == 0 {
@@ -538,7 +538,7 @@ func (s *SystemScheduler) addBlocked(node *structs.Node) error {
 	}
 
 	blocked := s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs)
-	blocked.StatusDescription = status.BlockedEvalFailedPlacements
+	blocked.StatusDescription = sstructs.BlockedEvalFailedPlacements
 	blocked.NodeID = node.ID
 
 	return s.planner.CreateEval(blocked)

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -263,18 +263,18 @@ func (s *SystemScheduler) computeJobAllocs() error {
 
 	// Add all the allocs to stop
 	for _, e := range r.Stop {
-		s.plan.AppendStoppedAlloc(e.Alloc, sstructs.AllocNotNeeded, "", "")
+		s.plan.AppendStoppedAlloc(e.Alloc, sstructs.StatusAllocNotNeeded, "", "")
 	}
 
 	// Add all the allocs to migrate
 	for _, e := range r.Migrate {
-		s.plan.AppendStoppedAlloc(e.Alloc, sstructs.AllocNodeTainted, "", "")
+		s.plan.AppendStoppedAlloc(e.Alloc, sstructs.StatusAllocNodeTainted, "", "")
 	}
 
 	// Lost allocations should be transitioned to desired status stop and client
 	// status lost.
 	for _, e := range r.Lost {
-		s.plan.AppendStoppedAlloc(e.Alloc, sstructs.AllocLost, structs.AllocClientStatusLost, "")
+		s.plan.AppendStoppedAlloc(e.Alloc, sstructs.StatusAllocLost, structs.AllocClientStatusLost, "")
 	}
 
 	for _, e := range r.Disconnecting {
@@ -308,7 +308,7 @@ func (s *SystemScheduler) computeJobAllocs() error {
 	}
 
 	// Treat non in-place updates as an eviction and new placement.
-	s.limitReached = evictAndPlace(s.ctx, r, r.Update, sstructs.AllocUpdating, &limit)
+	s.limitReached = evictAndPlace(s.ctx, r, r.Update, sstructs.StatusAllocUpdating, &limit)
 
 	// Nothing remaining to do if placement is not required
 	if len(r.Place) == 0 {
@@ -538,7 +538,7 @@ func (s *SystemScheduler) addBlocked(node *structs.Node) error {
 	}
 
 	blocked := s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs)
-	blocked.StatusDescription = sstructs.BlockedEvalFailedPlacements
+	blocked.StatusDescription = sstructs.DescBlockedEvalFailedPlacements
 	blocked.NodeID = node.ID
 
 	return s.planner.CreateEval(blocked)

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/scheduler/reconcile"
+	"github.com/hashicorp/nomad/scheduler/status"
 )
 
 const (
@@ -255,27 +257,27 @@ func (s *SystemScheduler) computeJobAllocs() error {
 	live, term := structs.SplitTerminalAllocs(allocs)
 
 	// Diff the required and existing allocations
-	diff := diffSystemAllocs(s.job, s.nodes, s.notReadyNodes, tainted, live, term,
+	r := reconcile.Node(s.job, s.nodes, s.notReadyNodes, tainted, live, term,
 		s.planner.ServersMeetMinimumVersion(minVersionMaxClientDisconnect, true))
-	s.logger.Debug("reconciled current state with desired state", "results", log.Fmt("%#v", diff))
+	s.logger.Debug("reconciled current state with desired state", "results", log.Fmt("%#v", r))
 
 	// Add all the allocs to stop
-	for _, e := range diff.stop {
-		s.plan.AppendStoppedAlloc(e.Alloc, allocNotNeeded, "", "")
+	for _, e := range r.Stop {
+		s.plan.AppendStoppedAlloc(e.Alloc, status.AllocNotNeeded, "", "")
 	}
 
 	// Add all the allocs to migrate
-	for _, e := range diff.migrate {
-		s.plan.AppendStoppedAlloc(e.Alloc, allocNodeTainted, "", "")
+	for _, e := range r.Migrate {
+		s.plan.AppendStoppedAlloc(e.Alloc, status.AllocNodeTainted, "", "")
 	}
 
 	// Lost allocations should be transitioned to desired status stop and client
 	// status lost.
-	for _, e := range diff.lost {
-		s.plan.AppendStoppedAlloc(e.Alloc, allocLost, structs.AllocClientStatusLost, "")
+	for _, e := range r.Lost {
+		s.plan.AppendStoppedAlloc(e.Alloc, status.AllocLost, structs.AllocClientStatusLost, "")
 	}
 
-	for _, e := range diff.disconnecting {
+	for _, e := range r.Disconnecting {
 		s.plan.AppendUnknownAlloc(e.Alloc)
 	}
 
@@ -283,11 +285,11 @@ func (s *SystemScheduler) computeJobAllocs() error {
 	// Attempt to do the upgrades in place.
 	// Reconnecting allocations need to be updated to persists alloc state
 	// changes.
-	updates := make([]allocTuple, 0, len(diff.update)+len(diff.reconnecting))
-	updates = append(updates, diff.update...)
-	updates = append(updates, diff.reconnecting...)
+	updates := make([]reconcile.AllocTuple, 0, len(r.Update)+len(r.Reconnecting))
+	updates = append(updates, r.Update...)
+	updates = append(updates, r.Reconnecting...)
 	destructiveUpdates, inplaceUpdates := inplaceUpdate(s.ctx, s.eval, s.job, s.stack, updates)
-	diff.update = destructiveUpdates
+	r.Update = destructiveUpdates
 
 	for _, inplaceUpdate := range inplaceUpdates {
 		allocExistsForTaskGroup[inplaceUpdate.TaskGroup.Name] = true
@@ -295,21 +297,21 @@ func (s *SystemScheduler) computeJobAllocs() error {
 
 	if s.eval.AnnotatePlan {
 		s.plan.Annotations = &structs.PlanAnnotations{
-			DesiredTGUpdates: desiredUpdates(diff, inplaceUpdates, destructiveUpdates),
+			DesiredTGUpdates: desiredUpdates(r, inplaceUpdates, destructiveUpdates),
 		}
 	}
 
 	// Check if a rolling upgrade strategy is being used
-	limit := len(diff.update)
+	limit := len(r.Update)
 	if !s.job.Stopped() && s.job.Update.Rolling() {
 		limit = s.job.Update.MaxParallel
 	}
 
 	// Treat non in-place updates as an eviction and new placement.
-	s.limitReached = evictAndPlace(s.ctx, diff, diff.update, allocUpdating, &limit)
+	s.limitReached = evictAndPlace(s.ctx, r, r.Update, status.AllocUpdating, &limit)
 
 	// Nothing remaining to do if placement is not required
-	if len(diff.place) == 0 {
+	if len(r.Place) == 0 {
 		if !s.job.Stopped() {
 			for _, tg := range s.job.TaskGroups {
 				s.queuedAllocs[tg.Name] = 0
@@ -319,16 +321,16 @@ func (s *SystemScheduler) computeJobAllocs() error {
 	}
 
 	// Record the number of allocations that needs to be placed per Task Group
-	for _, allocTuple := range diff.place {
+	for _, allocTuple := range r.Place {
 		s.queuedAllocs[allocTuple.TaskGroup.Name] += 1
 	}
 
-	for _, ignoredAlloc := range diff.ignore {
+	for _, ignoredAlloc := range r.Ignore {
 		allocExistsForTaskGroup[ignoredAlloc.TaskGroup.Name] = true
 	}
 
 	// Compute the placements
-	return s.computePlacements(diff.place, allocExistsForTaskGroup)
+	return s.computePlacements(r.Place, allocExistsForTaskGroup)
 }
 
 func mergeNodeFiltered(acc, curr *structs.AllocMetric) *structs.AllocMetric {
@@ -356,7 +358,7 @@ func mergeNodeFiltered(acc, curr *structs.AllocMetric) *structs.AllocMetric {
 }
 
 // computePlacements computes placements for allocations
-func (s *SystemScheduler) computePlacements(place []allocTuple, existingByTaskGroup map[string]bool) error {
+func (s *SystemScheduler) computePlacements(place []reconcile.AllocTuple, existingByTaskGroup map[string]bool) error {
 	nodeByID := make(map[string]*structs.Node, len(s.nodes))
 	for _, node := range s.nodes {
 		nodeByID[node.ID] = node
@@ -536,7 +538,7 @@ func (s *SystemScheduler) addBlocked(node *structs.Node) error {
 	}
 
 	blocked := s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs)
-	blocked.StatusDescription = blockedEvalFailedPlacements
+	blocked.StatusDescription = status.BlockedEvalFailedPlacements
 	blocked.NodeID = node.ID
 
 	return s.planner.CreateEval(blocked)
@@ -564,5 +566,23 @@ func (s *SystemScheduler) canHandle(trigger string) bool {
 			return false
 		}
 	}
+	return true
+}
+
+// evictAndPlace is used to mark allocations for evicts and add them to the
+// placement queue. evictAndPlace modifies both the diffResult and the
+// limit. It returns true if the limit has been reached.
+func evictAndPlace(ctx Context, diff *reconcile.NodeReconcileResult, allocs []reconcile.AllocTuple, desc string, limit *int) bool {
+	n := len(allocs)
+	for i := 0; i < n && i < *limit; i++ {
+		a := allocs[i]
+		ctx.Plan().AppendStoppedAlloc(a.Alloc, desc, "", "")
+		diff.Place = append(diff.Place, a)
+	}
+	if n <= *limit {
+		*limit -= n
+		return false
+	}
+	*limit = 0
 	return true
 }

--- a/scheduler/status/status.go
+++ b/scheduler/status/status.go
@@ -1,0 +1,57 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package status
+
+/*
+ * This package containst only statuses and descriptions used across the whole
+ * scheduler package.
+ */
+
+const (
+	// AllocNotNeeded is the status used when a job no longer requires an allocation
+	AllocNotNeeded = "alloc not needed due to job update"
+
+	// AllocReconnected is the status to use when a replacement allocation is stopped
+	// because a disconnected node reconnects.
+	AllocReconnected = "alloc not needed due to disconnected client reconnect"
+
+	// AllocMigrating is the status used when we must migrate an allocation
+	AllocMigrating = "alloc is being migrated"
+
+	// AllocUpdating is the status used when a job requires an update
+	AllocUpdating = "alloc is being updated due to job update"
+
+	// AllocLost is the status used when an allocation is lost
+	AllocLost = "alloc is lost since its node is down"
+
+	// AllocUnknown is the status used when an allocation is unknown
+	AllocUnknown = "alloc is unknown since its node is disconnected"
+
+	// AllocInPlace is the status used when speculating on an in-place update
+	AllocInPlace = "alloc updating in-place"
+
+	// AllocNodeTainted is the status used when stopping an alloc because its
+	// node is tainted.
+	AllocNodeTainted = "alloc not needed as node is tainted"
+
+	// AllocRescheduled is the status used when an allocation failed and was rescheduled
+	AllocRescheduled = "alloc was rescheduled because it failed"
+
+	// BlockedEvalMaxPlanDesc is the description used for blocked evals that are
+	// a result of hitting the max number of plan attempts
+	BlockedEvalMaxPlanDesc = "created due to placement conflicts"
+
+	// BlockedEvalFailedPlacements is the description used for blocked evals
+	// that are a result of failing to place all allocations.
+	BlockedEvalFailedPlacements = "created to place remaining allocations"
+
+	// ReschedulingFollowupEvalDesc is the description used when creating follow
+	// up evals for delayed rescheduling
+	ReschedulingFollowupEvalDesc = "created for delayed rescheduling"
+
+	// DisconnectTimeoutFollowupEvalDesc is the description used when creating follow
+	// up evals for allocations that be should be stopped after its disconnect
+	// timeout has passed.
+	DisconnectTimeoutFollowupEvalDesc = "created for delayed disconnect timeout"
+)

--- a/scheduler/structs/const.go
+++ b/scheduler/structs/const.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package status
+package structs
 
 /*
  * This package containst only statuses and descriptions used across the whole

--- a/scheduler/structs/const.go
+++ b/scheduler/structs/const.go
@@ -3,55 +3,52 @@
 
 package structs
 
-/*
- * This package containst only statuses and descriptions used across the whole
- * scheduler package.
- */
-
 const (
-	// AllocNotNeeded is the status used when a job no longer requires an allocation
-	AllocNotNeeded = "alloc not needed due to job update"
+	// StatusAllocNotNeeded is the status used when a job no longer requires an
+	// allocation
+	StatusAllocNotNeeded = "alloc not needed due to job update"
 
-	// AllocReconnected is the status to use when a replacement allocation is stopped
-	// because a disconnected node reconnects.
-	AllocReconnected = "alloc not needed due to disconnected client reconnect"
+	// StatusAllocReconnected is the status to use when a replacement allocation is
+	// stopped because a disconnected node reconnects.
+	StatusAllocReconnected = "alloc not needed due to disconnected client reconnect"
 
-	// AllocMigrating is the status used when we must migrate an allocation
-	AllocMigrating = "alloc is being migrated"
+	// StatusAllocMigrating is the status used when we must migrate an allocation
+	StatusAllocMigrating = "alloc is being migrated"
 
-	// AllocUpdating is the status used when a job requires an update
-	AllocUpdating = "alloc is being updated due to job update"
+	// StatusAllocUpdating is the status used when a job requires an update
+	StatusAllocUpdating = "alloc is being updated due to job update"
 
-	// AllocLost is the status used when an allocation is lost
-	AllocLost = "alloc is lost since its node is down"
+	// StatusAllocLost is the status used when an allocation is lost
+	StatusAllocLost = "alloc is lost since its node is down"
 
-	// AllocUnknown is the status used when an allocation is unknown
-	AllocUnknown = "alloc is unknown since its node is disconnected"
+	// StatusAllocUnknown is the status used when an allocation is unknown
+	StatusAllocUnknown = "alloc is unknown since its node is disconnected"
 
-	// AllocInPlace is the status used when speculating on an in-place update
-	AllocInPlace = "alloc updating in-place"
+	// StatusAllocInPlace is the status used when speculating on an in-place update
+	StatusAllocInPlace = "alloc updating in-place"
 
-	// AllocNodeTainted is the status used when stopping an alloc because its
+	// StatusAllocNodeTainted is the status used when stopping an alloc because its
 	// node is tainted.
-	AllocNodeTainted = "alloc not needed as node is tainted"
+	StatusAllocNodeTainted = "alloc not needed as node is tainted"
 
-	// AllocRescheduled is the status used when an allocation failed and was rescheduled
-	AllocRescheduled = "alloc was rescheduled because it failed"
+	// StatusAllocRescheduled is the status used when an allocation failed and was
+	// rescheduled
+	StatusAllocRescheduled = "alloc was rescheduled because it failed"
 
-	// BlockedEvalMaxPlanDesc is the description used for blocked evals that are
+	// DescBlockedEvalMaxPlan is the description used for blocked evals that are
 	// a result of hitting the max number of plan attempts
-	BlockedEvalMaxPlanDesc = "created due to placement conflicts"
+	DescBlockedEvalMaxPlan = "created due to placement conflicts"
 
-	// BlockedEvalFailedPlacements is the description used for blocked evals
+	// DescBlockedEvalFailedPlacements is the description used for blocked evals
 	// that are a result of failing to place all allocations.
-	BlockedEvalFailedPlacements = "created to place remaining allocations"
+	DescBlockedEvalFailedPlacements = "created to place remaining allocations"
 
-	// ReschedulingFollowupEvalDesc is the description used when creating follow
+	// DescReschedulingFollowupEval is the description used when creating follow
 	// up evals for delayed rescheduling
-	ReschedulingFollowupEvalDesc = "created for delayed rescheduling"
+	DescReschedulingFollowupEval = "created for delayed rescheduling"
 
-	// DisconnectTimeoutFollowupEvalDesc is the description used when creating follow
+	// DescDisconnectTimeoutFollowupEval is the description used when creating follow
 	// up evals for allocations that be should be stopped after its disconnect
 	// timeout has passed.
-	DisconnectTimeoutFollowupEvalDesc = "created for delayed disconnect timeout"
+	DescDisconnectTimeoutFollowupEval = "created for delayed disconnect timeout"
 )

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -649,7 +649,7 @@ func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
 		// the current allocation is discounted when checking for feasibility.
 		// Otherwise we would be trying to fit the tasks current resources and
 		// updated resources. After select is called we can remove the evict.
-		ctx.Plan().AppendStoppedAlloc(update.Alloc, sstructs.AllocInPlace, "", "")
+		ctx.Plan().AppendStoppedAlloc(update.Alloc, sstructs.StatusAllocInPlace, "", "")
 
 		// Attempt to match the task group
 		option := stack.Select(update.TaskGroup,
@@ -838,7 +838,7 @@ func updateNonTerminalAllocsToLost(plan *structs.Plan, tainted map[string]*struc
 			alloc.DesiredStatus == structs.AllocDesiredStatusEvict) &&
 			(alloc.ClientStatus == structs.AllocClientStatusRunning ||
 				alloc.ClientStatus == structs.AllocClientStatusPending) {
-			plan.AppendStoppedAlloc(alloc, sstructs.AllocLost, structs.AllocClientStatusLost, "")
+			plan.AppendStoppedAlloc(alloc, sstructs.StatusAllocLost, structs.AllocClientStatusLost, "")
 		}
 	}
 }
@@ -896,7 +896,7 @@ func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) reconcile.All
 		// the current allocation is discounted when checking for feasibility.
 		// Otherwise we would be trying to fit the tasks current resources and
 		// updated resources. After select is called we can remove the evict.
-		ctx.Plan().AppendStoppedAlloc(existing, sstructs.AllocInPlace, "", "")
+		ctx.Plan().AppendStoppedAlloc(existing, sstructs.StatusAllocInPlace, "", "")
 
 		// Attempt to match the task group
 		option := stack.Select(newTG, &SelectOptions{AllocName: existing.Name})

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler/reconcile"
-	"github.com/hashicorp/nomad/scheduler/status"
+	sstructs "github.com/hashicorp/nomad/scheduler/structs"
 )
 
 // readyNodesInDCsAndPool returns all the ready nodes in the given datacenters
@@ -649,7 +649,7 @@ func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
 		// the current allocation is discounted when checking for feasibility.
 		// Otherwise we would be trying to fit the tasks current resources and
 		// updated resources. After select is called we can remove the evict.
-		ctx.Plan().AppendStoppedAlloc(update.Alloc, status.AllocInPlace, "", "")
+		ctx.Plan().AppendStoppedAlloc(update.Alloc, sstructs.AllocInPlace, "", "")
 
 		// Attempt to match the task group
 		option := stack.Select(update.TaskGroup,
@@ -838,7 +838,7 @@ func updateNonTerminalAllocsToLost(plan *structs.Plan, tainted map[string]*struc
 			alloc.DesiredStatus == structs.AllocDesiredStatusEvict) &&
 			(alloc.ClientStatus == structs.AllocClientStatusRunning ||
 				alloc.ClientStatus == structs.AllocClientStatusPending) {
-			plan.AppendStoppedAlloc(alloc, status.AllocLost, structs.AllocClientStatusLost, "")
+			plan.AppendStoppedAlloc(alloc, sstructs.AllocLost, structs.AllocClientStatusLost, "")
 		}
 	}
 }
@@ -896,7 +896,7 @@ func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) reconcile.All
 		// the current allocation is discounted when checking for feasibility.
 		// Otherwise we would be trying to fit the tasks current resources and
 		// updated resources. After select is called we can remove the evict.
-		ctx.Plan().AppendStoppedAlloc(existing, status.AllocInPlace, "", "")
+		ctx.Plan().AppendStoppedAlloc(existing, sstructs.AllocInPlace, "", "")
 
 		// Attempt to match the task group
 		option := stack.Select(newTG, &SelectOptions{AllocName: existing.Name})

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -15,35 +15,9 @@ import (
 	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/scheduler/reconcile"
+	"github.com/hashicorp/nomad/scheduler/status"
 )
-
-// allocTuple is a tuple of the allocation name and potential alloc ID
-type allocTuple struct {
-	Name      string
-	TaskGroup *structs.TaskGroup
-	Alloc     *structs.Allocation
-}
-
-// diffResult is used to return the sets that result from the diff
-type diffResult struct {
-	place, update, migrate, stop, ignore, lost, disconnecting, reconnecting []allocTuple
-}
-
-func (d *diffResult) GoString() string {
-	return fmt.Sprintf("allocs: (place %d) (update %d) (migrate %d) (stop %d) (ignore %d) (lost %d) (disconnecting %d) (reconnecting %d)",
-		len(d.place), len(d.update), len(d.migrate), len(d.stop), len(d.ignore), len(d.lost), len(d.disconnecting), len(d.reconnecting))
-}
-
-func (d *diffResult) Append(other *diffResult) {
-	d.place = append(d.place, other.place...)
-	d.update = append(d.update, other.update...)
-	d.migrate = append(d.migrate, other.migrate...)
-	d.stop = append(d.stop, other.stop...)
-	d.ignore = append(d.ignore, other.ignore...)
-	d.lost = append(d.lost, other.lost...)
-	d.disconnecting = append(d.disconnecting, other.disconnecting...)
-	d.reconnecting = append(d.reconnecting, other.reconnecting...)
-}
 
 // readyNodesInDCsAndPool returns all the ready nodes in the given datacenters
 // and pool, and a mapping of each data center to the count of ready nodes.
@@ -615,7 +589,7 @@ func setStatus(logger log.Logger, planner Planner,
 // inplaceUpdate attempts to update allocations in-place where possible. It
 // returns the allocs that couldn't be done inplace and then those that could.
 func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
-	stack Stack, updates []allocTuple) (destructive, inplace []allocTuple) {
+	stack Stack, updates []reconcile.AllocTuple) (destructive, inplace []reconcile.AllocTuple) {
 
 	// doInplace manipulates the updates map to make the current allocation
 	// an inplace update.
@@ -675,7 +649,7 @@ func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
 		// the current allocation is discounted when checking for feasibility.
 		// Otherwise we would be trying to fit the tasks current resources and
 		// updated resources. After select is called we can remove the evict.
-		ctx.Plan().AppendStoppedAlloc(update.Alloc, allocInPlace, "", "")
+		ctx.Plan().AppendStoppedAlloc(update.Alloc, status.AllocInPlace, "", "")
 
 		// Attempt to match the task group
 		option := stack.Select(update.TaskGroup,
@@ -743,11 +717,11 @@ func inplaceUpdate(ctx Context, eval *structs.Evaluation, job *structs.Job,
 // desiredUpdates takes the diffResult as well as the set of inplace and
 // destructive updates and returns a map of task groups to their set of desired
 // updates.
-func desiredUpdates(diff *diffResult, inplaceUpdates,
-	destructiveUpdates []allocTuple) map[string]*structs.DesiredUpdates {
+func desiredUpdates(diff *reconcile.NodeReconcileResult, inplaceUpdates,
+	destructiveUpdates []reconcile.AllocTuple) map[string]*structs.DesiredUpdates {
 	desiredTgs := make(map[string]*structs.DesiredUpdates)
 
-	for _, tuple := range diff.place {
+	for _, tuple := range diff.Place {
 		name := tuple.TaskGroup.Name
 		des, ok := desiredTgs[name]
 		if !ok {
@@ -758,7 +732,7 @@ func desiredUpdates(diff *diffResult, inplaceUpdates,
 		des.Place++
 	}
 
-	for _, tuple := range diff.stop {
+	for _, tuple := range diff.Stop {
 		name := tuple.Alloc.TaskGroup
 		des, ok := desiredTgs[name]
 		if !ok {
@@ -769,7 +743,7 @@ func desiredUpdates(diff *diffResult, inplaceUpdates,
 		des.Stop++
 	}
 
-	for _, tuple := range diff.ignore {
+	for _, tuple := range diff.Ignore {
 		name := tuple.TaskGroup.Name
 		des, ok := desiredTgs[name]
 		if !ok {
@@ -780,7 +754,7 @@ func desiredUpdates(diff *diffResult, inplaceUpdates,
 		des.Ignore++
 	}
 
-	for _, tuple := range diff.migrate {
+	for _, tuple := range diff.Migrate {
 		name := tuple.TaskGroup.Name
 		des, ok := desiredTgs[name]
 		if !ok {
@@ -864,7 +838,7 @@ func updateNonTerminalAllocsToLost(plan *structs.Plan, tainted map[string]*struc
 			alloc.DesiredStatus == structs.AllocDesiredStatusEvict) &&
 			(alloc.ClientStatus == structs.AllocClientStatusRunning ||
 				alloc.ClientStatus == structs.AllocClientStatusPending) {
-			plan.AppendStoppedAlloc(alloc, allocLost, structs.AllocClientStatusLost, "")
+			plan.AppendStoppedAlloc(alloc, status.AllocLost, structs.AllocClientStatusLost, "")
 		}
 	}
 }
@@ -875,7 +849,7 @@ func updateNonTerminalAllocsToLost(plan *structs.Plan, tainted map[string]*struc
 // by the reconciler to make decisions about how to update an allocation. The
 // factory allows the reconciler to be unaware of how to determine the type of
 // update necessary and can minimize the set of objects it is exposed to.
-func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) allocUpdateType {
+func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) reconcile.AllocUpdateType {
 	return func(existing *structs.Allocation, newJob *structs.Job, newTG *structs.TaskGroup) (ignore, destructive bool, updated *structs.Allocation) {
 		// Same index, so nothing to do
 		if existing.Job.JobModifyIndex == newJob.JobModifyIndex {
@@ -922,7 +896,7 @@ func genericAllocUpdateFn(ctx Context, stack Stack, evalID string) allocUpdateTy
 		// the current allocation is discounted when checking for feasibility.
 		// Otherwise we would be trying to fit the tasks current resources and
 		// updated resources. After select is called we can remove the evict.
-		ctx.Plan().AppendStoppedAlloc(existing, allocInPlace, "", "")
+		ctx.Plan().AppendStoppedAlloc(existing, status.AllocInPlace, "", "")
 
 		// Attempt to match the task group
 		option := stack.Select(newTG, &SelectOptions{AllocName: existing.Name})


### PR DESCRIPTION
This moves all the code of service/batch and system/sysbatch reconciliation into a new `reconcile` package.

Internal ref: https://hashicorp.atlassian.net/browse/NMD-812