### PR TITLE
Avoid panic during startup with 1.10.2

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1569,6 +1569,12 @@ func (c *Client) setupNode() error {
 		node.NodeResources.MinDynamicPort = newConfig.MinDynamicPort
 		node.NodeResources.MaxDynamicPort = newConfig.MaxDynamicPort
 		node.NodeResources.Processors = newConfig.Node.NodeResources.Processors
+
+		if node.NodeResources.Processors.Empty() {
+			node.NodeResources.Processors = structs.NodeProcessorResources{
+				Topology: &numalib.Topology{},
+			}
+		}
 	}
 	if node.ReservedResources == nil {
 		node.ReservedResources = &structs.NodeReservedResources{}

--- a/client/lib/numalib/detect.go
+++ b/client/lib/numalib/detect.go
@@ -18,7 +18,7 @@ type SystemScanner interface {
 // a single Topology, which can then be used to answer questions about the CPU
 // topology of the system.
 func Scan(scanners []SystemScanner) *Topology {
-	top := new(Topology)
+	top := &Topology{}
 	for _, scanner := range scanners {
 		scanner.ScanSystem(top)
 	}

--- a/nomad/structs/cpucompat_default.go
+++ b/nomad/structs/cpucompat_default.go
@@ -28,7 +28,7 @@ func (n *NodeResources) Compatibility() {
 		// the LegacyNodeCpuResources field, and so we synthesize a pseudo
 		// NodeProcessorResources field
 		n.Processors.Topology = topologyFromLegacy(n.Cpu)
-	} else if !n.Processors.empty() {
+	} else if !n.Processors.Empty() {
 		// When we receive a node update from a 1.7+ client it contains a
 		// NodeProcessorResources field, and we populate the LegacyNodeCpuResources
 		// field using that information.

--- a/nomad/structs/cpucompat_linux.go
+++ b/nomad/structs/cpucompat_linux.go
@@ -31,7 +31,7 @@ func (n *NodeResources) Compatibility() {
 		// the LegacyNodeCpuResources field, and so we synthesize a pseudo
 		// NodeProcessorResources field
 		n.Processors.Topology = topologyFromLegacy(n.Cpu)
-	} else if !n.Processors.empty() {
+	} else if !n.Processors.Empty() {
 		// When we receive a node update from a 1.7+ client it contains a
 		// NodeProcessorResources field, and we populate the LegacyNodeCpuResources
 		// field using that information.

--- a/nomad/structs/numa.go
+++ b/nomad/structs/numa.go
@@ -128,7 +128,7 @@ type NodeProcessorResources struct {
 
 // partial struct serialization / copy / merge sadness means this struct can
 // exist with no data, which is a condition we must detect during the upgrade path
-func (r NodeProcessorResources) empty() bool {
+func (r NodeProcessorResources) Empty() bool {
 	return r.Topology == nil || len(r.Topology.Cores) == 0
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -36,6 +36,7 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib"
 	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 	"github.com/hashicorp/nomad/command/agent/host"
 	"github.com/hashicorp/nomad/command/agent/pprof"
@@ -2256,6 +2257,12 @@ func (n *Node) Canonicalize() {
 					}
 				}
 				n.NodeResources.NodeNetworks = append(n.NodeResources.NodeNetworks, nnr)
+			}
+		}
+
+		if n.NodeResources.Processors.Empty() {
+			n.NodeResources.Processors = NodeProcessorResources{
+				Topology: &numalib.Topology{},
 			}
 		}
 	}


### PR DESCRIPTION
### Description
This PR addresses [GH-23203](https://github.com/hashicorp/nomad/issues/26203). When starting the nomad client on linux with no fingerprinting, it panics because no topology is assigned. This PR initialises the topology as an empty one to avoid nil 
pointers.

### Testing & Reproduction steps
To reproduces it, just start a client on linux with:
```client {
  options = {
    "fingerprint.allowlist" = "network"
  }
}
```

And see it panic.

### Links
[GH-23203](https://github.com/hashicorp/nomad/issues/26203).

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
