### PR TITLE
Fix job_run to show appropriate namespace in web UI link

### DIFF
--- a/.changelog/26738.txt
+++ b/.changelog/26738.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed nomad run web ui link for namespaces
+```

--- a/command/job_run.go
+++ b/command/job_run.go
@@ -308,9 +308,9 @@ func (c *JobRunCommand) Run(args []string) int {
 
 	evalID := resp.EvalID
 
-	jobNamespace := c.Meta.namespace
-	if jobNamespace == "" {
-		jobNamespace = "default"
+	jobNamespace := "default"
+	if job.Namespace != nil && *job.Namespace != "" {
+		jobNamespace = *job.Namespace
 	}
 
 	// Check if we should enter monitor mode


### PR DESCRIPTION
### Description

Fix the UI link to show the appropriate namespace

```
Example here of "old" behavior, where it was incorrectly showing default namespace.

% nomad run ../services/big-brain/pre-pull-images.nomad
Job registration successful

==> View this job in the Web UI: https://nomad.prod.cvx.is:443/ui/jobs/pre-pull-big-brain@default
```

### Testing & Reproduction steps

 `nomad run` something not in the default namespace

### Links

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

