### PR TITLE
Add historical journald and log export flags to operator debug command

### DIFF
--- a/.changelog/26410.txt
+++ b/.changelog/26410.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+command: Add historical log capture to `nomad operator debug` command with `-log-lookback` and `-log-file-export` flags
+```

--- a/client/agent_endpoint_test.go
+++ b/client/agent_endpoint_test.go
@@ -454,14 +454,7 @@ func TestMonitor_MonitorExport(t *testing.T) {
 	ci.Parallel(t)
 
 	// Create test file
-	dir := t.TempDir()
-	f, err := os.CreateTemp(dir, "log")
-	must.NoError(t, err)
-	for range 1000 {
-		_, _ = f.WriteString(fmt.Sprintf("%v [INFO] it's log, it's log, it's big it's heavy it's wood", time.Now()))
-	}
-	f.Close()
-	testFilePath := f.Name()
+	testFilePath := monitor.PrepFile(t).Name()
 	testFileContents, err := os.ReadFile(testFilePath)
 	must.NoError(t, err)
 

--- a/command/agent/monitor/monitor_test.go
+++ b/command/agent/monitor/monitor_test.go
@@ -100,14 +100,7 @@ func TestMonitor_Export(t *testing.T) {
 		expectedText = "log log log log log"
 	)
 
-	dir := t.TempDir()
-	f, err := os.CreateTemp(dir, "log")
-	must.NoError(t, err)
-	for range 1000 {
-		_, _ = f.WriteString(fmt.Sprintf("%v [INFO] it's log, it's log, it's big it's heavy it's wood", time.Now()))
-	}
-	f.Close()
-	goldenFilePath := f.Name()
+	goldenFilePath := PrepFile(t).Name()
 	goldenFileContents, err := os.ReadFile(goldenFilePath)
 	must.NoError(t, err)
 

--- a/command/agent/monitor/stream_helpers_test.go
+++ b/command/agent/monitor/stream_helpers_test.go
@@ -17,27 +17,6 @@ import (
 	"github.com/shoenig/test/must"
 )
 
-var writeLine = []byte("[INFO] log log log made of wood you are heavy but so good\n")
-
-func prepFile(t *testing.T) *os.File {
-	const loopCount = 10
-	// Create test file to read from
-	dir := t.TempDir()
-	f, err := os.CreateTemp(dir, "log")
-	must.NoError(t, err)
-
-	for range loopCount {
-		_, _ = f.Write(writeLine)
-	}
-	f.Close()
-
-	// Create test file reader for stream set up
-	goldenFilePath := f.Name()
-	fileReader, err := os.Open(goldenFilePath)
-	must.NoError(t, err)
-	return fileReader
-}
-
 func TestClientStreamReader_StreamFixed(t *testing.T) {
 	ci.Parallel(t)
 
@@ -80,7 +59,7 @@ func TestClientStreamReader_StreamFixed(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			file := prepFile(t)
+			file := PrepFile(t)
 			goldenFileContents, err := os.ReadFile(file.Name())
 			must.NoError(t, err)
 

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -45,10 +45,8 @@ type OperatorDebugCommand struct {
 	interval           time.Duration
 	pprofInterval      time.Duration
 	pprofDuration      time.Duration
-	logFileExport      bool
-	logIncludeLocation bool
 	logLevel           string
-	logLookback        time.Duration
+	logIncludeLocation bool
 	maxNodes           int
 	nodeClass          string
 	nodeIDs            []string
@@ -419,13 +417,12 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 	}
 	// Parse logLookback and logFileExport to set export string with whichever is set
 	if logLookback != "" && logFileExport == "" {
-		l, err := time.ParseDuration(logLookback)
+		_, err := time.ParseDuration(logLookback)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf("Error parsing log-lookback value: %s: %s", logLookback, err.Error()))
 			return 1
 		}
 		export = logLookback
-		c.logLookback = l
 	}
 
 	if logFileExport != "" && logLookback == "" {
@@ -436,7 +433,6 @@ func (c *OperatorDebugCommand) Run(args []string) int {
 		}
 		if t {
 			export = logFileExport
-			c.logFileExport = t
 		}
 	}
 

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -891,9 +891,10 @@ func (c *OperatorDebugCommand) startMonitorExport(path, idKey, nodeID, since str
 			fh.Write(out.Data)
 
 		case err := <-errCh:
-			fh.WriteString(fmt.Sprintf("monitor: %s\n", err.Error()))
-			return
-
+			if err != io.EOF {
+				fh.WriteString(fmt.Sprintf("monitor: %s\n", err.Error()))
+				return
+			}
 		case <-c.ctx.Done():
 			return
 		}

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -187,17 +187,17 @@ Debug Options:
 
   -log-file-export=bool
     Include the contents of agents' Nomad logfile in the debug capture. The
-    log export monitor runs alongside the running log monitor and ignores the
-    "log-level" and "log-include-location" flags used to configure that
-    monitor. Nomad will return an error if the agent does not have a
-    file logging configured. Cannot be used with -log-lookback.
+    log export monitor runs concurrently with the log monitor and ignores the
+    -log-level and -log-include-location flags used to configure that monitor.
+    Nomad will return an error if the agent does not have file logging configured.
+    Cannot be used with -log-lookback.
 
   -log-lookback=<duration>
     Include historical journald logs in the debug capture.  The journald
-    export monitor runs alongside the running log monitor and ignores the
-    -log-level and -log-include-location flags used to configure that monitor
-    This flag is only available on Linux, see the -log-file-export flag to
-    retrieve historical logs on non-Linux systems. Cannot be used with
+    export monitor runs concurrently with the log monitor and ignores the
+    -log-level and -log-include-location flags used to configure that monitor.
+    This flag is only available on Linux systems, see the -log-file-export flag
+    to retrieve historical logs on non-Linux systems. Cannot be used with
     -log-file-export.
 
   -max-nodes=<count>

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -183,7 +183,7 @@ Debug Options:
     Include file and line information in each log line monitored. The default
     is true.
 
-  -log-file-export=bool
+  -log-file-export=<bool>
     Include the contents of agents' Nomad logfiles in the debug capture. The
     log export monitor runs concurrently with the log monitor and ignores the
     -log-level and -log-include-location flags used to configure that monitor.

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -1094,7 +1094,6 @@ func TestDebug_MonitorExportFiles(t *testing.T) {
 	duration := 2 * time.Second
 	interval := 750 * time.Millisecond
 	waitTime := 2 * duration
-	var emptyDur time.Duration
 
 	baseArgs := []string{
 		"-address", url,

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -1113,7 +1113,7 @@ func TestDebug_MonitorExportFiles(t *testing.T) {
 	}{
 		{
 			name:         "exporter",
-			cmdArgs:      []string{"-log-file-export", "true"},
+			cmdArgs:      []string{"-log-file-export"},
 			wantExporter: true,
 		},
 		{
@@ -1121,16 +1121,9 @@ func TestDebug_MonitorExportFiles(t *testing.T) {
 			wantExporter: false,
 		},
 		{
-			name:         "bad_value_for_log_export_file",
-			cmdArgs:      []string{"-log-file-export", "blue"},
-			errString:    "Error parsing log-file-export value",
-			runErr:       true,
-			wantExporter: false,
-		},
-		{
 			name:         "bad_value_for_log_lookback",
 			cmdArgs:      []string{"-log-lookback", "blue"},
-			errString:    "Error parsing log-lookback value",
+			errString:    "Error parsing -log-lookback",
 			runErr:       true,
 			wantExporter: false,
 		},
@@ -1138,9 +1131,9 @@ func TestDebug_MonitorExportFiles(t *testing.T) {
 			name: "set_both_flags",
 			cmdArgs: []string{
 				"-log-lookback", "5h",
-				"-log-file-export", "true",
+				"-log-file-export",
 			},
-			errString:    "Error parsing inputs, -log-file-export and -log-lookback cannot be used together.",
+			errString:    "Error parsing inputs, -log-file-export and -log-lookback cannot be used together",
 			runErr:       true,
 			wantExporter: false,
 		},
@@ -1175,6 +1168,7 @@ func TestDebug_MonitorExportFiles(t *testing.T) {
 			// Wait until client's monitor.log file is written
 			clientPaths := buildPathSlice(cmd.path(clientDir, clientID), clientFiles)
 			t.Logf("Waiting for client files in path: %s", clientDir)
+
 			testutil.WaitForFilesUntil(t, clientPaths[:0], waitTime)
 
 			// Wait until server's monitor.log file is written

--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -1032,14 +1032,7 @@ func TestMonitor_MonitorExport(t *testing.T) {
 		shortText = "log log log log log"
 	)
 	// Create test file
-	dir := t.TempDir()
-	f, err := os.CreateTemp(dir, "log")
-	must.NoError(t, err)
-	for range 1000 {
-		_, _ = f.WriteString(fmt.Sprintf("%v [INFO] it's log, it's log, it's big it's heavy it's wood", time.Now()))
-	}
-	f.Close()
-	longFilePath := f.Name()
+	longFilePath := monitor.PrepFile(t).Name()
 	longFileContents, err := os.ReadFile(longFilePath)
 	must.NoError(t, err)
 

--- a/website/content/commands/operator/debug.mdx
+++ b/website/content/commands/operator/debug.mdx
@@ -54,17 +54,18 @@ true.
 - `-log-include-location`: Include file and line information in each log line
   monitored. The default is `true`.
 
-- `log-file-export`:Include agents' Nomad logfiles in the debug capture.
-  Historical log export runs alongside the running log monitor and will ignore
-  the `log-level` and `log-include-location` flags passed to that monitor.
-  Nomad will return an error if the agent does not have a log_file configured.
-  Cannot be used with `log-lookback`.
+- `log-file-export`: Include agents' Nomad logfiles in the debug capture.
+   The historical log export monitor runs alongside the running log monitor
+   and ignores the `log-level` and `log-include-location` flags used to configure
+   that monitor. Nomad will return an error if the agent does not have a log_file
+   configured. Cannot be used with `log-lookback`.
 
-- `log-file-export`: Include historical journald logs in the debug capture.
-  Historical log export runs alongside the running log monitor and will ignore
+- `log-lookback`: Include historical journald logs in the debug capture.
+  Historical log export runs alongside the running log monitor ignores
   the `log-level` and `log-include-location` flags passed to that monitor.
   This flag is only available on Linux systems, see the `log-file-export`
-  flag to retrieve historical logs from non-Linux systems.
+  flag to retrieve historical logs from non-Linux systems. Cannot be used
+  with `log-file-export`.
 
 - `-max-nodes=<count>`: Cap the maximum number of client nodes included
   in the capture. Defaults to 10, set to 0 for unlimited.
@@ -85,10 +86,6 @@ true.
 - `-server-id=<server1>,<server2>`: Comma separated list of Nomad server names to
   monitor for logs, API outputs, and pprof profiles. Accepts server names, "leader", or
   "all". Defaults to `all`.
-
-- `-since=<duration>`: Duration that, if set, includes historical journald logs in
-  the debug capture. Historical log export will ignore flags passed to `log-level`
-  or `log-include-location` and return logs as they are written to disk.
 
 - `-stale=<true|false>`: If "false", the default, get membership data from the
   cluster leader. If the cluster is in an outage unable to establish

--- a/website/content/commands/operator/debug.mdx
+++ b/website/content/commands/operator/debug.mdx
@@ -63,9 +63,9 @@ true.
 - `log-lookback`: Include historical journald logs in the debug capture. The
   journald export monitor runs concurrently with the log monitor and ignores
   the `-log-level` and `-log-include-location` flags passed to that monitor.
-  This flag is only available on Linux systems, see the `-log-file-export`
-  flag to retrieve historical logs from non-Linux systems. Cannot be used
-  with `-log-file-export`.
+  This flag is only available on Linux systems using systemd, see the 
+  `-log-file-export` flag to retrieve historical logs from non-Linux systems,
+  or those without systemd. Cannot be used with `-log-file-export`.
 
 - `-max-nodes=<count>`: Cap the maximum number of client nodes included
   in the capture. Defaults to 10, set to 0 for unlimited.

--- a/website/content/commands/operator/debug.mdx
+++ b/website/content/commands/operator/debug.mdx
@@ -55,13 +55,13 @@ true.
   monitored. The default is `true`.
 
 - `log-file-export`: Include agents' Nomad logfiles in the debug capture.
-   The historical log export monitor runs concurrently with the log monitor
-   and ignores the `-log-level` and `-log-include-location` flags used to
-   configure that monitor. Nomad will return an error if the agent does not
-   have file logging configured. Cannot be used with `-log-lookback`.
+  The historical log export monitor runs concurrently with the log monitor
+  and ignores the `-log-level` and `-log-include-location` flags used to
+  configure that monitor. Nomad will return an error if the agent does not
+  have file logging configured. Cannot be used with `-log-lookback`.
 
-- `log-lookback`: Include historical journald logs in the debug capture.
-  Historical log export runs concurrently with the log monitor and ignores
+- `log-lookback`: Include historical journald logs in the debug capture. The
+  journald export monitor runs concurrently with the log monitor and ignores
   the `-log-level` and `-log-include-location` flags passed to that monitor.
   This flag is only available on Linux systems, see the `-log-file-export`
   flag to retrieve historical logs from non-Linux systems. Cannot be used

--- a/website/content/commands/operator/debug.mdx
+++ b/website/content/commands/operator/debug.mdx
@@ -55,17 +55,17 @@ true.
   monitored. The default is `true`.
 
 - `log-file-export`: Include agents' Nomad logfiles in the debug capture.
-   The historical log export monitor runs alongside the running log monitor
-   and ignores the `log-level` and `log-include-location` flags used to configure
-   that monitor. Nomad will return an error if the agent does not have a log_file
-   configured. Cannot be used with `log-lookback`.
+   The historical log export monitor runs concurrently with the log monitor
+   and ignores the `-log-level` and `-log-include-location` flags used to
+   configure that monitor. Nomad will return an error if the agent does not
+   have file logging configured. Cannot be used with `-log-lookback`.
 
 - `log-lookback`: Include historical journald logs in the debug capture.
-  Historical log export runs alongside the running log monitor ignores
-  the `log-level` and `log-include-location` flags passed to that monitor.
-  This flag is only available on Linux systems, see the `log-file-export`
+  Historical log export runs concurrently with the log monitor and ignores
+  the `-log-level` and `-log-include-location` flags passed to that monitor.
+  This flag is only available on Linux systems, see the `-log-file-export`
   flag to retrieve historical logs from non-Linux systems. Cannot be used
-  with `log-file-export`.
+  with `-log-file-export`.
 
 - `-max-nodes=<count>`: Cap the maximum number of client nodes included
   in the capture. Defaults to 10, set to 0 for unlimited.

--- a/website/content/commands/operator/debug.mdx
+++ b/website/content/commands/operator/debug.mdx
@@ -54,6 +54,18 @@ true.
 - `-log-include-location`: Include file and line information in each log line
   monitored. The default is `true`.
 
+- `log-file-export`:Include agents' Nomad logfiles in the debug capture.
+  Historical log export runs alongside the running log monitor and will ignore
+  the `log-level` and `log-include-location` flags passed to that monitor.
+  Nomad will return an error if the agent does not have a log_file configured.
+  Cannot be used with `log-lookback`.
+
+- `log-file-export`: Include historical journald logs in the debug capture.
+  Historical log export runs alongside the running log monitor and will ignore
+  the `log-level` and `log-include-location` flags passed to that monitor.
+  This flag is only available on Linux systems, see the `log-file-export`
+  flag to retrieve historical logs from non-Linux systems.
+
 - `-max-nodes=<count>`: Cap the maximum number of client nodes included
   in the capture. Defaults to 10, set to 0 for unlimited.
 
@@ -73,6 +85,10 @@ true.
 - `-server-id=<server1>,<server2>`: Comma separated list of Nomad server names to
   monitor for logs, API outputs, and pprof profiles. Accepts server names, "leader", or
   "all". Defaults to `all`.
+
+- `-since=<duration>`: Duration that, if set, includes historical journald logs in
+  the debug capture. Historical log export will ignore flags passed to `log-level`
+  or `log-include-location` and return logs as they are written to disk.
 
 - `-stale=<true|false>`: If "false", the default, get membership data from the
   cluster leader. If the cluster is in an outage unable to establish


### PR DESCRIPTION
### Description
Support requested the ability to retrieve historical journald logs as part of the debug capture returned by `nomad operator debug`.  PR #26178  introduced a `MonitorExport()` RPC capable of streaming the contents of an agent's log file (if file logging is enabled) or its journald logs.

This PR adds that functionality to `operator debug` with the inclusion of either a `log-file-export=true` flag or a `-log-lookback=<duration>` flag.  An agent's historical log capture runs alongside the capture of running logs and results in both  `monitor.log` and `monitor_export.log` files appearing in each agent's debug capture.

Note to reviewers: I exported a test helper from PR #26178  for this new test case. The helper  generates a golden log file for testing against stream results. And since the helper is now exported, I also refactored a few tests from that PR to use it as well since they were using the same mechanism.

### Testing & Reproduction steps
To run locally:
1. Build branch
2. Run a debug command with one of the historical log operators e.g `nomad operator debug -duration=10s -interval=5s -log-file-export=true`
3. Unzip the debug archive to display a `monitor.log` and `monitor_export.log` file for each agent in the cluster.
﻿
### Example below
<img width="727" height="830" alt="Screenshot 2025-08-01 at 4 35 25 PM" src="https://github.com/user-attachments/assets/d779b7e8-6c78-4cc1-84c6-3b135cefda8e" />


### Links
Requested in: [NMD-141](https://hashicorp.atlassian.net/browse/NMD-141?atlOrigin=eyJpIjoiOTdmMGE2MDg2YjUxNGZjMGIwNzJmMTAyNzAxZmFlNzAiLCJwIjoiaiJ9)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[NMD-141]: https://hashicorp.atlassian.net/browse/NMD-141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ