### PR TITLE
namespace: Avoid potential panic when logging namespace name.

### DIFF
--- a/nomad/namespace_endpoint.go
+++ b/nomad/namespace_endpoint.go
@@ -305,7 +305,7 @@ func (n *Namespace) namespaceNoAssociatedVarsLocally(namespace string, snap *sta
 func (n *Namespace) namespaceNoAssociatedQuotasLocally(namespace string, snap *state.StateSnapshot) (bool, error) {
 	ns, _ := snap.NamespaceByName(nil, namespace)
 	if ns == nil {
-		return false, fmt.Errorf("namespace %s does not exist", ns.Name)
+		return false, fmt.Errorf("namespace %s does not exist", namespace)
 	}
 	if ns.Quota != "" {
 		return false, nil


### PR DESCRIPTION
When the namespace was not found in state, indicated by a nil object, we were using the name field of the nil object for the return error.

This code path does not currently get triggered as the call flow ensures the namespace will always be found within state. Make this change makes sure we do not hit this panic in the future.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

