### PR TITLE
Feature: adding a Dev Container to Nomad

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,41 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+{
+	"name": "Hashicorp - Nomad",
+	
+	// Docker image to use
+	"image": "ubuntu:latest",
+	
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	// "build": {
+	//   // Path is relative to the devcontainer.json file.
+	//   "dockerfile": "../Dockerfile"
+	// }
+
+	"features": {
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {
+			"enableNonRootDocker": "true",
+			"moby": "true"
+		}
+	},
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [4646],
+	"portsAttributes": {
+		"4646": {
+			"label": "Nomad UI",
+			"onAutoForward": "notify"
+		}
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bash .devcontainer/install-nomad.sh",
+
+	// Use 'postStartCommand' to run commands after the container is created like starting nomad.
+	"postStartCommand": "bash -c 'nomad -version && nomad agent -dev'"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/install-nomad.sh
+++ b/.devcontainer/install-nomad.sh
@@ -1,0 +1,11 @@
+# https://developer.hashicorp.com/nomad/tutorials/get-started/gs-install
+#!/bin/bash
+
+apt-get update && \
+apt-get install -y lsb-release wget gpg coreutils
+
+wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/hashicorp.list
+
+apt-get update && apt-get install -y nomad

--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ See [Developer: Getting Started](https://developer.hashicorp.com/nomad/tutorials
 
 Optionally, find Terraform manifests for bringing up a development Nomad cluster on a public cloud in the [`terraform`](terraform/) directory.
 
+You can also run Nomad in a Gihub Codespace for Development or Evaluation purposes
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/hashicorp/nomad?quickstart=1)
+
 #### Production
 See [Developer: Nomad Reference Architecture](https://developer.hashicorp.com/nomad/tutorials/enterprise/production-reference-architecture-vm-with-consul) for recommended practices and a reference architecture for production deployments.
 


### PR DESCRIPTION
This PR adds a Dev Container to nomad repository. Enabling us to run Nomad in a Github Codespace or locally using a Dev Container

When we create a Github Codespace a new VSCode window will open
<img width="1917" height="1037" alt="image" src="https://github.com/user-attachments/assets/fa2a5e82-e734-4409-93ed-d3df0938a5d2" />

The Codespace will display the output of the postCreateCommand `bash .devcontainer/install-nomad.sh` and the postStartCommand `bash -c 'nomad -version && nomad agent -dev'`
<img width="1917" height="1037" alt="image" src="https://github.com/user-attachments/assets/ccd3fe96-1809-4164-80ff-2dc1a90e66bb" />

Port 4646 Nomad UI will be available in the Ports tab
<img width="1914" height="1038" alt="image" src="https://github.com/user-attachments/assets/8792e980-df3f-451c-bec9-8587296355d1" />

We can right click on that port and open it ina. new browser window
<img width="1913" height="1038" alt="image" src="https://github.com/user-attachments/assets/50f18f1e-b449-419a-935a-e7b467e83502" />

And we will be greeted by the Nomad UI
<img width="1913" height="1038" alt="image" src="https://github.com/user-attachments/assets/b391cae7-b6e4-487e-9476-27f3e7154b5b" />

This is to my knowledge the fastest way to launch Nomad for demo or evaluation purposes live on the internet.

Thank you for this great project!
