### PR TITLE
docs: Versioned redirect logic

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -511,7 +511,7 @@ module.exports = [
   },
   {
     source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/deploy/nomad-agent/',
-    destination: '/nomad/docs/:versions/operations/nomad-agent',
+    destination: '/nomad/docs/:version/operations/nomad-agent',
     permanent: true
   },
   {


### PR DESCRIPTION
### Description

This PR adds redirects to support advanced version picker behavior in Nomad following the IA restructure. 

Specifically, it covers two situations:

1. A user is on a page in v.10, and they select version 1.8 or 1.9. This page used to be in a different location. Instead of generating a 404, the user is redirected to the correct page in their selected version.

2. A user is on a page in v1.10 and they select version 1.8 or 1.9. This page used to be a tutorial. The user is redirected to an archived version of the tutorial, which preserves the content as it did when that version was available.

The behavior will not appear online immediately after merging this PR. A PR in a different internal repository will change the version picker behavior so that the version picker will appear on a page that didn't exist in a previous version, with version options beginning at 1.8 