### PR TITLE
docs: update Vault/Consul compatibility matrix

### DIFF
--- a/website/content/docs/networking/consul/index.mdx
+++ b/website/content/docs/networking/consul/index.mdx
@@ -132,15 +132,15 @@ the [`consul.cluster`][] parameter.
 ## Compatibility
 
 All currently supported versions of Nomad are compatible with recent versions of
-Consul, with some exceptions.
+Consul.
 
 * Nomad is not compatible with Consul Data Plane.
 
-|                   | Consul 1.17.0+ | Consul 1.18.0+ | Consul 1.19.0+ |
-|-------------------|----------------|----------------|----------------|
-| Nomad 1.8.0+      | ✅             | ✅             | ✅            |
-| Nomad 1.7.0+      | ✅             | ✅             | ✅            |
-| Nomad 1.6.0+      | ✅             | ✅             | ✅            |
+|               | Consul 1.19.0+ | Consul 1.20.0+ | Consul 1.21.0+ |
+|---------------|----------------|----------------|----------------|
+| Nomad 1.10.0+ | ✅             | ✅             | ✅             |
+| Nomad 1.9.0+  | ✅             | ✅             | ✅             |
+| Nomad 1.8.0+  | ✅             | ✅             | ✅             |
 
 [Automatic Clustering with Consul]: /nomad/docs/deploy/clusters/connect-nodes
 [CDP]: /consul/docs/connect/dataplane

--- a/website/content/docs/secure/vault/index.mdx
+++ b/website/content/docs/secure/vault/index.mdx
@@ -54,12 +54,14 @@ Jobs that need access to Vault may specify which Vault cluster to use with the
 
 ## Compatibility
 
-* Nomad versions 1.4.0 and above are compatible with any currently supported
-  version of Vault.
+All currently supported versions of Nomad are compatible with recent versions of
+Vault.
 
-|              | Vault 1.13.0+ |
-|--------------|---------------|
-| Nomad 1.4.0+ | ✅            |
+|               | Vault 1.18.0+ | Vault 1.19.0+ | Vault 1.20.0+ |
+|---------------|---------------|---------------|---------------|
+| Nomad 1.10.0+ | ✅            | ✅            | ✅            |
+| Nomad 1.9.0+  | ✅            | ✅            | ✅            |
+| Nomad 1.8.0+  | ✅            | ✅            | ✅            |
 
 [Consul Template]: https://github.com/hashicorp/consul-template
 [Vault]:  https://www.vaultproject.io/ 'Vault by HashiCorp'


### PR DESCRIPTION
Update our support matrix to show currently-supported versions of Consul, Vault, and Nomad.
