### PR TITLE
docs: revert to labels={"foo.bar": "baz"} style

### DIFF
--- a/drivers/docker/config_test.go
+++ b/drivers/docker/config_test.go
@@ -4,6 +4,7 @@
 package docker
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
@@ -193,160 +194,8 @@ config {
 func TestConfig_ParseAllHCL(t *testing.T) {
 	ci.Parallel(t)
 
-	cfgStr := `
-config {
-  image = "redis:7"
-  image_pull_timeout = "15m"
-  advertise_ipv6_address = true
-  args = ["command_arg1", "command_arg2"]
-  auth {
-    username = "myusername"
-    password = "mypassword"
-    email = "myemail@example.com"
-    server_address = "https://example.com"
-  }
-
-  auth_soft_fail = true
-  cap_add = ["CAP_SYS_NICE"]
-  cap_drop = ["CAP_SYS_ADMIN", "CAP_SYS_TIME"]
-  command = "/bin/bash"
-  container_exists_attempts = 10
-  cgroupns = "host"
-  cpu_hard_limit = true
-  cpu_cfs_period = 20
-  devices = [
-    {"host_path"="/dev/null", "container_path"="/tmp/container-null", cgroup_permissions="rwm"},
-    {"host_path"="/dev/random", "container_path"="/tmp/container-random"},
-    {"host_path"="/dev/bus/usb"},
-  ]
-  dns_search_domains = ["sub.example.com", "sub2.example.com"]
-  dns_options = ["debug", "attempts:10"]
-  dns_servers = ["8.8.8.8", "1.1.1.1"]
-  entrypoint = ["/bin/bash", "-c"]
-  extra_hosts = ["127.0.0.1  localhost.example.com"]
-  force_pull = true
-  group_add = ["group1", "group2"]
-  healthchecks {
-    disable = true
-  }
-  hostname = "self.example.com"
-  interactive = true
-  ipc_mode = "host"
-  ipv4_address = "10.0.2.1"
-  ipv6_address = "2601:184:407f:b37c:d834:412e:1f86:7699"
-  labels {
-    owner = "hashicorp-nomad"
-    key = "val"
-  }
-  load = "/tmp/image.tar.gz"
-  logging {
-    driver = "json-file-driver"
-    type   = "json-file"
-    config {
-      "max-file" = "3"
-      "max-size" = "10m"
-    }
-  }
-  mac_address = "02:42:ac:11:00:02"
-  memory_hard_limit = 512
-
-  mount {
-    type = "bind"
-    target ="/mount-bind-target"
-    source = "/bind-source-mount"
-    readonly = true
-    bind_options {
-      propagation = "rshared"
-    }
-  }
-
-  mount {
-    type = "tmpfs"
-    target ="/mount-tmpfs-target"
-    readonly = true
-    tmpfs_options {
-      size = 30000
-      mode = 0777
-    }
-  }
-
-  mounts = [
-    {
-      type = "bind"
-      target = "/bind-target",
-      source = "/bind-source"
-      readonly = true
-      bind_options {
-        propagation = "rshared"
-      }
-    },
-    {
-      type = "tmpfs"
-      target = "/tmpfs-target",
-      readonly = true
-      tmpfs_options {
-        size = 30000
-        mode = 0777
-      }
-    },
-    {
-      type = "volume"
-      target = "/volume-target"
-      source = "/volume-source"
-      readonly = true
-      volume_options {
-        no_copy = true
-        labels {
-          label_key = "label_value"
-	}
-        driver_config {
-          name = "nfs"
-          options {
-            option_key = "option_value"
-          }
-        }
-      }
-    },
-  ]
-  network_aliases = ["redis"]
-  network_mode = "host"
-  oom_score_adj = 1000
-  pids_limit = 2000
-	pid_mode = "host"
-	ports = ["http", "https"]
-  port_map {
-    http = 80
-    redis = 6379
-  }
-  privileged = true
-  readonly_rootfs = true
-  runtime = "runc"
-  security_opt = [
-    "credentialspec=file://gmsaUser.json"
-  ],
-  shm_size = 30000
-  storage_opt {
-    dm.thinpooldev = "dev/mapper/thin-pool"
-    dm.use_deferred_deletion = "true"
-    dm.use_deferred_removal = "true"
-
-  }
-  sysctl {
-    net.core.somaxconn = "16384"
-  }
-  tty = true
-  ulimit {
-    nproc = "4242"
-    nofile = "2048:4096"
-  }
-  uts_mode = "host"
-  userns_mode = "host"
-  volumes = [
-    "/host-path:/container-path:rw",
-  ]
-  volume_driver = "host"
-  work_dir = "/tmp/workdir"
-}`
+	cfgStr, err := os.ReadFile("testdata/TestConfig_ParseAllHCL.hcl")
+	must.NoError(t, err)
 
 	expected := &TaskConfig{
 		AdvertiseIPv6Addr: true,
@@ -398,8 +247,9 @@ config {
 		IPv4Address:      "10.0.2.1",
 		IPv6Address:      "2601:184:407f:b37c:d834:412e:1f86:7699",
 		Labels: map[string]string{
-			"owner": "hashicorp-nomad",
-			"key":   "val",
+			"owner":       "hashicorp-nomad",
+			"key":         "val",
+			"dotted.keys": "work",
 		},
 		LoadImage: "/tmp/image.tar.gz",
 		Logging: DockerLogging{
@@ -460,7 +310,8 @@ config {
 				VolumeOptions: DockerVolumeOptions{
 					NoCopy: true,
 					Labels: map[string]string{
-						"label_key": "label_value",
+						"label_key":   "label_value",
+						"dotted.keys": "always work",
 					},
 					DriverConfig: DockerVolumeDriverConfig{
 						Name: "nfs",
@@ -511,7 +362,7 @@ config {
 	}
 
 	var tc *TaskConfig
-	hclutils.NewConfigParser(taskConfigSpec).ParseHCL(t, cfgStr, &tc)
+	hclutils.NewConfigParser(taskConfigSpec).ParseHCL(t, string(cfgStr), &tc)
 
 	require.EqualValues(t, expected, tc)
 }

--- a/drivers/docker/testdata/TestConfig_ParseAllHCL.hcl
+++ b/drivers/docker/testdata/TestConfig_ParseAllHCL.hcl
@@ -1,0 +1,155 @@
+config {
+  image                  = "redis:7"
+  image_pull_timeout     = "15m"
+  advertise_ipv6_address = true
+  args                   = ["command_arg1", "command_arg2"]
+  auth {
+    username       = "myusername"
+    password       = "mypassword"
+    email          = "myemail@example.com"
+    server_address = "https://example.com"
+  }
+
+  auth_soft_fail            = true
+  cap_add                   = ["CAP_SYS_NICE"]
+  cap_drop                  = ["CAP_SYS_ADMIN", "CAP_SYS_TIME"]
+  command                   = "/bin/bash"
+  container_exists_attempts = 10
+  cgroupns                  = "host"
+  cpu_hard_limit            = true
+  cpu_cfs_period            = 20
+  devices = [
+    { "host_path" = "/dev/null", "container_path" = "/tmp/container-null", cgroup_permissions = "rwm" },
+    { "host_path" = "/dev/random", "container_path" = "/tmp/container-random" },
+    { "host_path" = "/dev/bus/usb" },
+  ]
+  dns_search_domains = ["sub.example.com", "sub2.example.com"]
+  dns_options        = ["debug", "attempts:10"]
+  dns_servers        = ["8.8.8.8", "1.1.1.1"]
+  entrypoint         = ["/bin/bash", "-c"]
+  extra_hosts        = ["127.0.0.1  localhost.example.com"]
+  force_pull         = true
+  group_add          = ["group1", "group2"]
+  healthchecks {
+    disable = true
+  }
+  hostname     = "self.example.com"
+  interactive  = true
+  ipc_mode     = "host"
+  ipv4_address = "10.0.2.1"
+  ipv6_address = "2601:184:407f:b37c:d834:412e:1f86:7699"
+  labels = {
+    owner         = "hashicorp-nomad"
+    key           = "val"
+    "dotted.keys" = "work"
+  }
+  load = "/tmp/image.tar.gz"
+  logging {
+    driver = "json-file-driver"
+    type   = "json-file"
+    config {
+      "max-file" = "3"
+      "max-size" = "10m"
+    }
+  }
+  mac_address       = "02:42:ac:11:00:02"
+  memory_hard_limit = 512
+
+  mount {
+    type     = "bind"
+    target   = "/mount-bind-target"
+    source   = "/bind-source-mount"
+    readonly = true
+    bind_options {
+      propagation = "rshared"
+    }
+  }
+
+  mount {
+    type     = "tmpfs"
+    target   = "/mount-tmpfs-target"
+    readonly = true
+    tmpfs_options {
+      size = 30000
+      mode = 0777
+    }
+  }
+
+  mounts = [
+    {
+      type     = "bind"
+      target   = "/bind-target",
+      source   = "/bind-source"
+      readonly = true
+      bind_options {
+        propagation = "rshared"
+      }
+    },
+    {
+      type     = "tmpfs"
+      target   = "/tmpfs-target",
+      readonly = true
+      tmpfs_options {
+        size = 30000
+        mode = 0777
+      }
+    },
+    {
+      type     = "volume"
+      target   = "/volume-target"
+      source   = "/volume-source"
+      readonly = true
+      volume_options {
+        no_copy = true
+        labels = {
+          label_key = "label_value"
+          "dotted.keys" = "always work"
+        }
+        driver_config {
+          name = "nfs"
+          options {
+            option_key = "option_value"
+          }
+        }
+      }
+    },
+  ]
+  network_aliases = ["redis"]
+  network_mode    = "host"
+  oom_score_adj   = 1000
+  pids_limit      = 2000
+  pid_mode        = "host"
+  ports           = ["http", "https"]
+  port_map {
+    http  = 80
+    redis = 6379
+  }
+  privileged      = true
+  readonly_rootfs = true
+  runtime         = "runc"
+  security_opt = [
+    "credentialspec=file://gmsaUser.json"
+  ],
+  shm_size = 30000
+  storage_opt {
+    dm.thinpooldev           = "dev/mapper/thin-pool"
+    dm.use_deferred_deletion = "true"
+    dm.use_deferred_removal  = "true"
+
+  }
+  sysctl {
+    net.core.somaxconn = "16384"
+  }
+  tty = true
+  ulimit {
+    nproc  = "4242"
+    nofile = "2048:4096"
+  }
+  uts_mode    = "host"
+  userns_mode = "host"
+  volumes = [
+    "/host-path:/container-path:rw",
+  ]
+  volume_driver = "host"
+  work_dir      = "/tmp/workdir"
+}

--- a/drivers/docker/testdata/TestConfig_ParseAllHCL.hcl
+++ b/drivers/docker/testdata/TestConfig_ParseAllHCL.hcl
@@ -105,7 +105,7 @@ config {
       volume_options {
         no_copy = true
         labels = {
-          label_key = "label_value"
+          label_key     = "label_value"
           "dotted.keys" = "always work"
         }
         driver_config {

--- a/drivers/docker/testdata/TestConfig_ParseAllHCL.hcl
+++ b/drivers/docker/testdata/TestConfig_ParseAllHCL.hcl
@@ -1,3 +1,6 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
 config {
   image                  = "redis:7"
   image_pull_timeout     = "15m"

--- a/website/content/docs/job-declare/task-driver/docker.mdx
+++ b/website/content/docs/job-declare/task-driver/docker.mdx
@@ -27,7 +27,7 @@ task "webservice" {
 
   config {
     image = "redis:7"
-    labels {
+    labels = {
       group = "webservice-cache"
     }
   }
@@ -222,25 +222,10 @@ The `docker` driver supports the following configuration in the job spec. Only
 
   ```hcl
   config {
-    labels {
+    labels = {
       foo = "bar"
-      zip = "zap"
+      "quote.dotted.keys" = "zap"
     }
-  }
-  ```
-
-  A more verbose syntax must be used to specify labels with keys that require
-  quoting. For example DataDog's autodiscovery mechanism looks for labels with
-  dots in the key which must be quoted:
-
-  ```hcl
-  config {
-    labels = [
-      {
-        "com.datadoghq.ad.check_names"  =  "[\"openmetrics\"]"
-        "com.datadoghq.ad.init_configs" = "[{}]"
-      }
-    ]
   }
   ```
 
@@ -430,7 +415,7 @@ The `docker` driver supports the following configuration in the job spec. Only
       readonly = false
       volume_options {
         no_copy = false
-        labels {
+        labels = {
           foo = "bar"
         }
         driver_config {


### PR DESCRIPTION
Back in #24074 I thought it was necessary to wrap labels in a list to support quoted keys in hcl2. This... doesn't appear to be true at all? The simpler `labels={...}` syntax appears to work just fine.

I updated the docs and a test (and modernized it a bit). I also switched some other examples to the `labels = {}` format from the old `labels{}` format.

### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
