### PR TITLE
E2E: disable sdnotify for Consul agents

### DIFF
--- a/e2e/terraform/packer/ubuntu-jammy-amd64/consul.service
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/consul.service
@@ -6,11 +6,12 @@ After=network-online.target
 [Service]
 Restart=on-failure
 Environment=CONSUL_ALLOW_PRIVILEGED_PORTS=true
-ExecStart=/usr/local/bin/consul agent -config-dir="/etc/consul.d"
+WorkingDirectory=/etc/consul.d
+ExecStart=/usr/bin/consul agent -config-dir="/etc/consul.d"
 ExecReload=/bin/kill -HUP $MAINPID
 KillSignal=SIGTERM
-User=root
-Group=root
+User=consul
+Group=consul
 
 [Install]
 WantedBy=multi-user.target

--- a/e2e/terraform/provision-infra/provision-nomad/etc/consul.d/consul.service
+++ b/e2e/terraform/provision-infra/provision-nomad/etc/consul.d/consul.service
@@ -4,7 +4,6 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-Type=notify
 Restart=on-failure
 Environment=CONSUL_ALLOW_PRIVILEGED_PORTS=true
 WorkingDirectory=/etc/consul.d


### PR DESCRIPTION
In our E2E environment we've seen some flakiness with the Consul-related tests. As it turns out, the Consul agents are getting restarted every 90s or so because they're timing out their systemd notification.

> consul.service: start operation timed out. Terminating.

This appears to be a known issue in Consul and we'll try to contribute some help to hunt down the cause if they want help, but in the meantime let's remove it from our systemd unit files for the Consul agents.

Ref: https://github.com/hashicorp/consul/issues/16844#issuecomment-1913282248
Ref: https://github.com/hashicorp/nomad-e2e/actions/runs/15724328518/job/44311243757