### PR TITLE
end-to-end testing improvements for CSI

### DIFF
--- a/e2e/csi/input/ebs-volume0.hcl
+++ b/e2e/csi/input/ebs-volume0.hcl
@@ -21,6 +21,9 @@ capability {
 
 parameters {
   type = "gp2"
+
+  # ref https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md#storageclass-tagging
+  tagSpecification_1 = "Name=e2e-testing-vol0"
 }
 
 topology_request {

--- a/e2e/csi/input/ebs-volume1.hcl
+++ b/e2e/csi/input/ebs-volume1.hcl
@@ -21,6 +21,9 @@ capability {
 
 parameters {
   type = "gp2"
+
+  # ref https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/docs/tagging.md#storageclass-tagging
+  tagSpecification_1 = "Name=e2e-testing-vol1"
 }
 
 topology_request {

--- a/e2e/csi/input/plugin-aws-ebs-controller.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-controller.nomad
@@ -6,7 +6,6 @@
 # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/deploy/kubernetes
 
 job "plugin-aws-ebs-controller" {
-  datacenters = ["dc1", "dc2"]
 
   constraint {
     attribute = "${attr.kernel.name}"
@@ -25,7 +24,7 @@ job "plugin-aws-ebs-controller" {
       driver = "docker"
 
       config {
-        image = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.33.0"
+        image = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.48.0"
 
         args = [
           "controller",

--- a/e2e/csi/input/plugin-aws-ebs-nodes.nomad
+++ b/e2e/csi/input/plugin-aws-ebs-nodes.nomad
@@ -6,7 +6,6 @@
 # https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/deploy/kubernetes
 
 job "plugin-aws-ebs-nodes" {
-  datacenters = ["dc1", "dc2"]
 
   constraint {
     attribute = "${attr.kernel.name}"
@@ -22,7 +21,7 @@ job "plugin-aws-ebs-nodes" {
       driver = "docker"
 
       config {
-        image = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.33.0"
+        image = "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.48.0"
 
         args = [
           "node",

--- a/e2e/terraform/Makefile
+++ b/e2e/terraform/Makefile
@@ -5,7 +5,8 @@ CONSUL_LICENSE_PATH ?=
 # deploy for quick local development testing
 
 custom.tfvars:
-	echo 'nomad_local_binary = "$(PKG_PATH)"' > custom.tfvars
+	echo 'name = "$(shell whoami)-testing"' > custom.tfvars
+	echo 'nomad_local_binary = "$(PKG_PATH)"' >> custom.tfvars
 	echo 'volumes = false' >> custom.tfvars
 	echo 'client_count_linux = 3' >> custom.tfvars
 	echo 'client_count_windows_2022 = 0' >> custom.tfvars

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -8,6 +8,7 @@ provider "aws" {
 module "provision-infra" {
   source = "./provision-infra"
 
+  name                                   = var.name
   server_count                           = var.server_count
   client_count_linux                     = var.client_count_linux
   client_count_windows_2022              = var.client_count_windows_2022
@@ -20,5 +21,12 @@ module "provision-infra" {
   nomad_region                           = var.nomad_region
   instance_arch                          = var.instance_arch
   instance_type                          = var.instance_type
-  name                                   = var.name
+  volumes                                = var.volumes
+  availability_zone                      = var.availability_zone
+  aws_kms_alias                          = var.aws_kms_alias
+  hcp_hvn_cidr                           = var.hcp_hvn_cidr
+  hcp_vault_cluster_id                   = var.hcp_vault_cluster_id
+  hcp_vault_namespace                    = var.hcp_vault_namespace
+  region                                 = var.region
+  restrict_ingress_cidrblock             = var.restrict_ingress_cidrblock
 }

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -88,6 +88,12 @@ variable "hcp_vault_namespace" {
   default     = "admin"
 }
 
+variable "hcp_hvn_cidr" {
+  description = "The CIDR block of the HVN peered into the account."
+  type        = string
+  default     = "172.25.16.0/20"
+}
+
 variable "aws_kms_alias" {
   description = "The alias for the AWS KMS key ID"
   type        = string


### PR DESCRIPTION
While working on #26831 and #26832 I made some minor improvements to our end-to-end test setup for CSI:

* bump the AWS EBS plugin versions to latest release (1.48.0)
* remove the unnnecessary `datacenters` field from the AWS EBS plugin jobs
* add a name tag to the EBS volumes we create
* add a user-specific name tag to the cluster name when using the makefile to deploy a cluster
* add volumes and other missing variables from the `provision-infra` module to the main E2E module

Ref: https://github.com/hashicorp/nomad/pull/26832
Ref: https://github.com/hashicorp/nomad/pull/26831


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

