### PR TITLE
account for discontinuous node IDs in numa detection

### DIFF
--- a/.changelog/27277.txt
+++ b/.changelog/27277.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+numa: Fixed a bug where NUMA detection would cause a panic on hosts with discontinuous node IDs
+```

--- a/client/lib/numalib/detect_linux.go
+++ b/client/lib/numalib/detect_linux.go
@@ -103,22 +103,21 @@ func (*Sysfs) discoverCosts(st *Topology, readerFunc pathReaderFn) {
 
 	dimension := st.nodeIDs.Size()
 	st.Distances = make(SLIT, st.nodeIDs.Size())
-	for i := 0; i < dimension; i++ {
+	for i := range dimension {
 		st.Distances[i] = make([]Cost, dimension)
 	}
 
-	_ = st.nodeIDs.ForEach(func(id hw.NodeID) error {
+	for idx, id := range st.nodeIDs.Slice() {
 		s, err := getString(distanceFile, readerFunc, id)
 		if err != nil {
-			return err
+			break
 		}
 
 		for i, c := range strings.Fields(s) {
 			cost, _ := strconv.ParseUint(c, 10, 8)
-			st.Distances[id][i] = Cost(cost)
+			st.Distances[idx][i] = Cost(cost)
 		}
-		return nil
-	})
+	}
 }
 
 func (*Sysfs) discoverCores(st *Topology, readerFunc pathReaderFn) {


### PR DESCRIPTION
When we read from the distance tables for NUMA, the code iterates over the node list but implicitly assumes that the node ID is equivalent to the index within the distance table. As it turns out, it's entirely possible to have 8 nodes with IDs like `0,2-8`, which will then hit an index out of range error when we try to read the final node. The unit tests included this case, but obscured this bug because they had invalid distance data where a single distance was listed for 2 nodes.

Use the index of the node ID within the slice when recording the values in the distance tables, and correct the tests.

Fixes: https://github.com/hashicorp/nomad/issues/27266

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
