### PR TITLE
e2e: install exec2 driver v0.1.0

### DIFF
--- a/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
@@ -127,7 +127,7 @@ sudo chmod +x /usr/local/bin/pledge
 
 # Exec2
 echo "Installing Exec2 Driver"
-sudo hc-install install --path ${NOMAD_PLUGIN_DIR} --version v0.1.0-alpha.2 nomad-driver-exec2
+sudo hc-install install --path ${NOMAD_PLUGIN_DIR} --version v0.1.0 nomad-driver-exec2
 sudo chmod +x ${NOMAD_PLUGIN_DIR}/nomad-driver-exec2
 
 # Envoy


### PR DESCRIPTION
#26558 removed explicit unveils of `NOMAD_SECRETS_DIR`, assuming that we installed a version of `exec2` that did that automatically, but it (the PR, not me!) was wrong!

the e2e errors that surface from this are not very direct, so we may wish to improve exec2's reporting of such problems, but I believe this will fix these two tests:

```
=== FAIL: e2e/exec2 TestExec2/testSecretsDir (2.84s)
    exec2_test.go:48: submitting job: "./input/secrets.hcl"
    jobs3.go:487: 
        jobs3.go:487: expected not to execute this code path
        ↪ PostScript | annotation ↷
        	group "group" allocation 53f0e477-28c8-fe94-93db-c6d5f665b257 failed
    jobs3.go:652: tg 'group' alloc status 'failed': Failed tasks
    jobs3.go:658: tg 'group' task 'password' event: Task received by client
    jobs3.go:658: tg 'group' task 'password' event: Building Task Directory
    jobs3.go:658: tg 'group' task 'password' event: Task started by client
    jobs3.go:658: tg 'group' task 'password' event: Exit Code: 1
    jobs3.go:658: tg 'group' task 'password' event: Policy allows no restarts

=== FAIL: e2e/exec2 TestExec2/testCountdash (20.81s)
    exec2_test.go:65: submitting job: "./input/countdash.hcl"
    jobs3.go:422: 
        jobs3.go:422: expected not to execute this code path
        ↪ PostScript | annotation ↷
        	timeout reached waiting for deployment
    jobs3.go:652: tg 'api' alloc status 'running': Tasks are running
    jobs3.go:652: tg 'dashboard' alloc status 'running': Tasks are running
    jobs3.go:658: tg 'api' task 'connect-proxy-count-api' event: Task received by client
    jobs3.go:658: tg 'api' task 'connect-proxy-count-api' event: Building Task Directory
    jobs3.go:658: tg 'api' task 'connect-proxy-count-api' event: Task started by client
    jobs3.go:658: tg 'api' task 'connect-proxy-count-api' event: Exit Code: 1
    jobs3.go:658: tg 'api' task 'connect-proxy-count-api' event: Task restarting in 18.174391286s
    jobs3.go:658: tg 'dashboard' task 'dashboard' event: Task received by client
    jobs3.go:658: tg 'dashboard' task 'dashboard' event: Building Task Directory
    jobs3.go:658: tg 'dashboard' task 'dashboard' event: Downloading image
    jobs3.go:658: tg 'dashboard' task 'dashboard' event: Task started by client
```