### PR TITLE
security: bypass scan for GO-2025-3829

### DIFF
--- a/.release/security-scan.hcl
+++ b/.release/security-scan.hcl
@@ -31,7 +31,7 @@ binary {
       vulnerabilities = [
         "GO-2022-0635", // github.com/aws/aws-sdk-go@v1.55.6 TODO(jrasell): remove when dep updated.
         "GO-2025-3543", // github.com/opencontainers/runc    TODO(jrasell): remove once withdrawn from DBs.
-        "GO-2025-3829", https://github.com/moby/moby/releases/tag/v28.3.3 TODO(tgross): remove once verified, updated or withdrawn https://pkg.go.dev/vuln/GO-2025-3829
+        "GO-2025-3829", // https://github.com/moby/moby/releases/tag/v28.3.3 TODO(tgross): remove once verified, updated or withdrawn https://pkg.go.dev/vuln/GO-2025-3829
       ]
     }
   }


### PR DESCRIPTION
This report is unverified by upstream and has no release fixing it. In any case, this problem with firewalld doesn't impact Nomad's use of the dependency as a library, only the uses of it in `dockerd`. Bypass it from our scans for now.

Ref: https://github.com/moby/moby/releases/tag/v28.3.3
Ref: https://pkg.go.dev/vuln/GO-2025-3829
