### PR TITLE
client: Fix task env calculation of alloc addr using static ports.

### DIFF
--- a/.changelog/27305.txt
+++ b/.changelog/27305.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed generation of the "NOMAD_ALLOC_ADDR_" environment variable when using static port assignments
+```

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -1067,7 +1067,17 @@ func buildUpstreamsEnv(envMap map[string]string, upstreams []structs.ConsulUpstr
 // from this function.
 func addNomadAllocNetwork(envMap map[string]string, p structs.AllocatedPorts, netStatus *structs.AllocNetworkStatus) {
 	for _, allocatedPort := range p {
-		portStr := strconv.Itoa(allocatedPort.To)
+
+		// Determine the port number of use in the ADDR var which is dependant
+		// on what the operator specified within the network block.
+		var portStr string
+
+		if allocatedPort.To != 0 {
+			portStr = strconv.Itoa(allocatedPort.To)
+		} else {
+			portStr = strconv.Itoa(allocatedPort.Value)
+		}
+
 		envMap[AllocPrefix+"INTERFACE_"+allocatedPort.Label] = netStatus.InterfaceName
 		envMap[AllocPrefix+"IP_"+allocatedPort.Label] = netStatus.Address
 		envMap[AllocPrefix+"ADDR_"+allocatedPort.Label] = net.JoinHostPort(netStatus.Address, portStr)

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -860,6 +860,21 @@ func Test_addNetNamespacePort(t *testing.T) {
 		},
 		{
 			inputPorts: structs.AllocatedPorts{
+				{Label: "http", Value: 80},
+			},
+			inputNetwork: &structs.AllocNetworkStatus{
+				InterfaceName: "eth0",
+				Address:       "172.26.64.11",
+			},
+			expectedOutput: map[string]string{
+				"NOMAD_ALLOC_INTERFACE_http": "eth0",
+				"NOMAD_ALLOC_IP_http":        "172.26.64.11",
+				"NOMAD_ALLOC_ADDR_http":      "172.26.64.11:80",
+			},
+			name: "single static input port",
+		},
+		{
+			inputPorts: structs.AllocatedPorts{
 				{Label: "http", To: 80},
 				{Label: "https", To: 443},
 			},


### PR DESCRIPTION
The "NOMAD_ALLOC_ADDR_" task env var was not correctly generating the value when the allocation used a static port allocation. The resulting env var would always have an address with its port as 0.

The change correctly handles dynamic and static port definitions, so the "NOMAD_ALLOC_ADDR_" is properly formed.

### Testing & Reproduction steps
The following job spec can be used on Linux to observe the behaviour:
```hcl
job "example" {

  group "cache" {
    network {
      mode = "bridge"
      port "db" {
        static = 6379
      }
    }

    task "redis" {
      driver = "docker"

      config {
        image          = "redis:7"
        ports          = ["db"]
        auth_soft_fail = true
      }

      identity {
        env  = true
        file = true
      }

      resources {
        cpu    = 500
        memory = 256
      }
    }
  }
}
```

You can then use the command `nomad alloc exec <alloc_id> env` to query the task environment and identify the incorrect task env var.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

