### PR TITLE
sysbatch: fix panic from reschedule block

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -202,7 +202,7 @@ func (r *ReschedulePolicy) Merge(rp *ReschedulePolicy) {
 }
 
 func (r *ReschedulePolicy) Canonicalize(jobType string) {
-	if r == nil || jobType == JobTypeSystem || jobType == JobTypeSysbatch {
+	if r == nil {
 		return
 	}
 	dp := NewDefaultReschedulePolicy(jobType)
@@ -289,6 +289,8 @@ func NewDefaultReschedulePolicy(jobType string) *ReschedulePolicy {
 		// GH-7203: it is possible an unknown job type is passed to this
 		// function and we need to ensure a non-nil object is returned so that
 		// the canonicalization runs without panicking.
+		// This also applies to batch/sysbatch jobs, which do not reschedule;
+		// we still want to return a safe object.
 		dp = &ReschedulePolicy{
 			Attempts:      pointerOf(0),
 			Interval:      pointerOf(time.Duration(0)),

--- a/e2e/docker_registry/registry-auths.hcl
+++ b/e2e/docker_registry/registry-auths.hcl
@@ -46,10 +46,6 @@ job "registry-auths" {
   }
 
   group "create-files" {
-    reschedule {
-      attempts  = 0
-      unlimited = false
-    }
 
     # write out the test.sh file into var.helper_dir
     task "create-helper-file" {

--- a/e2e/docker_registry/registry.hcl
+++ b/e2e/docker_registry/registry.hcl
@@ -28,11 +28,6 @@ job "registry" {
       min_healthy_time = "4s"
     }
 
-    reschedule {
-      attempts  = 0
-      unlimited = false
-    }
-
     restart {
       attempts = 0
       mode     = "fail"

--- a/e2e/metrics/input/setup.hcl
+++ b/e2e/metrics/input/setup.hcl
@@ -10,10 +10,6 @@ job "setup-podman-auth" {
   }
 
   group "create-files" {
-    reschedule {
-      attempts  = 0
-      unlimited = false
-    }
 
     restart {
       attempts = 0

--- a/e2e/v3/jobs3/jobs3.go
+++ b/e2e/v3/jobs3/jobs3.go
@@ -236,6 +236,7 @@ type Cleanup func()
 
 func Submit(t *testing.T, filename string, opts ...Option) (*Submission, Cleanup) {
 	t.Helper()
+	t.Logf("submitting job: %q", filename)
 	sub := initialize(t, filename)
 
 	for _, opt := range opts {


### PR DESCRIPTION
commit 279775082c3aa43828faa7e0d22b15561d36ce68 (pr #26279) intended to return an error for sysbatch jobs with a reschedule block, but in bypassing populating the `ReschedulePolicy`'s pointer fields, a nil pointer panic occurred before the job could get rejected with the desired error.

this surfaced as "EOF" API call errors in some e2e tests (the http server panics, so the connection is dropped).

in particular, in `command/agent/job_endpoint.go`, `func ApiTgToStructsTG`,

```
if taskGroup.ReschedulePolicy != nil {
	tg.ReschedulePolicy = &structs.ReschedulePolicy{
		Attempts:      *taskGroup.ReschedulePolicy.Attempts,
		Interval:      *taskGroup.ReschedulePolicy.Interval,
```

`*taskGroup.ReschedulePolicy.Interval` was a nil pointer.

---

repro job:

```hcl
job "j" {
  type = "sysbatch"
  group "g" {
    reschedule {
      attempts  = 0
      unlimited = false
    }
    task "t" {
      driver = "raw_exec"
      config {
        command = "sh"
        args    = ["-c", "echo hello"]
      }
    }
  }
}
```

correct error with this patch:

```
$ nomad run sysbatch-reschedule.nomad.hcl 
Error submitting job: Unexpected response code: 500 (1 error occurred:
	* Task group g validation failed: 1 error occurred:
	* System or sysbatch jobs should not have a reschedule policy)
```

error from job runner's POV without this patch:

```
$ nomad run sysbatch-reschedule.nomad.hcl 
Error submitting job: Put "http://127.0.0.1:4646/v1/jobs": EOF
```

error in nomad agent:

```
[ERROR] http: http: panic serving 127.0.0.1:53496: runtime error: invalid memory address or nil pointer dereference
goroutine 1492 [running]:
net/http.(*conn).serve.func1()
	net/http/server.go:1947 +0xbe
panic({0x3110be0?, 0x5e77e00?})
	runtime/panic.go:792 +0x132
github.com/hashicorp/nomad/command/agent.ApiTgToStructsTG(0xc000cdc248, 0xc0003af200, 0xc00087ec60)
	github.com/hashicorp/nomad/command/agent/job_endpoint.go:1258 +0x619
github.com/hashicorp/nomad/command/agent.ApiJobToStructJob(0xc0013dc820)
	github.com/hashicorp/nomad/command/agent/job_endpoint.go:1225 +0xcca
github.com/hashicorp/nomad/command/agent.(*HTTPServer).apiJobAndRequestToStructs(0xc000634bd0, 0xc0013dc820, 0xc0012be280, {{0x0, 0x0}, {0x0, 0x0}, {0x0, 0x0}})
	github.com/hashicorp/nomad/command/agent/job_endpoint.go:1056 +0x2bd
github.com/hashicorp/nomad/command/agent.(*HTTPServer).jobUpdate(0xc000634bd0, {0x405c010, 0xc000ef6fc0}, 0xc0012be280, {0x0, 0x0})
	github.com/hashicorp/nomad/command/agent/job_endpoint.go:599 +0x47e
github.com/hashicorp/nomad/command/agent.(*HTTPServer).JobsRequest(0xc000bad898?, {0x405c010?, 0xc000ef6fc0?}, 0x4fa833?)
	github.com/hashicorp/nomad/command/agent/job_endpoint.go:35 +0x6d
github.com/hashicorp/nomad/command/agent.(*HTTPServer).registerHandlers.(*HTTPServer).wrap.func2({0x405c010, 0xc000ef6fc0}, 0xc0012be280)
	github.com/hashicorp/nomad/command/agent/http.go:728 +0x168
... etc ...
```