### PR TITLE
fix: Validate the existence of configured volume paths on an OS 

### DIFF
--- a/.changelog/27288.txt
+++ b/.changelog/27288.txt
@@ -1,3 +1,3 @@
-```release-note:bug
-fix: Validate the existence of configured volume paths on an OS
+```release-note:improvement
+cli: The `nomad config validate` command now validates the existence of configured host volume paths
 ```

--- a/.changelog/27288.txt
+++ b/.changelog/27288.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+fix: Validate the existence of configured volume paths on an OS
+```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright (c) HashiCorp, Inc.
 // SPDX-License-Identifier: BUSL-1.1
 
 package agent
@@ -446,6 +446,15 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 			c.Ui.Error("Missing path in host_volume config")
 			return false
 		}
+		fileInfo, err := os.Stat(volumeConfig.Path)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return false
+		}
+		if !fileInfo.IsDir() {
+			c.Ui.Error(fmt.Sprintf("Host volume %s is not a directory", volumeConfig.Path))
+			return false
+		}
 	}
 
 	if config.Client.MinDynamicPort < 0 || config.Client.MinDynamicPort > structs.MaxValidPort {
@@ -573,7 +582,6 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 // The function needs to be public due to the way it is used within the Nomad
 // Enterprise codebase.
 func SetupLoggers(ui cli.Ui, config *Config) (*gatedwriter.Writer, io.Writer) {
-
 	// Pull the log level from the configuration, ensure it is titled and then
 	// perform validation. Do this before the gated writer, as this can
 	// generate an error, whereas the writer does not.
@@ -1254,7 +1262,6 @@ func (c *Command) handleReload() error {
 
 // setupTelemetry is used to set up the telemetry sub-systems.
 func (c *Command) setupTelemetry(config *Config) (*metrics.InmemSink, error) {
-
 	var telConfig *Telemetry
 	if config.Telemetry == nil {
 		telConfig = &Telemetry{}

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -446,13 +446,9 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 			c.Ui.Error("Missing path in host_volume config")
 			return false
 		}
-		fileInfo, err := os.Stat(volumeConfig.Path)
+		_, err := os.Stat(volumeConfig.Path)
 		if err != nil {
 			c.Ui.Error(err.Error())
-			return false
-		}
-		if !fileInfo.IsDir() {
-			c.Ui.Error(fmt.Sprintf("Host volume %s is not a directory", volumeConfig.Path))
 			return false
 		}
 	}

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2015, 2025
 // SPDX-License-Identifier: BUSL-1.1
 
 package agent
@@ -578,6 +578,7 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 // The function needs to be public due to the way it is used within the Nomad
 // Enterprise codebase.
 func SetupLoggers(ui cli.Ui, config *Config) (*gatedwriter.Writer, io.Writer) {
+
 	// Pull the log level from the configuration, ensure it is titled and then
 	// perform validation. Do this before the gated writer, as this can
 	// generate an error, whereas the writer does not.
@@ -1258,6 +1259,7 @@ func (c *Command) handleReload() error {
 
 // setupTelemetry is used to set up the telemetry sub-systems.
 func (c *Command) setupTelemetry(config *Config) (*metrics.InmemSink, error) {
+
 	var telConfig *Telemetry
 	if config.Telemetry == nil {
 		telConfig = &Telemetry{}

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -446,8 +446,7 @@ func (c *Command) IsValidConfig(config, cmdConfig *Config) bool {
 			c.Ui.Error("Missing path in host_volume config")
 			return false
 		}
-		_, err := os.Stat(volumeConfig.Path)
-		if err != nil {
+		if _, err := os.Stat(volumeConfig.Path); err != nil {
 			c.Ui.Error(err.Error())
 			return false
 		}

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -264,13 +264,11 @@ func TestIsValidConfig(t *testing.T) {
 	ci.Parallel(t)
 
 	tempDir := t.TempDir()
-	dirPath1 := filepath.Join(tempDir, "path1")
-	dirPath2 := filepath.Join(tempDir, "path2")
+	dirPath := filepath.Join(tempDir, "path1")
 	filePath := filepath.Join(tempDir, "afile")
-	nonExistingDir := filepath.Join(tempDir, "non_existing_dir")
+	nonExistingPath := filepath.Join(tempDir, "non_existing_path")
 
-	os.Mkdir(dirPath1, 0o755)
-	os.Mkdir(dirPath2, 0o755)
+	os.Mkdir(dirPath, 0o755)
 	// We just need it created, no need to have open descriptor.
 	// TODO: Properly fail test on error
 	fd, _ := os.Create(filePath)
@@ -481,41 +479,8 @@ func TestIsValidConfig(t *testing.T) {
 						{
 							Name:     "test",
 							ReadOnly: true,
-							Path:     dirPath1,
+							Path:     dirPath,
 						},
-						{
-							Name:     "test",
-							ReadOnly: true,
-							Path:     dirPath2,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "MissingVolumeDirectory",
-			conf: Config{
-				DataDir: "/tmp",
-				Client: &ClientConfig{
-					Enabled: true,
-					HostVolumes: []*structs.ClientHostVolumeConfig{
-						{
-							Name:     "test",
-							ReadOnly: true,
-							Path:     nonExistingDir,
-						},
-					},
-				},
-			},
-			err: fmt.Sprintf("stat %s: no such file or directory", nonExistingDir),
-		},
-		{
-			name: "VolumeIsNotDir",
-			conf: Config{
-				DataDir: "/tmp",
-				Client: &ClientConfig{
-					Enabled: true,
-					HostVolumes: []*structs.ClientHostVolumeConfig{
 						{
 							Name:     "test",
 							ReadOnly: true,
@@ -524,7 +489,23 @@ func TestIsValidConfig(t *testing.T) {
 					},
 				},
 			},
-			err: fmt.Sprintf("Host volume %s is not a directory", filePath),
+		},
+		{
+			name: "MissingVolumePath",
+			conf: Config{
+				DataDir: "/tmp",
+				Client: &ClientConfig{
+					Enabled: true,
+					HostVolumes: []*structs.ClientHostVolumeConfig{
+						{
+							Name:     "test",
+							ReadOnly: true,
+							Path:     nonExistingPath,
+						},
+					},
+				},
+			},
+			err: fmt.Sprintf("stat %s: no such file or directory", nonExistingPath),
 		},
 		{
 			name: "BadOIDCIssuer",

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -269,9 +269,9 @@ func TestIsValidConfig(t *testing.T) {
 	nonExistingPath := filepath.Join(tempDir, "non_existing_path")
 
 	os.Mkdir(dirPath, 0o755)
-	// We just need it created, no need to have open descriptor.
-	// TODO: Properly fail test on error
-	fd, _ := os.Create(filePath)
+	fd, err := os.Create(filePath)
+	require.NoError(t, err)
+	// We just need it to exist, no need to have open descriptor.
 	fd.Close()
 
 	cases := []struct {

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -477,12 +477,12 @@ func TestIsValidConfig(t *testing.T) {
 					Enabled: true,
 					HostVolumes: []*structs.ClientHostVolumeConfig{
 						{
-							Name:     "test",
+							Name:     "directoryVolume",
 							ReadOnly: true,
 							Path:     dirPath,
 						},
 						{
-							Name:     "test",
+							Name:     "fileVolume",
 							ReadOnly: true,
 							Path:     filePath,
 						},
@@ -498,7 +498,7 @@ func TestIsValidConfig(t *testing.T) {
 					Enabled: true,
 					HostVolumes: []*structs.ClientHostVolumeConfig{
 						{
-							Name:     "test",
+							Name:     "missingVolume",
 							ReadOnly: true,
 							Path:     nonExistingPath,
 						},

--- a/command/agent/command_test.go
+++ b/command/agent/command_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) HashiCorp, Inc.
+// Copyright IBM Corp. 2015, 2025
 // SPDX-License-Identifier: BUSL-1.1
 
 package agent
@@ -131,7 +131,7 @@ func TestCommand_MetaConfigValidation(t *testing.T) {
 				"nested.var" = "is nested"
 				"deeply.nested.var" = "is deeply nested"
 			}
-    	}`), 0o600)
+    	}`), 0600)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -181,7 +181,7 @@ func TestCommand_InvalidCharInDatacenter(t *testing.T) {
         datacenter = "`+tc+`"
         client{
 			enabled = true
-    	}`), 0o600)
+    	}`), 0600)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -228,7 +228,7 @@ func TestCommand_NullCharInRegion(t *testing.T) {
         region = "`+tc+`"
         client{
 			enabled = true
-    	}`), 0o600)
+    	}`), 0600)
 		if err != nil {
 			t.Fatalf("err: %s", err)
 		}
@@ -427,7 +427,7 @@ func TestIsValidConfig(t *testing.T) {
 				Client: &ClientConfig{
 					Enabled: true,
 					HostNetworks: []*structs.ClientHostNetworkConfig{
-						{
+						&structs.ClientHostNetworkConfig{
 							Name:          "test",
 							ReservedPorts: "3-2147483647",
 						},
@@ -490,7 +490,7 @@ func TestIsValidConfig(t *testing.T) {
 				},
 			},
 		},
-		{
+	{
 			name: "MissingVolumePath",
 			conf: Config{
 				DataDir: "/tmp",
@@ -620,7 +620,7 @@ vault {
 
 	configDir := t.TempDir()
 	for k, v := range configFiles {
-		err := os.WriteFile(path.Join(configDir, k), []byte(v), 0o644)
+		err := os.WriteFile(path.Join(configDir, k), []byte(v), 0644)
 		must.NoError(t, err)
 	}
 
@@ -696,6 +696,7 @@ vault {
 }
 
 func TestCommand_readConfig_clientIntroToken(t *testing.T) {
+
 	t.Run("env var", func(t *testing.T) {
 		t.Setenv("NOMAD_CLIENT_INTRO_TOKEN", "test-intro-token")
 
@@ -723,6 +724,7 @@ func TestCommand_readConfig_clientIntroToken(t *testing.T) {
 }
 
 func Test_setupLoggers_logFile(t *testing.T) {
+
 	// Generate a mock UI and temporary log file location to write to.
 	mockUI := cli.NewMockUi()
 	logFile := filepath.Join(t.TempDir(), "nomad.log")


### PR DESCRIPTION
### Description
This PR adds simple validation for existence of configured `host_volume` path on OS, where `nomad config validate` is run.

### Testing & Reproduction steps

Without the fix, the validation of config:

```hcl
data_dir  = "/var/lib/nomad"

client {
  enabled       = true

  host_volume "avolume" {
    path = "/tmp/avolume"
  }
}
```

Runs successfully whether the file exists or not:
```
$ nomad config validate /tmp/config.hcl    
WARNING: mTLS is not configured - Nomad is not secure without mTLS!
Configuration is valid!
```

With the patch, it results in an error:
```
$ ./nomad-build config validate /tmp/config.hcl
WARNING: mTLS is not configured - Nomad is not secure without mTLS!
stat /tmp/avolume: no such file or directory
Configuration is invalid
```

### Links

Fixes: https://github.com/hashicorp/nomad/issues/16968

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

There are no changes to security controls.
