### PR TITLE
docs: document handling of unset affinity/constraint values

### DIFF
--- a/website/content/docs/job-specification/affinity.mdx
+++ b/website/content/docs/job-specification/affinity.mdx
@@ -89,10 +89,11 @@ allocations.
   For a detailed explanation of these values and their behavior, please see
   the [operator values section](#operator-values).
 
-- `value` `(string: "")` - Specifies the value to compare the attribute against
-  using the specified operation. This can be a literal value, another attribute,
-  or any [Nomad interpolated
+- `value` `(string: <required>)` - Specifies the value to compare the attribute
+  against using the specified operation. This can be a literal value, another
+  attribute, or any [Nomad interpolated
   values](/nomad/docs/reference/runtime-variable-interpolation#interpreted_node_vars).
+  The `value` field is required.
 
 - `weight` `(integer: 50)` - Specifies a weight for the affinity. The weight is used
   during scoring and must be an integer between -100 to 100. Negative weights act as

--- a/website/content/docs/job-specification/constraint.mdx
+++ b/website/content/docs/job-specification/constraint.mdx
@@ -99,7 +99,9 @@ allocations.
 - `value` `(string: "")` - Specifies the value to compare the attribute against
   using the specified operation. This can be a literal value, another attribute,
   or any [Nomad interpolated
-  values](/nomad/docs/reference/runtime-variable-interpolation#interpreted_node_vars).
+  values](/nomad/docs/reference/runtime-variable-interpolation#interpreted_node_vars). The
+  value field is required except for when using the `is_set`, `is_not_set`,
+  `distinct_hosts`, or `distinct_property` operators.
 
 ### `operator` values
 


### PR DESCRIPTION
Affinities and contraints use similar feasibility checking logic to determine if a given node matches (although affinities don't support all the same operators). Most operators don't allow `value` to be unset. Update the docs to reflect this.

Fixes: https://github.com/hashicorp/nomad/issues/24983