### PR TITLE
fix(ui): add missing namespace when tagging a job version

### DIFF
--- a/.changelog/27282.txt
+++ b/.changelog/27282.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Tagging job versions in another namespace than the default-namespace resulted in an error
+```

--- a/ui/app/adapters/version-tag.js
+++ b/ui/app/adapters/version-tag.js
@@ -13,18 +13,19 @@ export default class VersionTagAdapter extends ApplicationAdapter {
   urlForCreateRecord(_modelName, model) {
     const tagName = model.attr('name');
     const jobName = model.attr('jobName');
-    return `${this.buildURL()}/job/${jobName}/versions/${tagName}/tag`;
+    const namespace = model.attr('jobNamespace');
+    return `${this.buildURL()}/job/${jobName}/versions/${tagName}/tag?namespace=${namespace}`;
   }
 
-  async deleteTag(jobName, tagName) {
+  async deleteTag(namespace, jobName, tagName) {
     let deletion = this.ajax(
-      this.urlForDeleteRecord(jobName, tagName),
+      this.urlForDeleteRecord(namespace, jobName, tagName),
       'DELETE'
     );
     return deletion;
   }
 
-  urlForDeleteRecord(jobName, tagName) {
-    return `${this.buildURL()}/job/${jobName}/versions/${tagName}/tag`;
+  urlForDeleteRecord(namespace, jobName, tagName) {
+    return `${this.buildURL()}/job/${jobName}/versions/${tagName}/tag?namespace=${namespace}`;
   }
 }

--- a/ui/app/components/job-version.js
+++ b/ui/app/components/job-version.js
@@ -51,6 +51,7 @@ export default class JobVersion extends Component {
       this.editableTag = this.store.createRecord('versionTag');
     }
     this.editableTag.versionNumber = this.version.number;
+    this.editableTag.jobNamespace = this.version.get('job.namespace.name');
     this.editableTag.jobName = this.version.get('job.plainId');
   }
 
@@ -224,7 +225,11 @@ export default class JobVersion extends Component {
     try {
       await this.store
         .adapterFor('version-tag')
-        .deleteTag(this.editableTag.jobName, this.editableTag.name);
+        .deleteTag(
+          this.editableTag.jobNamespace,
+          this.editableTag.jobName,
+          this.editableTag.name
+        );
       this.notifications.add({
         title: 'Job Version Un-Tagged',
         color: 'success',

--- a/ui/app/models/version-tag.js
+++ b/ui/app/models/version-tag.js
@@ -11,5 +11,6 @@ export default class VersionTagModel extends Fragment {
   @attr() description;
   @attr() taggedTime;
   @attr('number') versionNumber;
+  @attr('string') jobNamespace;
   @attr('string') jobName;
 }


### PR DESCRIPTION
### Description
This PR adds the missing namespace to the server request when tagging a job version from the UI.

### Testing & Reproduction steps
See #26185

### Links
Fixes #26185

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
