### PR TITLE
secrets: pass task WI to custom plugins

### DIFF
--- a/client/allocrunner/taskrunner/secrets_hook.go
+++ b/client/allocrunner/taskrunner/secrets_hook.go
@@ -99,7 +99,7 @@ func (h *secretsHook) Name() string {
 func (h *secretsHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
 	templates := []*structs.Template{}
 
-	providers, err := h.buildSecretProviders(req.TaskDir.SecretsDir)
+	providers, err := h.buildSecretProviders(req.TaskDir.SecretsDir, req.NomadToken)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func (h *secretsHook) Prestart(ctx context.Context, req *interfaces.TaskPrestart
 	return nil
 }
 
-func (h *secretsHook) buildSecretProviders(secretDir string) ([]SecretProvider, error) {
+func (h *secretsHook) buildSecretProviders(secretDir string, nomadToken string) ([]SecretProvider, error) {
 	// Any configuration errors will be found when calling the secret providers constructor,
 	// so use a multierror to collect all errors and return them to the user at the same time.
 	providers, mErr := []SecretProvider{}, new(multierror.Error)
@@ -190,7 +190,7 @@ func (h *secretsHook) buildSecretProviders(secretDir string) ([]SecretProvider, 
 				providers = append(providers, p)
 			}
 		default:
-			plug, err := commonplugins.NewExternalSecretsPlugin(h.clientConfig.CommonPluginDir, s.Provider)
+			plug, err := commonplugins.NewExternalSecretsPlugin(h.clientConfig.CommonPluginDir, s.Provider, nomadToken)
 			if err != nil {
 				multierror.Append(mErr, err)
 				continue

--- a/client/commonplugins/secrets_plugin.go
+++ b/client/commonplugins/secrets_plugin.go
@@ -41,9 +41,13 @@ type externalSecretsPlugin struct {
 
 	// pluginPath is the path on the host to the plugin executable
 	pluginPath string
+
+	// nomadToken is the nomad workload identity token passed
+	// to the plugin for optional authentication
+	nomadToken string
 }
 
-func NewExternalSecretsPlugin(commonPluginDir string, name string) (*externalSecretsPlugin, error) {
+func NewExternalSecretsPlugin(commonPluginDir string, name string, nomadToken string) (*externalSecretsPlugin, error) {
 	executable := filepath.Join(commonPluginDir, SecretsPluginDir, name)
 	f, err := os.Stat(executable)
 	if err != nil {
@@ -58,6 +62,7 @@ func NewExternalSecretsPlugin(commonPluginDir string, name string) (*externalSec
 
 	return &externalSecretsPlugin{
 		pluginPath: executable,
+		nomadToken: nomadToken,
 	}, nil
 }
 
@@ -93,6 +98,9 @@ func (e *externalSecretsPlugin) Fetch(ctx context.Context, path string) (*Secret
 
 	cmd := exec.CommandContext(plugCtx, e.pluginPath, "fetch", path)
 	cmd.Env = []string{
+		// set the task's workload identity token
+		fmt.Sprintf("NOMAD_TOKEN=%s", e.nomadToken),
+
 		"CPI_OPERATION=fetch",
 	}
 

--- a/client/commonplugins/secrets_plugin_test.go
+++ b/client/commonplugins/secrets_plugin_test.go
@@ -21,7 +21,7 @@ func TestExternalSecretsPlugin_Fingerprint(t *testing.T) {
 	t.Run("runs successfully", func(t *testing.T) {
 		pluginDir, pluginName := setupTestPlugin(t, fmt.Appendf([]byte{}, "#!/bin/sh\ncat <<EOF\n%s\nEOF\n", `{"type": "secrets", "version": "1.0.0"}`))
 
-		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName)
+		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName, "")
 		must.NoError(t, err)
 
 		res, err := plugin.Fingerprint(context.Background())
@@ -34,7 +34,7 @@ func TestExternalSecretsPlugin_Fingerprint(t *testing.T) {
 	t.Run("errors on non-zero exit code", func(t *testing.T) {
 		pluginDir, pluginName := setupTestPlugin(t, fmt.Append([]byte{}, "#!/bin/sh\nexit 1\n"))
 
-		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName)
+		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName, "")
 		must.NoError(t, err)
 
 		res, err := plugin.Fingerprint(context.Background())
@@ -45,7 +45,7 @@ func TestExternalSecretsPlugin_Fingerprint(t *testing.T) {
 	t.Run("errors on timeout", func(t *testing.T) {
 		pluginDir, pluginName := setupTestPlugin(t, fmt.Appendf([]byte{}, "#!/bin/sh\nleep .5\n"))
 
-		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName)
+		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName, "")
 		must.NoError(t, err)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -58,7 +58,7 @@ func TestExternalSecretsPlugin_Fingerprint(t *testing.T) {
 	t.Run("errors on invalid json", func(t *testing.T) {
 		pluginDir, pluginName := setupTestPlugin(t, fmt.Append([]byte{}, "#!/bin/sh\ncat <<EOF\ninvalid\nEOF\n"))
 
-		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName)
+		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName, "")
 		must.NoError(t, err)
 
 		res, err := plugin.Fingerprint(context.Background())
@@ -73,7 +73,7 @@ func TestExternalSecretsPlugin_Fetch(t *testing.T) {
 	t.Run("runs successfully", func(t *testing.T) {
 		pluginDir, pluginName := setupTestPlugin(t, fmt.Appendf([]byte{}, "#!/bin/sh\ncat <<EOF\n%s\nEOF\n", `{"result": {"key": "value"}}`))
 
-		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName)
+		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName, "")
 		must.NoError(t, err)
 
 		res, err := plugin.Fetch(context.Background(), "test-path")
@@ -86,7 +86,7 @@ func TestExternalSecretsPlugin_Fetch(t *testing.T) {
 	t.Run("errors on non-zero exit code", func(t *testing.T) {
 		pluginDir, pluginName := setupTestPlugin(t, fmt.Append([]byte{}, "#!/bin/sh\nexit 1\n"))
 
-		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName)
+		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName, "")
 		must.NoError(t, err)
 
 		_, err = plugin.Fetch(context.Background(), "test-path")
@@ -96,7 +96,7 @@ func TestExternalSecretsPlugin_Fetch(t *testing.T) {
 	t.Run("errors on timeout", func(t *testing.T) {
 		pluginDir, pluginName := setupTestPlugin(t, fmt.Append([]byte{}, "#!/bin/sh\nsleep .5\n"))
 
-		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName)
+		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName, "")
 		must.NoError(t, err)
 
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
@@ -109,7 +109,7 @@ func TestExternalSecretsPlugin_Fetch(t *testing.T) {
 	t.Run("errors on timeout", func(t *testing.T) {
 		pluginDir, pluginName := setupTestPlugin(t, fmt.Appendf([]byte{}, "#!/bin/sh\ncat <<EOF\n%s\nEOF\n", `invalid`))
 
-		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName)
+		plugin, err := NewExternalSecretsPlugin(pluginDir, pluginName, "")
 		must.NoError(t, err)
 
 		_, err = plugin.Fetch(context.Background(), "dummy-path")

--- a/client/fingerprint/secrets.go
+++ b/client/fingerprint/secrets.go
@@ -53,7 +53,7 @@ func (s *SecretsPluginFingerprint) Fingerprint(request *FingerprintRequest, resp
 	// map of plugin names to fingerprinted versions
 	plugins := map[string]string{}
 	for name := range files {
-		plug, err := commonplugins.NewExternalSecretsPlugin(request.Config.CommonPluginDir, name)
+		plug, err := commonplugins.NewExternalSecretsPlugin(request.Config.CommonPluginDir, name, "")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes add the tasks workload identity token to custom plugins as an environment variable. This allows the option for external secret providers to use this token for authentication when fetching secrets.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
