### PR TITLE
artifact: implement findHomeDir helper as specified

### DIFF
--- a/client/allocrunner/taskrunner/getter/util_linux.go
+++ b/client/allocrunner/taskrunner/getter/util_linux.go
@@ -24,7 +24,7 @@ var initialDirs = map[string]string{
 	"/usr/libexec":   "rx",
 }
 
-// findHomeDir returns the home directory as provided by os.UserHomeDir. In case
+// findHomeDir returns the home directory as provided by homedir.Dir(). In case
 // os.UserHomeDir returns an error, we return /root if the current process is being
 // run by root, or /dev/null otherwise.
 func findHomeDir() string {
@@ -42,7 +42,7 @@ func findHomeDir() string {
 	}
 
 	// nothing safe to do
-	return "/nonexistent"
+	return "/dev/null"
 }
 
 // findConfigDir returns the config directory as provided by os.UserConfigDir. In


### PR DESCRIPTION
### Description
This makes a couple small changes to the findHomeDir helper function to properly match the described behavior. It will attempt to use os.UserHomeDir first, and if no path can be discovered, it will return /dev/null.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
