### PR TITLE
server: Ensure node pools are created with a default identity TTL.

### DIFF
--- a/nomad/state/state_store_node_pools.go
+++ b/nomad/state/state_store_node_pools.go
@@ -159,8 +159,12 @@ func (s *StateStore) fetchOrCreateNodePoolTxn(txn *txn, index uint64, name strin
 		return nil, err
 	}
 
+	// If the node pool does not exist within state already, hydrate the object
+	// with the supplied name. Ensure we canonicalize the object before, so we
+	// set critical default values.
 	if pool == nil {
 		pool = &structs.NodePool{Name: name}
+		pool.Canonicalize()
 		err = s.upsertNodePoolTxn(txn, index, pool)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
When a node registers it optionally creates the node pool it will reside within. Upon upsert, this node pool needs to be canonicalized, so that we can ensure it has a non-zero identity TTL for nodes.

### Links
Jira: https://hashicorp.atlassian.net/browse/NMD-1035
Closes #26948

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


