### PR TITLE
metrics: reduce heap usage of eval broker metrics

### DIFF
--- a/.changelog/26737.txt
+++ b/.changelog/26737.txt
@@ -1,0 +1,7 @@
+```release-note:breaking-change
+metrics: Eval broker metrics that previously used the job ID as a label will now use the parent ID of dispatch and periodic jobs
+```
+
+```release-note:improvement
+metrics: Reduce memory usage on the Nomad leader for collecting eval broker metrics.
+```

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -562,3 +562,17 @@ func ParsePortRanges(spec string) ([]uint64, error) {
 
 	return ports, nil
 }
+
+// ParentIDFromJobID returns the parent job ID of a given dispatch or periodic
+// job. Generally you should use the child job's Job.ParentID field instead, but
+// this is useful for contexts where the Job struct isn't present.
+func ParentIDFromJobID(jobID string) string {
+	if strings.Index(jobID, "/") == 0 {
+		// do a cheap O(n) check first before we do the more expensive Cut
+		// method
+		return jobID
+	}
+	jobID, _, _ = strings.Cut(jobID, DispatchLaunchSuffix)
+	jobID, _, _ = strings.Cut(jobID, PeriodicLaunchSuffix)
+	return jobID
+}

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -20,6 +20,16 @@ In Nomad 1.11.0, submitting a sysbatch job with a `reschedule` block returns
 an error instead of being silently ignored, as it was in previous versions. The
 same behavior applies to system jobs.
 
+#### Eval broker metrics for dispatch and periodic jobs
+
+The leader records metrics for the eval broker. In Nomad 1.11.0 the `job` label
+on the `nomad.nomad.broker.wait_time`, `nomad.nomad.broker.process_time`,
+`nomad.nomad.broker.response_time`, and `nomad.nomad.broker.eval_waiting`
+metrics refers to the parent job ID for dispatch and periodic jobs. The
+`nomad.nomad.broker.eval_waiting` no longer has an `eval_id` label. For clusters
+running high volume dispatch workloads, this change significantly reduces
+metrics cardinality and memory usage on the leader.
+
 ## Nomad 1.10.2
 
 #### Clients respect `telemetry.publish_allocation_metrics`


### PR DESCRIPTION
The metrics on the eval broker include labels for the job ID, but under a high volume of dispatch workloads, this results in excessive heap usage on the leader. Dispatch workloads should use their parent ID rather than their child ID for any metrics we collect.

Also, eliminate an extra copy of the labels. And remove the extremely high cardinality `"eval_id"` label from the `nomad.broker.eval_waiting` metric.

Fixes: https://github.com/hashicorp/nomad/issues/26657

### Testing

I've built out a test to demonstrate the difference in heap usage. *tl;dr this PR saves us ~220 MiB per 1000 dispatch evals processed by the broker.*

The test setup was:
* 3 servers w/ `num_schedulers=4`.
* 0 clients (so that all evals will be blocked).
* Prometheus metrics enabled but not scraped.
* Run 1000 dispatches.
* Wait for all evals to be processed, such that `nomad operator api "/v1/evaluations" | jq -r '.[].Status' | sort | uniq -c` shows 1000 complete and 1000 blocked.
* Take heap profiles of all servers via `/v1/agent/pprof/heap`

I tested once with `main` as of 0b699996988367b5df3654bebb0b462da71daee5, once with only the extra label allocation removed, and once with this PR.

The heap on the leader on `main`:

<img width="1988" height="964" alt="heap-main" src="https://github.com/user-attachments/assets/55508eec-1225-4672-a455-1145c9b1b27f" />


With just the extra label allocation removed:

<img width="1988" height="964" alt="heap-no-extra-label" src="https://github.com/user-attachments/assets/784bd8d0-ca9a-4e27-b511-ea0b78dfc192" />


With everything in this PR:

<img width="1988" height="964" alt="heap-parent-id" src="https://github.com/user-attachments/assets/6fe7ff15-dfd1-4b4c-9f0f-65ca15404670" />

Note that in practice, this is mostly signficiant when there is a high volume of concurrent dispatch, as once you scrape the Prometheus metrics the values will be removed and then the number of in-memory labels wil age-out over time.


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

