### PR TITLE
claims: add JSON serialization for interface arrays

### DIFF
--- a/.changelog/26958.txt
+++ b/.changelog/26958.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+oidc: add support for array-based OIDC claims
+```

--- a/lib/auth/claims.go
+++ b/lib/auth/claims.go
@@ -152,16 +152,23 @@ func getClaim(all map[string]interface{}, claim string) interface{} {
 // stringifyClaimValue will try to convert the provided raw value into a
 // faithful string representation of that value per these rules:
 //
-// - strings      => unchanged
-// - bool         => "true" / "false"
-// - json.Number  => String()
-// - float32/64   => truncated to int64 and then formatted as an ascii string
-// - intXX/uintXX => casted to int64 and then formatted as an ascii string
+// - []interface{} => marshaling to JSON string
+// - strings       => unchanged
+// - bool          => "true" / "false"
+// - json.Number   => String()
+// - float32/64    => truncated to int64 and then formatted as an ascii string
+// - intXX/uintXX  => casted to int64 and then formatted as an ascii string
 //
 // If successful the string value and true are returned. otherwise an empty
 // string and false are returned.
 func stringifyClaimValue(rawValue interface{}) (string, bool) {
 	switch v := rawValue.(type) {
+	case []interface{}:
+		b, err := json.Marshal(v)
+		if err != nil {
+			return "", false
+		}
+		return string(b), true
 	case string:
 		return v, true
 	case bool:

--- a/lib/auth/claims_test.go
+++ b/lib/auth/claims_test.go
@@ -68,6 +68,24 @@ func TestSelectorData(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			"nested list claim",
+			nil,
+			map[string]string{"roles": "r"},
+			map[string]any{
+				"roles": []any{
+					[]any{"role1", "role2", "roleN"}, 42, false,
+				},
+			},
+			&structs.ACLAuthClaims{
+				Value: map[string]string{},
+				List: map[string][]string{
+					"r": {`["role1","role2","roleN"]`, "42", "false"},
+				},
+			},
+		},
+
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
The current implementation lacks support for parsing and handling array structures in OIDC claims, which severely limits SSO integration with OIDC providers like Keycloak. Previously, array values in OIDC claims were raising "converting claim" errors. The parsing failed to properly map user roles from array-based claims.

### Description

- Added type case for `[]interface{}` that marshals arrays to JSON string format.
- Enables proper processing of multi-value OIDC claims such as roles.
- Maintains backward compatibility while extending support for array structures.

### Testing & Reproduction Steps

#### Before fix

Trying to map the `roles` claim results in a 500 error:

```bash
http: request failed: method=POST path=/v1/acl/oidc/complete-auth \
error="error converting claim 'roles' to string from unknown type []interface {}" code=500
```
#### After fix
- The same configuration now properly processes array claims.
- Array values are serialized to JSON strings for consistent handling.
- User roles are correctly mapped from the OIDC provider.

Example of the processed claim:
```bash
internal_claims = {
  "roles": "[\"role1\",\"role2\",\"roleN\"]"
}
```

### Changes to Security Controls

Yes, this PR includes changes to security controls:
    Access Controls: Enables proper role mapping from OIDC providers, ensuring users receive correct authorization levels