### PR TITLE
e2e: fix TestScaling/TestScaling_System

### DIFF
--- a/e2e/scaling/scaling_test.go
+++ b/e2e/scaling/scaling_test.go
@@ -187,6 +187,9 @@ func testScalingSystemJob(t *testing.T) {
 		must.Eq(t, a.ID, initialAllocs[i].ID)
 	}
 
+	// Wait for the deployment to finish
+	must.NoError(t, e2eutil.WaitForLastDeploymentStatus(jobID, defaultNS, "successful", nil))
+
 	// Scale down to 0
 	testMeta = map[string]any{"scaling-e2e-test": "value"}
 	scaleResp, _, err = nomad.Jobs().Scale(jobID, "system_job_group", pointer.Of(0),


### PR DESCRIPTION
We need to wait for the deployment for a system job to finish before scaling, otherwise:

```
=== RUN   TestScaling/TestScaling_System
    scaling_test.go:194:
        scaling_test.go:194: expected nil error
        ↪ error: Unexpected response code: 400 (job scaling blocked due to active deployment)
--- FAIL: TestScaling (56.34s)
```