### PR TITLE
e2e: set longer job submission time for failing system jobs

### DIFF
--- a/e2e/metrics/metrics_test.go
+++ b/e2e/metrics/metrics_test.go
@@ -54,11 +54,11 @@ func TestMetrics(t *testing.T) {
 	t.Cleanup(cleanupSetup)
 
 	t.Log("running metrics job cpustress ...")
-	jobCPU, cleanupCPU := jobs3.Submit(t, "./input/cpustress.hcl")
+	jobCPU, cleanupCPU := jobs3.Submit(t, "./input/cpustress.hcl", jobs3.Timeout(60*time.Second))
 	t.Cleanup(cleanupCPU)
 
 	t.Log("running metrics job nomadagent ...")
-	jobHP, cleanupHP := jobs3.Submit(t, "./input/nomadagent.hcl")
+	jobHP, cleanupHP := jobs3.Submit(t, "./input/nomadagent.hcl", jobs3.Timeout(60*time.Second))
 	t.Cleanup(cleanupHP)
 
 	t.Log("running metrics job prometheus ...")
@@ -74,7 +74,7 @@ func TestMetrics(t *testing.T) {
 	t.Cleanup(cleanupCaddy)
 
 	t.Log("running metrics job winagent ...")
-	jobWin, cleanupWin := jobs3.Submit(t, "./input/winagent.hcl")
+	jobWin, cleanupWin := jobs3.Submit(t, "./input/winagent.hcl", jobs3.Timeout(60*time.Second))
 	t.Cleanup(cleanupWin)
 
 	t.Log("let the metrics collect for a bit (10s) ...")

--- a/e2e/scheduler_system/systemsched_test.go
+++ b/e2e/scheduler_system/systemsched_test.go
@@ -29,6 +29,7 @@ func testJobUpdateOnIneligbleNode(t *testing.T) {
 	job, cleanup := jobs3.Submit(t,
 		"./input/system_job0.nomad",
 		jobs3.DisableRandomJobID(),
+		jobs3.Timeout(60*time.Second),
 	)
 	t.Cleanup(cleanup)
 
@@ -66,6 +67,7 @@ func testJobUpdateOnIneligbleNode(t *testing.T) {
 	job2, cleanup2 := jobs3.Submit(t,
 		"./input/system_job1.nomad",
 		jobs3.DisableRandomJobID(),
+		jobs3.Timeout(60*time.Second),
 	)
 	t.Cleanup(cleanup2)
 
@@ -93,6 +95,7 @@ func testCanaryUpdate(t *testing.T) {
 	_, cleanup := jobs3.Submit(t,
 		"./input/system_canary_v0.nomad.hcl",
 		jobs3.DisableRandomJobID(),
+		jobs3.Timeout(60*time.Second),
 	)
 	t.Cleanup(cleanup)
 
@@ -100,6 +103,7 @@ func testCanaryUpdate(t *testing.T) {
 	job2, cleanup2 := jobs3.Submit(t,
 		"./input/system_canary_v1.nomad.hcl",
 		jobs3.DisableRandomJobID(),
+		jobs3.Timeout(60*time.Second),
 		jobs3.Detach(),
 	)
 	t.Cleanup(cleanup2)


### PR DESCRIPTION
I cannot replicate this locally, but it appears that on CI some of our system jobs take longer than the default 20s to finish deploying. This PR is just to make sure this isn't the reason these tests fail.