### PR TITLE
test: Ensure client rpclogger is set on RPC only client.

### DIFF
--- a/client/testing.go
+++ b/client/testing.go
@@ -107,6 +107,7 @@ func TestRPCOnlyClient(t testing.TB, cb func(c *config.Config), srvAddr net.Addr
 	client := &Client{
 		config:           conf,
 		logger:           testLogger,
+		rpcLogger:        testLogger.Named("rpc"),
 		shutdownCh:       make(chan struct{}),
 		EnterpriseClient: newEnterpriseClient(testLogger),
 	}


### PR DESCRIPTION
If a test encounters an RPC error using the test client, it will panic as the rpc logger is not set when it attempts to log the error.

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
