### PR TITLE
docs: expand `check.address_mode` to show valid values

### DIFF
--- a/website/content/docs/job-specification/check.mdx
+++ b/website/content/docs/job-specification/check.mdx
@@ -497,3 +497,4 @@ Output     =  nomad: Get "http://:9999/": dial tcp :9999: connect: connection re
 [service]: /nomad/docs/job-specification/service
 [service_task]: /nomad/docs/job-specification/service#task-1
 [on_update]: /nomad/docs/job-specification/service#on_update
+[network_mode]: /nomad/docs/job-specification/network#mode


### PR DESCRIPTION
The documentation for the health check `address_mode` field refers back to the service `address_mode` field for valid values, but this is somewhat misleading. Checks don't support the `"auto"` mode, and although this is mentioned in the text it's easy to miss or forget once you've clicked away to the service docs. The text of the service `address_mode` options also specifically refers to advertisement, which is typically going to be what a user is trying to avoid when setting the check to a non-default mode. And the `check.address_mode` text refers to both `service.address` and `service.address_mode` in such a way that it can be confused as a typo.

Bring over the valid mode descriptions from services and clean them up to refer to the checks and not advertisement in this context.

Ref: https://github.com/hashicorp/nomad/issues/26900
Preview link: https://nomad-git-docs-check-address-mode-hashicorp.vercel.app/nomad/docs/job-specification/check#address_mode
