### PR TITLE
build: fix copywrite configuration file syntax

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -12,10 +12,10 @@ project {
     "command/agent/bindata_assetfs.go",
     "ui/node_modules",
     "pnpm-workspace.yaml",
-    "pnpm-lock.yaml"
+    "pnpm-lock.yaml",
 
     // Enterprise files do not fall under the open source licensing. CE-ENT
     // merge conflicts might happen here, please be sure to put new CE
-    // exceptions above this comment.
+    // exceptions above this comment and make sure they end with a trailing ","
   ]
 }


### PR DESCRIPTION
Because the Enterprise code has a set of copywrite exclusion entries below the one listed here in CE, we need to make sure that the last CE line in the configuration file ends in a comma.
