### PR TITLE
fsm: Add identity signing key handling for node status updates.

### DIFF
--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -498,7 +498,7 @@ func (n *nomadFSM) applyStatusUpdate(msgType structs.MessageType, buf []byte, in
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
 
-	if err := n.state.UpdateNodeStatus(msgType, index, req.NodeID, req.Status, req.UpdatedAt, req.NodeEvent); err != nil {
+	if err := n.state.UpdateNodeStatus(msgType, index, &req); err != nil {
 		n.logger.Error("UpdateNodeStatus failed", "error", err)
 		return err
 	}

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -377,7 +377,7 @@ func TestEventsFromChanges_NodeUpdateStatusRequest(t *testing.T) {
 		NodeEvent: &structs.NodeEvent{Message: "down"},
 	}
 
-	must.NoError(t, s.UpdateNodeStatus(msgType, 100, req.NodeID, req.Status, req.UpdatedAt, req.NodeEvent))
+	must.NoError(t, s.UpdateNodeStatus(msgType, 100, req))
 	events := WaitForEvents(t, s, 100, 1, 1*time.Second)
 	must.Len(t, 1, events)
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1097,21 +1097,26 @@ func (s *StateStore) deleteNodeTxn(txn *txn, index uint64, nodes []string) error
 }
 
 // UpdateNodeStatus is used to update the status of a node
-func (s *StateStore) UpdateNodeStatus(msgType structs.MessageType, index uint64, nodeID, status string, updatedAt int64, event *structs.NodeEvent) error {
+func (s *StateStore) UpdateNodeStatus(
+	msgType structs.MessageType,
+	index uint64,
+	req *structs.NodeUpdateStatusRequest,
+) error {
+
 	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
 
-	if err := s.updateNodeStatusTxn(txn, nodeID, status, updatedAt, event); err != nil {
+	if err := s.updateNodeStatusTxn(txn, req); err != nil {
 		return err
 	}
 
 	return txn.Commit()
 }
 
-func (s *StateStore) updateNodeStatusTxn(txn *txn, nodeID, status string, updatedAt int64, event *structs.NodeEvent) error {
+func (s *StateStore) updateNodeStatusTxn(txn *txn, req *structs.NodeUpdateStatusRequest) error {
 
 	// Lookup the node
-	existing, err := txn.First("nodes", "id", nodeID)
+	existing, err := txn.First(TableNodes, indexID, req.NodeID)
 	if err != nil {
 		return fmt.Errorf("node lookup failed: %v", err)
 	}
@@ -1122,15 +1127,23 @@ func (s *StateStore) updateNodeStatusTxn(txn *txn, nodeID, status string, update
 	// Copy the existing node
 	existingNode := existing.(*structs.Node)
 	copyNode := existingNode.Copy()
-	copyNode.StatusUpdatedAt = updatedAt
+	copyNode.StatusUpdatedAt = req.UpdatedAt
+
+	// If the request has a signing key ID, we should update the node reference
+	// to this. We need to check for the empty string, as a new identity won't
+	// always be generated, and we don't want to overwrite the exiting entry
+	// with an empty string.
+	if req.IdentitySigningKeyID != "" {
+		copyNode.IdentitySigningKeyID = req.IdentitySigningKeyID
+	}
 
 	// Add the event if given
-	if event != nil {
-		appendNodeEvents(txn.Index, copyNode, []*structs.NodeEvent{event})
+	if req.NodeEvent != nil {
+		appendNodeEvents(txn.Index, copyNode, []*structs.NodeEvent{req.NodeEvent})
 	}
 
 	// Update the status in the copy
-	copyNode.Status = status
+	copyNode.Status = req.Status
 	copyNode.ModifyIndex = txn.Index
 
 	// Update last missed heartbeat if the node became unresponsive or reset it
@@ -1143,10 +1156,10 @@ func (s *StateStore) updateNodeStatusTxn(txn *txn, nodeID, status string, update
 	}
 
 	// Insert the node
-	if err := txn.Insert("nodes", copyNode); err != nil {
+	if err := txn.Insert(TableNodes, copyNode); err != nil {
 		return fmt.Errorf("node update failed: %v", err)
 	}
-	if err := txn.Insert("index", &IndexEntry{"nodes", txn.Index}); err != nil {
+	if err := txn.Insert(tableIndex, &IndexEntry{TableNodes, txn.Index}); err != nil {
 		return fmt.Errorf("index update failed: %v", err)
 	}
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -643,8 +643,18 @@ type NodeServerInfo struct {
 // NodeUpdateStatusRequest is used for Node.UpdateStatus endpoint
 // to update the status of a node.
 type NodeUpdateStatusRequest struct {
-	NodeID    string
-	Status    string
+	NodeID string
+	Status string
+
+	// IdentitySigningKeyID is the ID of the root key used to sign the node's
+	// identity. This is not provided by the client, but is set by the server,
+	// so that the value can be propagated through Raft.
+	IdentitySigningKeyID string
+
+	// ForceIdentityRenewal is used to force the Nomad server to generate a new
+	// identity for the node.
+	ForceIdentityRenewal bool
+
 	NodeEvent *NodeEvent
 	UpdatedAt int64
 	WriteRequest


### PR DESCRIPTION
When a node heartbeats, the RPC handler will optionally generate an identity to return to the caller. The identity key ID will be stored in the node object, so we have tracking of keys in use.

The state store has been updated to handle node status update requests that include a signing key ID. Rather than add another parameter into the function signature, the FSM function now takes the entire request object.

### Links
internal jira: https://hashicorp.atlassian.net/browse/NMD-779
internal design doc: https://docs.google.com/document/d/1MYjlFlOAmGHmWGC3VsrIMUL_VSgKwjLAq6GUymDY38M/edit?tab=t.0

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
