### PR TITLE
document version check requirement on Raft message types

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -140,6 +140,9 @@ const (
 
 	// NOTE: MessageTypes are shared between CE and ENT. If you need to add a
 	// new type, check that ENT is not already using that value.
+	//
+	// NOTE: Adding a new MessageType above? You need to have a version check
+	// for the feature to avoid panics during upgrades.
 )
 
 const (


### PR DESCRIPTION
Whenever we add a new Raft message type, we almost always need to add a new version check to ensure that leaders aren't trying to write unknown Raft entries to older followers. Leave a note about this where the edits happen to reduce the risk of this unfortunately common bug.

Ref: https://github.com/hashicorp/nomad-enterprise/pull/2973