### PR TITLE
scheduler: fix debug-level logging for node reconciler

### DIFF
--- a/scheduler/reconciler/reconcile_node.go
+++ b/scheduler/reconciler/reconcile_node.go
@@ -332,14 +332,14 @@ type NodeReconcileResult struct {
 
 func (d *NodeReconcileResult) Fields() []any {
 	fields := []any{
-		"ignore", d.Ignore,
-		"place", d.Place,
-		"update", d.Update,
-		"stop", d.Stop,
-		"migrate", d.Migrate,
-		"lost", d.Lost,
-		"disconnecting", d.Disconnecting,
-		"reconnecting", d.Reconnecting,
+		"ignore", len(d.Ignore),
+		"place", len(d.Place),
+		"update", len(d.Update),
+		"stop", len(d.Stop),
+		"migrate", len(d.Migrate),
+		"lost", len(d.Lost),
+		"disconnecting", len(d.Disconnecting),
+		"reconnecting", len(d.Reconnecting),
 	}
 
 	return fields

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -688,7 +688,7 @@ func inplaceUpdate(ctx feasible.Context, eval *structs.Evaluation, job *structs.
 	}
 
 	if len(updates) > 0 {
-		ctx.Logger().Debug("made in-place updates", "in-place", inplaceCount, "total_updates", len(updates))
+		ctx.Logger().Debug("made updates", "in-place", inplaceCount, "total_updates", len(updates))
 	}
 	return updates[:n], updates[n:]
 }


### PR DESCRIPTION
In #26169 we started emitting structured logs from the reconciler. But the node reconciler results are `AllocTuple` structs and not counts, so the information we put in the logs ends up being pointer addresses in hex. Fix this so that we're recording the number of allocs in each bucket instead.

Fix another misleading log-line while we're here.

Ref: https://github.com/hashicorp/nomad/pull/26169