### PR TITLE
agent: Ensure node identity renew handler decodes the request body.

### DIFF
--- a/command/agent/node_identity_endpoint.go
+++ b/command/agent/node_identity_endpoint.go
@@ -47,8 +47,20 @@ func (s *HTTPServer) NodeIdentityGetRequest(resp http.ResponseWriter, req *http.
 }
 
 func (s *HTTPServer) NodeIdentityRenewRequest(resp http.ResponseWriter, req *http.Request) (any, error) {
-	// Build the request by parsing all common parameters and node id
+
+	// Only allow POST and PUT methods.
+	if !(req.Method == http.MethodPut || req.Method == http.MethodPost) {
+		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
+	}
+
+	// Build the request by decoding the request body which will contain the
+	// node ID and the common parameters.
 	args := structs.NodeIdentityRenewReq{}
+
+	if err := decodeBody(req, &args); err != nil {
+		return nil, CodedError(http.StatusBadRequest, err.Error())
+	}
+
 	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
 	parseNode(req, &args.NodeID)
 

--- a/command/agent/node_identity_endpoint_test.go
+++ b/command/agent/node_identity_endpoint_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
 	"github.com/shoenig/test/must"
 )
 
@@ -80,6 +82,82 @@ func TestHTTPServer_NodeIdentityGetRequest(t *testing.T) {
 				must.Eq(t, http.StatusMethodNotAllowed, codedErr.Code())
 				must.Eq(t, ErrInvalidMethod, codedErr.Error())
 			}
+		})
+	})
+}
+
+func TestHTTPServer_NodeIdentityRenewRequest(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("405 invalid method", func(t *testing.T) {
+		httpTest(t, nil, func(s *TestAgent) {
+			respW := httptest.NewRecorder()
+
+			badMethods := []string{
+				http.MethodConnect,
+				http.MethodDelete,
+				http.MethodGet,
+				http.MethodHead,
+				http.MethodOptions,
+				http.MethodPatch,
+				http.MethodTrace,
+			}
+
+			for _, method := range badMethods {
+				req, err := http.NewRequest(method, "/v1/client/identity/renew", nil)
+				must.NoError(t, err)
+
+				_, err = s.Server.NodeIdentityRenewRequest(respW, req)
+				must.ErrorContains(t, err, "Invalid method")
+
+				codedErr, ok := err.(HTTPCodedError)
+				must.True(t, ok)
+				must.Eq(t, http.StatusMethodNotAllowed, codedErr.Code())
+				must.Eq(t, ErrInvalidMethod, codedErr.Error())
+			}
+		})
+	})
+
+	t.Run("400 no node", func(t *testing.T) {
+		httpTest(t, nil, func(s *TestAgent) {
+
+			reqObj := structs.NodeIdentityRenewReq{NodeID: uuid.Generate()}
+
+			buf := encodeReq(reqObj)
+
+			respW := httptest.NewRecorder()
+
+			req, err := http.NewRequest(http.MethodPost, "/v1/client/identity/renew", buf)
+			must.NoError(t, err)
+
+			_, err = s.Server.NodeIdentityRenewRequest(respW, req)
+			must.ErrorContains(t, err, "Unknown node")
+		})
+	})
+
+	t.Run("200 ok", func(t *testing.T) {
+
+		// Enable the client, so we have something to renew.
+		configFn := func(c *Config) { c.Client.Enabled = true }
+
+		httpTest(t, configFn, func(s *TestAgent) {
+
+			testutil.WaitForClient(t, s.RPC, s.client.NodeID(), s.config().Region)
+
+			reqObj := structs.NodeIdentityRenewReq{NodeID: s.client.NodeID()}
+
+			buf := encodeReq(reqObj)
+
+			respW := httptest.NewRecorder()
+
+			req, err := http.NewRequest(http.MethodPost, "/v1/client/identity/renew", buf)
+			must.NoError(t, err)
+
+			obj, err := s.Server.NodeIdentityRenewRequest(respW, req)
+			must.NoError(t, err)
+
+			_, ok := obj.(structs.NodeIdentityRenewResp)
+			must.True(t, ok)
 		})
 	})
 }


### PR DESCRIPTION
The HTTP request body contains the node ID where the request should be routed and without decoding this, we cannot route to anything other than local nodes.

### Testing & Reproduction steps
Found within the new e2e identity tests. Additional unit tests have been added to help cover the endpoint a little more.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 

