### PR TITLE
system scheduler: account for alloc resources when checking node feasibility

### DIFF
--- a/scheduler/scheduler_system_ce.go
+++ b/scheduler/scheduler_system_ce.go
@@ -1,0 +1,68 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+// +build !ent
+
+package scheduler
+
+import (
+	"slices"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/scheduler/feasible"
+	"github.com/hashicorp/nomad/scheduler/reconciler"
+	sstructs "github.com/hashicorp/nomad/scheduler/structs"
+)
+
+// findNodesForTG runs feasibility checks on nodes. The result includes all nodes for each
+// task group (feasible and infeasible) along with metrics information on the checks.
+func (s *SystemScheduler) findNodesForTG(buckets *reconciler.NodeReconcileResult) (tgNodes map[string]taskGroupNodes, filteredMetrics map[string]*structs.AllocMetric) {
+	tgNodes = make(map[string]taskGroupNodes)
+	filteredMetrics = make(map[string]*structs.AllocMetric)
+
+	nodeByID := make(map[string]*structs.Node, len(s.nodes))
+	for _, node := range s.nodes {
+		nodeByID[node.ID] = node
+	}
+
+	nodes := make([]*structs.Node, 1)
+	for _, a := range slices.Concat(buckets.Place, buckets.Update, buckets.Ignore) {
+		tgName := a.TaskGroup.Name
+		if tgNodes[tgName] == nil {
+			tgNodes[tgName] = taskGroupNodes{}
+		}
+
+		node, ok := nodeByID[a.Alloc.NodeID]
+		if !ok {
+			s.logger.Debug("could not find node", "node", a.Alloc.NodeID)
+			continue
+		}
+
+		// Update the set of placement nodes
+		nodes[0] = node
+		s.stack.SetNodes(nodes)
+
+		if a.Alloc.ID != "" {
+			// temporarily include the old alloc from a destructive update so
+			// that we can account for resources that will be freed by that
+			// allocation. We'll back this change out if we end up needing to
+			// limit placements by max_parallel or canaries.
+			s.plan.AppendStoppedAlloc(a.Alloc, sstructs.StatusAllocUpdating, "", "")
+		}
+
+		// Attempt to match the task group
+		option := s.stack.Select(a.TaskGroup, &feasible.SelectOptions{AllocName: a.Name})
+
+		// Always store the results. Keep the metrics that were generated
+		// for the match attempt so they can be used during placement.
+		tgNodes[tgName] = append(tgNodes[tgName], &taskGroupNode{node.ID, option, s.ctx.Metrics().Copy()})
+
+		if option == nil {
+			// When no match is found, merge the filter metrics for the task
+			// group so proper reporting can be done during placement.
+			filteredMetrics[tgName] = mergeNodeFiltered(filteredMetrics[tgName], s.ctx.Metrics())
+		}
+	}
+	return
+}


### PR DESCRIPTION
CE part of nomad-enterprise PR
https://github.com/hashicorp/nomad-enterprise/pull/3372

----

In the past, when doing feasibility checks, we'd perform them in one big loop
in the computePlacements method. At the very end of each node check, should
we get a feasible option from the stack, we'd construct an allocation and
append it to plan. On every subsequent iteration of the loop, stack iterators
that needed to take into account accumulative resource usage (at the moment
it's just the QuotaIterator) would look at the plan and judge feasibility
based on it. Although not a perfect solution (the first placement would
always go through even if it violated the quota!), merging
https://github.com/hashicorp/nomad/pull/26953 broke this behavior, because now
feasible nodes are being found before any placements or plan appends happen.
Thus, QuotaIterator would always get a clean slate of resources used and we
would end up with placements that violate limits.

This changeset modifies the behavior of findNodesForTG method in the
scheduler. If there are quotas enabled for the namespace, it creates a dummy
allocation and temporarily appends it to the plan, in order to get accurate
quota checks.

