### PR TITLE
Docs Chore: Change CLI overview pages usage to use plaintext code block

### DIFF
--- a/website/content/commands/acl/index.mdx
+++ b/website/content/commands/acl/index.mdx
@@ -17,7 +17,9 @@ requires that ACLs have been bootstrapped in the authoritative region.
 
 ## Usage
 
-Usage: `nomad acl <subcommand> [options]`
+```plaintext
+nomad acl <subcommand> [options]
+```
 
 Run `nomad acl <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/alloc/index.mdx
+++ b/website/content/commands/alloc/index.mdx
@@ -11,7 +11,9 @@ The `alloc` command is used to interact with allocations.
 
 ## Usage
 
-Usage: `nomad alloc <subcommand> [options]`
+```plaintext
+nomad alloc <subcommand> [options]
+```
 
 Run `nomad alloc <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/config/index.mdx
+++ b/website/content/commands/config/index.mdx
@@ -11,7 +11,9 @@ The `config` command is used to interact with configurations.
 
 ## Usage
 
-Usage: `nomad config <subcommand> [options]`
+```plaintext
+nomad config <subcommand> [options]
+```
 
 Run `nomad config <subcommand> -h` for help on that subcommand. The
 following subcommands are available:

--- a/website/content/commands/deployment/index.mdx
+++ b/website/content/commands/deployment/index.mdx
@@ -11,7 +11,9 @@ The `deployment` command is used to interact with deployments.
 
 ## Usage
 
-Usage: `nomad deployment <subcommand> [options]`
+```plaintext
+nomad deployment <subcommand> [options]
+```
 
 Run `nomad deployment <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/eval/index.mdx
+++ b/website/content/commands/eval/index.mdx
@@ -11,7 +11,9 @@ The `eval` command is used to interact with evals.
 
 ## Usage
 
-Usage: `nomad eval <subcommand> [options]`
+```plaintext
+nomad eval <subcommand> [options]
+```
 
 Run `nomad eval <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/job/index.mdx
+++ b/website/content/commands/job/index.mdx
@@ -11,7 +11,9 @@ The `job` command is used to interact with jobs.
 
 ## Usage
 
-Usage: `nomad job <subcommand> [options]`
+```plaintext
+nomad job <subcommand> [options]
+```
 
 Run `nomad job <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/job/tag/index.mdx
+++ b/website/content/commands/job/tag/index.mdx
@@ -13,7 +13,9 @@ Use the `job tag` command to manage tags for job versions.
 
 ## Usage
 
-Usage: `nomad job tag <subcommand> [options] [args]`
+```plaintext
+nomad job tag <subcommand> [options] [args]
+```
 
 `job tag` has the following subcommands:
 

--- a/website/content/commands/license/index.mdx
+++ b/website/content/commands/license/index.mdx
@@ -14,7 +14,9 @@ server, or inspect and validate a license.
 
 ## Usage
 
-Usage: `nomad license <subcommand> [options]`
+```plaintext
+nomad license <subcommand> [options]
+```
 
 Run `nomad license <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/namespace/index.mdx
+++ b/website/content/commands/namespace/index.mdx
@@ -13,7 +13,9 @@ Visit [Create and use namespaces](/nomad/docs/govern/namespaces) for more inform
 
 ## Usage
 
-Usage: `nomad namespace <subcommand> [options]`
+```plaintext
+nomad namespace <subcommand> [options]
+```
 
 Run `nomad namespace <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/node-pool/index.mdx
+++ b/website/content/commands/node-pool/index.mdx
@@ -11,7 +11,9 @@ The `node pool` command is used to interact with node pools.
 
 ## Usage
 
-Usage: `nomad node pool <subcommand> [options]`
+```plaintext
+nomad node pool <subcommand> [options]
+```
 
 Run `nomad node pool <subcommand> -h` for help on that subcommand. The
 following subcommands are available:

--- a/website/content/commands/node/index.mdx
+++ b/website/content/commands/node/index.mdx
@@ -11,7 +11,9 @@ The `node` command is used to interact with nodes.
 
 ## Usage
 
-Usage: `nomad node <subcommand> [options]`
+```plaintext
+nomad node <subcommand> [options]
+```
 
 Run `nomad node <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/node/meta/index.mdx
+++ b/website/content/commands/node/meta/index.mdx
@@ -12,7 +12,9 @@ available for [interpolation using the `${meta.<key>}` syntax in jobs][interp].
 
 ## Usage
 
-Usage: `nomad node meta <subcommand> [options]`
+```plaintext
+nomad node meta <subcommand> [options]
+```
 
 The `apply` subcommand allows for dynamically updating node metadata. The
 `read` subcommand allows reading all of the metadata set on the client. All

--- a/website/content/commands/operator/index.mdx
+++ b/website/content/commands/operator/index.mdx
@@ -19,7 +19,9 @@ documentation for the [Operator] endpoint.
 
 ## Usage
 
-Usage: `nomad operator <subcommand> <subcommand> [options]`
+```plaintext
+nomad operator <subcommand> <subcommand> [options]
+```
 
 Run `nomad operator <subcommand>` with no arguments for help on that subcommand.
 The following subcommands are available:

--- a/website/content/commands/plugin/index.mdx
+++ b/website/content/commands/plugin/index.mdx
@@ -13,7 +13,9 @@ Storage Interface (CSI)][csi] plugins.
 
 ## Usage
 
-Usage: `nomad plugin <subcommand> [options]`
+```plaintext
+nomad plugin <subcommand> [options]
+```
 
 Run `nomad plugin <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/quota/index.mdx
+++ b/website/content/commands/quota/index.mdx
@@ -13,7 +13,9 @@ The `quota` command is used to interact with quota specifications.
 
 ## Usage
 
-Usage: `nomad quota <subcommand> [options]`
+```plaintext
+nomad quota <subcommand> [options]
+```
 
 Run `nomad quota <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/recommendation/index.mdx
+++ b/website/content/commands/recommendation/index.mdx
@@ -13,7 +13,9 @@ The `recommendation` command is used to interact with recommendations.
 
 ## Usage
 
-Usage: `nomad recommendation <subcommand> [options]`
+```plaintext
+nomad recommendation <subcommand> [options]
+```
 
 Run `nomad recommendation <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/scaling/index.mdx
+++ b/website/content/commands/scaling/index.mdx
@@ -11,7 +11,9 @@ The `scaling` command is used to interact with the scaling API.
 
 ## Usage
 
-Usage: `nomad scaling <subcommand> [options]`
+```plaintext
+nomad scaling <subcommand> [options]
+```
 
 Run `nomad scaling <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/sentinel/index.mdx
+++ b/website/content/commands/sentinel/index.mdx
@@ -13,7 +13,9 @@ The `sentinel` command is used to interact with Sentinel policies.
 
 ## Usage
 
-Usage: `nomad sentinel <subcommand> [options]`
+```plaintext
+nomad sentinel <subcommand> [options]
+```
 
 Run `nomad sentinel <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/server/index.mdx
+++ b/website/content/commands/server/index.mdx
@@ -13,7 +13,9 @@ The `server` command is used to interact with servers.
 
 ## Usage
 
-Usage: `nomad server <subcommand> [options]`
+```plaintext
+nomad server <subcommand> [options]
+```
 
 Run `nomad server <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/service/index.mdx
+++ b/website/content/commands/service/index.mdx
@@ -11,7 +11,9 @@ The `service` command is used to interact with the service API.
 
 ## Usage
 
-Usage: `nomad service <subcommand> [options]`
+```plaintext
+nomad service <subcommand> [options]
+```
 
 Run `nomad service <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/setup/index.mdx
+++ b/website/content/commands/setup/index.mdx
@@ -19,7 +19,9 @@ versions of Nomad.
 
 ## Usage
 
-Usage: `nomad setup <subcommand> [options]`
+```plaintext
+nomad setup <subcommand> [options]
+```
 
 Run `nomad setup <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/system/index.mdx
+++ b/website/content/commands/system/index.mdx
@@ -12,7 +12,9 @@ used for system maintenance and should not be necessary for most users.
 
 ## Usage
 
-Usage: `nomad system <subcommand> [options]`
+```plaintext
+nomad system <subcommand> [options]
+```
 
 Run `nomad system <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/tls/cert-create.mdx
+++ b/website/content/commands/tls/cert-create.mdx
@@ -14,7 +14,9 @@ configuration of the agents.
 
 ## Usage
 
-Usage: `nomad tls cert create [options]`
+```plaintext
+nomad tls cert create [options]
+```
 
 ## Options
 

--- a/website/content/commands/tls/index.mdx
+++ b/website/content/commands/tls/index.mdx
@@ -11,7 +11,9 @@ The `tls` command is used to help with setting up a self signed CA and certifica
 
 ## Usage
 
-Usage: `nomad tls <subcommand> <subcommand> [options]`
+```plaintext
+nomad tls <subcommand> <subcommand> [options]
+```
 
 Run `nomad tls <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/var/index.mdx
+++ b/website/content/commands/var/index.mdx
@@ -11,7 +11,9 @@ The `var` command is used to interact with Nomad [variables].
 
 ## Usage
 
-Usage: `nomad var <subcommand> [options] [args]`
+```plaintext
+nomad var <subcommand> [options] [args]
+```
 
 Run `nomad var <subcommand> -h` for help on that subcommand. The following
 subcommands are available:

--- a/website/content/commands/volume/index.mdx
+++ b/website/content/commands/volume/index.mdx
@@ -11,7 +11,9 @@ The `volume` command is used to interact with volumes.
 
 ## Usage
 
-Usage: `nomad volume <subcommand> [options]`
+```plaintext
+nomad volume <subcommand> [options]
+```
 
 Run `nomad volume <subcommand> -h` for help on that subcommand. The following
 subcommands are available:


### PR DESCRIPTION
### Description

- Over pages, Usage section: change to use plaintext code block, which is what the individual command pages use.

### Links

Jira: [CE-1008]

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

