### PR TITLE
scheduler: move result mutation into `computeStop`

### DIFF
--- a/scheduler/reconciler/reconcile_cluster.go
+++ b/scheduler/reconciler/reconcile_cluster.go
@@ -588,7 +588,7 @@ func (a *AllocReconciler) computeGroup(group string, all allocSet) (*ReconcileRe
 		result.DesiredTGUpdates[group].Ignore += uint64(len(destructive))
 	}
 
-	a.computeMigrations(result, migrate, tg, isCanarying)
+	a.computeMigrations(migrate, isCanarying, tg, result)
 	result.Deployment = a.createDeployment(
 		tg.Name, tg.Update, existingDeployment, dstate, all, destructive, int(result.DesiredTGUpdates[group].InPlaceUpdate))
 
@@ -995,8 +995,8 @@ func (a *AllocReconciler) computeDestructiveUpdates(destructive allocSet, underP
 
 // computeMigrations updates the result with the stops and placements required
 // for migration.
-func (a *AllocReconciler) computeMigrations(result *ReconcileResults, migrate allocSet,
-	tg *structs.TaskGroup, isCanarying bool) {
+func (a *AllocReconciler) computeMigrations(migrate allocSet, isCanarying bool,
+	tg *structs.TaskGroup, result *ReconcileResults) {
 
 	result.DesiredTGUpdates[tg.Name].Migrate += uint64(len(migrate))
 


### PR DESCRIPTION
The `computeStop` method returns two values that only get used to mutate the result and the untainted set. Move the mutation into the method to match the work done in #26325.

(Includes a minor reordering of parameters for `computeMigrations` as well for consistency.)

Ref: https://github.com/hashicorp/nomad/pull/26325
Ref: https://hashicorp.atlassian.net/browse/NMD-819

---

Note for reviewers: this feels like an ambiguous improvement compare to the other recent work. It makes the call site more consistent but I don't love the implementation result. I'd definitely love to hear a "this feels good/bad" from reviewers and it's totally fine if we decide to simply not merge this. :grin: 