### PR TITLE
cli: fix panic when starting stopped jobs with no scaling policies

### DIFF
--- a/command/job_start.go
+++ b/command/job_start.go
@@ -159,7 +159,13 @@ func (c *JobStartCommand) Run(args []string) int {
 
 			sps := lastJob.GetScalingPoliciesPerTaskGroup()
 			for _, tg := range job.TaskGroups {
-				tg.Scaling.Enabled = sps[*tg.Name].Enabled
+				// guard for nil values in case the tg doesn't have any scaling policy
+				if sps[*tg.Name] != nil {
+					if tg.Scaling == nil {
+						tg.Scaling = &api.ScalingPolicy{}
+					}
+					tg.Scaling.Enabled = sps[*tg.Name].Enabled
+				}
 			}
 		}
 	}

--- a/command/job_start_test.go
+++ b/command/job_start_test.go
@@ -135,6 +135,42 @@ func TestStartCommand(t *testing.T) {
 
 	})
 
+	t.Run("succeeds when starting a stopped job with no scaling policies", func(t *testing.T) {
+		job := testJob(uuid.Generate())
+
+		client, err := cmd.Meta.Client()
+		must.NoError(t, err)
+
+		job.TaskGroups[0].Scaling = nil
+
+		jsonBytes, err := json.Marshal(job)
+		must.NoError(t, err)
+
+		_, _, err = client.Jobs().RegisterOpts(job, &api.RegisterOptions{
+			Submission: &api.JobSubmission{
+				Source: string(jsonBytes),
+				Format: "json",
+			},
+		}, nil)
+		must.NoError(t, err)
+
+		waitForJobAllocsStatus(t, client, *job.ID, api.AllocClientStatusRunning, "")
+
+		_, _, err = client.Jobs().Deregister(*job.ID, false, nil)
+		must.Nil(t, err)
+
+		waitForJobAllocsStatus(t, client, *job.ID, api.AllocClientStatusComplete, "")
+
+		res := cmd.Run([]string{"-address", addr, *job.ID})
+		must.Zero(t, res)
+
+		pol, _, err := client.Scaling().ListPolicies(nil)
+		must.NoError(t, err)
+		must.One(t, len(pol))
+		must.True(t, *job.TaskGroups[0].Scaling.Enabled)
+
+	})
+
 	t.Run("fails to start a job not previously stopped", func(t *testing.T) {
 		job := testJob(uuid.Generate())
 


### PR DESCRIPTION
Restoring scaling policies during the start of a stopped job did not account for
jobs that didn't have any scaling policies, and led to a panic when users tried
to restart such jobs.

Fixes #26103