### PR TITLE
scheduler: skip setting preferred node when nodepool changes

### DIFF
--- a/.changelog/26662.txt
+++ b/.changelog/26662.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: fixes a bug selecting nodes for updated jobs with ephemeral disks when nodepool changes
+```

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -860,6 +860,12 @@ func (s *GenericScheduler) findPreferredNode(place reconciler.PlacementResult) (
 	if prev == nil {
 		return nil, nil
 	}
+
+	// if node pool was updated, don't set the preferred node
+	if prev.Job != nil && prev.Job.NodePool != s.job.NodePool {
+		return nil, nil
+	}
+
 	if place.TaskGroup().EphemeralDisk.Sticky || place.TaskGroup().EphemeralDisk.Migrate {
 		var preferredNode *structs.Node
 		ws := memdb.NewWatchSet()

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -6,6 +6,7 @@ package scheduler
 import (
 	"fmt"
 	"runtime/debug"
+	"slices"
 	"sort"
 	"time"
 
@@ -863,6 +864,11 @@ func (s *GenericScheduler) findPreferredNode(place reconciler.PlacementResult) (
 
 	// if node pool was updated, don't set the preferred node
 	if prev.Job != nil && prev.Job.NodePool != s.job.NodePool {
+		return nil, nil
+	}
+
+	// if the datacenters field was updated, skip preferred node
+	if !slices.Equal(prev.Job.Datacenters, s.job.Datacenters) {
 		return nil, nil
 	}
 

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -862,12 +862,12 @@ func (s *GenericScheduler) findPreferredNode(place reconciler.PlacementResult) (
 		return nil, nil
 	}
 
-	// if node pool was updated, don't set the preferred node
+	// when a jobs nodepool or datacenter are updated, we should ignore setting a preferred node
+	// even if a task has ephemeral disk, as this would bypass the normal nodepool/datacenter node
+	// selection logic, which would result in the alloc being place incorrectly.
 	if prev.Job != nil && prev.Job.NodePool != s.job.NodePool {
 		return nil, nil
 	}
-
-	// if the datacenters field was updated, skip preferred node
 	if !slices.Equal(prev.Job.Datacenters, s.job.Datacenters) {
 		return nil, nil
 	}

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -135,7 +135,7 @@ func TestServiceSched_JobRegister_EphemeralDisk(t *testing.T) {
 		h := tests.NewHarness(t)
 
 		// Create some nodes
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			node := mock.Node()
 			must.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 		}
@@ -223,11 +223,8 @@ func TestServiceSched_JobRegister_EphemeralDisk(t *testing.T) {
 		h := tests.NewHarness(t)
 
 		// Create some nodes
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			node := mock.Node()
-			if i == 0 {
-				node.NodePool = "test"
-			}
 			must.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
 		}
 

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -158,9 +158,7 @@ func TestServiceSched_JobRegister_EphemeralDisk(t *testing.T) {
 		must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 		// Process the evaluation
-		if err := h.Process(NewServiceScheduler, eval); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		must.NoError(t, h.Process(NewServiceScheduler, eval))
 
 		// Ensure the plan allocated
 		plan := h.Plans[0]
@@ -190,9 +188,7 @@ func TestServiceSched_JobRegister_EphemeralDisk(t *testing.T) {
 		}
 		must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 		h1 := tests.NewHarnessWithState(t, h.State)
-		if err := h1.Process(NewServiceScheduler, eval); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		must.NoError(t, h1.Process(NewServiceScheduler, eval))
 
 		// Ensure we have created only one new allocation
 		// Ensure a single plan
@@ -274,9 +270,7 @@ func TestServiceSched_JobRegister_EphemeralDisk(t *testing.T) {
 		must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 
 		// Process the evaluation
-		if err := h.Process(NewServiceScheduler, eval); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		must.NoError(t, h.Process(NewServiceScheduler, eval))
 
 		// Ensure the plan allocated
 		plan := h.Plans[0]
@@ -307,9 +301,7 @@ func TestServiceSched_JobRegister_EphemeralDisk(t *testing.T) {
 		}
 		must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
 		h1 := tests.NewHarnessWithState(t, h.State)
-		if err := h1.Process(NewServiceScheduler, eval); err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		must.NoError(t, h1.Process(NewServiceScheduler, eval))
 
 		// Ensure we have created only one new allocation
 		// Ensure a single plan

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
-	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/scheduler/reconciler"
 	sstructs "github.com/hashicorp/nomad/scheduler/structs"
@@ -244,14 +243,6 @@ func TestServiceSched_JobRegister_EphemeralDisk(t *testing.T) {
 			testPool,
 		}
 		h.State.UpsertNodePools(structs.MsgTypeTestSetup, h.NextIndex(), nodePools)
-
-		iterator, err := h.State.NodePools(nil, state.SortDefault)
-		must.NoError(t, err)
-		for obj := iterator.Next(); obj != nil; obj = iterator.Next() {
-			if pool, ok := obj.(*structs.NodePool); ok {
-				fmt.Println(pool.Name)
-			}
-		}
 
 		// Create a job
 		job := mock.Job()

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -153,8 +153,7 @@ func TestServiceSched_JobRegister_EphemeralDisk(t *testing.T) {
 		return job
 	}
 
-	t.Run("sticky ephemeral allocs in same node pool", func(t *testing.T) {
-
+	t.Run("sticky ephemeral allocs in same node pool does not change nodes", func(t *testing.T) {
 		h := tests.NewHarness(t)
 
 		// Create some nodes
@@ -166,7 +165,7 @@ func TestServiceSched_JobRegister_EphemeralDisk(t *testing.T) {
 		// create a job
 		job := createEphemeralJob(t, h, true, false)
 
-		// // Ensure the plan allocated
+		// Ensure the plan allocated
 		plan := h.Plans[0]
 		planned := make(map[string]*structs.Allocation)
 		for _, allocList := range plan.NodeAllocation {


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Preferred node is used when a task group has an ephemeral disk, so we ideally stay on the same node. However if the jobs node pool changes, we should not select the current node as the preferred node, and let the scheduler decide which node to pick from the correct node pool.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes [GH #26600](https://github.com/hashicorp/nomad/issues/26600)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

