### PR TITLE
Fix secrets redaction for CSI volumes to avoid state corruption

### DIFF
--- a/.changelog/27176.txt
+++ b/.changelog/27176.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where reading a volume from the API or event stream could erase its secrets
+```

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -578,6 +578,27 @@ func (v *CSIVolume) Copy() *CSIVolume {
 	return out
 }
 
+// Sanitize returns a deep copy of the volume, with sensitive fields redacted
+func (v *CSIVolume) Sanitize() *CSIVolume {
+	if v == nil {
+		return nil
+	}
+
+	clean := v.Copy()
+
+	// would be better not to have at all but left in and redacted for backwards
+	// compatibility with the existing API
+	clean.Secrets = nil
+
+	// MountFlags can contain secrets, so we always redact it but want to show
+	// the user that we have the value
+	if v.MountOptions != nil {
+		clean.MountOptions = clean.MountOptions.Sanitize()
+	}
+
+	return clean
+}
+
 // Claim updates the allocations and changes the volume state
 func (v *CSIVolume) Claim(claim *CSIVolumeClaim, alloc *Allocation) error {
 	// COMPAT: volumes registered prior to 1.1.0 will be missing caps for the

--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -1093,6 +1093,30 @@ func TestTaskCSIPluginConfig_Equal(t *testing.T) {
 	}})
 }
 
+func TestCSIVolumeSanitize(t *testing.T) {
+	ci.Parallel(t)
+
+	orig := &CSIVolume{
+		ID: "foo",
+		MountOptions: &CSIMountOptions{
+			FSType:     "ext4",
+			MountFlags: []string{"ro", "noatime"},
+		},
+		Secrets: CSISecrets{
+			"foo": "bar",
+			"baz": "qux",
+		},
+		Parameters: map[string]string{"example": "unchanged"},
+	}
+
+	sanitized := orig.Sanitize()
+	must.Eq(t, []string{"[REDACTED]"}, sanitized.MountOptions.MountFlags)
+	must.Nil(t, sanitized.Secrets)
+
+	orig.Parameters["example"] = "different"
+	must.Eq(t, "unchanged", sanitized.Parameters["example"])
+}
+
 func TestCSISecretsSanitize(t *testing.T) {
 	ci.Parallel(t)
 

--- a/nomad/structs/extensions.go
+++ b/nomad/structs/extensions.go
@@ -69,7 +69,7 @@ func nodeExt(v interface{}) interface{} {
 }
 
 func csiVolumeExt(v interface{}) interface{} {
-	vol := v.(*CSIVolume)
+	vol := v.(*CSIVolume).Sanitize()
 	type EmbeddedCSIVolume CSIVolume
 
 	allocCount := len(vol.ReadAllocs) + len(vol.WriteAllocs)
@@ -99,16 +99,6 @@ func csiVolumeExt(v interface{}) interface{} {
 			apiVol.Allocations = append(apiVol.Allocations, a.Stub(nil))
 		}
 	}
-
-	// MountFlags can contain secrets, so we always redact it but want
-	// to show the user that we have the value
-	if vol.MountOptions != nil && len(vol.MountOptions.MountFlags) > 0 {
-		apiVol.MountOptions.MountFlags = []string{"[REDACTED]"}
-	}
-
-	// would be better not to have at all but left in and redacted for
-	// backwards compatibility with the existing API
-	apiVol.Secrets = nil
 
 	return apiVol
 }


### PR DESCRIPTION
In #12583 we changed the serialization code for CSI volumes so that we were using the extension method we use for topology and nodes. This reduces an enormous amount of boilerplate code, but we introduced a state store corruption bug in the process. The extension method sanitizes the volume without copying it, so a read of the volume (such as getting an event from the event stream) can cause the volume's secrets to be redacted in subsequent requests to publish or mount the volume.

Move the sanitization code into a testable method on the volume, and add a copy to the method.

Ref: https://github.com/hashicorp/nomad/pull/12583
Fixes: https://github.com/hashicorp/nomad/issues/26766

### Testing & Reproduction steps

In addition to the unit test here, you can reproduce this behavior with the [hostpath plugin demo](https://github.com/hashicorp/nomad/tree/main/demo/csi/hostpath). Comment out the steps to claim the volume. Run the `run.sh` script and examine the allocation logs for the plugin. You'll see the unredacted secrets there. Then read from the event stream via `nomad operator api "/v1/event/stream?topic=CSIVolume"`. Uncomment the steps to claim the volume and run the workload. Examine the allocation logs for the plugin again and you'll see the secret is being redacted. With this patch it works as expected.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
