### PR TITLE
csi: send secrets with snapshot delete command

### DIFF
--- a/.changelog/26022.txt
+++ b/.changelog/26022.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed -secret values not being sent with the `nomad volume snapshot delete` command
+```

--- a/nomad/client_csi_endpoint_test.go
+++ b/nomad/client_csi_endpoint_test.go
@@ -47,6 +47,7 @@ type MockClientCSI struct {
 	NextNodeDetachError                error
 	NextNodeExpandError                error
 	LastNodeExpandRequest              *cstructs.ClientCSINodeExpandVolumeRequest
+	LastDeleteSnapshotRequest          *cstructs.ClientCSIControllerDeleteSnapshotRequest
 }
 
 func newMockClientCSI() *MockClientCSI {
@@ -93,6 +94,7 @@ func (c *MockClientCSI) ControllerCreateSnapshot(req *cstructs.ClientCSIControll
 }
 
 func (c *MockClientCSI) ControllerDeleteSnapshot(req *cstructs.ClientCSIControllerDeleteSnapshotRequest, resp *cstructs.ClientCSIControllerDeleteSnapshotResponse) error {
+	c.LastDeleteSnapshotRequest = req
 	return c.NextDeleteSnapshotError
 }
 

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -1627,7 +1627,10 @@ func (v *CSIVolume) DeleteSnapshot(args *structs.CSISnapshotDeleteRequest, reply
 
 		method := "ClientCSI.ControllerDeleteSnapshot"
 
-		cReq := &cstructs.ClientCSIControllerDeleteSnapshotRequest{ID: snap.ID}
+		cReq := &cstructs.ClientCSIControllerDeleteSnapshotRequest{
+			ID:      snap.ID,
+			Secrets: snap.Secrets,
+		}
 		cReq.PluginID = plugin.ID
 		cResp := &cstructs.ClientCSIControllerDeleteSnapshotResponse{}
 		err = v.serializedControllerRPC(plugin.ID, func() error {


### PR DESCRIPTION
When running `nomad volume snapshot delete -secret X=Y ...`, the secret(s) are discarded along the way, and do not make it to the CSI plugin.  This adds them to the RPC handler.

Fixes #25976

Unit test covers this change, and I also proved it out with a toy CSI plugin running on an agent.