### PR TITLE
eval status: sort plan annotations by task group

### DIFF
--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -382,8 +382,16 @@ func formatPlanAnnotations(desiredTGUpdates map[string]*api.DesiredUpdates, verb
 		}
 	}
 
+	taskGroups := []string{}
+	for tg := range desiredTGUpdates {
+		taskGroups = append(taskGroups, tg)
+	}
+	sort.StringSlice(taskGroups).Sort()
+
 	i := 1
-	for tg, updates := range desiredTGUpdates {
+	for _, tg := range taskGroups {
+		updates := desiredTGUpdates[tg]
+
 		// we always show the first 5 columns
 		annotations[i] = fmt.Sprintf("%s|%d|%d|%d|%d|%d",
 			tg,

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"fmt"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -386,7 +387,7 @@ func formatPlanAnnotations(desiredTGUpdates map[string]*api.DesiredUpdates, verb
 	for tg := range desiredTGUpdates {
 		taskGroups = append(taskGroups, tg)
 	}
-	sort.StringSlice(taskGroups).Sort()
+	slices.Sort(taskGroups)
 
 	i := 1
 	for _, tg := range taskGroups {

--- a/command/eval_status_test.go
+++ b/command/eval_status_test.go
@@ -236,6 +236,6 @@ func TestEvalStatus_FormatPlanAnnotations(t *testing.T) {
 
 	out := formatPlanAnnotations(updates, false)
 	must.Eq(t, `Task Group  Ignore  Place  Stop  InPlace  Destructive  Canary  Reconnect
-foo         2       1      0     0        0            1       0
-bar         0       1      3     0        0            0       2`, out)
+bar         0       1      3     0        0            0       2
+foo         2       1      0     0        0            1       0`, out)
 }


### PR DESCRIPTION
The plan annotations table isn't sorted by task group, which makes for a less beautiful UX and a flaky test.

---

This feature hasn't shipped in production code, so it doesn't need backports.