### PR TITLE
sysbatch: correctly validate that reschedule policy is not allowed

### DIFF
--- a/.changelog/26279.txt
+++ b/.changelog/26279.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+sysbatch: Submitting a sysbatch job with a `reschedule` block will now return an error instead of being silently ignored
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7112,9 +7112,9 @@ func (tg *TaskGroup) Validate(j *Job) error {
 		}
 	}
 
-	if j.Type == JobTypeSystem {
+	if j.Type == JobTypeSystem || j.Type == JobTypeSysBatch {
 		if tg.ReschedulePolicy != nil {
-			mErr = multierror.Append(mErr, fmt.Errorf("System jobs should not have a reschedule policy"))
+			mErr = multierror.Append(mErr, fmt.Errorf("System or sysbatch jobs should not have a reschedule policy"))
 		}
 	} else {
 		if tg.ReschedulePolicy != nil {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1512,7 +1512,7 @@ func TestTaskGroup_Validate(t *testing.T) {
 				},
 			},
 			expErr: []string{
-				"System jobs should not have a reschedule policy",
+				"System or sysbatch jobs should not have a reschedule policy",
 			},
 			jobType: JobTypeSystem,
 		},

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -16,9 +16,9 @@ used to document those details separately from the standard upgrade flow.
 
 #### Sysbatch jobs will no longer accept `reschedule` blocks
 
-Nomad 1.11.0 fixed a bug where submitting a sysbatch job with a `reschedule`
-block will return an error instead of being silently ignored, matching the
-behavior of system jobs.
+In Nomad 1.11.0, submitting a sysbatch job with a `reschedule` block returns
+an error instead of being silently ignored, as it was in previous versions. The
+same behavior applies to system jobs. 
 
 ## Nomad 1.10.2
 

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -12,6 +12,14 @@ upgrade. However, specific versions of Nomad may have more details provided for
 their upgrades as a result of new features or changed behavior. This page is
 used to document those details separately from the standard upgrade flow.
 
+## Nomad 1.11.0
+
+#### Sysbatch jobs will no longer accept `reschedule` blocks
+
+Nomad 1.11.0 fixed a bug where submitting a sysbatch job with a `reschedule`
+block will return an error instead of being silently ignored, matching the
+behavior of system jobs.
+
 ## Nomad 1.10.2
 
 #### Clients respect `telemetry.publish_allocation_metrics`


### PR DESCRIPTION
System and sysbatch jobs don't support the reschedule block, because we'd always replace allocations back onto the same node. The job validation for system jobs asserts that the user hasn't set a `reschedule` block so that users aren't submitting jobs expecting it to be supported. But this validation was missing for sysbatch jobs.

Validate that sysbatch jobs don't have a reschedule block.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] ~**Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.~ No backport
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
