### PR TITLE
Docs redirects: Add back /nomad/s/port-plan-failure

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -32,7 +32,7 @@ module.exports = [
 
   /**
    * /s/* redirects for useful links that need a stable URL but we may need to
-   * change its destination in the future.
+   * change its destination in the future. Some of these used in CLI output.
    */
   {
     source: '/nomad/s/envoy-bootstrap-error',
@@ -44,6 +44,11 @@ module.exports = [
     source: '/nomad/s/vault-workload-identity-migration',
     destination:
       'https://developer.hashicorp.com/nomad/docs/v1.8.x/integrations/vault/acl#migrating-to-using-workload-identity-with-vault',
+    permanent: false,
+  },
+  {
+    source: '/nomad/s/port-plan-failure',
+    destination: 'https://github.com/hashicorp/nomad/issues/9506',
     permanent: false,
   },
   {


### PR DESCRIPTION
### Description

User reported that a link in CLI output results in 404. I found the specialized redirect in a much older docs version and have added to current redirects. Not sure when that redirect entry was removed.

This partially fixes the NMD ticket in that the linked GH issue was fixed in 2023, so the CLI code should be updated at some point.

### Links

Jira: [CE-1080]   partial [NMD-953]
GitHub: fixes https://github.com/hashicorp/nomad/issues/26687

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.



[CE-1080]: https://hashicorp.atlassian.net/browse/CE-1080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NMD-953]: https://hashicorp.atlassian.net/browse/NMD-953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ