### PR TITLE
[agent] Fix error checking within retry join

### DIFF
--- a/command/agent/retry_join.go
+++ b/command/agent/retry_join.go
@@ -187,11 +187,16 @@ func (r *retryJoiner) RetryJoin() {
 		}
 
 		if len(addrs) > 0 && r.joinFunc != nil {
-			numJoined, err := r.joinFunc(addrs)
+			var numJoined int
+			numJoined, err = r.joinFunc(addrs)
 			if err == nil {
 				r.logger.Info("retry join completed", "initial_servers", numJoined)
 				return
 			}
+		}
+
+		if err != nil {
+			r.logger.Warn("join failed", "error", err, "retry", r.joinCfg.RetryInterval)
 		}
 
 		attempt++
@@ -201,9 +206,6 @@ func (r *retryJoiner) RetryJoin() {
 			return
 		}
 
-		if err != nil {
-			r.logger.Warn("join failed", "error", err, "retry", r.joinCfg.RetryInterval)
-		}
 		time.Sleep(r.joinCfg.RetryInterval)
 	}
 }


### PR DESCRIPTION
### Description

The `RetryJoin` function checks for an error and logs it before
retrying. The error variables were shadowed which resulted in
the errors never being logged. This predefines the variables
to prevent them from being shadowed.

The testlog package was also updated to support providing a custom
writer which allows logging output to be easily caught and inspected.

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
