### PR TITLE
build: Add tzdata to Docker container final image.

### DIFF
--- a/.changelog/26794.txt
+++ b/.changelog/26794.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+build: Add tzdata to Docker container final image
+```


### PR DESCRIPTION
Nomad's periodic block includes a "time_zone" parameter which lets operators set the time zone at which the next launch interval is checked against. For this to work, Nomad needs to use the "time.LoadLocation" which in-turn can use multiple TZ data sources.

When using the Docker image to trigger Nomad job registrations, it currently does not have access to any TZ data, meaning it is only aware of UTC. Adding the tzdata package contents to the release image provides the required data for this to work.

It would have also been possible to set the "-tags" build tag when releasing Nomad which would embed a copy of the timezone database in the code. We decided against using the build tag approach as it is a subtle way that we could introduce bugs that are very difficult to track down and we prefer the commit approach.

Note: backporting seems appropriate here; it is not a direct Nomad change but will be useful for CI and other users of the Dockerfile.

### Testing & Reproduction steps
Container before change:
```console
/ # date
Wed Sep 17 15:55:39 UTC 2025
/ # TZ=Europe/Berlin date
Wed Sep 17 15:56:01 Europe 2025
/ #
```

Container after change:
```console
/ # date
Wed Sep 17 15:56:37 UTC 2025
/ # TZ=Europe/Berlin date
Wed Sep 17 17:56:41 CEST 2025
/ #
```

### Links
Jira: https://hashicorp.atlassian.net/browse/NMD-880
Closes: https://github.com/hashicorp/nomad/issues/23900

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


