### PR TITLE
deployment: return nil when copying nil deployment state

### DIFF
--- a/.changelog/27262.txt
+++ b/.changelog/27262.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+deployment: Fixed a bug where deploying a system job could panic the leader
+```

--- a/nomad/structs/deployment.go
+++ b/nomad/structs/deployment.go
@@ -303,6 +303,9 @@ func (d *DeploymentState) GoString() string {
 }
 
 func (d *DeploymentState) Copy() *DeploymentState {
+	if d == nil {
+		return nil
+	}
 	c := &DeploymentState{}
 	*c = *d
 	c.PlacedCanaries = slices.Clone(d.PlacedCanaries)


### PR DESCRIPTION
Ensure we safely handle a nil `DeploymentState` when copying.

Fixes: https://github.com/hashicorp/nomad/issues/27261

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
