### PR TITLE
docs: cni: add tproxy conflist example

### DIFF
--- a/website/content/docs/networking/cni.mdx
+++ b/website/content/docs/networking/cni.mdx
@@ -78,14 +78,14 @@ network](/img/nomad-bridge-network.png)](/img/nomad-bridge-network.png)
 
 When setting up a bridge network, Nomad uses a configuration template based on
 the CNI Specification's [example
-configuration](https://www.cni.dev/docs/spec/#example-configuration). Refer to
-the external [configuration
-format](https://www.cni.dev/docs/spec/#example-configuration) for a complete
-explanation of the fields.
+configuration](https://www.cni.dev/docs/spec/#example-configuration).
+Refer to that documentation for a complete explanation of the fields.
 
-You can use the following template as a basis for your own CNI-based bridge
+You can use the following templates as a basis for your own CNI-based bridge
 network configuration in cases where you need access to an unsupported option
 in the default configuration.
+
+### Configuration files
 
 <Tabs>
   <Tab heading="Default">
@@ -150,8 +150,8 @@ The `NOMAD-ADMIN` internal constant provides the value for
   </Tab>
   <Tab heading="IPv6">
 
-If you [configure IPv6][] to use the example range of `2001:db8::/112`,
-Nomad adds two more lines to the configuration.
+If you [configure IPv6][] on the Nomad client agent using the example range
+`2001:db8::/112`, Nomad adds two more lines to the configuration.
 
 <CodeBlockConfig highlight="19,23">
 
@@ -192,6 +192,66 @@ Nomad adds two more lines to the configuration.
       "type": "portmap",
       "capabilities": {"portMappings": true},
       "snat": true
+    }
+  ]
+}
+```
+
+</CodeBlockConfig>
+
+  </Tab>
+  <Tab heading="Transparent Proxy">
+
+Jobs that use the
+[`transparent_proxy`](/nomad/docs/job-specification/transparent_proxy)
+block add a `consul-cni` plugin to the bottom of the CNI configuration.
+
+Refer to the
+[transparent proxy](/nomad/docs/networking/consul/service-mesh#transparent-proxy)
+section of Nomad's Consul service mesh documentation to ensure that
+the node is configured correctly for this feature.
+
+<CodeBlockConfig highlight="36-39">
+
+```json
+{
+  "cniVersion": "1.0.0",
+  "name": "nomad",
+  "plugins": [
+    {
+      "type": "loopback"
+    },
+    {
+      "type": "bridge",
+      "bridge": "nomad",
+      "ipMasq": true,
+      "isGateway": true,
+      "forceAddress": true,
+      "hairpinMode": false,
+      "ipam": {
+        "type": "host-local",
+        "ranges": [
+          [{"subnet": "172.26.64.0/20"}]
+        ],
+        "routes": [
+          {"dst": "0.0.0.0/0"}
+        ],
+        "dataDir": "/var/run/cni"
+      }
+    },
+    {
+      "type": "firewall",
+      "backend": "iptables",
+      "iptablesAdminChainName": "NOMAD-ADMIN"
+    },
+    {
+      "type": "portmap",
+      "capabilities": {"portMappings": true},
+      "snat": true
+    },
+    {
+      "type": "consul-cni",
+      "log_level": "debug"
     }
   ]
 }


### PR DESCRIPTION
#26456 documented more variations to Nomad's "bridge" CNI network configuration.

This adds transparent proxy for Consul service mesh to the tab list.

Preview link: https://nomad-git-docs-cni-tproxy-hashicorp.vercel.app/nomad/docs/networking/cni#configuration-files