### PR TITLE
server: Check failed servers when gating node identity feature.

### DIFF
--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -220,7 +220,7 @@ func (n *Node) Register(args *structs.NodeRegisterRequest, reply *structs.NodeUp
 	if n.srv.peersCache.ServersMeetMinimumVersion(
 		n.srv.Region(),
 		minVersionNodeIdentity,
-		false,
+		true,
 	) {
 
 		// Track the TTL that will be used for the node identity.
@@ -748,7 +748,7 @@ func (n *Node) UpdateStatus(args *structs.NodeUpdateStatusRequest, reply *struct
 	if n.srv.peersCache.ServersMeetMinimumVersion(
 		n.srv.Region(),
 		minVersionNodeIdentity,
-		false,
+		true,
 	) {
 		// Track the TTL that will be used for the node identity.
 		var identityTTL time.Duration


### PR DESCRIPTION
We should guard more heavily when checking whether the server cluster can support node identity features. If a failed server did rejoin the cluster and a number of nodes connected to it that had identities, they would fail as the old server would not be able to understand the node authentication token.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


