### PR TITLE
system scheduler: keep track of previously used canary nodes

### DIFF
--- a/scheduler/reconciler/reconcile_node.go
+++ b/scheduler/reconciler/reconcile_node.go
@@ -105,7 +105,9 @@ func computeCanaryNodes(required map[string]*structs.TaskGroup, nodeAllocs map[s
 					continue
 				}
 				if a.TaskGroup == tg.Name {
-					canaryNodes[nodeID] = map[string]bool{}
+					if _, ok := canaryNodes[nodeID]; !ok {
+						canaryNodes[nodeID] = map[string]bool{}
+					}
 					canaryNodes[nodeID][tg.Name] = true
 
 					// this node should no longer be considered when searching

--- a/scheduler/reconciler/reconcile_node.go
+++ b/scheduler/reconciler/reconcile_node.go
@@ -122,11 +122,15 @@ func computeCanaryNodes(required map[string]*structs.TaskGroup, nodeAllocs map[s
 		}
 
 		for i, n := range eligibleNodesList {
-			canaryNodes[n.ID] = map[string]bool{}
 
 			if i > numberOfCanaryNodes-1 {
 				break
 			}
+			
+			if _, ok := canaryNodes[n.ID]; !ok {
+				canaryNodes[n.ID] = map[string]bool{}
+			}
+			
 
 			canaryNodes[n.ID][tg.Name] = true
 		}

--- a/scheduler/reconciler/reconcile_node_test.go
+++ b/scheduler/reconciler/reconcile_node_test.go
@@ -889,7 +889,15 @@ func Test_computeCanaryNodes(t *testing.T) {
 					{DeploymentStatus: &structs.AllocDeploymentStatus{Canary: true}, TaskGroup: "bar"},
 				},
 			},
-			terminalAllocs: nil,
+			terminalAllocs: structs.TerminalByNodeByName{
+				fiveEligibleNodeNames[2]: map[string]*structs.Allocation{
+					"foo": {
+						DeploymentStatus: &structs.AllocDeploymentStatus{
+							Canary: true,
+						},
+					},
+				},
+			},
 			required: map[string]*structs.TaskGroup{
 				"foo": {
 					Name: "foo",
@@ -914,6 +922,7 @@ func Test_computeCanaryNodes(t *testing.T) {
 			expectedCanaryNodeID: map[string]string{
 				fiveEligibleNodeNames[0]: "foo",
 				fiveEligibleNodeNames[1]: "bar",
+				fiveEligibleNodeNames[2]: "foo",
 			},
 		},
 	}


### PR DESCRIPTION
In the system scheduler, we need to keep track which nodes were previously used
as "canary nodes" and not pick them at random, in case of previously failed
canaries or changes to the amount of canaries in the jobspec. 

Targets the feature branch f-system-deployments.

Internal ref: https://hashicorp.atlassian.net/browse/NMD-891