### PR TITLE
docs: include Consul namespace claim mapping in auth config example

### DIFF
--- a/website/content/docs/secure/acl/consul.mdx
+++ b/website/content/docs/secure/acl/consul.mdx
@@ -276,8 +276,11 @@ Consul Enterprise supports multiple namespaces and Nomad Enterprise allows jobs
 to use the [`consul.namespace`][] parameter to register services and read KV
 data from different Consul namespaces.
 
-In a multi-namespace environment, you'll configure the auth method to include
-the `consul_namespace` claim mapping.
+In Nomad Enterprise, workload identities for tasks and services placed within
+the scope of a `consul` block with a `namespace` value, have an additional claim
+called `consul_namespace` that represents the Consul namespace defined in Nomad
+for the workload. In a multi-namespace environment, you should configure the
+auth method to include the `consul_namespace` claim mapping.
 
 <CodeBlockConfig highlight="6" filename="auth-method.json">
 
@@ -298,8 +301,8 @@ the `consul_namespace` claim mapping.
 
 </CodeBlockConfig>
 
-You should create the auth method and binding rules in the `default` namespace
-and configure the auth method with a set of [`NamespaceRules`][].
+You should create the auth method and binding rules in the `default` Consul
+namespace and configure the auth method with a set of [`NamespaceRules`][].
 
 ```shell-session
 $ consul acl auth-method create \
@@ -312,18 +315,13 @@ $ consul acl auth-method create \
 
 Similarly to binding rules, namespace rules have a [`Selector`][] expression to
 determine when the rule should be applied and a [`BindNamespace`][] value that
-defines the namespace used.
+defines the Consul namespace used.
 
 Auth methods with a namespace rule create Consul tokens in that Consul
 namespace. Binding rules with `-bind-type role` also target a role and
-associated policies in that same Consul namespace. So you should create the
-auth method and binding rules in the default namespace, and the role and
-policies in the target namespaces.
-
-In Nomad Enterprise, workload identities for tasks and services placed within
-the scope of a `consul` block with a `namespace` value, have an additional
-claim called `consul_namespace` that represents the Consul namespace defined
-in Nomad for the workload.
+associated policies in that same Consul namespace. So you should create the auth
+method and binding rules in the default Consul namespace, and the role and
+policies in the target Consul namespaces.
 
 <CodeBlockConfig highlight="9-11" filename="example.nomad.hcl">
 


### PR DESCRIPTION
When configuring Nomad Enterprise with Consul Enterprise and multiple namespaces, you need to include the `consul_namespace` mapping in the auth method configuration. Otherwise you'll see an error like "unknown variable accessed: value.consul_namespace". There's no example of the updated auth method configuration you need, which makes this detail unclear when we're showing the claim being used in the following `consul acl auth-method create` command.

Preview link: https://nomad-git-docs-consul-ent-claim-mapping-hashicorp.vercel.app/nomad/docs/secure/acl/consul#consul-namespace-rules

