### PR TITLE
fix: developer website task driver virt link

### DIFF
--- a/website/content/partials/task-driver-intro.mdx
+++ b/website/content/partials/task-driver-intro.mdx
@@ -56,6 +56,6 @@ to create your own drivers without having to recompile Nomad. Refer to the
 [Isolated Fork/Exec]: /nomad/docs/drivers/exec
 [Podman]: /nomad/plugins/drivers/podman
 [Java]: /nomad/docs/drivers/java
-[Virt]: /nomad/plugins/drivers/virt/index
+[Virt]: /nomad/plugins/drivers/virt
 [QEMU]: /nomad/docs/drivers/qemu
 [Raw Fork/Exec]: /nomad/docs/drivers/raw_exec


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

This PR fixes the link to the developer website task driver page link for the virt plugin https://developer.hashicorp.com/nomad/docs/drivers

![Jul-08-2025 23-33-02](https://github.com/user-attachments/assets/a2978955-0b01-4eeb-af80-8d5a85ffa79d)

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

- Go to https://developer.hashicorp.com/nomad/docs/drivers and click on the Virt link under [Nomad Task Drivers](https://developer.hashicorp.com/nomad/docs/drivers) plugins column using any web browser

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
