### PR TITLE
quotas: update quota init command to include node_pool

### DIFF
--- a/command/quota_init.go
+++ b/command/quota_init.go
@@ -130,6 +130,10 @@ limit {
       variables    = 1000   # in MB
       host_volumes = 100000 # in MB
     }
+    node_pool "example" {
+      cpu    = 500
+      memory = 100
+    }
   }
 }
 `)
@@ -155,6 +159,10 @@ var defaultJsonQuotaSpec = strings.TrimSpace(`
         "Storage": {
           "Variables": 1000,
           "HostVolumes": 100000
+        },
+        "NodePool": {
+          "CPU": 500,
+          "MemoryMB": 1000
         }
       }
     }


### PR DESCRIPTION
We should include the new `node_pool` key in the example spec generated by `quota init`. Vide https://github.com/hashicorp/nomad-enterprise/pull/3483