### PR TITLE
api: event stream should allow topic without filter

### DIFF
--- a/.changelog/27065.txt
+++ b/.changelog/27065.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fixed a bug in the Go API where an event stream request without a topic filter would require a management token
+```

--- a/api/event_stream.go
+++ b/api/event_stream.go
@@ -181,6 +181,10 @@ func (e *EventStream) Stream(ctx context.Context, topics map[Topic][]string, ind
 
 	// Build topic query params
 	for topic, keys := range topics {
+		if len(keys) == 0 {
+			r.params.Add("topic", fmt.Sprintf("%s", topic))
+			continue
+		}
 		for _, k := range keys {
 			r.params.Add("topic", fmt.Sprintf("%s:%s", topic, k))
 		}


### PR DESCRIPTION
When using the Go API to read from the event stream, the API documentation says the topic filter is optional. But if omitted, we end up not sending any topic parameter. Making an event stream query without a topic or with a `*` wildcard topic filter is only allowed by the management token.

If the developer provides a topic without a filter, treat this as a bare topic request as one would expect.

Fixes: https://github.com/hashicorp/nomad/issues/27063

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the  Nomad website documentation to reflect this. Refer to
  the [website README](../website/README.md) for docs guidelines. Please also consider whether the
  change requires notes within the [upgrade guide](../website/content/docs/upgrade/upgrade-specific.mdx).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

