### PR TITLE
release: add changelog for pr 25921 (ipv6 addr normalization)

### DIFF
--- a/.changelog/25921.txt
+++ b/.changelog/25921.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ipv6: bind and advertise addresses are now made to adhere to RFC-5942 §4 (reference: https://www.rfc-editor.org/rfc/rfc5952.html#section-4)
+```


### PR DESCRIPTION
I neglected to add a changelog entry in #25921 (and backport #26015) -- `ipv6: normalize addrs per RFC-5942 §4`

Calling it an "improvement" seems like a stretch, but if your goal is compliance with USGv6, then it is an improvement.