### PR TITLE
e2e: ui: bump playwright version

### DIFF
--- a/e2e/ui/run.sh
+++ b/e2e/ui/run.sh
@@ -33,7 +33,7 @@ EOF
 }
 
 
-IMAGE="mcr.microsoft.com/playwright:v1.52.0-jammy"
+IMAGE="mcr.microsoft.com/playwright:v1.53.1-jammy"
 pushd $(dirname "${BASH_SOURCE[0]}") > /dev/null
 
 run_tests() {


### PR DESCRIPTION
yet another fix for

```
 Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1179/chrome-linux/headless_shell
╔══════════════════════════════════════════════════════════════════════╗
║ Looks like Playwright Test or Playwright was just updated to 1.53.1. ║
║ Please update docker image as well.                                  ║
║ -  current: mcr.microsoft.com/playwright:v1.52.0-jammy               ║
║ - required: mcr.microsoft.com/playwright:v1.53.1-jammy               ║
║                                                                      ║
║ <3 Playwright Team                                                   ║
╚══════════════════════════════════════════════════════════════════════╝
```