### PR TITLE
Expose Kind field for Consul Service Registrations

### DIFF
--- a/.changelog/26170.txt
+++ b/.changelog/26170.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+consul: Added kind field to service block for Consul service registrations
+```

--- a/api/services.go
+++ b/api/services.go
@@ -254,6 +254,9 @@ type Service struct {
 
 	// Cluster is valid only for Nomad Enterprise with provider: consul
 	Cluster string `hcl:"cluster,optional"`
+
+	// Kind defines the consul service kind, valid only when provider: consul
+	Kind string `hcl:"kind,optional"`
 }
 
 const (

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1362,9 +1362,10 @@ func (c *ServiceClient) serviceRegs(
 	// This enables the consul UI to show that Nomad registered this service
 	meta["external-source"] = "nomad"
 
-	// Explicitly set the Consul service Kind in case this service represents
-	// one of the Connect gateway types.
-	kind := api.ServiceKindTypical
+	// Set the Consul service Kind from the service.Kind, to be overwritten if
+	// the service is connect gateway (empty string is api.ServiceKindTypical)
+	kind := api.ServiceKind(service.Kind)
+
 	switch {
 	case service.Connect.IsIngress():
 		kind = api.ServiceKindIngressGateway

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1713,6 +1713,7 @@ func ApiServicesToStructs(in []*api.Service, group bool) []*structs.Service {
 			OnUpdate:          s.OnUpdate,
 			Provider:          s.Provider,
 			Cluster:           s.Cluster,
+			Kind:              s.Kind,
 		}
 
 		if l := len(s.Checks); l != 0 {

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -2890,6 +2890,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 								FailuresBeforeWarning:  2,
 							},
 						},
+						Kind: "api-gateway",
 						Connect: &api.ConsulConnect{
 							Native: false,
 							SidecarService: &api.ConsulSidecarService{
@@ -3302,6 +3303,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 							Passing: 5,
 							Warning: 1,
 						},
+						Kind:     "api-gateway",
 						OnUpdate: structs.OnUpdateRequireHealthy,
 						Checks: []*structs.ServiceCheck{
 							{

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -3588,6 +3588,12 @@ func TestTaskGroupDiff(t *testing.T) {
 							},
 							{
 								Type: DiffTypeNone,
+								Name: "Kind",
+								Old:  "",
+								New:  "",
+							},
+							{
+								Type: DiffTypeNone,
 								Name: "Name",
 								Old:  "foo",
 								New:  "foo",
@@ -7080,6 +7086,10 @@ func TestTaskDiff(t *testing.T) {
 							},
 							{
 								Type: DiffTypeNone,
+								Name: "Kind",
+							},
+							{
+								Type: DiffTypeNone,
 								Name: "Name",
 								Old:  "foo",
 								New:  "foo",
@@ -7243,6 +7253,10 @@ func TestTaskDiff(t *testing.T) {
 								Name: "EnableTagOverride",
 								Old:  "false",
 								New:  "false",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "Kind",
 							},
 							{
 								Type: DiffTypeNone,
@@ -7793,6 +7807,10 @@ func TestTaskDiff(t *testing.T) {
 								Name: "EnableTagOverride",
 								Old:  "false",
 								New:  "false",
+							},
+							{
+								Type: DiffTypeNone,
+								Name: "Kind",
 							},
 							{
 								Type: DiffTypeNone,
@@ -9559,6 +9577,10 @@ func TestServicesDiff(t *testing.T) {
 							New:  "false",
 						},
 						{
+							Type: DiffTypeNone,
+							Name: "Kind",
+						},
+						{
 							Type: DiffTypeEdited,
 							Name: "Name",
 							Old:  "webapp",
@@ -9678,6 +9700,10 @@ func TestServicesDiff(t *testing.T) {
 							New:  "false",
 						},
 						{
+							Type: DiffTypeNone,
+							Name: "Kind",
+						},
+						{
 							Type: DiffTypeAdded,
 							Name: "Name",
 							New:  "webapp",
@@ -9749,6 +9775,10 @@ func TestServicesDiff(t *testing.T) {
 							Type: DiffTypeAdded,
 							Name: "EnableTagOverride",
 							New:  "false",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Kind",
 						},
 						{
 							Type: DiffTypeAdded,
@@ -9830,6 +9860,10 @@ func TestServicesDiff(t *testing.T) {
 						},
 						{
 							Type: DiffTypeNone,
+							Name: "Kind",
+						},
+						{
+							Type: DiffTypeNone,
 							Name: "Name",
 							Old:  "webapp",
 							New:  "webapp",
@@ -9848,6 +9882,82 @@ func TestServicesDiff(t *testing.T) {
 							Old:  "http",
 							New:  "https-redirect",
 						}, {
+							Type: DiffTypeNone,
+							Name: "Provider",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "TaskName",
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:       "Modify service kind field",
+			Contextual: true,
+			Old: []*Service{
+				{
+					Name: "webapp",
+					Kind: "api-gateway",
+				},
+			},
+			New: []*Service{
+				{
+					Name: "webapp",
+					Kind: "mesh-gateway",
+				},
+			},
+			Expected: []*ObjectDiff{
+				{
+					Type: DiffTypeEdited,
+					Name: "Service",
+					Fields: []*FieldDiff{
+						{
+							Type: DiffTypeNone,
+							Name: "Address",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "AddressMode",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Cluster",
+							Old:  "",
+							New:  "",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "EnableTagOverride",
+							Old:  "false",
+							New:  "false",
+						},
+						{
+							Type: DiffTypeEdited,
+							Name: "Kind",
+							Old:  "api-gateway",
+							New:  "mesh-gateway",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Name",
+							Old:  "webapp",
+							New:  "webapp",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Namespace",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "OnUpdate",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "PortLabel",
+						},
+						{
 							Type: DiffTypeNone,
 							Name: "Provider",
 						},
@@ -9910,6 +10020,10 @@ func TestServicesDiff(t *testing.T) {
 							Name: "EnableTagOverride",
 							Old:  "false",
 							New:  "false",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Kind",
 						},
 						{
 							Type: DiffTypeNone,
@@ -10005,6 +10119,10 @@ func TestServicesDiff(t *testing.T) {
 							Name: "EnableTagOverride",
 							Old:  "false",
 							New:  "false",
+						},
+						{
+							Type: DiffTypeNone,
+							Name: "Kind",
 						},
 						{
 							Type: DiffTypeNone,

--- a/nomad/structs/services_test.go
+++ b/nomad/structs/services_test.go
@@ -492,6 +492,10 @@ func TestService_Hash(t *testing.T) {
 		try(t, func(s *svc) { s.PortLabel = "newPortLabel" })
 	})
 
+	t.Run("mod kind", func(t *testing.T) {
+		try(t, func(s *svc) { s.Kind = "api-gateway" })
+	})
+
 	t.Run("mod tags", func(t *testing.T) {
 		try(t, func(s *svc) { s.Tags = []string{"new", "tags"} })
 	})
@@ -2039,6 +2043,25 @@ func TestService_Validate(t *testing.T) {
 			expErr:    true,
 			expErrStr: "notes must not be longer than 255 characters",
 		},
+		{
+			name: "provider consul with service kind",
+			input: &Service{
+				Name:     "testservice",
+				Provider: "consul",
+				Kind:     "api-gateway",
+			},
+			expErr: false,
+		},
+		{
+			name: "provider consul with invalid service kind",
+			input: &Service{
+				Name:     "testservice",
+				Provider: "consul",
+				Kind:     "garbage",
+			},
+			expErr:    true,
+			expErrStr: "Service testservice kind must be one of consul service kind or empty",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -2138,6 +2161,9 @@ func TestService_Equal(t *testing.T) {
 	assertDiff()
 
 	o.TaggedAddresses = map[string]string{"foo": "bar"}
+	assertDiff()
+
+	o.Kind = "api-gateway"
 	assertDiff()
 }
 

--- a/website/content/docs/job-specification/service.mdx
+++ b/website/content/docs/job-specification/service.mdx
@@ -108,6 +108,11 @@ Service Mesh][connect] integration.
 - `connect` - Configures the [Consul Connect][connect] integration. Only
   available on group services and where `provider = "consul"`.
 
+- `kind` `(string: <optional>)` - Configures the [Consul Service
+Kind][consul_kind] to pass to Consul during service registration. Only available
+when `provider = "consul"`, and is ignored if a Consul Connect Gateway is
+defined.
+
 - `identity` <code>([Identity][identity_block]: nil)</code> - Specifies a
   Workload Identity to use when obtaining Service Identity tokens from Consul to
   register the service. Only available where `provider = "consul"`. Typically
@@ -537,6 +542,7 @@ advertise and check directly since Nomad isn't managing any port assignments.
 [qemu]: /nomad/docs/drivers/qemu 'Nomad QEMU Driver'
 [restart_block]: /nomad/docs/job-specification/restart 'restart block'
 [connect]: /nomad/docs/job-specification/connect 'Nomad Consul Connect Integration'
+[kind]: /consul/api-docs/agent/service#kind
 [type]: /nomad/docs/job-specification/service#type
 [shutdowndelay]: /nomad/docs/job-specification/task#shutdown_delay
 [killsignal]: /nomad/docs/job-specification/task#kill_signal


### PR DESCRIPTION
### Description
Adds the `Kind` field to the service block in the jobspec, and allows Consul services to be registered with the [Consul Kind type](https://developer.hashicorp.com/consul/api-docs/agent/service#kind) manually. Previously this was only set when using a defined type of Consul Connect [gateway](https://developer.hashicorp.com/nomad/docs/job-specification/gateway), but with the new change, it can be specified on the service itself. If both values (`kind` and a consul connect gateway) are defined, the service will use the Consul Connect Gateway.

### Testing & Reproduction steps
Add `kind` to jobspec, observe the gateway specified for the service in Consul.

### Links
internal Ref https://hashicorp.atlassian.net/browse/NMD-702

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
