### PR TITLE
secrets: Support custom plugins in Windows

### DIFF
--- a/client/commonplugins/secrets_plugin.go
+++ b/client/commonplugins/secrets_plugin.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
@@ -51,6 +52,9 @@ type externalSecretsPlugin struct {
 // which will be used as environment variables for Fetch.
 func NewExternalSecretsPlugin(commonPluginDir string, name string, env map[string]string) (*externalSecretsPlugin, error) {
 	// validate plugin
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
 	executable := filepath.Join(commonPluginDir, SecretsPluginDir, name)
 	f, err := os.Stat(executable)
 	if err != nil {

--- a/client/fingerprint/secrets.go
+++ b/client/fingerprint/secrets.go
@@ -53,6 +53,7 @@ func (s *SecretsPluginFingerprint) Fingerprint(request *FingerprintRequest, resp
 	// map of plugin names to fingerprinted versions
 	plugins := map[string]string{}
 	for name := range files {
+		name = strings.TrimSuffix(name, ".exe")
 		plug, err := commonplugins.NewExternalSecretsPlugin(request.Config.CommonPluginDir, name, nil)
 		if err != nil {
 			return err

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -569,7 +569,3 @@ func FindExecutableFiles(path string) (map[string]string, error) {
 	}
 	return executables, nil
 }
-
-func IsExecutable(i os.FileInfo) bool {
-	return !i.IsDir() && i.Mode()&0o111 != 0
-}

--- a/helper/funcs_unix.go
+++ b/helper/funcs_unix.go
@@ -1,0 +1,13 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package helper
+
+import "os"
+
+func IsExecutable(i os.FileInfo) bool {
+	return !i.IsDir() && i.Mode()&0o111 != 0
+}

--- a/helper/funcs_windows.go
+++ b/helper/funcs_windows.go
@@ -1,0 +1,16 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build windows
+// +build windows
+
+package helper
+
+import (
+	"os"
+	"strings"
+)
+
+func IsExecutable(i os.FileInfo) bool {
+	return strings.HasSuffix(i.Name(), ".exe")
+}


### PR DESCRIPTION
### Description
I was testing secrets plugins support added  by #26681 and noticed it does not load plugins in Windows because those always have `exe` extension. So this fixes that.

### Testing & Reproduction steps
<details>
  <summary>Secrets plugin</summary>

```golang
package main

import (
	"encoding/json"
	"fmt"
	"os"
)

type FingerprintResponse struct {
	Type    string `json:"type"`
	Version string `json:"version"`
}

type FetchResponse struct {
	Result map[string]string `json:"result"`
}

func fingerprint() {
	resp := FingerprintResponse{
		Type:    "secrets",
		Version: "0.0.1",
	}
	output, _ := json.Marshal(resp)
	fmt.Println(string(output))
}

func fetch() {
	secretMap := make(map[string]string)
	secretMap["password"] = "P@ssw0rd!"
	resp := FetchResponse{Result: secretMap}
	output, _ := json.Marshal(resp)
	fmt.Println(string(output))
}

func main() {
	if len(os.Args) < 2 {
		os.Exit(1)
	}

	command := os.Args[1]

	switch command {
	case "fingerprint":
		fingerprint()
	case "fetch":
		fetch()
	default:
		os.Exit(1)
	}
}
```
</details>
<details>
  <summary>Test job</summary>

```hcl
job "custom_secret" {
  namespace = "test"
  group "group" {
    task "task" {
      driver = "docker"
      config {
        image   = "mcr.microsoft.com/windows/nanoserver:ltsc2025"
        command = "ping"
        args    = ["-t", "127.0.0.1"]
      }

      secret "testsecret" {
        provider = "secret-provider"
        path     = "some/path"
      }

      env {
        TEST_SECRET = "${secret.testsecret.password}"
      }
    }
  }
}
```
</details>
<img width="603" height="158" alt="image" src="https://github.com/user-attachments/assets/4a5495fe-3904-4cce-a4a2-9a105d61b872" />
