### PR TITLE
E2E: allow setting instance_type variable

### DIFF
--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -19,5 +19,6 @@ module "provision-infra" {
   consul_license                         = var.consul_license
   nomad_region                           = var.nomad_region
   instance_arch                          = var.instance_arch
+  instance_type                          = var.instance_type
   name                                   = var.name
 }


### PR DESCRIPTION
When we refactored the E2E provisioning to allow it to be reused by the upgrade testing, we didn't thread the `instance_type` variable from the main module down into the `provision-infra` module. This prevents you from setting a custom instance size when deploying the E2E cluster manually.