### PR TITLE
state store: add alloc and volume id's to CSI claim error

### DIFF
--- a/nomad/csi_endpoint_test.go
+++ b/nomad/csi_endpoint_test.go
@@ -447,7 +447,7 @@ func TestCSIVolumeEndpoint_Claim(t *testing.T) {
 	require.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc2}))
 	claimReq.AllocationID = alloc2.ID
 	err = msgpackrpc.CallWithCodec(codec, "CSIVolume.Claim", claimReq, claimResp)
-	require.EqualError(t, err, structs.ErrCSIVolumeMaxClaims.Error(),
+	require.ErrorContains(t, err, structs.ErrCSIVolumeMaxClaims.Error(),
 		"expected 'volume max claims reached' because we only allow 1 writer")
 
 	// Fix the mode and our claim will succeed

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2829,13 +2829,13 @@ func (s *StateStore) CSIVolumeClaim(index uint64, now int64, namespace, id strin
 		return err
 	}
 
-	// in the case of a job deregistration, there will be no allocation ID
+	// In the case of a job deregistration, there will be no allocation ID
 	// for the claim but we still want to write an updated index to the volume
 	// so that volume reaping is triggered
 	if claim.AllocationID != "" {
 		err = volume.Claim(claim, alloc)
 		if err != nil {
-			return err
+			return fmt.Errorf("alloc '%s' failed to claim volume '%s': %v", claim.AllocationID, volume.ID, err)
 		}
 	}
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -2835,7 +2835,7 @@ func (s *StateStore) CSIVolumeClaim(index uint64, now int64, namespace, id strin
 	if claim.AllocationID != "" {
 		err = volume.Claim(claim, alloc)
 		if err != nil {
-			return fmt.Errorf("alloc '%s' failed to claim volume '%s': %v", claim.AllocationID, volume.ID, err)
+			return fmt.Errorf("alloc %q failed to claim volume %q: %w", claim.AllocationID, volume.ID, err)
 		}
 	}
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Adding some information to CSI Claim errors to provide users a bit more context to what might be failing.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Part of investigative work for #27324 

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
