### PR TITLE
docs: Fix link in service page documentation

### DIFF
--- a/website/content/docs/job-specification/service.mdx
+++ b/website/content/docs/job-specification/service.mdx
@@ -109,7 +109,7 @@ Service Mesh][connect] integration.
   available on group services and where `provider = "consul"`.
 
 - `kind` `(string: <optional>)` - Configures the [Consul Service
-Kind][consul_kind] to pass to Consul during service registration. Only available
+Kind][kind] to pass to Consul during service registration. Only available
 when `provider = "consul"`, and is ignored if a Consul Connect Gateway is
 defined.
 

--- a/website/content/docs/job-specification/service.mdx
+++ b/website/content/docs/job-specification/service.mdx
@@ -109,9 +109,9 @@ Service Mesh][connect] integration.
   available on group services and where `provider = "consul"`.
 
 - `kind` `(string: <optional>)` - Configures the [Consul Service
-Kind][kind] to pass to Consul during service registration. Only available
-when `provider = "consul"`, and is ignored if a Consul Connect Gateway is
-defined.
+  Kind][kind] to pass to Consul during service registration. Only available
+  when `provider = "consul"`, and is ignored if a Consul Connect Gateway is
+  defined.
 
 - `identity` <code>([Identity][identity_block]: nil)</code> - Specifies a
   Workload Identity to use when obtaining Service Identity tokens from Consul to


### PR DESCRIPTION
### Description
Fixes the link in the doc page to correctly link to the Consul docs

### Testing & Reproduction steps
n/a

### Links
Fixes doc issue introduced in https://github.com/hashicorp/nomad/pull/26170

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
