### PR TITLE
docs: clarified azure cloud auto-join requirements

### DIFF
--- a/website/content/docs/configuration/server_join.mdx
+++ b/website/content/docs/configuration/server_join.mdx
@@ -208,7 +208,9 @@ region which have the given `tag_key` and `tag_value`.
 
 This returns the first private IP address of all servers in the given region
 which have the given `tag_key` and `tag_value` in the tenant and subscription, or in
-the given `resource_group` of a `vm_scale_set` for Virtual Machine Scale Sets.
+the given `resource_group` of a `vm_scale_set` for Virtual Machine Scale Sets. If using tags,
+the `tag_key` and `tag_value` must be set on the network interface resource attached to the server
+not on the virtual machine resource itself.
 
 ```json
 {
@@ -221,6 +223,7 @@ the given `resource_group` of a `vm_scale_set` for Virtual Machine Scale Sets.
 - `provider` (required) - the name of the provider ("azure" in this case).
 - `tenant_id` (required) - the tenant to join machines in.
 - `client_id` (required) - the client to authenticate with.
+- `subscription_id` (required) - the Azure subscription ID.
 - `secret_access_key` (required) - the secret client key.
 
 Use these configuration parameters when using tags:


### PR DESCRIPTION
### Description

I set up cloud auto-join on Azure and discovered that the documentation was a bit sparse. For instance, the (required) `subscription_id` was not listed in the list of properties (but it was listed in the example join string). It was also not immediately clear that the tags had to be on the NICs not on the VMs.

### Testing & Reproduction steps
N/A

### Links
N/A

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
