### PR TITLE
alloc exec: don't panic rootless raw_exec tasks

### DIFF
--- a/.changelog/26401.txt
+++ b/.changelog/26401.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+alloc exec: Fixed executor panic when exec-ing a rootless raw_exec task
+```

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -7,7 +7,6 @@ package executor
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -766,7 +765,7 @@ func (l *LibcontainerExecutor) configureCgroups(cfg *runc.Config, command *ExecC
 
 	cg := command.StatsCgroup()
 	if cg == "" {
-		return errors.New("cgroup must be set")
+		return fmt.Errorf("configureCgroups: %w", ErrCgroupMustBeSet)
 	}
 
 	// // set the libcontainer hook for writing the PID to cgroup.procs file

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -30,27 +30,32 @@ const (
 // setSubCmdCgroup sets the cgroup for non-Task child processes of the
 // executor.Executor (since in cg2 it lives outside the task's cgroup)
 func (e *UniversalExecutor) setSubCmdCgroup(cmd *exec.Cmd, cgroup string) (func(), error) {
+
+	// no extra setup needed for cg v1 or when cgroups are "off"
+	switch cgroupslib.GetMode() {
+	case cgroupslib.OFF, cgroupslib.CG1:
+		return func() {}, nil
+	default:
+		// continue for cg v2
+	}
+
 	if cgroup == "" {
-		panic("cgroup must be set")
+		return nil, fmt.Errorf("error setting up exec subcommand: %w", ErrCgroupMustBeSet)
+	}
+
+	fd, cleanup, err := e.statCG(cgroup)
+	if err != nil {
+		return nil, err
 	}
 
 	// make sure attrs struct has been set
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = new(syscall.SysProcAttr)
 	}
+	cmd.SysProcAttr.UseCgroupFD = true
+	cmd.SysProcAttr.CgroupFD = fd
 
-	switch cgroupslib.GetMode() {
-	case cgroupslib.CG2:
-		fd, cleanup, err := e.statCG(cgroup)
-		if err != nil {
-			return nil, err
-		}
-		cmd.SysProcAttr.UseCgroupFD = true
-		cmd.SysProcAttr.CgroupFD = fd
-		return cleanup, nil
-	default:
-		return func() {}, nil
-	}
+	return cleanup, nil
 }
 
 func (e *UniversalExecutor) ListProcesses() set.Collection[procstats.ProcessID] {
@@ -93,11 +98,8 @@ func (e *UniversalExecutor) configureResourceContainer(
 ) (runningFunc, cleanupFunc, error) {
 	cgroup := command.StatsCgroup()
 
-	// ensure tasks get the desired oom_score_adj value set
-	if err := e.setOomAdj(command.OOMScoreAdj); err != nil {
-		return nil, nil, err
-	}
-
+	// we specify these return funcs as empty but non-nil,
+	// because callers may call them even if this function errors.
 	// deleteCgroup will be called after the task has been launched
 	// v1: remove the executor process from the task's cgroups
 	// v2: let go of the file descriptor of the task's cgroup
@@ -106,6 +108,11 @@ func (e *UniversalExecutor) configureResourceContainer(
 		moveProcess  = func() error { return nil }
 	)
 
+	// ensure tasks get the desired oom_score_adj value set
+	if err := e.setOomAdj(command.OOMScoreAdj); err != nil {
+		return moveProcess, deleteCgroup, err
+	}
+
 	// manually configure cgroup for cpu / memory constraints
 	switch cgroupslib.GetMode() {
 	case cgroupslib.CG1:
@@ -113,9 +120,10 @@ func (e *UniversalExecutor) configureResourceContainer(
 			return moveProcess, deleteCgroup, err
 		}
 		moveProcess, deleteCgroup = e.enterCG1(cgroup, command.CpusetCgroup())
+
 	case cgroupslib.OFF:
-		deleteCgroup = func() {}
-		moveProcess = func() error { return nil }
+		// do nothing
+
 	default:
 		e.configureCG2(cgroup, command)
 		// configure child process to spawn in the cgroup


### PR DESCRIPTION
### Description

`nomad alloc exec` on a `raw_exec` task that is successfully running / managed by a non-root Nomad agent causes an executor panic.

The executor dies, leaving an orphaned process still running.

Note: I initially opened this as a draft, because I'm hazy on potential knock-on issues, and I can't think of a very good way to test this (aside from running it on my laptop).

#### The panic fix (we should at least fix this):

* `setSubCmdCgroup()` - return an error instead of `panic()`ing
* `configureResourceContainer()` - always return empty (but non-nil) func on cgroup error, so `UniversalExecutor.Launch()` doesn't panic trying to run it later.
   * in `Launch()` it explicitly says this should be okay: https://github.com/hashicorp/nomad/blob/v1.10.3/drivers/shared/executor/executor.go#L388-L389

#### Feature fix (this is nice to have):

 * `Exec()` and `ExecStreaming()` - allow non-root agent to proceed with `alloc exec` when cgroups are off

### Testing & Reproduction steps

```shell
$ nomad agent -dev
$ nomad run raw.nomad.hcl
# ...
$ nomad exec -job raw whoami
dbennett
```

with this minimal jobspec:

```hcl
job "raw" {
  group "g" {
    task "t" {
      driver = "raw_exec"
      config {
        command = "sleep"
        args    = ["3600"]
      }
    }
  }
}
```


### Links

Fixes #26287

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
