### PR TITLE
acl: Support delegating namespace create and delete

### DIFF
--- a/.changelog/26795.txt
+++ b/.changelog/26795.txt
@@ -1,0 +1,3 @@
+```release-note:security
+acl: Support delegating namespace create and delete
+```

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -30,6 +30,8 @@ const (
 	// combined we take the union of all capabilities. If the deny capability is present, it
 	// takes precedence and overwrites all other capabilities.
 
+	NamespaceCapabilityCreate               = "create"
+	NamespaceCapabilityDelete               = "delete"
 	NamespaceCapabilityDeny                 = "deny"
 	NamespaceCapabilityListJobs             = "list-jobs"
 	NamespaceCapabilityParseJob             = "parse-job"
@@ -207,7 +209,8 @@ func (p *PluginPolicy) isValid() bool {
 // isNamespaceCapabilityValid ensures the given capability is valid for a namespace policy
 func isNamespaceCapabilityValid(cap string) bool {
 	switch cap {
-	case NamespaceCapabilityDeny, NamespaceCapabilityParseJob, NamespaceCapabilityListJobs, NamespaceCapabilityReadJob,
+	case NamespaceCapabilityCreate, NamespaceCapabilityDelete,
+		NamespaceCapabilityDeny, NamespaceCapabilityParseJob, NamespaceCapabilityListJobs, NamespaceCapabilityReadJob,
 		NamespaceCapabilitySubmitJob, NamespaceCapabilityDispatchJob, NamespaceCapabilityReadLogs,
 		NamespaceCapabilityReadFS, NamespaceCapabilityAllocLifecycle,
 		NamespaceCapabilityAllocExec, NamespaceCapabilityAllocNodeExec,

--- a/website/content/api-docs/namespaces.mdx
+++ b/website/content/api-docs/namespaces.mdx
@@ -125,9 +125,9 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | ACL Required |
-| ---------------- | ------------ |
-| `NO`             | `management` |
+| Blocking Queries | ACL Required       |
+| ---------------- | ------------------ |
+| `NO`             | `namespace:create` |
 
 ### Parameters
 
@@ -220,9 +220,9 @@ The table below shows this endpoint's support for
 [blocking queries](/nomad/api-docs#blocking-queries) and
 [required ACLs](/nomad/api-docs#acls).
 
-| Blocking Queries | ACL Required |
-| ---------------- | ------------ |
-| `NO`             | `management` |
+| Blocking Queries | ACL Required       |
+| ---------------- | ------------------ |
+| `NO`             | `namespace:delete` |
 
 ### Parameters
 


### PR DESCRIPTION
### Description
Support delegating namespace create and delete.

Closes #14003

### Testing & Reproduction steps
1. Create policy and token which uses it.
```hcl
namespace "test-*" {
  capabilities = ["create", "delete"]
}
```
2. Create/delete namespace which matches to prefix.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


## Changes to Security Controls
Updated namespace create/delete features to support delegated tokens.

