### PR TITLE
rpc: Move register args initial validation into separate function.

### DIFF
--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -125,33 +125,9 @@ func (n *Node) Register(args *structs.NodeRegisterRequest, reply *structs.NodeUp
 
 	defer metrics.MeasureSince([]string{"nomad", "client", "register"}, time.Now())
 
-	// Validate the arguments
-	if args.Node == nil {
-		return fmt.Errorf("missing node for client registration")
-	}
-	if args.Node.ID == "" {
-		return fmt.Errorf("missing node ID for client registration")
-	}
-	if args.Node.Datacenter == "" {
-		return fmt.Errorf("missing datacenter for client registration")
-	}
-	if args.Node.Name == "" {
-		return fmt.Errorf("missing node name for client registration")
-	}
-	if len(args.Node.Attributes) == 0 {
-		return fmt.Errorf("missing attributes for client registration")
-	}
-	if args.Node.SecretID == "" {
-		return fmt.Errorf("missing node secret ID for client registration")
-	}
-	if args.Node.NodePool != "" {
-		err := structs.ValidateNodePoolName(args.Node.NodePool)
-		if err != nil {
-			return fmt.Errorf("invalid node pool: %v", err)
-		}
-		if args.Node.NodePool == structs.NodePoolAll {
-			return fmt.Errorf("node is not allowed to register in node pool %q", structs.NodePoolAll)
-		}
+	// Perform validation of the base provided request.
+	if err := args.Validate(); err != nil {
+		return err
 	}
 
 	// Default the status if none is given

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -551,6 +551,40 @@ type NodeRegisterRequest struct {
 	WriteRequest
 }
 
+// Validate checks that the NodeRegisterRequest is valid. Any returned error can
+// be sent back to the client as a response to the RPC call.
+func (n *NodeRegisterRequest) Validate() error {
+
+	if n.Node == nil {
+		return errors.New("missing node for client registration")
+	}
+	if n.Node.ID == "" {
+		return errors.New("missing node ID for client registration")
+	}
+	if n.Node.Datacenter == "" {
+		return errors.New("missing datacenter for client registration")
+	}
+	if n.Node.Name == "" {
+		return errors.New("missing node name for client registration")
+	}
+	if len(n.Node.Attributes) == 0 {
+		return errors.New("missing attributes for client registration")
+	}
+	if n.Node.SecretID == "" {
+		return errors.New("missing node secret ID for client registration")
+	}
+	if n.Node.NodePool != "" {
+		if err := ValidateNodePoolName(n.Node.NodePool); err != nil {
+			return fmt.Errorf("invalid node pool: %v", err)
+		}
+		if n.Node.NodePool == NodePoolAll {
+			return fmt.Errorf("node is not allowed to register in node pool %q", NodePoolAll)
+		}
+	}
+
+	return nil
+}
+
 // ShouldGenerateNodeIdentity compliments the functionality within
 // AuthenticateNodeIdentityGenerator to determine whether a new node identity
 // should be generated within the RPC handler.

--- a/nomad/structs/node_test.go
+++ b/nomad/structs/node_test.go
@@ -287,7 +287,7 @@ func TestNodeRegisterRequest_Validate(t *testing.T) {
 	testCases := []struct {
 		name          string
 		request       *NodeRegisterRequest
-		expectedError bool
+		errorContains string
 	}{
 		{
 			name: "valid",
@@ -302,14 +302,14 @@ func TestNodeRegisterRequest_Validate(t *testing.T) {
 					Attributes: map[string]string{"key1": "value1"},
 				},
 			},
-			expectedError: false,
+			errorContains: "",
 		},
 		{
 			name: "nil node",
 			request: &NodeRegisterRequest{
 				Node: nil,
 			},
-			expectedError: true,
+			errorContains: "missing node for client registration",
 		},
 		{
 			name: "missing ID",
@@ -324,7 +324,7 @@ func TestNodeRegisterRequest_Validate(t *testing.T) {
 					Attributes: map[string]string{"key1": "value1"},
 				},
 			},
-			expectedError: true,
+			errorContains: "missing node ID for client registration",
 		},
 		{
 			name: "missing datacenter",
@@ -339,7 +339,7 @@ func TestNodeRegisterRequest_Validate(t *testing.T) {
 					Attributes: map[string]string{"key1": "value1"},
 				},
 			},
-			expectedError: true,
+			errorContains: "missing datacenter for client registration",
 		},
 		{
 			name: "missing name",
@@ -354,7 +354,7 @@ func TestNodeRegisterRequest_Validate(t *testing.T) {
 					Attributes: map[string]string{"key1": "value1"},
 				},
 			},
-			expectedError: true,
+			errorContains: "missing node name for client registration",
 		},
 		{
 			name: "missing attributes",
@@ -369,7 +369,7 @@ func TestNodeRegisterRequest_Validate(t *testing.T) {
 					Attributes: map[string]string{},
 				},
 			},
-			expectedError: true,
+			errorContains: "missing attributes for client registration",
 		},
 		{
 			name: "missing secret ID",
@@ -384,7 +384,7 @@ func TestNodeRegisterRequest_Validate(t *testing.T) {
 					Attributes: map[string]string{"key1": "value1"},
 				},
 			},
-			expectedError: true,
+			errorContains: "missing node secret ID for client registration",
 		},
 		{
 			name: "invalid node pool name",
@@ -399,7 +399,7 @@ func TestNodeRegisterRequest_Validate(t *testing.T) {
 					Attributes: map[string]string{"key1": "value1"},
 				},
 			},
-			expectedError: true,
+			errorContains: `invalid node pool: invalid name "****"`,
 		},
 		{
 			name: "invalid node pool all use",
@@ -414,15 +414,15 @@ func TestNodeRegisterRequest_Validate(t *testing.T) {
 					Attributes: map[string]string{"key1": "value1"},
 				},
 			},
-			expectedError: true,
+			errorContains: `node is not allowed to register in node pool "all"`,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualError := tc.request.Validate()
-			if tc.expectedError {
-				must.Error(t, actualError)
+			if tc.errorContains != "" {
+				must.ErrorContains(t, actualError, tc.errorContains)
 			} else {
 				must.NoError(t, actualError)
 			}

--- a/nomad/structs/node_test.go
+++ b/nomad/structs/node_test.go
@@ -281,6 +281,155 @@ func TestGenerateNodeIdentityClaims(t *testing.T) {
 	must.NotNil(t, claims.Expiry)
 }
 
+func TestNodeRegisterRequest_Validate(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name          string
+		request       *NodeRegisterRequest
+		expectedError bool
+	}{
+		{
+			name: "valid",
+			request: &NodeRegisterRequest{
+				Node: &Node{
+					ID:         "node-id",
+					SecretID:   "node-secret-id",
+					Name:       "node-name",
+					NodePool:   "node-pool",
+					NodeClass:  "node-class",
+					Datacenter: "node-datacenter",
+					Attributes: map[string]string{"key1": "value1"},
+				},
+			},
+			expectedError: false,
+		},
+		{
+			name: "nil node",
+			request: &NodeRegisterRequest{
+				Node: nil,
+			},
+			expectedError: true,
+		},
+		{
+			name: "missing ID",
+			request: &NodeRegisterRequest{
+				Node: &Node{
+					ID:         "",
+					SecretID:   "node-secret-id",
+					Name:       "node-name",
+					NodePool:   "node-pool",
+					NodeClass:  "node-class",
+					Datacenter: "node-datacenter",
+					Attributes: map[string]string{"key1": "value1"},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "missing datacenter",
+			request: &NodeRegisterRequest{
+				Node: &Node{
+					ID:         "node-id",
+					SecretID:   "node-secret-id",
+					Name:       "node-name",
+					NodePool:   "node-pool",
+					NodeClass:  "node-class",
+					Datacenter: "",
+					Attributes: map[string]string{"key1": "value1"},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "missing name",
+			request: &NodeRegisterRequest{
+				Node: &Node{
+					ID:         "node-id",
+					SecretID:   "node-secret-id",
+					Name:       "",
+					NodePool:   "node-pool",
+					NodeClass:  "node-class",
+					Datacenter: "node-datacenter",
+					Attributes: map[string]string{"key1": "value1"},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "missing attributes",
+			request: &NodeRegisterRequest{
+				Node: &Node{
+					ID:         "node-id",
+					SecretID:   "node-secret-id",
+					Name:       "node-name",
+					NodePool:   "node-pool",
+					NodeClass:  "node-class",
+					Datacenter: "node-datacenter",
+					Attributes: map[string]string{},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "missing secret ID",
+			request: &NodeRegisterRequest{
+				Node: &Node{
+					ID:         "node-id",
+					SecretID:   "",
+					Name:       "node-name",
+					NodePool:   "node-pool",
+					NodeClass:  "node-class",
+					Datacenter: "node-datacenter",
+					Attributes: map[string]string{"key1": "value1"},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "invalid node pool name",
+			request: &NodeRegisterRequest{
+				Node: &Node{
+					ID:         "node-id",
+					SecretID:   "node-secret-id",
+					Name:       "node-name",
+					NodePool:   "****",
+					NodeClass:  "node-class",
+					Datacenter: "node-datacenter",
+					Attributes: map[string]string{"key1": "value1"},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			name: "invalid node pool all use",
+			request: &NodeRegisterRequest{
+				Node: &Node{
+					ID:         "node-id",
+					SecretID:   "node-secret-id",
+					Name:       "node-name",
+					NodePool:   NodePoolAll,
+					NodeClass:  "node-class",
+					Datacenter: "node-datacenter",
+					Attributes: map[string]string{"key1": "value1"},
+				},
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualError := tc.request.Validate()
+			if tc.expectedError {
+				must.Error(t, actualError)
+			} else {
+				must.NoError(t, actualError)
+			}
+		})
+	}
+}
+
 func TestNodeRegisterRequest_ShouldGenerateNodeIdentity(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
The RPC handler function is quite long, so moving the argument validation into its own function reduces this and makese sense from an organisation view.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
