### PR TITLE
cli: Fix a bug where self token lookups via token CLI flag failed.

### DIFF
--- a/.changelog/26183.txt
+++ b/.changelog/26183.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug where the `acl token self` command only performed lookups for tokens set as environment variables and not by the `-token` flag.
+```


### PR DESCRIPTION
The meta client looks for both an environment variable and a CLI flag when generating a client. The CLI UUID checker needs to do this also, so we account for users using both env vars and CLI flag tokens.

### Testing & Reproduction steps
You can run a local Nomad agent in dev mode with this change and ACLs enabled, and then perform the `nomad acl token -self` with the ACL token set via either as an env var or as a flag.

### Links
Jira: https://hashicorp.atlassian.net/browse/NMD-874
Closes #26176

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
