### PR TITLE
fingerprint: Add retry and failure config to env fingerprinters.

### DIFF
--- a/.changelog/27161.txt
+++ b/.changelog/27161.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Added a new `fingerprint` configuration block which allows users to specify retry behavior for the `env_aws`, `env_azure`, `env_digitalocean` and `env_gcp` fingerprinters.
+```

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -395,6 +395,10 @@ type Config struct {
 
 	// LogFile is used by MonitorExport to stream a server's log file
 	LogFile string `hcl:"log_file"`
+
+	// Fingerprinters is a map of fingerprinter configurations by name. This
+	// currently only applies to env fingerprinters such as "env_aws".
+	Fingerprinters map[string]*Fingerprint
 }
 
 type APIListenerRegistrar interface {
@@ -931,6 +935,7 @@ func DefaultConfig() *Config {
 			MinDynamicUser: 80_000,
 			MaxDynamicUser: 89_999,
 		},
+		Fingerprinters: map[string]*Fingerprint{},
 	}
 
 	return cfg

--- a/client/config/fingerprint.go
+++ b/client/config/fingerprint.go
@@ -1,0 +1,120 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+// validEnvFingerprinters contains the fingerprinters that are valid
+// environment fingerprinters and is used for input validation.
+var validEnvFingerprinters = []string{
+	"env_aws",
+	"env_azure",
+	"env_gce",
+	"env_digitalocean",
+}
+
+// Fingerprint is an optional configuration block for environment fingerprinters
+// can control retry behavior and failure handling.
+type Fingerprint struct {
+
+	// Name is the fingerprinter identifier that this configuration block
+	// relates to. It is gathered from the HCL block label.
+	Name string `hcl:",key"`
+
+	// RetryInterval is the specifies the time to wait between fingerprint
+	// attempts.
+	RetryInterval    time.Duration
+	RetryIntervalHCL string `hcl:"retry_interval,optional"`
+
+	// RetryAttempts specifies the maximum number of fingerprint attempts to be
+	// made before the failure is considered terminal.
+	RetryAttempts int `hcl:"retry_attempts,optional"`
+
+	// ExitOnFailure indicates whether the fingerprinter should cause the agent
+	// to exit if it fails to correctly perform its fingerprint run. This is
+	// useful if the fingerprinter provides critical information used by Nomad
+	// workloads.
+	ExitOnFailure *bool `hcl:"exit_on_failure,optional"`
+
+	// ExtraKeysHCL is used by hcl to surface unexpected keys
+	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
+}
+
+// Copy is used to satisfy to helper.Copyable interface, so we can perform
+// copies of the fingerprint config slice.
+func (f *Fingerprint) Copy() *Fingerprint {
+	if f == nil {
+		return nil
+	}
+
+	c := new(Fingerprint)
+	*c = *f
+	return c
+}
+
+// Merge is used to combine two fingerprint blocks with the block passed into
+// the function taking precedence. The name is not overwritten as this is
+// expected to match as it's the block label. It is the callers responsibility
+// to ensure the two fingerprint blocks are for the same fingerprinter
+// implementation.
+func (f *Fingerprint) Merge(z *Fingerprint) *Fingerprint {
+	if f == nil {
+		return z
+	}
+
+	result := *f
+
+	if z == nil {
+		return &result
+	}
+
+	if z.RetryInterval != 0 {
+		result.RetryInterval = z.RetryInterval
+	}
+	if z.RetryIntervalHCL != "" {
+		result.RetryIntervalHCL = z.RetryIntervalHCL
+	}
+	if z.RetryAttempts != 0 {
+		result.RetryAttempts = z.RetryAttempts
+	}
+	if z.ExitOnFailure != nil {
+		result.ExitOnFailure = z.ExitOnFailure
+	}
+
+	return &result
+}
+
+// Validate the fingerprint block to ensure we do not have any values that
+// cannot be handled.
+func (f *Fingerprint) Validate() error {
+
+	if f == nil {
+		return nil
+	}
+
+	if f.Name == "" {
+		return errors.New("fingerprint name cannot be empty")
+	}
+	if !slices.Contains(validEnvFingerprinters, f.Name) {
+		return fmt.Errorf("fingerprint %q does not support configuration", f.Name)
+	}
+	if f.RetryInterval < 0 {
+		return fmt.Errorf("fingerprint %q retry interval cannot be negative", f.Name)
+	}
+	if f.RetryAttempts < -1 {
+		return fmt.Errorf("fingerprint %q retry attempts cannot be less than -1", f.Name)
+	}
+	if len(f.ExtraKeysHCL) > 0 {
+		return fmt.Errorf("fingerprint %q contains unknown configuration options: %s",
+			f.Name, strings.Join(f.ExtraKeysHCL, ","))
+	}
+
+	return nil
+}

--- a/client/config/fingerprint.go
+++ b/client/config/fingerprint.go
@@ -28,7 +28,7 @@ type Fingerprint struct {
 	// relates to. It is gathered from the HCL block label.
 	Name string `hcl:",key"`
 
-	// RetryInterval is the specifies the time to wait between fingerprint
+	// RetryInterval specifies the time to wait between fingerprint
 	// attempts.
 	RetryInterval    time.Duration
 	RetryIntervalHCL string `hcl:"retry_interval,optional"`

--- a/client/config/fingerprint_test.go
+++ b/client/config/fingerprint_test.go
@@ -1,0 +1,292 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
+)
+
+func TestFingerprint_Copy(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("nil", func(t *testing.T) {
+		var f *Fingerprint
+		result := f.Copy()
+		must.Nil(t, result)
+	})
+
+	t.Run("full", func(t *testing.T) {
+		exitOnFailure := true
+		original := &Fingerprint{
+			Name:             "env_aws",
+			RetryInterval:    5 * time.Minute,
+			RetryIntervalHCL: "5m",
+			RetryAttempts:    3,
+			ExitOnFailure:    &exitOnFailure,
+		}
+
+		copied := original.Copy()
+
+		must.Eq(t, original.Name, copied.Name)
+		must.Eq(t, original.RetryInterval, copied.RetryInterval)
+		must.Eq(t, original.RetryIntervalHCL, copied.RetryIntervalHCL)
+		must.Eq(t, original.RetryAttempts, copied.RetryAttempts)
+		must.Eq(t, *original.ExitOnFailure, *copied.ExitOnFailure)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		original := &Fingerprint{}
+		copied := original.Copy()
+
+		must.NotNil(t, copied)
+		must.Eq(t, "", copied.Name)
+		must.Eq(t, time.Duration(0), copied.RetryInterval)
+		must.Eq(t, "", copied.RetryIntervalHCL)
+		must.Eq(t, 0, copied.RetryAttempts)
+		must.Nil(t, copied.ExitOnFailure)
+	})
+}
+
+func TestFingerprint_Merge(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("nil receiver", func(t *testing.T) {
+		var f *Fingerprint
+		other := &Fingerprint{
+			Name:          "env_aws",
+			RetryInterval: 5 * time.Minute,
+		}
+
+		result := f.Merge(other)
+		must.Eq(t, other, result)
+	})
+
+	t.Run("nil argument", func(t *testing.T) {
+		exitOnFailure := true
+		f := &Fingerprint{
+			Name:          "env_aws",
+			RetryInterval: 5 * time.Minute,
+			RetryAttempts: 3,
+			ExitOnFailure: &exitOnFailure,
+		}
+
+		result := f.Merge(nil)
+		must.Eq(t, f.Name, result.Name)
+		must.Eq(t, f.RetryInterval, result.RetryInterval)
+		must.Eq(t, f.RetryAttempts, result.RetryAttempts)
+		must.Eq(t, *f.ExitOnFailure, *result.ExitOnFailure)
+	})
+
+	t.Run("merge overwrites non-zero values", func(t *testing.T) {
+		exitOnFailure1 := false
+		exitOnFailure2 := true
+
+		base := &Fingerprint{
+			Name:             "env_aws",
+			RetryInterval:    5 * time.Minute,
+			RetryIntervalHCL: "5m",
+			RetryAttempts:    3,
+			ExitOnFailure:    &exitOnFailure1,
+		}
+
+		override := &Fingerprint{
+			Name:             "env_aws",
+			RetryInterval:    10 * time.Minute,
+			RetryIntervalHCL: "10m",
+			RetryAttempts:    5,
+			ExitOnFailure:    &exitOnFailure2,
+		}
+
+		result := base.Merge(override)
+
+		must.Eq(t, "env_aws", result.Name)
+		must.Eq(t, 10*time.Minute, result.RetryInterval)
+		must.Eq(t, "10m", result.RetryIntervalHCL)
+		must.Eq(t, 5, result.RetryAttempts)
+		must.True(t, *result.ExitOnFailure)
+	})
+
+	t.Run("merge preserves base values for zero values in override", func(t *testing.T) {
+		exitOnFailure := true
+		base := &Fingerprint{
+			Name:             "env_aws",
+			RetryInterval:    5 * time.Minute,
+			RetryIntervalHCL: "5m",
+			RetryAttempts:    3,
+			ExitOnFailure:    &exitOnFailure,
+		}
+
+		override := &Fingerprint{
+			Name: "env_aws",
+		}
+
+		result := base.Merge(override)
+
+		must.Eq(t, "env_aws", result.Name)
+		must.Eq(t, 5*time.Minute, result.RetryInterval)
+		must.Eq(t, "5m", result.RetryIntervalHCL)
+		must.Eq(t, 3, result.RetryAttempts)
+		must.True(t, *result.ExitOnFailure)
+	})
+
+	t.Run("merge partial override", func(t *testing.T) {
+		base := &Fingerprint{
+			Name:          "env_azure",
+			RetryInterval: 5 * time.Minute,
+			RetryAttempts: 3,
+		}
+
+		newExitOnFailure := true
+		override := &Fingerprint{
+			Name:          "env_azure",
+			RetryAttempts: 10,
+			ExitOnFailure: &newExitOnFailure,
+		}
+
+		result := base.Merge(override)
+
+		must.Eq(t, "env_azure", result.Name)
+		must.Eq(t, 5*time.Minute, result.RetryInterval)
+		must.Eq(t, 10, result.RetryAttempts)
+		must.True(t, *result.ExitOnFailure)
+	})
+
+	t.Run("merge does not mutate original", func(t *testing.T) {
+		base := &Fingerprint{
+			Name:          "env_gce",
+			RetryInterval: 5 * time.Minute,
+			RetryAttempts: 3,
+		}
+
+		override := &Fingerprint{
+			Name:          "env_gce",
+			RetryInterval: 10 * time.Minute,
+		}
+
+		result := base.Merge(override)
+
+		must.Eq(t, 5*time.Minute, base.RetryInterval)
+		must.Eq(t, 3, base.RetryAttempts)
+		must.Eq(t, 10*time.Minute, result.RetryInterval)
+		must.Eq(t, 3, result.RetryAttempts)
+	})
+}
+
+func TestFingerprint_Validate(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("nil fingerprint", func(t *testing.T) {
+		var f *Fingerprint
+		must.NoError(t, f.Validate())
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		f := &Fingerprint{
+			Name: "",
+		}
+		must.ErrorContains(t, f.Validate(), "fingerprint name cannot be empty")
+	})
+
+	t.Run("invalid fingerprinter name", func(t *testing.T) {
+		f := &Fingerprint{
+			Name: "invalid_fingerprinter",
+		}
+		must.ErrorContains(t, f.Validate(), "does not support configuration")
+	})
+
+	t.Run("negative retry interval", func(t *testing.T) {
+		f := &Fingerprint{
+			Name:          "env_aws",
+			RetryInterval: -5 * time.Minute,
+		}
+		must.ErrorContains(t, f.Validate(), "retry interval cannot be negative")
+	})
+
+	t.Run("retry attempts less than -1", func(t *testing.T) {
+		f := &Fingerprint{
+			Name:          "env_aws",
+			RetryAttempts: -2,
+		}
+		must.ErrorContains(t, f.Validate(), "retry attempts cannot be less than -1")
+	})
+
+	t.Run("retry attempts of -1 is valid", func(t *testing.T) {
+		f := &Fingerprint{
+			Name:          "env_aws",
+			RetryAttempts: -1,
+		}
+		must.NoError(t, f.Validate())
+	})
+
+	t.Run("valid env_aws fingerprint", func(t *testing.T) {
+		exitOnFailure := true
+		f := &Fingerprint{
+			Name:          "env_aws",
+			RetryInterval: 5 * time.Minute,
+			RetryAttempts: 3,
+			ExitOnFailure: &exitOnFailure,
+		}
+		must.NoError(t, f.Validate())
+	})
+
+	t.Run("valid env_azure fingerprint", func(t *testing.T) {
+		f := &Fingerprint{
+			Name:          "env_azure",
+			RetryInterval: 10 * time.Minute,
+			RetryAttempts: 5,
+		}
+		must.NoError(t, f.Validate())
+	})
+
+	t.Run("valid env_gce fingerprint", func(t *testing.T) {
+		f := &Fingerprint{
+			Name:          "env_gce",
+			RetryInterval: 2 * time.Minute,
+			RetryAttempts: 10,
+		}
+		must.NoError(t, f.Validate())
+	})
+
+	t.Run("valid env_digitalocean fingerprint", func(t *testing.T) {
+		f := &Fingerprint{
+			Name:          "env_digitalocean",
+			RetryInterval: 1 * time.Minute,
+			RetryAttempts: 0,
+		}
+		must.NoError(t, f.Validate())
+	})
+
+	t.Run("valid fingerprint with zero values", func(t *testing.T) {
+		f := &Fingerprint{
+			Name:          "env_aws",
+			RetryInterval: 0,
+			RetryAttempts: 0,
+		}
+		must.NoError(t, f.Validate())
+	})
+
+	t.Run("unknown keys", func(t *testing.T) {
+		f := &Fingerprint{
+			Name:          "env_aws",
+			RetryInterval: 0,
+			RetryAttempts: 0,
+			ExtraKeysHCL:  []string{"bad"},
+		}
+		must.ErrorContains(t, f.Validate(), "unknown configuration options: bad")
+	})
+}
+
+func Test_validEnvFingerprinters(t *testing.T) {
+	expectedFingerprinters := []string{
+		"env_aws",
+		"env_azure",
+		"env_gce",
+		"env_digitalocean",
+	}
+	must.Eq(t, expectedFingerprinters, validEnvFingerprinters)
+}

--- a/client/fingerprint/env_aws.go
+++ b/client/fingerprint/env_aws.go
@@ -27,8 +27,8 @@ const (
 	// services.
 	AwsMetadataTimeout = 2 * time.Second
 
-	// awsFingerprinterName is the name of the AWS fingerprinter and used in
-	// configuration and logging.
+	// awsFingerprinterName is the name of the AWS fingerprinter and is used
+	// in configuration and logging.
 	awsFingerprinterName = "env_aws"
 )
 

--- a/client/fingerprint/env_aws_test.go
+++ b/client/fingerprint/env_aws_test.go
@@ -19,11 +19,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_NewEnvAWSFingerprint(t *testing.T) {
+	ci.Parallel(t)
+
+	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
+	must.NotNil(t, f)
+
+	retryWrapper, ok := f.(*RetryWrapper)
+	must.True(t, ok)
+	must.Eq(t, awsFingerprinterName, retryWrapper.name)
+
+	_, ok = retryWrapper.fingerprinter.(*EnvAWSFingerprint)
+	must.True(t, ok)
+}
+
 func TestEnvAWSFingerprint_nonAws(t *testing.T) {
 	ci.Parallel(t)
 
 	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
-	f.(*EnvAWSFingerprint).endpoint = "http://127.0.0.1/latest"
+	f.(*RetryWrapper).fingerprinter.(*EnvAWSFingerprint).endpoint = "http://127.0.0.1/latest"
 
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -43,7 +57,7 @@ func TestEnvAWSFingerprint_aws(t *testing.T) {
 	defer cleanup()
 
 	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
-	f.(*EnvAWSFingerprint).endpoint = endpoint
+	f.(*RetryWrapper).fingerprinter.(*EnvAWSFingerprint).endpoint = endpoint
 
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -114,7 +128,7 @@ func TestEnvAWSFingerprint_handleImdsError(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		err := f.(*EnvAWSFingerprint).handleImdsError(c.err, "some attribute")
+		err := f.(*RetryWrapper).fingerprinter.(*EnvAWSFingerprint).handleImdsError(c.err, "some attribute")
 		must.Eq(t, c.exp, err)
 	}
 }
@@ -126,7 +140,7 @@ func TestNetworkFingerprint_AWS(t *testing.T) {
 	defer cleanup()
 
 	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
-	f.(*EnvAWSFingerprint).endpoint = endpoint
+	f.(*RetryWrapper).fingerprinter.(*EnvAWSFingerprint).endpoint = endpoint
 
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -156,7 +170,7 @@ func TestNetworkFingerprint_AWS_network(t *testing.T) {
 	defer cleanup()
 
 	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
-	f.(*EnvAWSFingerprint).endpoint = endpoint
+	f.(*RetryWrapper).fingerprinter.(*EnvAWSFingerprint).endpoint = endpoint
 
 	{
 		node := &structs.Node{
@@ -219,7 +233,7 @@ func TestNetworkFingerprint_AWS_NoNetwork(t *testing.T) {
 	defer cleanup()
 
 	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
-	f.(*EnvAWSFingerprint).endpoint = endpoint
+	f.(*RetryWrapper).fingerprinter.(*EnvAWSFingerprint).endpoint = endpoint
 
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -247,7 +261,7 @@ func TestNetworkFingerprint_AWS_IncompleteImitation(t *testing.T) {
 	defer cleanup()
 
 	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
-	f.(*EnvAWSFingerprint).endpoint = endpoint
+	f.(*RetryWrapper).fingerprinter.(*EnvAWSFingerprint).endpoint = endpoint
 
 	node := &structs.Node{
 		Attributes: make(map[string]string),
@@ -271,7 +285,7 @@ func TestCPUFingerprint_AWS_InstanceFound(t *testing.T) {
 	defer cleanup()
 
 	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
-	f.(*EnvAWSFingerprint).endpoint = endpoint
+	f.(*RetryWrapper).fingerprinter.(*EnvAWSFingerprint).endpoint = endpoint
 
 	node := &structs.Node{Attributes: make(map[string]string)}
 
@@ -289,7 +303,7 @@ func TestCPUFingerprint_AWS_InstanceNotFound(t *testing.T) {
 	defer cleanup()
 
 	f := NewEnvAWSFingerprint(testlog.HCLogger(t))
-	f.(*EnvAWSFingerprint).endpoint = endpoint
+	f.(*RetryWrapper).fingerprinter.(*EnvAWSFingerprint).endpoint = endpoint
 
 	node := &structs.Node{Attributes: make(map[string]string)}
 

--- a/client/fingerprint/fingerprint_retry.go
+++ b/client/fingerprint/fingerprint_retry.go
@@ -1,0 +1,148 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package fingerprint
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+
+	"github.com/hashicorp/nomad/client/config"
+)
+
+// RetryWrapper is a fingerprinter wrapper that adds retry logic to an existing
+// fingerprinter. This is currently supported for environment fingerprinters
+// only and is controller via the client fingerprinter config.
+type RetryWrapper struct {
+
+	// fingerprinter is the underlying fingerprinter being wrapped with retry
+	// logic.
+	fingerprinter Fingerprint
+
+	// name is the name of the fingerprinter being wrapped and is used to pull
+	// any configuration for it.
+	name string
+
+	logger hclog.Logger
+
+	// StaticFingerprinter is embedded to indicate that this fingerprinter does
+	// not support periodic execution.
+	StaticFingerprinter
+}
+
+// NewRetryWrapper wraps the passed fingerprinter with retry logic. The returned
+// fingerprinter will consult the client configuration for any retry settings.
+//
+// It staisifes the Fingerprinter interface and is a static fingerprinter, so
+// does not support periodic execution.
+func NewRetryWrapper(fingerprinter Fingerprint, logger hclog.Logger, name string) Fingerprint {
+	return &RetryWrapper{
+		fingerprinter: fingerprinter,
+		logger:        logger,
+		name:          name,
+	}
+}
+
+// Fingerprint executes the underlying fingerprinter with retry logic based
+// on the client configuration and implements the Fingerprinter interface.
+//
+// If the fingerprinter fails after all retry attempts, the error from the last
+// attempt is returned, unless the configuration indicates that failures should
+// be skipped for this fingerprinter and the error is of the type that indicates
+// an initial probe failure.
+func (rw *RetryWrapper) Fingerprint(req *FingerprintRequest, resp *FingerprintResponse) error {
+
+	cfg := req.Config.Fingerprinters[rw.name]
+
+	var (
+		attempts int
+		err      error
+	)
+
+	// Ensure we default to a 2 second retry interval if not configured. Doing
+	// this here means we do not have to do this each loop iteration at the
+	// cost of the config potentially being empty and the loop exiting after the
+	// first attempt.
+	retryInterval := 2 * time.Second
+
+	if cfg != nil && cfg.RetryInterval > 0 {
+		retryInterval = cfg.RetryInterval
+	}
+
+	for {
+		err = rw.fingerprinter.Fingerprint(req, resp)
+		if err == nil {
+			return nil
+		}
+
+		// If the fingerprinter does not have a config, no retry behaviour is
+		// defined, so exit the loop.
+		if cfg == nil {
+			break
+		}
+
+		var shouldRetry bool
+
+		switch cfg.RetryAttempts {
+		case -1:
+			shouldRetry = true
+		case 0:
+		default:
+			if attempts < cfg.RetryAttempts {
+				shouldRetry = true
+			}
+		}
+
+		if !shouldRetry {
+			break
+		}
+
+		rw.logger.Warn("fingerprinting failed, retrying",
+			"current_attempts", attempts,
+			"retry_attempts", cfg.RetryAttempts,
+			"retry_interval", retryInterval,
+			"error", err,
+		)
+
+		attempts++
+		time.Sleep(retryInterval)
+	}
+
+	if shouldSkipEnvFingerprinter(cfg, err) {
+		rw.logger.Debug("error performing initial probe, skipping")
+		return nil
+	}
+
+	rw.logger.Error("fingerprinting failed after all attempts", "error", err)
+	return err
+}
+
+// errEnvProbeQueryFailed is used to indicate that the initial probe to
+// determine if the environment fingerprinter is applicable has failed.
+var errEnvProbeQueryFailed = errors.New("fingerprint initial probe failed")
+
+// wrapProbeError wraps the passed error with errEnvProbeQueryFailed to indicate
+// that the initial probe has failed.
+func wrapProbeError(err error) error {
+	return fmt.Errorf("%w: %w", errEnvProbeQueryFailed, err)
+}
+
+// shouldSkipEnvFingerprinter determines if an environment fingerprinter should
+// be skipped based on the passed configuration and error from the
+// fingerprinter. Skipped indicates the client is not running in the environment
+// the fingerprinter is designed for.
+func shouldSkipEnvFingerprinter(cfg *config.Fingerprint, err error) bool {
+
+	if err == nil {
+		return false
+	}
+
+	if cfg != nil && cfg.ExitOnFailure != nil {
+		return !*cfg.ExitOnFailure
+	}
+
+	return errors.Is(err, errEnvProbeQueryFailed)
+}

--- a/client/fingerprint/fingerprint_retry.go
+++ b/client/fingerprint/fingerprint_retry.go
@@ -78,25 +78,17 @@ func (rw *RetryWrapper) Fingerprint(req *FingerprintRequest, resp *FingerprintRe
 			return nil
 		}
 
-		// If the fingerprinter does not have a config, no retry behaviour is
-		// defined, so exit the loop.
-		if cfg == nil {
+		// Determine if we should exit the loop based on the configured retry
+		// attempts.
+		//
+		// If there is not configuration or retry attempts has a value of 0, no
+		// retries are expected, so we exit immediately. A positive value
+		// indicates a fixed number of retries, so we exit once we've hit that
+		// number. A negative value indicates infinite retries, so we never exit
+		// based on attempts.
+		if cfg == nil || cfg.RetryAttempts == 0 {
 			break
-		}
-
-		var shouldRetry bool
-
-		switch cfg.RetryAttempts {
-		case -1:
-			shouldRetry = true
-		case 0:
-		default:
-			if attempts < cfg.RetryAttempts {
-				shouldRetry = true
-			}
-		}
-
-		if !shouldRetry {
+		} else if cfg.RetryAttempts > 0 && attempts >= cfg.RetryAttempts {
 			break
 		}
 

--- a/client/fingerprint/fingerprint_retry_test.go
+++ b/client/fingerprint/fingerprint_retry_test.go
@@ -1,0 +1,330 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package fingerprint
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/helper/pointer"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+// mockFingerprinter is a mock implementation of the Fingerprint interface that
+// allows controlling behavior for testing the RetryWrapper.
+type mockFingerprinter struct {
+	callCount     atomic.Int32
+	errorSequence []error
+	StaticFingerprinter
+}
+
+func (m *mockFingerprinter) Fingerprint(req *FingerprintRequest, resp *FingerprintResponse) error {
+	callNum := int(m.callCount.Add(1)) - 1
+
+	if callNum < len(m.errorSequence) {
+		if err := m.errorSequence[callNum]; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *mockFingerprinter) getCallCount() int {
+	return int(m.callCount.Load())
+}
+
+func newMockFingerprinter(errorSequence []error) *mockFingerprinter {
+	return &mockFingerprinter{
+		errorSequence: errorSequence,
+	}
+}
+
+func TestRetryWrapper_Fingerprint(t *testing.T) {
+	ci.Parallel(t)
+
+	genericError := errors.New("test error")
+	probeError := wrapProbeError(genericError)
+
+	testCases := []struct {
+		name              string
+		errorSequence     []error
+		fpConfig          *config.Fingerprint
+		expectedErr       error
+		expectedCallCount int
+	}{
+		{
+			name:              "success on first attempt",
+			errorSequence:     []error{nil},
+			fpConfig:          nil,
+			expectedErr:       nil,
+			expectedCallCount: 1,
+		},
+		{
+			name:              "no config probe error",
+			errorSequence:     []error{probeError},
+			fpConfig:          nil,
+			expectedErr:       nil,
+			expectedCallCount: 1,
+		},
+		{
+			name:          "exit on failure probe error",
+			errorSequence: []error{probeError},
+			fpConfig: &config.Fingerprint{
+				Name:          "test",
+				ExitOnFailure: pointer.Of(true),
+			},
+			expectedErr:       probeError,
+			expectedCallCount: 1,
+		},
+		{
+			name:          "no exit on failure probe error",
+			errorSequence: []error{probeError},
+			fpConfig: &config.Fingerprint{
+				Name:          "test",
+				ExitOnFailure: pointer.Of(false),
+			},
+			expectedErr:       nil,
+			expectedCallCount: 1,
+		},
+		{
+			name: "no config with error",
+			errorSequence: []error{
+				genericError,
+			},
+			fpConfig:          nil,
+			expectedErr:       genericError,
+			expectedCallCount: 1,
+		},
+		{
+			name: "retry attempts 0 with error",
+			errorSequence: []error{
+				genericError,
+			},
+			fpConfig: &config.Fingerprint{
+				Name:          "test",
+				RetryAttempts: 0,
+			},
+			expectedErr:       genericError,
+			expectedCallCount: 1,
+		},
+		{
+			name: "retry attempts 1 fails twice",
+			errorSequence: []error{
+				genericError,
+				genericError,
+			},
+			fpConfig: &config.Fingerprint{
+				Name:          "test",
+				RetryAttempts: 1,
+				RetryInterval: 10 * time.Millisecond,
+			},
+			expectedErr:       genericError,
+			expectedCallCount: 2,
+		},
+		{
+			name: "retry attempts 1 succeeds on second try",
+			errorSequence: []error{
+				genericError,
+				nil,
+			},
+			fpConfig: &config.Fingerprint{
+				Name:          "test",
+				RetryAttempts: 1,
+				RetryInterval: 10 * time.Millisecond,
+			},
+			expectedErr:       nil,
+			expectedCallCount: 2,
+		},
+		{
+			name: "retry attempts 3 succeeds on third try",
+			errorSequence: []error{
+				genericError,
+				genericError,
+				nil,
+			},
+			fpConfig: &config.Fingerprint{
+				Name:          "test",
+				RetryAttempts: 3,
+				RetryInterval: 10 * time.Millisecond,
+			},
+			expectedErr:       nil,
+			expectedCallCount: 3,
+		},
+		{
+			name: "retry attempts 2 fails all attempts",
+			errorSequence: []error{
+				genericError,
+				genericError,
+				genericError,
+			},
+			fpConfig: &config.Fingerprint{
+				Name:          "test",
+				RetryAttempts: 2,
+				RetryInterval: 10 * time.Millisecond,
+			},
+			expectedErr:       genericError,
+			expectedCallCount: 3,
+		},
+		{
+			name: "retry attempts -1 retries indefinitely until success",
+			errorSequence: []error{
+				genericError,
+				genericError,
+				genericError,
+				genericError,
+				genericError,
+				genericError,
+				genericError,
+				nil,
+			},
+			fpConfig: &config.Fingerprint{
+				Name:          "test",
+				RetryAttempts: -1,
+				RetryInterval: 10 * time.Millisecond,
+			},
+			expectedErr:       nil,
+			expectedCallCount: 8,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			mock := newMockFingerprinter(tc.errorSequence)
+
+			wrapper := NewRetryWrapper(mock, testlog.HCLogger(t), "test")
+
+			cfg := &config.Config{
+				Fingerprinters: map[string]*config.Fingerprint{
+					"test": tc.fpConfig,
+				},
+			}
+
+			req := &FingerprintRequest{Config: cfg, Node: &structs.Node{}}
+			var resp FingerprintResponse
+
+			startTime := time.Now()
+			err := wrapper.Fingerprint(req, &resp)
+			elapsed := time.Since(startTime)
+
+			// Ensure the correct error response has been obtained. This is the
+			// final result of the finerprinter run.
+			if tc.expectedErr != nil {
+				must.Error(t, err)
+				must.Eq(t, tc.expectedErr, err)
+			} else {
+				must.NoError(t, err)
+			}
+
+			// Check the retry logic was triggered the expected number of times.
+			must.Eq(t, tc.expectedCallCount, mock.getCallCount())
+
+			// Attempt to verify that the fingerprinter took at least the
+			// expected amount of time, accounting for retries. This gives us
+			// further confidence that the retry logic was executed correctly.
+			if tc.fpConfig != nil && tc.expectedCallCount > 1 {
+				expectedMinTime := tc.fpConfig.RetryInterval
+				if expectedMinTime == 0 {
+					expectedMinTime = 2 * time.Second
+				}
+				minExpectedDuration := time.Duration(tc.expectedCallCount-1) * expectedMinTime
+				must.GreaterEq(t, minExpectedDuration-100*time.Millisecond, elapsed)
+			}
+		})
+	}
+}
+
+func Test_wrapProbeError(t *testing.T) {
+	ci.Parallel(t)
+
+	baseErr := errors.New("base error")
+	wrappedErr := wrapProbeError(baseErr)
+
+	must.Error(t, wrappedErr)
+	must.ErrorIs(t, wrappedErr, errEnvProbeQueryFailed)
+	must.ErrorIs(t, wrappedErr, baseErr)
+	must.StrContains(t, wrappedErr.Error(), "fingerprint initial probe failed")
+	must.StrContains(t, wrappedErr.Error(), "base error")
+}
+
+func Test_shouldSkipEnvFingerprinter(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name           string
+		inputCfg       *config.Fingerprint
+		inputError     error
+		expectedOutput bool
+	}{
+		{
+			name:           "nil config and nil error",
+			inputCfg:       nil,
+			inputError:     nil,
+			expectedOutput: false,
+		},
+		{
+			name:           "nil config and initial error",
+			inputCfg:       nil,
+			inputError:     wrapProbeError(errors.New("initial error")),
+			expectedOutput: true,
+		},
+		{
+			name:           "nil config and non-initial error",
+			inputCfg:       nil,
+			inputError:     errors.New("initial error"),
+			expectedOutput: false,
+		},
+		{
+			name:           "exit on failure not set and initial error",
+			inputCfg:       &config.Fingerprint{},
+			inputError:     wrapProbeError(errors.New("initial error")),
+			expectedOutput: true,
+		},
+		{
+			name: "exit on failure false and initial error",
+			inputCfg: &config.Fingerprint{
+				ExitOnFailure: pointer.Of(false),
+			},
+			inputError:     wrapProbeError(errors.New("initial error")),
+			expectedOutput: true,
+		},
+		{
+			name: "exit on failure true and initial error",
+			inputCfg: &config.Fingerprint{
+				ExitOnFailure: pointer.Of(true),
+			},
+			inputError:     wrapProbeError(errors.New("initial error")),
+			expectedOutput: false,
+		},
+		{
+			name: "exit on failure false and non-initial error",
+			inputCfg: &config.Fingerprint{
+				ExitOnFailure: pointer.Of(false),
+			},
+			inputError:     errors.New("initial error"),
+			expectedOutput: true,
+		},
+		{
+			name: "exit on failure true and non-initial error",
+			inputCfg: &config.Fingerprint{
+				ExitOnFailure: pointer.Of(true),
+			},
+			inputError:     errors.New("initial error"),
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			must.Eq(t, tc.expectedOutput, shouldSkipEnvFingerprinter(tc.inputCfg, tc.inputError))
+		})
+	}
+}

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1080,7 +1080,7 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 
 	conf.Users = clientconfig.UsersConfigFromAgent(agentConfig.Client.Users)
 
-	// Iterate the fingerprinter configs and populated the client mapping. The
+	// Iterate the fingerprinter configs and populate the client mapping. The
 	// validation function returns a suitable error that can be returned without
 	// formatting.
 	for _, fingerprinterCfg := range agentConfig.Client.Fingerprinters {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1080,6 +1080,16 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 
 	conf.Users = clientconfig.UsersConfigFromAgent(agentConfig.Client.Users)
 
+	// Iterate the fingerprinter configs and populated the client mapping. The
+	// validation function returns a suitable error that can be returned without
+	// formatting.
+	for _, fingerprinterCfg := range agentConfig.Client.Fingerprinters {
+		if err := fingerprinterCfg.Validate(); err != nil {
+			return nil, err
+		}
+		conf.Fingerprinters[fingerprinterCfg.Name] = fingerprinterCfg
+	}
+
 	conf.LogFile = agentConfig.LogFile
 	return conf, nil
 }

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -434,15 +434,20 @@ type ClientConfig struct {
 	// Users is used to configure parameters around operating system users.
 	Users *config.UsersConfig `hcl:"users"`
 
-	// ExtraKeysHCL is used by hcl to surface unexpected keys
-	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
-
 	// NodeMaxAllocs sets the maximum number of allocations per node
 	// Defaults to 0 and ignored if unset.
 	NodeMaxAllocs int `hcl:"node_max_allocs"`
 
 	// LogFile is used by MonitorExport to stream a client's log file
 	LogFile string `hcl:"log_file"`
+
+	// Fingerprinters contains configuration for individual fingerprinters. The
+	// external configuration is a slice but later converted to a map for
+	// internal use.
+	Fingerprinters []*client.Fingerprint `hcl:"fingerprint"`
+
+	// ExtraKeysHCL is used by hcl to surface unexpected keys
+	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
 
 func (c *ClientConfig) Copy() *ClientConfig {
@@ -465,6 +470,7 @@ func (c *ClientConfig) Copy() *ClientConfig {
 	nc.Artifact = c.Artifact.Copy()
 	nc.Drain = c.Drain.Copy()
 	nc.Users = c.Users.Copy()
+	nc.Fingerprinters = helper.CopySlice(c.Fingerprinters)
 	nc.ExtraKeysHCL = slices.Clone(c.ExtraKeysHCL)
 	return &nc
 }
@@ -1756,6 +1762,7 @@ func DefaultConfig() *Config {
 			Artifact:                       config.DefaultArtifactConfig(),
 			Drain:                          nil,
 			Users:                          config.DefaultUsersConfig(),
+			Fingerprinters:                 []*client.Fingerprint{},
 		},
 		Server: &ServerConfig{
 			Enabled:           false,
@@ -2154,6 +2161,37 @@ func mergeKEKProviderConfigs(left, right []*structs.KEKProviderConfig) []*struct
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].ID() < results[j].ID()
 	})
+
+	return results
+}
+
+func mergeClientFingerprinterConfigs(left, right []*client.Fingerprint) []*client.Fingerprint {
+	if len(left) == 0 {
+		return right
+	}
+	if len(right) == 0 {
+		return left
+	}
+	results := []*client.Fingerprint{}
+	doMerge := func(dstConfigs, srcConfigs []*client.Fingerprint) []*client.Fingerprint {
+		for _, src := range srcConfigs {
+			var found bool
+			for i, dst := range dstConfigs {
+				if dst.Name == src.Name {
+					dstConfigs[i] = dst.Merge(src)
+					found = true
+					break
+				}
+			}
+			if !found {
+				dstConfigs = append(dstConfigs, src)
+			}
+		}
+		return dstConfigs
+	}
+
+	results = doMerge(results, left)
+	results = doMerge(results, right)
 
 	return results
 }
@@ -2881,6 +2919,10 @@ func (c *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	}
 	if b.IntroToken != "" {
 		result.IntroToken = b.IntroToken
+	}
+
+	if b.Fingerprinters != nil {
+		result.Fingerprinters = mergeClientFingerprinterConfigs(c.Fingerprinters, b.Fingerprinters)
 	}
 
 	return &result

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -2000,6 +2000,55 @@ func Test_mergeKEKProviderConfigs(t *testing.T) {
 	}, result)
 }
 
+func Test_mergeClientFingerprinterConfigs(t *testing.T) {
+	ci.Parallel(t)
+
+	left := []*client.Fingerprint{
+		{
+			Name:          "env_aws",
+			RetryAttempts: 2,
+		},
+		{
+			Name:          "env_gce",
+			ExitOnFailure: pointer.Of(false),
+		},
+	}
+	right := []*client.Fingerprint{
+		{
+			Name:          "env_aws",
+			RetryInterval: 10 * time.Second,
+		},
+		{
+			Name:          "env_gce",
+			RetryAttempts: 10,
+			RetryInterval: 10 * time.Second,
+			ExitOnFailure: pointer.Of(true),
+		},
+		{
+			Name:          "env_azure",
+			ExitOnFailure: pointer.Of(true),
+		},
+	}
+
+	must.Eq(t, []*client.Fingerprint{
+		{
+			Name:          "env_aws",
+			RetryAttempts: 2,
+			RetryInterval: 10 * time.Second,
+		},
+		{
+			Name:          "env_gce",
+			RetryAttempts: 10,
+			RetryInterval: 10 * time.Second,
+			ExitOnFailure: pointer.Of(true),
+		},
+		{
+			Name:          "env_azure",
+			ExitOnFailure: pointer.Of(true),
+		},
+	}, mergeClientFingerprinterConfigs(left, right))
+}
+
 func TestConfig_LoadClientNodeMaxAllocs(t *testing.T) {
 	ci.Parallel(t)
 	testCases := []struct {

--- a/command/agent/testdata/basic.hcl
+++ b/command/agent/testdata/basic.hcl
@@ -107,6 +107,12 @@ client {
   bridge_network_name        = "custom_bridge_name"
   bridge_network_subnet      = "custom_bridge_subnet"
   bridge_network_subnet_ipv6 = "custom_bridge_subnet_ipv6"
+
+  fingerprint "env_aws" {
+    retry_interval  = "1s"
+    retry_attempts  = 3
+    exit_on_failure = true
+  }
 }
 
 server {

--- a/command/agent/testdata/basic.json
+++ b/command/agent/testdata/basic.json
@@ -143,6 +143,17 @@
         "a.b.c:80",
         "127.0.0.1:1234"
       ],
+      "fingerprint": [
+        {
+          "env_aws": [
+            {
+              "retry_interval": "1s",
+              "retry_attempts": 3,
+              "exit_on_failure": true
+            }
+          ]
+        }
+      ],
       "state_dir": "/tmp/client-state",
       "stats": [
         {

--- a/command/agent/testdata/fingerprint.hcl
+++ b/command/agent/testdata/fingerprint.hcl
@@ -1,0 +1,27 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+client {
+  enabled = true
+
+  fingerprint "env_aws" {
+    retry_interval  = "5m"
+    retry_attempts  = 3
+    exit_on_failure = true
+  }
+
+  fingerprint "env_azure" {
+    retry_interval  = "10m"
+    retry_attempts  = 5
+    exit_on_failure = false
+  }
+
+  fingerprint "env_gce" {
+    retry_interval = "2m"
+    retry_attempts = -1
+  }
+
+  fingerprint "env_digitalocean" {
+    retry_interval = "1m"
+  }
+}

--- a/command/agent/testdata/fingerprint.json
+++ b/command/agent/testdata/fingerprint.json
@@ -1,0 +1,40 @@
+{
+  "client": {
+    "enabled": true,
+    "fingerprint": [
+      {
+        "env_aws": [
+          {
+            "retry_interval": "5m",
+            "retry_attempts": 3,
+            "exit_on_failure": true
+          }
+        ]
+      },
+      {
+        "env_azure": [
+          {
+            "retry_interval": "10m",
+            "retry_attempts": 5,
+            "exit_on_failure": false
+          }
+        ]
+      },
+      {
+        "env_gce": [
+          {
+            "retry_interval": "2m",
+            "retry_attempts": -1
+          }
+        ]
+      },
+      {
+        "env_digitalocean": [
+          {
+            "retry_interval": "1m"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This change introduces new optional client fingerprinter configuration fields which can be used to control how the env fingerprinters perform retries and whether errors should halt the agent startup.

The retry wrapper is used by the env_aws, env_azure, env_gce, and env_digitalocean fingerprinters and is the handler for retry and error logic on the main fingerprinter. The change is backwards compatible, so running this change without any new config options results in the same behaviour as previously.

  - retry_interval: Specifies the time to wait between fingerprint attempts. This will default to 2 seconds.
  - retry_attempts: Specifies the maximum number of fingerprint retries to be made. This will default to 0 and can be set to -1 if the operator wants infinite retries.
  - exit_on_failure: Determines how the agent handles failure in performing the fingerprint.

The change helps alleviate problems in cloud providers where a machine starts before the metadata service and endpoint is available. In this situation, Nomad timesout the fingerprinter quickly and marks it as skipped, thus assuming we are not running within that environment. Operators can use the new configuration options to handle these race conditions, and wait for the metadata service to be available and respond.

### Links
Jira: https://hashicorp.atlassian.net/browse/NMD-1061

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

