### PR TITLE
[landlock] Allow read access for random content

### DIFF
--- a/client/allocrunner/taskrunner/getter/util_linux.go
+++ b/client/allocrunner/taskrunner/getter/util_linux.go
@@ -89,6 +89,7 @@ func additionalFilesForVCS() []*landlock.Path {
 		gitGlobalFile  = "/etc/gitconfig"           // https://git-scm.com/docs/git-config#SCOPES
 		hgGlobalFile   = "/etc/mercurial/hgrc"      // https://www.mercurial-scm.org/doc/hgrc.5.html#files
 		hgGlobalDir    = "/etc/mercurial/hgrc.d"    // https://www.mercurial-scm.org/doc/hgrc.5.html#files
+		urandom        = "/dev/urandom"             // git
 	)
 	return filesForVCS(
 		homeSSHDir,
@@ -98,6 +99,7 @@ func additionalFilesForVCS() []*landlock.Path {
 		gitGlobalFile,
 		hgGlobalFile,
 		hgGlobalDir,
+		urandom,
 	)
 }
 
@@ -108,7 +110,8 @@ func filesForVCS(
 	etcKnownHosts,
 	gitGlobalFile,
 	hgGlobalFile,
-	hgGlobalDir string) []*landlock.Path {
+	hgGlobalDir,
+	urandom string) []*landlock.Path {
 
 	// omit ssh if there is no home directory
 	home := findHomeDir()
@@ -142,6 +145,9 @@ func filesForVCS(
 	}
 	if exists(hgGlobalDir) {
 		result = append(result, landlock.Dir(hgGlobalDir, "r"))
+	}
+	if exists(urandom) {
+		result = append(result, landlock.File(urandom, "r"))
 	}
 	return result
 }

--- a/client/allocrunner/taskrunner/getter/util_linux_test.go
+++ b/client/allocrunner/taskrunner/getter/util_linux_test.go
@@ -23,6 +23,7 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 
 	fakeEtc := t.TempDir()
 	fakeHome := t.TempDir()
+	fakeDev := t.TempDir()
 
 	homedir.DisableCache = true
 	t.Cleanup(func() {
@@ -44,6 +45,7 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 		etcKnownHosts  = filepath.Join(fakeEtc, "ssh/ssh_known_hosts")
 		sshDir         = filepath.Join(fakeHome, homeSSH)
 		knownHostsFile = filepath.Join(fakeHome, homeKnownHosts)
+		urandom        = filepath.Join(fakeDev, "urandom")
 	)
 
 	err := os.WriteFile(gitConfig, []byte("git"), filePerm)
@@ -70,6 +72,9 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 	err = os.WriteFile(knownHostsFile, []byte("home known hosts"), filePerm)
 	must.NoError(t, err)
 
+	err = os.WriteFile(urandom, []byte("urandom"), filePerm)
+	must.NoError(t, err)
+
 	paths := filesForVCS(
 		homeSSH,
 		homeKnownHosts,
@@ -78,6 +83,7 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 		gitConfig,
 		hgFile,
 		hgDir,
+		urandom,
 	)
 	must.SliceEqual(t, []*landlock.Path{
 		landlock.Dir(sshDir, "r"),
@@ -87,5 +93,6 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 		landlock.File(gitConfig, "r"),
 		landlock.File(hgFile, "r"),
 		landlock.Dir(hgDir, "r"),
+		landlock.File(urandom, "r"),
 	}, paths)
 }


### PR DESCRIPTION
### Description

When attempting to clone a git repository within a sandbox that is
configured with landlock, the clone will fail with error messages
related to inability to get random bytes for a temporary file.
Including a read rule for `/dev/urandom` resolves the error
and the git clone works as expected.

### Links

Old report: #16899
Fixes #25912

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
