### PR TITLE
keyring: allow legacy keyring to fallback for HA

### DIFF
--- a/.changelog/27279.txt
+++ b/.changelog/27279.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+keyring (Enterprise): Fixed a bug where servers configured with high availability keyrings with pre-1.9.0 keystores would not start if one of the external KMS was unreachable
+```


### PR DESCRIPTION
In Nomad Enterprise, users can have multiple `keyring` blocks so that when a server comes up it can try to decrypt the key material using multiple external KMS. But this functionality is broken with the legacy keystore files present in 1.8.x+ent and earlier.

Although the `loadKeystore` function has plumbing to handle graceful fallback, there's a bug where we exit early rather than saving the error and returning it only if no other KMS can decrypt that key. Fix that by saving the error and returning from the `filepath.Walk` step to allow moving on to the next file.

Fixes: https://hashicorp.atlassian.net/browse/NMD-1107
Ref: https://developer.hashicorp.com/nomad/docs/configuration/keyring#high-availability

### Testing & Reproduction steps

See my comment below. But also, see the failing unit test without this patch:

```
$ go test -v -count=1 ./nomad -run TestEncrypter_LoadSave
=== RUN   TestEncrypter_LoadSave
=== PAUSE TestEncrypter_LoadSave
=== CONT  TestEncrypter_LoadSave
=== RUN   TestEncrypter_LoadSave/aes256-gcm
=== RUN   TestEncrypter_LoadSave/legacy_aead_wrapper
=== RUN   TestEncrypter_LoadSave/legacy_wrapper_HA
    encrypter_test.go:168:
        encrypter_test.go:168: expected nil error
        ↪ error: could not load key file /tmp/TestEncrypter_LoadSave2262746609/001/9332b94f-e2ca-44e6-9823-59dbf5f2e427.0.nks.json from keystore: unable to create key wrapper: crypto/aes: invalid key size 0
--- FAIL: TestEncrypter_LoadSave (0.15s)
    --- PASS: TestEncrypter_LoadSave/aes256-gcm (0.01s)
    --- PASS: TestEncrypter_LoadSave/legacy_aead_wrapper (0.07s)
    --- FAIL: TestEncrypter_LoadSave/legacy_wrapper_HA (0.07s)
FAIL
FAIL    github.com/hashicorp/nomad/nomad        0.169s
FAIL
```

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
