### PR TITLE
Add NOMAD_UNIQUE_HOSTNAME environment variable

### DIFF
--- a/.changelog/26252.txt
+++ b/.changelog/26252.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: Add NOMAD_UNIQUE_HOSTNAME environment variable
+```

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -89,6 +89,9 @@ const (
 	// Region is the environment variable for passing the region in which the alloc is running.
 	Region = "NOMAD_REGION"
 
+	// UniqueHostname is the environment variable for passing the unique hostname of the node.
+	UniqueHostname = "NOMAD_UNIQUE_HOSTNAME"
+
 	// AddrPrefix is the prefix for passing both dynamic and static port
 	// allocations to tasks.
 	// E.g $NOMAD_ADDR_http=127.0.0.1:80
@@ -592,6 +595,11 @@ func (b *Builder) buildEnv(allocDir, localDir, secretsDir string,
 	}
 	if b.region != "" {
 		envMap[Region] = b.region
+	}
+
+	// Add the unique hostname from node attributes
+	if uniqueHostname := nodeAttrs[fmt.Sprintf("%s%s", nodeAttributePrefix, "unique.hostname")]; uniqueHostname != "" {
+		envMap[UniqueHostname] = uniqueHostname
 	}
 
 	// Build the network related env vars

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -598,7 +598,7 @@ func (b *Builder) buildEnv(allocDir, localDir, secretsDir string,
 	}
 
 	// Add the unique hostname from node attributes
-	if uniqueHostname := nodeAttrs[fmt.Sprintf("%s%s", nodeAttributePrefix, "unique.hostname")]; uniqueHostname != "" {
+	if uniqueHostname := nodeAttrs[nodeAttributePrefix+"unique.hostname"]; uniqueHostname != "" {
 		envMap[UniqueHostname] = uniqueHostname
 	}
 

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -162,6 +162,7 @@ func TestEnvironment_AsList(t *testing.T) {
 	n.Meta = map[string]string{
 		"metaKey": "metaVal",
 	}
+	n.Attributes["unique.hostname"] = "test-hostname"
 	a := mock.Alloc()
 	a.Job.ParentID = fmt.Sprintf("mock-parent-service-%s", uuid.Generate())
 	a.AllocatedResources.Tasks["web"] = &structs.AllocatedTaskResources{
@@ -245,6 +246,7 @@ func TestEnvironment_AsList(t *testing.T) {
 		"NOMAD_DC=dc1",
 		"NOMAD_NAMESPACE=not-default",
 		"NOMAD_REGION=global",
+		"NOMAD_UNIQUE_HOSTNAME=test-hostname",
 		"NOMAD_MEMORY_LIMIT=256",
 		"NOMAD_MEMORY_MAX_LIMIT=512",
 		"NOMAD_META_ELB_CHECK_INTERVAL=30s",
@@ -281,6 +283,7 @@ func TestEnvironment_AllValues(t *testing.T) {
 		"invalid...metakey": "b",
 	}
 	n.CgroupParent = "abc.slice"
+	n.Attributes["unique.hostname"] = "test-hostname"
 	a := mock.ConnectAlloc()
 	a.Job.ParentID = fmt.Sprintf("mock-parent-service-%s", uuid.Generate())
 	a.AllocatedResources.Tasks["web"].Networks[0] = &structs.NetworkResource{
@@ -421,6 +424,7 @@ func TestEnvironment_AllValues(t *testing.T) {
 		"NOMAD_PARENT_CGROUP":                       "abc.slice",
 		"NOMAD_NAMESPACE":                           "default",
 		"NOMAD_REGION":                              "global",
+		"NOMAD_UNIQUE_HOSTNAME":                     "test-hostname",
 		"NOMAD_MEMORY_LIMIT":                        "256",
 		"NOMAD_META_ELB_CHECK_INTERVAL":             "30s",
 		"NOMAD_META_ELB_CHECK_MIN":                  "3",


### PR DESCRIPTION
### Description
This PR adds support for exposing the node's `unique.hostname` attribute as the `NOMAD_UNIQUE_HOSTNAME` environment variable in task environments.

This enhancement allows tasks to access the node's unique hostname without needing to query the Nomad API, simplifying access to node-specific information within running tasks.

### Testing & Reproduction steps
* Added test cases in `client/taskenv/env_test.go` to verify the environment variable is properly set when the node has a `unique.hostname` attribute
* The test verifies that `NOMAD_UNIQUE_HOSTNAME` is included in the task environment with the correct value

### Links
* Related to node attributes functionality
* Enhances task environment variables similar to existing variables like `NOMAD_DC` and `NOMAD_REGION`

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 