### PR TITLE
docs: describe shutdown order on `lifecycle` page

### DIFF
--- a/website/content/docs/job-specification/lifecycle.mdx
+++ b/website/content/docs/job-specification/lifecycle.mdx
@@ -25,6 +25,11 @@ tasks or "sidecar" tasks that are expected to run for the duration of the main t
 The absence of the sidecar flag indicates that the task is ephemeral
 and should not be restarted if it completes successfully.
 
+The `lifecycle` block also controls the order Nomad stops tasks in an
+allocation. Nomad first waits for the group's [shutdown_delay][]. It then stops
+the [leader][] task, if present. Then Nomad stops any non-sidecar and
+non-poststop tasks, and finally any sidecar tasks.
+
 Learn more about [Nomad's task dependencies][learn-taskdeps].
 
 ## Parameters
@@ -45,6 +50,8 @@ Learn more about [Nomad's task dependencies][learn-taskdeps].
   restarted as long as the allocation is running.
 
 [learn-taskdeps]: /nomad/tutorials/task-deps
+[shutdown_delay]: /nomad/docs/job-specification/group#shutdown_delay
+[leader]: /nomad/docs/job-specification/task#leader
 
 ## Examples
 

--- a/website/content/docs/job-specification/task.mdx
+++ b/website/content/docs/job-specification/task.mdx
@@ -72,12 +72,12 @@ job "docs" {
 
 - `leader` `(bool: false)` - Specifies whether the task is the leader task of
   the task group. If set to `true`, when the leader task completes, all other
-  tasks within the task group will be gracefully shutdown. The shutdown
-  process starts by applying the `shutdown_delay` if configured. It then stops the
-  the leader task first, followed by non-sidecar and non-poststop tasks,
-  and finally sidecar tasks. Once this process completes, post-stop tasks
-  are triggered. See the [lifecycle][] documentation for a complete description
-  of task lifecycle management.
+  tasks within the task group will be gracefully shutdown. The shutdown process
+  starts by applying the `shutdown_delay` if configured. It then stops the the
+  leader task first, if any, followed by non-sidecar and non-poststop tasks, and
+  finally sidecar tasks. Once this process completes, post-stop tasks are
+  triggered. See the [lifecycle][] documentation for a complete description of
+  task lifecycle management.
 
 - `lifecycle` <code>([Lifecycle][]: nil)</code> - Specifies when a task is run
   within the lifecycle of a task group. Added in Nomad v0.11.


### PR DESCRIPTION
We have a description of the order of shutdown in the `task.leader` docs, but the `lifecycle` block is an intuitive place to look for this same information, and the behavior is largely governed by that feature anyways.
