### PR TITLE
backport of: client: set network status on tasks when restoring allocations (#26699)

### DIFF
--- a/.changelog/26699.txt
+++ b/.changelog/26699.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: restore task network status on client restart so restarted tasks receive proper networking environment variables, hosts file, and resolv.conf.
+```

--- a/client/allocrunner/network_hook_linux_test.go
+++ b/client/allocrunner/network_hook_linux_test.go
@@ -39,7 +39,7 @@ func TestNetworkHook_Prerun_Postrun_ExistingNetNS(t *testing.T) {
 		Labels: map[string]string{"abc": "123"},
 	}
 	isolationSetter := &mockNetworkIsolationSetter{t: t, expectedSpec: spec}
-	statusSetter := &mockNetworkStatusSetter{t: t, expectedStatus: nil}
+	statusSetter := &mockNetworkStatus{t: t, expectedStatus: mock.AllocNetworkStatus()}
 
 	callCounts := testutil.NewCallCounter()
 
@@ -84,6 +84,8 @@ func TestNetworkHook_Prerun_Postrun_ExistingNetNS(t *testing.T) {
 		expectSetupCalls                 int
 		expectPostrunDestroyNetworkCalls int
 		expectPrerunError                string
+		expectGetStatusCalls             int
+		expectSetStatusCalls             int
 	}{
 		{
 			name:                             "good check",
@@ -92,6 +94,8 @@ func TestNetworkHook_Prerun_Postrun_ExistingNetNS(t *testing.T) {
 			expectPrerunDestroyNetworkCalls:  0,
 			expectCheckCalls:                 1,
 			expectSetupCalls:                 0,
+			expectGetStatusCalls:             1,
+			expectSetStatusCalls:             1,
 			expectPostrunDestroyNetworkCalls: 1,
 		},
 		{
@@ -102,6 +106,8 @@ func TestNetworkHook_Prerun_Postrun_ExistingNetNS(t *testing.T) {
 			expectPrerunDestroyNetworkCalls:  1,
 			expectCheckCalls:                 2,
 			expectSetupCalls:                 0,
+			expectGetStatusCalls:             1,
+			expectSetStatusCalls:             1,
 			expectPostrunDestroyNetworkCalls: 2,
 		},
 		{
@@ -116,6 +122,8 @@ func TestNetworkHook_Prerun_Postrun_ExistingNetNS(t *testing.T) {
 			expectCheckCalls:                 2,
 			expectSetupCalls:                 0,
 			expectPostrunDestroyNetworkCalls: 2,
+			expectGetStatusCalls:             0,
+			expectSetStatusCalls:             0,
 			expectPrerunError:                "failed to configure networking for alloc: network namespace already exists but was misconfigured: whatever",
 		},
 		{
@@ -125,6 +133,8 @@ func TestNetworkHook_Prerun_Postrun_ExistingNetNS(t *testing.T) {
 			expectPrerunDestroyNetworkCalls:  0,
 			expectCheckCalls:                 0,
 			expectSetupCalls:                 0,
+			expectGetStatusCalls:             1,
+			expectSetStatusCalls:             1,
 			expectPostrunDestroyNetworkCalls: 1,
 		},
 	}
@@ -135,6 +145,8 @@ func TestNetworkHook_Prerun_Postrun_ExistingNetNS(t *testing.T) {
 			callCounts.Reset()
 			fakePlugin.counter.Reset()
 			fakePlugin.checkErrors = tc.checkErrs
+			statusSetter.getCalls = 0
+			statusSetter.setCalls = 0
 			configurator.nodeAttrs["plugins.cni.version.bridge"] = tc.cniVersion
 			hook := newNetworkHook(testlog.HCLogger(t), isolationSetter,
 				alloc, nm, configurator, statusSetter)
@@ -158,6 +170,8 @@ func TestNetworkHook_Prerun_Postrun_ExistingNetNS(t *testing.T) {
 			test.Eq(t, tc.expectPostrunDestroyNetworkCalls,
 				callCounts.Get()["DestroyNetwork"], test.Sprint("DestroyNetwork calls after postrun"))
 
+			test.Eq(t, tc.expectGetStatusCalls, statusSetter.getCalls, test.Sprint("NetworkStatus Calls"))
+			test.Eq(t, tc.expectSetStatusCalls, statusSetter.setCalls, test.Sprint("SetNetworkStatus Calls"))
 		})
 	}
 }

--- a/client/allocrunner/network_hook_test.go
+++ b/client/allocrunner/network_hook_test.go
@@ -28,15 +28,21 @@ func (m *mockNetworkIsolationSetter) SetNetworkIsolation(spec *drivers.NetworkIs
 	test.Eq(m.t, m.expectedSpec, spec)
 }
 
-type mockNetworkStatusSetter struct {
+type mockNetworkStatus struct {
 	t              *testing.T
 	expectedStatus *structs.AllocNetworkStatus
-	called         bool
+	getCalls       int
+	setCalls       int
 }
 
-func (m *mockNetworkStatusSetter) SetNetworkStatus(status *structs.AllocNetworkStatus) {
-	m.called = true
+func (m *mockNetworkStatus) SetNetworkStatus(status *structs.AllocNetworkStatus) {
+	m.setCalls++
 	test.Eq(m.t, m.expectedStatus, status)
+}
+
+func (m *mockNetworkStatus) NetworkStatus() *structs.AllocNetworkStatus {
+	m.getCalls++
+	return m.expectedStatus
 }
 
 // Test that the prerun and postrun hooks call the setter with the expected
@@ -75,9 +81,9 @@ func TestNetworkHook_Prerun_Postrun_group(t *testing.T) {
 		t:            t,
 		expectedSpec: spec,
 	}
-	statusSetter := &mockNetworkStatusSetter{
+	statusSetter := &mockNetworkStatus{
 		t:              t,
-		expectedStatus: nil,
+		expectedStatus: mock.AllocNetworkStatus(),
 	}
 
 	logger := testlog.HCLogger(t)
@@ -119,7 +125,7 @@ func TestNetworkHook_Prerun_Postrun_host(t *testing.T) {
 		t:            t,
 		expectedSpec: nil,
 	}
-	statusSetter := &mockNetworkStatusSetter{
+	statusSetter := &mockNetworkStatus{
 		t:              t,
 		expectedStatus: nil,
 	}


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

Manual backport of PR #26699 

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

