### PR TITLE
dispatch: write evaluation atomically with dispatch registration

### DIFF
--- a/.changelog/26710.txt
+++ b/.changelog/26710.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+dispatch: Fixed a bug where evaluations were not created atomically with dispatched jobs, which could prevent dispatch jobs from creating allocations
+```

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -734,8 +734,8 @@ func (n *nomadFSM) applyUpsertJob(msgType structs.MessageType, buf []byte, index
 		}
 	}
 
-	// COMPAT: Prior to Nomad 0.12.x evaluations were submitted in a separate Raft log,
-	// so this may be nil during server upgrades.
+	// Not all job registrations will include an eval (ex. registering a
+	// dispatch/periodic job)
 	if req.Eval != nil {
 		req.Eval.JobModifyIndex = index
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -2107,12 +2107,29 @@ func (j *Job) Dispatch(args *structs.JobDispatchRequest, reply *structs.JobDispa
 	// Compress the payload
 	dispatchJob.Payload = snappy.Encode(nil, args.Payload)
 
+	// If the job is periodic, we don't create an eval.
+	var eval *structs.Evaluation
+	if !dispatchJob.IsPeriodic() {
+		now := time.Now().UnixNano()
+		eval = &structs.Evaluation{
+			ID:          uuid.Generate(),
+			Namespace:   args.RequestNamespace(),
+			Priority:    dispatchJob.Priority,
+			Type:        dispatchJob.Type,
+			TriggeredBy: structs.EvalTriggerJobRegister,
+			JobID:       dispatchJob.ID,
+			Status:      structs.EvalStatusPending,
+			CreateTime:  now,
+			ModifyTime:  now,
+		}
+	}
+
 	regReq := &structs.JobRegisterRequest{
 		Job:          dispatchJob,
 		WriteRequest: args.WriteRequest,
+		Eval:         eval,
 	}
 
-	// Commit this update via Raft
 	_, jobCreateIndex, err := j.srv.raftApply(structs.JobRegisterRequestType, regReq)
 	if err != nil {
 		j.logger.Error("dispatched job register failed", "error", err)
@@ -2123,38 +2140,9 @@ func (j *Job) Dispatch(args *structs.JobDispatchRequest, reply *structs.JobDispa
 	reply.DispatchedJobID = dispatchJob.ID
 	reply.Index = jobCreateIndex
 
-	// If the job is periodic, we don't create an eval.
-	if !dispatchJob.IsPeriodic() {
-		// Create a new evaluation
-		now := time.Now().UnixNano()
-		eval := &structs.Evaluation{
-			ID:             uuid.Generate(),
-			Namespace:      args.RequestNamespace(),
-			Priority:       dispatchJob.Priority,
-			Type:           dispatchJob.Type,
-			TriggeredBy:    structs.EvalTriggerJobRegister,
-			JobID:          dispatchJob.ID,
-			JobModifyIndex: jobCreateIndex,
-			Status:         structs.EvalStatusPending,
-			CreateTime:     now,
-			ModifyTime:     now,
-		}
-		update := &structs.EvalUpdateRequest{
-			Evals:        []*structs.Evaluation{eval},
-			WriteRequest: structs.WriteRequest{Region: args.Region},
-		}
-
-		// Commit this evaluation via Raft
-		_, evalIndex, err := j.srv.raftApply(structs.EvalUpdateRequestType, update)
-		if err != nil {
-			j.logger.Error("eval create failed", "error", err, "method", "dispatch")
-			return err
-		}
-
-		// Setup the reply
+	if eval != nil {
 		reply.EvalID = eval.ID
-		reply.EvalCreateIndex = evalIndex
-		reply.Index = evalIndex
+		reply.EvalCreateIndex = jobCreateIndex
 	}
 
 	return nil


### PR DESCRIPTION
In #8435 (shipped in 0.12.1), we updated the `Job.Register` RPC to atomically write the eval along with the job. But this didn't get copied to `Job.Dispatch`. Under excessive load testing we demonstrated this can result in dispatched jobs without corresponding evals.

Update the dispatch RPC to write the eval in the same Raft log as the job registration. Note that we don't need to version-check this change for upgrades, because the register and dispatch RPCs share the same `JobRegisterRequestType` Raft message, and therefore all supported server versions already look for the eval in the FSM. If an updated leader includes the eval, older followers will write the eval. If a non-updated leader writes the eval in a separate Raft entry, updated followers will write those evals normally.

Fixes: https://github.com/hashicorp/nomad/issues/26655
Ref: https://hashicorp.atlassian.net/browse/NMD-947
Ref: https://github.com/hashicorp/nomad/pull/8435

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

