### PR TITLE
test: add task validation when using vault secret provider

### DIFF
--- a/client/allocrunner/taskrunner/secrets/nomad_provider.go
+++ b/client/allocrunner/taskrunner/secrets/nomad_provider.go
@@ -13,6 +13,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+const SecretProviderNomad = "nomad"
+
 type nomadProviderConfig struct {
 	Namespace string `mapstructure:"namespace"`
 }

--- a/client/allocrunner/taskrunner/secrets/vault_provider.go
+++ b/client/allocrunner/taskrunner/secrets/vault_provider.go
@@ -14,6 +14,8 @@ import (
 )
 
 const (
+	SecretProviderVault = "vault"
+
 	VAULT_KV    = "kv"
 	VAULT_KV_V2 = "kv_v2"
 )

--- a/client/allocrunner/taskrunner/secrets_hook.go
+++ b/client/allocrunner/taskrunner/secrets_hook.go
@@ -185,13 +185,13 @@ func (h *secretsHook) buildSecretProviders(secretDir string) ([]TemplateProvider
 
 		tmplFile := fmt.Sprintf("temp-%d", idx)
 		switch s.Provider {
-		case "nomad":
+		case secrets.SecretProviderNomad:
 			if p, err := secrets.NewNomadProvider(s, secretDir, tmplFile, h.nomadNamespace); err != nil {
 				multierror.Append(mErr, err)
 			} else {
 				tmplProvider = append(tmplProvider, p)
 			}
-		case "vault":
+		case secrets.SecretProviderVault:
 			if p, err := secrets.NewVaultProvider(s, secretDir, tmplFile); err != nil {
 				multierror.Append(mErr, err)
 			} else {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8329,6 +8329,10 @@ func (t *Task) Validate(jobType string, tg *TaskGroup) error {
 			secrets[s.Name] = true
 		}
 
+		if s.Provider == "vault" && t.Vault == nil {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("Secret %q has provider \"vault\" but no vault block", s.Name))
+		}
+
 		if err := s.Validate(); err != nil {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Secret %q is invalid: %w", s.Name, err))
 		}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -219,6 +219,9 @@ const (
 	RateMetricRead  = "read"
 	RateMetricList  = "list"
 	RateMetricWrite = "write"
+
+	// Vault secret provider used in task validation
+	SecretProviderVault = "vault"
 )
 
 var (
@@ -8329,7 +8332,7 @@ func (t *Task) Validate(jobType string, tg *TaskGroup) error {
 			secrets[s.Name] = true
 		}
 
-		if s.Provider == "vault" && t.Vault == nil {
+		if s.Provider == SecretProviderVault && t.Vault == nil {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Secret %q has provider \"vault\" but no vault block", s.Name))
 		}
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
Adds task level validation that requires users to have a vault block if they are using the vault secrets provider.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
