### PR TITLE
docs: fix self-referencing link for raw_exec driver config

### DIFF
--- a/website/content/docs/job-declare/task-driver/raw_exec.mdx
+++ b/website/content/docs/job-declare/task-driver/raw_exec.mdx
@@ -13,7 +13,7 @@ isolation. Further, the task is started as the same user as the Nomad process.
 As such, it should be used with extreme care and is disabled by default.
 
 Refer to [Configure the Raw Fork/Exec task
-driver](/nomad/docs/job-declare/task-driver/raw_exec) for capabilities, client
+driver](/nomad/docs/deploy/task-driver/raw_exec) for capabilities, client
 requirements, and plugin configuration.
 
 ## Task configuration


### PR DESCRIPTION
During the big docs rearchitecture, we split up the task driver pages into separate job declaration and driver configuration pages. The link for the `raw_exec` driver to the configuration page is a self-reference.
