### PR TITLE
scheduler: doc.go files for new packages

### DIFF
--- a/scheduler/doc.go
+++ b/scheduler/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package scheduler defines Nomad schedulers for service, batch, system, and
+// sysbatch job types.
+package scheduler

--- a/scheduler/feasible/doc.go
+++ b/scheduler/feasible/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package feasible contains the logic of picking the correct node(s) by the
+// scheduler: eligibiligy, feasibility checking and ranking
+package feasible

--- a/scheduler/reconciler/doc.go
+++ b/scheduler/reconciler/doc.go
@@ -1,0 +1,5 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package reconciler contains the reconciliation logic for all scheduler types.
+package reconciler

--- a/scheduler/structs/doc.go
+++ b/scheduler/structs/doc.go
@@ -1,0 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package structs contains definitions of shared objects, constants, and
+// top-level interfaces for the scheduler.
+package structs


### PR DESCRIPTION
a) it's reasonably good practice to have package documentation that we have all but abandoned. 
b) my gopls has been complaining about this. 