### PR TITLE
scheduler: avoid importing the Planner test harness in scheduler calls

### DIFF
--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -2064,7 +2064,7 @@ func (n *nomadFSM) reconcileQueuedAllocations(index uint64) error {
 		if job.IsParameterized() || job.IsPeriodic() {
 			continue
 		}
-		planner := &sstructs.Plan{
+		planner := &sstructs.PlanBuilder{
 			State: &snap.StateStore,
 		}
 		// Create an eval and mark it as requiring annotations and insert that as well

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1894,7 +1894,7 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 
 	// Create an in-memory Planner that returns no errors and stores the
 	// submitted plan and created evals.
-	planner := &sstructs.Plan{
+	planner := &sstructs.PlanBuilder{
 		State: &snap.StateStore,
 	}
 

--- a/scheduler/tests/testing.go
+++ b/scheduler/tests/testing.go
@@ -48,16 +48,16 @@ func (r *RejectPlan) ReblockEval(*structs.Evaluation) error {
 type Harness struct {
 	t testing.TB
 
-	*sstructs.Plan
+	*sstructs.PlanBuilder
 }
 
 // NewHarness is used to make a new testing harness
 func NewHarness(t testing.TB) *Harness {
 	state := state.TestStateStore(t)
-	plan := sstructs.NewPlanWithSateAndIndex(state, 1, true)
+	plan := sstructs.NewPlanWithStateAndIndex(state, 1, true)
 	h := &Harness{
-		t:    t,
-		Plan: plan,
+		t:           t,
+		PlanBuilder: plan,
 	}
 	return h
 }
@@ -65,10 +65,10 @@ func NewHarness(t testing.TB) *Harness {
 // NewHarnessWithState creates a new harness with the given state for testing
 // purposes.
 func NewHarnessWithState(t testing.TB, state *state.StateStore) *Harness {
-	plan := sstructs.NewPlanWithSateAndIndex(state, 1, false)
+	plan := sstructs.NewPlanWithStateAndIndex(state, 1, false)
 	return &Harness{
-		t:    t,
-		Plan: plan,
+		t:           t,
+		PlanBuilder: plan,
 	}
 }
 


### PR DESCRIPTION
For a while now, we've had only 2 implementations of the [`Planner` interface](https://github.com/hashicorp/nomad/blob/main/scheduler/structs/interfaces.go#L108-L133) in Nomad: one was the [`Worker`](https://github.com/hashicorp/nomad/blob/main/nomad/worker.go#L92-L125), and the other was [the scheduler test harness](https://github.com/hashicorp/nomad/blob/main/scheduler/tests/testing.go#L52-L72), which was then used as argument to the scheduler constructors in FSM and job endpoint RPC. That's not great, and one of the [recent refactors](https://github.com/hashicorp/nomad/pull/26031) made it apparent that we're importing testing code in places we really shouldn't. We finally got [called out](https://github.com/hashicorp/nomad/issues/26542) for it, and this PR attempts to remedy the situation by splitting the `Harness` into `Plan` (which contains actual plan submission logic) and separating it from testing code. 

Fixes #26542 