### PR TITLE
scheduler: adds implicit constraint for secrets plugin node attributes

### DIFF
--- a/client/fingerprint/fingerprint.go
+++ b/client/fingerprint/fingerprint.go
@@ -43,6 +43,7 @@ var (
 		"nomad":               NewNomadFingerprint,
 		"plugins_cni":         NewPluginsCNIFingerprint,
 		"host_volume_plugins": NewPluginsHostVolumeFingerprint,
+		"secrets":             NewPluginsSecretsFingerprint,
 		"signal":              NewSignalFingerprint,
 		"storage":             NewStorageFingerprint,
 		"vault":               NewVaultFingerprint,

--- a/client/fingerprint/secrets.go
+++ b/client/fingerprint/secrets.go
@@ -1,0 +1,34 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package fingerprint
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+)
+
+type SecretsPluginFingerprint struct {
+	logger hclog.Logger
+}
+
+func NewPluginsSecretsFingerprint(logger hclog.Logger) Fingerprint {
+	return &SecretsPluginFingerprint{
+		logger: logger.Named("secrets_plugins"),
+	}
+}
+
+func (s *SecretsPluginFingerprint) Fingerprint(request *FingerprintRequest, response *FingerprintResponse) error {
+	// Add builtin secrets providers
+	response.AddAttribute(fmt.Sprintf("plugins.secrets.%s.version", "nomad"), "1.0.0")
+	response.AddAttribute(fmt.Sprintf("plugins.secrets.%s.version", "vault"), "1.0.0")
+	response.Detected = true
+
+	return nil
+}
+
+func (s *SecretsPluginFingerprint) Periodic() (bool, time.Duration) {
+	return false, 0
+}

--- a/client/fingerprint/secrets.go
+++ b/client/fingerprint/secrets.go
@@ -4,7 +4,6 @@
 package fingerprint
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -22,8 +21,8 @@ func NewPluginsSecretsFingerprint(logger hclog.Logger) Fingerprint {
 
 func (s *SecretsPluginFingerprint) Fingerprint(request *FingerprintRequest, response *FingerprintResponse) error {
 	// Add builtin secrets providers
-	response.AddAttribute(fmt.Sprintf("plugins.secrets.%s.version", "nomad"), "1.0.0")
-	response.AddAttribute(fmt.Sprintf("plugins.secrets.%s.version", "vault"), "1.0.0")
+	response.AddAttribute("plugins.secrets.nomad.version", "1.0.0")
+	response.AddAttribute("plugins.secrets.vault.version", "1.0.0")
 	response.Detected = true
 
 	return nil

--- a/client/fingerprint/secrets_test.go
+++ b/client/fingerprint/secrets_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package fingerprint
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/shoenig/test/must"
+)
+
+func TestPluginsSecretsFingerprint(t *testing.T) {
+	fp := NewPluginsSecretsFingerprint(testlog.HCLogger(t))
+
+	resp := FingerprintResponse{}
+	err := fp.Fingerprint(&FingerprintRequest{}, &resp)
+	must.NoError(t, err)
+	must.True(t, resp.Detected)
+	must.MapContainsKeys(t, resp.Attributes, []string{
+		"plugins.secrets.nomad.version",
+		"plugins.secrets.vault.version",
+	})
+}

--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -88,6 +88,13 @@ func Job() *structs.Job {
 								Args:    []string{"hello world"},
 							},
 						},
+						Secrets: []*structs.Secret{
+							{
+								Name:     "test-secret",
+								Provider: "foo",
+								Path:     "test/path",
+							},
+						},
 						Constraints: []*structs.Constraint{
 							{
 								LTarget: "${attr.consul.version}",

--- a/nomad/mock/job.go
+++ b/nomad/mock/job.go
@@ -88,13 +88,6 @@ func Job() *structs.Job {
 								Args:    []string{"hello world"},
 							},
 						},
-						Secrets: []*structs.Secret{
-							{
-								Name:     "test-secret",
-								Provider: "foo",
-								Path:     "test/path",
-							},
-						},
 						Constraints: []*structs.Constraint{
 							{
 								LTarget: "${attr.consul.version}",

--- a/scheduler/feasible/stack_test.go
+++ b/scheduler/feasible/stack_test.go
@@ -220,6 +220,34 @@ func TestServiceStack_Select_DriverFilter(t *testing.T) {
 	must.Eq(t, zero, node.Node)
 }
 
+func TestServiceStack_Select_Secrets(t *testing.T) {
+	ci.Parallel(t)
+
+	_, ctx := MockContext(t)
+	nodes := []*structs.Node{
+		mock.Node(),
+		mock.Node(),
+	}
+	zero := nodes[0]
+	zero.Attributes["plugins.secrets.foo.version"] = "0.0.1"
+	must.NoError(t, zero.ComputeClass())
+
+	stack := NewGenericStack(false, ctx)
+	stack.SetNodes(nodes)
+
+	job := mock.Job()
+	job.TaskGroups[0].Tasks[0].Secrets[0] = &structs.Secret{
+		Provider: "foo",
+	}
+	stack.SetJob(job)
+
+	selectOptions := &SelectOptions{}
+	node := stack.Select(job.TaskGroups[0], selectOptions)
+	must.NotNil(t, node, must.Sprintf("missing node %#v", ctx.Metrics()))
+
+	must.Eq(t, zero, node.Node)
+}
+
 func TestServiceStack_Select_HostVolume(t *testing.T) {
 	ci.Parallel(t)
 
@@ -562,6 +590,42 @@ func TestSystemStack_Select_DriverFilter(t *testing.T) {
 	must.Eq(t, zero, node.Node)
 
 	zero.Attributes["driver.foo"] = "0"
+	must.NoError(t, zero.ComputeClass())
+
+	stack = NewSystemStack(false, ctx)
+	stack.SetNodes(nodes)
+	stack.SetJob(job)
+	node = stack.Select(job.TaskGroups[0], selectOptions)
+	must.Nil(t, node)
+}
+
+func TestSystemStack_Select_Secrets(t *testing.T) {
+	ci.Parallel(t)
+
+	_, ctx := MockContext(t)
+	nodes := []*structs.Node{
+		mock.Node(),
+		mock.Node(),
+	}
+	zero := nodes[0]
+	zero.Attributes["plugins.secrets.foo.version"] = "0.0.1"
+	must.NoError(t, zero.ComputeClass())
+
+	stack := NewSystemStack(false, ctx)
+	stack.SetNodes(nodes)
+
+	job := mock.Job()
+	job.TaskGroups[0].Tasks[0].Secrets[0] = &structs.Secret{
+		Provider: "foo",
+	}
+	stack.SetJob(job)
+
+	selectOptions := &SelectOptions{}
+	node := stack.Select(job.TaskGroups[0], selectOptions)
+	must.NotNil(t, node, must.Sprintf("missing node %#v", ctx.Metrics()))
+	must.Eq(t, zero, node.Node)
+
+	delete(zero.Attributes, "plugins.secrets.foo.version")
 	must.NoError(t, zero.ComputeClass())
 
 	stack = NewSystemStack(false, ctx)

--- a/scheduler/feasible/stack_test.go
+++ b/scheduler/feasible/stack_test.go
@@ -617,8 +617,10 @@ func TestSystemStack_Select_Secrets(t *testing.T) {
 	stack.SetNodes(nodes)
 
 	job := mock.Job()
-	job.TaskGroups[0].Tasks[0].Secrets[0] = &structs.Secret{
-		Provider: "foo",
+	job.TaskGroups[0].Tasks[0].Secrets = []*structs.Secret{
+		{
+			Provider: "foo",
+		},
 	}
 	stack.SetJob(job)
 

--- a/scheduler/feasible/stack_test.go
+++ b/scheduler/feasible/stack_test.go
@@ -236,8 +236,10 @@ func TestServiceStack_Select_Secrets(t *testing.T) {
 	stack.SetNodes(nodes)
 
 	job := mock.Job()
-	job.TaskGroups[0].Tasks[0].Secrets[0] = &structs.Secret{
-		Provider: "foo",
+	job.TaskGroups[0].Tasks[0].Secrets = []*structs.Secret{
+		{
+			Provider: "foo",
+		},
 	}
 	stack.SetJob(job)
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Adds basic fingerprinting for builtin Nomad and Vault secrets providers and adds feasibility checks in the Nomad schedulers for the node attributes added during fingerprinting.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
