### PR TITLE
e2e: shorten restart delay in docker registry task

### DIFF
--- a/e2e/docker_registry/registry-auths.hcl
+++ b/e2e/docker_registry/registry-auths.hcl
@@ -47,6 +47,10 @@ job "registry-auths" {
 
   group "create-files" {
 
+    restart {
+      delay = "2s"
+    }
+
     # write out the test.sh file into var.helper_dir
     task "create-helper-file" {
       driver = "pledge"


### PR DESCRIPTION
tests that use this local docker registry (docker and podman tests) occasionally flake, I think due to the timeout being reached, despite passing after a restart.

> jobs3.go:658: tg 'create-files' task 'create-auth-file' event: Task received by client
> jobs3.go:658: tg 'create-files' task 'create-auth-file' event: Building Task Directory
> jobs3.go:658: tg 'create-files' task 'create-auth-file' event: Task started by client
> jobs3.go:658: tg 'create-files' task 'create-auth-file' event: Exit Code: 1
> jobs3.go:658: tg 'create-files' task 'create-auth-file' event: Task restarting in 16.212149445s
> jobs3.go:658: tg 'create-files' task 'create-auth-file' event: Task started by client
> jobs3.go:658: tg 'create-files' task 'create-auth-file' event: Exit Code: 0

setting the delay lower will (hopefully) keep within the job timeout.

I'm not sure why the `pledge` task apparently flakes like this; I could find no useful info in the logs.