### PR TITLE
config: fix merging of configuration for `common_plugin_dir`

### DIFF
--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -2702,6 +2702,9 @@ func (c *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	if b.HostVolumePluginDir != "" {
 		result.HostVolumePluginDir = b.HostVolumePluginDir
 	}
+	if b.CommonPluginDir != "" {
+		result.CommonPluginDir = b.CommonPluginDir
+	}
 	if b.NodeClass != "" {
 		result.NodeClass = b.NodeClass
 	}


### PR DESCRIPTION
While testing the new secret block with a custom plugin, I noticed the `client.common_plugin_dir` configuration value was not being respected and Nomad was always looking in the default location. This is because we're not merging the value from a loaded file onto the default value.

Ref: https://hashicorp.atlassian.net/browse/NMD-988