### PR TITLE
dispatch: ensure idempotency token is checked in FSM

### DIFF
--- a/.changelog/27353.txt
+++ b/.changelog/27353.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+dispatch: Fixed a bug where concurrent dispatch requests could ignore the idempotency token
+```

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -636,7 +636,7 @@ func (n *nomadFSM) applyUpsertJob(msgType structs.MessageType, buf []byte, index
 
 	if req.IdempotencyToken != "" {
 		found, err := n.state.CheckIdempotencyToken(
-			req.RequestNamespace(), req.Job.ParentID, req.IdempotencyToken)
+			req.Job.Namespace, req.Job.ParentID, req.IdempotencyToken)
 		if err != nil {
 			n.logger.Error("failed to check idempotency token", "error", err)
 			return err

--- a/nomad/state/helpers.go
+++ b/nomad/state/helpers.go
@@ -1,0 +1,18 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+package state
+
+import memdb "github.com/hashicorp/go-memdb"
+
+// IterCount is a helper that consumes an iterator and returns a count of the
+// objects found in it
+func (s *StateStore) IterCount(iter memdb.ResultIterator) int {
+	count := 0
+	for {
+		if iter.Next() == nil {
+			return count
+		}
+		count++
+	}
+}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1875,8 +1875,7 @@ func (s *StateStore) upsertJobImpl(index uint64, sub *structs.JobSubmission, job
 func (s *StateStore) CheckIdempotencyToken(ns, parentID, idempotencyToken string) (*structs.Job, error) {
 	iter, err := s.JobsByIDPrefix(nil, ns, parentID, SortDefault)
 	if err != nil {
-		const errMsg = "failed to retrieve jobs for idempotency check"
-		return nil, fmt.Errorf(errMsg)
+		return nil, errors.New("failed to retrieve jobs for idempotency check")
 	}
 
 	for {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -1869,6 +1869,33 @@ func (s *StateStore) upsertJobImpl(index uint64, sub *structs.JobSubmission, job
 	return nil
 }
 
+// CheckIdempotencyToken finds all children of the parent job ID and checks to
+// make sure none of them were dispatched with the idempotency token passed as
+// an argument. Returns the child job found, if any.
+func (s *StateStore) CheckIdempotencyToken(ns, parentID, idempotencyToken string) (*structs.Job, error) {
+	iter, err := s.JobsByIDPrefix(nil, ns, parentID, SortDefault)
+	if err != nil {
+		const errMsg = "failed to retrieve jobs for idempotency check"
+		return nil, fmt.Errorf(errMsg)
+	}
+
+	for {
+		raw := iter.Next()
+		if raw == nil {
+			break
+		}
+		existingDispatch := raw.(*structs.Job)
+		if existingDispatch.ParentID != parentID {
+			continue
+		}
+		if existingDispatch.DispatchIdempotencyToken == idempotencyToken {
+			return existingDispatch, nil
+		}
+	}
+
+	return nil, nil
+}
+
 // DeleteJob is used to deregister a job
 func (s *StateStore) DeleteJob(index uint64, namespace, jobID string) error {
 	txn := s.db.WriteTxn(index)


### PR DESCRIPTION
The Job Dispatch API has an `idempotency_token` field intended to prevent retries of a dispatch from running more than once. But we only check the token in the RPC handler, which has the nice UX and performance benefit of letting us return early with the correct ID and index. But this allows concurrent dispatches with the same token to both run.

Do the check again during FSM apply to prevent the race condition.

Fixes: https://github.com/hashicorp/nomad/issues/26690
Ref: https://hashicorp.atlassian.net/browse/NMD-954

### Testing & Reproduction steps

Kind of hard to trigger the concurrency without introducing an artificial delay in the state store. But this is what you get if you dispatch from two different terminals if you do.

<details><summary>jobspec</summary>

```hcl
job "example" {
  type = "batch"

  parameterized {
    payload = "required"
  }

  group "group" {

    task "task" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "/bin/sh"
        args    = ["-c", "cat local/payload.txt; sleep 300"]
      }

      dispatch_payload {
        file = "payload.txt"
      }
   }
  }
}
```

</details>


```
$ echo 'hello, world' > dispatch.txt

$ nomad job dispatch -idempotency-token=xyzzy example ./dispatch.txt
Dispatched Job ID = example/dispatch-1768333080-ef6cf106
Evaluation ID     = 93a6733c

==> 2026-01-13T14:38:00-05:00: Monitoring evaluation "93a6733c"
    2026-01-13T14:38:00-05:00: Evaluation triggered by job "example/dispatch-1768333080-ef6cf106"
    2026-01-13T14:38:01-05:00: Allocation "8f615a14" created: node "46607dd1", group "group"
    2026-01-13T14:38:01-05:00: Evaluation status changed: "pending" -> "complete"
==> 2026-01-13T14:38:01-05:00: Evaluation "93a6733c" finished with status "complete"

$ nomad job dispatch -idempotency-token=xyzzy example ./jobs/dispatch.txt
Dispatched Job ID = example/dispatch-1768333080-ef6cf106

$ nomad eval list
ID        Priority  Triggered By  Job ID                                Namespace  Node ID  Status    Placement Failures
93a6733c  50        job-register  example/dispatch-1768333080-ef6cf106  default    <none>   complete  false
```


### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
