### PR TITLE
disconnect: remove deprecated cluster version check

### DIFF
--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -548,24 +548,6 @@ func (a *Allocation) DisconnectTimeout(now time.Time) time.Time {
 	return now.Add(timeout)
 }
 
-// SupportsDisconnectedClients determines whether both the server and the task group
-// are configured to allow the allocation to reconnect after network connectivity
-// has been lost and then restored.
-func (a *Allocation) SupportsDisconnectedClients(serverSupportsDisconnectedClients bool) bool {
-	if !serverSupportsDisconnectedClients {
-		return false
-	}
-
-	if a.Job != nil {
-		tg := a.Job.LookupTaskGroup(a.TaskGroup)
-		if tg != nil {
-			return tg.GetDisconnectLostAfter() != 0
-		}
-	}
-
-	return false
-}
-
 // ReplaceOnDisconnect determines if an alloc can be replaced
 // when Disconnected.
 func (a *Allocation) ReplaceOnDisconnect() bool {

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -13,7 +13,6 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -35,9 +34,6 @@ const (
 	// that we track when unlimited rescheduling is enabled
 	maxPastRescheduleEvents = 5
 )
-
-// minVersionMaxClientDisconnect is the minimum version that supports max_client_disconnect.
-var minVersionMaxClientDisconnect = version.Must(version.NewVersion("1.3.0"))
 
 // SetStatusError is used to set the status of the evaluation to the given error
 type SetStatusError struct {
@@ -355,9 +351,8 @@ func (s *GenericScheduler) computeJobAllocs() error {
 			EvalPriority:      s.eval.Priority,
 		},
 		reconciler.ClusterState{
-			TaintedNodes:                tainted,
-			SupportsDisconnectedClients: s.planner.ServersMeetMinimumVersion(minVersionMaxClientDisconnect, true),
-			Now:                         time.Now().UTC(),
+			TaintedNodes: tainted,
+			Now:          time.Now().UTC(),
 		})
 	result := r.Compute()
 	if s.logger.IsDebug() {

--- a/scheduler/reconciler/allocs_test.go
+++ b/scheduler/reconciler/allocs_test.go
@@ -139,7 +139,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 			}{ // These two cases test that we maintain parity with pre-disconnected-clients behavior.
 				{
 					name:            "lost-client",
-					state:           ClusterState{nodes, false, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						"untainted1": {
@@ -241,7 +241,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 				{
 					name:  "lost-client-only-tainted-nodes",
-					state: ClusterState{nodes, false, time.Now()},
+					state: ClusterState{nodes, time.Now()},
 					// The logic associated with this test case can only trigger if there
 					// is a tainted node. Therefore, testing with a nil node set produces
 					// false failures, so don't perform that test if in this case.
@@ -287,7 +287,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 				{
 					name:            "disco-client-disconnect-unset-max-disconnect",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: true,
 					all: allocSet{
 						// Non-terminal allocs on disconnected nodes w/o max-disconnect are lost
@@ -322,7 +322,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				// Everything below this line tests the disconnected client mode.
 				{
 					name:            "disco-client-untainted-reconnect-failed-and-replaced",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						"running-replacement": {
@@ -381,7 +381,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 				{
 					name:            "disco-client-reconnecting-running-no-replacement",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						// Running allocs on reconnected nodes with no replacement are reconnecting.
@@ -419,7 +419,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 				{
 					name:            "disco-client-terminal",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						// Allocs on reconnected nodes that are complete need to be updated to stop
@@ -567,7 +567,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 				{
 					name:            "disco-client-disconnect",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: true,
 					all: allocSet{
 						// Non-terminal allocs on disconnected nodes are disconnecting
@@ -709,7 +709,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 				{
 					name:            "disco-client-reconnect",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						// Expired allocs on reconnected clients are lost
@@ -745,7 +745,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 				{
 					name:            "disco-client-running-reconnecting-and-replacement-untainted",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						"running-replacement": {
@@ -805,7 +805,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 					// "untainted" instead of "reconnecting" to allow changes such as
 					// job updates to be applied properly.
 					name:            "disco-client-reconnected-alloc-untainted",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						"running-reconnected": {
@@ -841,7 +841,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				// Everything below this line tests the single instance on lost mode.
 				{
 					name:            "lost-client-single-instance-on",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						"untainted1": {
@@ -942,54 +942,8 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 					expiring:      allocSet{},
 				},
 				{
-					name:  "lost-client-only-tainted-nodes-single-instance-on",
-					state: ClusterState{nodes, false, time.Now()},
-					// The logic associated with this test case can only trigger if there
-					// is a tainted node. Therefore, testing with a nil node set produces
-					// false failures, so don't perform that test if in this case.
-					skipNilNodeTest: true,
-					all: allocSet{
-						// Non-terminal allocs on lost nodes are down
-						"lost1": {
-							ID:           "lost1",
-							ClientStatus: structs.AllocClientStatusPending,
-							Job:          testJobSingle,
-							NodeID:       "down",
-						},
-						// Non-terminal allocs on lost nodes are down
-						"lost2": {
-							ID:           "lost2",
-							ClientStatus: structs.AllocClientStatusRunning,
-							Job:          testJobSingle,
-							NodeID:       "down",
-						},
-					},
-					untainted:     allocSet{},
-					migrate:       allocSet{},
-					disconnecting: allocSet{},
-					reconnecting:  allocSet{},
-					ignore:        allocSet{},
-					lost: allocSet{
-						// Non-terminal allocs on lost nodes are down
-						"lost1": {
-							ID:           "lost1",
-							ClientStatus: structs.AllocClientStatusPending,
-							Job:          testJobSingle,
-							NodeID:       "down",
-						},
-						// Non-terminal allocs on lost nodes are down
-						"lost2": {
-							ID:           "lost2",
-							ClientStatus: structs.AllocClientStatusRunning,
-							Job:          testJobSingle,
-							NodeID:       "down",
-						},
-					},
-					expiring: allocSet{},
-				},
-				{
 					name:            "disco-client-disconnect-unset-max-disconnect-single-instance-on",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: true,
 					all: allocSet{
 						// Non-terminal allocs on disconnected nodes w/o max-disconnect are lost
@@ -1021,7 +975,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 				{
 					name:            "disco-client-untainted-reconnect-failed-and-replaced-single-instance-on",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						"running-replacement": {
@@ -1080,7 +1034,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 				{
 					name:            "disco-client-reconnect-single-instance-on",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						// Expired allocs on reconnected clients are lost
@@ -1116,7 +1070,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 				{
 					name:            "disco-client-running-reconnecting-and-replacement-untainted-single-instance-on",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						"running-replacement": {
@@ -1176,7 +1130,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 					// "untainted" instead of "reconnecting" to allow changes such as
 					// job updates to be applied properly.
 					name:            "disco-client-reconnected-alloc-untainted",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: false,
 					all: allocSet{
 						"running-reconnected": {
@@ -1211,7 +1165,7 @@ func TestAllocSet_filterByTainted(t *testing.T) {
 				},
 				{
 					name:            "disco-client-reconnected-alloc-untainted-single-instance-on",
-					state:           ClusterState{nodes, true, time.Now()},
+					state:           ClusterState{nodes, time.Now()},
 					skipNilNodeTest: true,
 					all: allocSet{
 						"untainted-unknown": {
@@ -1810,12 +1764,11 @@ func TestAllocSet_filterByRescheduleable(t *testing.T) {
 	}
 
 	type testCase struct {
-		name                        string
-		all                         allocSet
-		isBatch                     bool
-		supportsDisconnectedClients bool
-		isDisconnecting             bool
-		deployment                  *structs.Deployment
+		name            string
+		all             allocSet
+		isBatch         bool
+		isDisconnecting bool
+		deployment      *structs.Deployment
 
 		// expected results
 		untainted allocSet

--- a/scheduler/reconciler/filters.go
+++ b/scheduler/reconciler/filters.go
@@ -125,7 +125,7 @@ func (set allocSet) filterByTainted(state ClusterState) (untainted, migrate, los
 		if alloc.ClientStatus == structs.AllocClientStatusUnknown ||
 			alloc.ClientStatus == structs.AllocClientStatusRunning ||
 			alloc.ClientStatus == structs.AllocClientStatusFailed {
-			shouldReconnect = alloc.NeedsToReconnect() && state.SupportsDisconnectedClients
+			shouldReconnect = alloc.NeedsToReconnect()
 		}
 
 		// Failed allocs that need to be reconnected must be added to
@@ -177,10 +177,6 @@ func (set allocSet) filterByTainted(state ClusterState) (untainted, migrate, los
 
 		taintedNode, nodeIsTainted := state.TaintedNodes[alloc.NodeID]
 		if taintedNode != nil && taintedNode.Status == structs.NodeStatusDisconnected {
-			if !state.SupportsDisconnectedClients {
-				lost[alloc.ID] = alloc
-				continue
-			}
 			// ignore allocs already marked unknown, they should already have a followup eval
 			if alloc.ClientStatus == structs.AllocClientStatusUnknown {
 				untainted[alloc.ID] = alloc

--- a/scheduler/reconciler/reconcile_cluster.go
+++ b/scheduler/reconciler/reconcile_cluster.go
@@ -241,12 +241,10 @@ func (r *ReconcileResults) Fields() []any {
 // ClusterState holds frequently used information about the state of the
 // cluster:
 // - a map of tainted nodes
-// - whether we support disconnected clients
 // - current time
 type ClusterState struct {
-	TaintedNodes                map[string]*structs.Node
-	SupportsDisconnectedClients bool
-	Now                         time.Time
+	TaintedNodes map[string]*structs.Node
+	Now          time.Time
 }
 
 // NewAllocReconciler creates a new reconciler that should be used to determine

--- a/scheduler/reconciler/reconcile_cluster_prop_test.go
+++ b/scheduler/reconciler/reconcile_cluster_prop_test.go
@@ -110,10 +110,6 @@ func TestAllocReconciler_PropTest(t *testing.T) {
 			t.Fatal("failed deployments should never result in new deployments")
 		}
 
-		if !ar.clusterState.SupportsDisconnectedClients && results.ReconnectUpdates != nil {
-			t.Fatal("task groups that don't support disconnected clients should never result in reconnect updates")
-		}
-
 		if ar.jobState.DeploymentCurrent == nil && ar.jobState.DeploymentOld == nil && len(ar.jobState.ExistingAllocs) == 0 {
 			count := 0
 			for _, tg := range ar.jobState.Job.TaskGroups {
@@ -302,9 +298,8 @@ func genClusterState(idg *idGenerator, now time.Time) *rapid.Generator[ClusterSt
 			nodes, func(n *structs.Node) string { return n.ID })
 
 		return ClusterState{
-			TaintedNodes:                taintedNodes,
-			SupportsDisconnectedClients: rapid.Bool().Draw(t, "supports_disconnected_clients"),
-			Now:                         now,
+			TaintedNodes: taintedNodes,
+			Now:          now,
 		}
 	})
 }

--- a/scheduler/reconciler/reconcile_cluster_test.go
+++ b/scheduler/reconciler/reconcile_cluster_test.go
@@ -359,9 +359,8 @@ func TestReconciler_Place_NoExisting(t *testing.T) {
 			ExistingAllocs:    nil,
 			EvalPriority:      job.Priority,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -409,9 +408,8 @@ func TestReconciler_Place_Existing(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -461,9 +459,8 @@ func TestReconciler_ScaleDown_Partial(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 
 	r := reconciler.Compute()
@@ -515,9 +512,8 @@ func TestReconciler_ScaleDown_Zero(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -569,9 +565,8 @@ func TestReconciler_ScaleDown_Zero_DuplicateNames(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -618,9 +613,8 @@ func TestReconciler_Inplace(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -670,9 +664,8 @@ func TestReconciler_Inplace_ScaleUp(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -724,9 +717,8 @@ func TestReconciler_Inplace_ScaleDown(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -800,9 +792,8 @@ func TestReconciler_Inplace_Rollback(t *testing.T) {
 			EvalID:            uuid.Generate(),
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -858,9 +849,8 @@ func TestReconciler_Destructive(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -905,9 +895,8 @@ func TestReconciler_DestructiveMaxParallel(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -955,9 +944,8 @@ func TestReconciler_Destructive_ScaleUp(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -1008,9 +996,8 @@ func TestReconciler_Destructive_ScaleDown(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -1067,9 +1054,8 @@ func TestReconciler_LostNode(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                tainted,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: tainted,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -1131,9 +1117,8 @@ func TestReconciler_LostNode_ScaleUp(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                tainted,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: tainted,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -1195,9 +1180,8 @@ func TestReconciler_LostNode_ScaleDown(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                tainted,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: tainted,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -1254,9 +1238,8 @@ func TestReconciler_DrainNode(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                tainted,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: tainted,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -1315,8 +1298,7 @@ func TestReconciler_MigrateBatchAllocs(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			Now: time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -1376,8 +1358,7 @@ func TestReconciler_MigrateDisablePlacementBatchAllocs(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			Now: time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -1442,8 +1423,7 @@ func TestReconciler_MigrateRescheduleBatchAllocs(t *testing.T) {
 				EvalPriority:      50,
 				EvalID:            uuid.Generate(),
 			}, ClusterState{
-				SupportsDisconnectedClients: true,
-				Now:                         time.Now().UTC(),
+				Now: time.Now().UTC(),
 			})
 		r := reconciler.Compute()
 
@@ -1498,8 +1478,7 @@ func TestReconciler_MigrateRescheduleBatchAllocs(t *testing.T) {
 				EvalPriority:      50,
 				EvalID:            uuid.Generate(),
 			}, ClusterState{
-				SupportsDisconnectedClients: true,
-				Now:                         time.Now().UTC(),
+				Now: time.Now().UTC(),
 			})
 		r := reconciler.Compute()
 
@@ -1551,8 +1530,7 @@ func TestReconciler_MigrateRescheduleBatchAllocs(t *testing.T) {
 				EvalPriority:      50,
 				EvalID:            uuid.Generate(),
 			}, ClusterState{
-				SupportsDisconnectedClients: true,
-				Now:                         time.Now().UTC(),
+				Now: time.Now().UTC(),
 			})
 		r := reconciler.Compute()
 
@@ -1608,8 +1586,7 @@ func TestReconciler_MigrateRescheduleBatchAllocs(t *testing.T) {
 				EvalPriority:      50,
 				EvalID:            uuid.Generate(),
 			}, ClusterState{
-				SupportsDisconnectedClients: true,
-				Now:                         time.Now().UTC(),
+				Now: time.Now().UTC(),
 			})
 		r := reconciler.Compute()
 
@@ -1671,9 +1648,8 @@ func TestReconciler_DrainNode_ScaleUp(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                tainted,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: tainted,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -1738,9 +1714,8 @@ func TestReconciler_DrainNode_ScaleDown(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                tainted,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: tainted,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -1797,9 +1772,8 @@ func TestReconciler_RemovedTG(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -1879,9 +1853,8 @@ func TestReconciler_JobStopped(t *testing.T) {
 					ExistingAllocs:    allocs,
 					EvalPriority:      50,
 				}, ClusterState{
-					TaintedNodes:                nil,
-					SupportsDisconnectedClients: true,
-					Now:                         time.Now().UTC(),
+					TaintedNodes: nil,
+					Now:          time.Now().UTC(),
 				})
 			r := reconciler.Compute()
 
@@ -1962,9 +1935,8 @@ func TestReconciler_JobStopped_TerminalAllocs(t *testing.T) {
 					ExistingAllocs:    allocs,
 					EvalPriority:      50,
 				}, ClusterState{
-					TaintedNodes:                nil,
-					SupportsDisconnectedClients: true,
-					Now:                         time.Now().UTC(),
+					TaintedNodes: nil,
+					Now:          time.Now().UTC(),
 				})
 			r := reconciler.Compute()
 
@@ -2013,9 +1985,8 @@ func TestReconciler_MultiTG(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -2079,9 +2050,8 @@ func TestReconciler_MultiTG_SingleUpdateBlock(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -2168,9 +2138,8 @@ func TestReconciler_RescheduleLater_Batch(t *testing.T) {
 			EvalID:            uuid.Generate(),
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -2262,9 +2231,8 @@ func TestReconciler_RescheduleLaterWithBatchedEvals_Batch(t *testing.T) {
 			EvalID:            uuid.Generate(),
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -2370,9 +2338,8 @@ func TestReconciler_RescheduleNow_Batch(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -2457,9 +2424,8 @@ func TestReconciler_RescheduleLater_Service(t *testing.T) {
 			EvalID:            uuid.Generate(),
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -2541,9 +2507,8 @@ func TestReconciler_Service_ClientStatusComplete(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -2611,9 +2576,8 @@ func TestReconciler_Service_DesiredStop_ClientStatusComplete(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -2699,9 +2663,8 @@ func TestReconciler_RescheduleNow_Service(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -2789,9 +2752,8 @@ func TestReconciler_RescheduleNow_WithinAllowedTimeWindow(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         now,
+			TaintedNodes: nil,
+			Now:          now,
 		})
 	r := reconciler.Compute()
 
@@ -2883,9 +2845,8 @@ func TestReconciler_RescheduleNow_EvalIDMatch(t *testing.T) {
 			EvalID:            evalID,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         now,
+			TaintedNodes: nil,
+			Now:          now,
 		})
 	r := reconciler.Compute()
 
@@ -3003,9 +2964,8 @@ func TestReconciler_RescheduleNow_Service_WithCanaries(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -3138,9 +3098,8 @@ func TestReconciler_RescheduleNow_Service_Canaries(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         now,
+			TaintedNodes: nil,
+			Now:          now,
 		})
 	r := reconciler.Compute()
 
@@ -3276,9 +3235,8 @@ func TestReconciler_RescheduleNow_Service_Canaries_Limit(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         now,
+			TaintedNodes: nil,
+			Now:          now,
 		})
 	r := reconciler.Compute()
 
@@ -3354,9 +3312,8 @@ func TestReconciler_DontReschedule_PreviouslyRescheduled(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -3455,9 +3412,8 @@ func TestReconciler_CancelDeployment_JobStop(t *testing.T) {
 					ExistingAllocs:    allocs,
 					EvalPriority:      50,
 				}, ClusterState{
-					TaintedNodes:                nil,
-					SupportsDisconnectedClients: true,
-					Now:                         time.Now().UTC(),
+					TaintedNodes: nil,
+					Now:          time.Now().UTC(),
 				})
 			r := reconciler.Compute()
 
@@ -3546,9 +3502,8 @@ func TestReconciler_CancelDeployment_JobUpdate(t *testing.T) {
 					ExistingAllocs:    allocs,
 					EvalPriority:      50,
 				}, ClusterState{
-					TaintedNodes:                nil,
-					SupportsDisconnectedClients: true,
-					Now:                         time.Now().UTC(),
+					TaintedNodes: nil,
+					Now:          time.Now().UTC(),
 				})
 			r := reconciler.Compute()
 
@@ -3609,9 +3564,8 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Destructive(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -3668,9 +3622,8 @@ func TestReconciler_CreateDeployment_RollingUpgrade_Inplace(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -3726,9 +3679,8 @@ func TestReconciler_CreateDeployment_NewerCreateIndex(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -3786,9 +3738,8 @@ func TestReconciler_DontCreateDeployment_NoChanges(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -3878,9 +3829,8 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreCanaries(t *testing.T) {
 					ExistingAllocs:    allocs,
 					EvalPriority:      50,
 				}, ClusterState{
-					TaintedNodes:                nil,
-					SupportsDisconnectedClients: true,
-					Now:                         time.Now().UTC(),
+					TaintedNodes: nil,
+					Now:          time.Now().UTC(),
 				})
 			r := reconciler.Compute()
 
@@ -3957,9 +3907,8 @@ func TestReconciler_PausedOrFailedDeployment_NoMorePlacements(t *testing.T) {
 					ExistingAllocs:    allocs,
 					EvalPriority:      50,
 				}, ClusterState{
-					TaintedNodes:                nil,
-					SupportsDisconnectedClients: true,
-					Now:                         time.Now().UTC(),
+					TaintedNodes: nil,
+					Now:          time.Now().UTC(),
 				})
 			r := reconciler.Compute()
 
@@ -4045,9 +3994,8 @@ func TestReconciler_PausedOrFailedDeployment_NoMoreDestructiveUpdates(t *testing
 					ExistingAllocs:    allocs,
 					EvalPriority:      50,
 				}, ClusterState{
-					TaintedNodes:                nil,
-					SupportsDisconnectedClients: true,
-					Now:                         time.Now().UTC(),
+					TaintedNodes: nil,
+					Now:          time.Now().UTC(),
 				})
 			r := reconciler.Compute()
 
@@ -4133,9 +4081,8 @@ func TestReconciler_DrainNode_Canary(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                tainted,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: tainted,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -4219,9 +4166,8 @@ func TestReconciler_LostNode_Canary(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                tainted,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: tainted,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -4299,9 +4245,8 @@ func TestReconciler_StopOldCanaries(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -4368,9 +4313,8 @@ func TestReconciler_NewCanaries(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -4432,9 +4376,8 @@ func TestReconciler_NewCanaries_CountGreater(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -4499,9 +4442,8 @@ func TestReconciler_NewCanaries_MultiTG(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -4568,9 +4510,8 @@ func TestReconciler_NewCanaries_ScaleUp(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -4632,9 +4573,8 @@ func TestReconciler_NewCanaries_ScaleDown(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -4725,9 +4665,8 @@ func TestReconciler_NewCanaries_FillNames(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -4808,9 +4747,8 @@ func TestReconciler_PromoteCanaries_Unblock(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -4896,9 +4834,8 @@ func TestReconciler_PromoteCanaries_CanariesEqualCount(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5009,9 +4946,8 @@ func TestReconciler_DeploymentLimit_HealthAccounting(t *testing.T) {
 					ExistingAllocs:    allocs,
 					EvalPriority:      50,
 				}, ClusterState{
-					TaintedNodes:                nil,
-					SupportsDisconnectedClients: true,
-					Now:                         time.Now().UTC(),
+					TaintedNodes: nil,
+					Now:          time.Now().UTC(),
 				})
 			r := reconciler.Compute()
 
@@ -5104,9 +5040,8 @@ func TestReconciler_TaintedNode_RollingUpgrade(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                tainted,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: tainted,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5203,9 +5138,8 @@ func TestReconciler_FailedDeployment_TaintedNodes(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                tainted,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: tainted,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5273,9 +5207,8 @@ func TestReconciler_CompleteDeployment(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5342,9 +5275,8 @@ func TestReconciler_MarkDeploymentComplete_FailedAllocations(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5451,9 +5383,8 @@ func TestReconciler_FailedDeployment_CancelCanaries(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5534,9 +5465,8 @@ func TestReconciler_FailedDeployment_NewJob(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5603,9 +5533,8 @@ func TestReconciler_MarkDeploymentComplete(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5686,9 +5615,8 @@ func TestReconciler_JobChange_ScaleUp_SecondEval(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5735,9 +5663,8 @@ func TestReconciler_RollingUpgrade_MissingAllocs(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5805,9 +5732,8 @@ func TestReconciler_Batch_Rerun(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5880,9 +5806,8 @@ func TestReconciler_FailedDeployment_DontReschedule(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -5949,9 +5874,8 @@ func TestReconciler_DeploymentWithFailedAllocs_DontReschedule(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -6048,9 +5972,8 @@ func TestReconciler_FailedDeployment_AutoRevert_CancelCanaries(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -6124,9 +6047,8 @@ func TestReconciler_SuccessfulDeploymentWithFailedAllocs_Reschedule(t *testing.T
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -6200,9 +6122,8 @@ func TestReconciler_ForceReschedule_Service(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -6294,9 +6215,8 @@ func TestReconciler_RescheduleNot_Service(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	r := reconciler.Compute()
 
@@ -6709,9 +6629,8 @@ func TestReconciler_Disconnected_Client(t *testing.T) {
 					ExistingAllocs:    allocs,
 					EvalPriority:      50,
 				}, ClusterState{
-					TaintedNodes:                map[string]*structs.Node{testNode.ID: testNode},
-					SupportsDisconnectedClients: true,
-					Now:                         now,
+					TaintedNodes: map[string]*structs.Node{testNode.ID: testNode},
+					Now:          now,
 				})
 
 			mpc := &mockPicker{
@@ -6812,9 +6731,8 @@ func TestReconciler_RescheduleNot_Batch(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         now,
+			TaintedNodes: nil,
+			Now:          now,
 		})
 	r := reconciler.Compute()
 
@@ -6855,9 +6773,8 @@ func TestReconciler_Node_Disconnect_Updates_Alloc_To_Unknown(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nodes,
-			SupportsDisconnectedClients: true,
-			Now:                         now,
+			TaintedNodes: nodes,
+			Now:          now,
 		})
 	results := reconciler.Compute()
 
@@ -6929,9 +6846,8 @@ func TestReconciler_Disconnect_UpdateJobAfterReconnect(t *testing.T) {
 			ExistingAllocs:    allocs,
 			EvalPriority:      50,
 		}, ClusterState{
-			TaintedNodes:                nil,
-			SupportsDisconnectedClients: true,
-			Now:                         time.Now().UTC(),
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
 		})
 	results := reconciler.Compute()
 
@@ -7296,9 +7212,8 @@ func TestReconciler_Client_Disconnect_Canaries(t *testing.T) {
 					ExistingAllocs:    allocs,
 					EvalPriority:      50,
 				}, ClusterState{
-					TaintedNodes:                tainted,
-					SupportsDisconnectedClients: true,
-					Now:                         time.Now().UTC(),
+					TaintedNodes: tainted,
+					Now:          time.Now().UTC(),
 				})
 			result := reconciler.Compute()
 
@@ -7455,9 +7370,8 @@ func TestReconciler_ComputeDeploymentPaused(t *testing.T) {
 					DeploymentCurrent: deployment,
 					EvalPriority:      50,
 				}, ClusterState{
-					TaintedNodes:                nil,
-					SupportsDisconnectedClients: true,
-					Now:                         time.Now().UTC(),
+					TaintedNodes: nil,
+					Now:          time.Now().UTC(),
 				})
 			reconciler.Compute()
 

--- a/scheduler/reconciler/reconcile_node_test.go
+++ b/scheduler/reconciler/reconcile_node_test.go
@@ -73,7 +73,7 @@ func TestDiffSystemAllocsForNode_Sysbatch_terminal(t *testing.T) {
 		}
 
 		nr := NewNodeReconciler(nil)
-		diff := nr.computeForNode(job, "node1", eligible, nil, tainted, required, live, terminal, true)
+		diff := nr.computeForNode(job, "node1", eligible, nil, tainted, required, live, terminal)
 
 		assertDiffCount(t, diffResultCount{ignore: 1, place: 1}, diff)
 		if len(diff.Ignore) > 0 {
@@ -96,7 +96,7 @@ func TestDiffSystemAllocsForNode_Sysbatch_terminal(t *testing.T) {
 		}
 
 		nr := NewNodeReconciler(nil)
-		diff := nr.computeForNode(job, "node1", eligible, nil, tainted, required, live, terminal, true)
+		diff := nr.computeForNode(job, "node1", eligible, nil, tainted, required, live, terminal)
 		assertDiffCount(t, diffResultCount{update: 1, place: 1}, diff)
 	})
 
@@ -160,7 +160,7 @@ func TestDiffSystemAllocsForNode_Placements(t *testing.T) {
 			nr := NewNodeReconciler(nil)
 			diff := nr.computeForNode(
 				job, tc.nodeID, eligible, nil,
-				tainted, required, allocsForNode, terminal, true)
+				tainted, required, allocsForNode, terminal)
 
 			assertDiffCount(t, tc.expected, diff)
 		})
@@ -218,7 +218,7 @@ func TestDiffSystemAllocsForNode_Stops(t *testing.T) {
 
 	nr := NewNodeReconciler(nil)
 	diff := nr.computeForNode(
-		job, node.ID, eligible, nil, tainted, required, allocs, terminal, true)
+		job, node.ID, eligible, nil, tainted, required, allocs, terminal)
 
 	assertDiffCount(t, diffResultCount{ignore: 1, stop: 1, update: 1}, diff)
 	if len(diff.Update) > 0 {
@@ -289,8 +289,7 @@ func TestDiffSystemAllocsForNode_IneligibleNode(t *testing.T) {
 			nr := NewNodeReconciler(nil)
 			diff := nr.computeForNode(
 				job, tc.nodeID, eligible, ineligible, tainted,
-				required, []*structs.Allocation{alloc}, terminal, true,
-			)
+				required, []*structs.Allocation{alloc}, terminal)
 			assertDiffCount(t, tc.expect, diff)
 		})
 	}
@@ -346,7 +345,7 @@ func TestDiffSystemAllocsForNode_DrainingNode(t *testing.T) {
 	nr := NewNodeReconciler(nil)
 	diff := nr.computeForNode(
 		job, drainNode.ID, map[string]*structs.Node{}, nil,
-		tainted, required, allocs, terminal, true)
+		tainted, required, allocs, terminal)
 
 	assertDiffCount(t, diffResultCount{migrate: 1, ignore: 1}, diff)
 	if len(diff.Migrate) > 0 {
@@ -398,7 +397,7 @@ func TestDiffSystemAllocsForNode_LostNode(t *testing.T) {
 	nr := NewNodeReconciler(nil)
 	diff := nr.computeForNode(
 		job, deadNode.ID, map[string]*structs.Node{}, nil,
-		tainted, required, allocs, terminal, true)
+		tainted, required, allocs, terminal)
 
 	assertDiffCount(t, diffResultCount{lost: 2}, diff)
 	if len(diff.Migrate) > 0 {
@@ -524,8 +523,7 @@ func TestDiffSystemAllocsForNode_DisconnectedNode(t *testing.T) {
 			nr := NewNodeReconciler(nil)
 			got := nr.computeForNode(
 				job, tc.node.ID, eligibleNodes, nil, taintedNodes,
-				required, []*structs.Allocation{alloc}, terminal, true,
-			)
+				required, []*structs.Allocation{alloc}, terminal)
 			assertDiffCount(t, tc.expect, got)
 		})
 	}
@@ -611,7 +609,7 @@ func TestDiffSystemAllocs(t *testing.T) {
 	}
 
 	nr := NewNodeReconciler(nil)
-	diff := nr.Compute(job, nodes, nil, tainted, allocs, terminal, true)
+	diff := nr.Compute(job, nodes, nil, tainted, allocs, terminal)
 	assertDiffCount(t, diffResultCount{
 		update: 1, ignore: 1, migrate: 1, lost: 1, place: 6}, diff)
 
@@ -766,7 +764,7 @@ func TestNodeDeployments(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			nr := NewNodeReconciler(tc.existingDeployment)
-			nr.Compute(tc.job, nodes, nil, nil, tc.liveAllocs, tc.terminalAllocs, true)
+			nr.Compute(tc.job, nodes, nil, nil, tc.liveAllocs, tc.terminalAllocs)
 			if tc.newDeployment {
 				must.NotNil(t, nr.DeploymentCurrent, must.Sprintf("expected a non-nil deployment"))
 				must.Eq(t, nr.DeploymentCurrent.Status, tc.expectedNewDeploymentStatus)

--- a/scheduler/scheduler_sysbatch.go
+++ b/scheduler/scheduler_sysbatch.go
@@ -232,8 +232,7 @@ func (s *SysBatchScheduler) computeJobAllocs() error {
 
 	// Diff the required and existing allocations
 	nr := reconciler.NewNodeReconciler(nil)
-	r := nr.Compute(s.job, s.nodes, s.notReadyNodes, tainted, live, term,
-		s.planner.ServersMeetMinimumVersion(minVersionMaxClientDisconnect, true))
+	r := nr.Compute(s.job, s.nodes, s.notReadyNodes, tainted, live, term)
 	if s.logger.IsDebug() {
 		s.logger.Debug("reconciled current state with desired state", r.Fields()...)
 	}

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -250,7 +250,7 @@ func (s *SystemScheduler) computeJobAllocs() error {
 	// Diff the required and existing allocations
 	nr := reconciler.NewNodeReconciler(s.deployment)
 	reconciliationResult := nr.Compute(s.job, s.nodes, s.notReadyNodes, tainted,
-		live, term, s.planner.ServersMeetMinimumVersion(minVersionMaxClientDisconnect, true))
+		live, term)
 	if s.logger.IsDebug() {
 		s.logger.Debug("reconciled current state with desired state", reconciliationResult.Fields()...)
 	}


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Removes a cluster version check that happens in the reconciler. This check was necessary when support for disconnected clients was added but is no longer necessary as upgrading directly from 1.2.x to 1.11.x is not supported.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
