### PR TITLE
docs: add upgrade guide note for publish_allocation_metrics

### DIFF
--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -12,6 +12,17 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 1.10.2
+
+#### Clients respect `telemetry.publish_allocation_metrics`
+
+Nomad 1.10.2 fixed a bug where allocation metrics were collected and published
+even if the
+[`telemetry.publish_allocation_metrics`](/nomad/docs/configuration/telemetry#publish_allocation_metrics)
+configuration field was unset or set to `false`. If you are monitoring
+allocation metrics, you will need to ensure your Nomad clients set this field to
+`true`.
+
 ## Nomad 1.10.1
 
 #### Remove Raft peer by address removed


### PR DESCRIPTION
In #25870 we fixed a longstanding bug where allocation metrics were being collected and published even if `telemetry.publish_allocation_metrics` was disabled (the default). This change is unexpected enough that we should surface it in the upgrade guide.

Ref: https://github.com/hashicorp/nomad/pull/25870
Fixes: https://github.com/hashicorp/nomad/issues/26166