### PR TITLE
allocrunner: run all postrun hooks, even on error

### DIFF
--- a/.changelog/26271.txt
+++ b/.changelog/26271.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: run all allocrunner postrun (cleanup) hooks, even if any of them error
+```

--- a/client/allocrunner/interfaces/runner_lifecycle.go
+++ b/client/allocrunner/interfaces/runner_lifecycle.go
@@ -30,8 +30,8 @@ type RunnerPreKillHook interface {
 }
 
 // A RunnerPostrunHook is executed after calling TaskRunner.Run, even for
-// terminal allocations. Therefore Postrun hooks must be safe to call without
-// first calling Prerun hooks.
+// terminal allocations, and all Postrun hooks will be run even if any of them error.
+// Therefore, Postrun hooks must be safe to call without first calling Prerun hooks.
 type RunnerPostrunHook interface {
 	RunnerHook
 	Postrun() error


### PR DESCRIPTION
E.g. if the Consul postrun hook fails, continue running the subsequent postrun hooks, which among other things includes network/CNI cleanup (including deleting iptables rules).

Internal ref: https://hashicorp.atlassian.net/browse/NMD-306