### PR TITLE
CSI: ensure only client-terminal allocs are treated as past claims

### DIFF
--- a/.changelog/26831.txt
+++ b/.changelog/26831.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where volumes could be unmounted while in use by a task that was shutting down
+```

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2918,6 +2918,7 @@ func (s *StateStore) volSafeToForce(txn Txn, v *structs.CSIVolume) bool {
 	}
 
 	for _, alloc := range vol.ReadAllocs {
+		// note we check that both server and client agree on terminal status
 		if alloc != nil && !alloc.TerminalStatus() {
 			return false
 		}
@@ -3029,7 +3030,7 @@ func (s *StateStore) csiVolumeDenormalizeTxn(txn Txn, ws memdb.WatchSet, vol *st
 			}
 
 			currentAllocs[id] = a
-			if (a == nil || a.TerminalStatus()) && pastClaim == nil {
+			if (a == nil || a.ClientTerminalStatus()) && pastClaim == nil {
 				// the alloc is garbage collected but nothing has written a PastClaim,
 				// so create one now
 				pastClaim = &structs.CSIVolumeClaim{

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -3680,6 +3680,8 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	must.NoError(t, err)
 	vs = slurp(iter)
 	must.False(t, vs[0].HasFreeWriteClaims())
+	must.MapLen(t, 1, vs[0].ReadClaims)
+	must.MapLen(t, 0, vs[0].PastClaims)
 
 	claim2 := new(structs.CSIVolumeClaim)
 	*claim2 = *claim0
@@ -3692,7 +3694,20 @@ func TestStateStore_CSIVolume(t *testing.T) {
 	vs = slurp(iter)
 	must.True(t, vs[0].ReadSchedulable())
 
-	// deregistration is an error when the volume is in use
+	// alloc finishes, so we should see a past claim
+	a0 = a0.Copy()
+	a0.ClientStatus = structs.AllocClientStatusComplete
+	index++
+	err = state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{a0})
+	must.NoError(t, err)
+
+	v0, err = state.CSIVolumeByID(nil, ns, vol0)
+	must.NoError(t, err)
+	must.MapLen(t, 1, v0.ReadClaims)
+	must.MapLen(t, 1, v0.PastClaims)
+
+	// but until this claim is freed the volume is in use, so deregistration is
+	// still an error
 	index++
 	err = state.CSIVolumeDeregister(index, ns, []string{vol0}, false)
 	must.Error(t, err, must.Sprint("volume deregistered while in use"))

--- a/nomad/volumewatcher/volume_watcher.go
+++ b/nomad/volumewatcher/volume_watcher.go
@@ -184,10 +184,6 @@ func (vw *volumeWatcher) volumeReap(vol *structs.CSIVolume) {
 	}
 }
 
-func (vw *volumeWatcher) isUnclaimed(vol *structs.CSIVolume) bool {
-	return len(vol.ReadClaims) == 0 && len(vol.WriteClaims) == 0 && len(vol.PastClaims) == 0
-}
-
 // volumeReapImpl unpublished all the volume's PastClaims. PastClaims
 // will be populated from nil or terminal allocs when we call
 // CSIVolumeDenormalize(), so this assumes we've done so in the caller


### PR DESCRIPTION
The volume watcher checks whether any allocations that have claims are terminal so that it knows if it's safe to unpublish the volume. This check was considering a claim as unpublishable if the allocation was terminal on either the server or client, rather than the client alone. In many circumstances this is safe.

But if an allocation takes a while to stop (ex. it has a `shutdown_delay`), it's possible for garbage collection to run in the window between when the alloc is marked server-terminal and when the task is actually stopped. The server unpublishes the volume which sends a node plugin RPC. The plugin unmounts the volume while it's in use, and then unmounts it again when the allocation stops and the CSI postrun hook runs. If the task writes to the volume during the unmounting process, some providers end up in a broken state and the volume is not usable unless it's detached and reattached.

Fix this by considering a claim a "past claim" only when the allocation is client terminal. This way if garbage collection runs while we're waiting for allocation shutdown, the alloc will only be server-terminal and we won't send the extra node RPCs.

Fixes: https://github.com/hashicorp/nomad/issues/24130
Fixes: https://github.com/hashicorp/nomad/issues/25819
Ref: https://hashicorp.atlassian.net/browse/NMD-1001
Ref: https://hashicorp.atlassian.net/browse/NMD-501

---

### Testing & Reproduction steps

Setup:
* Nomad deployed to AWS (I used the E2E cluster adjusted to have a single server and two clients)
* CSI plugin for AWS EBS deployed and configured
* Server and clients both have `log_level="trace"`
* Server has [`server.csi_volume_claim_gc_interval="1m"`](https://developer.hashicorp.com/nomad/docs/configuration/server#csi_volume_claim_gc_interval)
* Create a volume
* Deploy a job with a long `shutdown_delay`
* Destructively update the job and redeploy.

<details><summary>volume spec</summary>

```hcl
id        = "test-vol"
name      = "318f1e3c-21da-4ef0-b915-e5313d1e39b2" # any UUID
type      = "csi"
plugin_id = "aws-ebs0"

capacity_min = "10GiB"
capacity_max = "20GiB"

capability {
  access_mode     = "single-node-writer"
  attachment_mode = "file-system"
}

parameters {
  type = "gp2"
}

topology_request {
  required {
    topology {
      segments {
        # this zone should match the one set in e2e/terraform/variables.tf
        "topology.ebs.csi.aws.com/zone" = "us-east-1b"
      }
    }
  }
}
```

</details>


<details><summary>job spec</summary>

```hcl
job "example" {

  group "group" {

    shutdown_delay = "90s"

    volume "test" {
      type            = "csi"
      source          = "test-vol"
      attachment_mode = "file-system"
      access_mode     = "single-node-writer"
    }

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
    }

    task "task" {
      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local/test"]
        ports   = ["www"]
      }

      volume_mount {
        volume      = "test"
        destination = "${NOMAD_TASK_DIR}/test"
        read_only   = false
      }

      service {
        name     = "httpd-web"
        provider = "nomad"
        port     = "www"
        check {
          type     = "http"
          interval = "1s"
          path     = "/health.json"
          timeout  = "1s"
        }
      }

      resources {
        cpu    = 128
        memory = 128
      }
    }

  }
}
```

</details>

On `main`, you'll see two sets of unpublish and unstage RPC calls in the node plugin alloc logs. You'll also see in the trace-level logs on the server the attempt to unpublish in the volume watcher, as well as two sets of `UnmountVolume` method calls in the client. With this patch, you'll only see the RPC calls that happen when the task is finally stopped.

Alternate approach, see https://github.com/hashicorp/nomad/issues/25819#issuecomment-3329812508

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

