### PR TITLE
build:replicate nomad-ent 49732e8447086745c4ed1913ae9a5e76b1a4b345

### DIFF
--- a/.github/actions/setup-js/action.yml
+++ b/.github/actions/setup-js/action.yml
@@ -12,6 +12,15 @@ runs:
       with:
         run_install: false
 
+  # avoid missing pnpm cache directory causing fatal error in "Post Setup node"
+  # https://github.com/actions/setup-node/issues/1137#issuecomment-2508963254
+    - name: Ensure PNPM cache dir
+      run: |
+        pnpm_dir="$(pnpm store path --silent)"
+        echo "pnpm_dir: $pnpm_dir"
+        mkdir -pv "$pnpm_dir"
+      shell: bash
+
     - name: Setup node
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,16 +116,8 @@ jobs:
 
       - name: Build dependencies
         run: make deps
-      
-      - name: Install PNPM
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          run_install: false
-      - name: Setup node
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version-file: package.json
-          cache: pnpm
+
+      - uses: ./.github/actions/setup-js
 
       - name: Build prerelease
         run: make prerelease
@@ -177,15 +169,7 @@ jobs:
       - name: Build dependencies
         run: make deps
 
-      - name: Install PNPM
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          run_install: false
-      - name: Setup node
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version-file: package.json
-          cache: pnpm
+      - uses: ./.github/actions/setup-js
 
       - name: Build prerelease
         run: make prerelease
@@ -299,15 +283,7 @@ jobs:
       - name: Build dependencies
         run: make deps
 
-      - name: Install PNPM
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          run_install: false
-      - name: Setup node
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version-file: package.json
-          cache: pnpm
+      - uses: ./.github/actions/setup-js
 
       - name: Build prerelease
         run: make prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,15 +86,7 @@ jobs:
         with:
           go-version: ${{ steps.get-go-version.outputs.go-version }}
 
-      - name: Install PNPM
-        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-        with:
-          run_install: false
-      - name: Setup node
-        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
-        with:
-          node-version-file: package.json
-          cache: pnpm
+      - uses: ./.github/actions/setup-js
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### Description
Porting @gulducat's hot fix  to the [release/1.8.17+ent ](https://github.com/hashicorp/nomad-enterprise/commit/557e5331acda4d86d717deb73622308944c82f31)and [1.9.13+ent](https://github.com/hashicorp/nomad-enterprise/commit/49732e8447086745c4ed1913ae9a5e76b1a4b345) branches.

This fix resolves an issue with the setup-node action's clean up stage by ensuring that the path returned by `pnpm store path --silent` exists and creating the directory if not.  This prevents the action from failing otherwise successful builds during the clean up stage.


### Testing & Reproduction steps
Successful manual invocation of this repo's build stage [here](https://github.com/hashicorp/nomad/actions/runs/17598638896)

### Links
There are no open issues for this but this is the original build failure on [1.9.13+ent](https://github.com/hashicorp/nomad-enterprise/actions/runs/17586044823) and [1.8/17+ent](https://github.com/hashicorp/nomad-enterprise/actions/runs/17586054746)


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

