### PR TITLE
qemu: enable use of other emulators and machine types

### DIFF
--- a/.changelog/27128.txt
+++ b/.changelog/27128.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-qemu: Adds config parameters to modify qemu emulator binary and machine types. Defaults to previously used values for backwards compatability.
+qemu: Adds config parameters to modify qemu emulator binary and machine types and removes some hardcoded KVM accelerator settings. Defaults to previously used values of qemu-system-x86_64 and pc. The driver no longer forces machine type "host", or the -smp flag when using resources.cores with the KVM accelerator.
 ```

--- a/.changelog/27128.txt
+++ b/.changelog/27128.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+qemu: Adds config parameters to modify qemu emulator binary and machine types. Defaults to previously used values for backwards compatability.
+```

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -432,7 +432,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		emulator = driverConfig.Emulator
 
 	}
-	accelerator := ""
+	accelerator := "tcg"
 	if driverConfig.Accelerator != "" {
 		accelerator = driverConfig.Accelerator
 	}
@@ -460,14 +460,9 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		return nil, nil, fmt.Errorf("Unsupported drive_interface")
 	}
 
-	machineCfg := fmt.Sprintf("type=%s", machineType)
-	if accelerator != "" {
-		machineCfg += ",accel=" + accelerator
-	}
-
 	args := []string{
 		absPath,
-		"-machine", machineCfg,
+		"-machine", "type=" + machineType + ",accel=" + accelerator,
 		"-name", vmID,
 		"-m", mem,
 		// setting a drive ID allows users to attach this to other devices

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -566,6 +566,8 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 			return nil, nil, errors.New("KVM accelerator is unsupported on the current platform")
 		}
 
+		args = append(args, "-enable-kvm")
+
 		// If the user has not set the -smp flag, default to resources.cores
 		if !slices.Contains(args, "-smp") && cfg.Resources.LinuxResources != nil && cfg.Resources.LinuxResources.CpusetCpus != "" {
 			cores := strings.Split(cfg.Resources.LinuxResources.CpusetCpus, ",")

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -460,9 +460,14 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		return nil, nil, fmt.Errorf("Unsupported drive_interface")
 	}
 
+	machineCfg := fmt.Sprintf("type=%s", machineType)
+	if accelerator != "" {
+		machineCfg += ",accel=" + accelerator
+	}
+
 	args := []string{
 		absPath,
-		"-machine", "type=" + machineType + ",accel=" + accelerator,
+		"-machine", machineCfg,
 		"-name", vmID,
 		"-m", mem,
 		// setting a drive ID allows users to attach this to other devices

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -149,7 +149,7 @@ type Config struct {
 	// prevent access to devices
 	ArgsAllowList []string `codec:"args_allowlist"`
 
-	// FingerprintEmulator specifices which QEMU binary is used
+	// FingerprintEmulator specifies which QEMU binary is used
 	// for fingerprinting
 	FingerprintEmulator string `codec:"fingerprint_emulator"`
 }

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -246,7 +246,7 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 		HealthDescription: drivers.DriverHealthy,
 	}
 
-	fpEmulator := "qemu-system-x86-64"
+	fpEmulator := "qemu-system-x86_64"
 	if d.config.FingerprintEmulator != "" {
 		fpEmulator = d.config.FingerprintEmulator
 	}


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
The qemu driver is currently hardcoded to use the x86 emulator and `pc` machine. These changes allow users to configure these values. A benefit of this is better performance for users with ARM devices.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

Fixes [GH #17419](https://github.com/hashicorp/nomad/issues/17419) 
Fixes [GH #4684](https://github.com/hashicorp/nomad/issues/4684)

Closes out https://github.com/hashicorp/nomad/pull/15510 as duplicate

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is
  stored in the [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to
  the [`web-unified-docs` contributor
  guide](https://github.com/hashicorp/web-unified-docs/docs/contribute.md) for
  docs guidelines. Please also consider whether the
  change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific).
  If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository. 


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

