### PR TITLE
[landlock] allow access to user git config

### DIFF
--- a/client/allocrunner/taskrunner/getter/util_linux_test.go
+++ b/client/allocrunner/taskrunner/getter/util_linux_test.go
@@ -31,6 +31,7 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 	})
 
 	t.Setenv("HOME", fakeHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(fakeHome, ".config"))
 
 	const (
 		homeSSH          = ".ssh"

--- a/client/allocrunner/taskrunner/getter/util_linux_test.go
+++ b/client/allocrunner/taskrunner/getter/util_linux_test.go
@@ -33,12 +33,16 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 	t.Setenv("HOME", fakeHome)
 
 	const (
-		homeSSH        = ".ssh"
-		homeKnownHosts = ".ssh/known_hosts"
+		homeSSH          = ".ssh"
+		homeKnownHosts   = ".ssh/known_hosts"
+		gitGlobalFile    = ".gitconfig"
+		gitGlobalFileXDG = "git/config"
 	)
 
 	var (
-		gitConfig      = filepath.Join(fakeEtc, "gitconfig")
+		gitSystem      = filepath.Join(fakeEtc, "gitconfig")
+		gitGlobal      = filepath.Join(fakeHome, ".gitconfig")
+		gitGlobalXDG   = filepath.Join(fakeHome, ".config/git/config")
 		hgFile         = filepath.Join(fakeEtc, "hgrc")
 		hgDir          = filepath.Join(fakeEtc, "hgrc.d")
 		etcPasswd      = filepath.Join(fakeEtc, "passwd")
@@ -48,7 +52,14 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 		urandom        = filepath.Join(fakeDev, "urandom")
 	)
 
-	err := os.WriteFile(gitConfig, []byte("git"), filePerm)
+	err := os.WriteFile(gitSystem, []byte("git"), filePerm)
+	must.NoError(t, err)
+
+	err = os.WriteFile(gitGlobal, []byte("git"), filePerm)
+	must.NoError(t, err)
+
+	must.NoError(t, os.MkdirAll(filepath.Dir(gitGlobalXDG), 0755))
+	err = os.WriteFile(gitGlobalXDG, []byte("git"), filePerm)
 	must.NoError(t, err)
 
 	err = os.WriteFile(hgFile, []byte("hg"), filePerm)
@@ -80,7 +91,9 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 		homeKnownHosts,
 		etcPasswd,
 		etcKnownHosts,
-		gitConfig,
+		gitSystem,
+		gitGlobalFile,
+		gitGlobalFileXDG,
 		hgFile,
 		hgDir,
 		urandom,
@@ -90,7 +103,9 @@ func TestUtil_loadVersionControlGlobalConfigs(t *testing.T) {
 		landlock.File(knownHostsFile, "rw"),
 		landlock.File(etcPasswd, "r"),
 		landlock.File(etcKnownHosts, "r"),
-		landlock.File(gitConfig, "r"),
+		landlock.File(gitSystem, "r"),
+		landlock.File(gitGlobal, "r"),
+		landlock.File(gitGlobalXDG, "r"),
 		landlock.File(hgFile, "r"),
 		landlock.Dir(hgDir, "r"),
 		landlock.File(urandom, "r"),


### PR DESCRIPTION
### Description
When setting up landlock, allow read access to user git config files. Includes both variations of the global config file paths and updates the path originally named global to system to properly reflect which file it references.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
