### PR TITLE
[artifact] add artifact inspection after download

### DIFF
--- a/.changelog/26608.txt
+++ b/.changelog/26608.txt
@@ -1,0 +1,3 @@
+```release-note:security
+client: inspect artifacts for sandbox escape when landlock is unavailable
+```

--- a/client/allocrunner/taskrunner/getter/params.go
+++ b/client/allocrunner/taskrunner/getter/params.go
@@ -31,6 +31,7 @@ type parameters struct {
 	S3Timeout                     time.Duration `json:"s3_timeout"`
 	DecompressionLimitFileCount   int           `json:"decompression_limit_file_count"`
 	DecompressionLimitSize        int64         `json:"decompression_limit_size"`
+	DisableArtifactInspection     bool          `json:"disable_artifact_inspection"`
 	DisableFilesystemIsolation    bool          `json:"disable_filesystem_isolation"`
 	FilesystemIsolationExtraPaths []string      `json:"filesystem_isolation_extra_paths"`
 	SetEnvironmentVariables       string        `json:"set_environment_variables"`
@@ -99,6 +100,8 @@ func (p *parameters) Equal(o *parameters) bool {
 	case p.DecompressionLimitFileCount != o.DecompressionLimitFileCount:
 		return false
 	case p.DecompressionLimitSize != o.DecompressionLimitSize:
+		return false
+	case p.DisableArtifactInspection != o.DisableArtifactInspection:
 		return false
 	case p.DisableFilesystemIsolation != o.DisableFilesystemIsolation:
 		return false

--- a/client/allocrunner/taskrunner/getter/params_test.go
+++ b/client/allocrunner/taskrunner/getter/params_test.go
@@ -24,6 +24,7 @@ const paramsAsJSON = `
   "s3_timeout": 5000000000,
   "decompression_limit_file_count": 3,
   "decompression_limit_size": 98765,
+  "disable_artifact_inspection": false,
   "disable_filesystem_isolation": true,
   "filesystem_isolation_extra_paths": [
     "f:r:/dev/urandom",

--- a/client/allocrunner/taskrunner/getter/sandbox.go
+++ b/client/allocrunner/taskrunner/getter/sandbox.go
@@ -52,6 +52,7 @@ func (s *Sandbox) Get(env interfaces.EnvReplacer, artifact *structs.TaskArtifact
 		S3Timeout:                     s.ac.S3Timeout,
 		DecompressionLimitFileCount:   s.ac.DecompressionLimitFileCount,
 		DecompressionLimitSize:        s.ac.DecompressionLimitSize,
+		DisableArtifactInspection:     s.ac.DisableArtifactInspection,
 		DisableFilesystemIsolation:    s.ac.DisableFilesystemIsolation,
 		FilesystemIsolationExtraPaths: s.ac.FilesystemIsolationExtraPaths,
 		SetEnvironmentVariables:       s.ac.SetEnvironmentVariables,

--- a/client/allocrunner/taskrunner/getter/sandbox_test.go
+++ b/client/allocrunner/taskrunner/getter/sandbox_test.go
@@ -4,9 +4,12 @@
 package getter
 
 import (
+	"fmt"
 	"net/http"
+	"net/http/cgi"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -108,4 +111,127 @@ func TestSandbox_Get_chown(t *testing.T) {
 
 	uid := info.Sys().(*syscall.Stat_t).Uid
 	must.Eq(t, 65534, uid) // nobody's conventional uid
+}
+
+func TestSandbox_Get_inspection(t *testing.T) {
+	// These tests disable filesystem isolation as the
+	// artifact inspection is what is being tested.
+	testutil.RequireRoot(t)
+	logger := testlog.HCLogger(t)
+
+	// Create a temporary directory directly so the repos
+	// don't end up being found improperly
+	tdir, err := os.MkdirTemp("", "nomad-test")
+	must.NoError(t, err, must.Sprint("failed to create top level local repo directory"))
+
+	t.Run("symlink escaped sandbox", func(t *testing.T) {
+		dir, err := os.MkdirTemp(tdir, "fake-repo")
+		must.NoError(t, err, must.Sprint("failed to create local repo directory"))
+		must.NoError(t, os.Symlink("/", filepath.Join(dir, "bad-file")), must.Sprint("could not create symlink in local repo"))
+		srv := makeAndServeGitRepo(t, dir)
+
+		artifact := &structs.TaskArtifact{
+			RelativeDest: "local/symlink",
+			GetterSource: fmt.Sprintf("git::%s/%s", srv.URL, filepath.Base(dir)),
+		}
+
+		t.Run("default", func(t *testing.T) {
+			ac := artifactConfig(10 * time.Second)
+			sbox := New(ac, logger)
+
+			_, taskDir := SetupDir(t)
+			env := noopTaskEnv(taskDir)
+			sbox.ac.DisableFilesystemIsolation = true
+
+			err := sbox.Get(env, artifact, "nobody")
+			must.ErrorIs(t, err, ErrSandboxEscape)
+		})
+
+		t.Run("DisableArtifactInspection", func(t *testing.T) {
+			ac := artifactConfig(10 * time.Second)
+			sbox := New(ac, logger)
+
+			_, taskDir := SetupDir(t)
+			env := noopTaskEnv(taskDir)
+			sbox.ac.DisableFilesystemIsolation = true
+			sbox.ac.DisableArtifactInspection = true
+
+			err := sbox.Get(env, artifact, "nobody")
+			must.NoError(t, err)
+		})
+	})
+
+	t.Run("symlink within sandbox", func(t *testing.T) {
+		dir, err := os.MkdirTemp(tdir, "fake-repo")
+		must.NoError(t, err, must.Sprint("failed to create local repo"))
+		// create a file to link to
+		f, err := os.Create(filepath.Join(dir, "test-file"))
+		must.NoError(t, err, must.Sprint("could not create test file in local repo"))
+		f.Close()
+		// move into local repo to create relative link
+		wd, err := os.Getwd()
+		must.NoError(t, err, must.Sprint("cannot determine working directory"))
+		must.NoError(t, os.Chdir(dir))
+		must.NoError(t, os.Symlink(filepath.Base(f.Name()), "good-file"), must.Sprint("could not create symlink in local repo"))
+		must.NoError(t, os.Chdir(wd))
+
+		// now serve the repo
+		srv := makeAndServeGitRepo(t, dir)
+
+		artifact := &structs.TaskArtifact{
+			RelativeDest: "local/symlink",
+			GetterSource: fmt.Sprintf("git::%s/%s", srv.URL, filepath.Base(dir)),
+		}
+
+		ac := artifactConfig(10 * time.Second)
+		sbox := New(ac, logger)
+
+		_, taskDir := SetupDir(t)
+		env := noopTaskEnv(taskDir)
+		sbox.ac.DisableFilesystemIsolation = true
+
+		err = sbox.Get(env, artifact, "nobody")
+		must.NoError(t, err)
+	})
+}
+
+func makeAndServeGitRepo(t *testing.T, repoPath string) *httptest.Server {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	must.NoError(t, err, must.Sprint("could not determine working directory"))
+	must.NoError(t, os.Chdir(repoPath), must.Sprint("failed to change into repository directory"))
+	defer func() { must.NoError(t, os.Chdir(wd), must.Sprint("failed to return to working directory")) }()
+
+	git, err := exec.LookPath("git")
+	must.NoError(t, err, must.Sprint("could not locate git executable"))
+
+	cmd := exec.Command("git", "init", ".")
+	must.NoError(t, cmd.Run(), must.Sprint("cannot init git repository"))
+
+	cmd = exec.Command("git", "config", "user.email", "user@example.com")
+	must.NoError(t, cmd.Run(), must.Sprint("cannot configure git repository"))
+
+	cmd = exec.Command("git", "config", "user.name", "test user")
+	must.NoError(t, cmd.Run(), must.Sprint("cannot configure git repository"))
+
+	cmd = exec.Command("git", "add", "--all")
+	must.NoError(t, cmd.Run(), must.Sprint("could not add files to git repository"))
+
+	cmd = exec.Command("git", "commit", "-m", "test commit")
+	must.NoError(t, cmd.Run(), must.Sprint("cannot commit git repository content"))
+
+	handler := &cgi.Handler{
+		Path: git,
+		Args: []string{"http-backend"},
+		Env: []string{
+			"GIT_HTTP_EXPORT_ALL=true",
+			fmt.Sprintf("GIT_PROJECT_ROOT=%s", filepath.Dir(repoPath)),
+		},
+	}
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	return srv
 }

--- a/client/allocrunner/taskrunner/getter/testing.go
+++ b/client/allocrunner/taskrunner/getter/testing.go
@@ -33,6 +33,7 @@ func TestSandbox(t *testing.T) *Sandbox {
 func SetupDir(t *testing.T) (string, string) {
 	allocDir := t.TempDir()
 	taskDir := filepath.Join(allocDir, "local")
+	tmpDir := filepath.Join(taskDir, "tmp")
 	topDir := filepath.Dir(allocDir)
 
 	must.NoError(t, os.Chmod(topDir, 0o755))
@@ -41,5 +42,8 @@ func SetupDir(t *testing.T) (string, string) {
 
 	must.NoError(t, os.Mkdir(taskDir, 0o755))
 	must.NoError(t, os.Chmod(taskDir, 0o755))
+	must.NoError(t, os.Mkdir(tmpDir, 0o755))
+	must.NoError(t, os.Chmod(tmpDir, 0o755))
+
 	return allocDir, taskDir
 }

--- a/client/allocrunner/taskrunner/getter/util_default.go
+++ b/client/allocrunner/taskrunner/getter/util_default.go
@@ -9,6 +9,11 @@ import (
 	"path/filepath"
 )
 
+// lockdown is not available by default
+func lockdownAvailable() bool {
+	return false
+}
+
 // lockdown is not implemented by default
 func lockdown(string, string, []string) error {
 	return nil

--- a/client/allocrunner/taskrunner/getter/util_linux.go
+++ b/client/allocrunner/taskrunner/getter/util_linux.go
@@ -46,6 +46,12 @@ func defaultEnvironment(taskDir string) map[string]string {
 	}
 }
 
+// lockdownAvailable returns if lockdown is implemented for
+// the current platform.
+func lockdownAvailable() bool {
+	return landlock.Available()
+}
+
 // lockdown isolates this process to only be able to write and
 // create files in the task's task directory.
 // dir - the task directory

--- a/client/allocrunner/taskrunner/getter/util_windows.go
+++ b/client/allocrunner/taskrunner/getter/util_windows.go
@@ -11,6 +11,11 @@ import (
 )
 
 // lockdown is not implemented on Windows
+func lockdownAvailable() bool {
+	return false
+}
+
+// lockdown is not implemented on Windows
 func lockdown(string, string, []string) error {
 	return nil
 }

--- a/client/config/artifact.go
+++ b/client/config/artifact.go
@@ -26,6 +26,7 @@ type ArtifactConfig struct {
 	DecompressionLimitFileCount int
 	DecompressionLimitSize      int64
 
+	DisableArtifactInspection     bool
 	DisableFilesystemIsolation    bool
 	FilesystemIsolationExtraPaths []string
 	SetEnvironmentVariables       string
@@ -78,6 +79,7 @@ func ArtifactConfigFromAgent(c *config.ArtifactConfig) (*ArtifactConfig, error) 
 		S3Timeout:                     s3Timeout,
 		DecompressionLimitFileCount:   *c.DecompressionFileCountLimit,
 		DecompressionLimitSize:        int64(decompressionSizeLimit),
+		DisableArtifactInspection:     *c.DisableArtifactInspection,
 		DisableFilesystemIsolation:    *c.DisableFilesystemIsolation,
 		FilesystemIsolationExtraPaths: slices.Clone(c.FilesystemIsolationExtraPaths),
 		SetEnvironmentVariables:       *c.SetEnvironmentVariables,

--- a/website/content/docs/configuration/client.mdx
+++ b/website/content/docs/configuration/client.mdx
@@ -488,6 +488,11 @@ refer to the [drivers documentation](/nomad/docs/job-declare/task-driver).
   of files that will be decompressed before triggering an error and cancelling the
   operation. Set to `0` to not enforce a limit.
 
+- `disable_artifact_inspection` `(bool: false)` - Specifies whether to disable
+  artifact inspection for sandbox escapes. If the platform supports filesystem
+  isolation, and it is not disabled, artifact inspection will not be performed
+  regardless of this value.
+
 - `disable_filesystem_isolation` `(bool: false)` - Specifies whether filesystem
   isolation should be disabled for artifact downloads. Applies only to systems
   where filesystem isolation via [landlock] is possible (Linux kernel 5.13+).


### PR DESCRIPTION
### Description

This adds artifact inspection after download to detect any issues
with the content fetched. Currently this means checking for any
symlinks within the artifact that resolve outside the task or
allocation directories. On platforms where lockdown is available
(some Linux) this inspection is not performed.

The inspection can be disabled with the DisableArtifactInspection
option. A dedicated option for disabling this behavior allows
the DisableFilesystemIsolation option to be enabled but still
have artifacts inspected after download.

### Links

[SECVULN-12425](https://hashicorp.atlassian.net/browse/SECVULN-12425)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.



[SECVULN-12425]: https://hashicorp.atlassian.net/browse/SECVULN-12425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ