### PR TITLE
server: Log contextual server parts when Serf node joins or leaves.

### DIFF
--- a/nomad/serf.go
+++ b/nomad/serf.go
@@ -59,7 +59,7 @@ func (s *Server) nodeJoin(me serf.MemberEvent) {
 			s.logger.Warn("non-server in gossip pool", "member", m.Name)
 			continue
 		}
-		s.logger.Info("adding server", "server", parts)
+		s.logger.Info("adding server", "name", parts.Name, "addr", parts.Addr, "dc", parts.Datacenter)
 
 		// Check if this server is known
 		found := false
@@ -243,7 +243,7 @@ func (s *Server) nodeFailed(me serf.MemberEvent) {
 		if !ok {
 			continue
 		}
-		s.logger.Info("removing server", "server", parts)
+		s.logger.Info("removing server", "name", parts.Name, "addr", parts.Addr, "dc", parts.Datacenter)
 
 		// Remove the server if known
 		s.peerLock.Lock()


### PR DESCRIPTION
When a Nomad server joined or left the cluster via Serf, we emit a log message to indicate this. It was previously using a single kv context to detail the server name, dc, and address which likely was created before the switch to hclog and use of contextual logging.

This change splits the log message, so that each server part is a kv entry, which will be easier to parse with log collecting tools.

### Testing & Reproduction steps
Before change:
```console
2025-09-29T09:09:04.384+0100 [INFO]  nomad: adding server: server="jrasell-XXXXXXXX.global (Addr: 127.0.0.1:4647) (DC: dc1)"
```

After change:
```console
2025-09-29T09:13:54.988+0100 [INFO]  nomad: adding server: name=jrasell-XXXXXXXX.global addr=127.0.0.1:4647 dc=dc1
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


