### PR TITLE
jobspec: define DiffID for Constraint and Affinity

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9954,6 +9954,11 @@ func (c *Constraint) Validate() error {
 	return mErr.ErrorOrNil()
 }
 
+// DiffID fulfills the DiffableWithID interface.
+func (c *Constraint) DiffID() string {
+	return c.String()
+}
+
 type Constraints []*Constraint
 
 // Equal compares Constraints as a set
@@ -10068,6 +10073,11 @@ func (a *Affinity) Validate() error {
 	}
 
 	return mErr.ErrorOrNil()
+}
+
+// DiffID fulfills the DiffableWithID interface.
+func (a *Affinity) DiffID() string {
+	return a.String()
 }
 
 // Spread is used to specify desired distribution of allocations according to weight


### PR DESCRIPTION
### Description
this PR implements `DiffableWithID` for `Constraint` and `Affinity` through `DiffID`, which should reduce the time taken to run `primitiveObjectSetDiff()` for those types since they don't need to be hashed

### Testing & Reproduction steps
`go test -run Diff ./nomad/structs`

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
