### PR TITLE
api: fix allocation stats to exclude non running tasks from usage

### DIFF
--- a/.changelog/27317.txt
+++ b/.changelog/27317.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: only include running tasks in allocation resource usage
+```

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -1314,9 +1314,11 @@ func (ar *allocRunner) LatestAllocStats(taskFilter string) (*cstructs.AllocResou
 
 		if usage := tr.LatestResourceUsage(); usage != nil {
 			astat.Tasks[name] = usage
-			astat.ResourceUsage.Add(usage.ResourceUsage)
-			if usage.Timestamp > astat.Timestamp {
-				astat.Timestamp = usage.Timestamp
+			if tr.IsRunning() {
+				astat.ResourceUsage.Add(usage.ResourceUsage)
+				if usage.Timestamp > astat.Timestamp {
+					astat.Timestamp = usage.Timestamp
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
That allocation stats endpoint should not include stats from non running/completed tasks in it's current resource usage metrics. These changes exclude adding the latest stats if the task is not running.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
Run a job with a prestart task that takes a lot of CPU or memory (ex. `stress-ng`). Have main task sleep. See that allocation resource usage is still very high.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes #27294

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
