### PR TITLE
state: avoid unnecessary allocation object copies

### DIFF
--- a/.changelog/27311.txt
+++ b/.changelog/27311.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-state: reduce unneded allocation copy when building event payload
+state: avoid unneded allocation copy when building event payload
 ```

--- a/.changelog/27311.txt
+++ b/.changelog/27311.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+state: reduce unneded allocation copy when building event payload
+```

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -107,6 +107,8 @@ func (s *HTTPServer) nodeAllocations(resp http.ResponseWriter, req *http.Request
 	for _, alloc := range out.Allocs {
 		if alloc.SignedIdentities != nil {
 			alloc = alloc.Sanitize()
+		} else {
+			alloc = alloc.Copy()
 		}
 		alloc.SetEventDisplayMessages()
 	}

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -105,11 +105,7 @@ func (s *HTTPServer) nodeAllocations(resp http.ResponseWriter, req *http.Request
 		out.Allocs = make([]*structs.Allocation, 0)
 	}
 	for _, alloc := range out.Allocs {
-		if alloc.SignedIdentities != nil {
-			alloc = alloc.Sanitize()
-		} else {
-			alloc = alloc.Copy()
-		}
+		alloc = alloc.Sanitize()
 		alloc.SetEventDisplayMessages()
 	}
 	return out.Allocs, nil

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -105,7 +105,9 @@ func (s *HTTPServer) nodeAllocations(resp http.ResponseWriter, req *http.Request
 		out.Allocs = make([]*structs.Allocation, 0)
 	}
 	for _, alloc := range out.Allocs {
-		alloc = alloc.Sanitize()
+		if alloc.SignedIdentities != nil {
+			alloc = alloc.Sanitize()
+		}
 		alloc.SetEventDisplayMessages()
 	}
 	return out.Allocs, nil

--- a/command/agent/node_endpoint.go
+++ b/command/agent/node_endpoint.go
@@ -104,11 +104,14 @@ func (s *HTTPServer) nodeAllocations(resp http.ResponseWriter, req *http.Request
 	if out.Allocs == nil {
 		out.Allocs = make([]*structs.Allocation, 0)
 	}
+
+	sanitizedAllocs := []*structs.Allocation{}
 	for _, alloc := range out.Allocs {
 		alloc = alloc.Sanitize()
 		alloc.SetEventDisplayMessages()
+		sanitizedAllocs = append(sanitizedAllocs, alloc)
 	}
-	return out.Allocs, nil
+	return sanitizedAllocs, nil
 }
 
 func (s *HTTPServer) nodeToggleDrain(resp http.ResponseWriter, req *http.Request,

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -159,7 +159,9 @@ func (a *Alloc) GetAlloc(args *structs.AllocSpecificRequest,
 
 			// Setup the output
 			if out != nil {
-				out = out.Sanitize()
+				if out.SignedIdentities != nil {
+					out = out.Sanitize()
+				}
 				reply.Alloc = out
 				// Re-check namespace in case it differs from request.
 				if !aclObj.AllowClientOp() && !allowNsOp(aclObj, out.Namespace) {

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -331,24 +331,19 @@ func eventFromChange(change memdb.Change) (structs.Event, bool) {
 		if !ok {
 			return structs.Event{}, false
 		}
-		alloc := after.Copy()
+		alloc := after.CopySkipJob()
 
 		filterKeys := []string{
 			alloc.JobID,
 			alloc.DeploymentID,
 		}
 
-		// remove job info to help keep size of alloc event down
-		alloc.Job = nil
-
 		return structs.Event{
 			Topic:      structs.TopicAllocation,
 			Key:        after.ID,
 			FilterKeys: filterKeys,
 			Namespace:  after.Namespace,
-			Payload: &structs.AllocationEvent{
-				Allocation: alloc.Sanitize(),
-			},
+			Payload:    &structs.AllocationEvent{alloc},
 		}, true
 	case "jobs":
 		after, ok := change.After.(*structs.Job)

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -331,7 +331,7 @@ func eventFromChange(change memdb.Change) (structs.Event, bool) {
 		if !ok {
 			return structs.Event{}, false
 		}
-		alloc := after.CopySkipJob()
+		alloc := after.CopySkipJobAndSanitize()
 
 		filterKeys := []string{
 			alloc.JobID,

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -338,6 +338,9 @@ func eventFromChange(change memdb.Change) (structs.Event, bool) {
 			alloc.DeploymentID,
 		}
 
+		// remove job info to help keep size of alloc event down
+		alloc.Job = nil
+
 		return structs.Event{
 			Topic:      structs.TopicAllocation,
 			Key:        after.ID,

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -343,7 +343,7 @@ func eventFromChange(change memdb.Change) (structs.Event, bool) {
 			Key:        after.ID,
 			FilterKeys: filterKeys,
 			Namespace:  after.Namespace,
-			Payload:    &structs.AllocationEvent{alloc},
+			Payload:    &structs.AllocationEvent{Allocation: alloc},
 		}, true
 	case "jobs":
 		after, ok := change.After.(*structs.Job)

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -331,7 +331,7 @@ func eventFromChange(change memdb.Change) (structs.Event, bool) {
 		if !ok {
 			return structs.Event{}, false
 		}
-		alloc := after.CopySkipJobAndSanitize()
+		alloc := after.Sanitize()
 
 		filterKeys := []string{
 			alloc.JobID,

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -190,10 +190,6 @@ func (a *Allocation) Sanitize() *Allocation {
 		return nil
 	}
 
-	if a.SignedIdentities == nil {
-		return a
-	}
-
 	clean := a.Copy()
 	clean.SignedIdentities = nil
 	return clean

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -276,12 +276,32 @@ func AllocIndexFromName(allocName, jobID, taskGroup string) uint {
 
 // Copy provides a copy of the allocation and deep copies the job
 func (a *Allocation) Copy() *Allocation {
-	return a.copyImpl(true)
+	return a.copyImpl(true, false)
+}
+
+// CopyAndSanitize provides a copy of the allocation, deep copies the job, and
+// sanitizes the SignedIdentities field
+//
+// WARNING: this method *always* deep copies the allocation. In cases where copy
+// is not necessary, the Sanitize method should be used instead (it returns the
+// original object if SignedIdentities is nil).
+func (a *Allocation) CopyAndSanitize() *Allocation {
+	return a.copyImpl(true, true)
 }
 
 // CopySkipJob provides a copy of the allocation but doesn't deep copy the job
 func (a *Allocation) CopySkipJob() *Allocation {
-	return a.copyImpl(false)
+	return a.copyImpl(false, false)
+}
+
+// CopySkipJobAndSanitize provides a copy of the allocation, doesn't deep copy
+// the job, but sanitizes the SignedIdentities field
+//
+// WARNING: this method *always* copies the allocation. In cases where copy is
+// not necessary, the Sanitize method should be used instead (it returns the
+// original object if SignedIdentities is nil).
+func (a *Allocation) CopySkipJobAndSanitize() *Allocation {
+	return a.copyImpl(false, true)
 }
 
 // Canonicalize Allocation to ensure fields are initialized to the expectations
@@ -314,7 +334,7 @@ func (a *Allocation) Canonicalize() {
 	a.Job.Canonicalize()
 }
 
-func (a *Allocation) copyImpl(job bool) *Allocation {
+func (a *Allocation) copyImpl(job, sanitize bool) *Allocation {
 	if a == nil {
 		return nil
 	}
@@ -323,6 +343,10 @@ func (a *Allocation) copyImpl(job bool) *Allocation {
 
 	if job {
 		na.Job = na.Job.Copy()
+	}
+
+	if sanitize {
+		na.SignedIdentities = nil
 	}
 
 	na.AllocatedResources = na.AllocatedResources.Copy()

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -276,12 +276,12 @@ func AllocIndexFromName(allocName, jobID, taskGroup string) uint {
 
 // Copy provides a copy of the allocation and deep copies the job
 func (a *Allocation) Copy() *Allocation {
-	return a.copyImpl(true, false)
+	return a.copyImpl(true)
 }
 
 // CopySkipJob provides a copy of the allocation but doesn't deep copy the job
 func (a *Allocation) CopySkipJob() *Allocation {
-	return a.copyImpl(false, false)
+	return a.copyImpl(false)
 }
 
 // Canonicalize Allocation to ensure fields are initialized to the expectations
@@ -314,7 +314,7 @@ func (a *Allocation) Canonicalize() {
 	a.Job.Canonicalize()
 }
 
-func (a *Allocation) copyImpl(job, sanitize bool) *Allocation {
+func (a *Allocation) copyImpl(job bool) *Allocation {
 	if a == nil {
 		return nil
 	}
@@ -323,10 +323,6 @@ func (a *Allocation) copyImpl(job, sanitize bool) *Allocation {
 
 	if job {
 		na.Job = na.Job.Copy()
-	}
-
-	if sanitize {
-		na.SignedIdentities = nil
 	}
 
 	na.AllocatedResources = na.AllocatedResources.Copy()

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -194,7 +194,7 @@ func (a *Allocation) Sanitize() *Allocation {
 		return a
 	}
 
-	clean := a.Copy()
+	clean := a.CopySkipJob()
 	clean.SignedIdentities = nil
 	return clean
 }
@@ -282,16 +282,6 @@ func (a *Allocation) Copy() *Allocation {
 // CopySkipJob provides a copy of the allocation but doesn't deep copy the job
 func (a *Allocation) CopySkipJob() *Allocation {
 	return a.copyImpl(false, false)
-}
-
-// CopySkipJobAndSanitize provides a copy of the allocation, doesn't deep copy
-// the job, but sanitizes the SignedIdentities field
-//
-// WARNING: this method *always* copies the allocation. In cases where copy is
-// not necessary, the Sanitize method should be used instead (it returns the
-// original object if SignedIdentities is nil).
-func (a *Allocation) CopySkipJobAndSanitize() *Allocation {
-	return a.copyImpl(false, true)
 }
 
 // Canonicalize Allocation to ensure fields are initialized to the expectations

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -279,16 +279,6 @@ func (a *Allocation) Copy() *Allocation {
 	return a.copyImpl(true, false)
 }
 
-// CopyAndSanitize provides a copy of the allocation, deep copies the job, and
-// sanitizes the SignedIdentities field
-//
-// WARNING: this method *always* deep copies the allocation. In cases where copy
-// is not necessary, the Sanitize method should be used instead (it returns the
-// original object if SignedIdentities is nil).
-func (a *Allocation) CopyAndSanitize() *Allocation {
-	return a.copyImpl(true, true)
-}
-
 // CopySkipJob provides a copy of the allocation but doesn't deep copy the job
 func (a *Allocation) CopySkipJob() *Allocation {
 	return a.copyImpl(false, false)

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -194,7 +194,7 @@ func (a *Allocation) Sanitize() *Allocation {
 		return a
 	}
 
-	clean := a.CopySkipJob()
+	clean := a.Copy()
 	clean.SignedIdentities = nil
 	return clean
 }


### PR DESCRIPTION
While investigating [NMD-1105](https://hashicorp.atlassian.net/browse/NMD-1105) (possible memory leak in the event stream), I noticed that when we copy allocations, we first call the `Copy` method which returns us a deep copy of the object, and then we remove the job information from it to save space. Afterwards, we sanitize the allocation (i.e., we remove the `SignedIdentities` data) and during that operation we perform _another_ copy. 

This changeset doesn't necessarily resolve NMD-1105, but should definitely lower the memory footprint of `eventFromChange`. 

[NMD-1105]: https://hashicorp.atlassian.net/browse/NMD-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ