### PR TITLE
client: Use single time variable when handling heartbeat response.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -2145,7 +2145,7 @@ func (c *Client) updateNodeStatus() error {
 		c.triggerDiscovery()
 		return fmt.Errorf("failed to update status: %v", err)
 	}
-	end := time.Now()
+	endTime := time.Now()
 
 	if len(resp.EvalIDs) != 0 {
 		c.logger.Debug("evaluations triggered by node update", "num_evals", len(resp.EvalIDs))
@@ -2156,7 +2156,7 @@ func (c *Client) updateNodeStatus() error {
 	last := c.lastHeartbeat()
 	oldTTL := c.heartbeatTTL
 	haveHeartbeated := c.haveHeartbeated
-	c.heartbeatStop.setLastOk(time.Now())
+	c.heartbeatStop.setLastOk(endTime)
 	c.heartbeatTTL = resp.HeartbeatTTL
 	c.haveHeartbeated = true
 	c.heartbeatLock.Unlock()
@@ -2168,7 +2168,7 @@ func (c *Client) updateNodeStatus() error {
 		// We have potentially missed our TTL log how delayed we were
 		if haveHeartbeated {
 			c.logger.Warn("missed heartbeat",
-				"req_latency", end.Sub(start), "heartbeat_ttl", oldTTL, "since_last_heartbeat", time.Since(last))
+				"req_latency", endTime.Sub(start), "heartbeat_ttl", oldTTL, "since_last_heartbeat", time.Since(last))
 		}
 	}
 


### PR DESCRIPTION
When the client handles an update status response from the server, it modifies its heartbeat stop tracker with a time set once the RPC call returns. It optionally also emits a log message, if the client suspects it has missed a heartbeat.

These times were originally tracked by two different calls to the time function which were executed 2 microseconds apart. There is no reason we cannot use a single time variable for both uses which saves us one whole call to time.Now.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
