### PR TITLE
Docs infra: Add redirects for commands dir prior to 1.8

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1035,7 +1035,7 @@ module.exports = [
   },
   /* redirects to commands prior to version 1.8 for version pick list entries */
   {
-    source: '/nomad/commands/:version(v1\\.(?:7|6|5|4|3|2|1)\\.x)/:path*',
+    source: '/nomad/commands/:version(v1\\.(?:7|6|5|4|3|2|1|0)\\.x)/:path*',
     destination: '/nomad/docs/:version/commands/:path*',
     permanent: true,
   },


### PR DESCRIPTION
### Description

Add redirects for /commands/ directory in versions 0.11-1.7.

Note that the deploy preview does not support prior versions. Assigning to Jeff Boruszak to approve from an Education standpoint but will still need DevDot or NomadEng for merge approval.


### Links

Jira: [CE-1075]

https://nomad-git-ce1075redirect-hashicorp.vercel.app/nomad

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


[CE-1075]: https://hashicorp.atlassian.net/browse/CE-1075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ