### PR TITLE
state: nil-check waiting evals before attempting to cancel them

### DIFF
--- a/.changelog/26872.txt
+++ b/.changelog/26872.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+state: Fixed a bug where the server could panic when attempting to remove unneeded evals from the eval broker
+```

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1034,7 +1034,7 @@ func (n *nomadFSM) applyAllocClientUpdate(msgType structs.MessageType, buf []byt
 				"eval_id", evalID, "error", err)
 			return err
 		}
-		if !eval.ShouldEnqueue() {
+		if eval != nil && !eval.ShouldEnqueue() {
 			n.evalBroker.DropWaiting(eval)
 		}
 	}


### PR DESCRIPTION
When we attempt to drop unneeded evals from the eval broker, if the eval has been GC'd before the check is made, we hit a nil pointer. Check that the eval actually exists before attempting to remove it from the broker.

Fixes: https://github.com/hashicorp/nomad/issues/26871

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

