### PR TITLE
auth: Build client introduction string for authenticated identity.

### DIFF
--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -933,3 +933,12 @@ func (n *NodeIntroductionIdentityClaims) LoggingPairs() []any {
 
 	return pairs
 }
+
+// String returns a string representation of the node introduction identity
+// claims.
+func (n *NodeIntroductionIdentityClaims) String() string {
+	if n.NodeName == "" {
+		return n.NodePool
+	}
+	return n.NodePool + ":" + n.NodeName
+}

--- a/nomad/structs/node_test.go
+++ b/nomad/structs/node_test.go
@@ -306,7 +306,7 @@ func TestNodeIdentityClaims_LoggingPairs(t *testing.T) {
 		claims.NodeIdentityClaims.LoggingPairs(),
 	)
 }
-  
+
 func TestNodeRegisterRequest_Validate(t *testing.T) {
 	ci.Parallel(t)
 
@@ -953,4 +953,28 @@ func TestNodeIntroductionIdentityClaims_LoggingPairs(t *testing.T) {
 		"claim_node_name", "node-name-1",
 		"claim_node_pool", "custom-pool",
 	}, claims.LoggingPairs())
+}
+
+func TestNodeIntroductionIdentityClaims_string(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("empty node name", func(t *testing.T) {
+
+		claims := &NodeIntroductionIdentityClaims{
+			NodeName: "",
+			NodePool: "custom-pool",
+		}
+
+		must.Eq(t, "custom-pool", claims.String())
+	})
+
+	t.Run("non-empty node name", func(t *testing.T) {
+
+		claims := &NodeIntroductionIdentityClaims{
+			NodeName: "node-name-1",
+			NodePool: "custom-pool",
+		}
+
+		must.Eq(t, "custom-pool:node-name-1", claims.String())
+	})
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -555,6 +555,9 @@ func (ai *AuthenticatedIdentity) String() string {
 	if ai.Claims != nil && ai.Claims.IsNode() {
 		return "client:" + ai.Claims.NodeID
 	}
+	if ai.Claims != nil && ai.Claims.IsNodeIntroduction() {
+		return "client-introduction:" + ai.Claims.NodeIntroductionIdentityClaims.String()
+	}
 	return ai.TLSName + ":" + ai.RemoteIP.String()
 }
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -280,6 +280,29 @@ func TestAuthenticatedIdentity_String(t *testing.T) {
 			},
 			expectedOutput: "my-testing-tls-name:192.168.135.232",
 		},
+		{
+			name: "client introduction node pool",
+			inputAuthenticatedIdentity: &AuthenticatedIdentity{
+				Claims: &IdentityClaims{
+					NodeIntroductionIdentityClaims: &NodeIntroductionIdentityClaims{
+						NodePool: "my-testing-node-pool",
+					},
+				},
+			},
+			expectedOutput: "client-introduction:my-testing-node-pool",
+		},
+		{
+			name: "client introduction node pool and name",
+			inputAuthenticatedIdentity: &AuthenticatedIdentity{
+				Claims: &IdentityClaims{
+					NodeIntroductionIdentityClaims: &NodeIntroductionIdentityClaims{
+						NodeName: "my-testing-node-name",
+						NodePool: "my-testing-node-pool",
+					},
+				},
+			},
+			expectedOutput: "client-introduction:my-testing-node-pool:my-testing-node-name",
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
When emitting rate metrics, we use the identity string within the labels to better describe the caller. If the register RPC uses an introduction identity, we can correctly detail this.

### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
