### PR TITLE
command: prevent panic on graceful shutdown

### DIFF
--- a/.changelog/26018.txt
+++ b/.changelog/26018.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fixed a bug to prevent a possible panic during graceful shutdown
+```


### PR DESCRIPTION
### Description

When performing a graceful shutdown a channel is used to wait for
the agent to leave. The channel is closed when the agent leaves
successfully, but it also is closed within a deferral. If the
agent successfully leaves and closes the channel, a panic will
occur when the channel is closed the second time within the
deferral. To prevent this from occurring, the channel closing
is wrapped within a `OnceFunc` so the channel is only closed
once.

### Testing & Reproduction steps

Panic encountered during shutdown:

```
panic: close of closed channel
goroutine 1 [running]:
github.com/hashicorp/nomad/command/agent.(*Command).terminateGracefully(0xc000948720, 0xc000538e70, {0x0?, 0x0?})
        github.com/hashicorp/nomad/command/agent/command.go:1019 +0x2a5
github.com/hashicorp/nomad/command/agent.(*Command).handleSignals(0xc000948720)
        github.com/hashicorp/nomad/command/agent/command.go:1069 +0x811
github.com/hashicorp/nomad/command/agent.(*Command).Run(0xc000948720, {0xc000072120, 0x2, 0x2})
        github.com/hashicorp/nomad/command/agent/command.go:909 +0xf25
github.com/hashicorp/cli.(*CLI).Run(0xc000a7cb40)
        github.com/hashicorp/cli@v1.1.7/cli.go:265 +0x4de
main.Run({0xc000072110, 0x3, 0x3})
        github.com/hashicorp/nomad/main.go:111 +0x225
main.main()
        github.com/hashicorp/nomad/main.go:82 +0x45
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
