### PR TITLE
test: Deflake client agent endpoint test.

### DIFF
--- a/nomad/client_agent_endpoint_test.go
+++ b/nomad/client_agent_endpoint_test.go
@@ -841,7 +841,9 @@ func TestAgentHost_Server(t *testing.T) {
 
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
+	testutil.WaitForKeyring(t, s1.RPC, s1.Region())
 	testutil.WaitForLeader(t, s2.RPC)
+	testutil.WaitForKeyring(t, s2.RPC, s2.Region())
 
 	// determine leader and nonleader
 	servers := []*Server{s1, s2}
@@ -865,8 +867,8 @@ func TestAgentHost_Server(t *testing.T) {
 	defer cleanupC()
 
 	testutil.WaitForResult(func() (bool, error) {
-		nodes := s2.connectedNodes()
-		return len(nodes) == 1, nil
+		numNodes := len(s1.connectedNodes()) + len(s2.connectedNodes())
+		return numNodes == 1, nil
 	}, func(err error) {
 		t.Fatalf("should have a clients")
 	})


### PR DESCRIPTION
This test has been failing regularly on our release branches and passes after a re-run. Running 100 times locally with this change:
```console
$ go test ./nomad -run TestAgentHost_Server -count 100
ok  	github.com/hashicorp/nomad/nomad	58.496s
```

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

