### PR TITLE
Docs: Clarify service.port  allowed value types

### DIFF
--- a/website/content/docs/job-specification/connect.mdx
+++ b/website/content/docs/job-specification/connect.mdx
@@ -59,7 +59,7 @@ Used to configure a connect service. Only one of `native`, `sidecar_service`,
 or `gateway` may be realized per `connect` block.
 
 - `native` - `(bool: false)` - This is used to configure the service as
-  supporting [Consul service mesh native](/consul/docs/connect/native)
+  supporting [Consul service mesh native][consul-service-mesh-native]
   applications.
 
 - `sidecar_service` - <code>([sidecar_service][]: nil)</code> - This is used to
@@ -76,7 +76,7 @@ or `gateway` may be realized per `connect` block.
 ### Using Consul service mesh native
 
 The following example is a minimal service block for a
-[Consul service mesh native](/consul/docs/connect/native)
+[Consul service mesh native][consul-service-mesh-native]
 application implemented by a task named `generate`. Make sure to include the
 [service `name`](/nomad/docs/job-specification/service#name) and [service
 `port`](/nomad/docs/job-specification/service##port) fields so that Consul
@@ -267,23 +267,13 @@ job "ingress-demo" {
 
 
 [gateway]: /nomad/docs/job-specification/gateway
-
 [gh-7221]: https://github.com/hashicorp/nomad/issues/7221
-
-[group]: /nomad/docs/job-specification/group "Nomad group Job Specification"
-
-[interpolation]: /nomad/docs/reference/runtime-variable-interpolation "Nomad interpolation"
-
-[job]: /nomad/docs/job-specification/job "Nomad job Job Specification"
-
-[native]: /consul/docs/connect/native
-
-[service_task]: /nomad/docs/job-specification/service#task-1 "Nomad service task"
-
-[sidecar_service]: /nomad/docs/job-specification/sidecar_service "Nomad sidecar service Specification"
-
-[sidecar_task]: /nomad/docs/job-specification/sidecar_task "Nomad sidecar task config Specification"
-
-[task]: /nomad/docs/job-specification/task "Nomad task Job Specification"
-
-[upstreams]: /nomad/docs/job-specification/upstreams "Nomad sidecar service upstreams Specification"
+[group]: /nomad/docs/job-specification/group
+[interpolation]: /nomad/docs/reference/runtime-variable-interpolation
+[job]: /nomad/docs/job-specification/job
+[service_task]: /nomad/docs/job-specification/service#task-1
+[sidecar_service]: /nomad/docs/job-specification/sidecar_service
+[sidecar_task]: /nomad/docs/job-specification/sidecar_task
+[task]: /nomad/docs/job-specification/task
+[upstreams]: /nomad/docs/job-specification/upstreams
+[consul-service-mesh-native]: /consul/docs/automate/native

--- a/website/content/docs/job-specification/service.mdx
+++ b/website/content/docs/job-specification/service.mdx
@@ -16,8 +16,8 @@ description: |-
 />
 
 The `service` block instructs Nomad to register a service with the specified
-provider; Nomad or Consul. This section of the documentation will discuss the
-configuration, but please also read the
+provider: Nomad or Consul. This section of the documentation discusses the
+configuration, but you should also read the
 [Nomad service discovery documentation][service-discovery] for more detailed
 information about the external integrations.
 
@@ -71,13 +71,13 @@ job "docs" {
 }
 ```
 
-This section of the documentation only cover the job file fields and blocks
-for service discovery. For more details on using Nomad with Consul please see
+This section of the documentation only covers the job file fields and blocks
+for service discovery. For more details on using Nomad with Consul, refer to
 the [Consul integration documentation][service-discovery].
 
 The `service` block can also be at task group level.
 This enables services in the same task group to opt into [Consul
-Service Mesh][connect] integration.
+service mesh][connect] integration.
 
 ## Parameters
 
@@ -157,6 +157,15 @@ Service Mesh][connect] integration.
   - `host` - Advertise the host port for this service. `port` must match a port
     _label_ specified in the [`network`][network] block.
 
+  | Service kind | Allowed port value type |
+  | -------- | ------- |
+  | Normal       | Numeric or port mapping label |
+  | Uses [`connect` native][connect-native] | Numeric or port mapping label |
+  | Uses [`connect` sidecar][connect-sidecar] | Numeric |
+  | Ingress gateway | Port mapping label (optional) |
+  | Terminating gateway | None (optional) |
+  | Mesh gateway | External port mapping label |
+
 - `tags` `(array<string>: [])` - Specifies the list of tags to associate with
   this service. If this is not supplied, no tags will be assigned to the service
   when it is registered.
@@ -207,7 +216,7 @@ Service Mesh][connect] integration.
 
 - `task` `(string: "")` - Specifies the name of the Nomad task associated with
   this service definition. Only available on group services. Must be set if this
-  service definition represents a Consul service mesh-native service and there is more
+  service definition represents a Consul service mesh native service and there is more
   than one task in the task group.
 
 - `meta` <code>([Meta][]: nil)</code> - Specifies a key-value map that annotates
@@ -555,3 +564,5 @@ advertise and check directly since Nomad isn't managing any port assignments.
 [`consul.service_identity`]: /nomad/docs/configuration/consul#service_identity
 [identity_block]: /nomad/docs/job-specification/identity
 [weights]: /consul/docs/services/configuration/services-configuration-reference#weights
+[connect-sidecar]: /nomad/docs/job-specification/connect#using-sidecar-service
+[connect-native]: /nomad/docs/job-specification/connect#using-consul-service-mesh-native

--- a/website/content/docs/job-specification/sidecar_service.mdx
+++ b/website/content/docs/job-specification/sidecar_service.mdx
@@ -12,7 +12,7 @@ description: |-
 
 The `sidecar_service` block allows configuring various options for the sidecar
 proxy managed by Nomad for [Consul
-Connect](/nomad/docs/networking/consul) integration. It is
+service mesh](/nomad/docs/networking/consul) integration. It is
 valid only within the context of a connect block.
 
 ```hcl

--- a/website/content/docs/job-specification/sidecar_task.mdx
+++ b/website/content/docs/job-specification/sidecar_task.mdx
@@ -12,7 +12,7 @@ description: |-
 
 The `sidecar_task` block allows configuring various options for the proxy
 sidecar or Connect gateway managed by Nomad for the [Consul
-Connect](/nomad/docs/networking/consul) integration such as
+service mesh](/nomad/docs/networking/consul) integration such as
 resource requirements, kill timeouts and more as defined below. It is valid
 only within the context of a [`connect`][connect] block.
 


### PR DESCRIPTION
### Description

- Add table to service.port parameter entry to clarify allowed port value types by service kind. See the Jira ticket for more context. **Note** that I added a row for using connect native since [the example on the connect page](https://developer.hashicorp.com/nomad/docs/job-specification/connect#using-consul-service-mesh-native) shows a port label.
- Update a few outdated links to Consul native docs.


### Links

Jira: [CE-855]

https://nomad-git-ce855-hashicorp.vercel.app/nomad/docs/job-specification/service#port

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[CE-855]: https://hashicorp.atlassian.net/browse/CE-855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ