### PR TITLE
event broker: make sure there are no memory leaks when closing subscriptions

### DIFF
--- a/.changelog/27312.txt
+++ b/.changelog/27312.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+event broker: fix memory leak in methods that close subscriptions
+```

--- a/nomad/stream/event_broker.go
+++ b/nomad/stream/event_broker.go
@@ -246,8 +246,8 @@ func (s *subscriptions) add(req *SubscribeRequest, sub *Subscription) {
 }
 
 func (s *subscriptions) closeSubscriptionsForTokens(tokenSecretIDs []string) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	for _, secretID := range tokenSecretIDs {
 		if subs, ok := s.byToken[secretID]; ok {
@@ -264,8 +264,8 @@ func (s *subscriptions) closeSubscriptionsForTokens(tokenSecretIDs []string) {
 }
 
 func (s *subscriptions) closeSubscriptionFunc(tokenSecretID string, fn func(*Subscription) bool) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
 
 	// early exit
 	subs, ok := s.byToken[tokenSecretID]
@@ -273,7 +273,7 @@ func (s *subscriptions) closeSubscriptionFunc(tokenSecretID string, fn func(*Sub
 		return
 	}
 
-	for req, sub := range s.byToken[tokenSecretID] {
+	for req, sub := range subs {
 		if fn(sub) {
 			sub.forceClose()
 			delete(subs, req)

--- a/nomad/stream/event_broker_test.go
+++ b/nomad/stream/event_broker_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/shoenig/test/must"
-
-	"github.com/stretchr/testify/require"
 )
 
 func TestEventBroker_PublishChangesAndSubscribe(t *testing.T) {
@@ -323,8 +321,8 @@ func assertNoResult(t *testing.T, eventCh <-chan subNextResult) {
 	t.Helper()
 	select {
 	case next := <-eventCh:
-		require.NoError(t, next.Err)
-		require.Len(t, next.Events, 1)
+		must.NoError(t, next.Err)
+		must.Len(t, 1, next.Events)
 		t.Fatalf("received unexpected event: %#v", next.Events[0].Payload)
 	case <-time.After(100 * time.Millisecond):
 	}


### PR DESCRIPTION
While investigating [NMD-1105](https://hashicorp.atlassian.net/browse/NMD-1105), I noticed that the methods for closing subscriptions of the eval broker don't remove subscriptions from map tokens, which hold references to `Subscription` objects. Only `unsubscribeFn` removed entries correctly, but that only gets called when users unsubscribe explicitly. 

Internal ref: https://hashicorp.atlassian.net/browse/NMD-1105

[NMD-1105]: https://hashicorp.atlassian.net/browse/NMD-1105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ