### PR TITLE
scheduler: remove unnecessary reconnecting and ignore allocset assignment

### DIFF
--- a/scheduler/reconciler/reconcile_cluster.go
+++ b/scheduler/reconciler/reconcile_cluster.go
@@ -490,8 +490,6 @@ func (a *AllocReconciler) computeGroup(group string, all allocSet) (*ReconcileRe
 		migrate = migrate.difference(stopAllocSet)
 		lost = lost.difference(stopAllocSet)
 		disconnecting = disconnecting.difference(stopAllocSet)
-		reconnecting = reconnecting.difference(stopAllocSet)
-		ignore = ignore.difference(stopAllocSet)
 
 		// Validate and add reconnecting allocations to the plan so they are
 		// logged.


### PR DESCRIPTION
I noticed this during my work on system deployments. These values aren't used anywhere, and the code is confusing as is. 