### PR TITLE
secrets: improve plugin error messages

### DIFF
--- a/client/allocrunner/taskrunner/secrets/plugin_provider.go
+++ b/client/allocrunner/taskrunner/secrets/plugin_provider.go
@@ -14,8 +14,12 @@ type ExternalPluginProvider struct {
 	// plugin is the commonplugin to be executed by this secret
 	plugin commonplugins.SecretsPlugin
 
-	// name of the secret executing the plugin
-	name string
+	// pluginName refers to the provider parameter of the secret block
+	// and is here mainly for debugging purposes
+	pluginName string
+
+	// secretName is the secret block name executing the plugin
+	secretName string
 
 	// path is the secret location used in Fetch
 	path string
@@ -26,26 +30,27 @@ type Response struct {
 	Error  *string           `json:"error,omitempty"`
 }
 
-func NewExternalPluginProvider(plugin commonplugins.SecretsPlugin, name string, path string) *ExternalPluginProvider {
+func NewExternalPluginProvider(plugin commonplugins.SecretsPlugin, pluginName, secretName, path string) *ExternalPluginProvider {
 	return &ExternalPluginProvider{
-		plugin: plugin,
-		name:   name,
-		path:   path,
+		plugin:     plugin,
+		pluginName: pluginName,
+		secretName: secretName,
+		path:       path,
 	}
 }
 
 func (p *ExternalPluginProvider) Fetch(ctx context.Context) (map[string]string, error) {
 	resp, err := p.plugin.Fetch(ctx, p.path)
 	if err != nil {
-		return nil, fmt.Errorf("failed executing plugin for secret %q: %w", p.name, err)
+		return nil, fmt.Errorf("failed executing plugin %q for secret %q: %w", p.pluginName, p.secretName, err)
 	}
 	if resp.Error != nil {
-		return nil, fmt.Errorf("secret %q plugin response contained error: %q", p.name, *resp.Error)
+		return nil, fmt.Errorf("provider %q for secret %q response contained error: %q", p.pluginName, p.secretName, *resp.Error)
 	}
 
 	formatted := make(map[string]string, len(resp.Result))
 	for k, v := range resp.Result {
-		formatted[fmt.Sprintf("secret.%s.%s", p.name, k)] = v
+		formatted[fmt.Sprintf("secret.%s.%s", p.secretName, k)] = v
 	}
 
 	return formatted, nil

--- a/client/allocrunner/taskrunner/secrets/plugin_provider.go
+++ b/client/allocrunner/taskrunner/secrets/plugin_provider.go
@@ -14,7 +14,7 @@ type ExternalPluginProvider struct {
 	// plugin is the commonplugin to be executed by this secret
 	plugin commonplugins.SecretsPlugin
 
-	// name of the plugin and also the executable
+	// name of the secret executing the plugin
 	name string
 
 	// path is the secret location used in Fetch
@@ -37,10 +37,10 @@ func NewExternalPluginProvider(plugin commonplugins.SecretsPlugin, name string, 
 func (p *ExternalPluginProvider) Fetch(ctx context.Context) (map[string]string, error) {
 	resp, err := p.plugin.Fetch(ctx, p.path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch secret from plugin %s: %w", p.name, err)
+		return nil, fmt.Errorf("failed executing plugin for secret %q: %w", p.name, err)
 	}
 	if resp.Error != nil {
-		return nil, fmt.Errorf("error returned from secret plugin %s: %s", p.name, *resp.Error)
+		return nil, fmt.Errorf("secret %q plugin response contained error: %q", p.name, *resp.Error)
 	}
 
 	formatted := make(map[string]string, len(resp.Result))

--- a/client/allocrunner/taskrunner/secrets/plugin_provider_test.go
+++ b/client/allocrunner/taskrunner/secrets/plugin_provider_test.go
@@ -42,7 +42,7 @@ func TestExternalPluginProvider_Fetch(t *testing.T) {
 		mockSecretPlugin := new(MockSecretPlugin)
 		mockSecretPlugin.On("Fetch", mock.Anything).Return(nil, errors.New("something bad"))
 
-		testProvider := NewExternalPluginProvider(mockSecretPlugin, "test", "test")
+		testProvider := NewExternalPluginProvider(mockSecretPlugin, "test-provider", "test", "test")
 
 		vars, err := testProvider.Fetch(t.Context())
 		must.ErrorContains(t, err, "something bad")
@@ -57,10 +57,10 @@ func TestExternalPluginProvider_Fetch(t *testing.T) {
 			Error:  &testError,
 		}, nil)
 
-		testProvider := NewExternalPluginProvider(mockSecretPlugin, "test", "test")
+		testProvider := NewExternalPluginProvider(mockSecretPlugin, "test-provider", "test", "test")
 
 		vars, err := testProvider.Fetch(t.Context())
-		must.ErrorContains(t, err, "secret \"test\" plugin response contained error")
+		must.ErrorContains(t, err, "provider \"test-provider\" for secret \"test\" response contained error")
 		must.Nil(t, vars)
 	})
 
@@ -73,7 +73,7 @@ func TestExternalPluginProvider_Fetch(t *testing.T) {
 			Error: nil,
 		}, nil)
 
-		testProvider := NewExternalPluginProvider(mockSecretPlugin, "test", "test")
+		testProvider := NewExternalPluginProvider(mockSecretPlugin, "test-provider", "test", "test")
 
 		result, err := testProvider.Fetch(t.Context())
 		must.NoError(t, err)

--- a/client/allocrunner/taskrunner/secrets/plugin_provider_test.go
+++ b/client/allocrunner/taskrunner/secrets/plugin_provider_test.go
@@ -60,7 +60,7 @@ func TestExternalPluginProvider_Fetch(t *testing.T) {
 		testProvider := NewExternalPluginProvider(mockSecretPlugin, "test", "test")
 
 		vars, err := testProvider.Fetch(t.Context())
-		must.ErrorContains(t, err, "error returned from secret plugin")
+		must.ErrorContains(t, err, "secret \"test\" plugin response contained error")
 		must.Nil(t, vars)
 	})
 

--- a/client/allocrunner/taskrunner/secrets_hook.go
+++ b/client/allocrunner/taskrunner/secrets_hook.go
@@ -213,7 +213,7 @@ func (h *secretsHook) buildSecretProviders(secretDir string) ([]TemplateProvider
 				multierror.Append(mErr, err)
 				continue
 			}
-			pluginProvider = append(pluginProvider, secrets.NewExternalPluginProvider(plug, s.Name, s.Path))
+			pluginProvider = append(pluginProvider, secrets.NewExternalPluginProvider(plug, s.Provider, s.Name, s.Path))
 		}
 	}
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes attempt to improve the error messages of secret plugins.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes #27226 
### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
