### PR TITLE
test: Fix test flake in client get registration token

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1515,13 +1515,15 @@ func TestClient_getRegistrationToken(t *testing.T) {
 		})
 		t.Cleanup(func() { _ = testClientCleanup() })
 
+		// Ensure the identity is written to state before marking as registered,
+		// as would happen in a real client.
+		must.NoError(t, testClient.stateDB.PutNodeIdentity("my-identity-token"))
+
 		must.NoError(t, testClient.stateDB.PutNodeRegistration(
 			&cstructs.NodeRegistration{
 				HasRegistered: true,
 			},
 		))
-
-		must.NoError(t, testClient.stateDB.PutNodeIdentity("my-identity-token"))
 
 		must.Eq(t, "my-identity-token", testClient.getRegistrationToken())
 	})


### PR DESCRIPTION
The test was incorrectly writing to state that registration had been finished before writing the node identity token. This is the opposite of what happens in the client code and caused a timing issue which meant we read registration as completed before we had the identity available and therefore returned the secret ID.

### Testing & Reproduction steps
Before change:
```console
$ NOMAD_TEST_LOG_LEVEL=ERROR gotestsum -- -v -count=10 ./client -run TestClient_getRegistrationToken/node_identity_registered_state
✖  client (2.37s)

=== Failed
=== FAIL: client TestClient_getRegistrationToken/node_identity_registered_state (0.17s)
2025-09-18T09:48:02.447+0100 [ERROR] client/client.go:3134: client: error discovering nomad servers: error="no Nomad Servers advertising service \"nomad\" in Consul datacenters: [\"dc1\"]"
2025-09-18T09:48:02.449+0100 [ERROR] docker/driver.go:867: client.driver_mgr.docker: failed to list pause containers for recovery: driver=docker error="Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"
2025-09-18T09:48:02.473+0100 [ERROR] client/client.go:2178: client: closing register channel: t=d1b9160b-aaaa-42d9-caa3-746d843fea41
2025-09-18T09:48:02.473+0100 [ERROR] client/client_test.go:1525: client: getting token
2025-09-18T09:48:02.474+0100 [ERROR] client/client.go:2147: client: registered channel closed: t=d1b9160b-aaaa-42d9-caa3-746d843fea41
    client_test.go:1526:
        client_test.go:1526: expected equality via cmp.Equal function
        ↪ Assertion | differential ↷
          string(
        - 	"my-identity-token",
        + 	"d1b9160b-aaaa-42d9-caa3-746d843fea41",
          )
2025-09-18T09:48:02.474+0100 [ERROR] client/client.go:1915: client: error heartbeating. retrying: error="failed to update status: no servers" period=1s
    --- FAIL: TestClient_getRegistrationToken/node_identity_registered_state (0.17s)

=== FAIL: client TestClient_getRegistrationToken (0.17s)

DONE 20 tests, 2 failures in 5.624s
```

After change:
```console
$ NOMAD_TEST_LOG_LEVEL=ERROR gotestsum -- -v -count=1000 ./client -run TestClient_getRegistrationToken/node_identity_registered_state
✓  client (2m41.409s)

DONE 2000 tests in 166.425s
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


