### PR TITLE
ci: docker GO_TAGS must be quoted

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
           CGO_ENABLED: 1
         run: |
           go clean -cache
-          docker run --user "$(id --user):$(id --group)" --env HOME=/tmp --env GO_TAGS=${{env.GO_TAGS}} -v "$(pwd)":/build localhost:5000/nomad-builder:${{ github.sha }} make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
+          docker run --user "$(id --user):$(id --group)" --env HOME=/tmp --env GO_TAGS="${{env.GO_TAGS}}" -v "$(pwd)":/build localhost:5000/nomad-builder:${{ github.sha }} make pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip
           mv pkg/${{ matrix.goos }}_${{ matrix.goarch }}.zip ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}.zip
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:


### PR DESCRIPTION
ent builds use multiple tags, not having `GO_TAGS` quoted breaks the build on ent. 