### PR TITLE
e2e: correct assertion in the system deployments test

### DIFF
--- a/e2e/scheduler_system/input/system_canary_v0_100.nomad.hcl
+++ b/e2e/scheduler_system/input/system_canary_v0_100.nomad.hcl
@@ -13,7 +13,7 @@ job "system_job" {
 
   group "system_job_group" {
     update {
-      max_parallel     = 1
+      max_parallel     = 5
       min_healthy_time = "1s"
       healthy_deadline = "1m"
       auto_revert      = false

--- a/e2e/scheduler_system/input/system_canary_v1_100.nomad.hcl
+++ b/e2e/scheduler_system/input/system_canary_v1_100.nomad.hcl
@@ -13,7 +13,7 @@ job "system_job" {
 
   group "system_job_group" {
     update {
-      max_parallel     = 1
+      max_parallel     = 5
       min_healthy_time = "1s"
       healthy_deadline = "1m"
       auto_revert      = false

--- a/e2e/scheduler_system/systemsched_test.go
+++ b/e2e/scheduler_system/systemsched_test.go
@@ -152,7 +152,7 @@ func testCanaryUpdate(t *testing.T) {
 			count += 1
 		}
 	}
-	must.Eq(t, int(math.Ceil(float64(len(initialAllocs)/2))), count, must.Sprint("expected canaries to be placed on 50% of feasible nodes"))
+	must.Eq(t, int(math.Ceil(float64(len(initialAllocs)/2))), count, must.Sprint("expected canaries to be placed on 1 node only since max_parallel is set to 1"))
 
 	// promote canaries
 	deployments, _, err := deploymentsApi.List(nil)


### PR DESCRIPTION
Since #27062 we correctly handle `max_parallel` for any destructive updates, which includes canary placements. This should be reflected in the e2e test. This PR updates the assertion of the `testCanaryUpdate` to expect 1 canary placement (since `max_parallel` is set to 1 in that test jobspec), and updates the sample jobspecs for `testCanaryDeploymentToAllEligibleNodes` to deploy with `max_parallel = 5` to test that it gets deployed to all feasible nodes. 