### PR TITLE
system deployments: count pending allocs against max_parallel limit

### DIFF
--- a/.changelog/27284.txt
+++ b/.changelog/27284.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+deployments: Fixed a bug where system deployments can violate update.max_parallel if another eval for the job is triggered while allocs are pending
+```


### PR DESCRIPTION
When we check for the limit of `update.max_parallel` during a system job deployment, we don't account for allocations that exist but are not yet marked healthy because they haven't reached the `min_healthy_time`. If an eval gets triggered by an allocation from another group in the same job, or from some other cluster event like an allocation failure, then this can result in violations of the `max_parallel` field.

Add a check for allocation health in `evictAndPlace` to mirror the logic found in the cluster reconciler used by service jobs.

Fixes: https://github.com/hashicorp/nomad/issues/27271
Ref: https://hashicorp.atlassian.net/browse/NMD-1122

### Testing & Reproduction steps

See https://github.com/hashicorp/nomad/pull/27284#issuecomment-3675401208 below

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
