### PR TITLE
docker: clamp CPU shares to minimum of 2

### DIFF
--- a/.changelog/26081.txt
+++ b/.changelog/26081.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fixed a bug where very low resources.cpu values could generate invalid cpu weights on hosts with very large client.cpu_total_compute values
+```

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -129,6 +129,12 @@ func TestDockerDriver_NormalizeCPUShares(t *testing.T) {
 	driver.compute.TotalCompute = maxCPUShares + 1
 	must.Eq(t, 262143, driver.cpuResources(maxCPUShares))
 
+	driver.compute.TotalCompute = maxCPUShares + 1
+	must.Eq(t, 2, driver.cpuResources(2))
+
+	driver.compute.TotalCompute = maxCPUShares + 1
+	must.Eq(t, 2, driver.cpuResources(1))
+
 	driver.compute.TotalCompute = maxCPUShares * 2
 	must.Eq(t, 500, driver.cpuResources(1000))
 	must.Eq(t, maxCPUShares/2, driver.cpuResources(maxCPUShares))

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -1089,6 +1089,9 @@ func TestExecutor_clampCPUShares(t *testing.T) {
 	le.compute.TotalCompute = MaxCPUShares + 1
 	must.Eq(t, 262143, le.clampCpuShares(MaxCPUShares))
 
+	le.compute.TotalCompute = MaxCPUShares + 1
+	must.Eq(t, 2, le.clampCpuShares(1))
+
 	le.compute = cpustats.Compute{TotalCompute: MaxCPUShares * 2}
 	must.Eq(t, 500, le.clampCpuShares(1000))
 	must.Eq(t, MaxCPUShares/2, le.clampCpuShares(MaxCPUShares))


### PR DESCRIPTION
In #25963 we added normalization of CPU shares for large hosts where the total compute was larger than the maximum CPU shares. But if the result after normalization is less than 2, runc will have an integer overflow. We prevent this in the shared executor for the `exec`/`rawexec` driver by clamping to the safe minimum value. Do this for the `docker` driver as well and add test coverage of it for the shared executor too.

Fixes: https://github.com/hashicorp/nomad/issues/26080
Fixes: https://hashicorp.atlassian.net/browse/NMD-858
Ref: https://github.com/hashicorp/nomad/pull/25963

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
