### PR TITLE
adds implied secrets constraint to job hook

### DIFF
--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -279,6 +279,8 @@ func (jobImpliedConstraints) Mutate(j *structs.Job) (*structs.Job, []error, erro
 
 	taskScheduleTaskGroups := j.RequiredScheduleTask()
 
+	secretBlocks := j.Secrets()
+
 	// Hot path where none of our things require constraints.
 	//
 	// [UPDATE THIS] if you are adding a new constraint thing!
@@ -286,7 +288,8 @@ func (jobImpliedConstraints) Mutate(j *structs.Job) (*structs.Job, []error, erro
 		nativeServiceDisco.Empty() && len(consulServiceDisco) == 0 &&
 		numaTaskGroups.Empty() && bridgeNetworkingTaskGroups.Empty() &&
 		transparentProxyTaskGroups.Empty() &&
-		taskScheduleTaskGroups.Empty() {
+		taskScheduleTaskGroups.Empty() &&
+		len(secretBlocks) == 0 {
 		return j, nil, nil
 	}
 
@@ -300,6 +303,14 @@ func (jobImpliedConstraints) Mutate(j *structs.Job) (*structs.Job, []error, erro
 		for _, vaultTask := range vaultTasks {
 			vaultBlock := vaultBlocks[tg.Name][vaultTask]
 			mutateConstraint(constraintMatcherLeft, tg, vaultConstraintFn(vaultBlock))
+		}
+
+		secretTasks := lang.MapKeys(secretBlocks[tg.Name])
+		for _, secretTask := range secretTasks {
+			secretBlock := secretBlocks[tg.Name][secretTask]
+			for _, secret := range secretBlock {
+				mutateConstraint(constraintMatcherLeft, tg, secretsConstraintFn(secret))
+			}
 		}
 
 		// If the task group utilizes NUMA resources, run the mutator.
@@ -380,6 +391,17 @@ func vaultConstraintFn(vault *structs.Vault) *structs.Constraint {
 		}
 	}
 	return vaultConstraint
+}
+
+// secretsConstraintFn returns a constraint that checks for the existence of a
+// fingerprinted secrets plugin. This is to support upgrades to 1.11 where a nomad
+// server follower may not be upgraded yet and attempt to place a job on a client
+// that has not been upgraded. This should be removed in Nomad 1.14.
+func secretsConstraintFn(secret *structs.Secret) *structs.Constraint {
+	return &structs.Constraint{
+		LTarget: fmt.Sprintf("${attr.plugins.secrets.%s.version}", secret.Provider),
+		Operand: structs.ConstraintAttributeIsSet,
+	}
 }
 
 // consulConstraintFn returns a service discovery constraint that matches the

--- a/nomad/job_endpoint_hooks.go
+++ b/nomad/job_endpoint_hooks.go
@@ -305,11 +305,9 @@ func (jobImpliedConstraints) Mutate(j *structs.Job) (*structs.Job, []error, erro
 			mutateConstraint(constraintMatcherLeft, tg, vaultConstraintFn(vaultBlock))
 		}
 
-		secretTasks := lang.MapKeys(secretBlocks[tg.Name])
-		for _, secretTask := range secretTasks {
-			secretBlock := secretBlocks[tg.Name][secretTask]
-			for _, secret := range secretBlock {
-				mutateConstraint(constraintMatcherLeft, tg, secretsConstraintFn(secret))
+		for _, secretProviders := range secretBlocks {
+			for _, provider := range secretProviders {
+				mutateConstraint(constraintMatcherLeft, tg, secretsConstraintFn(provider))
 			}
 		}
 
@@ -397,9 +395,9 @@ func vaultConstraintFn(vault *structs.Vault) *structs.Constraint {
 // fingerprinted secrets plugin. This is to support upgrades to 1.11 where a nomad
 // server follower may not be upgraded yet and attempt to place a job on a client
 // that has not been upgraded. This should be removed in Nomad 1.14.
-func secretsConstraintFn(secret *structs.Secret) *structs.Constraint {
+func secretsConstraintFn(provider string) *structs.Constraint {
 	return &structs.Constraint{
-		LTarget: fmt.Sprintf("${attr.plugins.secrets.%s.version}", secret.Provider),
+		LTarget: fmt.Sprintf("${attr.plugins.secrets.%s.version}", provider),
 		Operand: structs.ConstraintAttributeIsSet,
 	}
 }

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -1280,6 +1280,51 @@ func Test_jobImpliedConstraints_Mutate(t *testing.T) {
 			expectedOutputWarnings: nil,
 			expectedOutputError:    nil,
 		},
+		{
+			name: "task with secret",
+			inputJob: &structs.Job{
+				Name: "example",
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "group-with-secret",
+						Tasks: []*structs.Task{
+							{
+								Name: "task-with-secret",
+								Secrets: []*structs.Secret{
+									{
+										Provider: "test",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedOutputJob: &structs.Job{
+				Name: "example",
+				TaskGroups: []*structs.TaskGroup{
+					{
+						Name: "group-with-secret",
+						Tasks: []*structs.Task{
+							{
+								Name: "task-with-secret",
+								Secrets: []*structs.Secret{
+									{
+										Provider: "test",
+									},
+								},
+							},
+						},
+						Constraints: []*structs.Constraint{
+							{
+								LTarget: "${attr.plugins.secrets.test.version}",
+								Operand: structs.ConstraintAttributeIsSet,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5124,6 +5124,29 @@ func (j *Job) Vault() map[string]map[string]*Vault {
 	return blocks
 }
 
+// Secrets returns the set of secrets per task group, per task
+func (j *Job) Secrets() map[string]map[string][]*Secret {
+	blocks := make(map[string]map[string][]*Secret, len(j.TaskGroups))
+
+	for _, tg := range j.TaskGroups {
+		tgBlocks := make(map[string][]*Secret, len(tg.Tasks))
+
+		for _, task := range tg.Tasks {
+			if len(task.Secrets) == 0 {
+				continue
+			}
+
+			tgBlocks[task.Name] = task.Secrets
+		}
+
+		if len(tgBlocks) != 0 {
+			blocks[tg.Name] = tgBlocks
+		}
+	}
+
+	return blocks
+}
+
 // ConnectTasks returns the set of Consul Connect enabled tasks defined on the
 // job that will require a Service Identity token in the case that Consul ACLs
 // are enabled. The TaskKind.Value is the name of the Consul service.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5125,22 +5125,26 @@ func (j *Job) Vault() map[string]map[string]*Vault {
 }
 
 // Secrets returns the set of secrets per task group, per task
-func (j *Job) Secrets() map[string]map[string][]*Secret {
-	blocks := make(map[string]map[string][]*Secret, len(j.TaskGroups))
+func (j *Job) Secrets() map[string][]string {
+	blocks := make(map[string][]string, len(j.TaskGroups))
 
 	for _, tg := range j.TaskGroups {
-		tgBlocks := make(map[string][]*Secret, len(tg.Tasks))
+		secrets := []string{}
 
 		for _, task := range tg.Tasks {
 			if len(task.Secrets) == 0 {
 				continue
 			}
 
-			tgBlocks[task.Name] = task.Secrets
+			for _, s := range task.Secrets {
+				if !slices.Contains(secrets, s.Provider) {
+					secrets = append(secrets, s.Provider)
+				}
+			}
 		}
 
-		if len(tgBlocks) != 0 {
-			blocks[tg.Name] = tgBlocks
+		if len(secrets) != 0 {
+			blocks[tg.Name] = secrets
 		}
 	}
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes introduce implied job constraints via the job endpoint hook when secrets are present. Adding these constraints eliminates the possibility of job placement when upgrading to 1.11.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
