### PR TITLE
E2E: update Consul/Vault compat versions tested

### DIFF
--- a/e2e/consulcompat/shared_download_test.go
+++ b/e2e/consulcompat/shared_download_test.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	binDir           = "consul-bins"
-	minConsulVersion = "1.16.0"
+	minConsulVersion = "1.18.0" // oldest supported LTS
 
 	// environment variable to pick only one Consul version for testing
 	exactConsulVersionEnv = "NOMAD_E2E_CONSULCOMPAT_CONSUL_VERSION"

--- a/e2e/vaultcompat/vaultcompat_test.go
+++ b/e2e/vaultcompat/vaultcompat_test.go
@@ -292,7 +292,7 @@ func downloadVaultBuild(t *testing.T, b build) {
 }
 
 func getMinimumVersion(t *testing.T) *version.Version {
-	v, err := version.NewVersion("1.11.0")
+	v, err := version.NewVersion("1.16.0") // oldest supported LTS
 	must.NoError(t, err)
 	return v
 }


### PR DESCRIPTION
Update our E2E compatibility test for Consul and Vault to only include back to the oldest-supported LTS versions of Consul and Vault. This will still leave a few unsupported non-LTS versions in the matrix between the two oldest LTS, but this is a small number of tests and fixing it would mean hard-coding the LTS support matrix in our tests.