### PR TITLE
api: exit EventStream.Stream on first error

### DIFF
--- a/.changelog/27141.txt
+++ b/.changelog/27141.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: exit EventStream.Stream on first error
+```

--- a/api/event_stream_test.go
+++ b/api/event_stream_test.go
@@ -131,7 +131,6 @@ func TestEvent_Stream(t *testing.T) {
 				must.Unreachable(t, must.Sprintf("chan closed before EOF received"))
 			}
 
-			// Sadly decode doesn't return io.EOF
 			if event.Err != nil && errors.Is(event.Err, io.ErrUnexpectedEOF) {
 				// Succcess! Make sure chan gets closed
 				select {

--- a/api/event_stream_test.go
+++ b/api/event_stream_test.go
@@ -6,7 +6,8 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"strings"
+	"errors"
+	"io"
 	"testing"
 	"time"
 
@@ -131,7 +132,7 @@ func TestEvent_Stream(t *testing.T) {
 			}
 
 			// Sadly decode doesn't return io.EOF
-			if event.Err != nil && strings.HasSuffix(event.Err.Error(), "EOF") {
+			if event.Err != nil && errors.Is(event.Err, io.ErrUnexpectedEOF) {
 				// Succcess! Make sure chan gets closed
 				select {
 				case _, ok := <-streamCh:


### PR DESCRIPTION
Errors from Decode are non-recoverable and should cause Stream to return. Otherwise Stream will loop forever on EOF from Decode.

Fixes #27133

Repro: https://gist.github.com/schmichael/247a39bf36406c08c8a95fc8c85bd56a

### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
