### PR TITLE
tests: fix conflict from parallelism in state store variables test

### DIFF
--- a/nomad/state/state_store_variables_test.go
+++ b/nomad/state/state_store_variables_test.go
@@ -4,7 +4,6 @@
 package state
 
 import (
-	"encoding/json"
 	"errors"
 	"sort"
 	"strings"
@@ -735,22 +734,6 @@ func TestStateStore_ListVariablesByKeyID(t *testing.T) {
 	must.Eq(t, 5, count)
 }
 
-func printVariable(tsv *structs.VariableEncrypted) string {
-	b, _ := json.Marshal(tsv)
-	return string(b)
-}
-
-func printVariables(tsvs []*structs.VariableEncrypted) string {
-	if len(tsvs) == 0 {
-		return ""
-	}
-	var out strings.Builder
-	for _, tsv := range tsvs {
-		out.WriteString(printVariable(tsv) + "\n")
-	}
-	return out.String()
-}
-
 // TestStateStore_Variables_DeleteCAS
 func TestStateStore_Variables_DeleteCAS(t *testing.T) {
 	ci.Parallel(t)
@@ -822,7 +805,7 @@ func TestStateStore_Variables_DeleteCAS(t *testing.T) {
 	t.Run("real_locked_var-cas_0", func(t *testing.T) {
 		ci.Parallel(t)
 		sv := mock.VariableEncrypted()
-		sv.Path = "real_var/cas_0"
+		sv.Path = "real_locked_var/cas_0"
 		resp := ts.VarSet(10, &structs.VarApplyStateRequest{
 			Op:  structs.VarOpSet,
 			Var: sv,


### PR DESCRIPTION
The state store test for Variables check-and-set behavior for deletes uses the same state store for a set of parallel tests. But one of the tests overlaps another by using the same path, and this can cause spurious test failures by hitting the CAS conflict error. This overlap doesn't appear to be intentional, so change the test to use a different path.

Also cleaned up some unused test helpers in the same file.

---

Previously this can fail in two places, but the specific errors for line 819 can vary depending on exact interleaving:

```
$ go test -count=100 -race ./nomad/state -run TestStateStore_Variables_DeleteCAS
...
--- FAIL: TestStateStore_Variables_DeleteCAS (0.00s)
    --- FAIL: TestStateStore_Variables_DeleteCAS/real_var-cas_0 (0.00s)
        state_store_variables_test.go:807:
            state_store_variables_test.go:807: expected condition to be true; is false
            ↪ PostScript | annotation ↷
                resp: &{Op:set Result:conflict Error:<nil> Conflict:0xc00029c150 WrittenSVMeta:<nil> WriteMeta:{Index:10}}
--- FAIL: TestStateStore_Variables_DeleteCAS (0.00s)
    --- FAIL: TestStateStore_Variables_DeleteCAS/real_var-cas_0 (0.00s)
        state_store_variables_test.go:819:
            state_store_variables_test.go:819: expected equality via cmp.Equal function
            ↪ Assertion | differential ↷
              structs.VariableMetadata(
            -   {Namespace: "default", Path: "real_var/cas_0", CreateIndex: 10, ModifyIndex: 10},
            +   {Namespace: "default", Path: "real_var/cas_0", CreateIndex: 10, ModifyIndex: 20},
              )
```

Now:

```
$ go test -count=100 -race ./nomad/state -run TestStateStore_Variables_DeleteCAS
ok      github.com/hashicorp/nomad/nomad/state  1.279s
```