### PR TITLE
scheduler: do not create deployments for system job reschedules

### DIFF
--- a/scheduler/reconciler/reconcile_node.go
+++ b/scheduler/reconciler/reconcile_node.go
@@ -542,6 +542,7 @@ func (nr *NodeReconciler) createDeployment(job *structs.Job, tg *structs.TaskGro
 		if hadRunningCondition(alloc) {
 			nr.compatHasSameVersionAllocs = true
 			hadRunning = true
+			break
 		}
 	}
 
@@ -550,6 +551,7 @@ func (nr *NodeReconciler) createDeployment(job *structs.Job, tg *structs.TaskGro
 	for _, alloc := range terminal {
 		if hadRunningCondition(alloc) {
 			hadRunning = true
+			break
 		}
 	}
 

--- a/scheduler/reconciler/reconcile_node.go
+++ b/scheduler/reconciler/reconcile_node.go
@@ -415,8 +415,8 @@ func (nr *NodeReconciler) computeForNode(
 		})
 	}
 
-	// as we iterate over require groups, we'll keep track of whether the deployment
-	// is complete or not
+	// as we iterate over require groups, we'll keep track of whether the
+	// deployment is complete or not
 	deploymentComplete := false
 
 	// Scan the required groups
@@ -516,7 +516,7 @@ func (nr *NodeReconciler) computeForNode(
 
 		// maxParallel of 0 means no deployments
 		if maxParallel != 0 {
-			nr.createDeployment(job, tg, dstate, len(result.Update), liveAllocs)
+			nr.createDeployment(job, tg, dstate, len(result.Update), liveAllocs, terminal[nodeID])
 		}
 	}
 
@@ -524,7 +524,7 @@ func (nr *NodeReconciler) computeForNode(
 }
 
 func (nr *NodeReconciler) createDeployment(job *structs.Job, tg *structs.TaskGroup,
-	dstate *structs.DeploymentState, updates int, allocs []*structs.Allocation) {
+	dstate *structs.DeploymentState, updates int, allocs []*structs.Allocation, terminal map[string]*structs.Allocation) {
 
 	// programming error
 	if dstate == nil {
@@ -534,9 +534,21 @@ func (nr *NodeReconciler) createDeployment(job *structs.Job, tg *structs.TaskGro
 	updatingSpec := updates != 0
 
 	hadRunning := false
+	hadRunningCondition := func(a *structs.Allocation) bool {
+		return a.Job.ID == job.ID && a.Job.Version == job.Version && a.Job.CreateIndex == job.CreateIndex
+	}
+
 	for _, alloc := range allocs {
-		if alloc.Job.ID == job.ID && alloc.Job.Version == job.Version && alloc.Job.CreateIndex == job.CreateIndex {
+		if hadRunningCondition(alloc) {
 			nr.compatHasSameVersionAllocs = true
+			hadRunning = true
+		}
+	}
+
+	// if there's a terminal allocation it means we're doing a reschedule.
+	// We don't create deployments for reschedules.
+	for _, alloc := range terminal {
+		if hadRunningCondition(alloc) {
 			hadRunning = true
 		}
 	}


### PR DESCRIPTION
System jobs that get rescheduled should not get new deployments. 

Fixes unit test failure from https://github.com/hashicorp/nomad/pull/26777