### PR TITLE
test: Fix race condition in unpublish test counter.

### DIFF
--- a/nomad/volumewatcher/interfaces_test.go
+++ b/nomad/volumewatcher/interfaces_test.go
@@ -4,6 +4,8 @@
 package volumewatcher
 
 import (
+	"sync/atomic"
+
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -70,12 +72,12 @@ type MockRPCServer struct {
 
 	nextCSIUnpublishResponse *structs.CSIVolumeUnpublishResponse
 	nextCSIUnpublishError    error
-	countCSIUnpublish        int
+	countCSIUnpublish        atomic.Int32
 }
 
 func (srv *MockRPCServer) Unpublish(args *structs.CSIVolumeUnpublishRequest, reply *structs.CSIVolumeUnpublishResponse) error {
 	reply = srv.nextCSIUnpublishResponse
-	srv.countCSIUnpublish++
+	srv.countCSIUnpublish.Add(1)
 	return srv.nextCSIUnpublishError
 }
 

--- a/nomad/volumewatcher/volume_watcher_test.go
+++ b/nomad/volumewatcher/volume_watcher_test.go
@@ -55,7 +55,7 @@ func TestVolumeWatch_Reap(t *testing.T) {
 	// verify no change has been made
 	must.MapLen(t, 1, vol.ReadClaims)
 	must.MapLen(t, 0, vol.PastClaims)
-	must.Eq(t, 0, srv.countCSIUnpublish)
+	must.Eq(t, 0, srv.countCSIUnpublish.Load())
 
 	alloc = alloc.Copy()
 	alloc.ClientStatus = structs.AllocClientStatusComplete
@@ -70,7 +70,7 @@ func TestVolumeWatch_Reap(t *testing.T) {
 
 	err = w.volumeReapImpl(vol)
 	must.NoError(t, err)
-	must.Eq(t, 1, srv.countCSIUnpublish)
+	must.Eq(t, 1, srv.countCSIUnpublish.Load())
 
 	// simulate updated past claim from a previous pass
 	vol.PastClaims = map[string]*structs.CSIVolumeClaim{
@@ -84,7 +84,7 @@ func TestVolumeWatch_Reap(t *testing.T) {
 	err = w.volumeReapImpl(vol)
 	must.NoError(t, err)
 	must.MapLen(t, 1, vol.PastClaims)
-	must.Eq(t, 2, srv.countCSIUnpublish)
+	must.Eq(t, 2, srv.countCSIUnpublish.Load())
 
 	// claim emitted by a GC event
 	vol.PastClaims = map[string]*structs.CSIVolumeClaim{
@@ -97,7 +97,7 @@ func TestVolumeWatch_Reap(t *testing.T) {
 	err = w.volumeReapImpl(vol)
 	must.NoError(t, err)
 	must.MapLen(t, 2, vol.PastClaims) // alloc claim + GC claim
-	must.Eq(t, 4, srv.countCSIUnpublish)
+	must.Eq(t, 4, srv.countCSIUnpublish.Load())
 
 	// release claims of a previously GC'd allocation
 	vol.ReadAllocs[alloc.ID] = nil
@@ -111,7 +111,7 @@ func TestVolumeWatch_Reap(t *testing.T) {
 	err = w.volumeReapImpl(vol)
 	must.NoError(t, err)
 	must.MapLen(t, 2, vol.PastClaims) // alloc claim + GC claim
-	must.Eq(t, 6, srv.countCSIUnpublish)
+	must.Eq(t, 6, srv.countCSIUnpublish.Load())
 }
 
 func TestVolumeReapBadState(t *testing.T) {
@@ -141,5 +141,5 @@ func TestVolumeReapBadState(t *testing.T) {
 
 	err = w.volumeReapImpl(vol)
 	must.NoError(t, err)
-	must.Eq(t, 2, srv.countCSIUnpublish)
+	must.Eq(t, 2, srv.countCSIUnpublish.Load())
 }

--- a/nomad/volumewatcher/volumes_watcher_test.go
+++ b/nomad/volumewatcher/volumes_watcher_test.go
@@ -109,7 +109,7 @@ func TestVolumeWatch_LeadershipTransition(t *testing.T) {
 
 	vol, _ = srv.State().CSIVolumeByID(nil, vol.Namespace, vol.ID)
 	must.MapLen(t, 0, vol.PastClaims, must.Sprint("expected to have 0 PastClaims"))
-	must.Eq(t, srv.countCSIUnpublish, 0, must.Sprint("expected no CSI.Unpublish RPC calls"))
+	must.Eq(t, 0, srv.countCSIUnpublish.Load(), must.Sprint("expected no CSI.Unpublish RPC calls"))
 
 	// trying to test a dropped watch is racy, so to reliably simulate
 	// this condition, step-down the watcher first and then perform
@@ -165,7 +165,7 @@ func TestVolumeWatch_LeadershipTransition(t *testing.T) {
 				return false
 			}
 
-			return srv.countCSIUnpublish == 1
+			return srv.countCSIUnpublish.Load() == 1
 		}),
 		wait.Timeout(2*time.Second),
 		wait.Gap(200*time.Millisecond),


### PR DESCRIPTION
The mock RPC server stores an unpublish counter to test the number of publish calls. This was being concurrently read and written to causing a test race condition. Using an atomic int32 fixes this issue.

### Testing & Reproduction steps
<details>
<summary>before change</summary>

```console
$ go test -v -race ./"nomad/volumewatcher"
# github.com/hashicorp/nomad/nomad/volumewatcher.test
=== RUN   TestVolumeWatch_Reap
=== PAUSE TestVolumeWatch_Reap
=== RUN   TestVolumeReapBadState
=== PAUSE TestVolumeReapBadState
=== RUN   TestVolumeWatch_EnableDisable
=== PAUSE TestVolumeWatch_EnableDisable
=== RUN   TestVolumeWatch_LeadershipTransition
=== PAUSE TestVolumeWatch_LeadershipTransition
=== RUN   TestVolumeWatch_StartStop
=== PAUSE TestVolumeWatch_StartStop
=== RUN   TestVolumeWatch_Delete
=== PAUSE TestVolumeWatch_Delete
=== RUN   TestVolumeWatch_RegisterDeregister
=== PAUSE TestVolumeWatch_RegisterDeregister
=== CONT  TestVolumeWatch_StartStop
=== CONT  TestVolumeWatch_LeadershipTransition
=== CONT  TestVolumeReapBadState
=== CONT  TestVolumeWatch_EnableDisable
=== CONT  TestVolumeWatch_RegisterDeregister
=== CONT  TestVolumeWatch_Reap
=== CONT  TestVolumeWatch_Delete
2025-11-27T11:23:45.676Z [ERROR] state/state_store.go:6014: state_store: new allocation inserted into state store with bad client status: alloc_id=0fec2a8a-dacc-2fe4-35b8-78950551ab1a client_status=running
--- PASS: TestVolumeWatch_RegisterDeregister (0.00s)
2025-11-27T11:23:45.677Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=ac2355f7-4600-89e2-8f7c-0aee48198271
2025-11-27T11:23:45.677Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=52184ce9-bb85-1953-2910-2eb0d4c6822d
2025-11-27T11:23:45.676Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=298578c1-bce7-6d39-2143-529fe8b9826c
2025-11-27T11:23:45.676Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=dcf789b8-47e8-b539-2161-5702773cfd4f
2025-11-27T11:23:45.677Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=ac2355f7-4600-89e2-8f7c-0aee48198271
2025-11-27T11:23:45.677Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=dcf789b8-47e8-b539-2161-5702773cfd4f
2025-11-27T11:23:45.678Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=52184ce9-bb85-1953-2910-2eb0d4c6822d
2025-11-27T11:23:45.677Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=def4734c-a2d0-8942-dda5-232931abcbc4
2025-11-27T11:23:45.678Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=c5351d92-14f8-0719-2811-115160eabd73
2025-11-27T11:23:45.678Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=298578c1-bce7-6d39-2143-529fe8b9826c
2025-11-27T11:23:45.678Z [TRACE] volumewatcher/volume_watcher.go:202: volumes_watcher: unpublishing volume: namespace=default volume_id=298578c1-bce7-6d39-2143-529fe8b9826c alloc=7d130f07-9d85-23d5-7501-21ab99488213
--- PASS: TestVolumeReapBadState (0.01s)
2025-11-27T11:23:45.678Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=58b689b5-c10e-3897-3894-4032c8e013bd
2025-11-27T11:23:45.679Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=58b689b5-c10e-3897-3894-4032c8e013bd
2025-11-27T11:23:45.679Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=58b689b5-c10e-3897-3894-4032c8e013bd
2025-11-27T11:23:45.679Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=cdcf041f-b5ca-23d8-cbd3-98fe8657dc08
2025-11-27T11:23:45.679Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=""
2025-11-27T11:23:45.679Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=""
2025-11-27T11:23:45.679Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=cdcf041f-b5ca-23d8-cbd3-98fe8657dc08
2025-11-27T11:23:45.679Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=""
2025-11-27T11:23:45.679Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=cdcf041f-b5ca-23d8-cbd3-98fe8657dc08
--- PASS: TestVolumeWatch_Reap (0.01s)
2025-11-27T11:23:45.680Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=58b689b5-c10e-3897-3894-4032c8e013bd
2025-11-27T11:23:45.687Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=298578c1-bce7-6d39-2143-529fe8b9826c
--- PASS: TestVolumeWatch_EnableDisable (0.01s)
2025-11-27T11:23:45.687Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=298578c1-bce7-6d39-2143-529fe8b9826c
2025-11-27T11:23:45.687Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=ac2355f7-4600-89e2-8f7c-0aee48198271
2025-11-27T11:23:45.687Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=ac2355f7-4600-89e2-8f7c-0aee48198271
--- PASS: TestVolumeWatch_Delete (0.01s)
2025-11-27T11:23:45.688Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=52184ce9-bb85-1953-2910-2eb0d4c6822d
2025-11-27T11:23:45.688Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=ac2355f7-4600-89e2-8f7c-0aee48198271
2025-11-27T11:23:45.688Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=ac2355f7-4600-89e2-8f7c-0aee48198271
2025-11-27T11:23:45.688Z [TRACE] volumewatcher/volume_watcher.go:202: volumes_watcher: unpublishing volume: namespace=default volume_id=ac2355f7-4600-89e2-8f7c-0aee48198271 alloc=8071790e-0150-1dc4-a35e-bb86af7bd516
==================
WARNING: DATA RACE
Write at 0x00c0002520e0 by goroutine 42:
  github.com/hashicorp/nomad/nomad/volumewatcher.(*MockRPCServer).Unpublish()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/interfaces_test.go:78 +0x54
  github.com/hashicorp/nomad/nomad/volumewatcher.(*volumeWatcher).unpublish()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volume_watcher.go:212 +0x378
  github.com/hashicorp/nomad/nomad/volumewatcher.(*volumeWatcher).volumeReapImpl()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volume_watcher.go:193 +0xe4
  github.com/hashicorp/nomad/nomad/volumewatcher.(*volumeWatcher).volumeReap()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volume_watcher.go:181 +0x70
  github.com/hashicorp/nomad/nomad/volumewatcher.(*volumeWatcher).watch()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volume_watcher.go:139 +0xd4
  github.com/hashicorp/nomad/nomad/volumewatcher.(*volumeWatcher).Start.gowrap2()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volume_watcher.go:93 +0x34

Previous read at 0x00c0002520e0 by goroutine 24:
  github.com/hashicorp/nomad/nomad/volumewatcher.TestVolumeWatch_LeadershipTransition.func3()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volumes_watcher_test.go:168 +0xe0
  github.com/shoenig/test/wait.boolFuncInitial.func1()
      /Users/jrasell/go/pkg/mod/github.com/shoenig/test@v1.12.2/wait/wait.go:201 +0x110
  github.com/shoenig/test/wait.(*Constraint).Run()
      /Users/jrasell/go/pkg/mod/github.com/shoenig/test@v1.12.2/wait/wait.go:430 +0xb4
  github.com/shoenig/test/internal/assertions.Wait()
      /Users/jrasell/go/pkg/mod/github.com/shoenig/test@v1.12.2/internal/assertions/assertions.go:1647 +0xcc
  github.com/shoenig/test/must.Wait()
      /Users/jrasell/go/pkg/mod/github.com/shoenig/test@v1.12.2/must/must.go:891 +0x4c
  github.com/hashicorp/nomad/nomad/volumewatcher.TestVolumeWatch_LeadershipTransition()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volumes_watcher_test.go:157 +0xf58
  testing.tRunner()
      /Users/jrasell/.asdf/installs/golang/1.25.4/go/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /Users/jrasell/.asdf/installs/golang/1.25.4/go/src/testing/testing.go:1997 +0x3c

Goroutine 42 (running) created at:
  github.com/hashicorp/nomad/nomad/volumewatcher.(*volumeWatcher).Start()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volume_watcher.go:93 +0x120
  github.com/hashicorp/nomad/nomad/volumewatcher.newVolumeWatcher()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volume_watcher.go:73 +0x604
  github.com/hashicorp/nomad/nomad/volumewatcher.(*Watcher).addLocked()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volumes_watcher.go:192 +0xe8
  github.com/hashicorp/nomad/nomad/volumewatcher.(*Watcher).add()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volumes_watcher.go:174 +0x84
  github.com/hashicorp/nomad/nomad/volumewatcher.(*Watcher).watchVolumes()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volumes_watcher.go:125 +0x1f0
  github.com/hashicorp/nomad/nomad/volumewatcher.(*Watcher).SetEnabled.gowrap2()
      /Users/jrasell/Projects/Go/nomad/nomad/volumewatcher/volumes_watcher.go:90 +0x48

Goroutine 24 (running) created at:
  testing.(*T).Run()
      /Users/jrasell/.asdf/installs/golang/1.25.4/go/src/testing/testing.go:1997 +0x6e0
  testing.runTests.func1()
      /Users/jrasell/.asdf/installs/golang/1.25.4/go/src/testing/testing.go:2477 +0x74
  testing.tRunner()
      /Users/jrasell/.asdf/installs/golang/1.25.4/go/src/testing/testing.go:1934 +0x164
  testing.runTests()
      /Users/jrasell/.asdf/installs/golang/1.25.4/go/src/testing/testing.go:2475 +0x734
  testing.(*M).Run()
      /Users/jrasell/.asdf/installs/golang/1.25.4/go/src/testing/testing.go:2337 +0xaf4
  main.main()
      _testmain.go:57 +0x100
==================
2025-11-27T11:23:45.780Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=58b689b5-c10e-3897-3894-4032c8e013bd
=== NAME  TestVolumeWatch_StartStop
    testing.go:1617: race detected during execution of test
--- FAIL: TestVolumeWatch_StartStop (0.12s)
2025-11-27T11:23:45.789Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=ac2355f7-4600-89e2-8f7c-0aee48198271
=== NAME  TestVolumeWatch_LeadershipTransition
    testing.go:1617: race detected during execution of test
--- FAIL: TestVolumeWatch_LeadershipTransition (0.22s)
FAIL
FAIL	github.com/hashicorp/nomad/nomad/volumewatcher	0.625s
FAIL
```

</details>

<details>
<summary>after change</summary>

```console
$ go test -v -race ./"nomad/volumewatcher"
# github.com/hashicorp/nomad/nomad/volumewatcher.test
=== RUN   TestVolumeWatch_Reap
=== PAUSE TestVolumeWatch_Reap
=== RUN   TestVolumeReapBadState
=== PAUSE TestVolumeReapBadState
=== RUN   TestVolumeWatch_EnableDisable
=== PAUSE TestVolumeWatch_EnableDisable
=== RUN   TestVolumeWatch_LeadershipTransition
=== PAUSE TestVolumeWatch_LeadershipTransition
=== RUN   TestVolumeWatch_StartStop
=== PAUSE TestVolumeWatch_StartStop
=== RUN   TestVolumeWatch_Delete
=== PAUSE TestVolumeWatch_Delete
=== RUN   TestVolumeWatch_RegisterDeregister
=== PAUSE TestVolumeWatch_RegisterDeregister
=== CONT  TestVolumeWatch_Reap
=== CONT  TestVolumeWatch_Delete
=== CONT  TestVolumeWatch_RegisterDeregister
=== CONT  TestVolumeWatch_StartStop
=== CONT  TestVolumeWatch_LeadershipTransition
=== CONT  TestVolumeWatch_EnableDisable
=== CONT  TestVolumeReapBadState
2025-11-27T11:28:56.348Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=15254e8b-8245-4614-30a6-6b52a92e0bfa
2025-11-27T11:28:56.349Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=15254e8b-8245-4614-30a6-6b52a92e0bfa
--- PASS: TestVolumeWatch_RegisterDeregister (0.00s)
2025-11-27T11:28:56.349Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=c74d0a5c-91a4-76cd-d489-4a618ba63cfe
2025-11-27T11:28:56.349Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=c74d0a5c-91a4-76cd-d489-4a618ba63cfe
2025-11-27T11:28:56.350Z [ERROR] state/state_store.go:6014: state_store: new allocation inserted into state store with bad client status: alloc_id=4f3c2413-9610-dead-f47e-7a71014c848d client_status=running
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=91f9c1cc-8097-9f1d-86ee-d160aadf3093
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=91f9c1cc-8097-9f1d-86ee-d160aadf3093
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=73477abf-8c0e-7d74-3e1f-031703feba62
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=629ea02f-ade6-cc98-c4d7-3ec17a237999
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=0a9534b5-66c0-1a56-5121-9884d7ef10a5
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=""
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=73477abf-8c0e-7d74-3e1f-031703feba62
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=0a9534b5-66c0-1a56-5121-9884d7ef10a5
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=""
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:202: volumes_watcher: unpublishing volume: namespace=default volume_id=0a9534b5-66c0-1a56-5121-9884d7ef10a5 alloc=db49199d-278d-6b9c-9cce-76bfae865a6a
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=73477abf-8c0e-7d74-3e1f-031703feba62
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=629ea02f-ade6-cc98-c4d7-3ec17a237999
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=0a9534b5-66c0-1a56-5121-9884d7ef10a5
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=73477abf-8c0e-7d74-3e1f-031703feba62
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=""
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=0a9534b5-66c0-1a56-5121-9884d7ef10a5
--- PASS: TestVolumeWatch_EnableDisable (0.00s)
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=629ea02f-ade6-cc98-c4d7-3ec17a237999
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=e22a8f20-c788-abc7-d94c-22c07ef23609
2025-11-27T11:28:56.351Z [TRACE] volumewatcher/volume_watcher.go:202: unpublishing volume: alloc=55115fc6-8b2c-9f8c-ccb4-9d52c0345fe1
--- PASS: TestVolumeWatch_Reap (0.01s)
--- PASS: TestVolumeReapBadState (0.00s)
2025-11-27T11:28:56.360Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=c74d0a5c-91a4-76cd-d489-4a618ba63cfe
--- PASS: TestVolumeWatch_Delete (0.02s)
2025-11-27T11:28:56.361Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=91f9c1cc-8097-9f1d-86ee-d160aadf3093
2025-11-27T11:28:56.361Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=91f9c1cc-8097-9f1d-86ee-d160aadf3093
2025-11-27T11:28:56.362Z [TRACE] volumewatcher/volume_watcher.go:89: volumes_watcher: starting watcher: namespace=default volume_id=91f9c1cc-8097-9f1d-86ee-d160aadf3093
2025-11-27T11:28:56.362Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=91f9c1cc-8097-9f1d-86ee-d160aadf3093
2025-11-27T11:28:56.362Z [TRACE] volumewatcher/volume_watcher.go:202: volumes_watcher: unpublishing volume: namespace=default volume_id=91f9c1cc-8097-9f1d-86ee-d160aadf3093 alloc=f1787937-8aef-3a31-3f25-97ceb5b1f40a
2025-11-27T11:28:56.462Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=91f9c1cc-8097-9f1d-86ee-d160aadf3093
--- PASS: TestVolumeWatch_LeadershipTransition (0.22s)
2025-11-27T11:28:57.352Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=73477abf-8c0e-7d74-3e1f-031703feba62
2025-11-27T11:28:58.352Z [TRACE] volumewatcher/volume_watcher.go:180: volumes_watcher: releasing unused volume claims: namespace=default volume_id=73477abf-8c0e-7d74-3e1f-031703feba62
2025-11-27T11:28:58.453Z [TRACE] volumewatcher/volume_watcher.go:97: volumes_watcher: no more claims: namespace=default volume_id=73477abf-8c0e-7d74-3e1f-031703feba62
--- PASS: TestVolumeWatch_StartStop (2.12s)
PASS
ok  	github.com/hashicorp/nomad/nomad/volumewatcher
```

</details>

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

