### PR TITLE
docs: note that CSI volume name must be unique

### DIFF
--- a/website/content/docs/other-specifications/volume/csi.mdx
+++ b/website/content/docs/other-specifications/volume/csi.mdx
@@ -80,9 +80,9 @@ Provide the file as either HCL or JSON to the commands and as JSON to the API.
   &lt;required&gt;)</code> - Options for mounting `file-system` volumes that
   don't already have a pre-formatted file system.
 
-- `name` `(string: <required>)` - The display name of the volume. On volume
-  creation, this field may be used by the external storage provider to tag the
-  volume.
+- `name` `(string: <required>)` - The name of the volume. On volume creation,
+  the external storage provider may use this field to tag the volume or as an
+  idempotency token, so it must be unique across all namespaces.
 
 - `namespace` `(string: <optional>)` - The namespace of the volume. This field
   overrides the namespace provided by the `-namespace` flag or `NOMAD_NAMESPACE`


### PR DESCRIPTION
When we originally implemented CSI, Nomad did not support the `CreateVolume` workflow, so the volume name field was just a display name. The `CreateVolume` CSI RPC requires that the volume name be unique. In retrospect, Nomad should probably have mapped the namespace + ID to the volume name field, but because we didn't the name field must be unique per storage provider. In future work we should try to figure out a way to unwind that decision but in the meantime let's make that requirement clear in the documentation.

Ref: https://gitlab.com/rocketduck/csi-plugin-nfs/-/issues/21