### PR TITLE
adjusting pr template for PCI compliance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -33,3 +33,13 @@ merged.
   history should be preserved.
 - [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
   within the public repository. 
+
+
+<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
+
+- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.
+
+## Changes to Security Controls
+
+Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
+


### PR DESCRIPTION
### Description
Change is for PCI required metadata in PR's. Modified to look more like Terraform community PR template.
