### PR TITLE
scheduler: correct handling of MaxParallel and obsoleting Stagger in the system scheduler

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5322,6 +5322,9 @@ var (
 type UpdateStrategy struct {
 	// Stagger is used to determine the rate at which allocations are migrated
 	// due to down or draining nodes.
+	//
+	// Deprecated: as of Nomad 1.11, this field is equivalent to MinHealthyTime
+	// and will be removed in future releases.
 	Stagger time.Duration
 
 	// MaxParallel is how many updates can be done in parallel

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -191,7 +191,7 @@ func (s *SystemScheduler) process() (bool, error) {
 	// If the limit of placements was reached we need to create an evaluation
 	// to pickup from here after the stagger period.
 	if s.limitReached && s.nextEval == nil {
-		s.nextEval = s.eval.NextRollingEval(s.job.Update.Stagger)
+		s.nextEval = s.eval.NextRollingEval(s.job.Update.MinHealthyTime)
 		if err := s.planner.CreateEval(s.nextEval); err != nil {
 			s.logger.Error("failed to make next eval for rolling update", "error", err)
 			return false, err


### PR DESCRIPTION
As per RFC-216, `Stagger` setting is basically `MinHealthyTime` now, and will be obsoleted in the future. 

Targets the feature branch f-system-deployments.

Internal ref: https://hashicorp.atlassian.net/browse/NMD-891