### PR TITLE
docker: validate namespace network mode limits

### DIFF
--- a/.changelog/26363.txt
+++ b/.changelog/26363.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: validate namespace network mode limits
+```


### PR DESCRIPTION
### Description
I noticed that namespace capability limit `enabled_network_modes` / `disabled_network_modes` which https://github.com/hashicorp/nomad/pull/23813 added is not effective for jobs which sets `network_mode` only under Docker task driver. So I fixed that.

### Testing & Reproduction steps
Tests updated 

### Links
N/A

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 

FYI @apollo13