### PR TITLE
docs: fix block syntax for `secret.config` block

### DIFF
--- a/website/content/docs/job-specification/secret.mdx
+++ b/website/content/docs/job-specification/secret.mdx
@@ -31,7 +31,7 @@ job "docs" {
       secret "my_secret" {
         provider = "vault"
         path     = "path/to/secret"
-        config   = {
+        config {
           engine = "kv_v2"
         }
       }

--- a/website/content/plugins/author/secret-provider.mdx
+++ b/website/content/plugins/author/secret-provider.mdx
@@ -149,13 +149,13 @@ following criteria:
 
 ### Operations
 
-A secrete provider plugin must fulfill all of the following operations:
+A secret provider plugin must fulfill all of the following operations:
 
 - [fingerprint](#fingerprint)
 - [fetch](#fetch)
 
-Nomad passes the operation as the first positional argument to the plugin.
-Pass that and other information as environment variables prefixed with `CPI_`.
+Nomad passes the operation as the first positional argument to the plugin and as
+an environment variable prefixed with `CPI_`.
 
 #### fingerprint
 
@@ -238,9 +238,3 @@ error returned to the user.
 [custom-providers]: /nomad/docs/job-specification/secret#custom-providers
 [go-version]: https://pkg.go.dev/github.com/hashicorp/go-version#pkg-constants
 [common_plugin_dir]: /nomad/docs/configuration/client#common_plugin_dir
-
-
-
-
-
-


### PR DESCRIPTION
The example jobspec configuration is a map and not a block, which will return a HCL validation error. Fix miscellaneous docs typos as well.

Ref: https://hashicorp.atlassian.net/browse/NMD-988