### PR TITLE
docs: Manual backport of versioned redirects to 1.10.x

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -433,4 +433,530 @@ module.exports = [
     destination: '/nomad/commands/:version/:path*',
     permanent: true,
   },
+  /* redirects for versioned docs in 1.9, 1.8 */
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/what-is-nomad/',
+    destination: '/nomad/docs/what-is-nomad',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/quickstart/',
+    destination: '/nomad/docs/:version/install/quickstart',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/architecture/',
+    destination: '/nomad/docs/:version/concepts/architecture',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/architecture/cluster/consensus/',
+    destination: '/nomad/docs/:version/concepts/consensus',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/architecture/cluster/federation/',
+    destination: '/nomad/docs/:version/concepts/architecture/federation',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/architecture/cluster/node-pools/',
+    destination: '/nomad/docs/:version/concepts/node-pools',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/architecture/cpu/',
+    destination: '/nomad/docs/:version/concepts/cpu',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/architecture/security/',
+    destination: '/nomad/docs/:version/concepts/security',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/architecture/security/gossip/',
+    destination: '/nomad/docs/:version/concepts/gossip',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/architecture/storage/:slug*',
+    destination: '/nomad/docs/:version/concepts/plugins/storage/:slug*',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/concepts/scheduling/how-scheduling-works/',
+    destination: '/nomad/docs/:version/concepts/scheduling/scheduling',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/concepts/scheduling/schedulers/',
+    destination: '/nomad/docs/:version/schedulers',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/intro/use-cases/',
+    destination: '/nomad/docs/use-cases',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/deploy/:slug*',
+    destination: '/nomad/docs/:version/install/:slug*',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/deploy/production/windows-service/',
+    destination: '/nomad/docs/:version/install/windows-service',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/deploy/nomad-agent/',
+    destination: '/nomad/docs/:version/operations/nomad-agent',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/deploy/clusters/federation-considerations/',
+    destination: '/nomad/docs/:version/operations/federation',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/deploy/clusters/federation-failure-scenarios/',
+    destination: '/nomad/docs/:version/operations/federation/failure',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/deploy/task-driver/:slug*',
+    destination: '/nomad/docs/:version/drivers/:slug*',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/networking/consul/',
+    destination: '/nomad/docs/:version/integrations',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/manage/garbage-collection/',
+    destination: '/nomad/docs/:version/operations/garbage-collection',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/manage/key-management/',
+    destination: '/nomad/docs/:version/operations/key-management',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/monitor/',
+    destination: '/nomad/docs/:version/operations/monitoring-nomad',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/networking/consul/service-mesh/',
+    destination: '/nomad/docs/:version/networking/service-mesh',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/networking/consul/',
+    destination: '/nomad/docs/:version/integrations/consul',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/acl/consul/',
+    destination: '/nomad/docs/:version/integrations/consul/acl',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/networking/consul/service-mesh/',
+    destination: '/nomad/docs/:version/integrations/consul/service-mesh',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/scale/benchmarking/',
+    destination: '/nomad/docs/:version/operations/benchmarking',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/authentication/jwt/',
+    destination: '/nomad/docs/:version/concepts/acl/auth-methods/jwt',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/authentication/oidc/',
+    destination: '/nomad/docs/:version/concepts/acl/auth-methods/oidc',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/vault/',
+    destination: '/nomad/docs/:version/integrations/vault',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/vault/',
+    destination: '/nomad/docs/:version/integrations/vault',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/vault/acl/',
+    destination: '/nomad/docs/:version/integrations/vault/acl',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/workload-identity/aws-oidc-provider/',
+    destination: '/nomad/docs/:version/operations/aws-oidc-provider',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/task-driver/',
+    destination: '/nomad/docs/:version/drivers',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/reference/hcl2/',
+    destination: '/nomad/docs/:version/job-specification/hcl2',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/reference/metrics/',
+    destination: '/nomad/docs/:version/operations/metrics-reference',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/reference/runtime-environment-settings/',
+    destination: '/nomad/docs/:version/runtime/environment',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/reference/runtime-variable-interpolation/',
+    destination: '/nomad/docs/:version/runtime/interpolation',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/reference/sentinel-policy/',
+    destination: '/nomad/docs/:version/enterprise/sentinel',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/use-cases/',
+    destination: '/nomad/docs/:version/who-uses-nomad',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/reference/runtime-environment-variables/',
+    destination: '/nomad/docs/:version/runtime/',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/reference/runtime-environment-settings/',
+    destination: '/nomad/docs/:version/runtime',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/acl/',
+    destination: '/nomad/tutorials/archive/access-control',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/acl/bootstrap/',
+    destination: '/nomad/tutorials/archive/access-control-bootstrap',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/acl/policies/create-policy/',
+    destination: '/nomad/tutorials/archive/access-control-create-policy',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/acl/policies/',
+    destination: '/nomad/tutorials/archive/access-control-policies',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/acl/tokens/',
+    destination: '/nomad/tutorials/archive/access-control-tokens',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/authentication/sso-auth0/',
+    destination: '/nomad/tutorials/archive/sso-oidc-auth0',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/authentication/sso-pkce-jwt/',
+    destination: '/nomad/tutorials/archive/sso-oidc-keycloak',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/acl/tokens/vault/',
+    destination: '/nomad/tutorials/archive/vault-nomad-secrets',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-scheduling/',
+    destination: '/nomad/tutorials/archive/advanced-scheduling',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-scheduling/affinity/',
+    destination: '/nomad/tutorials/archive/affinity',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-scheduling/preemption/',
+    destination: '/nomad/tutorials/archive/preemption',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-scheduling/spread/',
+    destination: '/nomad/tutorials/archive/spread',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/govern/',
+    destination: '/nomad/tutorials/archive/governance-and-policy',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/govern/resource-quotas/',
+    destination: '/nomad/tutorials/archive/quotas',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/govern/sentinel/',
+    destination: '/nomad/tutorials/archive/sentinel',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/monitor/event-stream/',
+    destination: '/nomad/tutorials/archive/event-stream',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/workload-identity/vault-acl/',
+    destination: '/nomad/tutorials/archive/vault-acl',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/acl/tokens/vault/',
+    destination: '/nomad/tutorials/archive/vault-nomad-secrets',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/failure/',
+    destination: '/nomad/tutorials/archive/failures',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/failure/check-restart/',
+    destination: '/nomad/tutorials/archive/failures-check-restart',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/failure/reschedule/',
+    destination: '/nomad/tutorials/archive/failures-reschedule',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/failure/restart/',
+    destination: '/nomad/tutorials/archive/failures-restart',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/nomad-actions/',
+    destination: '/nomad/tutorials/archive/job-spec-actions',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/strategy/blue-green-canary/',
+    destination: '/nomad/tutorials/archive/job-blue-green-and-canary-deployments',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/strategy/rolling/',
+    destination: '/nomad/tutorials/archive/job-rolling-update',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/exit-signals/',
+    destination: '/nomad/tutorials/archive/job-update-handle-signals',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/strategy/',
+    destination: '/nomad/tutorials/archive/job-update-strategies',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/manage/autopilot/',
+    destination: '/nomad/tutorials/archive/autopilot',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/deploy/clusters/connect-nodes/',
+    destination: '/nomad/tutorials/archive/clustering',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/deploy/clusters/federate-regions/',
+    destination: '/nomad/tutorials/archive/federation',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/multiregion/',
+    destination: '/nomad/tutorials/archive/multiregion-deployments',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/govern/namespaces/',
+    destination: '/nomad/tutorials/archive/namespaces',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/manage/migrate-workloads/',
+    destination: '/nomad/tutorials/archive/node-drain',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/manage/outage-recovery/',
+    destination: '/nomad/tutorials/archive/outage-recovery',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/deploy/clusters/reverse-proxy-ui/',
+    destination: '/nomad/tutorials/archive/reverse-proxy-ui',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/',
+    destination: '/nomad/tutorials/archive/jobs',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-run/logs/',
+    destination: '/nomad/tutorials/archive/jobs-accessing-logs',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/configure-tasks/',
+    destination: '/nomad/tutorials/archive/jobs-configuring',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-run/inspect/',
+    destination: '/nomad/tutorials/archive/jobs-inspect',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/create-job/',
+    destination: '/nomad/tutorials/archive/jobs-submit',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-run/utilization-metrics/',
+    destination: '/nomad/tutorials/archive/jobs-utilization',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-run/versions/',
+    destination: '/nomad/tutorials/archive/jobs-version',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)s/nomad-pack/advanced-usage/',
+    destination: '/nomad/tutorials/archive/nomad-pack-detailed-usage',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)s/nomad-pack/',
+    destination: '/nomad/tutorials/archive/nomad-pack-intro',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)s/nomad-pack/create-packs/',
+    destination: '/nomad/tutorials/archive/nomad-pack-writing-packs',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)archiving b/c LXC plugin removed a while ago/',
+    destination: '/nomad/tutorials/archive/plugin-lxc',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/authentication/sso-vault/',
+    destination: '/nomad/tutorials/archive/sso-oidc-vault',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/stateful-workloads/static-host-volumes/',
+    destination: '/nomad/tutorials/archive/exec-users-host-volumes',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/stateful-workloads/',
+    destination: '/nomad/tutorials/archive/stateful-workloads',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/stateful-workloads/csi-volumes/',
+    destination: '/nomad/tutorials/archive/stateful-workloads-csi-volumes',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/stateful-workloads/dynamic-host-volumes/',
+    destination: '/nomad/tutorials/archive/stateful-workloads-dynamic-host-volumes',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/stateful-workloads/static-host-volumes/',
+    destination: '/nomad/tutorials/archive/stateful-workloads-host-volumes',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/task-dependencies/',
+    destination: '/nomad/tutorials/archive/task-dependencies-interjob',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/manage/format-cli-output/',
+    destination: '/nomad/tutorials/archive/format-output-with-templates',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/reference/go-template-syntax/',
+    destination: '/nomad/tutorials/archive/go-template-syntax',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/traffic/',
+    destination: '/nomad/tutorials/archive/security-concepts',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/traffic/tls/',
+    destination: '/nomad/tutorials/archive/security-enable-tls',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/secure/traffic/gossip-encryption/',
+    destination: '/nomad/tutorials/archive/security-gossip-encryption',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/job-declare/nomad-variables/',
+    destination: '/nomad/tutorials/archive/variables-tasks',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/monitor/cluster-topology/',
+    destination: '/nomad/tutorials/archive/topology-visualization',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/monitor/inspect-cluster/',
+    destination: '/nomad/tutorials/archive/web-ui-cluster-info',
+    permanent: true
+  },
+  {
+    source: '/nomad/docs/:version(v1\.(?:8|9)\.x)/monitor/inspect-workloads/',
+    destination: '/nomad/tutorials/archive/web-ui-workload-info',
+    permanent: true
+  },
 ]


### PR DESCRIPTION
Manual backport of https://github.com/hashicorp/nomad/pull/26270

### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
