### PR TITLE
ci: release workflow accept last-release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
         required: true
         type: boolean
         default: false
+      changelog-last-release:
+        description: 'Release version to compare against when generating the changelog'
+        required: false
+        type: string
+        default: ''
       notification-channel:
         description: 'Slack channel to use for notifications'
         required: false
@@ -122,6 +127,8 @@ jobs:
 
           echo -e "## ${{ github.event.inputs.version }} ($(date '+%B %d, %Y'))\n$(make changelog)\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
           git diff --color=always CHANGELOG.md
+        env:
+          LAST_RELEASE: ${{ github.event.inputs.changelog-last-release }}
 
       - name: Generate static assets
         id: generate-static-assets


### PR DESCRIPTION
for changelog generation at the beginning of a release, instead of manually running it later on.