### PR TITLE
qemu: add emulator allowlist to driver config and add emulator validation

### DIFF
--- a/.changelog/27182.txt
+++ b/.changelog/27182.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+qemu: adds an emulator allowlist to qemu plugin config
+```

--- a/client/testutil/driver_compatible.go
+++ b/client/testutil/driver_compatible.go
@@ -113,14 +113,21 @@ func JavaCompatible(t *testing.T) {
 }
 
 // QemuCompatible skips tests unless:
-// - "qemu-system-x86_64" executable is detected on $PATH (!windows)
-// - "qemu-img" executable is detected on on $PATH (windows)
-func QemuCompatible(t *testing.T) {
+// - "qemu-system-x86_64" executable is detected on $PATH
+func QemuCompatible_x86_64(t *testing.T) {
 	// Check if qemu exists
 	bin := "qemu-system-x86_64"
-	if runtime.GOOS == "windows" {
-		bin = "qemu-img"
+	_, err := exec.Command(bin, "--version").CombinedOutput()
+	if err != nil {
+		t.Skipf("Test requires QEMU (%s)", bin)
 	}
+}
+
+// QemuCompatible skips tests unless:
+// - "qemu-system-aarch64" executable is detected on $PATH
+func QemuCompatible_aarch64(t *testing.T) {
+	// Check if qemu exists
+	bin := "qemu-system-aarch64"
 	_, err := exec.Command(bin, "--version").CombinedOutput()
 	if err != nil {
 		t.Skipf("Test requires QEMU (%s)", bin)

--- a/client/testutil/driver_compatible.go
+++ b/client/testutil/driver_compatible.go
@@ -112,7 +112,7 @@ func JavaCompatible(t *testing.T) {
 	}
 }
 
-// QemuCompatible skips tests unless:
+// QemuCompatible_x86_64 skips tests unless:
 // - "qemu-system-x86_64" executable is detected on $PATH
 func QemuCompatible_x86_64(t *testing.T) {
 	// Check if qemu exists
@@ -123,7 +123,7 @@ func QemuCompatible_x86_64(t *testing.T) {
 	}
 }
 
-// QemuCompatible skips tests unless:
+// QemuCompatible_aarch64 skips tests unless:
 // - "qemu-system-aarch64" executable is detected on $PATH
 func QemuCompatible_aarch64(t *testing.T) {
 	// Check if qemu exists

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -382,9 +382,10 @@ func findEmulators(allowList []string) []string {
 
 	for _, f := range bins {
 		em := strings.TrimPrefix(filepath.Base(f), "qemu-system-")
-		if err := validateEmulator(em, allowList); err == nil {
-			emulators = append(emulators, em)
+		if err := validateEmulator(em, allowList); err != nil {
+			continue
 		}
+		emulators = append(emulators, em)
 	}
 
 	return emulators

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -354,6 +354,8 @@ func (d *Driver) RecoverTask(handle *drivers.TaskHandle) error {
 	return nil
 }
 
+// findEmulators searches the $PATH for qemu-system binaries until they are found
+// and returns a slice of emulators that comply with the emulators allowlist.
 func findEmulators(allowList []string) []string {
 	var (
 		glob      string = "qemu-system-*"
@@ -380,12 +382,7 @@ func findEmulators(allowList []string) []string {
 
 	for _, f := range bins {
 		em := strings.TrimPrefix(filepath.Base(f), "qemu-system-")
-
-		if len(allowList) > 0 {
-			if slices.Contains(allowList, em) {
-				emulators = append(emulators, em)
-			}
-		} else {
+		if err := validateEmulator(em, allowList); err == nil {
 			emulators = append(emulators, em)
 		}
 	}
@@ -431,6 +428,7 @@ func isAllowedDriveInterface(driveInterface string) bool {
 	return false
 }
 
+// validateEmulator validate whether the specified emulator is in allowedEmulators
 func validateEmulator(emulator string, allowedEmulators []string) error {
 	if len(allowedEmulators) > 0 {
 		if !slices.Contains(allowedEmulators, emulator) {

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -276,8 +276,8 @@ func (d *Driver) buildFingerprint() *drivers.Fingerprint {
 	}
 	currentQemuVersion := matches[1]
 
-	fingerprint.Attributes[driverVersionAttr] = pstructs.NewStringAttribute(currentQemuVersion)
 	fingerprint.Attributes[driverAttr] = pstructs.NewBoolAttribute(true)
+	fingerprint.Attributes[driverVersionAttr] = pstructs.NewStringAttribute(currentQemuVersion)
 	fingerprint.Attributes[driverEmulatorsAttr] = pstructs.NewStringAttribute(strings.Join(emulators, ","))
 
 	return fingerprint
@@ -420,13 +420,7 @@ func isAllowedImagePath(allowedPaths []string, allocDir, imagePath string) bool 
 var allowedDriveInterfaces = []string{"ide", "scsi", "sd", "mtd", "floppy", "pflash", "virtio", "none"}
 
 func isAllowedDriveInterface(driveInterface string) bool {
-	for _, ai := range allowedDriveInterfaces {
-		if driveInterface == ai {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(allowedDriveInterfaces, driveInterface)
 }
 
 // validateEmulator validate whether the specified emulator is in allowedEmulators
@@ -565,7 +559,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 			return nil, nil, err
 		}
 		d.logger.Debug("got monitor path", "monitorPath", monitorPath)
-		args = append(args, "-monitor", fmt.Sprintf("unix:%s,server,nowait", monitorPath))
+		args = append(args, "-monitor", fmt.Sprintf("unix:%s,server=on,wait=off", monitorPath))
 	}
 
 	if driverConfig.GuestAgent {
@@ -578,7 +572,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 			return nil, nil, err
 		}
 
-		args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server,nowait,id=qga0", agentSocketPath))
+		args = append(args, "-chardev", fmt.Sprintf("socket,path=%s,server=on,wait=off,id=qga0", agentSocketPath))
 		args = append(args, "-device", "virtio-serial")
 		args = append(args, "-device", "virtserialport,chardev=qga0,name=org.qemu.guest_agent.0")
 	}

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -434,7 +434,7 @@ func isAllowedDriveInterface(driveInterface string) bool {
 func validateEmulator(emulator string, allowedEmulators []string) error {
 	if len(allowedEmulators) > 0 {
 		if !slices.Contains(allowedEmulators, emulator) {
-			return fmt.Errorf("emulator '%s' is not an allowed emulator", emulator)
+			return fmt.Errorf("'%s' is not an allowed emulator", emulator)
 		}
 	}
 	return nil

--- a/drivers/qemu/driver_test.go
+++ b/drivers/qemu/driver_test.go
@@ -255,7 +255,7 @@ func TestQemuDriver_Fingerprint(t *testing.T) {
 			ok, _ := finger.Attributes["driver.qemu"].GetBool()
 			must.True(t, ok)
 
-			emulators, _ := finger.Attributes[driverEmulatorAttr].GetString()
+			emulators, _ := finger.Attributes[driverEmulatorsAttr].GetString()
 			// Don't want to hardcode the exact amount of emulators installed by qemu-system
 			// but it's definitely more than 5
 			must.True(t, len(strings.Split(emulators, ",")) > 5)
@@ -291,7 +291,7 @@ func TestQemuDriver_Fingerprint(t *testing.T) {
 			ok, _ := finger.Attributes[driverAttr].GetBool()
 			must.True(t, ok)
 
-			emulators, _ := finger.Attributes[driverEmulatorAttr].GetString()
+			emulators, _ := finger.Attributes[driverEmulatorsAttr].GetString()
 			must.SliceContainsAll(t, allowedEms, strings.Split(emulators, ","))
 		case <-time.After(time.Duration(testutil.TestMultiplier()*5) * time.Second):
 			t.Fatal("timeout receiving fingerprint")

--- a/drivers/qemu/driver_test.go
+++ b/drivers/qemu/driver_test.go
@@ -346,12 +346,6 @@ func TestValidateEmulator(t *testing.T) {
 			exp:               nil,
 		},
 		{
-			name:              "empty valid emulators, invalid request",
-			validEmulators:    nil,
-			requestedEmulator: "some-binary",
-			exp:               errors.New("emulator 'some-binary' is not valid"),
-		},
-		{
 			name:              "non-empty valid emulators, valid request",
 			validEmulators:    []string{"qemu-system-x86_64"},
 			requestedEmulator: "qemu-system-x86_64",
@@ -361,7 +355,7 @@ func TestValidateEmulator(t *testing.T) {
 			name:              "non-empty valid emulators, invalid request",
 			validEmulators:    []string{"qemu-system-x86_64"},
 			requestedEmulator: "qemu-system-aarch64",
-			exp:               errors.New("emulator 'qemu-system-aarch64' is not an allowed emulator"),
+			exp:               errors.New("'qemu-system-aarch64' is not an allowed emulator"),
 		},
 	}
 

--- a/drivers/qemu/driver_test.go
+++ b/drivers/qemu/driver_test.go
@@ -34,7 +34,7 @@ import (
 // Verifies starting a qemu image and stopping it
 func TestQemuDriver_Start_Wait_Stop(t *testing.T) {
 	ci.Parallel(t)
-	ctestutil.QemuCompatible(t)
+	ctestutil.QemuCompatible_x86_64(t)
 	ctestutil.CgroupsCompatible(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -112,7 +112,7 @@ func copyFile(src, dst string, t *testing.T) {
 // Verifies starting a qemu image and stopping it
 func TestQemuDriver_User(t *testing.T) {
 	ci.Parallel(t)
-	ctestutil.QemuCompatible(t)
+	ctestutil.QemuCompatible_x86_64(t)
 	ctestutil.CgroupsCompatible(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -157,7 +157,7 @@ func TestQemuDriver_User(t *testing.T) {
 // TestQemuDriver_Stats	verifies we can get resources usage stats
 func TestQemuDriver_Stats(t *testing.T) {
 	ci.Parallel(t)
-	ctestutil.QemuCompatible(t)
+	ctestutil.QemuCompatible_x86_64(t)
 	ctestutil.CgroupsCompatible(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -238,7 +238,8 @@ func TestQemuDriver_Stats(t *testing.T) {
 func TestQemuDriver_Fingerprint(t *testing.T) {
 	ci.Parallel(t)
 
-	ctestutil.QemuCompatible(t)
+	ctestutil.QemuCompatible_x86_64(t)
+	ctestutil.QemuCompatible_aarch64(t)
 
 	t.Run("fingerpints all emulators", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -256,9 +257,7 @@ func TestQemuDriver_Fingerprint(t *testing.T) {
 			must.True(t, ok)
 
 			emulators, _ := finger.Attributes[driverEmulatorsAttr].GetString()
-			// Don't want to hardcode the exact amount of emulators installed by qemu-system
-			// but it's definitely more than 5
-			must.True(t, len(strings.Split(emulators, ",")) > 5)
+			must.Greater(t, 1, len(strings.Split(emulators, ",")))
 		case <-time.After(time.Duration(testutil.TestMultiplier()*5) * time.Second):
 			t.Fatal("timeout receiving fingerprint")
 		}
@@ -269,7 +268,7 @@ func TestQemuDriver_Fingerprint(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		allowedEms := []string{"x86_64", "aarch64"}
+		allowedEms := []string{"x86_64"}
 		d := NewQemuDriver(ctx, testlog.HCLogger(t))
 		config := &Config{
 			EmulatorsAllowList: allowedEms,

--- a/drivers/qemu/driver_test.go
+++ b/drivers/qemu/driver_test.go
@@ -360,7 +360,12 @@ func TestValidateEmulator(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			must.Eq(t, validateEmulator(tc.requestedEmulator, tc.validEmulators), tc.exp)
+			err := validateEmulator(tc.requestedEmulator, tc.validEmulators)
+			if tc.exp != nil {
+				must.ErrorContains(t, err, tc.exp.Error())
+			} else {
+				must.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes add the ability for nomad operators to specify a qemu emulator allowlist for fingerprinting and tasks. If no allowlist is specified, the driver fingerprints all available emulators. Additionally, the emulators are added to a new node attribute `driver.qemu.emulators` which enables using contraints to VM's on nodes with specific emulators, as this functionality is not yet built into the scheduler.

Removed the `fingerprint_emulator` config, which was added in #27128.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
