### PR TITLE
e2e: ui: fix token form fill

### DIFF
--- a/e2e/ui/global-setup.js
+++ b/e2e/ui/global-setup.js
@@ -21,8 +21,15 @@ module.exports = async config => {
   const context = await browser.newContext({ ignoreHTTPSErrors: true });
   const page = await context.newPage();
   await page.goto(NOMAD_ADDR+'/ui/settings/tokens');
-  await page.fill('input[id="token-input"]', NOMAD_TOKEN);
-  await page.click('button:has-text("Sign in")', {strict: true});
+
+  // playwright "locater" reference: https://playwright.dev/docs/locators
+  // visiting /ui/settings/tokens without a token gets the "anonymous token"
+  // automatically, so we need to sign out before we can sign in
+  // with a real token.
+  await page.getByRole('button', {name: 'Sign Out'}).click();
+  // now input the token and sign in
+  await page.getByLabel('Secret ID').fill(NOMAD_TOKEN);
+  await page.getByRole('button', {name: 'Sign In'}).click();
 
   const { storageState } = config.projects[0].use;
   await page.context().storageState({ path: storageState });


### PR DESCRIPTION
e2e ui test is getting stuck here

```
  23 |   await page.goto(NOMAD_ADDR+'/ui/settings/tokens');
> 24 |   await page.fill('input[id="token-input"]', NOMAD_TOKEN);
     |              ^
```

as described in the code comment,

>   // visiting /ui/settings/tokens without a token gets the "anonymous token"
>  // automatically, so we need to sign out before we can sign in
>  // with a real token.

test passes on my laptop:

```
nomad-enterprise/e2e/ui $ ./run.sh test

[ ... npm stuff ... ]

Running 2 tests using 2 workers

  ✓  1 [webkit] › tests/example.spec.js:8:1 › authenticated users can see their policies (1.3s)
  ✓  2 [chromium] › tests/example.spec.js:8:1 › authenticated users can see their policies (377ms)

  2 passed (2.8s)
```