### PR TITLE
docs: clarify requirements for deleting volumes

### DIFF
--- a/command/volume_delete.go
+++ b/command/volume_delete.go
@@ -26,8 +26,7 @@ Usage: nomad volume delete [options] <vol id>
   Delete a volume from an external storage provider. The volume must still be
   registered with Nomad in order to be deleted. Deleting will fail if the
   volume is still in use by an allocation or in the process of being
-  unpublished. If the volume no longer exists, this command will silently
-  return without an error.
+  unpublished.
 
   When ACLs are enabled, this command requires a token with the appropriate
   capability in the volume's namespace: the 'csi-write-volume' capability for

--- a/website/content/api-docs/volumes.mdx
+++ b/website/content/api-docs/volumes.mdx
@@ -497,6 +497,10 @@ for deleting the volume as comma-separated key-value pairs (see the
 example below). These secrets will be merged with any secrets already
 stored when the CSI volume was created.
 
+The volume must still be registered with Nomad in order to be deleted. This API
+call fails if an allocation still claims the volume or if Nomad is unpublishing
+the volume.
+
 ### Parameters
 
 - `:volume_id` `(string: <required>)` - Specifies the ID of the

--- a/website/content/commands/volume/delete.mdx
+++ b/website/content/commands/volume/delete.mdx
@@ -26,8 +26,7 @@ nomad volume delete [options] [volume]
 The `volume delete` command requires a single argument, specifying the ID of
 volume to be deleted. The volume must still be [registered][] with Nomad in
 order to be deleted. Deleting fails if the volume is still in use by an
-allocation or in the process of being unpublished. If the volume no longer
-exists, this command silently returns without an error.
+allocation or in the process of being unpublished.
 
 When ACLs are enabled, this command requires a token with the appropriate
 capability in the volume's namespace: the `csi-write-volume` capability for CSI


### PR DESCRIPTION
If you delete a CSI volume, the volume cannot be currently claimed by an allocation or in the process of being unpublished. This is documented in the CLI but not the API. Also, the documentation incorrectly says that the `volume delete` command silently returns without error if the volume doesn't exist, but that's incorrect.

Fixes: https://github.com/hashicorp/nomad/issues/24756

Previews:
* https://nomad-git-docs-api-csi-volume-delete-hashicorp.vercel.app/nomad/api-docs/volumes#delete-csi-volume-snapshot
* https://nomad-git-docs-api-csi-volume-delete-hashicorp.vercel.app/nomad/commands/volume/delete

---

```
$ nomad volume delete -type csi foo
Could not find existing CSI volume to delete: no volumes with prefix or ID "foo" found

$ nomad volume delete -type host efcf2370-4ea3-7b3f-073c-3ef6a90295b4
Error deleting volume: Unexpected response code: 500 (no such volume: efcf2370-4ea3-7b3f-073c-3ef6a90295b4)
```