### PR TITLE
scheduler: fixed a bug where the bandwidth of reserved cores were not taken into account

### DIFF
--- a/.changelog/26768.txt
+++ b/.changelog/26768.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: fixed a bug where the bandwidth of reserved cores were not taken into account
+```

--- a/client/lib/numalib/topology.go
+++ b/client/lib/numalib/topology.go
@@ -282,7 +282,17 @@ func (st *Topology) NumECores() int {
 	return total
 }
 
-// UsableCores returns the number of logical cores usable by the Nomad client
+// AllCores returns the set of logical cores detected. The UsableCores will
+// be equal to or less than this value.
+func (st *Topology) AllCores() *idset.Set[hw.CoreID] {
+	result := idset.Empty[hw.CoreID]()
+	for _, cpu := range st.Cores {
+		result.Insert(cpu.ID)
+	}
+	return result
+}
+
+// UsableCores returns the set of logical cores usable by the Nomad client
 // for running tasks. Nomad must subtract off any reserved cores (reserved.cores)
 // and/or must mask the cpuset to the one set in config (config.reservable_cores).
 func (st *Topology) UsableCores() *idset.Set[hw.CoreID] {

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -189,10 +189,8 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevi
 		return false, "cores", used, nil
 	}
 
-	// Check that the node resources (after subtracting reserved) are a
-	// super set of those that are being allocated
-	available := node.NodeResources.Comparable()
-	available.Subtract(node.ReservedResources.Comparable())
+	// Check that the node resources are a super set of those that are being allocated
+	available := node.Comparable()
 	if superset, dimension := available.Superset(used); !superset {
 		return false, dimension, used, nil
 	}
@@ -232,20 +230,12 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevi
 }
 
 func computeFreePercentage(node *Node, util *ComparableResources) (freePctCpu, freePctRam float64) {
-	reserved := node.ReservedResources.Comparable()
-	res := node.NodeResources.Comparable()
-
 	// Determine the node availability
-	nodeCpu := float64(res.Flattened.Cpu.CpuShares)
-	nodeMem := float64(res.Flattened.Memory.MemoryMB)
-	if reserved != nil {
-		nodeCpu -= float64(reserved.Flattened.Cpu.CpuShares)
-		nodeMem -= float64(reserved.Flattened.Memory.MemoryMB)
-	}
+	available := node.Comparable()
 
 	// Compute the free percentage
-	freePctCpu = 1 - (float64(util.Flattened.Cpu.CpuShares) / nodeCpu)
-	freePctRam = 1 - (float64(util.Flattened.Memory.MemoryMB) / nodeMem)
+	freePctCpu = 1 - (float64(util.Flattened.Cpu.CpuShares) / float64(available.Flattened.Cpu.CpuShares))
+	freePctRam = 1 - (float64(util.Flattened.Memory.MemoryMB) / float64(available.Flattened.Memory.MemoryMB))
 	return freePctCpu, freePctRam
 }
 

--- a/nomad/structs/numa.go
+++ b/nomad/structs/numa.go
@@ -172,3 +172,10 @@ func (r *NodeProcessorResources) TotalCompute() int {
 	}
 	return int(r.Topology.TotalCompute())
 }
+
+func (r *NodeProcessorResources) UsableCompute() int {
+	if r == nil || r.Topology == nil {
+		return 0
+	}
+	return int(r.Topology.UsableCompute())
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2247,6 +2247,19 @@ func (n *Node) Canonicalize() {
 	}
 }
 
+// Comparable returns a comparable version of the node's resources available for scheduling.
+// This conversion can be lossy so care must be taken when using it.
+func (n *Node) Comparable() *ComparableResources {
+	if n == nil {
+		return nil
+	}
+
+	resources := n.NodeResources.Comparable()
+	resources.Subtract(n.ReservedResources.Comparable())
+
+	return resources
+}
+
 func (n *Node) Copy() *Node {
 	if n == nil {
 		return nil
@@ -3244,8 +3257,8 @@ func (n *NodeResources) Comparable() *ComparableResources {
 		return nil
 	}
 
-	usableCores := n.Processors.Topology.UsableCores().Slice()
-	reservableCores := helper.ConvertSlice(usableCores, func(id hw.CoreID) uint16 {
+	allCores := n.Processors.Topology.AllCores().Slice()
+	cores := helper.ConvertSlice(allCores, func(id hw.CoreID) uint16 {
 		return uint16(id)
 	})
 
@@ -3253,7 +3266,7 @@ func (n *NodeResources) Comparable() *ComparableResources {
 		Flattened: AllocatedTaskResources{
 			Cpu: AllocatedCpuResources{
 				CpuShares:     int64(n.Processors.Topology.TotalCompute()),
-				ReservedCores: reservableCores,
+				ReservedCores: cores,
 			},
 			Memory: AllocatedMemoryResources{
 				MemoryMB: n.Memory.MemoryMB,

--- a/scheduler/feasible/preemption.go
+++ b/scheduler/feasible/preemption.go
@@ -162,13 +162,7 @@ func (p *Preemptor) Copy() *Preemptor {
 
 // SetNode sets the node
 func (p *Preemptor) SetNode(node *structs.Node) {
-	nodeRemainingResources := node.NodeResources.Comparable()
-
-	// Subtract the reserved resources of the node
-	if c := node.ReservedResources.Comparable(); c != nil {
-		nodeRemainingResources.Subtract(c)
-	}
-	p.nodeRemainingResources = nodeRemainingResources
+	p.nodeRemainingResources = node.Comparable()
 }
 
 // SetCandidates initializes the candidate set from which preemptions are chosen


### PR DESCRIPTION
### Description
Configuring `cores` as part of the client `reserved` resources only limits scheduling on those cores, but isn't reflected in the available MHz bandwidth, thus affecting logic in places such as bin spread . 


### Testing & Reproduction steps
```
[sandbox@nomad-dev ~]$ curl -s localhost:4646/v1/metrics?format=prometheus | egrep '^nomad_client_(un)?allocated_cpu'  | grep ready
nomad_client_allocated_cpu{datacenter="dc1",host="nomad-dev",node_class="none",node_id="4ed2046a-e208-0751-2d2d-2bf4d966c140",node_pool="default",node_scheduling_eligibility="eligible",node_status="ready"} 0
nomad_client_unallocated_cpu{datacenter="dc1",host="nomad-dev",node_class="none",node_id="4ed2046a-e208-0751-2d2d-2bf4d966c140",node_pool="default",node_scheduling_eligibility="eligible",node_status="ready"} 278380
```
```
[sandbox@nomad-dev nomad]$ cat config.hcl
  client {
    reserved {
      # cpu = 1000
      # cores = "0-122"
    }
  }
  ```
  versus
  ```
  [sandbox@nomad-dev nomad]$ curl -s localhost:4646/v1/metrics?format=prometheus | egrep '^nomad_client_(un)?allocated_cpu' | grep ready
nomad_client_allocated_cpu{datacenter="dc1",host="nomad-dev",node_class="none",node_id="dc93b9fe-e3ab-8058-5006-3ee5696c3e1e",node_pool="default",node_scheduling_eligibility="eligible",node_status="ready"} 0
nomad_client_unallocated_cpu{datacenter="dc1",host="nomad-dev",node_class="none",node_id="dc93b9fe-e3ab-8058-5006-3ee5696c3e1e",node_pool="default",node_scheduling_eligibility="eligible",node_status="ready"} 2245
[sandbox@nomad-dev nomad]$ cat config.hcl
  client {
    reserved {
      # cpu = 1000
      cores = "0-122"
    }
  }
  ```
  
  So on a VM with 124 cores, leaving the last core available for scheduling, we allegedly have 1 core or 2245 MHz / cpu available. While testing :
```
  [sandbox@nomad-dev nomad]$ cat job.hcl
job "redis-job" {
  type = "service"
  group "cache" {
    count = 1
    task "redis" {
      driver = "docker"
      config {
        image = "redis:latest"
      }
      resources {
        cpu = 3000
      }
    }
  }
}

[sandbox@nomad-dev nomad]$ nomad job plan job.hcl
+ Job: "redis-job"
+ Task Group: "cache" (1 create)
  + Task: "redis" (forces create)

Scheduler dry-run:
- All tasks successfully allocated.

Job Modify Index: 0
To submit the job with version verification run:

nomad job run -check-index 0 job.hcl

When running the job with the check-index flag, the job will only be run if the
job modify index given matches the server-side version. If the index has
changed, another user has modified the job and the plan's results are
potentially invalid.
```
```
[sandbox@nomad-dev nomad]$ cat job.hcl
job "redis-job" {
  type = "service"
  group "cache" {
    count = 1
    task "redis" {
      driver = "docker"
      config {
        image = "redis:latest"
      }
      resources {
        cores = 2
      }
    }
  }
}

[sandbox@nomad-dev nomad]$ nomad job plan job.hcl
+ Job: "redis-job"
+ Task Group: "cache" (1 create)
  + Task: "redis" (forces create)

Scheduler dry-run:
- WARNING: Failed to place all allocations.
  Task Group "cache" (failed to place 1 allocation):
    * Resources exhausted on 1 nodes
    * Dimension "cores" exhausted on 1 nodes

Job Modify Index: 0
To submit the job with version verification run:

nomad job run -check-index 0 job.hcl

When running the job with the check-index flag, the job will only be run if the
job modify index given matches the server-side version. If the index has
changed, another user has modified the job and the plan's results are
potentially invalid.
```
Mimic of the situation, where we reserve the same amount of bandwidth but using cpu instead of cores we do fail :
```
[sandbox@nomad-dev nomad]$ cat config.hcl
  client {
    reserved {
      cpu = 276135
    }
  }
[sandbox@nomad-dev nomad]$ cat job.hcl
job "redis-job" {
  type = "service"
  group "cache" {
    count = 1
    task "redis" {
      driver = "docker"
      config {
        image = "redis:latest"
      }
      resources {
        cpu = 3000
      }
    }
  }
}

[sandbox@nomad-dev nomad]$ nomad job plan job.hcl
+ Job: "redis-job"
+ Task Group: "cache" (1 create)
  + Task: "redis" (forces create)

Scheduler dry-run:
- WARNING: Failed to place all allocations.
  Task Group "cache" (failed to place 1 allocation):
    * Resources exhausted on 1 nodes
    * Dimension "cpu" exhausted on 1 nodes

Job Modify Index: 0
To submit the job with version verification run:

nomad job run -check-index 0 job.hcl

When running the job with the check-index flag, the job will only be run if the
job modify index given matches the server-side version. If the index has
changed, another user has modified the job and the plan's results are
potentially invalid.
```
  

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

