### PR TITLE
Docs: Add 1.10.4 release notes

### DIFF
--- a/website/content/commands/operator/debug.mdx
+++ b/website/content/commands/operator/debug.mdx
@@ -54,16 +54,16 @@ true.
 - `-log-include-location`: Include file and line information in each log line
   monitored. The default is `true`.
 
-- `log-file-export`: Include agents' Nomad logfiles in the debug capture.
+- `-log-file-export`: Include agents' Nomad logfiles in the debug capture.
   The historical log export monitor runs concurrently with the log monitor
   and ignores the `-log-level` and `-log-include-location` flags used to
   configure that monitor. Nomad will return an error if the agent does not
   have file logging configured. Cannot be used with `-log-lookback`.
 
-- `log-lookback`: Include historical journald logs in the debug capture. The
+- `-log-lookback`: Include historical journald logs in the debug capture. The
   journald export monitor runs concurrently with the log monitor and ignores
   the `-log-level` and `-log-include-location` flags passed to that monitor.
-  This flag is only available on Linux systems using systemd, see the 
+  This flag is only available on Linux systems using systemd, see the
   `-log-file-export` flag to retrieve historical logs from non-Linux systems,
   or those without systemd. Cannot be used with `-log-file-export`.
 

--- a/website/content/docs/release-notes/nomad/v1-10-x.mdx
+++ b/website/content/docs/release-notes/nomad/v1-10-x.mdx
@@ -15,7 +15,7 @@ We are pleased to announce the following Nomad updates.
 ### Nomad logs and journald output
 
 We have added functionality that enables you to retrieve journald output or the
-contents of the Nomad log file.
+contents of the Nomad log file remotely using the CLI.
 
 #### New monitor export command
 
@@ -46,8 +46,13 @@ Review the [server metrics in the Metrics reference](/nomad/docs/reference/metri
 ### Sentinel policy scope for CSI volumes <EnterpriseAlert inline />
 
 We added a new `submit-csi-volume` Sentinel policy scope, which lets you apply
-Sentinel policies to CSI volume creation and registration. You may also override
-any mandatory polices assigned to CSI volume creation and registration.
+Sentinel policies to CSI volume creation and registration.
+
+You may override `soft-mandatory` polices assigned to CSI volume creation and
+registration, but you may not override `hard-mandatory` policies. Refer to the
+[`EnforcementLevel`
+parameter](/nomad/api-docs/sentinel-policies#enforcementlevel) in the Sentinel
+Policies API for `soft-mandatory` and `hard-mandatory` definitions.
 
 Refer to the following documentation:
 
@@ -56,7 +61,7 @@ Refer to the following documentation:
   - [submit-csi-volume
     scope](/nomad/docs/reference/sentinel-policy#submit-csi-volume-scope)
   - [Sentinel CSI Volume
-    Objects](/nomad/docs/reference/sentinel-policy#submit-csi-volume-scope)
+    Objects](/nomad/docs/reference/sentinel-policy#sentinel-csi-volume-objects)
 
 - Volumes API reference
 


### PR DESCRIPTION
### Description

- Add 1.10.4 release highlights to 1.10.x release notes page. I used the items in the changelog's Improvements section and then enhanced with additional text and links to relevant docs.
- Add missing "-" to nomad operator debug log-lookback and log-file-export parms

**Note that the scope for this PR is only 1.10.4 updates.**

### Links

Jira: [CE-1009]

https://nomad-git-ce1009relnotes-hashicorp.vercel.app/nomad/docs/release-notes/nomad/v1-10-x

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[CE-1009]: https://hashicorp.atlassian.net/browse/CE-1009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ