### PR TITLE
core: limit job GC batch size to match other GC batches

### DIFF
--- a/.changelog/26974.txt
+++ b/.changelog/26974.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed a bug where GC batch sizes for jobs resulted in excessively large Raft logs
+```

--- a/nomad/core_sched.go
+++ b/nomad/core_sched.go
@@ -216,8 +216,10 @@ OUTER:
 
 // jobReap contacts the leader and issues a reap on the passed jobs
 func (c *CoreScheduler) jobReap(jobs []*structs.Job, leaderACL string) error {
-	// Call to the leader to issue the reap
-	for _, req := range c.partitionJobReap(jobs, leaderACL, structs.MaxUUIDsPerWriteRequest) {
+	// Call to the leader to issue the reap with a batch size intended to be
+	// similar to the GC by batches of UUIDs for evals, allocs, and nodes
+	// (limited by structs.MaxUUIDsPerWriteRequest)
+	for _, req := range c.partitionJobReap(jobs, leaderACL, 2048) {
 		var resp structs.JobBatchDeregisterResponse
 		if err := c.srv.RPC(structs.JobBatchDeregisterRPCMethod, req, &resp); err != nil {
 			c.logger.Error("batch job reap failed", "error", err)


### PR DESCRIPTION
In the core scheduler we have several object types where we can delete them by ID. We batch up to 7281 UUIDs because this works out to be about 256 KiB per request, which is well below the maximum Raft log entry size we want to have. When we GC jobs we use this same constant to size the batch, but the request body is not a list of UUIDs but instead a map of namespaced job IDs to a pointer to a struct. This pushes the batch size into 746 KiB (assuming UUID-sized job names), which is going to impact performance if GC happens during large volumes of short-lived dispatch work where users may be GC'ing jobs frequently.

Limit the batch size for `JobBatchDeregisterRequest` to roughly the same size as the requests that are lists of UUIDs.

Ref: https://hashicorp.atlassian.net/browse/NMD-1041

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
  * see https://github.com/hashicorp/nomad/pull/26974#issuecomment-3428919549
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

