### PR TITLE
build: add architecture detection to CNI makefile target

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -477,6 +477,8 @@ copywriteheaders:
 
 .PHONY: cni
 cni: ## Install CNI plugins. Run this as root.
+	@# Detect architecture: x86_64 -> amd64, aarch64 -> arm64
+	$(eval CNI_ARCH := $(shell if [ "$(THIS_ARCH)" = "aarch64" ]; then echo "arm64"; else echo "amd64"; fi))
 	mkdir -p /opt/cni/bin
-	curl --fail -LsO "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-amd64-v1.3.0.tgz"
-	tar -C /opt/cni/bin -xf cni-plugins-linux-amd64-v1.3.0.tgz
+	curl --fail -LsO "https://github.com/containernetworking/plugins/releases/download/v1.3.0/cni-plugins-linux-$(CNI_ARCH)-v1.3.0.tgz"
+	tar -C /opt/cni/bin -xf cni-plugins-linux-$(CNI_ARCH)-v1.3.0.tgz


### PR DESCRIPTION
## Summary
- Adds automatic architecture detection to the `cni` makefile target
- Enables arm64/aarch64 support alongside existing amd64 support
- Uses existing `THIS_ARCH` variable for consistency with other build targets

## Rationale
The `cni` make target was hardcoded to download amd64 CNI plugins, preventing users on arm64/aarch64 Linux systems from using this convenience target. This change detects the system architecture and downloads the appropriate CNI plugin binary.

## Changes
- Added architecture mapping logic: `aarch64` → `arm64`, `x86_64` → `amd64`
- Modified CNI plugin download URL to use detected architecture variable
- Added comment explaining the architecture detection

## Test Plan
- Verified make dry-run (`make -n cni`) correctly detects architecture
- Confirmed both amd64 and arm64 CNI plugin URLs exist and are accessible
- Tested on aarch64 system - correctly selects arm64 plugins

Fixes #26864