### PR TITLE
Update the error message for invalid variables

### DIFF
--- a/.changelog/26235.txt
+++ b/.changelog/26235.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed the error message presented for invalid Variables definitions
+```

--- a/ui/app/adapters/variable.js
+++ b/ui/app/adapters/variable.js
@@ -146,7 +146,7 @@ export default class VariableAdapter extends ApplicationAdapter {
       return new InvalidError([
         {
           detail:
-            'Invalid name. Name must contain only alphanumeric or "-", "_", "~", or "/" characters, and be fewer than 128 characters in length.',
+            'Invalid definition. Name must contain only alphanumeric or "-", "_", "~", or "/" characters, and be fewer than 128 characters in length and value should be be under 64KiB',
           status: 400,
         },
       ]);


### PR DESCRIPTION
### Description
Currently the message returned when a storing a variable fails is:

```
Error saving nomad/jobs/my-job
Invalid name. Name must contain only alphanumeric or "-", "_", "~", or "/" characters, and be fewer than 128 characters in length.
```

Update it to be more inclusive, so it expresses that not only the name can be the error.

Fixes: https://github.com/hashicorp/nomad/issues/26234

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
