### PR TITLE
ci: Run hclogvet across all codebase and fix found issue.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -34,6 +34,14 @@ ifndef NOMAD_NO_UI
 GO_TAGS := ui $(GO_TAGS)
 endif
 
+# Some Go tools require the tags to be a comma-separated list. Perform a
+# substitution from the space to a comma and create a new variable, so we can
+# use both
+null  :=
+space := $(null) #
+comma := ,
+GO_TAGS_COMMA := $(subst $(space),$(comma),$(strip $(GO_TAGS)))
+
 #GOTEST_GROUP is set in CI pipelines. We have to set it for local run.
 ifndef GOTEST_GROUP
 GOTEST_GROUP := nomad client command drivers quick
@@ -163,7 +171,7 @@ check: ## Lint the source code
 	@cd ./api && golangci-lint run --config ../.golangci.yml --build-tags "$(GO_TAGS)"
 
 	@echo "==> Linting hclog statements..."
-	@hclogvet .
+	@GOFLAGS="-tags=$(GO_TAGS_COMMA)" hclogvet ./...
 
 	@echo "==> Spell checking website..."
 	@misspell -error -source=text website/content/

--- a/command/agent/monitor/export_monitor.go
+++ b/command/agent/monitor/export_monitor.go
@@ -238,7 +238,7 @@ func (d *ExportMonitor) Start() <-chan []byte {
 		for {
 			n, readErr := d.ExportReader.Read(logChunk)
 			if readErr != nil && readErr != io.EOF {
-				d.logger.Error("unable to read logs into channel", readErr.Error())
+				d.logger.Error("unable to read logs into channel", "error", readErr.Error())
 				return
 			}
 


### PR DESCRIPTION
### Description
I've finally figured out how to correctly run hclogvet across all our code, not just the subset. This change updates our makefile to perform that action with the addition of a new Go tag format to make this possible. While this only has a single use case currently, I plan to also use this with a future PR around modernising aspects of the Go code. 

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 
