### PR TITLE
command: prevent server panic on graceful shutdown

### DIFF
--- a/.changelog/26171.txt
+++ b/.changelog/26171.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fixed a bug to prevent panic during graceful server shutdown
+```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -989,13 +989,14 @@ func (c *Command) terminateGracefully(signalCh chan os.Signal, sdSock io.Writer)
 
 	timeout := gracefulTimeout
 
-	config := c.agent.client.GetConfig()
-	if config == nil {
-		c.Ui.Output("Unable to read the agent configuration, using the default graceful timeout")
-	}
+	if c.agent.client != nil {
+		config := c.agent.client.GetConfig()
 
-	if config.Drain != nil && config.Drain.Deadline != 0 {
-		timeout += config.Drain.Deadline
+		if config == nil {
+			c.Ui.Output("Unable to read the agent configuration, using the default graceful timeout")
+		} else if config.Drain != nil && config.Drain.Deadline != 0 {
+			timeout += config.Drain.Deadline
+		}
 	}
 
 	c.Ui.Output("Gracefully shutting down agent...")


### PR DESCRIPTION
### Description
When performing a graceful shutdown the client drain configuration
is checked for a deadline which is appended to the timeout. When
running as a server the client will not be set. Attempting to get
the drain deadline will result in a panic. This checks for the
client being available prior to fetching the deadline value.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
