### PR TITLE
autopilot: Use peer cache to perform autopilot Serf member work.

### DIFF
--- a/nomad/peers/peers.go
+++ b/nomad/peers/peers.go
@@ -44,6 +44,11 @@ type Parts struct {
 	Status      serf.MemberStatus
 	NonVoter    bool
 
+	// Tags are the full Serf tags for the member. This duplicates some of the
+	// data which is also stored in other fields for convenience, so adds a
+	// little size overhead. It is included as Autopilot uses them.
+	Tags map[string]string
+
 	// Deprecated: Functionally unused but needs to always be set by 1 for
 	// compatibility with v1.2.x and earlier.
 	MajorVersion int
@@ -133,6 +138,7 @@ func IsNomadServer(m serf.Member) (bool, *Parts) {
 		RaftVersion:  raftVsn,
 		Status:       m.Status,
 		NonVoter:     nonVoter,
+		Tags:         m.Tags,
 		MajorVersion: deprecatedAPIMajorVersion,
 	}
 	return true, parts

--- a/nomad/peers/peers_test.go
+++ b/nomad/peers/peers_test.go
@@ -94,6 +94,7 @@ func TestIsNomadServer(t *testing.T) {
 	must.Eq(t, 7, parts.Build.Segments()[1])
 	must.Eq(t, 0, parts.Build.Segments()[2])
 	must.True(t, parts.NonVoter)
+	must.MapEq(t, m.Tags, parts.Tags)
 
 	m.Tags["bootstrap"] = "1"
 	valid, parts = IsNomadServer(m)


### PR DESCRIPTION
Nomad 1.11 introduced a new peer cache to store information about Serf peers in order to perform server version checking. This can be used to perform the autopilot functionality which reduces the need to parse Serf tags and iterate members.

Autopilot needs the existing Serf members tags, so these have been added to the peer parts object. While this takes up a little space, it reduces our time complexity. The autopilot code has also been simplified, as the Raft version identifier is already in the server parts.

### Links
Builds upon #26985

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


