### PR TITLE
Add job_max_count option to keep Nomad server from running out of memory

### DIFF
--- a/.changelog/26858.txt
+++ b/.changelog/26858.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-job: Added job_max_count option to limit number of allocs for a single job
+config: Added job_max_count option to limit number of allocs for a single job
 ```

--- a/.changelog/26858.txt
+++ b/.changelog/26858.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+job: Added job_max_count option to limit number of allocs for a single job
+```

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -352,6 +352,15 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	conf.JobMaxPriority = jobMaxPriority
 	conf.JobDefaultPriority = jobDefaultPriority
 
+	jobMaxCount := structs.JobDefaultMaxCount
+	if agentConfig.Server.JobMaxCount != nil && *agentConfig.Server.JobMaxCount != 0 {
+		jobMaxCount = *agentConfig.Server.JobMaxCount
+		if jobMaxCount < 1 {
+			return nil, fmt.Errorf("job_max_count cannot be %d. Must be at least 1", *agentConfig.Server.JobMaxCount)
+		}
+	}
+	conf.JobMaxCount = jobMaxCount
+
 	if agentConfig.Server.JobTrackedVersions != nil {
 		if *agentConfig.Server.JobTrackedVersions <= 0 {
 			return nil, fmt.Errorf("job_tracked_versions must be greater than 0")

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -353,10 +353,10 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 	conf.JobDefaultPriority = jobDefaultPriority
 
 	jobMaxCount := structs.JobDefaultMaxCount
-	if agentConfig.Server.JobMaxCount != nil && *agentConfig.Server.JobMaxCount != 0 {
+	if agentConfig.Server.JobMaxCount != nil {
 		jobMaxCount = *agentConfig.Server.JobMaxCount
-		if jobMaxCount < 1 {
-			return nil, fmt.Errorf("job_max_count cannot be %d. Must be at least 1", *agentConfig.Server.JobMaxCount)
+		if jobMaxCount < 0 {
+			return nil, fmt.Errorf("job_max_count (%d) cannot be negative", jobMaxCount)
 		}
 	}
 	conf.JobMaxCount = jobMaxCount

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -761,6 +761,9 @@ type ServerConfig struct {
 	// JobMaxPriority is an upper bound on the Job priority.
 	JobMaxPriority *int `hcl:"job_max_priority"`
 
+	// JobMaxCount is an upper bound on the number of instances in a Job.
+	JobMaxCount *int `hcl:"job_max_count"`
+
 	// JobMaxSourceSize limits the maximum size of a jobs source hcl/json
 	// before being discarded automatically. If unset, the maximum size defaults
 	// to 1 MB. If the value is zero, no job sources will be stored.
@@ -810,6 +813,7 @@ func (s *ServerConfig) Copy() *ServerConfig {
 	ns.RaftTrailingLogs = pointer.Copy(s.RaftTrailingLogs)
 	ns.JobDefaultPriority = pointer.Copy(s.JobDefaultPriority)
 	ns.JobMaxPriority = pointer.Copy(s.JobMaxPriority)
+	ns.JobMaxCount = pointer.Copy(s.JobMaxCount)
 	ns.JobTrackedVersions = pointer.Copy(s.JobTrackedVersions)
 	ns.ClientIntroduction = s.ClientIntroduction.Copy()
 	return &ns
@@ -2504,6 +2508,9 @@ func (s *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 	}
 	if b.JobMaxPriority != nil {
 		result.JobMaxPriority = pointer.Of(*b.JobMaxPriority)
+	}
+	if b.JobMaxCount != nil {
+		result.JobMaxCount = pointer.Of(*b.JobMaxCount)
 	}
 	if b.EvalGCThreshold != "" {
 		result.EvalGCThreshold = b.EvalGCThreshold

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -159,6 +159,7 @@ var basicConfig = &Config{
 		LicensePath:        "/tmp/nomad.hclic",
 		JobDefaultPriority: pointer.Of(100),
 		JobMaxPriority:     pointer.Of(200),
+		JobMaxCount:        pointer.Of(1000),
 		StartTimeout:       "1m",
 		ClientIntroduction: &ClientIntroduction{
 			Enforcement:           "warn",

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -388,6 +388,7 @@ func TestConfig_Merge(t *testing.T) {
 			},
 			JobMaxPriority:     pointer.Of(200),
 			JobDefaultPriority: pointer.Of(100),
+			JobMaxCount:        pointer.Of(1000),
 			OIDCIssuer:         "https://oidc.test.nomadproject.io",
 			StartTimeout:       "1m",
 		},

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -144,6 +144,7 @@ server {
   event_buffer_size             = 200
   job_default_priority          = 100
   job_max_priority              = 200
+  job_max_count                 = 1000
   start_timeout                 = "1m"
 
   plan_rejection_tracker {

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -370,6 +370,7 @@
       "license_path": "/tmp/nomad.hclic",
       "job_default_priority": 100,
       "job_max_priority": 200,
+      "job_max_count": 1000,
       "start_timeout": "1m"
     }
   ],

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -433,6 +433,9 @@ type Config struct {
 	// JobTrackedVersions is the number of historic Job versions that are kept.
 	JobTrackedVersions int
 
+	// JobMaxCount is the maximum number of task group instances for a single Job.
+	JobMaxCount int
+
 	Reporting *config.ReportingConfig
 
 	// OIDCIssuer is the URL for the OIDC Issuer field in Workload Identity JWTs.
@@ -664,6 +667,7 @@ func DefaultConfig() *Config {
 		DeploymentQueryRateLimit: deploymentwatcher.LimitStateQueriesPerSecond,
 		JobDefaultPriority:       structs.JobDefaultPriority,
 		JobMaxPriority:           structs.JobDefaultMaxPriority,
+		JobMaxCount:              structs.JobDefaultMaxCount,
 		JobTrackedVersions:       structs.JobDefaultTrackedVersions,
 		StartTimeout:             30 * time.Second,
 		NodeIntroductionConfig:   structs.DefaultNodeIntroductionConfig(),

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -433,7 +433,7 @@ type Config struct {
 	// JobTrackedVersions is the number of historic Job versions that are kept.
 	JobTrackedVersions int
 
-	// JobMaxCount is the maximum number of task group instances for a single Job.
+	// JobMaxCount is the maximum total task group counts for a single Job.
 	JobMaxCount int
 
 	Reporting *config.ReportingConfig

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -34,6 +34,14 @@ func Test_jobValidate_Validate(t *testing.T) {
 		_, err := impl.Validate(job)
 		must.NoError(t, err)
 	})
+
+	t.Run("no error if job_max_count is zero (i.e. unlimited)", func(t *testing.T) {
+		impl := jobValidate{srv: &Server{config: &Config{JobMaxCount: 0, JobMaxPriority: 100}}}
+		job := mock.Job()
+		job.TaskGroups[0].Count = structs.JobDefaultMaxCount + 1
+		_, err := impl.Validate(job)
+		must.NoError(t, err)
+	})
 }
 
 func Test_jobValidate_Validate_consul_service(t *testing.T) {

--- a/nomad/job_endpoint_hooks_test.go
+++ b/nomad/job_endpoint_hooks_test.go
@@ -16,6 +16,26 @@ import (
 	"github.com/shoenig/test/must"
 )
 
+func Test_jobValidate_Validate(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("error if task group count exceeds job_max_count", func(t *testing.T) {
+		impl := jobValidate{srv: &Server{config: &Config{JobMaxCount: 10, JobMaxPriority: 100}}}
+		job := mock.Job()
+		job.TaskGroups[0].Count = 11
+		_, err := impl.Validate(job)
+		must.ErrorContains(t, err, "total count was greater than configured job_max_count: 11 > 10")
+	})
+
+	t.Run("no error if task group count equals job_max_count", func(t *testing.T) {
+		impl := jobValidate{srv: &Server{config: &Config{JobMaxCount: 10, JobMaxPriority: 100}}}
+		job := mock.Job()
+		job.TaskGroups[0].Count = 10
+		_, err := impl.Validate(job)
+		must.NoError(t, err)
+	})
+}
+
 func Test_jobValidate_Validate_consul_service(t *testing.T) {
 	ci.Parallel(t)
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -7728,7 +7728,6 @@ func TestJobEndpoint_Scale_TaskGroupOutOfBounds(t *testing.T) {
 
 func TestJobEndpoint_Scale_JobOutOfBounds(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 
 	s1, cleanupS1 := TestServer(t, func(config *Config) {
 		config.JobMaxCount = 4
@@ -7744,7 +7743,7 @@ func TestJobEndpoint_Scale_JobOutOfBounds(t *testing.T) {
 
 	// register the job
 	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
-	require.Nil(err)
+	must.NoError(t, err)
 
 	var resp structs.JobRegisterResponse
 	scale := &structs.JobScaleRequest{
@@ -7761,8 +7760,8 @@ func TestJobEndpoint_Scale_JobOutOfBounds(t *testing.T) {
 		},
 	}
 	err = msgpackrpc.CallWithCodec(codec, "Job.Scale", scale, &resp)
-	require.Error(err)
-	require.Contains(err.Error(), "total count was greater than configured job_max_count: 6 > 4")
+	must.Error(t, err)
+	must.ErrorContains(t, err, "total count was greater than configured job_max_count: 6 > 4")
 }
 
 func TestJobEndpoint_Scale_NoEval(t *testing.T) {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4327,7 +4327,7 @@ const (
 	// JobMaxPriority is the maximum allowed configuration value for maximum job priority
 	JobMaxPriority = math.MaxInt16 - 1
 
-	// JobDefaultMaxCount is the default maximum allowed number of instances per job
+	// JobDefaultMaxCount is the default maximum total task group counts per job
 	JobDefaultMaxCount = 50000
 
 	// CoreJobPriority should be higher than any user

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4327,6 +4327,9 @@ const (
 	// JobMaxPriority is the maximum allowed configuration value for maximum job priority
 	JobMaxPriority = math.MaxInt16 - 1
 
+	// JobDefaultMaxCount is the default maximum allowed number of instances per job
+	JobDefaultMaxCount = 50000
+
 	// CoreJobPriority should be higher than any user
 	// specified job so that it gets priority. This is important
 	// for the system to remain healthy.

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -289,8 +289,13 @@ server {
 - `job_default_priority` `(int: 50)` - Specifies the default priority assigned to a job.
    A valid value must be between `50` and `job_max_priority`.
 
-- `jax_max_count` `(int: 50000)` - Specifies the maximum number of task group instances for
-   a single job. The value must be non-negative.
+- `job_max_count` `(int: 50000)` - Specifies the maximum number of allocations
+   for a job, as represented by the sum of its task group `count` fields. Jobs
+   of type `system` ignore this value. The child jobs of dispatched batch jobs
+   or periodic jobs are counted separately from their parent job. This value
+   must be non-negative. If set to 0, no limit is enforced. This value is enforced
+   at the time the job is submitted or scaled, and updating the value will not
+   impact existing jobs.
 
 - `job_max_source_size` `(string: "1M")` - Specifies the size limit of the associated
   job source content when registering a job. Note this is not a limit on the actual

--- a/website/content/docs/configuration/server.mdx
+++ b/website/content/docs/configuration/server.mdx
@@ -289,6 +289,9 @@ server {
 - `job_default_priority` `(int: 50)` - Specifies the default priority assigned to a job.
    A valid value must be between `50` and `job_max_priority`.
 
+- `jax_max_count` `(int: 50000)` - Specifies the maximum number of task group instances for
+   a single job. The value must be non-negative.
+
 - `job_max_source_size` `(string: "1M")` - Specifies the size limit of the associated
   job source content when registering a job. Note this is not a limit on the actual
   size of a job. If the limit is exceeded, the original source is simply discarded

--- a/website/content/docs/upgrade/upgrade-specific.mdx
+++ b/website/content/docs/upgrade/upgrade-specific.mdx
@@ -38,6 +38,15 @@ being silently ignored. Any existing policies with duplicate or invalid keys
 will continue to work, but the source policy document will need to be updated
 to be valid before it can be written to Nomad.
 
+#### Maximum number of allocations per job is limited by default
+
+Nomad 1.11.0 limits the maximum number of allocations for a job to the value of
+the new [`job_max_count`](/nomad/docs/configuration/server#job_max_count) server
+configuration option, which defaults to 50000. The number of allocations is
+determined from the sum of the job's task group `count` fields. This limit is
+enforced at the time the job is submitted or scaled, and updating the value will
+not impact existing jobs.
+
 ## Nomad 1.10.6
 
 #### ACL policies no longer silently ignore duplicate or invalid keys


### PR DESCRIPTION
### Description

If a Nomad job is started with a large number of instances (e.g. 4 billion), then the Nomad servers that attempt to schedule it will run out of memory and crash. While it's unlikely that anyone would intentionally schedule a job with 4 billion instances, we have occasionally run into issues with bugs in external automation. For example, an automated deployment system running on a test environment had an off-by-one error, and deployed a job with `count = uint32(-1)`, causing the Nomad servers for that environment to run out of memory and crash.

To prevent this, this PR introduces a `job_max_count` Nomad server configuration parameter. `job_max_count` limits the number of allocs that may be created from a job. The default value is 50000 - this is low enough that a job with the maximum possible number of allocs will not require much memory on the server, but is still much higher than the number of allocs in the largest Nomad job we have ever run.

For now, this PR is just an initial draft to get the conversation started - there are a few open questions from my side:

 1. While a per-job maximum is safer, it's more difficult to explain in the documentation. Is it worth using an easier-to-explain limit on the count for each group instead of a limit on total count for the job as a whole?

 2. The checks are written so that no validation is performed if `JobMaxCount` is zero. This avoids updating several hundred tests to use a configuration object with appropriate defaults, instead of a struct literal. Is this a good practice, or would it be better to update all of the affected tests?


### Testing & Reproduction steps

To reproduce running out of memory, submit a job with `count = 1000000000`.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

There are no changes to security controls.
