### PR TITLE
scheduler: allow device count to use different vendors/models

### DIFF
--- a/.changelog/26649.txt
+++ b/.changelog/26649.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: allow use of different vendor/models when checking for device counts while filtering feasible nodes
+```

--- a/scheduler/feasible/feasible.go
+++ b/scheduler/feasible/feasible.go
@@ -1451,13 +1451,6 @@ func (c *DeviceChecker) hasDevices(option *structs.Node) bool {
 		return true
 	}
 
-	// COMPAT(0.11): Remove in 0.11
-	// The node does not have the new resources object so it can not have any
-	// devices
-	if option.NodeResources == nil {
-		return false
-	}
-
 	// Check if the node has any devices
 	nodeDevs := option.NodeResources.Devices
 	if len(nodeDevs) == 0 {
@@ -1491,20 +1484,18 @@ OUTER:
 				continue
 			}
 
-			// First check we have enough instances of the device since this is
-			// cheaper than checking the constraints
-			if unused < desiredCount {
-				continue
-			}
-
 			// Check the constraints
 			if nodeDeviceMatches(c.ctx, d, req) {
-				// Consume the instances
-				available[d] -= desiredCount
+				for desiredCount > 0 && available[d] > 0 {
+					available[d] -= 1
+					desiredCount -= 1
+				}
 
-				// Move on to the next request
-				continue OUTER
+				if desiredCount == 0 {
+					continue OUTER
+				}
 			}
+
 		}
 
 		// We couldn't match the request for the device

--- a/scheduler/feasible/feasible_test.go
+++ b/scheduler/feasible/feasible_test.go
@@ -3113,10 +3113,31 @@ func TestDeviceChecker(t *testing.T) {
 		return n
 	}
 
-	nvidia := &structs.NodeDeviceResource{
+	nvidia_A := &structs.NodeDeviceResource{
 		Vendor: "nvidia",
 		Type:   "gpu",
 		Name:   "1080ti",
+		Attributes: map[string]*psstructs.Attribute{
+			"memory":        psstructs.NewIntAttribute(4, psstructs.UnitGiB),
+			"pci_bandwidth": psstructs.NewIntAttribute(995, psstructs.UnitMiBPerS),
+			"cores_clock":   psstructs.NewIntAttribute(800, psstructs.UnitMHz),
+		},
+		Instances: []*structs.NodeDevice{
+			{
+				ID:      uuid.Generate(),
+				Healthy: true,
+			},
+			{
+				ID:      uuid.Generate(),
+				Healthy: true,
+			},
+		},
+	}
+
+	nvidia_B := &structs.NodeDeviceResource{
+		Vendor: "nvidia",
+		Type:   "gpu",
+		Name:   "2080ti",
 		Attributes: map[string]*psstructs.Attribute{
 			"memory":        psstructs.NewIntAttribute(4, psstructs.UnitGiB),
 			"pci_bandwidth": psstructs.NewIntAttribute(995, psstructs.UnitMiBPerS),
@@ -3171,13 +3192,13 @@ func TestDeviceChecker(t *testing.T) {
 		{
 			Name:             "gpu devices by type",
 			Result:           true,
-			NodeDevices:      []*structs.NodeDeviceResource{nvidia},
+			NodeDevices:      []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{gpuTypeReq},
 		},
 		{
 			Name:             "wrong devices by type",
 			Result:           false,
-			NodeDevices:      []*structs.NodeDeviceResource{nvidia},
+			NodeDevices:      []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{fpgaTypeReq},
 		},
 		{
@@ -3189,37 +3210,37 @@ func TestDeviceChecker(t *testing.T) {
 		{
 			Name:             "gpu devices by vendor/type",
 			Result:           true,
-			NodeDevices:      []*structs.NodeDeviceResource{nvidia},
+			NodeDevices:      []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{gpuVendorTypeReq},
 		},
 		{
 			Name:             "wrong devices by vendor/type",
 			Result:           false,
-			NodeDevices:      []*structs.NodeDeviceResource{nvidia},
+			NodeDevices:      []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{fpgaVendorTypeReq},
 		},
 		{
 			Name:             "gpu devices by vendor/type/model",
 			Result:           true,
-			NodeDevices:      []*structs.NodeDeviceResource{nvidia},
+			NodeDevices:      []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{gpuFullReq},
 		},
 		{
 			Name:             "wrong devices by vendor/type/model",
 			Result:           false,
-			NodeDevices:      []*structs.NodeDeviceResource{nvidia},
+			NodeDevices:      []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{fpgaFullReq},
 		},
 		{
 			Name:             "too many requested",
 			Result:           false,
-			NodeDevices:      []*structs.NodeDeviceResource{nvidia},
+			NodeDevices:      []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{gpuTypeHighCountReq},
 		},
 		{
 			Name:        "meets constraints requirement",
 			Result:      true,
-			NodeDevices: []*structs.NodeDeviceResource{nvidia},
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{
 				{
 					Name:  "nvidia/gpu",
@@ -3248,7 +3269,7 @@ func TestDeviceChecker(t *testing.T) {
 						{
 							Operand: "set_contains",
 							LTarget: "${device.ids}",
-							RTarget: nvidia.Instances[0].ID,
+							RTarget: nvidia_A.Instances[0].ID,
 						},
 					},
 				},
@@ -3257,7 +3278,7 @@ func TestDeviceChecker(t *testing.T) {
 		{
 			Name:        "meets constraints requirement multiple count",
 			Result:      true,
-			NodeDevices: []*structs.NodeDeviceResource{nvidia},
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{
 				{
 					Name:  "nvidia/gpu",
@@ -3286,7 +3307,7 @@ func TestDeviceChecker(t *testing.T) {
 						{
 							Operand: "set_contains",
 							LTarget: "${device.ids}",
-							RTarget: fmt.Sprintf("%s,%s", nvidia.Instances[1].ID, nvidia.Instances[0].ID),
+							RTarget: fmt.Sprintf("%s,%s", nvidia_A.Instances[1].ID, nvidia_A.Instances[0].ID),
 						},
 					},
 				},
@@ -3295,7 +3316,7 @@ func TestDeviceChecker(t *testing.T) {
 		{
 			Name:        "meets constraints requirement over count",
 			Result:      false,
-			NodeDevices: []*structs.NodeDeviceResource{nvidia},
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{
 				{
 					Name:  "nvidia/gpu",
@@ -3328,7 +3349,7 @@ func TestDeviceChecker(t *testing.T) {
 		{
 			Name:        "does not meet first constraint",
 			Result:      false,
-			NodeDevices: []*structs.NodeDeviceResource{nvidia},
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{
 				{
 					Name:  "nvidia/gpu",
@@ -3361,7 +3382,7 @@ func TestDeviceChecker(t *testing.T) {
 		{
 			Name:        "does not meet second constraint",
 			Result:      false,
-			NodeDevices: []*structs.NodeDeviceResource{nvidia},
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{
 				{
 					Name:  "nvidia/gpu",
@@ -3394,7 +3415,7 @@ func TestDeviceChecker(t *testing.T) {
 		{
 			Name:        "does not meet ID constraint",
 			Result:      false,
-			NodeDevices: []*structs.NodeDeviceResource{nvidia},
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_A},
 			RequestedDevices: []*structs.RequestedDevice{
 				{
 					Name:  "nvidia/gpu",
@@ -3406,6 +3427,17 @@ func TestDeviceChecker(t *testing.T) {
 							RTarget: "not_valid",
 						},
 					},
+				},
+			},
+		},
+		{
+			Name:        "different model GPU's meets device request",
+			Result:      true,
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_A, nvidia_B},
+			RequestedDevices: []*structs.RequestedDevice{
+				{
+					Name:  "nvidia/gpu",
+					Count: 2,
 				},
 			},
 		},


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
A small optimization in the scheduler required users to specify specific models of devices if the required count was higher than the individual model/vendor on the node. This change removes that optimization to allow for more intuitive device scheduling when different vendor/model device types exist on a node.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

Fixes [GH #26584](https://github.com/hashicorp/nomad/issues/26584)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

