### PR TITLE
add input validation and path traversal protections

### DIFF
--- a/client/allocrunner/taskrunner/secrets/aws_provider.go
+++ b/client/allocrunner/taskrunner/secrets/aws_provider.go
@@ -1,0 +1,84 @@
+package secrets
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/mitchellh/mapstructure"
+)
+
+type AwsProvider struct {
+	secret   *structs.Secret
+	tmplPath string
+	config   *nomadProviderConfig
+}
+
+// NewNomadProvider takes a task secret and decodes the config, overwriting the default config fields
+// with any provided fields, returning an error if the secret or secret's config is invalid.
+func NewAWSProvider(secret *structs.Secret, path string, namespace string) (*AwsProvider, error) {
+	if secret == nil {
+		return nil, fmt.Errorf("empty secret for nomad provider")
+	}
+
+	conf := defaultNomadConfig(namespace)
+	if err := mapstructure.Decode(secret.Config, conf); err != nil {
+		return nil, err
+	}
+
+	return &AwsProvider{
+		config:   conf,
+		secret:   secret,
+		tmplPath: path,
+	}, nil
+}
+
+func (n *AwsProvider) BuildTemplate() *structs.Template {
+
+	// fmt.Println("fetching aws secret")
+	// secretName := "MyTestSecret"
+	// region := "us-east-2"
+	//
+	// client := &http.Client{
+	// 	Transport: cleanhttp.DefaultTransport(),
+	// }
+	// cfg, err := config.LoadDefaultConfig(context.Background(),
+	// 	config.WithRegion(region),
+	// 	config.WithHTTPClient(client),
+	// 	config.WithRetryMaxAttempts(0),
+	// )
+	// if err != nil {
+	// 	return nil
+	// }
+	//
+	// sm := secretsmanager.NewFromConfig(cfg)
+	//
+	// val, err := sm.GetSecretValue(context.Background(), &secretsmanager.GetSecretValueInput{
+	// 	SecretId:     aws.String(secretName),
+	// 	VersionStage: aws.String("AWSCURRENT"),
+	// })
+	// if err != nil {
+	// 	fmt.Println(err)
+	// 	return nil
+	// }
+	//
+	// var res string = *val.SecretString
+	//
+	// fmt.Println(res)
+
+	return &structs.Template{}
+}
+
+func (n *AwsProvider) Parse() (map[string]string, error) {
+	return nil, nil
+	// dest := filepath.Clean(n.tmplPath)
+	// f, err := os.Open(dest)
+	// if err != nil {
+	// 	return nil, fmt.Errorf("error opening env template: %v", err)
+	// }
+	// defer func() {
+	// 	f.Close()
+	// 	os.Remove(dest)
+	// }()
+	//
+	// return envparse.Parse(f)
+}

--- a/client/allocrunner/taskrunner/secrets/nomad_provider.go
+++ b/client/allocrunner/taskrunner/secrets/nomad_provider.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 
 	"github.com/hashicorp/go-envparse"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -24,27 +25,29 @@ func defaultNomadConfig(namespace string) *nomadProviderConfig {
 }
 
 type NomadProvider struct {
-	secret   *structs.Secret
-	tmplPath string
-	config   *nomadProviderConfig
+	secret    *structs.Secret
+	secretDir string
+	tmplFile  string
+	config    *nomadProviderConfig
 }
 
 // NewNomadProvider takes a task secret and decodes the config, overwriting the default config fields
 // with any provided fields, returning an error if the secret or secret's config is invalid.
-func NewNomadProvider(secret *structs.Secret, path string, namespace string) (*NomadProvider, error) {
-	if secret == nil {
-		return nil, fmt.Errorf("empty secret for nomad provider")
-	}
-
+func NewNomadProvider(secret *structs.Secret, secretDir string, tmplFile string, namespace string) (*NomadProvider, error) {
 	conf := defaultNomadConfig(namespace)
 	if err := mapstructure.Decode(secret.Config, conf); err != nil {
 		return nil, err
 	}
 
+	if err := validateNomadInputs(conf, secret.Path); err != nil {
+		return nil, err
+	}
+
 	return &NomadProvider{
-		config:   conf,
-		secret:   secret,
-		tmplPath: path,
+		config:    conf,
+		secret:    secret,
+		secretDir: secretDir,
+		tmplFile:  tmplFile,
 	}, nil
 }
 
@@ -59,22 +62,38 @@ func (n *NomadProvider) BuildTemplate() *structs.Template {
 
 	return &structs.Template{
 		EmbeddedTmpl: data,
-		DestPath:     n.tmplPath,
+		DestPath:     filepath.Join(n.secretDir, n.tmplFile),
 		ChangeMode:   structs.TemplateChangeModeNoop,
 		Once:         true,
 	}
 }
 
 func (n *NomadProvider) Parse() (map[string]string, error) {
-	dest := filepath.Clean(n.tmplPath)
-	f, err := os.Open(dest)
+	f, err := os.OpenInRoot(n.secretDir, n.tmplFile)
 	if err != nil {
 		return nil, fmt.Errorf("error opening env template: %v", err)
 	}
 	defer func() {
 		f.Close()
-		os.Remove(dest)
+		os.Remove(filepath.Join(n.secretDir, n.tmplFile))
 	}()
 
 	return envparse.Parse(f)
+}
+
+// validateNomadInputs ensures none of the user provided inputs contain delimiters
+// that could be used to inject other CT functions.
+func validateNomadInputs(conf *nomadProviderConfig, path string) error {
+	// match if a string contains (...), {{, or }}
+	var templateValidate = regexp.MustCompile(`\(.*\)|\{\{|\}\}`)
+
+	if templateValidate.MatchString(conf.Namespace) {
+		return fmt.Errorf("namespace cannot contain template delimiters or parenthesis")
+	}
+
+	if templateValidate.MatchString(path) {
+		return fmt.Errorf("path cannot contain template delimiters or parenthesis")
+	}
+
+	return nil
 }

--- a/client/allocrunner/taskrunner/secrets/nomad_provider.go
+++ b/client/allocrunner/taskrunner/secrets/nomad_provider.go
@@ -4,6 +4,7 @@
 package secrets
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -91,11 +92,11 @@ func (n *NomadProvider) Parse() (map[string]string, error) {
 // that could be used to inject other CT functions.
 func validateNomadInputs(conf *nomadProviderConfig, path string) error {
 	if strings.ContainsAny(conf.Namespace, "(){}") {
-		return fmt.Errorf("namespace cannot contain template delimiters or parenthesis")
+		return errors.New("namespace cannot contain template delimiters or parenthesis")
 	}
 
 	if strings.ContainsAny(path, "(){}") {
-		return fmt.Errorf("path cannot contain template delimiters or parenthesis")
+		return errors.New("path cannot contain template delimiters or parenthesis")
 	}
 
 	return nil

--- a/client/allocrunner/taskrunner/secrets/nomad_provider.go
+++ b/client/allocrunner/taskrunner/secrets/nomad_provider.go
@@ -63,7 +63,7 @@ func (n *NomadProvider) BuildTemplate() *structs.Template {
 
 	return &structs.Template{
 		EmbeddedTmpl: data,
-		DestPath:     filepath.Join(n.secretDir, n.tmplFile),
+		DestPath:     filepath.Clean(filepath.Join(n.secretDir, n.tmplFile)),
 		ChangeMode:   structs.TemplateChangeModeNoop,
 		Once:         true,
 	}

--- a/client/allocrunner/taskrunner/secrets/vault_provider.go
+++ b/client/allocrunner/taskrunner/secrets/vault_provider.go
@@ -4,6 +4,7 @@
 package secrets
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -45,7 +46,7 @@ func NewVaultProvider(secret *structs.Secret, secretDir string, tmplFile string)
 	}
 
 	if strings.ContainsAny(secret.Path, "(){}") {
-		return nil, fmt.Errorf("secret path cannot contain template delimiters or parenthesis")
+		return nil, errors.New("secret path cannot contain template delimiters or parenthesis")
 	}
 
 	return &VaultProvider{

--- a/client/allocrunner/taskrunner/secrets/vault_provider.go
+++ b/client/allocrunner/taskrunner/secrets/vault_provider.go
@@ -73,7 +73,7 @@ func (v *VaultProvider) BuildTemplate() *structs.Template {
 
 	return &structs.Template{
 		EmbeddedTmpl: data,
-		DestPath:     filepath.Join(v.secretDir, v.tmplFile),
+		DestPath:     filepath.Clean(filepath.Join(v.secretDir, v.tmplFile)),
 		ChangeMode:   structs.TemplateChangeModeNoop,
 		Once:         true,
 	}

--- a/client/allocrunner/taskrunner/secrets/vault_provider_test.go
+++ b/client/allocrunner/taskrunner/secrets/vault_provider_test.go
@@ -20,7 +20,7 @@ func TestVaultProvider_BuildTemplate(t *testing.T) {
 			Provider: "vault",
 			Path:     "/test/path",
 		}
-		p, err := NewVaultProvider(testSecret, testDir)
+		p, err := NewVaultProvider(testSecret, testDir, "test")
 		must.NoError(t, err)
 
 		tmpl := p.BuildTemplate()
@@ -47,7 +47,7 @@ func TestVaultProvider_BuildTemplate(t *testing.T) {
 				"engine": VAULT_KV_V2,
 			},
 		}
-		p, err := NewVaultProvider(testSecret, testDir)
+		p, err := NewVaultProvider(testSecret, testDir, "test")
 		must.NoError(t, err)
 
 		tmpl := p.BuildTemplate()
@@ -74,7 +74,18 @@ func TestVaultProvider_BuildTemplate(t *testing.T) {
 				"engine": 123,
 			},
 		}
-		_, err := NewVaultProvider(testSecret, testDir)
+		_, err := NewVaultProvider(testSecret, testDir, "test")
+		must.Error(t, err)
+	})
+
+	t.Run("path containing delimeter errors", func(t *testing.T) {
+		testDir := t.TempDir()
+		testSecret := &structs.Secret{
+			Name:     "foo",
+			Provider: "vault",
+			Path:     "/test/path}}",
+		}
+		_, err := NewVaultProvider(testSecret, testDir, "test")
 		must.Error(t, err)
 	})
 }
@@ -82,13 +93,14 @@ func TestVaultProvider_BuildTemplate(t *testing.T) {
 func TestVaultProvider_Parse(t *testing.T) {
 	testDir := t.TempDir()
 
-	tmplPath := filepath.Join(testDir, "foo")
+	tmplFile := "foo"
+	tmplPath := filepath.Join(testDir, tmplFile)
 
 	data := "foo=bar"
 	err := os.WriteFile(tmplPath, []byte(data), 0777)
 	must.NoError(t, err)
 
-	p, err := NewVaultProvider(&structs.Secret{}, tmplPath)
+	p, err := NewVaultProvider(&structs.Secret{}, testDir, tmplFile)
 	must.NoError(t, err)
 
 	vars, err := p.Parse()

--- a/client/allocrunner/taskrunner/secrets_hook.go
+++ b/client/allocrunner/taskrunner/secrets_hook.go
@@ -6,7 +6,6 @@ package taskrunner
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-multierror"

--- a/client/allocrunner/taskrunner/secrets_hook.go
+++ b/client/allocrunner/taskrunner/secrets_hook.go
@@ -90,7 +90,7 @@ func (h *secretsHook) Name() string {
 	return "secrets"
 }
 
-func (h *secretsHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, _ *interfaces.TaskPrestartResponse) error {
+func (h *secretsHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
 	templates := []*structs.Template{}
 
 	providers, err := h.buildSecretProviders(req.TaskDir.SecretsDir)
@@ -148,6 +148,7 @@ func (h *secretsHook) Prestart(ctx context.Context, req *interfaces.TaskPrestart
 		h.envBuilder.SetSecrets(vars)
 	}
 
+	resp.Done = true
 	return nil
 }
 
@@ -157,16 +158,20 @@ func (h *secretsHook) buildSecretProviders(secretDir string) ([]SecretProvider, 
 	providers, mErr := []SecretProvider{}, new(multierror.Error)
 
 	for idx, s := range h.secrets {
-		tmplPath := filepath.Join(secretDir, fmt.Sprintf("temp-%d", idx))
+		if s == nil {
+			continue
+		}
+
+		tmplFile := fmt.Sprintf("temp-%d", idx)
 		switch s.Provider {
 		case "nomad":
-			if p, err := secrets.NewNomadProvider(s, tmplPath, h.nomadNamespace); err != nil {
+			if p, err := secrets.NewNomadProvider(s, secretDir, tmplFile, h.nomadNamespace); err != nil {
 				multierror.Append(mErr, err)
 			} else {
 				providers = append(providers, p)
 			}
 		case "vault":
-			if p, err := secrets.NewVaultProvider(s, tmplPath); err != nil {
+			if p, err := secrets.NewVaultProvider(s, secretDir, tmplFile); err != nil {
 				multierror.Append(mErr, err)
 			} else {
 				providers = append(providers, p)

--- a/client/allocrunner/taskrunner/secrets_hook_test.go
+++ b/client/allocrunner/taskrunner/secrets_hook_test.go
@@ -94,7 +94,7 @@ func TestSecretsHook_Prestart_Nomad(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		t.Cleanup(cancel)
 
-		err := secretHook.Prestart(ctx, req, nil)
+		err := secretHook.Prestart(ctx, req, &interfaces.TaskPrestartResponse{})
 		must.NoError(t, err)
 
 		expected := map[string]string{
@@ -169,7 +169,7 @@ func TestSecretsHook_Prestart_Nomad(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		cancel() // cancel context to simulate task being stopped
 
-		err := secretHook.Prestart(ctx, req, nil)
+		err := secretHook.Prestart(ctx, req, &interfaces.TaskPrestartResponse{})
 		must.NoError(t, err)
 
 		expected := map[string]string{}
@@ -289,7 +289,7 @@ func TestSecretsHook_Prestart_Vault(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	t.Cleanup(cancel)
 
-	err := secretHook.Prestart(ctx, req, nil)
+	err := secretHook.Prestart(ctx, req, &interfaces.TaskPrestartResponse{})
 	must.NoError(t, err)
 
 	exp := map[string]string{


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Adds `OpenRoot` for accessing rendered template, and user input validation so users cannot inject template functions into secret block parameters.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
