### PR TITLE
release automation: new release workflows

### DIFF
--- a/.github/actions/semver/action.yml
+++ b/.github/actions/semver/action.yml
@@ -1,0 +1,36 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+name: semver
+description: 'Install semver CLI and validate an input version'
+
+inputs:
+  validate_version:
+    description: 'version to validate'
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    # a nice, tiny shell script: https://github.com/fsaintjacques/semver-tool
+    # npm and pip have `semver`s, but they have fewer features and are slower to install.
+    - name: Install semver CLI
+      shell: bash
+      run: |-
+        local_bin="${HOME}/.local/bin"
+        mkdir -p "${local_bin}"
+
+        curl -L --silent --show-error --output "${local_bin}/semver" \
+          https://raw.githubusercontent.com/fsaintjacques/semver-tool/3.3.0/src/semver
+
+        chmod +x "${local_bin}/semver"
+        echo "${local_bin}" >> "$GITHUB_PATH"
+
+    - name: Validate version
+      if: ${{ inputs.validate_version != '' }}
+      shell: bash
+      run: |-
+        test "$(semver validate "${{ inputs.validate_version }}")" == 'valid' && exit 0
+        echo "::error::Version '${{ inputs.validate_version }}' is invalid"
+        exit 1

--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -1,0 +1,57 @@
+name: Finalize Nomad release branch
+
+# merge a specific release/A.B.C branch back into a long-lived
+# release/A.B.x branch after it's been released.
+
+on:
+  workflow_call:
+    secrets:
+      gh-token:
+        required: true
+    inputs:
+      repo:
+        description: 'GitHub repository, e.g. hashicorp/nomad'
+        type: string
+        required: true
+      version:
+        description: 'Version that was released'
+        type: string
+        required: true
+      merge-from:
+        description: 'Specific-version branch to merge from, e.g. release/1.11.99'
+        type: string
+        required: true
+      merge-into:
+        description: 'Long-lived branch to merge into, e.g. release/1.11.x'
+        type: string
+        required: true
+
+jobs:
+  finalize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git config
+        run: |-
+          git config --global user.email "github-team-nomad-core@hashicorp.com"
+          git config --global user.name "hc-github-team-nomad-core"
+
+      - name: Checkout nomad
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.merge-from }}
+          fetch-depth: 0 # need history to merge
+          token: ${{ secrets.gh-token }}
+
+      - name: Semver CLI
+        uses: ./.github/actions/semver
+        with:
+          validate_version: ${{ inputs.version }}
+
+      - name: Run finalize script
+        env:
+          DO_PUSH: true
+          NEW_VERSION: ${{ inputs.version }}
+          MERGE_INTO: ${{ inputs.merge-into }}
+          DEBUG: ${{ runner.debug }}
+        run: ./scripts/release/finalize

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,137 @@
+name: Prepare Nomad release branch
+
+# create a specific release/A.B.C branch from a long-lived
+# release/A.B.x branch and prepare it to be built.
+
+on:
+  workflow_call:
+    secrets:
+      gh-token:
+        required: true
+    inputs:
+      repo:
+        description: 'GitHub repository, e.g. hashicorp/nomad'
+        type: string
+        required: true
+      version:
+        description: 'Version to be released'
+        type: string
+        required: true
+      new-branch-prefix:
+        description: 'Prefix to put in front of `version`, default "release/"'
+        type: string
+        required: false
+        default: 'release/'
+      source-branch:
+        description: 'Source branch to cut the release branch from, e.g. release/1.11.x'
+        type: string
+        required: true
+      compare-version:
+        description: 'Version to compare against when generating the changelog'
+        type: string
+        required: true
+      slack-channel:
+        type: string
+        required: false
+        default: 'C09LCDZTLGZ' # proj-nomad-releases
+    outputs:
+      build-ref:
+        description: 'git sha of the commit to use in the build workflow'
+        value: ${{ jobs.prepare.outputs.build-ref }}
+      new-branch:
+        description: 'name of the new branch created for this release'
+        value: ${{ jobs.prepare.outputs.new-branch }}
+
+env:
+  NEW_BRANCH: ${{ inputs.new-branch-prefix }}${{ inputs.version }}
+
+jobs:
+  prepare:
+    outputs:
+      new-branch: ${{ env.NEW_BRANCH }}
+      build-ref: ${{ steps.script.outputs.build-ref }}
+
+    # TODO: self-hosted runners? CI vault?
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Write handy summary
+        run: |-
+          repo_url="https://github.com/${{ inputs.repo }}"
+          cat <<EOF >> "$GITHUB_STEP_SUMMARY"
+          # Release ${{ inputs.version }}
+          - Source branch: [${{ inputs.source-branch }}]($repo_url/commits/${{ inputs.source-branch }})
+          - Release branch: [${{ env.NEW_BRANCH }}]($repo_url/commits/${{ env.NEW_BRANCH }})
+          EOF
+
+      # TODO: check github check status of source-branch?
+      # e.g. https://github.com/marketplace/actions/wait-for-github-status-check
+
+      - name: Git config
+        # note: the global url is mainly for the go toolchain for private repos
+        run: |-
+          git config --global user.email "github-team-nomad-core@hashicorp.com"
+          git config --global user.name "hc-github-team-nomad-core"
+          git config --global url.'https://${{ secrets.gh-token }}@github.com'.insteadOf 'https://github.com'
+
+      - name: Checkout nomad
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ inputs.repo }}
+          ref: ${{ inputs.source-branch }}
+          fetch-depth: 0
+          fetch-tags: true # for changelog
+          token: ${{ secrets.gh-token }}
+
+      - name: Semver CLI
+        uses: ./.github/actions/semver
+        with:
+          validate_version: ${{ inputs.version }}
+
+      # need go for changelog-build and static assets
+      - name: Setup Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: '.go-version'
+
+      - name: Update changelog
+        id: changelog # output: file
+        env:
+          NEW_VERSION: ${{ inputs.version }}
+          LAST_RELEASE: ${{ inputs.compare-version }}
+          DEBUG: ${{ runner.debug }}
+        run: |-
+          echo '::group::install changelog-build'
+          go install github.com/hashicorp/go-changelog/cmd/changelog-build@latest
+          echo '::endgroup::'
+          ./scripts/release/update-changelog
+
+      - name: Store changelog
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: 'changelog_${{ inputs.version }}'
+          path: ${{ steps.changelog.outputs.file }}
+          overwrite: true
+          compression-level: 0
+          if-no-files-found: error
+
+      - name: Install Go dependencies
+        run: make deps
+
+      - name: Setup JS
+        uses: ./.github/actions/setup-js
+
+      - name: Run prepare script
+        id: script # output: build-ref
+        env:
+          DO_PUSH: true
+          NEW_VERSION: ${{ inputs.version }}
+          SLACK_CHANNEL: ${{ inputs.slack-channel }}
+          GO_TAGS: release ${{ endsWith(inputs.version, '+ent') && 'ent consulent' }}
+          GOPRIVATE: 'github.com/hashicorp'
+          DEBUG: ${{ runner.debug }}
+        run: ./scripts/release/prepare
+
+      - name: Add build ref to summary
+        run: |-
+          echo "- Build ref: \`${{ steps.script.outputs.build-ref }}\`" >> "$GITHUB_STEP_SUMMARY"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -241,8 +241,7 @@ proto: ## Generate protobuf bindings
 	@buf --config tools/buf/buf.yaml --template tools/buf/buf.gen.yaml generate
 
 changelog: ## Generate changelog from entries
-	@changelog-build -last-release v$(LAST_RELEASE) -this-release HEAD \
-		-entries-dir .changelog/ -changelog-template ./.changelog/changelog.tmpl -note-template ./.changelog/note.tmpl
+	./scripts/release/update-changelog
 
 ## We skip the terraform directory as there are templated hcl configurations
 ## that do not successfully compile without rendering

--- a/scripts/release/check-working-dir
+++ b/scripts/release/check-working-dir
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if [ ! -f version/version.go ]; then
+  echo 'No version/version.go file here. Are you in the nomad/ repo root?'
+  exit 1
+fi
+
+if ! git diff-index --quiet HEAD --; then
+  echo 'need a clean worktree; try: `git clone $PWD /tmp/nomad && cd /tmp/nomad`'
+  exit 1
+fi

--- a/scripts/release/finalize
+++ b/scripts/release/finalize
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+# run by the release-finalize.yml github action workflow
+# * start from a release/A.B.C branch
+# * revert notification channel and remove generated static files
+# * update version in version.go and LAST_RELEASE in GNUMakefile
+# * commit and merge changes into the source release/A.B.x branch
+
+# by default, it will do everything except for `git push`
+# unless you `export DO_PUSH=true`
+
+[ -n "$DEBUG" ] && set -x
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/check-working-dir"
+
+echo 'Checking variables'
+  MERGE_FROM="${MERGE_FROM:-$(git branch --show-current)}"
+  DO_PUSH="${DO_PUSH:-false}"
+  # vars displayed this way for easier troubleshooting
+  cat <<VARS
+\`\`\`
+# required:
+export NEW_VERSION='${NEW_VERSION?is required}'
+export MERGE_INTO='${MERGE_INTO?is required}'
+# derived:
+export MERGE_FROM='$MERGE_FROM'
+# other:
+export DO_PUSH='$DO_PUSH'
+
+$0
+\`\`\`
+
+VARS
+
+echo 'Ensuring branches'
+  # merge-from second, so we proceed from there.
+  for b in "$MERGE_INTO" "$MERGE_FROM"; do
+    git fetch origin "$b"
+    git switch "$b"
+    git pull origin "$b"
+  done
+echo
+
+echo 'Updating magic strings in magic files'
+  # restore original notification_channel
+  git restore --source="origin/$MERGE_INTO" -- .release/ci.hcl
+
+  if [ -n "$(semver get prerel "$NEW_VERSION")" ]; then
+    echo "$NEW_VERSION is a prerelease; reverting changelog"
+    # we'll re-update changelog for GA.
+    git restore --source="origin/$MERGE_INTO" -- CHANGELOG.md
+
+  else
+    echo "$NEW_VERSION is not a prerelease; bumping versions"
+    next_patch="$(semver bump patch "$NEW_VERSION")"
+    sed -i.bak -e "s|\(Version * = *\"\)[^\"]*|\1${next_patch}|g" version/version.go
+    sed -i.bak -re "s|^(LAST_RELEASE\s+\?=\s).*$|\1$NEW_VERSION|g" GNUmakefile
+  fi
+
+  # set VersionPrerelease back to "dev"
+  sed -i.bak -e "s|\(VersionPrerelease * = *\"\)[^\"]*|\1dev|g" version/version.go
+
+  rm -f version/version.go.bak GNUmakefile.bak
+echo
+
+echo 'Removing generated static assets'
+  # These generated files are only needed when building the final
+  # binary and should be not be present in the repository afterwards.
+  find . -name '*.generated.go' -exec git rm -f '{}' \;
+echo
+
+push() {
+  if [ "$DO_PUSH" == 'true' ]; then
+    git push origin "$1"
+  else
+    echo "::warning::DO_PUSH != true, so skipping 'git push origin $1'"
+  fi
+}
+
+echo 'Committing changes'
+  # Display staged and unstaged diffs, skipping deleted files to avoid
+  # cluttering the output with the generated files.
+  git status
+  git diff --diff-filter=d --color=always HEAD | /bin/cat
+  git add -A .
+
+  if git diff-index --quiet HEAD --; then
+    echo '::notice::No files were updated'
+  else
+    git commit --message "release: Prepare for next release post-$NEW_VERSION"
+    push "$MERGE_FROM"
+  fi
+echo
+
+echo "Merging changes from '$MERGE_FROM' into '$MERGE_INTO'"
+  git switch "$MERGE_INTO"
+  if ! git merge --no-edit "$MERGE_FROM"; then
+    echo "::error::failed to merge $MERGE_FROM into $MERGE_INTO"
+    git status
+    git diff --color=always | /bin/cat
+    exit 1
+  fi
+  push "$MERGE_INTO"
+

--- a/scripts/release/prepare
+++ b/scripts/release/prepare
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+
+# run by the release-prepare.yml github action workflow
+# * start from a release/A.B.x branch
+# * update notification channel in ci.hcl and version in version.go
+# * generate static assets (make prerelease)
+# * commit and push changes to a new release/A.B.C branch
+# * output the new branch and commit ref to be built
+
+# by default, it will do everything except for `git push`
+# unless you `export DO_PUSH=true`
+
+[ -n "$DEBUG" ] && set -x
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/check-working-dir"
+
+echo 'Checking variables'
+  SOURCE_BRANCH="${SOURCE_BRANCH:-$(git branch --show-current)}"
+  NEW_BRANCH="${NEW_BRANCH:-release/$NEW_VERSION}" # default release/A.B.C
+  REPO="${REPO:-nomad}"
+  GO_TAGS="${GO_TAGS:-release}"
+  DO_PUSH="${DO_PUSH:-false}"
+  # vars displayed this way for easier troubleshooting
+  cat <<VARS
+\`\`\`
+# required:
+export NEW_VERSION='${NEW_VERSION?is required}'
+export SLACK_CHANNEL='${SLACK_CHANNEL?is required}'
+# derived:
+export SOURCE_BRANCH='$SOURCE_BRANCH'
+export NEW_BRANCH='$NEW_BRANCH'
+# other:
+export DO_PUSH='$DO_PUSH'
+export REPO='$REPO'
+export GO_TAGS='$GO_TAGS'
+export GOPRIVATE='${GOPRIVATE:-}'
+
+$0
+\`\`\`
+
+VARS
+
+echo 'Checking required commands'
+  semver --version
+  # these are run by `make prerelease`
+  go version
+  printf 'buf: '; buf --version
+  printf 'pnpm: '; pnpm --version
+echo
+
+echo 'Ensuring source branch'
+  git fetch origin "$SOURCE_BRANCH"
+  git switch "$SOURCE_BRANCH"
+  git pull origin "$SOURCE_BRANCH"
+echo
+
+echo 'Updating magic strings in magic files'
+  sed -i.bak -e "s|\(notification_channel * = *\"\\)[^\"]*|\1$SLACK_CHANNEL|g" .release/ci.hcl
+  
+  release=$(semver get release "$NEW_VERSION")
+  prerel=$(semver get prerel "$NEW_VERSION")
+  sed -i.bak \
+    -e "s|\(Version * = *\"\)[^\"]*|\1${release}|g" \
+    -e "s|\(VersionPrerelease * = *\"\)[^\"]*|\1${prerel}|g" \
+    version/version.go
+
+  rm -f version/version.go.bak .release/ci.hcl.bak
+echo
+
+echo '::group::Generate static assets'
+  make prerelease
+  # add the files now, so `git diff` doesn't show their noisy contents
+  git add --force \
+    ./{nomad,client}/structs/*.generated.go \
+    ./command/agent/bindata_assetfs.go
+echo '::endgroup::'
+
+echo 'Committing changes'
+  git switch --force-create "$NEW_BRANCH"
+  git status
+  git diff --color=always | /bin/cat
+  git add --all .
+
+  if git diff-index --quiet HEAD --; then
+    echo "::warning::No files were updated by prepare script"
+    exit
+  else
+    git commit --message "release: Generate files for $NEW_VERSION"
+  fi
+echo
+
+if [ "$DO_PUSH" == 'true' ]; then
+  echo "Pushing changes to $NEW_BRANCH"
+  git push origin -f "$NEW_BRANCH"
+else
+  echo '::warning::DO_PUSH != true, so skipping `git push`'
+fi
+
+# output ref for subsequent build job
+echo "build-ref=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT:-/dev/stderr}"

--- a/scripts/release/update-changelog
+++ b/scripts/release/update-changelog
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# run by the release-prepare.yml github action workflow
+# * start from a release/A.B.C branch
+# * create a changelog file with only this one version's entry
+#   * we'll store it as a github artifact and use it later
+#     to create a github release.
+# * update and commit CHANGELOG.md
+
+[ -n "$DEBUG" ] && set -x
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/check-working-dir"
+# note also that changelog-build is not `git worktree` friendly.
+# https://github.com/hashicorp/go-changelog/pull/49
+# -> https://github.com/go-git/go-git/issues/1812
+
+echo 'Checking variables'
+  SOURCE_BRANCH="${SOURCE_BRANCH:-$(git branch --show-current)}"
+  # vars displayed this way for easier troubleshooting
+  cat <<VARS
+\`\`\`
+# required:
+export NEW_VERSION='${NEW_VERSION?is required}'
+export LAST_RELEASE='${LAST_RELEASE?is required}'
+# derived:
+export SOURCE_BRANCH='$SOURCE_BRANCH'
+
+$0
+\`\`\`
+
+VARS
+
+echo 'Ensuring source branch'
+  git fetch origin "$SOURCE_BRANCH"
+  git switch "$SOURCE_BRANCH"
+  git pull origin "$SOURCE_BRANCH"
+echo
+
+cl_file="$(mktemp -t changelog-XXXXX-$NEW_VERSION.md)"
+
+echo "Generating the changelog from v$LAST_RELEASE to HEAD ($(git rev-parse HEAD))"
+  # changelog-build does checkouts, so hold on to current branch
+  _start_branch="$(git branch --show-current)"
+  changelog-build \
+    -last-release "v$LAST_RELEASE" \
+    -this-release HEAD \
+    -entries-dir .changelog \
+    -changelog-template .changelog/changelog.tmpl \
+    -note-template .changelog/note.tmpl \
+    -local-fs > "$cl_file"
+  # back to where we came from
+  git switch "$_start_branch"
+  
+  lines="$(wc -l "$cl_file" | awk '{print$1}')"
+  if [ "$lines" -eq 0 ]; then
+    echo "::error::Generated changelog is empty"
+    exit 1
+  fi
+echo
+
+echo "Updating CHANGELOG.md"
+  {
+    echo "## ${NEW_VERSION//+ent/ Enterprise} ($(date '+%B %d, %Y'))"
+    cat "$cl_file"
+    echo
+    cat CHANGELOG.md
+  } > "changelog.tmp.md"
+  mv "changelog.tmp.md" CHANGELOG.md
+echo
+
+echo "Committing changes"
+  git add CHANGELOG.md
+  git status
+  git diff --cached --color=always | /bin/cat
+  git commit -m "release: Update changelog for $NEW_VERSION"
+echo
+
+echo "file=$cl_file" >> "${GITHUB_OUTPUT:-/dev/stderr}"


### PR DESCRIPTION
Heavily modified from hashicorp/nomad-releases#502, these are the parts of the release process that manage the contents of the release branches, to replace `release.yml` and manual steps at the end of our release checklist.

* Prepare:
  * Cut a new `release/A.B.C` from a `release/A.B.x`
  * Create a changelog and prepare code to be built
* Todo in subsequent PRs: the actual build/release process
* Finalize:
  * Revert some changes from prepare, update version
  * Merge `release/A.B.C` back into `release/A.B.x`

~There are some rough bits, but note the base branch `automatic-releases` - not `main` yet.~

---

The meat of the logic is done in scripts, which can be run manually for troubleshooting, or as a fall-back during a release.  Their design is somewhat peculiar, since they're geared for running in GHA, but still hopefully pretty readable.

The workflows are called like this:

```yaml
on:
  workflow_call: # called from a release coordinator across multiple versions
    secrets:
      gh-token:
    inputs:
      repo:
      version:
      source-branch:
      compare-version:

jobs:
  prepare:
    # note: this example called from nomad-releases repo, hence the leading `hashicorp/nomad`
    uses: hashicorp/nomad/.github/workflows/release-prepare.yml@new-release-workflows
    with:
      repo: ${{ inputs.repo }}
      source-branch: ${{ inputs.source-branch }} 
      version: ${{ inputs.version }}
      compare-version: ${{ inputs.compare-version }}
    secrets:
      gh-token: ${{ secrets.gh-token }}

  # TODO: build, promote, verify, etc...

  finalize:
    needs: [prepare]
    uses: hashicorp/nomad/.github/workflows/release-finalize.yml@new-release-workflows
    with:
      repo: ${{ inputs.repo }}
      merge-from: ${{ needs.prepare.outputs.new-branch }}
      merge-into: ${{ inputs.source-branch }} 
      version: ${{ inputs.version }}
    secrets:
      gh-token: ${{ secrets.gh-token }}
```

Example multi-version run (ce and ent) in nomad-releases:
 * https://github.com/hashicorp/nomad-releases/actions/runs/20859319794
One of those jobs fails intentionally (`1.11.98+ent`), as an example error.

Resulting CE branches from that run, which would build ref `e6f95a555c9332f128d79bd608560fd612adb048`:
 * https://github.com/hashicorp/nomad/commits/db-testing/1.11.x
   Note the "Prepare for next release" is from `finalize`, ordinarily at the end of the process
 * https://github.com/hashicorp/nomad/commits/db-testing/1.11.99

---

Internal ref: https://hashicorp.atlassian.net/browse/NMD-1109