### PR TITLE
http: Fix client identity renew call when node ID is in URI.

### DIFF
--- a/command/agent/node_identity_endpoint_test.go
+++ b/command/agent/node_identity_endpoint_test.go
@@ -48,7 +48,7 @@ func TestHTTPServer_NodeIdentityGetRequest(t *testing.T) {
 		})
 	})
 
-	t.Run("400 no node query param", func(t *testing.T) {
+	t.Run("400 query param with unknown node", func(t *testing.T) {
 		httpTest(t, nil, func(s *TestAgent) {
 
 			respW := httptest.NewRecorder()
@@ -144,7 +144,7 @@ func TestHTTPServer_NodeIdentityRenewRequest(t *testing.T) {
 		})
 	})
 
-	t.Run("400 no node body", func(t *testing.T) {
+	t.Run("400 body with unknown node", func(t *testing.T) {
 		httpTest(t, nil, func(s *TestAgent) {
 
 			reqObj := structs.NodeIdentityRenewReq{
@@ -166,7 +166,7 @@ func TestHTTPServer_NodeIdentityRenewRequest(t *testing.T) {
 		})
 	})
 
-	t.Run("400 no node query param", func(t *testing.T) {
+	t.Run("400 query param with unknown node", func(t *testing.T) {
 		httpTest(t, nil, func(s *TestAgent) {
 
 			respW := httptest.NewRecorder()

--- a/command/agent/node_identity_endpoint_test.go
+++ b/command/agent/node_identity_endpoint_test.go
@@ -18,11 +18,67 @@ import (
 func TestHTTPServer_NodeIdentityGetRequest(t *testing.T) {
 	ci.Parallel(t)
 
-	t.Run("200 ok", func(t *testing.T) {
+	t.Run("405 invalid method", func(t *testing.T) {
 		httpTest(t, cb, func(s *TestAgent) {
 			respW := httptest.NewRecorder()
 
-			req, err := http.NewRequest(http.MethodGet, "/v1/client/identity", nil)
+			badMethods := []string{
+				http.MethodConnect,
+				http.MethodDelete,
+				http.MethodHead,
+				http.MethodOptions,
+				http.MethodPatch,
+				http.MethodPost,
+				http.MethodPut,
+				http.MethodTrace,
+			}
+
+			for _, method := range badMethods {
+				req, err := http.NewRequest(method, "/v1/client/identity", nil)
+				must.NoError(t, err)
+
+				_, err = s.Server.NodeIdentityGetRequest(respW, req)
+				must.ErrorContains(t, err, "Invalid method")
+
+				codedErr, ok := err.(HTTPCodedError)
+				must.True(t, ok)
+				must.Eq(t, http.StatusMethodNotAllowed, codedErr.Code())
+				must.Eq(t, ErrInvalidMethod, codedErr.Error())
+			}
+		})
+	})
+
+	t.Run("400 no node query param", func(t *testing.T) {
+		httpTest(t, nil, func(s *TestAgent) {
+
+			respW := httptest.NewRecorder()
+
+			req, err := http.NewRequest(
+				http.MethodGet,
+				"/v1/client/identity?node_id="+uuid.Generate(),
+				nil,
+			)
+			must.NoError(t, err)
+
+			_, err = s.Server.NodeIdentityGetRequest(respW, req)
+			must.ErrorContains(t, err, "Unknown node")
+		})
+	})
+
+	t.Run("200 ok query param", func(t *testing.T) {
+
+		// Enable the client, so we have something to renew.
+		configFn := func(c *Config) { c.Client.Enabled = true }
+
+		httpTest(t, configFn, func(s *TestAgent) {
+
+			respW := httptest.NewRecorder()
+
+			req, err := http.NewRequest(
+				http.MethodGet,
+				"/v1/client/identity?node_id="+s.client.NodeID(),
+				nil,
+			)
 			must.NoError(t, err)
 
 			obj, err := s.Server.NodeIdentityGetRequest(respW, req)
@@ -52,36 +108,6 @@ func TestHTTPServer_NodeIdentityGetRequest(t *testing.T) {
 				s.client.Datacenter(),
 				s.client.Node().NodePool,
 			})
-		})
-	})
-
-	t.Run("405 invalid method", func(t *testing.T) {
-		httpTest(t, cb, func(s *TestAgent) {
-			respW := httptest.NewRecorder()
-
-			badMethods := []string{
-				http.MethodConnect,
-				http.MethodDelete,
-				http.MethodHead,
-				http.MethodOptions,
-				http.MethodPatch,
-				http.MethodPost,
-				http.MethodPut,
-				http.MethodTrace,
-			}
-
-			for _, method := range badMethods {
-				req, err := http.NewRequest(method, "/v1/client/identity", nil)
-				must.NoError(t, err)
-
-				_, err = s.Server.NodeIdentityGetRequest(respW, req)
-				must.ErrorContains(t, err, "Invalid method")
-
-				codedErr, ok := err.(HTTPCodedError)
-				must.True(t, ok)
-				must.Eq(t, http.StatusMethodNotAllowed, codedErr.Code())
-				must.Eq(t, ErrInvalidMethod, codedErr.Error())
-			}
 		})
 	})
 }
@@ -118,10 +144,15 @@ func TestHTTPServer_NodeIdentityRenewRequest(t *testing.T) {
 		})
 	})
 
-	t.Run("400 no node", func(t *testing.T) {
+	t.Run("400 no node body", func(t *testing.T) {
 		httpTest(t, nil, func(s *TestAgent) {
 
-			reqObj := structs.NodeIdentityRenewReq{NodeID: uuid.Generate()}
+			reqObj := structs.NodeIdentityRenewReq{
+				NodeID: uuid.Generate(),
+				QueryOptions: structs.QueryOptions{
+					Region: s.config().Region,
+				},
+			}
 
 			buf := encodeReq(reqObj)
 
@@ -135,7 +166,24 @@ func TestHTTPServer_NodeIdentityRenewRequest(t *testing.T) {
 		})
 	})
 
-	t.Run("200 ok", func(t *testing.T) {
+	t.Run("400 no node query param", func(t *testing.T) {
+		httpTest(t, nil, func(s *TestAgent) {
+
+			respW := httptest.NewRecorder()
+
+			req, err := http.NewRequest(
+				http.MethodPost,
+				"/v1/client/identity/renew?node_id="+uuid.Generate(),
+				nil,
+			)
+			must.NoError(t, err)
+
+			_, err = s.Server.NodeIdentityRenewRequest(respW, req)
+			must.ErrorContains(t, err, "Unknown node")
+		})
+	})
+
+	t.Run("200 ok body", func(t *testing.T) {
 
 		// Enable the client, so we have something to renew.
 		configFn := func(c *Config) { c.Client.Enabled = true }
@@ -151,6 +199,32 @@ func TestHTTPServer_NodeIdentityRenewRequest(t *testing.T) {
 			respW := httptest.NewRecorder()
 
 			req, err := http.NewRequest(http.MethodPost, "/v1/client/identity/renew", buf)
+			must.NoError(t, err)
+
+			obj, err := s.Server.NodeIdentityRenewRequest(respW, req)
+			must.NoError(t, err)
+
+			_, ok := obj.(structs.NodeIdentityRenewResp)
+			must.True(t, ok)
+		})
+	})
+
+	t.Run("200 ok query param", func(t *testing.T) {
+
+		// Enable the client, so we have something to renew.
+		configFn := func(c *Config) { c.Client.Enabled = true }
+
+		httpTest(t, configFn, func(s *TestAgent) {
+
+			testutil.WaitForClient(t, s.RPC, s.client.NodeID(), s.config().Region)
+
+			respW := httptest.NewRecorder()
+
+			req, err := http.NewRequest(
+				http.MethodPost,
+				"/v1/client/identity/renew?node_id="+s.client.NodeID(),
+				nil,
+			)
 			must.NoError(t, err)
 
 			obj, err := s.Server.NodeIdentityRenewRequest(respW, req)


### PR DESCRIPTION
When calling the client identity renew API, it is possible the target node ID is provided by either the URI or within the request body. This change fixes a bug where all calls using a node_id query parameter would be reject as it failed to decode the empty request body.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


