### PR TITLE
fix(doc): fix links for task driver plugins

### DIFF
--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -263,19 +263,19 @@
             "routes": [
               {
                 "title": "Exec2",
-                "href": "http://develoepr.hashicorp.com/nomad/plugins/drivers/exec2"
+                "href": "http://developer.hashicorp.com/nomad/plugins/drivers/exec2"
               },
               {
                 "title": "Podman",
-                "href": "http://develoepr.hashicorp.com/nomad/plugins/drivers/podman"
+                "href": "http://developer.hashicorp.com/nomad/plugins/drivers/podman"
               },
               {
                 "title": "Virt <sup>Beta</sup>",
-                "href": "http://develoepr.hashicorp.com/nomad/plugins/drivers/virt"
+                "href": "http://developer.hashicorp.com/nomad/plugins/drivers/virt"
               },
               {
                 "title": "Community",
-                "href": "http://develoepr.hashicorp.com/nomad/plugins/drivers/community"
+                "href": "http://developer.hashicorp.com/nomad/plugins/drivers/community"
               }
             ]
           }


### PR DESCRIPTION
### Description
Website links about task driver plugins contains a typo on the host part.

### Testing & Reproduction steps
Just browse using the left menu, for example, on the [task driver part](https://developer.hashicorp.com/nomad/docs/deploy/task-driver).