### PR TITLE
cli: Ensure all no argument console messages are the same.

### DIFF
--- a/command/acl_auth_method_create.go
+++ b/command/acl_auth_method_create.go
@@ -131,7 +131,7 @@ func (a *ACLAuthMethodCreateCommand) Run(args []string) int {
 
 	// Check that we got no arguments.
 	if len(flags.Args()) != 0 {
-		a.Ui.Error("This command takes no arguments")
+		a.Ui.Error(uiMessageNoArguments)
 		a.Ui.Error(commandErrorText(a))
 		return 1
 	}

--- a/command/acl_auth_method_create_test.go
+++ b/command/acl_auth_method_create_test.go
@@ -41,7 +41,7 @@ func TestACLAuthMethodCreateCommand_Run(t *testing.T) {
 
 	// Test the basic validation on the command.
 	must.Eq(t, 1, cmd.Run([]string{"-address=" + url, "this-command-does-not-take-args"}))
-	must.StrContains(t, ui.ErrorWriter.String(), "This command takes no arguments")
+	must.StrContains(t, ui.ErrorWriter.String(), uiMessageNoArguments)
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()

--- a/command/acl_auth_method_list.go
+++ b/command/acl_auth_method_list.go
@@ -77,7 +77,7 @@ func (a *ACLAuthMethodListCommand) Run(args []string) int {
 
 	// Check that we got no arguments
 	if len(flags.Args()) != 0 {
-		a.Ui.Error("This command takes no arguments")
+		a.Ui.Error(uiMessageNoArguments)
 		a.Ui.Error(commandErrorText(a))
 		return 1
 	}

--- a/command/acl_binding_rule_create.go
+++ b/command/acl_binding_rule_create.go
@@ -117,7 +117,7 @@ func (a *ACLBindingRuleCreateCommand) Run(args []string) int {
 
 	// Check that we got no arguments.
 	if len(flags.Args()) != 0 {
-		a.Ui.Error("This command takes no arguments")
+		a.Ui.Error(uiMessageNoArguments)
 		a.Ui.Error(commandErrorText(a))
 		return 1
 	}

--- a/command/acl_binding_rule_create_test.go
+++ b/command/acl_binding_rule_create_test.go
@@ -39,7 +39,7 @@ func TestACLBindingRuleCreateCommand_Run(t *testing.T) {
 
 	// Test the basic validation on the command.
 	must.Eq(t, 1, cmd.Run([]string{"-address=" + url, "this-command-does-not-take-args"}))
-	must.StrContains(t, ui.ErrorWriter.String(), "This command takes no arguments")
+	must.StrContains(t, ui.ErrorWriter.String(), uiMessageNoArguments)
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()

--- a/command/acl_binding_rule_list.go
+++ b/command/acl_binding_rule_list.go
@@ -78,7 +78,7 @@ func (a *ACLBindingRuleListCommand) Run(args []string) int {
 
 	// Check that we got no arguments
 	if len(flags.Args()) != 0 {
-		a.Ui.Error("This command takes no arguments")
+		a.Ui.Error(uiMessageNoArguments)
 		a.Ui.Error(commandErrorText(a))
 		return 1
 	}

--- a/command/acl_policy_list.go
+++ b/command/acl_policy_list.go
@@ -74,7 +74,7 @@ func (c *ACLPolicyListCommand) Run(args []string) int {
 	// Check that we got no arguments
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/acl_policy_self.go
+++ b/command/acl_policy_self.go
@@ -69,7 +69,7 @@ func (c *ACLPolicySelfCommand) Run(args []string) int {
 	// Check that we have no arguments
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/acl_role_create.go
+++ b/command/acl_role_create.go
@@ -98,7 +98,7 @@ func (a *ACLRoleCreateCommand) Run(args []string) int {
 
 	// Check that we got no arguments.
 	if len(flags.Args()) != 0 {
-		a.Ui.Error("This command takes no arguments")
+		a.Ui.Error(uiMessageNoArguments)
 		a.Ui.Error(commandErrorText(a))
 		return 1
 	}

--- a/command/acl_role_create_test.go
+++ b/command/acl_role_create_test.go
@@ -38,7 +38,7 @@ func TestACLRoleCreateCommand_Run(t *testing.T) {
 
 	// Test the basic validation on the command.
 	must.One(t, cmd.Run([]string{"-address=" + url, "this-command-does-not-take-args"}))
-	must.StrContains(t, ui.ErrorWriter.String(), "This command takes no arguments")
+	must.StrContains(t, ui.ErrorWriter.String(), uiMessageNoArguments)
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()

--- a/command/acl_role_list.go
+++ b/command/acl_role_list.go
@@ -75,7 +75,7 @@ func (a *ACLRoleListCommand) Run(args []string) int {
 
 	// Check that we got no arguments
 	if len(flags.Args()) != 0 {
-		a.Ui.Error("This command takes no arguments")
+		a.Ui.Error(uiMessageNoArguments)
 		a.Ui.Error(commandErrorText(a))
 		return 1
 	}

--- a/command/acl_token_create.go
+++ b/command/acl_token_create.go
@@ -122,7 +122,7 @@ func (c *ACLTokenCreateCommand) Run(args []string) int {
 	// Check that we got no arguments
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/acl_token_list.go
+++ b/command/acl_token_list.go
@@ -72,7 +72,7 @@ func (c *ACLTokenListCommand) Run(args []string) int {
 	// Check that we got no arguments
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/acl_token_self.go
+++ b/command/acl_token_self.go
@@ -53,7 +53,7 @@ func (c *ACLTokenSelfCommand) Run(args []string) int {
 	// Check that we have no arguments
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/agent_info.go
+++ b/command/agent_info.go
@@ -74,7 +74,7 @@ func (c *AgentInfoCommand) Run(args []string) int {
 	// Check that we got no arguments
 	args = flags.Args()
 	if len(args) > 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/agent_monitor.go
+++ b/command/agent_monitor.go
@@ -92,7 +92,7 @@ func (c *MonitorCommand) Run(args []string) int {
 
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/check.go
+++ b/command/check.go
@@ -66,7 +66,7 @@ func (c *AgentCheckCommand) Run(args []string) int {
 
 	args = flags.Args()
 	if len(args) > 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/deployment_list.go
+++ b/command/deployment_list.go
@@ -83,7 +83,7 @@ func (c *DeploymentListCommand) Run(args []string) int {
 	// Check that we got no arguments
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/eval_list.go
+++ b/command/eval_list.go
@@ -121,7 +121,7 @@ func (c *EvalListCommand) Run(args []string) int {
 	// Check that we got no arguments
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -32,6 +32,10 @@ const (
 	formatHCL2 = "hcl2"
 )
 
+// uiMessageNoArguments is the message to write to the UI when a command is
+// passed arguments, but it does not take any.
+const uiMessageNoArguments = "This command takes no arguments"
+
 // maxLineLength is the maximum width of any line.
 const maxLineLength int = 78
 

--- a/command/login.go
+++ b/command/login.go
@@ -105,7 +105,7 @@ func (l *LoginCommand) Run(args []string) int {
 	args = flags.Args()
 
 	if len(args) != 0 {
-		l.Ui.Error("This command takes no arguments")
+		l.Ui.Error(uiMessageNoArguments)
 		l.Ui.Error(commandErrorText(l))
 		return 1
 	}

--- a/command/login_test.go
+++ b/command/login_test.go
@@ -36,7 +36,7 @@ func TestLoginCommand_Run(t *testing.T) {
 
 	// Test the basic validation on the command.
 	must.Eq(t, 1, cmd.Run([]string{"-address=" + agentURL, "this-command-does-not-take-args"}))
-	must.StrContains(t, ui.ErrorWriter.String(), "This command takes no arguments")
+	must.StrContains(t, ui.ErrorWriter.String(), uiMessageNoArguments)
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()

--- a/command/metrics.go
+++ b/command/metrics.go
@@ -78,7 +78,7 @@ func (c *OperatorMetricsCommand) Run(args []string) int {
 
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/namespace_list.go
+++ b/command/namespace_list.go
@@ -75,7 +75,7 @@ func (c *NamespaceListCommand) Run(args []string) int {
 	// Check that we got no arguments
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/node_pool_list.go
+++ b/command/node_pool_list.go
@@ -93,7 +93,7 @@ func (c *NodePoolListCommand) Run(args []string) int {
 
 	// Check that we don't have any arguments.
 	if len(flags.Args()) != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/node_pool_list_test.go
+++ b/command/node_pool_list_test.go
@@ -122,7 +122,7 @@ prod-1  <none>`,
 		{
 			name:         "fail because of arg",
 			args:         []string{"invalid"},
-			expectedErr:  "This command takes no arguments",
+			expectedErr:  uiMessageNoArguments,
 			expectedCode: 1,
 		},
 		{

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -462,7 +462,7 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	// Verify there are no extra arguments
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -326,7 +326,7 @@ func TestDebug_Failures(t *testing.T) {
 			name:          "fails incorrect args",
 			args:          []string{"some", "bad", "args"},
 			expectedCode:  1,
-			expectedError: "This command takes no arguments",
+			expectedError: uiMessageNoArguments,
 		},
 		{
 			name:          "Fails illegal node ids",

--- a/command/operator_gossip_keyring_list.go
+++ b/command/operator_gossip_keyring_list.go
@@ -68,7 +68,7 @@ func (c *OperatorGossipKeyringListCommand) Run(args []string) int {
 
 	args = flags.Args()
 	if len(args) != 0 {
-		c.Ui.Error("This command requires no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/operator_root_keyring_list.go
+++ b/command/operator_root_keyring_list.go
@@ -70,7 +70,7 @@ func (c *OperatorRootKeyringListCommand) Run(args []string) int {
 
 	args = flags.Args()
 	if len(args) != 0 {
-		c.Ui.Error("This command requires no arguments.")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/operator_root_keyring_rotate.go
+++ b/command/operator_root_keyring_rotate.go
@@ -94,7 +94,7 @@ func (c *OperatorRootKeyringRotateCommand) Run(args []string) int {
 
 	args = flags.Args()
 	if len(args) != 0 {
-		c.Ui.Error("This command requires no arguments.")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/operator_scheduler_set_config.go
+++ b/command/operator_scheduler_set_config.go
@@ -87,7 +87,7 @@ func (o *OperatorSchedulerSetConfig) Run(args []string) int {
 	// Check that we got no arguments.
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		o.Ui.Error("This command takes no arguments")
+		o.Ui.Error(uiMessageNoArguments)
 		o.Ui.Error(commandErrorText(o))
 		return 1
 	}

--- a/command/operator_utilization.go
+++ b/command/operator_utilization.go
@@ -77,7 +77,7 @@ func (c *OperatorUtilizationCommand) Run(args []string) int {
 
 	args = flags.Args()
 	if len(args) != 0 {
-		c.Ui.Error("This command requires no arguments.")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/quota_list.go
+++ b/command/quota_list.go
@@ -74,7 +74,7 @@ func (c *QuotaListCommand) Run(args []string) int {
 	// Check that we got no arguments
 	args = flags.Args()
 	if l := len(args); l != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/recommendation_list.go
+++ b/command/recommendation_list.go
@@ -94,7 +94,7 @@ func (r *RecommendationListCommand) Run(args []string) int {
 	}
 
 	if args = flags.Args(); len(args) > 0 {
-		r.Ui.Error("This command takes no arguments")
+		r.Ui.Error(uiMessageNoArguments)
 		r.Ui.Error(commandErrorText(r))
 	}
 

--- a/command/scaling_policy_list.go
+++ b/command/scaling_policy_list.go
@@ -93,7 +93,7 @@ func (s *ScalingPolicyListCommand) Run(args []string) int {
 	}
 
 	if args = flags.Args(); len(args) > 0 {
-		s.Ui.Error("This command takes no arguments")
+		s.Ui.Error(uiMessageNoArguments)
 		s.Ui.Error(commandErrorText(s))
 		return 1
 	}

--- a/command/sentinel_list.go
+++ b/command/sentinel_list.go
@@ -54,7 +54,7 @@ func (c *SentinelListCommand) Run(args []string) int {
 	}
 
 	if args = flags.Args(); len(args) > 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 	}
 	// Get the HTTP client

--- a/command/server_members.go
+++ b/command/server_members.go
@@ -91,7 +91,7 @@ func (c *ServerMembersCommand) Run(args []string) int {
 	// Check for extra arguments
 	args = flags.Args()
 	if len(args) != 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}

--- a/command/service_list.go
+++ b/command/service_list.go
@@ -81,7 +81,7 @@ func (s *ServiceListCommand) Run(args []string) int {
 	}
 
 	if args = flags.Args(); len(args) > 0 {
-		s.Ui.Error("This command takes no arguments")
+		s.Ui.Error(uiMessageNoArguments)
 		s.Ui.Error(commandErrorText(s))
 		return 1
 	}

--- a/command/service_list_test.go
+++ b/command/service_list_test.go
@@ -51,7 +51,7 @@ func TestServiceListCommand_Run(t *testing.T) {
 	// Run the command with some random arguments to ensure we are performing
 	// this check.
 	must.One(t, cmd.Run([]string{"-address=" + url, "pretty-please"}))
-	must.StrContains(t, ui.ErrorWriter.String(), "This command takes no arguments")
+	must.StrContains(t, ui.ErrorWriter.String(), uiMessageNoArguments)
 	ui.ErrorWriter.Reset()
 
 	// Create a test job with a Nomad service.

--- a/command/setup_consul.go
+++ b/command/setup_consul.go
@@ -120,7 +120,7 @@ func (s *SetupConsulCommand) Run(args []string) int {
 
 	// Check that we got no arguments.
 	if len(flags.Args()) != 0 {
-		s.Ui.Error("This command takes no arguments")
+		s.Ui.Error(uiMessageNoArguments)
 		s.Ui.Error(commandErrorText(s))
 		return 1
 	}

--- a/command/setup_vault.go
+++ b/command/setup_vault.go
@@ -159,7 +159,7 @@ func (s *SetupVaultCommand) Run(args []string) int {
 
 	// Check that we got no arguments.
 	if len(flags.Args()) != 0 {
-		s.Ui.Error("This command takes no arguments")
+		s.Ui.Error(uiMessageNoArguments)
 		s.Ui.Error(commandErrorText(s))
 		return 1
 	}

--- a/command/system_gc.go
+++ b/command/system_gc.go
@@ -51,7 +51,7 @@ func (c *SystemGCCommand) Run(args []string) int {
 	}
 
 	if args = flags.Args(); len(args) > 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 	}
 

--- a/command/system_reconcile_summaries.go
+++ b/command/system_reconcile_summaries.go
@@ -51,7 +51,7 @@ func (c *SystemReconcileSummariesCommand) Run(args []string) int {
 	}
 
 	if args = flags.Args(); len(args) > 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 	}
 

--- a/command/volume_snapshot_list.go
+++ b/command/volume_snapshot_list.go
@@ -107,7 +107,7 @@ func (c *VolumeSnapshotListCommand) Run(args []string) int {
 
 	args = flags.Args()
 	if len(args) > 0 {
-		c.Ui.Error("This command takes no arguments")
+		c.Ui.Error(uiMessageNoArguments)
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}


### PR DESCRIPTION
Use a constant to ensure consistency across the CLI when displaying a console message indicating the command was passed arguments when it takes none.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
