### PR TITLE
build: ui: setup-node v4.4.0 for cache update

### DIFF
--- a/.github/actions/setup-js/action.yml
+++ b/.github/actions/setup-js/action.yml
@@ -7,17 +7,20 @@ description: install node and pnpm, and run pnpm install
 runs:
   using: composite
   steps:
+    # install pnpm itself, but do not install deps yet
     - name: Install PNPM
       uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       with:
         run_install: false
 
+    # install appropriate node version, and point cache at pnpm
     - name: Setup node
-      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version-file: package.json
         cache: pnpm
 
+    # now that cache is properly configured, pnpm install the deps
     - name: PNPM install
       run: pnpm install
       shell: bash


### PR DESCRIPTION
Also add comments to clarify the step order.

---

fairly sure the main cache fix was regarding https://github.com/actions/toolkit/discussions/1890

successful runs with this version bump: [cache miss](https://github.com/hashicorp/nomad/actions/runs/17924011846/job/50965654398#step:6:57) followed by a [cache hit](https://github.com/hashicorp/nomad/actions/runs/17924011846/job/50969073405#step:6:62)

cache errors without:

```shell
# Setup
Warning: Failed to restore: Cache service responded with 400

# Post
Warning: Failed to save: <h2>Our services aren't available right now</h2><p>We're working to restore all services as soon as possible. Please check back soon.
```