### PR TITLE
Update Ports Section To Include OIDC Port

### DIFF
--- a/website/content/docs/deploy/production/requirements.mdx
+++ b/website/content/docs/deploy/production/requirements.mdx
@@ -90,6 +90,11 @@ allow the following traffic.
   WAN to other servers. It isn't required that Nomad clients can reach this address.
   TCP and UDP.
 
+- OIDC Callback (Default 4649). This is used for OIDC callbacks to finish the
+  authentication process after the configured provider has authorized your
+  session to the Nomad cluster. If you are not using OIDC, you do not need
+  to keep this port open and available.
+
 When tasks ask for dynamic ports, they are allocated out of the port range
 between 20,000 and 32,000. This is well under the ephemeral port range suggested
 by the [IANA](https://en.wikipedia.org/wiki/Ephemeral_port). If your operating


### PR DESCRIPTION
### Description
After reading through https://developer.hashicorp.com/nomad/docs/secure/authentication/sso-auth0 it is mentioned that the OIDC callback endpoint goes over 4649 which is missing from the list of ports in this list.

### Testing & Reproduction steps
This is just documentation so I did my best to write the new bullet in a similar style as the previous ones.

### Links
- Docs mentioning 4649 https://developer.hashicorp.com/nomad/docs/secure/authentication/sso-auth0

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
