### PR TITLE
Provide finer grained capabilities from submit-job

### DIFF
--- a/.changelog/27287.txt
+++ b/.changelog/27287.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: Add finer grain permissions for managing job submissions
+```

--- a/acl/acl.go
+++ b/acl/acl.go
@@ -325,6 +325,16 @@ func (a *ACL) AllowNsOpFunc(ops ...string) func(string) bool {
 	}
 }
 
+// AllowNsOpOr checks if any of the given operations are allowed for a namespace.
+func (a *ACL) AllowNsOpOr(ns string, ops []string) bool {
+	for _, op := range ops {
+		if a.AllowNamespaceOperation(ns, op) {
+			return true
+		}
+	}
+	return false
+}
+
 // AllowNamespaceOperation checks if a given operation is allowed for a namespace.
 func (a *ACL) AllowNamespaceOperation(ns string, op string) bool {
 	if a == nil {

--- a/acl/acl.go
+++ b/acl/acl.go
@@ -325,8 +325,8 @@ func (a *ACL) AllowNsOpFunc(ops ...string) func(string) bool {
 	}
 }
 
-// AllowNsOpOr checks if any of the given operations are allowed for a namespace.
-func (a *ACL) AllowNsOpOr(ns string, ops []string) bool {
+// AllowNsOpAnyOf checks if any of the given operations are allowed for a namespace.
+func (a *ACL) AllowNsOpAnyOf(ns string, ops ...string) bool {
 	for _, op := range ops {
 		if a.AllowNamespaceOperation(ns, op) {
 			return true

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -72,7 +72,6 @@ const (
 	NamespaceCapabilityFailDeployment           = "fail-deployment"
 	NamespaceCapabilityPauseDeployment          = "pause-deployment"
 	NamespaceCapabilityPromoteDeployment        = "promote-deployment"
-	NamespaceCapabilityRunDeployment            = "run-deployment"
 	NamespaceCapabilityUnblockDeployment        = "unblock-deployment"
 	NamespaceCapabilityCancelDeployment         = "cancel-deployment"
 	NamespaceCapabilitySetAllocHealthDeployment = "set-alloc-health-deployment"
@@ -261,7 +260,7 @@ func isNamespaceCapabilityValid(cap string) bool {
 		NamespaceCapabilityPurgeJob, NamespaceCapabilityPlanJob, NamespaceCapabilityTagJobVersion,
 		NamespaceCapabilityStableJob,
 		NamespaceCapabilityFailDeployment, NamespaceCapabilityPauseDeployment, NamespaceCapabilityPromoteDeployment,
-		NamespaceCapabilityRunDeployment, NamespaceCapabilityUnblockDeployment, NamespaceCapabilityCancelDeployment,
+		NamespaceCapabilityUnblockDeployment, NamespaceCapabilityCancelDeployment,
 		NamespaceCapabilitySetAllocHealthDeployment,
 		NamespaceCapabilityGCAllocation, NamespaceCapabilityPauseAllocation,
 		NamespaceCapabilityForcePeriodicJob, NamespaceCapabilityDeleteServiceRegistration:

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -80,7 +80,8 @@ const (
 	NamespaceCapabilityGCAllocation    = "gc-allocation"
 	NamespaceCapabilityPauseAllocation = "pause-allocation"
 
-	NamespaceCapabilityForcePeriodicJob = "force-periodic-job"
+	NamespaceCapabilityForcePeriodicJob          = "force-periodic-job"
+	NamespaceCapabilityDeleteServiceRegistration = "delete-service-registration"
 )
 
 var (
@@ -263,7 +264,7 @@ func isNamespaceCapabilityValid(cap string) bool {
 		NamespaceCapabilityRunDeployment, NamespaceCapabilityUnblockDeployment, NamespaceCapabilityCancelDeployment,
 		NamespaceCapabilitySetAllocHealthDeployment,
 		NamespaceCapabilityGCAllocation, NamespaceCapabilityPauseAllocation,
-		NamespaceCapabilityForcePeriodicJob:
+		NamespaceCapabilityForcePeriodicJob, NamespaceCapabilityDeleteServiceRegistration:
 		return true
 	// Separate the enterprise-only capabilities
 	case NamespaceCapabilitySentinelOverride, NamespaceCapabilitySubmitRecommendation:

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -58,6 +58,15 @@ const (
 	NamespaceCapabilityReadJobScaling       = "read-job-scaling"
 	NamespaceCapabilityScaleJob             = "scale-job"
 	NamespaceCapabilitySubmitRecommendation = "submit-recommendation"
+
+	NamespaceCapabilityRegisterJob   = "register-job"
+	NamespaceCapabilityRevertJob     = "revert-job"
+	NamespaceCapabilityDeregisterJob = "deregister-job"
+	NamespaceCapabilityPurgeJob      = "purge-job"
+	NamespaceCapabilityEvaluateJob   = "evaluate-job"
+	NamespaceCapabilityPlanJob       = "plan-job"
+	NamespaceCapabilityTagJobVersion = "tag-job-version"
+	NamespaceCapabilityStableJob     = "stable-job"
 )
 
 var (
@@ -232,7 +241,10 @@ func isNamespaceCapabilityValid(cap string) bool {
 		NamespaceCapabilityReadFS, NamespaceCapabilityAllocLifecycle,
 		NamespaceCapabilityAllocExec, NamespaceCapabilityAllocNodeExec,
 		NamespaceCapabilityCSIReadVolume, NamespaceCapabilityCSIWriteVolume, NamespaceCapabilityCSIListVolume, NamespaceCapabilityCSIMountVolume, NamespaceCapabilityCSIRegisterPlugin,
-		NamespaceCapabilityListScalingPolicies, NamespaceCapabilityReadScalingPolicy, NamespaceCapabilityReadJobScaling, NamespaceCapabilityScaleJob, NamespaceCapabilityHostVolumeCreate, NamespaceCapabilityHostVolumeRegister, NamespaceCapabilityHostVolumeWrite, NamespaceCapabilityHostVolumeRead:
+		NamespaceCapabilityListScalingPolicies, NamespaceCapabilityReadScalingPolicy, NamespaceCapabilityReadJobScaling, NamespaceCapabilityScaleJob, NamespaceCapabilityHostVolumeCreate, NamespaceCapabilityHostVolumeRegister, NamespaceCapabilityHostVolumeWrite, NamespaceCapabilityHostVolumeRead,
+		NamespaceCapabilityDeregisterJob, NamespaceCapabilityEvaluateJob, NamespaceCapabilityRevertJob, NamespaceCapabilityRegisterJob,
+		NamespaceCapabilityPurgeJob, NamespaceCapabilityPlanJob, NamespaceCapabilityTagJobVersion,
+		NamespaceCapabilityStableJob:
 		return true
 	// Separate the enterprise-only capabilities
 	case NamespaceCapabilitySentinelOverride, NamespaceCapabilitySubmitRecommendation:

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -59,6 +59,7 @@ const (
 	NamespaceCapabilityScaleJob             = "scale-job"
 	NamespaceCapabilitySubmitRecommendation = "submit-recommendation"
 
+	// Fine-grained job capabilities separated from submit-job
 	NamespaceCapabilityRegisterJob   = "register-job"
 	NamespaceCapabilityRevertJob     = "revert-job"
 	NamespaceCapabilityDeregisterJob = "deregister-job"
@@ -67,6 +68,19 @@ const (
 	NamespaceCapabilityPlanJob       = "plan-job"
 	NamespaceCapabilityTagJobVersion = "tag-job-version"
 	NamespaceCapabilityStableJob     = "stable-job"
+
+	NamespaceCapabilityFailDeployment           = "fail-deployment"
+	NamespaceCapabilityPauseDeployment          = "pause-deployment"
+	NamespaceCapabilityPromoteDeployment        = "promote-deployment"
+	NamespaceCapabilityRunDeployment            = "run-deployment"
+	NamespaceCapabilityUnblockDeployment        = "unblock-deployment"
+	NamespaceCapabilityCancelDeployment         = "cancel-deployment"
+	NamespaceCapabilitySetAllocHealthDeployment = "set-alloc-health-deployment"
+
+	NamespaceCapabilityGCAllocation    = "gc-allocation"
+	NamespaceCapabilityPauseAllocation = "pause-allocation"
+
+	NamespaceCapabilityForcePeriodicJob = "force-periodic-job"
 )
 
 var (
@@ -244,7 +258,12 @@ func isNamespaceCapabilityValid(cap string) bool {
 		NamespaceCapabilityListScalingPolicies, NamespaceCapabilityReadScalingPolicy, NamespaceCapabilityReadJobScaling, NamespaceCapabilityScaleJob, NamespaceCapabilityHostVolumeCreate, NamespaceCapabilityHostVolumeRegister, NamespaceCapabilityHostVolumeWrite, NamespaceCapabilityHostVolumeRead,
 		NamespaceCapabilityDeregisterJob, NamespaceCapabilityEvaluateJob, NamespaceCapabilityRevertJob, NamespaceCapabilityRegisterJob,
 		NamespaceCapabilityPurgeJob, NamespaceCapabilityPlanJob, NamespaceCapabilityTagJobVersion,
-		NamespaceCapabilityStableJob:
+		NamespaceCapabilityStableJob,
+		NamespaceCapabilityFailDeployment, NamespaceCapabilityPauseDeployment, NamespaceCapabilityPromoteDeployment,
+		NamespaceCapabilityRunDeployment, NamespaceCapabilityUnblockDeployment, NamespaceCapabilityCancelDeployment,
+		NamespaceCapabilitySetAllocHealthDeployment,
+		NamespaceCapabilityGCAllocation, NamespaceCapabilityPauseAllocation,
+		NamespaceCapabilityForcePeriodicJob:
 		return true
 	// Separate the enterprise-only capabilities
 	case NamespaceCapabilitySentinelOverride, NamespaceCapabilitySubmitRecommendation:

--- a/client/alloc_endpoint.go
+++ b/client/alloc_endpoint.go
@@ -61,10 +61,10 @@ func (a *Allocations) GarbageCollect(args *nstructs.AllocSpecificRequest, reply 
 	// Check namespace submit job permission.
 	if aclObj, err := a.c.ResolveToken(args.AuthToken); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(alloc.Namespace, []string{
+	} else if !aclObj.AllowNsOpAnyOf(alloc.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityGCAllocation,
-	}) {
+	) {
 		return nstructs.ErrPermissionDenied
 	}
 
@@ -104,10 +104,10 @@ func (a *Allocations) SetPauseState(args *nstructs.AllocPauseRequest, reply *nst
 
 	if aclObj, err := a.c.ResolveToken(args.AuthToken); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(alloc.Namespace, []string{
+	} else if !aclObj.AllowNsOpAnyOf(alloc.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityPauseAllocation,
-	}) {
+	) {
 		return nstructs.ErrPermissionDenied
 	}
 

--- a/client/alloc_endpoint.go
+++ b/client/alloc_endpoint.go
@@ -61,7 +61,10 @@ func (a *Allocations) GarbageCollect(args *nstructs.AllocSpecificRequest, reply 
 	// Check namespace submit job permission.
 	if aclObj, err := a.c.ResolveToken(args.AuthToken); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(alloc.Namespace, acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(alloc.Namespace, []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityGCAllocation,
+	}) {
 		return nstructs.ErrPermissionDenied
 	}
 
@@ -101,7 +104,10 @@ func (a *Allocations) SetPauseState(args *nstructs.AllocPauseRequest, reply *nst
 
 	if aclObj, err := a.c.ResolveToken(args.AuthToken); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(alloc.Namespace, acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(alloc.Namespace, []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityPauseAllocation,
+	}) {
 		return nstructs.ErrPermissionDenied
 	}
 

--- a/nomad/client_alloc_endpoint.go
+++ b/nomad/client_alloc_endpoint.go
@@ -179,10 +179,10 @@ func (a *ClientAllocations) SetPauseState(args *structs.AllocPauseRequest, reply
 	// Check namespace submit-job permission.
 	if aclObj, err := a.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(alloc.Namespace, []string{
+	} else if !aclObj.AllowNsOpAnyOf(alloc.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityPauseAllocation,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -293,10 +293,10 @@ func (a *ClientAllocations) GarbageCollect(args *structs.AllocSpecificRequest, r
 	// Check namespace submit-job permission.
 	if aclObj, err := a.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(alloc.Namespace, []string{
+	} else if !aclObj.AllowNsOpAnyOf(alloc.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityGCAllocation,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/client_alloc_endpoint.go
+++ b/nomad/client_alloc_endpoint.go
@@ -179,7 +179,10 @@ func (a *ClientAllocations) SetPauseState(args *structs.AllocPauseRequest, reply
 	// Check namespace submit-job permission.
 	if aclObj, err := a.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(alloc.Namespace, acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(alloc.Namespace, []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityPauseAllocation,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -290,7 +293,10 @@ func (a *ClientAllocations) GarbageCollect(args *structs.AllocSpecificRequest, r
 	// Check namespace submit-job permission.
 	if aclObj, err := a.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(alloc.Namespace, acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(alloc.Namespace, []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityGCAllocation,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -131,7 +131,10 @@ func (d *Deployment) Fail(args *structs.DeploymentFailRequest, reply *structs.De
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(deploy.Namespace, acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityFailDeployment,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -178,7 +181,10 @@ func (d *Deployment) Pause(args *structs.DeploymentPauseRequest, reply *structs.
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(deploy.Namespace, acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityPauseDeployment,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -229,7 +235,10 @@ func (d *Deployment) Promote(args *structs.DeploymentPromoteRequest, reply *stru
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(deploy.Namespace, acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityPromoteDeployment,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -276,7 +285,10 @@ func (d *Deployment) Run(args *structs.DeploymentRunRequest, reply *structs.Depl
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(deploy.Namespace, acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityRunDeployment,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -323,7 +335,10 @@ func (d *Deployment) Unblock(args *structs.DeploymentUnblockRequest, reply *stru
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(deploy.Namespace, acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityUnblockDeployment,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -370,7 +385,10 @@ func (d *Deployment) Cancel(args *structs.DeploymentCancelRequest, reply *struct
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(deploy.Namespace, acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityCancelDeployment,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -422,7 +440,10 @@ func (d *Deployment) SetAllocHealth(args *structs.DeploymentAllocHealthRequest, 
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(deploy.Namespace, acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilitySetAllocHealthDeployment,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -131,10 +131,10 @@ func (d *Deployment) Fail(args *structs.DeploymentFailRequest, reply *structs.De
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+	} else if !aclObj.AllowNsOpAnyOf(deploy.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityFailDeployment,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -181,10 +181,10 @@ func (d *Deployment) Pause(args *structs.DeploymentPauseRequest, reply *structs.
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+	} else if !aclObj.AllowNsOpAnyOf(deploy.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityPauseDeployment,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -235,10 +235,10 @@ func (d *Deployment) Promote(args *structs.DeploymentPromoteRequest, reply *stru
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+	} else if !aclObj.AllowNsOpAnyOf(deploy.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityPromoteDeployment,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -285,10 +285,10 @@ func (d *Deployment) Run(args *structs.DeploymentRunRequest, reply *structs.Depl
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+	} else if !aclObj.AllowNsOpAnyOf(deploy.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityRunDeployment,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -335,10 +335,10 @@ func (d *Deployment) Unblock(args *structs.DeploymentUnblockRequest, reply *stru
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+	} else if !aclObj.AllowNsOpAnyOf(deploy.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityUnblockDeployment,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -385,10 +385,10 @@ func (d *Deployment) Cancel(args *structs.DeploymentCancelRequest, reply *struct
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+	} else if !aclObj.AllowNsOpAnyOf(deploy.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityCancelDeployment,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -440,10 +440,10 @@ func (d *Deployment) SetAllocHealth(args *structs.DeploymentAllocHealthRequest, 
 	// Check namespace submit-job permissions
 	if aclObj, err := d.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(deploy.Namespace, []string{
+	} else if !aclObj.AllowNsOpAnyOf(deploy.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilitySetAllocHealthDeployment,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/deployment_endpoint.go
+++ b/nomad/deployment_endpoint.go
@@ -287,7 +287,7 @@ func (d *Deployment) Run(args *structs.DeploymentRunRequest, reply *structs.Depl
 		return err
 	} else if !aclObj.AllowNsOpAnyOf(deploy.Namespace,
 		acl.NamespaceCapabilitySubmitJob,
-		acl.NamespaceCapabilityRunDeployment,
+		acl.NamespaceCapabilityRegisterJob,
 	) {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -650,7 +650,10 @@ func (j *Job) Stable(args *structs.JobStabilityRequest, reply *structs.JobStabil
 	// Check for read-job permissions
 	if aclObj, err := j.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityStableJob,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -701,7 +704,10 @@ func (j *Job) Evaluate(args *structs.JobEvaluateRequest, reply *structs.JobRegis
 	// Check for submit-job permissions
 	if aclObj, err := j.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityEvaluateJob,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -1793,7 +1799,10 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 	if aclObj, err := j.srv.ResolveACL(args); err != nil {
 		return err
 	} else {
-		if !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilitySubmitJob) {
+		if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+			acl.NamespaceCapabilitySubmitJob,
+			acl.NamespaceCapabilityPlanJob,
+		}) {
 			return structs.ErrPermissionDenied
 		}
 		// Check if override is set and we do not have permissions
@@ -2420,7 +2429,10 @@ func (j *Job) TagVersion(args *structs.JobApplyTagRequest, reply *structs.JobTag
 	if err != nil {
 		return err
 	}
-	if !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilitySubmitJob) {
+	if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityTagJobVersion,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -156,8 +156,9 @@ func (j *Job) doRegister(aclObj *acl.ACL, additionalAllowedPermissions []string,
 	// Set the warning message
 	reply.Warnings = helper.MergeMultierrorWarnings(warnings...)
 
+	permissions := append([]string{acl.NamespaceCapabilitySubmitJob}, additionalAllowedPermissions...)
 	// Check job submission permissions
-	if !aclObj.AllowNsOpOr(args.RequestNamespace(), append([]string{acl.NamespaceCapabilitySubmitJob}, additionalAllowedPermissions...)) {
+	if !aclObj.AllowNsOpAnyOf(args.RequestNamespace(), permissions...) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -583,7 +584,10 @@ func (j *Job) Revert(args *structs.JobRevertRequest, reply *structs.JobRegisterR
 		return err
 	}
 
-	if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{acl.NamespaceCapabilitySubmitJob, acl.NamespaceCapabilityRevertJob}) {
+	if !aclObj.AllowNsOpAnyOf(args.RequestNamespace(),
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityRevertJob,
+	) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -662,10 +666,10 @@ func (j *Job) Stable(args *structs.JobStabilityRequest, reply *structs.JobStabil
 	// Check for read-job permissions
 	if aclObj, err := j.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+	} else if !aclObj.AllowNsOpAnyOf(args.RequestNamespace(),
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityStableJob,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -716,10 +720,10 @@ func (j *Job) Evaluate(args *structs.JobEvaluateRequest, reply *structs.JobRegis
 	// Check for submit-job permissions
 	if aclObj, err := j.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+	} else if !aclObj.AllowNsOpAnyOf(args.RequestNamespace(),
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityEvaluateJob,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -828,7 +832,7 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 		permissionsCheck = append(permissionsCheck, acl.NamespaceCapabilityDeregisterJob)
 	}
 
-	if !aclObj.AllowNsOpOr(args.RequestNamespace(), permissionsCheck) {
+	if !aclObj.AllowNsOpAnyOf(args.RequestNamespace(), permissionsCheck...) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -1819,10 +1823,10 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 	if aclObj, err := j.srv.ResolveACL(args); err != nil {
 		return err
 	} else {
-		if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+		if !aclObj.AllowNsOpAnyOf(args.RequestNamespace(),
 			acl.NamespaceCapabilitySubmitJob,
 			acl.NamespaceCapabilityPlanJob,
-		}) {
+		) {
 			return structs.ErrPermissionDenied
 		}
 		// Check if override is set and we do not have permissions
@@ -2449,10 +2453,10 @@ func (j *Job) TagVersion(args *structs.JobApplyTagRequest, reply *structs.JobTag
 	if err != nil {
 		return err
 	}
-	if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+	if !aclObj.AllowNsOpAnyOf(args.RequestNamespace(),
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityTagJobVersion,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -8622,51 +8622,6 @@ func TestJob_GetServiceRegistrations(t *testing.T) {
 func TestJob_TagVersion(t *testing.T) {
 	ci.Parallel(t)
 
-	s1, cleanupS1 := TestServer(t, nil)
-	defer cleanupS1()
-	codec := rpcClient(t, s1)
-	testutil.WaitForLeader(t, s1.RPC)
-
-	// Create the register request
-	job := mock.Job()
-	reg := &structs.JobRegisterRequest{
-		Job: job,
-		WriteRequest: structs.WriteRequest{
-			Region:    "global",
-			Namespace: job.Namespace,
-		},
-	}
-
-	// Fetch the response
-	var resp structs.JobRegisterResponse
-	if err := msgpackrpc.CallWithCodec(codec, "Job.Register", reg, &resp); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-
-	// Tag the job version
-	tagVersionReq := &structs.JobApplyTagRequest{
-		JobID: job.ID,
-		Tag: &structs.JobVersionTag{
-			Name:        "release",
-			Description: "Release version tag",
-		},
-		WriteRequest: structs.WriteRequest{
-			Region:    "global",
-			Namespace: job.Namespace,
-		},
-	}
-	var resp2 structs.JobTagResponse
-	if err := msgpackrpc.CallWithCodec(codec, "Job.TagVersion", tagVersionReq, &resp2); err != nil {
-		t.Fatalf("err: %v", err)
-	}
-	must.Eq(t, "release", resp2.Name)
-	must.Eq(t, "Release version tag", resp2.Description)
-	must.NotNil(t, resp2.TaggedTime)
-}
-
-func TestJob_TagVersion_ACL(t *testing.T) {
-	ci.Parallel(t)
-
 	s1, root, cleanupS1 := TestACLServer(t, nil)
 	defer cleanupS1()
 	codec := rpcClient(t, s1)
@@ -8722,4 +8677,7 @@ func TestJob_TagVersion_ACL(t *testing.T) {
 	err = msgpackrpc.CallWithCodec(codec, "Job.TagVersion", tagVersionReq, &resp3)
 	must.Nil(t, err)
 
+	must.Eq(t, "release", resp3.Name)
+	must.Eq(t, "Release version tag", resp3.Description)
+	must.NotNil(t, resp3.TaggedTime)
 }

--- a/nomad/periodic_endpoint.go
+++ b/nomad/periodic_endpoint.go
@@ -42,11 +42,11 @@ func (p *Periodic) Force(args *structs.PeriodicForceRequest, reply *structs.Peri
 	// Check for write-job permissions
 	if aclObj, err := p.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+	} else if !aclObj.AllowNsOpAnyOf(args.RequestNamespace(),
 		acl.NamespaceCapabilityDispatchJob,
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityForcePeriodicJob,
-	}) {
+	) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/periodic_endpoint.go
+++ b/nomad/periodic_endpoint.go
@@ -42,7 +42,11 @@ func (p *Periodic) Force(args *structs.PeriodicForceRequest, reply *structs.Peri
 	// Check for write-job permissions
 	if aclObj, err := p.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilityDispatchJob) && !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilitySubmitJob) {
+	} else if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+		acl.NamespaceCapabilityDispatchJob,
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityForcePeriodicJob,
+	}) {
 		return structs.ErrPermissionDenied
 	}
 

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -127,7 +127,10 @@ func (s *ServiceRegistration) DeleteByID(
 
 	if aclObj, err := s.srv.ResolveACL(args); err != nil {
 		return structs.ErrPermissionDenied
-	} else if !aclObj.AllowNsOp(args.RequestNamespace(), acl.NamespaceCapabilitySubmitJob) &&
+	} else if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+		acl.NamespaceCapabilitySubmitJob,
+		acl.NamespaceCapabilityDeregisterJob,
+	}) &&
 		!aclObj.AllowClientOp() {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -127,10 +127,10 @@ func (s *ServiceRegistration) DeleteByID(
 
 	if aclObj, err := s.srv.ResolveACL(args); err != nil {
 		return structs.ErrPermissionDenied
-	} else if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
+	} else if !aclObj.AllowNsOpAnyOf(args.RequestNamespace(),
 		acl.NamespaceCapabilitySubmitJob,
 		acl.NamespaceCapabilityDeleteServiceRegistration,
-	}) &&
+	) &&
 		!aclObj.AllowClientOp() {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/service_registration_endpoint.go
+++ b/nomad/service_registration_endpoint.go
@@ -129,7 +129,7 @@ func (s *ServiceRegistration) DeleteByID(
 		return structs.ErrPermissionDenied
 	} else if !aclObj.AllowNsOpOr(args.RequestNamespace(), []string{
 		acl.NamespaceCapabilitySubmitJob,
-		acl.NamespaceCapabilityDeregisterJob,
+		acl.NamespaceCapabilityDeleteServiceRegistration,
 	}) &&
 		!aclObj.AllowClientOp() {
 		return structs.ErrPermissionDenied

--- a/ui/app/abilities/deployment.js
+++ b/ui/app/abilities/deployment.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright IBM Corp. 2015, 2025
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import AbstractAbility from './abstract';
+import { computed } from '@ember/object';
+import { or } from '@ember/object/computed';
+
+export default class Deployment extends AbstractAbility {
+  @or(
+    'bypassAuthorization',
+    'selfTokenIsManagement',
+    'specificNamespaceSupportsFailing'
+  )
+  canFail;
+
+  @or(
+    'bypassAuthorization',
+    'selfTokenIsManagement',
+    'specificNamespaceSupportsPromoting'
+  )
+  canPromote;
+
+  @computed('rulesForNamespace.@each.capabilities')
+  get specificNamespaceSupportsFailing() {
+    return (
+      this.namespaceIncludesCapability('submit-job') ||
+      this.namespaceIncludesCapability('fail-deployment')
+    );
+  }
+
+  @computed('rulesForNamespace.@each.capabilities')
+  get specificNamespaceSupportsPromoting() {
+    return (
+      this.namespaceIncludesCapability('submit-job') ||
+      this.namespaceIncludesCapability('promote-deployment')
+    );
+  }
+}

--- a/ui/app/abilities/job.js
+++ b/ui/app/abilities/job.js
@@ -40,6 +40,34 @@ export default class Job extends AbstractAbility {
   )
   canDispatch;
 
+  @or(
+    'bypassAuthorization',
+    'selfTokenIsManagement',
+    'specificNamespaceSupportsStopping'
+  )
+  canStop;
+
+  @or(
+    'bypassAuthorization',
+    'selfTokenIsManagement',
+    'specificNamespaceSupportsPurging'
+  )
+  canPurge;
+
+  @or(
+    'bypassAuthorization',
+    'selfTokenIsManagement',
+    'specificNamespaceSupportsReverting'
+  )
+  canRevert;
+
+  @or(
+    'bypassAuthorization',
+    'selfTokenIsManagement',
+    'specificNamespaceSupportsRunning'
+  )
+  canStart;
+
   policyNamespacesIncludePermissions(policies = [], permissions = []) {
     // For each policy record, extract all policies of all namespaces
     const allNamespacePolicies = policies
@@ -63,7 +91,7 @@ export default class Job extends AbstractAbility {
   get policiesSupportRunning() {
     return this.policyNamespacesIncludePermissions(
       this.token.selfTokenPolicies,
-      ['submit-job']
+      ['submit-job', 'register-job']
     );
   }
 
@@ -77,12 +105,32 @@ export default class Job extends AbstractAbility {
 
   @computed('rulesForNamespace.@each.capabilities')
   get specificNamespaceSupportsRunning() {
-    return this.namespaceIncludesCapability('submit-job');
+    return (
+      this.namespaceIncludesCapability('submit-job') ||
+      this.namespaceIncludesCapability('register-job')
+    );
   }
 
   @computed('rulesForNamespace.@each.capabilities')
   get specificNamespaceSupportsReading() {
     return this.namespaceIncludesCapability('read-job');
+  }
+
+  @computed('rulesForNamespace.@each.capabilities')
+  get specificNamespaceSupportsStopping() {
+    return (
+      this.namespaceIncludesCapability('submit-job') ||
+      this.namespaceIncludesCapability('deregister-job') ||
+      this.namespaceIncludesCapability('purge-job')
+    );
+  }
+
+  @computed('rulesForNamespace.@each.capabilities')
+  get specificNamespaceSupportsPurging() {
+    return (
+      this.namespaceIncludesCapability('submit-job') ||
+      this.namespaceIncludesCapability('purge-job')
+    );
   }
 
   @computed('rulesForNamespace.@each.capabilities')
@@ -93,5 +141,13 @@ export default class Job extends AbstractAbility {
   @computed('rulesForNamespace.@each.capabilities')
   get policiesSupportDispatching() {
     return this.namespaceIncludesCapability('dispatch-job');
+  }
+
+  @computed('rulesForNamespace.@each.capabilities')
+  get specificNamespaceSupportsReverting() {
+    return (
+      this.namespaceIncludesCapability('submit-job') ||
+      this.namespaceIncludesCapability('revert-job')
+    );
   }
 }

--- a/ui/app/abilities/version.js
+++ b/ui/app/abilities/version.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright IBM Corp. 2015, 2025
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import AbstractAbility from './abstract';
+import { computed } from '@ember/object';
+import { or } from '@ember/object/computed';
+
+export default class Version extends AbstractAbility {
+  @or(
+    'bypassAuthorization',
+    'selfTokenIsManagement',
+    'specificNamespaceSupportsTagging'
+  )
+  canTag;
+
+  @computed('rulesForNamespace.@each.capabilities')
+  get specificNamespaceSupportsTagging() {
+    return (
+      this.namespaceIncludesCapability('submit-job') ||
+      this.namespaceIncludesCapability('tag-job-version')
+    );
+  }
+}

--- a/ui/app/components/job-page/parts/title.hbs
+++ b/ui/app/components/job-page/parts/title.hbs
@@ -40,6 +40,8 @@
         data-test-stop
         @alignRight={{true}}
         @idleText="Stop Job"
+        @disabled={{not (can "stop job" namespace=this.job.namespace)}}
+        @title={{if (can "stop job" namespace=this.job.namespace) null "You don’t have permission to stop jobs"}}
         @cancelText="Cancel"
         @confirmText="Yes, Stop Job"
         @confirmationMessage="Are you sure you want to stop this job?"
@@ -55,6 +57,8 @@
         data-test-purge
         @alignRight={{true}}
         @idleText="Purge Job"
+        @disabled={{not (can "purge job" namespace=this.job.namespace)}}
+        @title={{if (can "purge job" namespace=this.job.namespace) null "You don’t have permission to purge jobs"}}
         @cancelText="Cancel"
         @confirmText="Yes, Purge Job"
         @confirmationMessage="Are you sure? You cannot undo this action."
@@ -78,6 +82,8 @@
           data-test-start
           @alignRight={{true}}
           @idleText="Start Job"
+          @disabled={{not (can "start job" namespace=this.job.namespace)}}
+          @title={{if (can "start job" namespace=this.job.namespace) null "You don’t have permission to start jobs"}}
           @cancelText="Cancel"
           @confirmText="Yes, Start Job"
           @confirmationMessage="Are you sure you want to start this job?"
@@ -95,6 +101,8 @@
             data-test-revert
             @alignRight={{true}}
             @idleText="Revert to last stable version (v{{this.job.latestStableVersion.number}})"
+            @disabled={{not (can "revert job" namespace=this.job.namespace)}}
+            @title={{if (can "revert job" namespace=this.job.namespace) null "You don’t have permission to revert jobs"}}
             @cancelText="Cancel"
             @confirmText="Yes, Revert to last stable version"
             @confirmationMessage="Are you sure you want to revert to the last stable version?"

--- a/ui/app/components/job-status/panel/deploying.hbs
+++ b/ui/app/components/job-status/panel/deploying.hbs
@@ -13,18 +13,20 @@
         </h2>
         <div class="pull-right">
           {{#if @job.latestDeployment.isRunning}}
-            <Hds::Button
-              data-test-fail
-              {{on "click" (perform this.fail)}}
-              disabled={{this.fail.isRunning}}
-              @color="critical"
-              @text="Fail Deployment"
-              {{keyboard-shortcut
-                label="Fail Deployment"
-                pattern=(array "f" "a" "i" "l")
-                action=(perform this.fail)
-              }}
-            />
+            {{#if (can "fail deployment" namespace=@job.namespace)}}
+              <Hds::Button
+                data-test-fail
+                {{on "click" (perform this.fail)}}
+                disabled={{this.fail.isRunning}}
+                @color="critical"
+                @text="Fail Deployment"
+                {{keyboard-shortcut
+                  label="Fail Deployment"
+                  pattern=(array "f" "a" "i" "l")
+                  action=(perform this.fail)
+                }}
+              />
+            {{/if}}
           {{/if}}
         </div>
       </div>
@@ -36,12 +38,14 @@
             <Hds::Alert @type="inline" @color="warning" as |A|>
               <A.Title>Deployment requires promotion</A.Title>
               <A.Description>Your deployment requires manual promotion — all canary allocations have passed their health checks.</A.Description>
+              {{#if (can "promote deployment" namespace=@job.namespace)}}
               <A.Button
                 {{keyboard-shortcut
                   pattern=(array "p" "r" "o" "m" "o" "t" "e")
                   action=(action (perform this.promote))
                 }}
                 data-test-promote-canary @text="Promote Canary" @color="primary" {{on "click" (perform this.promote)}} />
+                {{/if}}
             </Hds::Alert>
           {{else}}
             {{#if this.someCanariesHaveFailed}}

--- a/ui/app/components/job-version.hbs
+++ b/ui/app/components/job-version.hbs
@@ -77,7 +77,18 @@
           {{#if this.version.versionTag}}
             <Hds::Button class="tag-button-primary" @text={{this.version.versionTag.name}} @color="primary" @size="small" @icon="tag" @iconPosition="leading" @isInline={{true}} {{on "click" (action "toggleEditTag")}} />
           {{else}}
-            <Hds::Button class="tag-button-secondary" @text="Tag this version" @color="secondary" @size="small" @icon="tag" @iconPosition="leading" @isInline={{true}} {{on "click" (action "toggleEditTag")}} />
+            {{#if (can "tag version" namespace=this.version.job.namespace)}}
+              <Hds::Button 
+                data-test-version-tag
+                class="tag-button-secondary" 
+                @text="Tag this version" 
+                @color="secondary" 
+                @size="small" 
+                @icon="tag" 
+                @iconPosition="leading" 
+                @isInline={{true}} {{on "click" (action "toggleEditTag")}} 
+              />
+            {{/if}}
           {{/if}}
           <span class="tag-description" title={{this.version.versionTag.description}}>
               {{this.version.versionTag.description}}
@@ -85,8 +96,8 @@
         </div>
         <div class="version-options">
           {{#unless this.isCurrent}}
-            {{#if (can "run job" namespace=this.version.job.namespace)}}
-              {{#if (eq this.cloneButtonStatus 'idle')}}
+            {{#if (eq this.cloneButtonStatus 'idle')}}
+              {{#if (can "run job")}}
                 <Hds::Button
                   data-test-clone-and-edit
                   @text="Clone and Edit"
@@ -95,7 +106,7 @@
                   @isInline={{true}}
                   {{on "click" (action (mut this.cloneButtonStatus) "confirming")}}
                 />
-
+              {{/if}}
                 <TwoStepButton
                   data-test-revert-to
                   @classes={{hash
@@ -103,6 +114,8 @@
                     confirmButton="is-warning"}}
                   @fadingBackground={{true}}
                   @idleText="Revert Version"
+                  @disabled={{not (can "revert job" namespace=this.version.job.namespace)}}
+                  @title={{if (can "revert job" namespace=this.version.job.namespace) null "You don’t have permission to revert"}}
                   @cancelText="Cancel"
                   @confirmText="Yes, Revert Version"
                   @confirmationMessage="Are you sure you want to revert to this version?"
@@ -120,14 +133,16 @@
                   @isInline={{true}}
                   {{on "click" (action (mut this.cloneButtonStatus) "idle")}}
                 />
-                <Hds::Button
-                  data-test-clone-as-new-version
-                  @text="Clone as New Version of {{this.version.job.name}}"
-                  @color="secondary"
-                  @size="small"
-                  @isInline={{true}}
-                  {{on "click" (action this.cloneAsNewVersion)}}
-                />
+                {{#if (can "start job" namespace=this.version.job.namespace)}}
+                  <Hds::Button
+                    data-test-clone-as-new-version
+                    @text="Clone as New Version of {{this.version.job.name}}"
+                    @color="secondary"
+                    @size="small"
+                    @isInline={{true}}
+                    {{on "click" (action this.cloneAsNewVersion)}}
+                  />
+                {{/if}}
                 <Hds::Button
                   data-test-clone-as-new-job
                   @text="Clone as New Job"
@@ -136,18 +151,6 @@
                   @isInline={{true}}
                   {{on "click" (action this.cloneAsNewJob)}}
                 />
-              {{/if}}
-            {{else}}
-              <Hds::Button
-                data-test-revert-to
-                class="is-fixed-width"
-                disabled
-                @size="small"
-                @color="secondary"
-                @isInline={{true}}
-                @text="Revert"
-                title="You don’t have permission to revert"
-              />
             {{/if}}
           {{/unless}}
         </div>

--- a/ui/app/components/two-step-button.hbs
+++ b/ui/app/components/two-step-button.hbs
@@ -10,6 +10,7 @@
     @text={{@idleText}}
     @color="critical"
     disabled={{@disabled}}
+    title={{@title}}
     {{on "click" this.promptForConfirmation}}
   />
 {{else if this.isPendingConfirmation}}

--- a/ui/app/components/two-step-button.js
+++ b/ui/app/components/two-step-button.js
@@ -27,6 +27,7 @@ export default class TwoStepButton extends Component {
   disabled = false;
   alignRight = false;
   inlineText = false;
+  title = '';
   onConfirm() {}
   onCancel() {}
   onPrompt() {}

--- a/ui/tests/acceptance/job-versions-test.js
+++ b/ui/tests/acceptance/job-versions-test.js
@@ -486,56 +486,104 @@ module('Acceptance | job versions (clone and edit)', function (hooks) {
 module('Acceptance | job versions (with client token)', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
+  let namespace2;
+  let namespace3;
+  let job2;
+  let job3;
 
   hooks.beforeEach(async function () {
     server.create('node-pool');
-    job = server.create('job', { createAllocations: false });
-    versions = server.db.jobVersions.where({ jobId: job.id });
-
+    server.create('namespace');
     server.create('token');
-    const clientToken = server.create('token');
-    window.localStorage.nomadTokenSecret = clientToken.secretId;
+    namespace = server.create('namespace');
 
-    await Versions.visit({ id: job.id });
-  });
-
-  test('reversion buttons are disabled when the token lacks permissions', async function (assert) {
-    const versionRowWithReversion = Versions.versions.filter(
-      (versionRow) => versionRow.revertToButton.isPresent
-    )[0];
-
-    if (versionRowWithReversion) {
-      assert.ok(versionRowWithReversion.revertToButtonIsDisabled);
-    } else {
-      assert.expect(0);
-    }
-
-    window.localStorage.clear();
-  });
-
-  test('reversion buttons are available when the client token has permissions', async function (assert) {
-    const REVERT_NAMESPACE = 'revert-namespace';
-    window.localStorage.clear();
-    const clientToken = server.create('token');
-
-    server.create('namespace', { id: REVERT_NAMESPACE });
-
-    const job = server.create('job', {
-      groupCount: 0,
+    job = server.create('job', {
+      namespaceId: namespace.id,
       createAllocations: false,
-      shallow: true,
-      noActiveDeployment: true,
-      namespaceId: REVERT_NAMESPACE,
+      noDeployments: true,
+      type: 'service',
     });
 
+    // Create some versions
+    server.create('job-version', {
+      job: job,
+      version: 0,
+    });
+    server.create('job-version', {
+      job: job,
+      version: 1,
+      versionTag: {
+        Name: 'test-tag',
+        Description: 'A tag with a brief description',
+      },
+    });
+
+    namespace2 = server.create('namespace');
+    job2 = server.create('job', {
+      namespaceId: namespace2.id,
+      createAllocations: false,
+      noDeployments: true,
+      type: 'service',
+    });
+
+    // Create job2 versions
+    server.create('job-version', {
+      job: job2,
+      version: 0,
+    });
+    server.create('job-version', {
+      job: job2,
+      version: 1,
+      versionTag: {
+        Name: 'test-tag',
+        Description: 'A tag with a brief description',
+      },
+    });
+
+    namespace3 = server.create('namespace');
+    job3 = server.create('job', {
+      namespaceId: namespace3.id,
+      createAllocations: false,
+      noDeployments: true,
+      type: 'service',
+    });
+
+    // Create job3 versions
+    server.create('job-version', {
+      job: job3,
+      version: 0,
+    });
+    server.create('job-version', {
+      job: job3,
+      version: 1,
+      versionTag: {
+        Name: 'test-tag',
+        Description: 'A tag with a brief description',
+      },
+    });
+  });
+
+  test('Revert buttons are disabled when the token lacks permissions', async function (assert) {
+    window.localStorage.clear();
+
+    const clientToken = server.create('token');
+
     const policy = server.create('policy', {
-      id: 'something',
-      name: 'something',
+      id: 'revert-policy',
+      name: 'revert-policy',
       rulesJSON: {
         Namespaces: [
           {
-            Name: REVERT_NAMESPACE,
+            Name: namespace.id,
             Capabilities: ['submit-job'],
+          },
+          {
+            Name: namespace2.id,
+            Capabilities: ['revert-job'],
+          },
+          {
+            Name: namespace2.id,
+            Capabilities: ['read-job'],
           },
         ],
       },
@@ -546,16 +594,229 @@ module('Acceptance | job versions (with client token)', function (hooks) {
 
     window.localStorage.nomadTokenSecret = clientToken.secretId;
 
-    versions = server.db.jobVersions.where({ jobId: job.id });
-    await Versions.visit({ id: job.id, namespace: REVERT_NAMESPACE });
-    const versionRowWithReversion = Versions.versions.filter(
-      (versionRow) => versionRow.revertToButton.isPresent
-    )[0];
+    await Versions.visit({ id: `${job.id}@${namespace.id}` });
+    Versions.versions.forEach((versionRow) => {
+      if (versionRow.number === job.version) {
+        assert.ok(versionRow.revertToButton.isHidden);
+      } else {
+        assert.ok(versionRow.revertToButton.isPresent);
+        assert.notOk(versionRow.revertToButton.isDisabled);
+      }
+    });
 
-    if (versionRowWithReversion) {
-      assert.ok(versionRowWithReversion.revertToButtonIsDisabled);
-    } else {
-      assert.expect(0);
-    }
+    await Versions.visit({ id: `${job2.id}@${namespace2.id}` });
+    Versions.versions.forEach((versionRow) => {
+      if (versionRow.number === job.version) {
+        assert.ok(versionRow.revertToButton.isHidden);
+      } else {
+        assert.ok(versionRow.revertToButton.isPresent);
+        assert.notOk(versionRow.revertToButton.isDisabled);
+      }
+    });
+
+    await Versions.visit({ id: `${job3.id}@${namespace3.id}` });
+    Versions.versions.forEach((versionRow) => {
+      if (versionRow.number === job.version) {
+        assert.ok(versionRow.revertToButton.isHidden);
+      } else {
+        assert.ok(versionRow.revertToButton.isPresent);
+        assert.ok(versionRow.revertToButton.isDisabled);
+      }
+    });
+  });
+
+  test('Clone buttons are removed when the token lacks job-register permissions', async function (assert) {
+    window.localStorage.clear();
+
+    const clientToken = server.create('token');
+
+    const policy = server.create('policy', {
+      id: 'clone-policy',
+      name: 'clone-policy',
+      rulesJSON: {
+        Namespaces: [
+          {
+            Name: '*',
+            Capabilities: ['read-job'],
+          },
+        ],
+      },
+    });
+
+    clientToken.policyIds = [policy.id];
+    clientToken.save();
+
+    window.localStorage.nomadTokenSecret = clientToken.secretId;
+
+    await Versions.visit({ id: `${job.id}@${namespace.id}` });
+    assert
+      .dom('[data-test-clone-and-edit]')
+      .doesNotExist(
+        'Current job version should not have clone or revert buttons'
+      );
+  });
+
+  test('Clone/Edit buttons are removed depending on client token permissions', async function (assert) {
+    window.localStorage.clear();
+
+    const clientToken = server.create('token');
+    const policy = server.create('policy', {
+      id: 'clone-policy',
+      name: 'clone-policy',
+      rulesJSON: {
+        Namespaces: [
+          {
+            Name: namespace.id,
+            Capabilities: ['submit-job'],
+          },
+          {
+            Name: namespace2.id,
+            Capabilities: ['register-job'],
+          },
+          {
+            Name: namespace2.id,
+            Capabilities: ['read-job'],
+          },
+        ],
+      },
+    });
+
+    clientToken.policyIds = [policy.id];
+    clientToken.save();
+
+    window.localStorage.nomadTokenSecret = clientToken.secretId;
+
+    await Versions.visit({ id: `${job.id}@${namespace.id}` });
+    assert
+      .dom('[data-test-clone-and-edit]')
+      .exists('Current job version should have clone or revert buttons');
+
+    await click(`[data-test-clone-and-edit]`);
+
+    assert
+      .dom(`[data-test-clone-as-new-version]`)
+      .exists(
+        'Confirmation-stage clone-as-new-version button exists after clicking clone and edit'
+      );
+
+    assert
+      .dom(`[data-test-clone-as-new-job]`)
+      .exists(
+        'Confirmation-stage clone-as-new-job button exists after clicking clone and edit'
+      );
+
+    await Versions.visit({ id: `${job2.id}@${namespace2.id}` });
+    assert
+      .dom('[data-test-clone-and-edit]')
+      .exists('Current job version should have clone or revert buttons');
+
+    await click(`[data-test-clone-and-edit]`);
+
+    assert
+      .dom(`[data-test-clone-as-new-version]`)
+      .exists(
+        'Confirmation-stage clone-as-new-version button exists after clicking clone and edit'
+      );
+
+    assert
+      .dom(`[data-test-clone-as-new-job]`)
+      .exists(
+        'Confirmation-stage clone-as-new-job button exists after clicking clone and edit'
+      );
+
+    await Versions.visit({ id: `${job3.id}@${namespace3.id}` });
+    assert
+      .dom('[data-test-clone-and-edit]')
+      .exists('Current job version does have clone or revert buttons');
+
+    await click(`[data-test-clone-and-edit]`);
+
+    assert
+      .dom(`[data-test-clone-as-new-version]`)
+      .doesNotExist(
+        'Confirmation-stage clone-as-new-version button does not exist after clicking clone and edit'
+      );
+
+    assert
+      .dom(`[data-test-clone-as-new-job]`)
+      .exists(
+        'Confirmation-stage clone-as-new-job button exists after clicking clone and edit'
+      );
+  });
+
+  test('Tag Version buttons are removed depending on client token permissions', async function (assert) {
+    window.localStorage.clear();
+
+    const clientToken = server.create('token');
+    const policy = server.create('policy', {
+      id: 'clone-policy',
+      name: 'clone-policy',
+      rulesJSON: {
+        Namespaces: [
+          {
+            Name: namespace.id,
+            Capabilities: ['submit-job'],
+          },
+          {
+            Name: namespace2.id,
+            Capabilities: ['tag-job-version'],
+          },
+          {
+            Name: namespace2.id,
+            Capabilities: ['read-job'],
+          },
+        ],
+      },
+    });
+
+    clientToken.policyIds = [policy.id];
+    clientToken.save();
+
+    window.localStorage.nomadTokenSecret = clientToken.secretId;
+
+    await Versions.visit({ id: `${job.id}@${namespace.id}` });
+    assert.dom('[data-test-tagged-version="true"]').exists();
+    assert.dom('[data-test-tagged-version="false"]').exists();
+
+    assert
+      .dom('[data-test-tagged-version="true"] .tag-button-primary')
+      .hasText('test-tag');
+    assert
+      .dom('[data-test-tagged-version="true"] .tag-description')
+      .hasText('A tag with a brief description');
+
+    assert
+      .dom('[data-test-tagged-version="false"] [data-test-version-tag]')
+      .exists();
+
+    await Versions.visit({ id: `${job2.id}@${namespace2.id}` });
+    assert.dom('[data-test-tagged-version="true"]').exists();
+    assert.dom('[data-test-tagged-version="false"]').exists();
+
+    assert
+      .dom('[data-test-tagged-version="true"] .tag-button-primary')
+      .hasText('test-tag');
+    assert
+      .dom('[data-test-tagged-version="true"] .tag-description')
+      .hasText('A tag with a brief description');
+
+    assert
+      .dom('[data-test-tagged-version="false"] [data-test-version-tag]')
+      .exists();
+
+    await Versions.visit({ id: `${job3.id}@${namespace3.id}` });
+    assert.dom('[data-test-tagged-version="true"]').exists();
+    assert.dom('[data-test-tagged-version="false"]').exists();
+
+    assert
+      .dom('[data-test-tagged-version="true"] .tag-button-primary')
+      .hasText('test-tag');
+    assert
+      .dom('[data-test-tagged-version="true"] .tag-description')
+      .hasText('A tag with a brief description');
+
+    assert
+      .dom('[data-test-tagged-version="false"] [data-test-version-tag]')
+      .doesNotExist();
   });
 });

--- a/ui/tests/integration/components/job-page/service-test.js
+++ b/ui/tests/integration/components/job-page/service-test.js
@@ -13,7 +13,6 @@ import {
   startJob,
   stopJob,
   purgeJob,
-  expectError,
   expectDeleteRequest,
   expectStartRequest,
   expectPurgeRequest,
@@ -29,10 +28,13 @@ module('Integration | Component | job-page/service', function (hooks) {
     fragmentSerializerInitializer(this.owner);
     window.localStorage.clear();
     this.store = this.owner.lookup('service:store');
+    this.token = this.owner.lookup('service:token');
     this.server = startMirage();
     this.server.create('namespace');
     this.server.create('node-pool');
     this.server.create('node');
+    let managementToken = this.server.create('token');
+    window.localStorage.nomadTokenSecret = managementToken.secretId;
   });
 
   hooks.afterEach(function () {
@@ -78,6 +80,8 @@ module('Integration | Component | job-page/service', function (hooks) {
   test('Stopping a job sends a delete request for the job', async function (assert) {
     assert.expect(1);
 
+    this.token.fetchSelfTokenAndPolicies.perform();
+
     const mirageJob = makeMirageJob(this.server);
     await this.store.findAll('job');
 
@@ -90,8 +94,8 @@ module('Integration | Component | job-page/service', function (hooks) {
     expectDeleteRequest(assert, this.server, job);
   });
 
-  test('Stopping a job without proper permissions shows an error message', async function (assert) {
-    assert.expect(4);
+  test('Stopping a job without proper permissions disables the button', async function (assert) {
+    assert.expect(2);
 
     this.server.pretender.delete('/v1/job/:id', () => [403, {}, '']);
 
@@ -103,14 +107,17 @@ module('Integration | Component | job-page/service', function (hooks) {
     this.setProperties(commonProperties(job));
     await render(commonTemplate);
 
-    await stopJob();
-    expectError(assert, 'Could Not Stop Job');
+    assert.ok(
+      find('[data-test-stop] [data-test-idle-button]').hasAttribute('disabled')
+    );
 
     await componentA11yAudit(this.element, assert);
   });
 
   test('Starting a job sends a post request for the job using the current definition', async function (assert) {
     assert.expect(1);
+
+    this.token.fetchSelfTokenAndPolicies.perform();
 
     const mirageJob = makeMirageJob(this.server, {
       status: 'dead',
@@ -128,8 +135,8 @@ module('Integration | Component | job-page/service', function (hooks) {
     expectStartRequest(assert, this.server, job);
   });
 
-  test('Starting a job without proper permissions shows an error message', async function (assert) {
-    assert.expect(3);
+  test('Starting a job without proper permissions disables the button', async function (assert) {
+    assert.expect(1);
 
     this.server.pretender.post('/v1/job/:id', () => [403, {}, '']);
 
@@ -145,12 +152,15 @@ module('Integration | Component | job-page/service', function (hooks) {
     this.setProperties(commonProperties(job));
     await render(commonTemplate);
 
-    await startJob();
-    await expectError(assert, 'Could Not Start Job');
+    assert.ok(
+      find('[data-test-start] [data-test-idle-button]').hasAttribute('disabled')
+    );
   });
 
   test('Purging a job sends a purge request for the job', async function (assert) {
     assert.expect(1);
+
+    this.token.fetchSelfTokenAndPolicies.perform();
 
     const mirageJob = makeMirageJob(this.server, {
       status: 'dead',
@@ -236,6 +246,7 @@ module('Integration | Component | job-page/service', function (hooks) {
 
   test('Active deployment can be promoted', async function (assert) {
     this.server.create('node');
+    this.token.fetchSelfTokenAndPolicies.perform();
     const mirageJob = makeMirageJob(this.server, { activeDeployment: true });
 
     const fullId = JSON.stringify([mirageJob.name, 'default']);
@@ -274,7 +285,7 @@ module('Integration | Component | job-page/service', function (hooks) {
 
   test('When promoting the active deployment fails, an error is shown', async function (assert) {
     assert.expect(4);
-
+    this.token.fetchSelfTokenAndPolicies.perform();
     this.server.pretender.post('/v1/deployment/promote/:id', () => [
       403,
       {},
@@ -335,6 +346,7 @@ module('Integration | Component | job-page/service', function (hooks) {
 
   test('Active deployment can be failed', async function (assert) {
     this.server.create('node');
+    this.token.fetchSelfTokenAndPolicies.perform();
     const mirageJob = makeMirageJob(this.server, { activeDeployment: true });
 
     await this.store.findAll('job');
@@ -359,7 +371,7 @@ module('Integration | Component | job-page/service', function (hooks) {
 
   test('When failing the active deployment fails, an error is shown', async function (assert) {
     assert.expect(4);
-
+    this.token.fetchSelfTokenAndPolicies.perform();
     this.server.pretender.post('/v1/deployment/fail/:id', () => [403, {}, '']);
 
     this.server.create('node');


### PR DESCRIPTION
### Description
Splits the capabilities given by `submit-job` into fine-grain capabilities, so they can be combined to provide access to any combination of permissions. This doesn't change anything about the current `submit-job` capability, only adds more specific permissions that explicitly map to the RPCs. 

The `Job.Deregister` RPC capability has been split into two different capabilities: one allowing just deregistering the job, and one that allows purging or deregistering the job. 

| Permission | RPC |
| --- | --- |
"register-job" | Job.Register 
"revert-job" | Job.Revert
"deregister-job" | Job.Deregister without `purge: true`
"purge-job" | Job.Deregister
"evaluate-job" | Job.Evaluation
 "plan-job" | Job.Plan
"tag-job-version" | Job.TagVersion
"stable-job" | Job.Stable
"fail-deployment" | Deployment.Fail
"pause-deployment" | Deployment.Pause
"promote-deployment" | Deployment.Promote
"unblock-deployment" | Deployment.Unblock
"cancel-deployment" | Deployment.Cancel 
"set-alloc-health-deployment" | Deployment.SetAllocHealth
"pause-allocation" | Allocations.SetPauseState
"gc-allocation" | Allocations.GarbageCollect
"force-periodic-job" | Periodic.Force 
"delete-service-registration" | ServiceRegistration.DeleteById |

This change will require updates to the UI, to be made in another PR,  and updates to the documentation.

### Testing & Reproduction steps
Tests were updated where they were already testing the ACLs, and new tests were added for RPCs that didn't have them. 

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Internal ref: https://hashicorp.atlassian.net/browse/NMD-905
Fixes: https://github.com/hashicorp/nomad/issues/4742

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
