### PR TITLE
e2e: Correctly handle IMDSv2 when discovering UI proxy address.

### DIFF
--- a/e2e/ui/input/proxy.nomad
+++ b/e2e/ui/input/proxy.nomad
@@ -74,6 +74,24 @@ job "nomad-proxy" {
         memory = 128
       }
 
+      action "get_proxy_public_address" {
+        command = "/bin/bash"
+        args    = ["-c", "local/get_proxy_public_ip.sh"]
+      }
+
+      template {
+        destination = "local/get_proxy_public_ip.sh"
+        perms       = "0755"
+        data        = <<EOT
+#!/usr/bin/env bash
+
+TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
+  -H "X-aws-ec2-metadata-token-ttl-seconds: 60")
+
+curl -s -H "X-aws-ec2-metadata-token: $TOKEN" "http://169.254.169.254/latest/meta-data/public-ipv4"
+EOT
+      }
+
       # this template is mostly lifted from the Learn Guide:
       # https://learn.hashicorp.com/tutorials/nomad/reverse-proxy-ui
       template {

--- a/e2e/ui/run.sh
+++ b/e2e/ui/run.sh
@@ -78,9 +78,7 @@ run_proxy() {
 }
 
 _get_aws_ip(){
-  aws_metadata_url="http://169.254.169.254/latest/meta-data"
-  nomad exec -namespace=proxy -job nomad-proxy \
-    curl -s "$aws_metadata_url/public-ipv4"
+  nomad action -namespace=proxy -job=nomad-proxy -group=proxy -task=nginx get_proxy_public_address
 }
 
 _get_svc_ip() {


### PR DESCRIPTION
The call to IMDSv1 has been failing since we switched to v2 which meant the UI e2e script attempted to use the service IP address for its tests. The service IP address is the Nomad client's private address which is not routable from the e2e test runner which means the test fails.

This change updates the IP discovery to use IMDSv2 which means the address is correctly populated and routable. The change also makes this discovery method by a job action within the proxy job. This exercises that feature and utilizes it in a way for which it was designed.

### Testing & Reproduction steps
I executed the UI e2e test locally against a cloud provisioned cluster:

```console
$ ./run.sh ci
+ run_proxy
+ nomad namespace apply proxy
Successfully applied namespace "proxy"!
+ nomad job run ./input/proxy.nomad
==> 2025-09-01T15:35:09+01:00: Monitoring evaluation "eb8c7188"
    2025-09-01T15:35:09+01:00: Evaluation triggered by job "nomad-proxy"
    2025-09-01T15:35:09+01:00: Evaluation within deployment: "a301b1c3"
    2025-09-01T15:35:09+01:00: Evaluation status changed: "pending" -> "complete"
==> 2025-09-01T15:35:09+01:00: Evaluation "eb8c7188" finished with status "complete"
==> 2025-09-01T15:35:09+01:00: Monitoring deployment "a301b1c3"
  ✓ Deployment "a301b1c3" successful

    2025-09-01T15:35:09+01:00
    ID          = a301b1c3
    Job ID      = nomad-proxy
    Job Version = 0
    Status      = successful
    Description = Deployment completed successfully

    Deployed
    Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
    proxy       1        1       1        0          2025-09-01T14:43:12Z
+ set +e
++ _get_aws_ip
++ nomad action -namespace=proxy -job=nomad-proxy -group=proxy -task=nginx get_proxy_public_address
+ IP=54.173.195.130
+ '[' -n 54.173.195.130 ']'
+ set -e
+ '[' -n 54.173.195.130 ']'
+ echo 'export NOMAD_ADDR=https://54.173.195.130:6464'
+ source /tmp/proxy_addr.env
++ export NOMAD_ADDR=https://54.173.195.130:6464
++ NOMAD_ADDR=https://54.173.195.130:6464
+ run_tests
+ run bash script.sh
+ local tty_args=
+ '[' -t 1 ']'
+ tty_args=-it
++ pwd
+ docker run -it --rm -v /Users/jrasell/Projects/go/nomad-enterprise/e2e/ui:/src -w /src -e NOMAD_ADDR=https://54.173.195.130:6464 -e NOMAD_TOKEN=37994785-14ee-fd9d-4a45-ce14271ecfc0 --ipc=host --net=host mcr.microsoft.com/playwright:v1.55.0-jammy bash script.sh
Unable to find image 'mcr.microsoft.com/playwright:v1.55.0-jammy' locally
v1.55.0-jammy: Pulling from playwright
2d14ac086288: Pull complete
7437f7b1263d: Pull complete
88de028998a2: Pull complete
7c08d2d1c59a: Pull complete
Digest: sha256:55db7b712a981e9cc1ec757a4511cd01c5ed4e20bd7c84b2dee4e1d320102b9d
Status: Downloaded newer image for mcr.microsoft.com/playwright:v1.55.0-jammy

changed 3 packages, and audited 4 packages in 2s

found 0 vulnerabilities
npm notice
npm notice New major version of npm available! 10.9.3 -> 11.5.2
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.5.2
npm notice To update run: npm install -g npm@11.5.2
npm notice

Running 2 tests using 2 workers

  ✓  1 [chromium] › tests/example.spec.js:8:1 › authenticated users can see their policies (2.3s)
  ✓  2 [webkit] › tests/example.spec.js:8:1 › authenticated users can see their policies (4.0s)

  2 passed (7.8s)
+ rc=0
+ stop_proxy
+ export NOMAD_ADDR=https://54.173.195.130:4646
+ NOMAD_ADDR=https://54.173.195.130:4646
+ nomad job stop -purge -namespace=proxy nomad-proxy
==> 2025-09-01T15:35:51+01:00: Monitoring evaluation "6ca55662"
    2025-09-01T15:35:51+01:00: Evaluation triggered by job "nomad-proxy"
    2025-09-01T15:35:51+01:00: Evaluation status changed: "pending" -> "complete"
==> 2025-09-01T15:35:51+01:00: Evaluation "6ca55662" finished with status "complete"
+ nomad namespace delete proxy
Successfully deleted namespace "proxy"!
+ exit 0
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


