### PR TITLE
chore: Remove use of deprecated strings.Title for cases.Title.

### DIFF
--- a/.semgrep/import_functions.yml
+++ b/.semgrep/import_functions.yml
@@ -1,0 +1,9 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+rules:
+  - id: disallow-strings-title-function-use
+    languages: [go]
+    message: "strings.Title is deprecated, use cases.Title instead."
+    severity: ERROR
+    pattern: strings.Title(...)

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -38,6 +38,8 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/version"
 	"github.com/posener/complete"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // gracefulTimeout controls how long we wait before forcefully terminating
@@ -927,7 +929,7 @@ func (c *Command) Run(args []string) int {
 		c.Ui.Info(fmt.Sprintf(
 			"%s%s: %s",
 			strings.Repeat(" ", padding-len(k)),
-			strings.Title(k),
+			cases.Title(language.English).String(k),
 			info[k]))
 	}
 	c.Ui.Output("")

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -34,6 +34,8 @@ import (
 	"github.com/hashicorp/nomad/helper/escapingfs"
 	"github.com/hashicorp/nomad/version"
 	"github.com/posener/complete"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type OperatorDebugCommand struct {
@@ -1853,7 +1855,7 @@ func parseTopic(input string) (string, string, error) {
 		return "", "", fmt.Errorf("Invalid key value pair for topic: %s", topic)
 	}
 
-	return strings.Title(topic), filter, nil
+	return cases.Title(language.English).String(topic), filter, nil
 }
 
 func allTopics() map[api.Topic][]string {

--- a/command/status.go
+++ b/command/status.go
@@ -10,6 +10,8 @@ import (
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 type StatusCommand struct {
@@ -194,7 +196,7 @@ func (c *StatusCommand) logMultiMatchError(id string, matches map[contexts.Conte
 			continue
 		}
 
-		c.Ui.Error(fmt.Sprintf("\n%s:", strings.Title(string(ctx))))
+		c.Ui.Error(fmt.Sprintf("\n%s:", cases.Title(language.English).String(string(ctx))))
 		c.Ui.Error(strings.Join(vers, ", "))
 	}
 }

--- a/command/ui.go
+++ b/command/ui.go
@@ -11,6 +11,8 @@ import (
 	"github.com/hashicorp/cap/util"
 	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 var (
@@ -232,7 +234,7 @@ func (c *UiCommand) logMultiMatchError(id string, matches map[contexts.Context][
 			continue
 		}
 
-		c.Ui.Error(fmt.Sprintf("\n%s:", strings.Title(string(ctx))))
+		c.Ui.Error(fmt.Sprintf("\n%s:", cases.Title(language.English).String(string(ctx))))
 		c.Ui.Error(strings.Join(vers, ", "))
 	}
 }

--- a/command/var_put.go
+++ b/command/var_put.go
@@ -23,6 +23,8 @@ import (
 	"github.com/hashicorp/nomad/helper"
 	"github.com/mitchellh/mapstructure"
 	"github.com/posener/complete"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Detect characters that are not valid identifiers to emit a warning when they
@@ -514,7 +516,10 @@ func parseVariableSpecImpl(result *api.Variable, list *ast.ObjectList) error {
 				return fmt.Errorf("%s must be integer; got (%T) %[2]v", index, value)
 			}
 			idx := uint64(vInt)
-			n := strings.ReplaceAll(strings.Title(strings.ReplaceAll(index, "_", " ")), " ", "")
+			n := strings.ReplaceAll(
+				cases.Title(language.English).String(
+					strings.ReplaceAll(index, "_", " "),
+				), " ", "")
 			m[n] = idx
 			delete(m, index)
 		}
@@ -526,7 +531,10 @@ func parseVariableSpecImpl(result *api.Variable, list *ast.ObjectList) error {
 			if !ok {
 				return fmt.Errorf("%s must be a int64; got a (%T) %[2]v", index, value)
 			}
-			n := strings.ReplaceAll(strings.Title(strings.ReplaceAll(index, "_", " ")), " ", "")
+			n := strings.ReplaceAll(
+				cases.Title(language.English).String(
+					strings.ReplaceAll(index, "_", " "),
+				), " ", "")
 			m[n] = vInt
 			delete(m, index)
 		}

--- a/go.mod
+++ b/go.mod
@@ -131,6 +131,7 @@ require (
 	golang.org/x/mod v0.30.0
 	golang.org/x/sync v0.18.0
 	golang.org/x/sys v0.38.0
+	golang.org/x/text v0.31.0
 	golang.org/x/time v0.14.0
 	google.golang.org/grpc v1.77.0
 	google.golang.org/protobuf v1.36.10
@@ -346,7 +347,6 @@ require (
 	golang.org/x/net v0.47.0 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
-	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 	google.golang.org/api v0.217.0 // indirect
 	google.golang.org/genproto v0.0.0-20250115164207-1a7da9e5054f // indirect


### PR DESCRIPTION
The change removes the use of strings.Title for the cases.Title function. The former is deprecated and does not correctly handle Unicode punctuation properly.

To ensure no new code reintroduces use of strings.Title a new semgrep rule has been added to catch import function use we want to disallow.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

