### PR TITLE
scheduler: rename reconciliation package to `reconciler`

### DIFF
--- a/ci/test-core.json
+++ b/ci/test-core.json
@@ -47,7 +47,7 @@
     "plugins/...",
     "scheduler/...",
     "scheduler/feasible/...",
-    "scheduler/reconcile/...",
+    "scheduler/reconciler/...",
     "testutil/..."
   ]
 }

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/hashicorp/nomad/scheduler/reconcile"
+	"github.com/hashicorp/nomad/scheduler/reconciler"
 	sstructs "github.com/hashicorp/nomad/scheduler/structs"
 	"github.com/hashicorp/nomad/scheduler/tests"
 	"github.com/shoenig/test"
@@ -7051,7 +7051,7 @@ func TestDowngradedJobForPlacement_PicksTheLatest(t *testing.T) {
 
 			sched.job = nj
 			sched.deployment = deployment
-			placement := &reconcile.AllocPlaceResult{}
+			placement := &reconciler.AllocPlaceResult{}
 			placement.SetTaskGroup(nj.TaskGroups[0])
 
 			// Here, assert the downgraded job version

--- a/scheduler/reconciler/allocs.go
+++ b/scheduler/reconciler/allocs.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package reconcile
+package reconciler
 
 import (
 	"errors"

--- a/scheduler/reconciler/allocs_test.go
+++ b/scheduler/reconciler/allocs_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package reconcile
+package reconciler
 
 import (
 	"testing"

--- a/scheduler/reconciler/reconcile_cluster.go
+++ b/scheduler/reconciler/reconcile_cluster.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package reconcile
+package reconciler
 
 // The reconciler is the first stage in the scheduler for service and batch
 // jobs. It compares the existing state to the desired state to determine the

--- a/scheduler/reconciler/reconcile_cluster_test.go
+++ b/scheduler/reconciler/reconcile_cluster_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package reconcile
+package reconciler
 
 import (
 	"fmt"

--- a/scheduler/reconciler/reconcile_node.go
+++ b/scheduler/reconciler/reconcile_node.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package reconcile
+package reconciler
 
 import (
 	"fmt"

--- a/scheduler/reconciler/reconcile_node_test.go
+++ b/scheduler/reconciler/reconcile_node_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package reconcile
+package reconciler
 
 import (
 	"fmt"

--- a/scheduler/reconciler/reconnecting_picker.go
+++ b/scheduler/reconciler/reconnecting_picker.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package reconcile
+package reconciler
 
 import (
 	"time"

--- a/scheduler/reconciler/reconnecting_picker_test.go
+++ b/scheduler/reconciler/reconnecting_picker_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
-package reconcile
+package reconciler
 
 import (
 	"testing"

--- a/scheduler/scheduler_system_test.go
+++ b/scheduler/scheduler_system_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler/feasible"
-	"github.com/hashicorp/nomad/scheduler/reconcile"
+	"github.com/hashicorp/nomad/scheduler/reconciler"
 	"github.com/hashicorp/nomad/scheduler/tests"
 	"github.com/shoenig/test/must"
 )
@@ -3294,13 +3294,13 @@ func TestEvictAndPlace_LimitLessThanAllocs(t *testing.T) {
 	ci.Parallel(t)
 
 	_, ctx := feasible.MockContext(t)
-	allocs := []reconcile.AllocTuple{
+	allocs := []reconciler.AllocTuple{
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 	}
-	diff := &reconcile.NodeReconcileResult{}
+	diff := &reconciler.NodeReconcileResult{}
 
 	limit := 2
 	must.True(t, evictAndPlace(ctx, diff, allocs, "", &limit),
@@ -3315,13 +3315,13 @@ func TestEvictAndPlace_LimitEqualToAllocs(t *testing.T) {
 	ci.Parallel(t)
 
 	_, ctx := feasible.MockContext(t)
-	allocs := []reconcile.AllocTuple{
+	allocs := []reconciler.AllocTuple{
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 	}
-	diff := &reconcile.NodeReconcileResult{}
+	diff := &reconciler.NodeReconcileResult{}
 
 	limit := 4
 	must.False(t, evictAndPlace(ctx, diff, allocs, "", &limit),
@@ -3335,13 +3335,13 @@ func TestEvictAndPlace_LimitGreaterThanAllocs(t *testing.T) {
 	ci.Parallel(t)
 
 	_, ctx := feasible.MockContext(t)
-	allocs := []reconcile.AllocTuple{
+	allocs := []reconciler.AllocTuple{
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 		{Alloc: &structs.Allocation{ID: uuid.Generate()}},
 	}
-	diff := &reconcile.NodeReconcileResult{}
+	diff := &reconciler.NodeReconcileResult{}
 
 	limit := 6
 	must.False(t, evictAndPlace(ctx, diff, allocs, "", &limit))

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler/feasible"
-	"github.com/hashicorp/nomad/scheduler/reconcile"
+	"github.com/hashicorp/nomad/scheduler/reconciler"
 	sstructs "github.com/hashicorp/nomad/scheduler/structs"
 )
 
@@ -565,7 +565,7 @@ func setStatus(logger log.Logger, planner sstructs.Planner,
 // inplaceUpdate attempts to update allocations in-place where possible. It
 // returns the allocs that couldn't be done inplace and then those that could.
 func inplaceUpdate(ctx feasible.Context, eval *structs.Evaluation, job *structs.Job,
-	stack feasible.Stack, updates []reconcile.AllocTuple) (destructive, inplace []reconcile.AllocTuple) {
+	stack feasible.Stack, updates []reconciler.AllocTuple) (destructive, inplace []reconciler.AllocTuple) {
 
 	// doInplace manipulates the updates map to make the current allocation
 	// an inplace update.
@@ -693,8 +693,8 @@ func inplaceUpdate(ctx feasible.Context, eval *structs.Evaluation, job *structs.
 // desiredUpdates takes the diffResult as well as the set of inplace and
 // destructive updates and returns a map of task groups to their set of desired
 // updates.
-func desiredUpdates(diff *reconcile.NodeReconcileResult, inplaceUpdates,
-	destructiveUpdates []reconcile.AllocTuple) map[string]*structs.DesiredUpdates {
+func desiredUpdates(diff *reconciler.NodeReconcileResult, inplaceUpdates,
+	destructiveUpdates []reconciler.AllocTuple) map[string]*structs.DesiredUpdates {
 	desiredTgs := make(map[string]*structs.DesiredUpdates)
 
 	for _, tuple := range diff.Place {
@@ -825,7 +825,7 @@ func updateNonTerminalAllocsToLost(plan *structs.Plan, tainted map[string]*struc
 // by the reconciler to make decisions about how to update an allocation. The
 // factory allows the reconciler to be unaware of how to determine the type of
 // update necessary and can minimize the set of objects it is exposed to.
-func genericAllocUpdateFn(ctx feasible.Context, stack feasible.Stack, evalID string) reconcile.AllocUpdateType {
+func genericAllocUpdateFn(ctx feasible.Context, stack feasible.Stack, evalID string) reconciler.AllocUpdateType {
 	return func(existing *structs.Allocation, newJob *structs.Job, newTG *structs.TaskGroup) (ignore, destructive bool, updated *structs.Allocation) {
 		// Same index, so nothing to do
 		if existing.Job.JobModifyIndex == newJob.JobModifyIndex {

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler/feasible"
-	"github.com/hashicorp/nomad/scheduler/reconcile"
+	"github.com/hashicorp/nomad/scheduler/reconciler"
 	"github.com/hashicorp/nomad/scheduler/tests"
 	"github.com/shoenig/test/must"
 )
@@ -698,7 +698,7 @@ func TestInplaceUpdate_ChangedTaskGroup(t *testing.T) {
 	tg.Tasks = nil
 	tg.Tasks = append(tg.Tasks, task)
 
-	updates := []reconcile.AllocTuple{{Alloc: alloc, TaskGroup: tg}}
+	updates := []reconciler.AllocTuple{{Alloc: alloc, TaskGroup: tg}}
 	stack := feasible.NewGenericStack(false, ctx)
 
 	// Do the inplace update.
@@ -752,7 +752,7 @@ func TestInplaceUpdate_AllocatedResources(t *testing.T) {
 		},
 	}
 
-	updates := []reconcile.AllocTuple{{Alloc: alloc, TaskGroup: tg}}
+	updates := []reconciler.AllocTuple{{Alloc: alloc, TaskGroup: tg}}
 	stack := feasible.NewGenericStack(false, ctx)
 
 	// Do the inplace update.
@@ -810,7 +810,7 @@ func TestInplaceUpdate_NoMatch(t *testing.T) {
 	resource := &structs.Resources{CPU: 99999}
 	tg.Tasks[0].Resources = resource
 
-	updates := []reconcile.AllocTuple{{Alloc: alloc, TaskGroup: tg}}
+	updates := []reconciler.AllocTuple{{Alloc: alloc, TaskGroup: tg}}
 	stack := feasible.NewGenericStack(false, ctx)
 
 	// Do the inplace update.
@@ -879,7 +879,7 @@ func TestInplaceUpdate_Success(t *testing.T) {
 	// Add the new services
 	tg.Tasks[0].Services = append(tg.Tasks[0].Services, newServices...)
 
-	updates := []reconcile.AllocTuple{{Alloc: alloc, TaskGroup: tg}}
+	updates := []reconciler.AllocTuple{{Alloc: alloc, TaskGroup: tg}}
 	stack := feasible.NewGenericStack(false, ctx)
 	stack.SetJob(job)
 
@@ -929,7 +929,7 @@ func TestInplaceUpdate_WildcardDatacenters(t *testing.T) {
 	must.NoError(t, store.UpsertJobSummary(1000, mock.JobSummary(alloc.JobID)))
 	must.NoError(t, store.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
 
-	updates := []reconcile.AllocTuple{{Alloc: alloc, TaskGroup: job.TaskGroups[0]}}
+	updates := []reconciler.AllocTuple{{Alloc: alloc, TaskGroup: job.TaskGroups[0]}}
 	stack := feasible.NewGenericStack(false, ctx)
 	unplaced, inplace := inplaceUpdate(ctx, eval, job, stack, updates)
 
@@ -971,7 +971,7 @@ func TestInplaceUpdate_NodePools(t *testing.T) {
 	must.NoError(t, store.UpsertAllocs(structs.MsgTypeTestSetup, 1004,
 		[]*structs.Allocation{alloc1, alloc2}))
 
-	updates := []reconcile.AllocTuple{
+	updates := []reconciler.AllocTuple{
 		{Alloc: alloc1, TaskGroup: job.TaskGroups[0]},
 		{Alloc: alloc2, TaskGroup: job.TaskGroups[0]},
 	}
@@ -1178,32 +1178,32 @@ func TestDesiredUpdates(t *testing.T) {
 	tg2 := &structs.TaskGroup{Name: "bar"}
 	a2 := &structs.Allocation{TaskGroup: "bar"}
 
-	place := []reconcile.AllocTuple{
+	place := []reconciler.AllocTuple{
 		{TaskGroup: tg1},
 		{TaskGroup: tg1},
 		{TaskGroup: tg1},
 		{TaskGroup: tg2},
 	}
-	stop := []reconcile.AllocTuple{
+	stop := []reconciler.AllocTuple{
 		{TaskGroup: tg2, Alloc: a2},
 		{TaskGroup: tg2, Alloc: a2},
 	}
-	ignore := []reconcile.AllocTuple{
+	ignore := []reconciler.AllocTuple{
 		{TaskGroup: tg1},
 	}
-	migrate := []reconcile.AllocTuple{
+	migrate := []reconciler.AllocTuple{
 		{TaskGroup: tg2},
 	}
-	inplace := []reconcile.AllocTuple{
+	inplace := []reconciler.AllocTuple{
 		{TaskGroup: tg1},
 		{TaskGroup: tg1},
 	}
-	destructive := []reconcile.AllocTuple{
+	destructive := []reconciler.AllocTuple{
 		{TaskGroup: tg1},
 		{TaskGroup: tg2},
 		{TaskGroup: tg2},
 	}
-	diff := &reconcile.NodeReconcileResult{
+	diff := &reconciler.NodeReconcileResult{
 		Place:   place,
 		Stop:    stop,
 		Ignore:  ignore,


### PR DESCRIPTION
Juanita is right, this should be called `reconciler`. Nouns are better than verbs for package names. 