### PR TITLE
vault: default tlsSkipVerify to false

### DIFF
--- a/.changelog/26664.txt
+++ b/.changelog/26664.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+keyring: fixes an issue where tlsSkipVerify was not defaulting to false
+```

--- a/.changelog/26664.txt
+++ b/.changelog/26664.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-keyring: fixes an issue where tlsSkipVerify was not defaulting to false
+keyring: fixes an issue with Vault transit configuration where tls_skip_verify was not defaulting to false
 ```

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -138,7 +138,8 @@ func fallbackVaultConfig(provider *structs.KEKProviderConfig, vaultcfg *config.V
 	setFallback("tls_client_key", vaultcfg.TLSKeyFile, "VAULT_CLIENT_KEY")
 	setFallback("tls_server_name", vaultcfg.TLSServerName, "VAULT_TLS_SERVER_NAME")
 
-	skipVerify := ""
+	// default to false as this will be parsed by the go-kms-wrapping package
+	skipVerify := "false"
 	if vaultcfg.TLSSkipVerify != nil {
 		skipVerify = fmt.Sprintf("%v", *vaultcfg.TLSSkipVerify)
 	}

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -118,32 +118,34 @@ func NewEncrypter(srv *Server, keystorePath string) (*Encrypter, error) {
 // fields
 func fallbackVaultConfig(provider *structs.KEKProviderConfig, vaultcfg *config.VaultConfig) {
 
-	setFallback := func(key, fallback, env string) {
+	setFallback := func(key, cfg, env, fallback string) {
 		if provider.Config == nil {
 			provider.Config = map[string]string{}
 		}
 		if _, ok := provider.Config[key]; !ok {
-			if fallback != "" {
-				provider.Config[key] = fallback
+			if cfg != "" {
+				provider.Config[key] = cfg
+			} else if envVal := os.Getenv(env); envVal != "" {
+				provider.Config[key] = envVal
 			} else {
-				provider.Config[key] = os.Getenv(env)
+				provider.Config[key] = fallback
 			}
 		}
 	}
 
-	setFallback("address", vaultcfg.Addr, "VAULT_ADDR")
-	setFallback("token", vaultcfg.Token, "VAULT_TOKEN")
-	setFallback("tls_ca_cert", vaultcfg.TLSCaPath, "VAULT_CACERT")
-	setFallback("tls_client_cert", vaultcfg.TLSCertFile, "VAULT_CLIENT_CERT")
-	setFallback("tls_client_key", vaultcfg.TLSKeyFile, "VAULT_CLIENT_KEY")
-	setFallback("tls_server_name", vaultcfg.TLSServerName, "VAULT_TLS_SERVER_NAME")
+	setFallback("address", vaultcfg.Addr, "VAULT_ADDR", "")
+	setFallback("token", vaultcfg.Token, "VAULT_TOKEN", "")
+	setFallback("tls_ca_cert", vaultcfg.TLSCaPath, "VAULT_CACERT", "")
+	setFallback("tls_client_cert", vaultcfg.TLSCertFile, "VAULT_CLIENT_CERT", "")
+	setFallback("tls_client_key", vaultcfg.TLSKeyFile, "VAULT_CLIENT_KEY", "")
+	setFallback("tls_server_name", vaultcfg.TLSServerName, "VAULT_TLS_SERVER_NAME", "")
 
 	// default to false as this will be parsed by the go-kms-wrapping package
-	skipVerify := "false"
+	skipVerify := ""
 	if vaultcfg.TLSSkipVerify != nil {
 		skipVerify = fmt.Sprintf("%v", *vaultcfg.TLSSkipVerify)
 	}
-	setFallback("tls_skip_verify", skipVerify, "VAULT_SKIP_VERIFY")
+	setFallback("tls_skip_verify", skipVerify, "VAULT_SKIP_VERIFY", "false")
 }
 
 func (e *Encrypter) loadKeystore() error {

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -817,11 +817,15 @@ func TestEncrypter_TransitConfigFallback(t *testing.T) {
 				},
 				{
 					Provider: "transit",
-					Name:     "fallback-to-vault-block",
+					Name:     "use-vault-config-if-set",
 				},
 				{
 					Provider: "transit",
-					Name:     "fallback-to-env",
+					Name:     "use-env-if-no-config",
+				},
+				{
+					Provider: "transit",
+					Name:     "use-fallback-if-no-env",
 				},
 			},
 		},
@@ -846,6 +850,10 @@ func TestEncrypter_TransitConfigFallback(t *testing.T) {
 
 	fallbackVaultConfig(providers[2], &config.VaultConfig{})
 	must.Eq(t, expect, providers[2].Config, must.Sprint("expected fallback to env"))
+
+	t.Setenv("VAULT_SKIP_VERIFY", "")
+	fallbackVaultConfig(providers[3], &config.VaultConfig{})
+	must.Eq(t, "false", providers[3].Config["tls_skip_verify"])
 }
 
 func TestEncrypter_IsReady_noTasks(t *testing.T) {

--- a/nomad/structs/config/vault.go
+++ b/nomad/structs/config/vault.go
@@ -109,6 +109,7 @@ func DefaultVaultConfig() *VaultConfig {
 		Addr:                "https://vault.service.consul:8200",
 		JWTAuthBackendPath:  "jwt-nomad",
 		ConnectionRetryIntv: DefaultVaultConnectRetryIntv,
+		TLSSkipVerify:       pointer.Of(false),
 	}
 }
 

--- a/nomad/structs/config/vault.go
+++ b/nomad/structs/config/vault.go
@@ -109,7 +109,6 @@ func DefaultVaultConfig() *VaultConfig {
 		Addr:                "https://vault.service.consul:8200",
 		JWTAuthBackendPath:  "jwt-nomad",
 		ConnectionRetryIntv: DefaultVaultConnectRetryIntv,
-		TLSSkipVerify:       pointer.Of(false),
 	}
 }
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
The transit keyring uses the go-kms-wrapper for parsing the vault config and errors if tlsSkipVerify is an empty string. We should ensure TLSSkipVerify is defaulting to false.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes [GH #26596](https://github.com/hashicorp/nomad/issues/26596)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

