### PR TITLE
consul connect: allow "cni/*" network mode

### DIFF
--- a/client/allocrunner/consul_grpc_sock_hook.go
+++ b/client/allocrunner/consul_grpc_sock_hook.go
@@ -117,8 +117,8 @@ func (*consulGRPCSocketHook) Name() string {
 func (h *consulGRPCSocketHook) shouldRun() bool {
 	tg := h.alloc.Job.LookupTaskGroup(h.alloc.TaskGroup)
 
-	// we must be in bridge networking and at least one connect sidecar task
-	if !tgFirstNetworkIsBridge(tg) {
+	// we must be in bridge/cni networking and at least one connect sidecar task
+	if !tgFirstNetworkCanConsulConnect(tg) {
 		return false
 	}
 

--- a/command/agent/consul/connect.go
+++ b/command/agent/consul/connect.go
@@ -264,7 +264,8 @@ func connectProxyConfig(cfg map[string]interface{}, port int, info structs.Alloc
 
 func connectProxyBindAddress(networks structs.Networks) string {
 	for _, n := range networks {
-		if n.Mode == "bridge" && n.IsIPv6() {
+		//if n.Mode == "bridge" && n.IsIPv6() {
+		if n.IsIPv6() {
 			return "::"
 		}
 	}

--- a/command/asset/connect.nomad.hcl
+++ b/command/asset/connect.nomad.hcl
@@ -156,7 +156,7 @@ job "countdash" {
     #   config {
     #     image = "${meta.connect.sidecar_image}"
     #     args  = [
-    #      "-c", "${NOMAD_TASK_DIR}/bootstrap.json",
+    #      "-c", "${NOMAD_SECRETS_DIR}/envoy_bootstrap.json",
     #      "-l", "${meta.connect.log_level}"
     #     ]
     #   }

--- a/e2e/connect/input/demo.nomad
+++ b/e2e/connect/input/demo.nomad
@@ -1,6 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+variable "network_mode" {
+  default = "bridge"
+}
+
 job "countdash" {
   datacenters = ["dc1"]
 
@@ -11,7 +15,7 @@ job "countdash" {
 
   group "api" {
     network {
-      mode = "bridge"
+      mode = var.network_mode
     }
 
     service {
@@ -43,7 +47,7 @@ job "countdash" {
 
   group "dashboard" {
     network {
-      mode = "bridge"
+      mode = var.network_mode
 
       port "http" {
         static = 9002

--- a/e2e/terraform/packer/ubuntu-jammy-amd64/cni/nomad_bridge_copy.conflist
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/cni/nomad_bridge_copy.conflist
@@ -1,0 +1,39 @@
+{
+  "cniVersion": "1.0.0",
+  "name": "nomad-bridge-copy",
+  "plugins": [
+    {
+      "type": "loopback"
+    },
+    {
+      "type": "bridge",
+      "bridge": "nomad",
+      "ipMasq": true,
+      "isGateway": true,
+      "forceAddress": true,
+      "hairpinMode": false,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [{"subnet": "172.26.64.0/20"}]
+        ],
+        "routes": [
+          {"dst": "0.0.0.0/0"}
+        ],
+        "dataDir": "/var/run/cni"
+      }
+    },
+    {
+      "type": "firewall",
+      "backend": "iptables",
+      "iptablesAdminChainName": "NOMAD-ADMIN"
+    },
+    {
+      "type": "portmap",
+      "capabilities": {
+        "portMappings": true
+      },
+      "snat": true
+    }
+  ]
+}

--- a/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
@@ -109,6 +109,10 @@ sudo mv /tmp/linux/cni/loopback.* /opt/cni/config/
 sudo mv /tmp/linux/cni/cni_args.conflist /opt/cni/config/
 sudo mv /tmp/linux/cni/cni_args.sh /opt/cni/bin/
 
+echo "Installing additional CNI network configs"
+# copy of nomad's "bridge" for connect+cni test (e2e/connect/)
+sudo mv /tmp/linux/cni/nomad_bridge_copy.conflist /opt/cni/config/
+
 # Podman
 echo "Installing Podman"
 sudo apt-get -y install podman catatonit

--- a/nomad/job_endpoint_hook_expose_check.go
+++ b/nomad/job_endpoint_hook_expose_check.go
@@ -147,14 +147,12 @@ func tgValidateUseOfCheckExpose(tg *structs.TaskGroup) error {
 // namespaces).
 func tgValidateExposeNetworkMode(tg *structs.TaskGroup) (warn, err error) {
 	if tgUsesExposeCheck(tg) {
-		if len(tg.Networks) != 1 {
-			return nil, fmt.Errorf("group %q must specify one bridge network for exposing service check(s)", tg.Name)
+		warn, err = groupConnectNetworkModeValidate(tg, false)
+		if warn != nil {
+			warn = fmt.Errorf("connect expose check: %w", warn)
 		}
-		mode := tg.Networks[0].Mode
-		if strings.HasPrefix(mode, "cni/") {
-			warn = fmt.Errorf("group %q uses network mode %q for Consul Connect, instead of Nomad's bridge; use at your own risk", tg.Name, mode)
-		} else if mode != "bridge" {
-			err = fmt.Errorf("group %q must use bridge or CNI network for exposing service check(s)", tg.Name)
+		if err != nil {
+			err = fmt.Errorf("connect expose check: %w", err)
 		}
 	}
 	return warn, err

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -6317,7 +6317,7 @@ func TestJobEndpoint_ValidateJob_ConsulConnect(t *testing.T) {
 
 		err := validateJob(j)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), `Consul Connect sidecar requires bridge network, found "host" in group "web"`)
+		require.Contains(t, err.Error(), `group "web" must use bridge or CNI network for Consul Connect`)
 	})
 
 }

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -6293,6 +6293,18 @@ func TestJobEndpoint_ValidateJob_ConsulConnect(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("valid consul connect with cni", func(t *testing.T) {
+		j := mock.Job()
+
+		tg := j.TaskGroups[0]
+		tg.Services = tgServices
+		tg.Networks[0].Mode = "cni/test-net"
+
+		err := validateJob(j)
+		must.ErrorContains(t, err, "1 warning:")
+		must.ErrorContains(t, err, ErrConnectWithCNIWarning.Error())
+	})
+
 	t.Run("consul connect but missing network", func(t *testing.T) {
 		j := mock.Job()
 
@@ -6301,8 +6313,7 @@ func TestJobEndpoint_ValidateJob_ConsulConnect(t *testing.T) {
 		tg.Networks = nil
 
 		err := validateJob(j)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), `Consul Connect sidecars require exactly 1 network`)
+		must.ErrorContains(t, err, ErrConnectRequireOneNetwork.Error())
 	})
 
 	t.Run("consul connect but non bridge network", func(t *testing.T) {
@@ -6316,8 +6327,7 @@ func TestJobEndpoint_ValidateJob_ConsulConnect(t *testing.T) {
 		}
 
 		err := validateJob(j)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), `group "web" must use bridge or CNI network for Consul Connect`)
+		must.ErrorContains(t, err, ErrConnectInvalidNetworkMode.Error())
 	})
 
 }

--- a/website/content/docs/job-declare/consul-service-mesh.mdx
+++ b/website/content/docs/job-declare/consul-service-mesh.mdx
@@ -36,15 +36,17 @@ service-based access control permissions throughout the entire mesh.
 Nomad has native integration with Consul to provide service mesh capabilities.
 The [`connect`][] block is the entrypoint for all service mesh configuration.
 Nomad automatically deploys a sidecar proxy task to all allocations that have a
-[`sidecar_service`][] block.
+[`sidecar_service`][] block. All external traffic is provided by the sidecar.
 
 This proxy task is responsible for exposing the service to the mesh and can
 also be used to access other services from within the allocation. These
 external services are called upstreams and are declared using the
 [`upstreams`][] block.
 
-The allocation `network_mode` must be set to `bridge` for network isolation and
-all external traffic is provided by the sidecar.
+You must set the group's `network` [`mode`][] to `bridge`, or an appropriately
+configured `cni/*` network, for network isolation. Using a `cni/*` network
+with Consul Connect requires extra care. You may model your network
+configuration on Nomad's [`bridge` network][].
 
 ~> **Warning:** To fully isolate your workloads make sure to bind them only to
    the `loopback` interface.
@@ -167,4 +169,5 @@ The types of gateways provided by Consul Service Mesh are:
 [`upstreams`]: /nomad/docs/job-specification/upstreams
 [consul_cli_envoy]: /consul/commands/connect/envoy
 [runtime_network]: /nomad/docs/reference/runtime-environment-settings#network-related-variables
-
+[`mode`]: /nomad/docs/job-specification/network#mode
+[`bridge` network]: /nomad/docs/networking/cni#create-a-cni-bridge-mode-configuration


### PR DESCRIPTION
Currently, to use Consul Connect (service mesh), you must use `"bridge"` network mode.

We've kept it this way so we can be confident that Connect can actually... connect.

But it's entirely possible to configure your own CNI network (Nomad's "bridge" is just a CNI network, after all) to be compatible with Connect.  We just can't make guarantees about it, because CNI is highly configurable.

This PR opens up the validation to allow `"cni/*"` network modes in a "use at your own risk" capacity.

The CLI even presents a warning on job `plan`/`run` when your jobspec is so configured:

```
$ nomad plan connect-cni.nomad.hcl
...
Job Warnings:
3 warnings:

* connect sidecar: use CNI networks with Consul Connect at your own risk: group "api" uses network mode "cni/my-nomad"
* connect gateway: use CNI networks with Consul Connect at your own risk: group "ingress" uses network mode "cni/my-nomad"
* connect expose check: use CNI networks with Consul Connect at your own risk: group "api" uses network mode "cni/my-nomad"
...
```

Closes #8953 (from Sep 2020!)
Internal ref: [NMD-585](https://hashicorp.atlassian.net/browse/NMD-585)