### PR TITLE
e2e: ui: fix playwright tag once and for all

### DIFF
--- a/e2e/ui/run.sh
+++ b/e2e/ui/run.sh
@@ -44,7 +44,7 @@ get_image_tag() {
   1>&2 echo 'detecting playwright image tag'
   local os='noble'
   curl -sS 'https://mcr.microsoft.com/api/v1/catalog/playwright/tags?reg=mar' \
-  | jq -r '[ .[] | select(.name | match("^v.*-'$os'$")) | .name ] | last'
+  | jq -r '[ .[].name | select(match("^v.*-jammy$")) ] | last '
   # '[ ..query.. ] | last' gets the bottom one in the api response
   # that matches the regex. the api returns them sorted oldest to newest.
 }


### PR DESCRIPTION
I'm sure this is the very last time I'll have to worry about this! :sweat_smile: 

I don't ever want to see this error again:

```
Error: browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1193/chrome-linux/headless_shell
╔══════════════════════════════════════════════════════════════════════╗
║ Looks like Playwright Test or Playwright was just updated to 1.55.1. ║
║ Please update docker image as well.                                  ║
║ -  current: mcr.microsoft.com/playwright:v1.55.0-jammy               ║
║ - required: mcr.microsoft.com/playwright:v1.55.1-jammy               ║
║                                                                      ║
║ <3 Playwright Team                                                   ║
╚══════════════════════════════════════════════════════════════════════╝

   at global-setup.js:20

  18 |   }
  19 |
> 20 |   const browser = await chromium.launch();
     |                                  ^
  21 |   const context = await browser.newContext({ ignoreHTTPSErrors: true });
  22 |   const page = await context.newPage();
  23 |   await page.goto(NOMAD_ADDR+'/ui/settings/tokens');
    at module.exports (/src/global-setup.js:20:34)
```

We've been manually updating this since 2022. PRs I can find at a quick glance:

* #13080
* #24158
* #24487 
* #24956 
* #25585
* #25740 
* #26119 
* #26650 

Works on my machine:

```
$ ./run.sh test
detecting playwright image tag
got playwright tag 'v1.55.1-noble'

up to date, audited 4 packages in 657ms

found 0 vulnerabilities
npm notice
npm notice New major version of npm available! 10.9.3 -> 11.6.1
npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.6.1
npm notice To update run: npm install -g npm@11.6.1
npm notice

Running 2 tests using 2 workers

  ✓  1 [webkit] › tests/example.spec.js:8:1 › authenticated users can see their policies (1.1s)
  ✓  2 [chromium] › tests/example.spec.js:8:1 › authenticated users can see their policies (377ms)

  2 passed (2.3s)
```