### PR TITLE
api: return 403 error when reading variables using invalid token

### DIFF
--- a/.changelog/27269.txt
+++ b/.changelog/27269.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-api: return proper 403 message when getting variables instead of swalling error
+api: return proper 403 message when getting variables instead of swallowing error
 ```

--- a/.changelog/27269.txt
+++ b/.changelog/27269.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: return proper 403 message when getting variables instead of swalling error
+```

--- a/api/error_unexpected_response.go
+++ b/api/error_unexpected_response.go
@@ -171,7 +171,9 @@ func requireStatusIn(statuses ...int) doRequestWrapper {
 
 		// The response technically succeeded, so we need to close the body
 		// if we are discarding the response object
-		_ = resp.Body.Close()
+		defer func() {
+			_ = resp.Body.Close()
+		}()
 
 		return d, nil, newUnexpectedResponseError(fromHTTPResponse(resp), withExpectedStatuses(statuses))
 	}

--- a/api/error_unexpected_response.go
+++ b/api/error_unexpected_response.go
@@ -160,9 +160,6 @@ func requireOK(d time.Duration, resp *http.Response, e error) (time.Duration, *h
 func requireStatusIn(statuses ...int) doRequestWrapper {
 	return func(d time.Duration, resp *http.Response, e error) (time.Duration, *http.Response, error) {
 		if e != nil {
-			if resp != nil {
-				_ = resp.Body.Close()
-			}
 			return d, nil, e
 		}
 
@@ -171,6 +168,10 @@ func requireStatusIn(statuses ...int) doRequestWrapper {
 				return d, resp, nil
 			}
 		}
+
+		// The response technically succeeded, so we need to close the body
+		// if we are discarding the response object
+		_ = resp.Body.Close()
 
 		return d, nil, newUnexpectedResponseError(fromHTTPResponse(resp), withExpectedStatuses(statuses))
 	}


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
The Nomad api was previously swallowing 403 errors, which was inconsistent with the rest of the api, and causing unexpected issues with consumers like Consul-Template

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes GH #27117
Fixes GH [#24698](https://github.com/hashicorp/nomad/issues/24698)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
