### PR TITLE
prototype of custom resource scheduling

### DIFF
--- a/api/allocations.go
+++ b/api/allocations.go
@@ -436,12 +436,14 @@ type AllocatedTaskResources struct {
 	Memory   AllocatedMemoryResources
 	Networks []*NetworkResource
 	Devices  []*AllocatedDeviceResource
+	Custom   []*CustomResource
 }
 
 type AllocatedSharedResources struct {
 	DiskMB   int64
 	Networks []*NetworkResource
 	Ports    []PortMapping
+	Custom   []*CustomResource
 }
 
 type PortMapping struct {

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -587,6 +587,7 @@ type NodeResources struct {
 	Disk     NodeDiskResources
 	Networks []*NetworkResource
 	Devices  []*NodeDeviceResource
+	Custom   []*NodeCustomResource
 
 	MinDynamicPort int
 	MaxDynamicPort int
@@ -627,6 +628,18 @@ type NodeReservedDiskResources struct {
 
 type NodeReservedNetworkResources struct {
 	ReservedHostPorts string
+}
+
+type NodeCustomResource struct {
+	Name    string              `hcl:"name,label"`
+	Version uint64              `hcl:"version,optional"`
+	Type    CustomResourceType  `hcl:"type,optional"`
+	Scope   CustomResourceScope `hcl:"scope,optional"`
+
+	Quantity int64             `hcl:"quantity,optional"`
+	Range    string            `hcl:"range,optional"`
+	Items    []any             `hcl:"items,optional"`
+	Meta     map[string]string `hcl:"meta,block"`
 }
 
 type CSITopologyRequest struct {

--- a/api/resources.go
+++ b/api/resources.go
@@ -20,6 +20,7 @@ type Resources struct {
 	Devices     []*RequestedDevice `hcl:"device,block"`
 	NUMA        *NUMAResource      `hcl:"numa,block"`
 	SecretsMB   *int               `mapstructure:"secrets" hcl:"secrets,optional"`
+	Custom      []*CustomResource  `mapstructure:"custom" hcl:"custom,block"`
 
 	// COMPAT(0.10)
 	// XXX Deprecated. Please do not use. The field will be removed in Nomad
@@ -330,3 +331,32 @@ func (d *RequestedDevice) Canonicalize() {
 		a.Canonicalize()
 	}
 }
+
+type CustomResource struct {
+	Name    string              `hcl:"name,label"`
+	Version uint64              `hcl:"version,optional"`
+	Type    CustomResourceType  `hcl:"type,optional"`
+	Scope   CustomResourceScope `hcl:"scope,optional"`
+
+	Quantity    int64         `hcl:"quantity,optional"`
+	Range       string        `hcl:"range,optional"`
+	Items       []any         `hcl:"items,optional"`
+	Constraints []*Constraint `hcl:"constraint,block"`
+}
+
+type CustomResourceScope string
+
+const (
+	CustomResourceScopeGroup CustomResourceScope = "group"
+	CustomResourceScopeTask  CustomResourceScope = "task"
+)
+
+type CustomResourceType string
+
+const (
+	CustomResourceTypeRatio           CustomResourceType = "ratio"        // ex. weight
+	CustomResourceTypeCappedRatio     CustomResourceType = "capped-ratio" // ex. resource.cpu
+	CustomResourceTypeCountable       CustomResourceType = "countable"    // ex. memory, disk
+	CustomResourceTypeDynamicInstance CustomResourceType = "dynamic"      // ex. ports, cores
+	CustomResourceTypeStaticInstance  CustomResourceType = "static"       // ex. ports, devices
+)

--- a/client/client.go
+++ b/client/client.go
@@ -1649,12 +1649,14 @@ func (c *Client) setupNode() error {
 		node.NodeResources.MinDynamicPort = newConfig.MinDynamicPort
 		node.NodeResources.MaxDynamicPort = newConfig.MaxDynamicPort
 		node.NodeResources.Processors = newConfig.Node.NodeResources.Processors
+		node.NodeResources.Custom = newConfig.CustomResources
 
 		if node.NodeResources.Processors.Empty() {
 			node.NodeResources.Processors = structs.NodeProcessorResources{
 				Topology: &numalib.Topology{},
 			}
 		}
+		node.NodeResources.Custom = newConfig.CustomResources
 	}
 	if node.ReservedResources == nil {
 		node.ReservedResources = &structs.NodeReservedResources{}
@@ -1813,6 +1815,8 @@ func (c *Client) updateNodeFromFingerprint(response *fingerprint.FingerprintResp
 		if cpu := response.NodeResources.Processors.TotalCompute(); cpu > 0 {
 			newConfig.CpuCompute = cpu
 		}
+
+		response.NodeResources.Custom = newConfig.CustomResources
 	}
 
 	if nodeHasChanged {

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -395,6 +395,8 @@ type Config struct {
 
 	// LogFile is used by MonitorExport to stream a server's log file
 	LogFile string `hcl:"log_file"`
+
+	CustomResources structs.CustomResources
 }
 
 type APIListenerRegistrar interface {
@@ -896,6 +898,7 @@ func (c *Config) Copy() *Config {
 	nc.ReservableCores = slices.Clone(c.ReservableCores)
 	nc.Artifact = c.Artifact.Copy()
 	nc.Users = c.Users.Copy()
+	nc.CustomResources = c.CustomResources.Copy()
 	return &nc
 }
 

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -158,6 +158,7 @@ func NewAgent(config *Config, logger log.InterceptLogger, logOutput io.Writer, i
 	if err := a.setupServer(); err != nil {
 		return nil, err
 	}
+
 	if err := a.setupClient(); err != nil {
 		return nil, err
 	}
@@ -936,6 +937,7 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	conf.Node.Meta = agentConfig.Client.Meta
 	conf.Node.NodeClass = agentConfig.Client.NodeClass
 	conf.Node.NodePool = agentConfig.Client.NodePool
+	conf.CustomResources = agentConfig.Client.CustomResources
 
 	// Set up the HTTP advertise address
 	conf.Node.HTTPAddr = agentConfig.AdvertiseAddrs.HTTP

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -443,6 +443,10 @@ type ClientConfig struct {
 
 	// LogFile is used by MonitorExport to stream a client's log file
 	LogFile string `hcl:"log_file"`
+
+	// CustomResources allows the user to define custom schedulable resources on
+	// this node
+	CustomResources structs.CustomResources `hcl:"custom_resource,block"`
 }
 
 func (c *ClientConfig) Copy() *ClientConfig {
@@ -466,6 +470,7 @@ func (c *ClientConfig) Copy() *ClientConfig {
 	nc.Drain = c.Drain.Copy()
 	nc.Users = c.Users.Copy()
 	nc.ExtraKeysHCL = slices.Clone(c.ExtraKeysHCL)
+	nc.CustomResources = c.CustomResources.Copy()
 	return &nc
 }
 
@@ -2881,6 +2886,10 @@ func (c *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	}
 	if b.IntroToken != "" {
 		result.IntroToken = b.IntroToken
+	}
+
+	if b.CustomResources != nil {
+		result.CustomResources.Merge(b.CustomResources)
 	}
 
 	return &result

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -330,6 +330,11 @@ func extraKeys(c *Config) error {
 		helper.RemoveEqualFold(&c.Client.ExtraKeysHCL, "host_network")
 	}
 
+	for _, cr := range c.Client.CustomResources {
+		helper.RemoveEqualFold(&c.Client.ExtraKeysHCL, "custom_resource")
+		helper.RemoveEqualFold(&c.Client.ExtraKeysHCL, cr.Name)
+	}
+
 	// Remove Template extra keys
 	for _, t := range []string{"function_denylist", "disable_file_sandbox", "max_stale", "wait", "wait_bounds", "block_query_wait", "consul_retry", "vault_retry", "nomad_retry"} {
 		helper.RemoveEqualFold(&c.Client.ExtraKeysHCL, t)

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1646,6 +1646,22 @@ func ApiResourcesToStructs(in *api.Resources) *structs.Resources {
 		out.SecretsMB = *in.SecretsMB
 	}
 
+	if len(in.Custom) > 0 {
+		out.Custom = []*structs.CustomResource{}
+		for _, apiCr := range in.Custom {
+			out.Custom = append(out.Custom, &structs.CustomResource{
+				Name:        apiCr.Name,
+				Version:     apiCr.Version,
+				Type:        structs.CustomResourceType(apiCr.Type),
+				Scope:       structs.CustomResourceScope(apiCr.Scope),
+				Quantity:    apiCr.Quantity,
+				Range:       apiCr.Range,
+				Items:       apiCr.Items,
+				Constraints: ApiConstraintsToStructs(apiCr.Constraints),
+			})
+		}
+	}
+
 	return out
 }
 

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -163,7 +163,8 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevi
 		cr := alloc.AllocatedResources.Comparable()
 		used.Add(cr)
 
-		// Adding the comparable resource unions reserved core sets, need to check if reserved cores overlap
+		// Adding the comparable resource unions reserved core sets, need to
+		// check if reserved cores overlap
 		for _, core := range cr.Flattened.Cpu.ReservedCores {
 			if _, ok := reservedCores[core]; ok {
 				coreOverlap = true

--- a/nomad/structs/resources.go
+++ b/nomad/structs/resources.go
@@ -1,0 +1,393 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package structs
+
+import (
+	"cmp"
+	"errors"
+	"fmt"
+	"maps"
+	"math/rand"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/go-set/v3"
+	"github.com/hashicorp/nomad/helper"
+)
+
+type CustomResource struct {
+	// TODO(tgross): we need this old ",key" construction for HCL v1 parsing of
+	// the client config; should this even be the same struct as the config?
+	Name    string `hcl:",key"`
+	Version uint64 // optional
+	Type    CustomResourceType
+	Scope   CustomResourceScope
+
+	Quantity int64  // for countable or capped-ratio
+	Range    string // for dynamic or static
+	Items    []any  // for dynamic or static
+	Meta     map[string]string
+
+	Constraints []*Constraint
+}
+
+type CustomResourceScope string
+
+const (
+	CustomResourceScopeGroup CustomResourceScope = "group"
+	CustomResourceScopeTask  CustomResourceScope = "task"
+)
+
+type CustomResourceType string
+
+const (
+	CustomResourceTypeRatio           CustomResourceType = "ratio"        // ex. weight
+	CustomResourceTypeCappedRatio     CustomResourceType = "capped-ratio" // ex. resource.cpu
+	CustomResourceTypeCountable       CustomResourceType = "countable"    // ex. memory, disk
+	CustomResourceTypeDynamicInstance CustomResourceType = "dynamic"      // ex. ports, cores
+	CustomResourceTypeStaticInstance  CustomResourceType = "static"       // ex. ports, devices
+)
+
+// Copy returns a deep clone of the CustomResource
+func (cr *CustomResource) Copy() *CustomResource {
+	ncr := new(CustomResource)
+	*ncr = *cr
+
+	ncr.Items = slices.Clone(cr.Items)
+	ncr.Meta = maps.Clone(cr.Meta)
+	ncr.Constraints = helper.CopySlice(cr.Constraints)
+	return ncr
+}
+
+func (cr *CustomResource) Validate() error {
+	// TODO(tgross): what do we need to do to validate these?
+	return nil
+}
+
+func (cr *CustomResource) Equal(or *CustomResource) bool {
+	if cr.Name != or.Name ||
+		cr.Quantity != or.Quantity ||
+		cr.Type != or.Type ||
+		cr.Scope != or.Scope ||
+		cr.Range != or.Range ||
+		len(cr.Items) != len(or.Items) ||
+		len(cr.Constraints) != len(or.Constraints) ||
+		!slices.Equal(cr.Items, or.Items) ||
+		!maps.Equal(cr.Meta, or.Meta) ||
+		!slices.EqualFunc(cr.Constraints, or.Constraints, func(l, r *Constraint) bool {
+			return l.Equal(r)
+		}) {
+		return false
+	}
+
+	return true
+}
+
+var (
+	ErrInvalidCustomResourceComparison = errors.New("custom resources could not be compared")
+	ErrCustomResourceExhausted         = errors.New("custom resources exhausted")
+	ErrSubtractFromNothing             = errors.New("custom resource request cannot be subtracted from non-existant base")
+)
+
+func (cr *CustomResource) Superset(other *CustomResource) (bool, string) {
+
+	if cr == nil || other == nil {
+		return false, fmt.Sprintf("custom resource: %s", cr.Name)
+	}
+	err := cr.compatible(other)
+	if err != nil {
+		return false, err.Error() // not ideal, but this matches the other Comparable APIs
+	}
+
+	switch cr.Type {
+	case CustomResourceTypeRatio:
+		// fallthrough: ratios always fit?
+
+	case CustomResourceTypeCappedRatio, CustomResourceTypeCountable:
+		if cr.Quantity-other.Quantity < 0 {
+			return false, fmt.Sprintf("custom resource: %s", cr.Name)
+		}
+
+	case CustomResourceTypeDynamicInstance, CustomResourceTypeStaticInstance:
+		items := set.From(cr.Items)
+		if !items.ContainsSlice(other.Items) {
+			return false, fmt.Sprintf("custom resource: %s", cr.Name)
+		}
+	}
+
+	return true, ""
+}
+
+// Add mutates the CustomResource by the delta
+func (cr *CustomResource) Add(delta *CustomResource) error {
+	if cr == nil || delta == nil {
+		return nil
+	}
+	err := cr.compatible(delta)
+	if err != nil {
+		return err
+	}
+
+	switch cr.Type {
+	case CustomResourceTypeRatio:
+		return nil // ratios don't sum up
+
+	case CustomResourceTypeCappedRatio, CustomResourceTypeCountable:
+		cr.Quantity += delta.Quantity
+
+	case CustomResourceTypeDynamicInstance, CustomResourceTypeStaticInstance:
+		items := set.From(cr.Items)
+		cr.Items = items.Union(set.From(delta.Items)).Slice()
+		if len(cr.Items) > 1 {
+			slices.SortFunc(cr.Items, func(a, b any) int {
+				switch a.(type) {
+				case string:
+					if _, ok := b.(string); !ok {
+						return 0
+					}
+					return strings.Compare(a.(string), b.(string))
+				case int:
+					if _, ok := b.(int); !ok {
+						return 0
+					}
+					return cmp.Compare(a.(int), b.(int))
+				}
+				return 0
+			})
+		}
+	}
+
+	return nil
+}
+
+// Subtract mutates the CustomResource by the delta
+func (cr *CustomResource) Subtract(delta *CustomResource) error {
+	if cr == nil || delta == nil {
+		return nil
+	}
+	err := cr.compatible(delta)
+	if err != nil {
+		return err
+	}
+
+	switch cr.Type {
+	case CustomResourceTypeRatio:
+		return nil // ratios don't sum up
+
+	case CustomResourceTypeCappedRatio, CustomResourceTypeCountable:
+		quantity := cr.Quantity - delta.Quantity
+		cr.Quantity = max(quantity, 0)
+
+	case CustomResourceTypeDynamicInstance, CustomResourceTypeStaticInstance:
+		items := set.From(cr.Items)
+		items.RemoveSet(set.From(delta.Items))
+		cr.Items = items.Slice()
+	}
+
+	return nil
+}
+
+func (cr *CustomResource) compatible(delta *CustomResource) error {
+	// TODO(tgross): these are programmer errors, I think?
+	if cr.Name != delta.Name {
+		return fmt.Errorf("%w: resource names %q and %q mismatch",
+			ErrInvalidCustomResourceComparison, cr.Name, delta.Name)
+	}
+	if cr.Version < delta.Version && delta.Version > 0 {
+		// requests for version 0 (default) can be considered compatible with
+		// any instance of the resource
+		return fmt.Errorf("%w: resource request %d for %q is newer than available version %d",
+			ErrInvalidCustomResourceComparison, delta.Version, delta.Name, cr.Version)
+	}
+	if cr.Type != delta.Type {
+		return fmt.Errorf("%w: resource types %q and %q for %q are not the same",
+			ErrInvalidCustomResourceComparison, cr.Type, delta.Type, delta.Name)
+	}
+	if cr.Scope != delta.Scope {
+		return fmt.Errorf("%w: resource scopes %q and %q for %q are not the same",
+			ErrInvalidCustomResourceComparison, cr.Scope, delta.Scope, delta.Name)
+	}
+
+	return nil
+}
+
+// CustomResources is a convenience wrapper around a slice of CustomResources
+type CustomResources []*CustomResource
+
+func (cr CustomResources) Copy() CustomResources {
+	return helper.CopySlice(cr)
+}
+
+func (cr *CustomResources) Select(available CustomResources) error {
+NEXT:
+	for _, r := range *cr {
+		for _, base := range available {
+			if base.Name == r.Name && base.Version == r.Version {
+				if r.Type != CustomResourceTypeDynamicInstance {
+					if ok, exhausted := base.Superset(r); !ok {
+						return fmt.Errorf("%w: %s", ErrCustomResourceExhausted, exhausted)
+					}
+				} else {
+					// for dynamic instances, we need to select items for the
+					// quantity and mutate the Items of this CustomResource with
+					// the selected items
+					if r.Quantity > int64(len(base.Items)) {
+						return fmt.Errorf("%w: %s", ErrCustomResourceExhausted, r.Name)
+					}
+
+					// selecting randomly by shuffling and slicing can be
+					// expensive, so this tries random picks similar to how we
+					// do port selection if we know the ratio of quantity to
+					// items is sparse. these values are selected by hunch, so
+					// this is a place for fine-tuning for sure
+					if len(base.Items) > 64 && r.Quantity < 8 {
+						r.Items = make([]any, 0, r.Quantity)
+						for int64(len(r.Items)) < r.Quantity {
+							item := base.Items[rand.Intn(len(base.Items))]
+							if !slices.Contains(r.Items, item) {
+								r.Items = append(r.Items, item)
+							}
+							// TODO(tgross): should we cap attempts?
+						}
+					} else {
+						baseItems := slices.Clone(base.Items)
+						rand.Shuffle(len(baseItems), func(i, j int) {
+							baseItems[i], baseItems[j] = baseItems[j], baseItems[i]
+						})
+						items := base.Items[:r.Quantity]
+						r.Items = items
+					}
+				}
+
+				continue NEXT
+			}
+		}
+	}
+
+	return nil
+}
+
+func (cr CustomResources) CopySharedOnly() CustomResources {
+	out := make([]*CustomResource, 0, len(cr))
+	for _, r := range cr {
+		if r.Scope == CustomResourceScopeGroup {
+			out = append(out, r)
+		}
+	}
+
+	return out
+}
+
+func (cr CustomResources) CopyTaskOnly() CustomResources {
+	out := make([]*CustomResource, 0, len(cr))
+	for _, r := range cr {
+		if r.Scope == CustomResourceScopeTask || r.Scope == "" {
+			out = append(out, r)
+		}
+	}
+
+	return out
+}
+
+// Merge combines other custom resources, overwriting the resources with
+// matching names and versions
+func (cr *CustomResources) Merge(other CustomResources) {
+	out := *cr
+
+NEXT:
+	for _, ocr := range other {
+		for i, base := range *cr {
+			if ocr.Name == base.Name && ocr.Version == base.Version {
+				out[i] = ocr
+				continue NEXT
+			}
+		}
+		out = append(out, ocr)
+	}
+
+	*cr = out
+}
+
+func (cr *CustomResources) Add(delta *CustomResources) error {
+	if cr == nil || delta == nil {
+		return nil
+	}
+
+	// it's possible to get an error after we've mutated one *CR in the slice,
+	// so copy to make the function succeed entirely or not at all
+	out := cr.Copy()
+	seen := []int{}
+NEXT:
+	for _, r := range out {
+		for i, o := range *delta {
+			if r.Name == o.Name {
+				seen = append(seen, i)
+				err := r.Add(o)
+				if err != nil {
+					return err
+				}
+				continue NEXT
+			}
+		}
+	}
+	for i, o := range *delta {
+		if !slices.Contains(seen, i) {
+			out = append(out, o)
+		}
+	}
+	*cr = out
+	return nil
+}
+
+func (cr CustomResources) Superset(other CustomResources) (bool, string) {
+	if other == nil {
+		return true, ""
+	}
+	if cr == nil {
+		return false, ErrInvalidCustomResourceComparison.Error()
+	}
+	for _, ocr := range other {
+		for _, base := range cr {
+			if ocr.Name != base.Name {
+				continue
+			}
+			if ok, name := base.Superset(ocr); !ok {
+				return false, name
+			}
+		}
+	}
+
+	return true, ""
+}
+
+func (cr *CustomResources) Subtract(delta *CustomResources) error {
+	if cr == nil || delta == nil {
+		return nil
+	}
+
+	// it's possible to get an error after we've mutated one *CR in the slice,
+	// so copy to make the function succeed entirely or not at all
+	out := cr.Copy()
+	seen := []int{}
+NEXT:
+	for _, r := range out {
+		for i, o := range *delta {
+			if r.Name == o.Name {
+				seen = append(seen, i)
+				err := r.Subtract(o)
+				if err != nil {
+					return err
+				}
+				continue NEXT
+			}
+		}
+	}
+	for i := range *delta {
+		if !slices.Contains(seen, i) {
+			return ErrSubtractFromNothing
+		}
+	}
+	*cr = out
+	return nil
+}

--- a/nomad/structs/resources_test.go
+++ b/nomad/structs/resources_test.go
@@ -1,0 +1,323 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package structs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test"
+	"github.com/shoenig/test/must"
+)
+
+func TestCustomResourcesMath(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name      string
+		have      *CustomResource
+		delta     *CustomResource
+		expect    *CustomResource
+		method    func(*CustomResource, *CustomResource) error
+		expectErr string
+	}{
+		{
+			name:      "incompatible",
+			have:      &CustomResource{Name: "foo"},
+			delta:     &CustomResource{Name: "bar"},
+			method:    (*CustomResource).Add,
+			expectErr: `custom resources could not be compared: resource names "foo" and "bar" mismatch`,
+		},
+		{
+			name: "countable add",
+			have: &CustomResource{
+				Name:     "disk",
+				Type:     CustomResourceTypeCountable,
+				Quantity: 100_000,
+			},
+			delta: &CustomResource{
+				Name:     "disk",
+				Type:     CustomResourceTypeCountable,
+				Quantity: 10_000,
+			},
+			method: (*CustomResource).Add,
+			expect: &CustomResource{
+				Name:     "disk",
+				Type:     CustomResourceTypeCountable,
+				Quantity: 110_000,
+			},
+		},
+		{
+			name: "countable subtract floor",
+			have: &CustomResource{
+				Name:     "disk",
+				Type:     CustomResourceTypeCountable,
+				Quantity: 10_000,
+			},
+			delta: &CustomResource{
+				Name:     "disk",
+				Type:     CustomResourceTypeCountable,
+				Quantity: 20_000,
+			},
+			method: (*CustomResource).Subtract,
+			expect: &CustomResource{
+				Name:     "disk",
+				Type:     CustomResourceTypeCountable,
+				Quantity: 0,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			got := tc.have.Copy()
+			delta := tc.delta.Copy()
+			err := tc.method(got, delta)
+
+			if tc.expectErr == "" {
+				must.NoError(t, err)
+				must.Eq(t, tc.expect, got)
+			} else {
+				must.EqError(t, err, tc.expectErr)
+				must.Eq(t, got, tc.have, must.Sprint("expected unchanged on error"))
+			}
+			must.Eq(t, tc.delta, delta, must.Sprint("expected delta to be unchanged"))
+		})
+	}
+
+}
+
+func TestCustomResourcesSuperset(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name      string
+		have      *CustomResource
+		want      *CustomResource
+		expectOk  bool
+		expectMsg string
+	}{
+		{
+			name:      "incompatible",
+			have:      &CustomResource{Name: "foo"},
+			want:      &CustomResource{Name: "bar"},
+			expectMsg: `custom resources could not be compared: resource names "foo" and "bar" mismatch`,
+		},
+		{
+			name: "countable ok",
+			have: &CustomResource{
+				Name:     "disk",
+				Type:     CustomResourceTypeCountable,
+				Quantity: 100_000,
+			},
+			want: &CustomResource{
+				Name:     "disk",
+				Type:     CustomResourceTypeCountable,
+				Quantity: 10_000,
+			},
+			expectOk: true,
+		},
+		{
+			name: "countable exhausted",
+			have: &CustomResource{
+				Name:     "disk",
+				Type:     CustomResourceTypeCountable,
+				Quantity: 100_000,
+			},
+			want: &CustomResource{
+				Name:     "disk",
+				Type:     CustomResourceTypeCountable,
+				Quantity: 200_000,
+			},
+			expectMsg: "custom resource: disk",
+		},
+		{
+			name: "dynamic ok",
+			have: &CustomResource{
+				Name:  "ports",
+				Type:  CustomResourceTypeDynamicInstance,
+				Items: []any{8001, 8002, 8003},
+			},
+			want: &CustomResource{
+				Name:  "ports",
+				Type:  CustomResourceTypeDynamicInstance,
+				Items: []any{8002},
+			},
+			expectOk: true,
+		},
+		{
+			name: "dynamic exhausted",
+			have: &CustomResource{
+				Name:  "ports",
+				Type:  CustomResourceTypeDynamicInstance,
+				Items: []any{8001, 8002, 8003},
+			},
+			want: &CustomResource{
+				Name:  "ports",
+				Type:  CustomResourceTypeDynamicInstance,
+				Items: []any{8006},
+			},
+			expectMsg: "custom resource: ports",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, msg := tc.have.Superset(tc.want)
+			test.Eq(t, tc.expectOk, ok)
+			test.Eq(t, tc.expectMsg, msg)
+		})
+	}
+
+}
+
+func TestCustomResourcesMerge(t *testing.T) {
+	ci.Parallel(t)
+
+	base := CustomResources{
+		{ // should be updated
+			Name:    "foo_dynamic",
+			Version: 1,
+			Type:    CustomResourceTypeDynamicInstance,
+			Scope:   CustomResourceScopeTask,
+			Range:   "1-3",
+			Items:   []any{1, 2, 3},
+		},
+		{ // different version, should be ignored
+			Name:     "bar_countable",
+			Type:     CustomResourceTypeCountable,
+			Scope:    CustomResourceScopeGroup,
+			Quantity: 10_000,
+		},
+		{ // should be ignored
+			Name:     "quuz_ratio",
+			Type:     CustomResourceTypeRatio,
+			Scope:    CustomResourceScopeTask,
+			Quantity: 100,
+		},
+	}
+
+	other := CustomResources{
+		{ // should update
+			Name:    "foo_dynamic",
+			Version: 1,
+			Type:    CustomResourceTypeDynamicInstance,
+			Scope:   CustomResourceScopeTask,
+			Range:   "2-4,7-8",
+			Items:   []any{2, 3, 4, 7, 8},
+		},
+		{ // different version, should be added
+			Name:     "bar_countable",
+			Version:  2,
+			Type:     CustomResourceTypeCountable,
+			Scope:    CustomResourceScopeGroup,
+			Quantity: 20_000,
+		},
+		{ // new resource, should be added
+			Name:  "baz_static",
+			Type:  CustomResourceTypeStaticInstance,
+			Scope: CustomResourceScopeGroup,
+			Items: []any{10, 20, 30},
+		},
+	}
+
+	got := base.Copy()
+	got.Merge(other)
+	must.Eq(t,
+		CustomResources{
+			{
+				Name:    "foo_dynamic",
+				Version: 1,
+				Type:    CustomResourceTypeDynamicInstance,
+				Scope:   CustomResourceScopeTask,
+				Range:   "2-4,7-8",
+				Items:   []any{2, 3, 4, 7, 8},
+			},
+			{
+				Name:     "bar_countable",
+				Type:     CustomResourceTypeCountable,
+				Scope:    CustomResourceScopeGroup,
+				Quantity: 10_000,
+			},
+			{
+				Name:     "quuz_ratio",
+				Type:     CustomResourceTypeRatio,
+				Scope:    CustomResourceScopeTask,
+				Quantity: 100,
+			},
+			{
+				Name:     "bar_countable",
+				Version:  2,
+				Type:     CustomResourceTypeCountable,
+				Scope:    CustomResourceScopeGroup,
+				Quantity: 20_000,
+			},
+			{
+				Name:  "baz_static",
+				Type:  CustomResourceTypeStaticInstance,
+				Scope: CustomResourceScopeGroup,
+				Items: []any{10, 20, 30},
+			},
+		},
+		got)
+
+}
+
+func TestCustomResources_Select(t *testing.T) {
+
+	ci.Parallel(t)
+
+	available := CustomResources{
+		{
+			Name:     "foo_countable",
+			Type:     CustomResourceTypeCountable,
+			Scope:    CustomResourceScopeGroup,
+			Quantity: 10_000,
+		},
+		{
+			Name:    "bar_dynamic",
+			Version: 1,
+			Type:    CustomResourceTypeDynamicInstance,
+			Scope:   CustomResourceScopeTask,
+			Range:   "1-10",
+			Items:   []any{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+		},
+	}
+
+	request := CustomResources{
+		{
+			Name:     "foo_countable",
+			Type:     CustomResourceTypeCountable,
+			Scope:    CustomResourceScopeGroup,
+			Quantity: 0,
+		},
+		{
+			Name:     "bar_dynamic",
+			Version:  1,
+			Type:     CustomResourceTypeDynamicInstance,
+			Scope:    CustomResourceScopeTask,
+			Quantity: 0,
+		},
+	}
+
+	request[0].Quantity = 10
+	request[1].Quantity = 20
+	err := request.Select(available)
+	must.EqError(t, err, "custom resources exhausted: bar_dynamic")
+
+	request[0].Quantity = 10
+	request[1].Quantity = 4
+	err = request.Select(available)
+	must.NoError(t, err)
+	must.Len(t, 4, request[1].Items)
+
+	available[1].Items = []any{}
+	for i := range 100 {
+		available[1].Items = append(available[1].Items, i)
+	}
+	err = request.Select(available)
+	must.NoError(t, err)
+	must.Len(t, 4, request[1].Items)
+}

--- a/scheduler/feasible/custom_resources.go
+++ b/scheduler/feasible/custom_resources.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package feasible
+
+import "github.com/hashicorp/nomad/nomad/structs"
+
+type customResourceChecker struct {
+	ask       *structs.CustomResources
+	proposed  *structs.CustomResources
+	available *structs.CustomResources
+}
+
+func (crc *customResourceChecker) addProposed(proposed []*structs.Allocation) {
+	for _, alloc := range proposed {
+		for _, task := range alloc.AllocatedResources.Tasks {
+			proposedResources := []*structs.CustomResource(*crc.proposed)
+			proposedResources = append(proposedResources, task.Custom...)
+		}
+	}
+}
+
+func (crc *customResourceChecker) Select(ask *structs.CustomResources) error {
+	crc.available.Subtract(crc.proposed)
+	return ask.Select(*crc.available)
+}


### PR DESCRIPTION
Platforms other than Linux, especially non-Unix platforms, may have a different view of resources that don't model well as `resources.cpu` or `resources.memory`. And users with unusual deployment environments have asked about the possibility of scheduling resources specific to those environments.

This PR is a prototype of the kind of interface we might want to be able to support. Nodes get a `client.custom_resource` block where they can define a resource the node will make available in its fingerprint. Resources are one of five types, designed to make it possible to model all our existing resources as custom resources:
* `ratio`: The resource is used as a value relative to other tasks with the same resource. An example of this would be Linux `cpu.weight` as implemented by a systemd unit file.
* `capped-ratio`: Like a ratio, except all the quantity used by tasks has a maximum total value. An example of this would be Linux `cpu.weight` as currently implemented in Nomad, where the "cap" is derived from the total Mhz of CPUs on the host.
* `countable`: The resource has a fixed but fungible amount. An example of this would be memory allocation (ignoring NUMA), where there's a certain amount of memory available on the host and it's "used up" by allocations, but we don't care about identity of the individual blocks of memory.
* `dynamic`: The resource has a fixed set of items with exclusive access, but the job doesn't care which ones it gets. An example of this would be Nomad's current dynamic port assignment or `resource.cores`.
* `static`: The resource has a fixed set of items with exclusive access, and the job wants a specific one of those items. An example of this woul dbe Nomad's current static port assignment.

We can use this prototype to anchor discussions about how we might implement a set of custom resource scheduling features but it's nowhere near production-ready. I've included enough plumbing to implement these five resource types, fingerprint them on clients via config files, and schedule them for allocations. What's not included, all of which we'd want to solve in any productionized version of this work:

* Support for exposing the custom resource allocation to a task driver. We'd need to thread custom resources into the protobufs we send via `go-plugin` and then the user's task driver would need to consume that data.
* Support for preemption
* Support for quotas
* Support for dynamically adding custom resources to a node

Ref: https://github.com/hashicorp/nomad/issues/1081