### PR TITLE
drainer: respect max parallel setting when draining

### DIFF
--- a/nomad/drainer/watch_jobs_test.go
+++ b/nomad/drainer/watch_jobs_test.go
@@ -345,6 +345,29 @@ func TestDrainingJobWatcher_HandleTaskGroup(t *testing.T) {
 			expectDone:     false,
 		},
 		{
+			name:           "migrating-allocs-not-healty-max-parallel-1",
+			expectDrained:  0,
+			expectMigrated: 0,
+			expectDone:     false,
+			addAllocFn: func(i int, a *structs.Allocation, drainingID, runningID string) {
+				if i == 1 {
+					a.DesiredTransition.Migrate = pointer.Of(true)
+				}
+			},
+		},
+		{
+			name:           "migrating-allocs-not-healty-max-parallel-5",
+			expectDrained:  1,
+			expectMigrated: 0,
+			expectDone:     false,
+			maxParallel:    5,
+			addAllocFn: func(i int, a *structs.Allocation, drainingID, runningID string) {
+				if i > 0 && i%2 == 0 {
+					a.DesiredTransition.Migrate = pointer.Of(true)
+				}
+			},
+		},
+		{
 			// allocs on a non-draining node, should not be drained
 			name:           "allocs-on-non-draining-node-should-not-drain",
 			expectDrained:  0,


### PR DESCRIPTION
### Description
When draining nodes allocs are checked for a healthy state and
marked to be drained, with the value in the max parallel setting
determining how many allocs will be migrated. Depending on the
circumstances, however, the max parallel setting may not be
properly respected.

Given a job with max parallel set to one, a group count greater
than one, and allocs on multiple nodes: Draining a single node
will result in one alloc being marked to drain. If another
node is immediately drained the alloc running on the first
node will be seen as "healthy" and another alloc will be
marked to be drained resulting in two allocs being marked
for migration at the same time. This can lead to issues with
service availablility.

To prevent this allocs can only be marked as healthy when the
alloc has not been marked for migration. This prevents migrating
allocs being seen as healthy which results in the max parallel
setting being properly respected.

### Testing & Reproduction steps
This can be reproduced by creating a job with task group having a count of 2. Spread placement so that allocs are placed on different nodes. Drain both nodes simultaneously. Currently, both allocs will be drained immediately:

```
docker-service.docker-group 2025-06-30T16:59:45-07:00: b272f076 - begin drain
docker-service.docker-group 2025-06-30T16:59:46-07:00: 9bc29c5d - begin drain
docker-service.docker-group 2025-06-30T16:59:46-07:00: b272f076 - finish drain
docker-service.docker-group 2025-06-30T16:59:47-07:00: 9bc29c5d - finish drain
```

With this change, draining both nodes results in allocs being drained individually:

```
docker-service.docker-group 2025-06-30T16:57:27-07:00: 18c95bdb - begin drain
docker-service.docker-group 2025-06-30T16:57:28-07:00: 18c95bdb - finish drain
docker-service.docker-group 2025-06-30T16:57:50-07:00: 19380095 - begin drain
docker-service.docker-group 2025-06-30T16:57:50-07:00: 19380095 - finish drain
```

### Links
Fixes #25979 

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
