### PR TITLE
template: add nomadSecret template function

### DIFF
--- a/.changelog/27214.txt
+++ b/.changelog/27214.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+template: Add `nomadSecret` template function for iterating over secrets from external plugins
+```

--- a/client/allocrunner/taskrunner/secrets_hook.go
+++ b/client/allocrunner/taskrunner/secrets_hook.go
@@ -128,6 +128,7 @@ func (h *secretsHook) Prestart(ctx context.Context, req *interfaces.TaskPrestart
 		MaxTemplateEventRate: template.DefaultMaxTemplateEventRate,
 		NomadNamespace:       h.nomadNamespace,
 		NomadToken:           req.NomadToken,
+		JobID:                h.jobId,
 		TaskID:               req.Alloc.ID + "-" + req.Task.Name,
 		Logger:               h.logger,
 

--- a/client/allocrunner/taskrunner/template/nomad_secret.go
+++ b/client/allocrunner/taskrunner/template/nomad_secret.go
@@ -1,0 +1,109 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package template
+
+import (
+	"context"
+	"fmt"
+	"text/template"
+
+	"github.com/hashicorp/nomad/client/commonplugins"
+	"github.com/hashicorp/nomad/client/taskenv"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+// NomadSecretItems is a map type returned by the secret template function
+// that can be iterated over in templates. It wraps a map[string]string.
+type NomadSecretItems map[string]string
+
+// nomadSecretConfig contains the configuration needed to create
+// secret plugin template functions.
+type nomadSecretConfig struct {
+	// CommonPluginDir is the directory containing common plugins
+	CommonPluginDir string
+
+	// Namespace is the Nomad namespace for the task
+	Namespace string
+
+	// JobID is the job ID for the task
+	JobID string
+
+	// Secrets is the list of secrets configured for the task
+	Secrets []*structs.Secret
+}
+
+// nomadSecretFuncs returns template functions for accessing secret plugins.
+// The returned FuncMap can be merged into consul-template's ExtFuncMap.
+func nomadSecretFuncs(cfg *nomadSecretConfig) template.FuncMap {
+	return template.FuncMap{
+		"nomadSecret": nomadSecretFunc(cfg),
+	}
+}
+
+// nomadSecretFunc returns a template function that fetches secrets from a
+// pre-configured secret block by name. The returned map can be iterated
+// over in templates using range.
+//
+// Usage in templates:
+//
+//	{{ range $k, $v := nomadSecret "app_secrets" }}
+//	{{ $k }}={{ $v }}
+//	{{ end }}
+//
+// Or with the `with` clause:
+//
+//	{{ with nomadSecret "db_creds" }}
+//	DB_USER={{ index . "username" }}
+//	DB_PASS={{ index . "password" }}
+//	{{ end }}
+func nomadSecretFunc(cfg *nomadSecretConfig) func(secretName string) (NomadSecretItems, error) {
+	// Build a lookup map of secrets by name for efficient access
+	secretsByName := make(map[string]*structs.Secret, len(cfg.Secrets))
+	for _, s := range cfg.Secrets {
+		if s != nil {
+			secretsByName[s.Name] = s
+		}
+	}
+
+	return func(secretName string) (NomadSecretItems, error) {
+		if secretName == "" {
+			return nil, fmt.Errorf("secret name is required")
+		}
+
+		// Look up the secret configuration by name
+		secret, ok := secretsByName[secretName]
+		if !ok {
+			return nil, fmt.Errorf("secret %q not found in task configuration", secretName)
+		}
+
+		// Build environment variables for the plugin
+		env := make(map[string]string)
+		// Copy any env vars configured on the secret block
+		for k, v := range secret.Env {
+			env[k] = v
+		}
+		// Add/override with Nomad-specific env vars
+		env[taskenv.Namespace] = cfg.Namespace
+		env[taskenv.JobID] = cfg.JobID
+
+		// Create the secrets plugin
+		plugin, err := commonplugins.NewExternalSecretsPlugin(cfg.CommonPluginDir, secret.Provider, env)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create secrets plugin %q for secret %q: %w", secret.Provider, secretName, err)
+		}
+
+		// Fetch the secrets using the configured path
+		ctx := context.Background()
+		resp, err := plugin.Fetch(ctx, secret.Path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch secret %q from plugin %q at path %q: %w", secretName, secret.Provider, secret.Path, err)
+		}
+
+		if resp.Error != nil {
+			return nil, fmt.Errorf("secret plugin %q returned error for secret %q: %s", secret.Provider, secretName, *resp.Error)
+		}
+
+		return NomadSecretItems(resp.Result), nil
+	}
+}

--- a/client/allocrunner/taskrunner/template/nomad_secret_test.go
+++ b/client/allocrunner/taskrunner/template/nomad_secret_test.go
@@ -1,0 +1,687 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package template
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"text/template"
+	"time"
+
+	ctconf "github.com/hashicorp/consul-template/config"
+	ctmanager "github.com/hashicorp/consul-template/manager"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/client/commonplugins"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+// setupTestPlugin creates a test secrets plugin in a temporary directory.
+// Returns the plugin directory and plugin name.
+func setupTestPlugin(t *testing.T, pluginName string, script []byte) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	// NewExternalSecretsPlugin expects the subdir "secrets" to be present
+	secretDir := filepath.Join(dir, commonplugins.SecretsPluginDir)
+	must.NoError(t, os.Mkdir(secretDir, 0755))
+
+	path := filepath.Join(secretDir, pluginName)
+	must.NoError(t, os.WriteFile(path, script, 0755))
+
+	return dir
+}
+
+func TestSecretFuncs_Registration(t *testing.T) {
+	ci.Parallel(t)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: "/nonexistent/plugins",
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets:         []*structs.Secret{},
+	}
+
+	funcs := nomadSecretFuncs(cfg)
+
+	// Verify the nomadSecret function is registered
+	_, ok := funcs["nomadSecret"]
+	must.True(t, ok, must.Sprint("nomadSecret function should be registered"))
+}
+
+func TestSecretFunc_EmptySecretName(t *testing.T) {
+	ci.Parallel(t)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: "/nonexistent/plugins",
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets:         []*structs.Secret{},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	_, err := fn("")
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "secret name is required")
+}
+
+func TestSecretFunc_SecretNotFound(t *testing.T) {
+	ci.Parallel(t)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: "/nonexistent/plugins",
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "existing_secret", Provider: "test", Path: "/path"},
+		},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	_, err := fn("nonexistent_secret")
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "secret \"nonexistent_secret\" not found in task configuration")
+}
+
+func TestSecretFunc_PluginNotFound(t *testing.T) {
+	ci.Parallel(t)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: "/nonexistent/plugins",
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "my_secret", Provider: "nonexistent-plugin", Path: "/path"},
+		},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	_, err := fn("my_secret")
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "failed to create secrets plugin")
+}
+
+func TestSecretFunc_SuccessfulFetch(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin that returns secrets
+	script := []byte(`#!/bin/sh
+cat <<EOF
+{"result": {"username": "AzureDiamond", "password": "hunter2"}}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "test-plugin", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "db_creds", Provider: "test-plugin", Path: "/db/creds"},
+		},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	result, err := fn("db_creds")
+	must.NoError(t, err)
+	must.NotNil(t, result)
+
+	// Verify the returned map contains expected values
+	must.Eq(t, "AzureDiamond", result["username"])
+	must.Eq(t, "hunter2", result["password"])
+	must.Eq(t, 2, len(result))
+}
+
+func TestSecretFunc_PluginReturnsError(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin that returns an error in the response
+	script := []byte(`#!/bin/sh
+cat <<EOF
+{"result": null, "error": "secret not found"}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "test-plugin", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "missing_secret", Provider: "test-plugin", Path: "/nonexistent/path"},
+		},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	_, err := fn("missing_secret")
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "secret not found")
+}
+
+func TestSecretFunc_PluginExitsNonZero(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin that exits with error
+	script := []byte(`#!/bin/sh
+exit 1
+`)
+	pluginDir := setupTestPlugin(t, "test-plugin", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "my_secret", Provider: "test-plugin", Path: "/path"},
+		},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	_, err := fn("my_secret")
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "failed to fetch secret")
+}
+
+func TestSecretFunc_PluginReturnsInvalidJSON(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin that returns invalid JSON
+	script := []byte(`#!/bin/sh
+echo "not valid json"
+`)
+	pluginDir := setupTestPlugin(t, "test-plugin", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "my_secret", Provider: "test-plugin", Path: "/path"},
+		},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	_, err := fn("my_secret")
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "failed to fetch secret")
+}
+
+func TestSecretFunc_EmptyResult(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin that returns empty result
+	script := []byte(`#!/bin/sh
+cat <<EOF
+{"result": {}}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "test-plugin", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "empty_secret", Provider: "test-plugin", Path: "/empty/path"},
+		},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	result, err := fn("empty_secret")
+	must.NoError(t, err)
+	must.NotNil(t, result)
+	must.Eq(t, 0, len(result))
+}
+
+func TestSecretFunc_EnvironmentVariablesFromSecretBlock(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin that echoes the environment variables
+	script := []byte(`#!/bin/sh
+cat <<EOF
+{"result": {"aws_region": "$AWS_REGION", "custom_var": "$CUSTOM_VAR", "namespace": "$NOMAD_NAMESPACE", "job_id": "$NOMAD_JOB_ID"}}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "aws-ssm", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "my-namespace",
+		JobID:           "my-job-id",
+		Secrets: []*structs.Secret{
+			{
+				Name:     "app_secrets",
+				Provider: "aws-ssm",
+				Path:     "/test/nomad/app",
+				Env: map[string]string{
+					"AWS_REGION": "us-east-1",
+					"CUSTOM_VAR": "custom-value",
+				},
+			},
+		},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	result, err := fn("app_secrets")
+	must.NoError(t, err)
+	must.Eq(t, "us-east-1", result["aws_region"])
+	must.Eq(t, "custom-value", result["custom_var"])
+	must.Eq(t, "my-namespace", result["namespace"])
+	must.Eq(t, "my-job-id", result["job_id"])
+}
+
+func TestSecretFunc_MultipleSecrets(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create mock plugins
+	dbScript := []byte(`#!/bin/sh
+cat <<EOF
+{"result": {"host": "db.example.com", "port": "5432"}}
+EOF
+`)
+	apiScript := []byte(`#!/bin/sh
+cat <<EOF
+{"result": {"api_key": "sk-12345", "api_secret": "secret-abc"}}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "db-plugin", dbScript)
+	// Add second plugin
+	secretDir := filepath.Join(pluginDir, commonplugins.SecretsPluginDir)
+	must.NoError(t, os.WriteFile(filepath.Join(secretDir, "api-plugin"), apiScript, 0755))
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "database", Provider: "db-plugin", Path: "/db/config"},
+			{Name: "api_creds", Provider: "api-plugin", Path: "/api/keys"},
+		},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	// Fetch first secret
+	dbResult, err := fn("database")
+	must.NoError(t, err)
+	must.Eq(t, "db.example.com", dbResult["host"])
+	must.Eq(t, "5432", dbResult["port"])
+
+	// Fetch second secret
+	apiResult, err := fn("api_creds")
+	must.NoError(t, err)
+	must.Eq(t, "sk-12345", apiResult["api_key"])
+	must.Eq(t, "secret-abc", apiResult["api_secret"])
+}
+
+func TestSecretFunc_SpecialCharactersInValues(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin that returns values with special characters
+	script := []byte(`#!/bin/sh
+cat <<'EOF'
+{"result": {"password": "p@ss=word\"with'special", "url": "https://example.com?foo=bar&baz=qux"}}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "test-plugin", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "special_chars", Provider: "test-plugin", Path: "/special/chars"},
+		},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	result, err := fn("special_chars")
+	must.NoError(t, err)
+	must.Eq(t, `p@ss=word"with'special`, result["password"])
+	must.Eq(t, "https://example.com?foo=bar&baz=qux", result["url"])
+}
+
+func TestNomadSecretItems_Iteration(t *testing.T) {
+	ci.Parallel(t)
+
+	// Test that NomadSecretItems can be iterated over
+	items := NomadSecretItems{
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+
+	// Count iterations
+	count := 0
+	for k, v := range items {
+		count++
+		must.NotEq(t, "", k)
+		must.NotEq(t, "", v)
+	}
+	must.Eq(t, 3, count)
+}
+
+func TestSecretFunc_TemplateIntegration(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin
+	script := []byte(`#!/bin/sh
+cat <<EOF
+{"result": {"DB_HOST": "localhost", "DB_PORT": "5432", "DB_USER": "admin"}}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "test-plugin", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "db_config", Provider: "test-plugin", Path: "/db/config"},
+		},
+	}
+
+	// Create a template that uses secret
+	tmplText := `{{ range $k, $v := nomadSecret "db_config" }}
+{{ $k }}={{ $v }}
+{{ end }}`
+
+	tmpl, err := template.New("test").Funcs(nomadSecretFuncs(cfg)).Parse(tmplText)
+	must.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, nil)
+	must.NoError(t, err)
+
+	output := buf.String()
+	must.StrContains(t, output, "DB_HOST=localhost")
+	must.StrContains(t, output, "DB_PORT=5432")
+	must.StrContains(t, output, "DB_USER=admin")
+}
+
+func TestSecretFunc_TemplateWithClause(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin
+	script := []byte(`#!/bin/sh
+cat <<EOF
+{"result": {"host": "db.example.com", "port": "3306"}}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "test-plugin", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "mysql_creds", Provider: "test-plugin", Path: "/mysql/creds"},
+		},
+	}
+
+	// Create a template that uses with clause and index
+	tmplText := `{{ with nomadSecret "mysql_creds" }}host={{ index . "host" }}:{{ index . "port" }}{{ end }}`
+
+	tmpl, err := template.New("test").Funcs(nomadSecretFuncs(cfg)).Parse(tmplText)
+	must.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, nil)
+	must.NoError(t, err)
+
+	must.Eq(t, "host=db.example.com:3306", buf.String())
+}
+
+func TestSecretFunc_TemplateErrorHandling(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin that returns an error
+	script := []byte(`#!/bin/sh
+cat <<EOF
+{"result": null, "error": "access denied"}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "test-plugin", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "denied_secret", Provider: "test-plugin", Path: "/denied/path"},
+		},
+	}
+
+	// Create a template that uses secret
+	tmplText := `{{ nomadSecret "denied_secret" }}`
+
+	tmpl, err := template.New("test").Funcs(nomadSecretFuncs(cfg)).Parse(tmplText)
+	must.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, nil)
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "access denied")
+}
+
+func TestSecretFunc_NilSecrets(t *testing.T) {
+	ci.Parallel(t)
+
+	// Test with nil secrets slice
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: "/nonexistent",
+		Secrets:         nil,
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	_, err := fn("any_secret")
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "not found in task configuration")
+}
+
+func TestSecretFunc_PathPassedToPlugin(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin that echoes the path argument
+	// The plugin receives path as $2 (first arg is "fetch", second is path)
+	script := []byte(`#!/bin/sh
+# $1 is "fetch", $2 is the path
+cat <<EOF
+{"result": {"path_received": "$2"}}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "test-plugin", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{Name: "my_secret", Provider: "test-plugin", Path: "/my/custom/secret/path"},
+		},
+	}
+
+	fn := nomadSecretFunc(cfg)
+
+	result, err := fn("my_secret")
+	must.NoError(t, err)
+	must.Eq(t, "/my/custom/secret/path", result["path_received"])
+}
+
+func TestSecretFunc_RealWorldAWSSSMExample(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Simulate an AWS SSM plugin response
+	script := []byte(`#!/bin/sh
+cat <<EOF
+{"result": {"DB_HOST": "prod-db.internal", "DB_PORT": "5432", "DB_USER": "app_user", "DB_PASS": "hunter2"}}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "aws-ssm", script)
+
+	cfg := &nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Namespace:       "default",
+		JobID:           "test-job",
+		Secrets: []*structs.Secret{
+			{
+				Name:     "app_secrets",
+				Provider: "aws-ssm",
+				Path:     "/prod/web-app/db",
+				Env: map[string]string{
+					"AWS_REGION":            "us-east-1",
+					"AWS_ACCESS_KEY_ID":     "test",
+					"AWS_SECRET_ACCESS_KEY": "test",
+				},
+			},
+		},
+	}
+
+	// Test template similar to what a user would write
+	tmplText := `{{ with nomadSecret "app_secrets" }}
+DATABASE_URL=postgres://{{ index . "DB_USER" }}:{{ index . "DB_PASS" }}@{{ index . "DB_HOST" }}:{{ index . "DB_PORT" }}/mydb
+{{ end }}`
+
+	tmpl, err := template.New("test").Funcs(nomadSecretFuncs(cfg)).Parse(tmplText)
+	must.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = tmpl.Execute(&buf, nil)
+	must.NoError(t, err)
+
+	must.StrContains(t, buf.String(), "DATABASE_URL=postgres://app_user:hunter2@prod-db.internal:5432/mydb")
+}
+
+func TestSecretFunc_ConsulTemplateRunner(t *testing.T) {
+	ci.Parallel(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	// Create a mock plugin
+	script := []byte(`#!/bin/sh
+cat <<EOF
+{"result": {"username": "testuser", "password": "testpass"}}
+EOF
+`)
+	pluginDir := setupTestPlugin(t, "test-plugin", script)
+
+	secrets := []*structs.Secret{
+		{Name: "my_secret", Provider: "test-plugin", Path: "/test/path"},
+	}
+
+	// Create the ExtFuncMap
+	extFuncMap := nomadSecretFuncs(&nomadSecretConfig{
+		CommonPluginDir: pluginDir,
+		Secrets:         secrets,
+	})
+
+	// Template content using our function
+	tmplContent := `{{ with nomadSecret "my_secret" }}user={{ index . "username" }}{{ end }}`
+
+	// Create destination file
+	destPath := filepath.Join(t.TempDir(), "output.txt")
+
+	// Create consul-template TemplateConfig with ExtFuncMap
+	tc := ctconf.DefaultTemplateConfig()
+	tc.Contents = &tmplContent
+	tc.Destination = &destPath
+	tc.ExtFuncMap = extFuncMap
+	tc.Finalize()
+
+	// Create consul-template Config
+	cfg := ctconf.DefaultConfig()
+	cfg.Once = true
+	cfg.Templates = &ctconf.TemplateConfigs{tc}
+	cfg.Finalize()
+
+	// Create and run the runner
+	runner, err := ctmanager.NewRunner(cfg, false)
+	must.NoError(t, err)
+
+	go runner.Start()
+	defer runner.Stop()
+
+	select {
+	case <-runner.DoneCh:
+		// Success
+	case err := <-runner.ErrCh:
+		t.Fatalf("runner error: %v", err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timeout waiting for runner")
+	}
+
+	// Read the output
+	content, err := os.ReadFile(destPath)
+	must.NoError(t, err)
+	must.Eq(t, "user=testuser", string(content))
+}

--- a/client/allocrunner/taskrunner/template_hook.go
+++ b/client/allocrunner/taskrunner/template_hook.go
@@ -215,6 +215,8 @@ func (h *templateHook) newManager(tmpls []*structs.Template) (manager *template.
 		MaxTemplateEventRate: template.DefaultMaxTemplateEventRate,
 		NomadNamespace:       h.config.nomadNamespace,
 		NomadToken:           h.nomadToken,
+		JobID:                h.config.alloc.Job.ID,
+		Secrets:              h.task.Secrets,
 		TaskID:               h.taskID,
 		Logger:               h.logger,
 	})

--- a/website/content/docs/job-specification/template.mdx
+++ b/website/content/docs/job-specification/template.mdx
@@ -659,6 +659,78 @@ upstream {{ .Name | toLower }} {
   }
 ```
 
+## Secret plugin integration
+
+Nomad supports external secret plugins that can be used to fetch secrets from
+custom backends. The `nomadSecret` template function allows you to retrieve
+secrets from a pre-configured [`secret`][secret plugins documentation] block
+and iterate over them in your templates.
+
+### `nomadSecret`
+
+The `nomadSecret` function fetches secrets from an external secrets plugin using
+a pre-configured secret block. It takes the secret block name as an argument
+and returns a map of key-value pairs that can be iterated over using `range`.
+
+First, define a secret block in your job specification:
+
+```hcl
+secret "app_secrets" {
+  provider = "aws-ssm"
+  path     = "/prod/myapp/db"
+  env {
+    AWS_REGION            = "us-east-1"
+    AWS_ACCESS_KEY_ID     = "AKIAIOSFODNN7EXAMPLE"
+    AWS_SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+  }
+}
+```
+
+Then reference the secret block by name in your template:
+
+```hcl
+template {
+  data = <<EOF
+{{ range $key, $value := nomadSecret "app_secrets" }}
+{{ $key }}={{ $value }}
+{{ end }}
+EOF
+
+  destination = "local/secrets.env"
+  env         = true
+}
+```
+
+The function automatically passes `NOMAD_NAMESPACE` and `NOMAD_JOB_ID`
+environment variables to the plugin in addition to any env vars configured
+in the secret block, allowing plugins to scope secrets appropriately.
+
+For example, to fetch database credentials from a custom secrets plugin:
+
+```hcl
+secret "db_creds" {
+  provider = "my-secrets-backend"
+  path     = "/database/creds"
+}
+
+template {
+  data = <<EOF
+{{ with nomadSecret "db_creds" }}
+DB_HOST={{ index . "host" }}
+DB_USER={{ index . "username" }}
+DB_PASS={{ index . "password" }}
+{{ end }}
+EOF
+
+  destination = "secrets/db.env"
+  env         = true
+}
+```
+
+Secret plugins must be installed in the Nomad client's common plugins directory
+under the `secrets/` subdirectory. Refer to the [secret plugins documentation][]
+for more information on configuring and developing secret plugins.
+
 ## Vault integration
 
 <Warning>
@@ -839,3 +911,4 @@ options](/nomad/docs/configuration/client#options):
 [`template.nomad_retry`]: /nomad/docs/configuration/client#nomad_retry
 [`template.consul_retry`]: /nomad/docs/configuration/client#consul_retry
 [`template.vault_retry`]: /nomad/docs/configuration/client#vault_retry
+[secret plugins documentation]: /nomad/docs/job-specification/secret 'Nomad Secret Block'


### PR DESCRIPTION
### Description
Add a `nomadSecret` template function that allows templates to fetch secrets from pre-configured `secret` blocks and iterate over all key/value pairs returned by external secret plugins.

This enables use cases where users want to inject all values from a secret backend into the environment without knowing the exact keys in advance. The function:
- Takes a secret block name as its single argument
- Looks up the provider, path, and environment variables from the task's secret configuration
- Returns a map that can be iterated over using `range` or accessed with `index`

### Testing & Reproduction steps
1. Configure a secrets plugin in the Nomad client's common plugins directory under `secrets/`
2. Define a secret block in a job specification:
   ```hcl
   secret "app_secrets" {
     provider = "my-plugin"
     path     = "/prod/myapp"
   }
   ```
3. Reference the secret block in a template:
   ```hcl
   template {
     data = <<EOF
   {{ range $k, $v := nomadSecret "app_secrets" }}
   {{ $k }}={{ $v }}
   {{ end }}
   EOF
     destination = "local/secrets.env"
     env         = true
   }
   ```
4. Run the job and verify secrets are rendered into the template


### Links

Closes #27214


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
