### PR TITLE
eliminate dead Vault-related code

### DIFF
--- a/client/vaultclient/vaultclient_test.go
+++ b/client/vaultclient/vaultclient_test.go
@@ -78,6 +78,11 @@ path "secret/metadata/*" {
   "token_policies": ["nomad-workloads"]
 }
 `
+
+	// VaultNamespaceHeaderName is the header set to specify which namespace
+	// the request is indented for. This is defined within Nomad, so we do not
+	// need to import the entire Vault SDK package.
+	VaultNamespaceHeaderName = "X-Vault-Namespace"
 )
 
 func renderVaultTemplate(tmplStr string, data any) ([]byte, error) {
@@ -285,7 +290,7 @@ func TestVaultClient_NamespaceSupport(t *testing.T) {
 	conf.Namespace = testNs
 	c, err := NewVaultClient(conf, logger)
 	must.NoError(t, err)
-	must.Eq(t, testNs, c.client.Headers().Get(structs.VaultNamespaceHeaderName))
+	must.Eq(t, testNs, c.client.Headers().Get(VaultNamespaceHeaderName))
 }
 
 func TestVaultClient_Heap(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -70,7 +70,6 @@ require (
 	github.com/hashicorp/go-netaddrs v0.1.0
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/hashicorp/go-secure-stdlib/listenerutil v0.1.10
-	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2
 	github.com/hashicorp/go-set/v3 v3.0.1
 	github.com/hashicorp/go-sockaddr v1.0.7
 	github.com/hashicorp/go-syslog v1.0.0
@@ -260,6 +259,7 @@ require (
 	github.com/hashicorp/go-secure-stdlib/awsutil v0.1.6 // indirect
 	github.com/hashicorp/go-secure-stdlib/parseutil v0.1.9 // indirect
 	github.com/hashicorp/go-secure-stdlib/reloadutil v0.1.1 // indirect
+	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/tlsutil v0.1.3 // indirect
 	github.com/hashicorp/go-set/v2 v2.1.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -84,7 +84,6 @@ func init() {
 		periodicLaunchTableSchema,
 		evalTableSchema,
 		allocTableSchema,
-		vaultAccessorTableSchema,
 		aclPolicyTableSchema,
 		aclTokenTableSchema,
 		oneTimeTokenTableSchema,
@@ -828,44 +827,6 @@ func allocTableSchema() *memdb.TableSchema {
 							},
 						},
 					},
-				},
-			},
-		},
-	}
-}
-
-// vaultAccessorTableSchema returns the MemDB schema for the Vault Accessor
-// Table. This table tracks Vault accessors for tokens created on behalf of
-// allocations required Vault tokens.
-func vaultAccessorTableSchema() *memdb.TableSchema {
-	return &memdb.TableSchema{
-		Name: "vault_accessors",
-		Indexes: map[string]*memdb.IndexSchema{
-			// The primary index is the accessor id
-			"id": {
-				Name:         "id",
-				AllowMissing: false,
-				Unique:       true,
-				Indexer: &memdb.StringFieldIndex{
-					Field: "Accessor",
-				},
-			},
-
-			"alloc_id": {
-				Name:         "alloc_id",
-				AllowMissing: false,
-				Unique:       false,
-				Indexer: &memdb.StringFieldIndex{
-					Field: "AllocID",
-				},
-			},
-
-			indexNodeID: {
-				Name:         indexNodeID,
-				AllowMissing: false,
-				Unique:       false,
-				Indexer: &memdb.StringFieldIndex{
-					Field: "NodeID",
 				},
 			},
 		},

--- a/nomad/structs/service_identities.go
+++ b/nomad/structs/service_identities.go
@@ -5,6 +5,9 @@ package structs
 
 // An SITokenAccessor is a reference to a created Consul Service Identity token on
 // behalf of an allocation's task.
+//
+// DEPRECATED (1.10.0): this object exists only to allow decoding any accessors
+// still left in state so they can be discarded during FSM restore
 type SITokenAccessor struct {
 	ConsulNamespace string
 	NodeID          string

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -1246,6 +1246,9 @@ type ClusterMetadata struct {
 
 // VaultAccessor is a reference to a created Vault token on behalf of
 // an allocation's task.
+//
+// DEPRECATED (1.10.0): this object exists only to allow decoding any accessors
+// still left in state so they can be discarded during FSM restore
 type VaultAccessor struct {
 	AllocID     string
 	Task        string

--- a/nomad/structs/vault.go
+++ b/nomad/structs/vault.go
@@ -5,77 +5,13 @@ package structs
 
 import (
 	"fmt"
-
-	"github.com/hashicorp/go-secure-stdlib/strutil"
-	vapi "github.com/hashicorp/vault/api"
-	"github.com/mitchellh/mapstructure"
 )
 
 const (
 	// VaultDefaultCluster is the name used for the Vault cluster that doesn't
 	// have a name.
 	VaultDefaultCluster = "default"
-
-	// VaultNamespaceHeaderName is the header set to specify which namespace
-	// the request is indented for. This is defined within Nomad, so we do not
-	// need to import the entire Vault SDK package.
-	VaultNamespaceHeaderName = "X-Vault-Namespace"
 )
-
-// VaultTokenData represents some of the fields returned in the Data map of the
-// sercret returned by the Vault API when doing a token lookup request.
-type VaultTokenData struct {
-	CreationTTL   int      `mapstructure:"creation_ttl"`
-	TTL           int      `mapstructure:"ttl"`
-	Renewable     bool     `mapstructure:"renewable"`
-	Policies      []string `mapstructure:"policies"`
-	Role          string   `mapstructure:"role"`
-	NamespacePath string   `mapstructure:"namespace_path"`
-
-	// root caches if the token has the "root" policy to avoid travesring the
-	// policies list every time.
-	root *bool
-}
-
-// Root returns true if the token has the `root` policy.
-func (d VaultTokenData) Root() bool {
-	if d.root != nil {
-		return *d.root
-	}
-
-	root := strutil.StrListContains(d.Policies, "root")
-	d.root = &root
-
-	return root
-}
-
-// VaultTokenRoleData represents some of the fields returned in the Data map of
-// the sercret returned by the Vault API when reading a token role.
-type VaultTokenRoleData struct {
-	Name                 string `mapstructure:"name"`
-	ExplicitMaxTtl       int    `mapstructure:"explicit_max_ttl"`
-	TokenExplicitMaxTtl  int    `mapstructure:"token_explicit_max_ttl"`
-	Orphan               bool
-	Period               int
-	TokenPeriod          int `mapstructure:"token_period"`
-	Renewable            bool
-	DisallowedPolicies   []string `mapstructure:"disallowed_policies"`
-	AllowedEntityAliases []string `mapstructure:"allowed_entity_aliases"`
-	AllowedPolicies      []string `mapstructure:"allowed_policies"`
-}
-
-// DecodeVaultSecretData decodes a Vault sercret Data map into a struct.
-func DecodeVaultSecretData(s *vapi.Secret, out interface{}) error {
-	if s == nil {
-		return fmt.Errorf("cannot decode nil Vault secret")
-	}
-
-	if err := mapstructure.WeakDecode(s.Data, &out); err != nil {
-		return err
-	}
-
-	return nil
-}
 
 func ValidateVaultClusterName(cluster string) error {
 	if !validConsulVaultClusterName.MatchString(cluster) {


### PR DESCRIPTION
When we removed the legacy Vault token workflow, we left behind a few bits of code that only served that workflow. Remove the dead code.
