### PR TITLE
ci: Revert hclogvet running across entire codebase.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -163,7 +163,7 @@ check: ## Lint the source code
 	@cd ./api && golangci-lint run --config ../.golangci.yml --build-tags "$(GO_TAGS)"
 
 	@echo "==> Linting hclog statements..."
-	@hclogvet ./...
+	@hclogvet .
 
 	@echo "==> Spell checking website..."
 	@misspell -error -source=text website/content/


### PR DESCRIPTION
It seems the tool requires a little attention and does not run well across our enterprise codebase. Rolling back that makefile change, so it does not stop enterprise work, backport, CI, etc.
