### PR TITLE
docs: fix missing entry from template function_denylist

### DIFF
--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -506,10 +506,11 @@ refer to the [drivers documentation](/nomad/docs/job-declare/task-driver).
 
 ### `template` Parameters
 
-- `function_denylist` `([]string: ["plugin", "writeToFile"])` - Specifies a
-  list of template rendering functions that should be disallowed in job specs.
-  By default the `plugin` and `writeToFile` functions are disallowed as they
-  allow unrestricted root access to the host.
+- `function_denylist` `([]string: ["plugin", "executeTemplate",
+  "writeToFile"])` - Specifies a list of template rendering functions that
+  should be disallowed in job specs.  By default the `plugin`, `executeTemplate`
+  and `writeToFile` functions are disallowed as they allow unrestricted root
+  access to the host or allow recursive execution.
 
 - `disable_file_sandbox` `(bool: false)` - Allows templates access to arbitrary
   files on the client host via the `file` function. By default, templates can

--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -795,12 +795,13 @@ access it by index. This secret was set using
 The `template` block has the following [client configuration
 options](/nomad/docs/configuration/client#options):
 
-- `function_denylist` `([]string: ["plugin"])` - Specifies a list of template
-  rendering functions that should be disallowed in job specs. By default, the
-  `plugin` function is disallowed as it allows running arbitrary commands on the
-  host as root (unless Nomad is configured to run as a non-root user),
-  `executeTemplate` is disallowed to prevent accidental or malicious infinitely
-  recursive execution, and `writeToFile` is disallowed.
+- `function_denylist` `([]string: ["plugin", "executeTemplate",
+  "writeToFile"])` - Specifies a list of template rendering functions that
+  should be disallowed in job specs. By default, the `plugin` function is
+  disallowed as it allows running arbitrary commands on the host as root (unless
+  Nomad is configured to run as a non-root user), `executeTemplate` is
+  disallowed to prevent accidental or malicious infinitely recursive execution,
+  and `writeToFile` is disallowed.
 
 - `disable_file_sandbox` `(bool: false)` - Allows templates access to arbitrary
   files on the client host via the `file` function. By default, templates can


### PR DESCRIPTION
The docs for the `template` block accurately describe the template configuration default function denylist in the body but the default parameters are missing values. The equivalent docs in the `client` configuration are missing `executeTemplate` as well.
