### PR TITLE
contributing: Add initial AI document.

### DIFF
--- a/contributing/README.md
+++ b/contributing/README.md
@@ -29,6 +29,9 @@ to implement and test your enhancement.
 If you'd like to contribute to an existing issue, you should post in the issue before 
 starting. Let us know you'd like to work on it and your proposed solution.
 
+If you are working on a code contribution and plan to use Generative AI tools to
+assist in your work, please review our [AI Usage Guidelines](ai.md).
+
 Developing with Vagrant
 ---
 A development environment is supplied via Vagrant to make getting started easier.

--- a/contributing/ai.md
+++ b/contributing/ai.md
@@ -1,0 +1,50 @@
+## AI Usage
+Regardless of the tools used in the development process, maintaining the
+stability and security of Nomad is our primary priority. If you choose to use AI
+tools to assist in your contributions, we ask that you do so using the three
+principles of transparency, accountability and quality to guide that work.
+
+### Transparency
+We value open communication about the tools and methods used to build Nomad. If
+you utilize AI to generate code, documentation, or tests, please disclose this
+in your Pull Request description.
+
+- Be specific: Clearly state the role AI played in your submission (e.g., "Used
+  to generate boilerplate for the new function," or "Used to refactor existing
+  tests").
+
+- Share the context: Where it adds clarity, share the process or prompts used.
+  This helps reviewers understand the intent and verify the output effectively.
+
+### Accountability
+Understanding that AI usage can range along a spectrum from AI assistance to AI
+led approaches we strongly prefer an approach that leaves the contributor in the
+drivers seat. AI is a tool, not a seperate contributor. The responsibility for
+changes submitted lies entirely with you, the human opening the PR.
+
+- Human ownership: All PRs must be submitted by a real, human-owned account. We
+  do not accept submissions from bot accounts used for code generation.
+
+- Human review: We proceed with the assumption that every line of code has been
+  reviewed by you. You must ensure that the code meets our quality standards,
+  that edge cases are handled, and that appropriate tests are written and
+  passing.
+
+- Deep understanding: You must understand the submitted code deeply enough to
+  explain it in your own words. If you cannot explain the logic, implications,
+  or side effects of a change without relying on the AI's explanation, the PR is
+  not ready for submission. You must own the PR.
+
+### Quality
+The bar for contributing to Nomad is high due to the complexity of the tool and
+the critical workflows it supports. That same expectation of quality persists
+regardless of the tools a contributor may or may not make use of.
+
+- Assistance, not automation: AI should be used to assist your process, not to
+  automate final decisions. It is easy for AI to generate plausible-looking but
+  incorrect or dangerous code.
+  
+- Adherence to guidelines: We discourage low-effort submissions where AI output
+  is pasted without refinement. We expect the same high quality, thoughtful
+  architecture, and adherence to our existing style and testing guidelines as we
+  do for manual code.


### PR DESCRIPTION
This change introduces an initial AI contributing guide that details expectations around PR's when assisted with AI tooling.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

