### PR TITLE
E2E: update TaskAPI test for Windows

### DIFF
--- a/e2e/workload_id/input/api-win.nomad.hcl
+++ b/e2e/workload_id/input/api-win.nomad.hcl
@@ -20,10 +20,7 @@ job "api-win" {
       driver = "raw_exec"
       config {
         command = "powershell"
-        args    = ["local/curl-7.87.0_4-win64-mingw/bin/curl.exe -H \"Authorization: Bearer $env:NOMAD_TOKEN\" --unix-socket $env:NOMAD_SECRETS_DIR/api.sock -v localhost:4646/v1/agent/health"]
-      }
-      artifact {
-        source = "https://curl.se/windows/dl-7.87.0_4/curl-7.87.0_4-win64-mingw.zip"
+        args    = ["curl.exe -H \"Authorization: Bearer $env:NOMAD_TOKEN\" --unix-socket $env:NOMAD_SECRETS_DIR/api.sock -v localhost:4646/v1/agent/health"]
       }
       identity {
         env = true


### PR DESCRIPTION
The current version of Windows we're using ships with curl, so we don't need to download it as an artifact anymore. Remove the broken reference to this in the TaskAPI test for Windows.

Ref: https://github.com/hashicorp/nomad-e2e/actions/runs/15708894856/job/44267973319