### PR TITLE
docs: clarify namespace support in autoscaler

### DIFF
--- a/website/content/tools/autoscaling/agent.mdx
+++ b/website/content/tools/autoscaling/agent.mdx
@@ -13,12 +13,12 @@ multiple configuration files or directories to configure the agent.
 
 ## Nomad Namespaces
 
-The Nomad Autoscaler agent's [`nomad`][autoscaler_agent_nomad] configuration
-block supports specifying a [Nomad namespace][nomad_namespaces]. If configured
-with a namespace, the Autoscaler will retrieve scaling policies and perform
-autoscaling only for jobs in that namespace. If the special wildcard namespace
-value `*` is used, the Autoscaler agent will retrieve scaling policies from all
-namespaces. A future version will include support for multiple namespaces.
+You can configure Nomad Autoscaler to use a [Nomad namespace][nomad_namespaces]
+using the agent's [`nomad`][autoscaler_agent_nomad] configuration block. The
+Autoscaler retrieves scaling policies and perform autoscaling only for jobs in
+that namespace. If you use the special wildcard namespace value `*`, the
+Autoscaler agent retrieves scaling policies from all namespaces. A future
+version will include support for multiple namespaces.
 
 ## Nomad ACLs
 

--- a/website/content/tools/autoscaling/agent.mdx
+++ b/website/content/tools/autoscaling/agent.mdx
@@ -13,13 +13,12 @@ multiple configuration files or directories to configure the agent.
 
 ## Nomad Namespaces
 
-The Nomad Autoscaler currently has limited support for
-[Nomad Namespaces][nomad_namespaces]. The `nomad` configuration below supports
-specifying a namespace; if configured with a namespace, the Autoscaler will
-retrieve scaling policies and perform autoscaling only for jobs in that
-namespace. If the special wildcard namespace value `*` is used, the Autoscaler
-agent will retrieve scaling policies from all namespaces. A future version will
-include support for multiple namespaces.
+The Nomad Autoscaler agent's [`nomad`][autoscaler_agent_nomad] configuration
+block supports specifying a [Nomad namespace][nomad_namespaces]. If configured
+with a namespace, the Autoscaler will retrieve scaling policies and perform
+autoscaling only for jobs in that namespace. If the special wildcard namespace
+value `*` is used, the Autoscaler agent will retrieve scaling policies from all
+namespaces. A future version will include support for multiple namespaces.
 
 ## Nomad ACLs
 


### PR DESCRIPTION
The current autoscaler docs imply that it has minimal or non-working support for Nomad namespaces. Whereas in fact the namespace support works fine but just doesn't allow configuring multiple namespaces without using a wildcard (for now). Make this more clear and fix the reference to the configuration "below", which is no longer on that same page.

Ref: https://github.com/hashicorp/nomad-autoscaler/issues/65
cc @sofixa