### PR TITLE
lint: Enable and fix SA9004 constant type lint errors.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -54,6 +54,7 @@ linters:
       checks:
         - SA4029
         - SA5008
+        - SA9004
         - ST1016
         - ST1020
   exclusions:

--- a/api/keyring.go
+++ b/api/keyring.go
@@ -43,10 +43,10 @@ type RootKeyState string
 
 const (
 	RootKeyStateInactive     RootKeyState = "inactive"
-	RootKeyStateActive                    = "active"
-	RootKeyStateRekeying                  = "rekeying"
-	RootKeyStateDeprecated                = "deprecated"
-	RootKeyStatePrepublished              = "prepublished"
+	RootKeyStateActive       RootKeyState = "active"
+	RootKeyStateRekeying     RootKeyState = "rekeying"
+	RootKeyStateDeprecated   RootKeyState = "deprecated"
+	RootKeyStatePrepublished RootKeyState = "prepublished"
 )
 
 // List lists all the keyring metadata

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -363,7 +363,7 @@ func extraKeys(c *Config) error {
 
 	helper.RemoveEqualFold(&c.ExtraKeysHCL, "keyring")
 	for _, provider := range c.KEKProviders {
-		helper.RemoveEqualFold(&c.ExtraKeysHCL, provider.Provider)
+		helper.RemoveEqualFold(&c.ExtraKeysHCL, provider.Provider.String())
 	}
 
 	// Remove reporting extra keys

--- a/helper/pool/conn.go
+++ b/helper/pool/conn.go
@@ -7,12 +7,12 @@ type RPCType byte
 
 const (
 	RpcNomad     RPCType = 0x01
-	RpcRaft              = 0x02
-	RpcMultiplex         = 0x03
-	RpcTLS               = 0x04
-	RpcStreaming         = 0x05
+	RpcRaft      RPCType = 0x02
+	RpcMultiplex RPCType = 0x03
+	RpcTLS       RPCType = 0x04
+	RpcStreaming RPCType = 0x05
 
 	// RpcMultiplexV2 allows a multiplexed connection to switch modes between
 	// RpcNomad and RpcStreaming per opened stream.
-	RpcMultiplexV2 = 0x06
+	RpcMultiplexV2 RPCType = 0x06
 )

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -799,13 +799,13 @@ func (e *Encrypter) wrapRootKey(rootKey *structs.UnwrappedRootKey, isUpgraded bo
 		}
 
 		switch {
-		case isUpgraded && provider.Provider == string(structs.KEKProviderAEAD):
+		case isUpgraded && provider.Provider == structs.KEKProviderAEAD:
 			// nothing to do but don't want to hit next case
 
 		case isUpgraded:
 			wrappedKey.KeyEncryptionKey = nil
 
-		case provider.Provider == string(structs.KEKProviderAEAD): // !isUpgraded
+		case provider.Provider == structs.KEKProviderAEAD: // !isUpgraded
 			kek := wrappedKey.KeyEncryptionKey
 			wrappedKey.KeyEncryptionKey = nil
 			e.writeKeyToDisk(rootKey.Meta, provider, wrappedKey, kek)
@@ -830,7 +830,7 @@ func (e *Encrypter) encryptDEK(rootKey *structs.UnwrappedRootKey, provider *stru
 	}
 	var kek []byte
 	var err error
-	if provider.Provider == string(structs.KEKProviderAEAD) || provider.Provider == "" {
+	if provider.Provider == structs.KEKProviderAEAD || provider.Provider == "" {
 		kek, err = crypto.Bytes(32)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate key wrapper key: %w", err)
@@ -847,7 +847,7 @@ func (e *Encrypter) encryptDEK(rootKey *structs.UnwrappedRootKey, provider *stru
 	}
 
 	kekWrapper := &structs.WrappedKey{
-		Provider:                 provider.Provider,
+		Provider:                 provider.Provider.String(),
 		ProviderID:               provider.ID(),
 		WrappedDataEncryptionKey: rootBlob,
 		WrappedRSAKey:            &kms.BlobInfo{},

--- a/nomad/encrypter_ce.go
+++ b/nomad/encrypter_ce.go
@@ -33,7 +33,7 @@ func getProviderConfigs(srv *Server) (map[string]*structs.KEKProviderConfig, err
 
 	if len(srv.config.KEKProviderConfigs) == 0 {
 		providerConfigs[string(structs.KEKProviderAEAD)] = &structs.KEKProviderConfig{
-			Provider: string(structs.KEKProviderAEAD),
+			Provider: structs.KEKProviderAEAD,
 			Active:   true,
 		}
 	}

--- a/nomad/structs/keyring.go
+++ b/nomad/structs/keyring.go
@@ -274,19 +274,23 @@ type RootKeyMeta struct {
 // KEKProviderName enum are the built-in KEK providers.
 type KEKProviderName string
 
+// String returns the string representation of the KEKProviderName and satisfies
+// the fmt.Stringer interface.
+func (n KEKProviderName) String() string { return string(n) }
+
 const (
 	KEKProviderAEAD          KEKProviderName = "aead"
-	KEKProviderAWSKMS                        = "awskms"
-	KEKProviderAzureKeyVault                 = "azurekeyvault"
-	KEKProviderGCPCloudKMS                   = "gcpckms"
-	KEKProviderVaultTransit                  = "transit"
+	KEKProviderAWSKMS        KEKProviderName = "awskms"
+	KEKProviderAzureKeyVault KEKProviderName = "azurekeyvault"
+	KEKProviderGCPCloudKMS   KEKProviderName = "gcpckms"
+	KEKProviderVaultTransit  KEKProviderName = "transit"
 )
 
 // KEKProviderConfig is the server configuration for an external KMS provider
 // the server will use as a Key Encryption Key (KEK) for encrypting/decrypting
 // the DEK.
 type KEKProviderConfig struct {
-	Provider string            `hcl:",key"`
+	Provider KEKProviderName   `hcl:",key"`
 	Name     string            `hcl:"name"`
 	Active   bool              `hcl:"active"`
 	Config   map[string]string `hcl:"-" json:"-"`
@@ -304,7 +308,7 @@ func (c *KEKProviderConfig) Validate() error {
 		return nil
 	}
 
-	switch KEKProviderName(c.Provider) {
+	switch c.Provider {
 	case KEKProviderAEAD, KEKProviderAWSKMS, KEKProviderAzureKeyVault,
 		KEKProviderGCPCloudKMS, KEKProviderVaultTransit:
 		return nil
@@ -335,9 +339,9 @@ func (c *KEKProviderConfig) Merge(o *KEKProviderConfig) *KEKProviderConfig {
 
 func (c *KEKProviderConfig) ID() string {
 	if c.Name == "" {
-		return c.Provider
+		return c.Provider.String()
 	}
-	return c.Provider + "." + c.Name
+	return c.Provider.String() + "." + c.Name
 }
 
 // RootKeyState enum describes the lifecycle of a root key.
@@ -345,14 +349,14 @@ type RootKeyState string
 
 const (
 	RootKeyStateInactive     RootKeyState = "inactive"
-	RootKeyStateActive                    = "active"
-	RootKeyStateRekeying                  = "rekeying"
-	RootKeyStatePrepublished              = "prepublished"
+	RootKeyStateActive       RootKeyState = "active"
+	RootKeyStateRekeying     RootKeyState = "rekeying"
+	RootKeyStatePrepublished RootKeyState = "prepublished"
 
 	// RootKeyStateDeprecated is, itself, deprecated and is no longer in
 	// use. For backwards compatibility, any existing keys with this state will
 	// be treated as RootKeyStateInactive
-	RootKeyStateDeprecated = "deprecated"
+	RootKeyStateDeprecated RootKeyState = "deprecated"
 )
 
 // NewRootKeyMeta returns a new RootKeyMeta with default values


### PR DESCRIPTION
When creating constants with a custom type, each definition should include the type definition. If only the first constant defines this, it will have a different type to the other constants.

This change fixes occurrences of this and enables SA9004 within CI linting to catch future problems while the change is in review.

### Links
Found while working on #26673 

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


