### PR TITLE
drivers: support reserve-only memory oversubscription

### DIFF
--- a/.changelog/27354.txt
+++ b/.changelog/27354.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+docker: Added support for reserved-only memory oversubscription without a hard limit
+```
+
+```release-note:improvement
+exec: Added support for reserved-only memory oversubscription without a hard limit
+```

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -1207,10 +1207,7 @@ func (tr *TaskRunner) buildTaskConfig() *drivers.TaskConfig {
 		}
 	}
 
-	memoryLimit := taskResources.Memory.MemoryMB
-	if max := taskResources.Memory.MemoryMaxMB; max > memoryLimit {
-		memoryLimit = max
-	}
+	memoryLimit := max(taskResources.Memory.MemoryMB, taskResources.Memory.MemoryMaxMB)
 
 	cpusetCpus := make([]string, len(taskResources.Cpu.ReservedCores))
 	for i, v := range taskResources.Cpu.ReservedCores {

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -2985,11 +2985,11 @@ func TestDockerDriver_memoryLimits(t *testing.T) {
 	ci.Parallel(t)
 
 	cases := []struct {
-		name           string
-		driverMemoryMB int64
-		taskResources  drivers.MemoryResources
-		expectedHard   int64
-		expectedSoft   int64
+		name             string
+		driverMemoryMB   int64
+		taskResources    drivers.MemoryResources
+		expectedHard     int64
+		expectedReserved int64
 	}{
 		{
 			"plain request",
@@ -3026,13 +3026,20 @@ func TestDockerDriver_memoryLimits(t *testing.T) {
 			30 * 1024 * 1024,
 			10 * 1024 * 1024,
 		},
+		{
+			"with reserved-only memory oversubscription",
+			20,
+			drivers.MemoryResources{MemoryMB: 20, MemoryMaxMB: -1},
+			0,
+			20 * 1024 * 1024,
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			hard, soft := memoryLimits(c.driverMemoryMB, c.taskResources)
+			hard, reserved := memoryLimits(c.driverMemoryMB, c.taskResources)
 			must.Eq(t, c.expectedHard, hard)
-			must.Eq(t, c.expectedSoft, soft)
+			must.Eq(t, c.expectedReserved, reserved)
 		})
 	}
 }

--- a/drivers/shared/executor/executor_linux_cgo.go
+++ b/drivers/shared/executor/executor_linux_cgo.go
@@ -797,16 +797,9 @@ func (*LibcontainerExecutor) configureCgroupHook(cfg *runc.Config, command *Exec
 }
 
 func (l *LibcontainerExecutor) configureCgroupMemory(cfg *runc.Config, command *ExecCommand) {
-	// Total amount of memory allowed to consume
-	res := command.Resources.NomadResources
-	memHard, memSoft := res.Memory.MemoryMaxMB, res.Memory.MemoryMB
-	if memHard <= 0 {
-		memHard = res.Memory.MemoryMB
-		memSoft = 0
-	}
-
-	cfg.Cgroups.Resources.Memory = memHard * 1024 * 1024
-	cfg.Cgroups.Resources.MemoryReservation = memSoft * 1024 * 1024
+	memHard, memReserved := memoryLimits(command.Resources.NomadResources.Memory)
+	cfg.Cgroups.Resources.Memory = memHard
+	cfg.Cgroups.Resources.MemoryReservation = memReserved
 
 	// Disable swap if possible, to avoid issues on the machine
 	cfg.Cgroups.Resources.MemorySwappiness = cgroupslib.MaybeDisableMemorySwappiness()

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -21,12 +21,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const (
-	// memoryNoLimit is a sentinel value for memory_max that indicates the
-	// raw_exec driver should not enforce a maximum memory limit
-	memoryNoLimit = -1
-)
-
 // setSubCmdCgroup sets the cgroup for non-Task child processes of the
 // executor.Executor (since in cg2 it lives outside the task's cgroup)
 func (e *UniversalExecutor) setSubCmdCgroup(cmd *exec.Cmd, cgroup string) (func(), error) {
@@ -207,11 +201,11 @@ func (e *UniversalExecutor) configureCG1(cgroup string, command *ExecCommand) er
 	}
 
 	// write memory limits
-	memHard, memSoft := e.computeMemory(command)
+	memHard, memReserved := memoryLimits(command.Resources.NomadResources.Memory)
 	ed := cgroupslib.OpenFromFreezerCG1(cgroup, "memory")
 	_ = ed.Write("memory.limit_in_bytes", strconv.FormatInt(memHard, 10))
-	if memSoft > 0 {
-		_ = ed.Write("memory.soft_limit_in_bytes", strconv.FormatInt(memSoft, 10))
+	if memReserved > 0 {
+		_ = ed.Write("memory.soft_limit_in_bytes", strconv.FormatInt(memReserved, 10))
 	}
 
 	// write memory swappiness
@@ -243,16 +237,16 @@ func (e *UniversalExecutor) configureCG2(cgroup string, command *ExecCommand) {
 	}
 
 	// write memory cgroup files
-	memHard, memSoft := e.computeMemory(command)
+	memHard, memReserved := memoryLimits(command.Resources.NomadResources.Memory)
 	ed := cgroupslib.OpenPath(cgroup)
 	if memHard == memoryNoLimit {
 		_ = ed.Write("memory.max", "max")
 	} else {
 		_ = ed.Write("memory.max", strconv.FormatInt(memHard, 10))
 	}
-	if memSoft > 0 {
+	if memReserved > 0 {
 		ed = cgroupslib.OpenPath(cgroup)
-		_ = ed.Write("memory.low", strconv.FormatInt(memSoft, 10))
+		_ = ed.Write("memory.low", strconv.FormatInt(memReserved, 10))
 	}
 
 	// set memory swappiness
@@ -283,31 +277,6 @@ func (*UniversalExecutor) computeCPU(command *ExecCommand) uint64 {
 	cpuShares := command.Resources.LinuxResources.CPUShares
 	cpuWeight := cgroups.ConvertCPUSharesToCgroupV2Value(uint64(cpuShares))
 	return cpuWeight
-}
-
-func mbToBytes(n int64) int64 {
-	return n * 1024 * 1024
-}
-
-// computeMemory returns the hard and soft memory limits for the task
-func (*UniversalExecutor) computeMemory(command *ExecCommand) (int64, int64) {
-	mem := command.Resources.NomadResources.Memory
-	memHard, memSoft := mem.MemoryMaxMB, mem.MemoryMB
-
-	switch memHard {
-	case 0:
-		// typical case where 'memory' is the hard limit
-		memHard = mem.MemoryMB
-		return mbToBytes(memHard), 0
-	case memoryNoLimit:
-		// special oversub case where 'memory' is soft limit and there is no
-		// hard limit - helping re-create old raw_exec behavior
-		return memoryNoLimit, mbToBytes(memSoft)
-	default:
-		// typical oversub case where 'memory' is soft limit and 'memory_max'
-		// is hard limit
-		return mbToBytes(memHard), mbToBytes(memSoft)
-	}
 }
 
 // withNetworkIsolation calls the passed function the network namespace `spec`

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -239,7 +239,7 @@ func (e *UniversalExecutor) configureCG2(cgroup string, command *ExecCommand) {
 	// write memory cgroup files
 	memHard, memReserved := memoryLimits(command.Resources.NomadResources.Memory)
 	ed := cgroupslib.OpenPath(cgroup)
-	if memHard == memoryNoLimit {
+	if memHard == MemoryNoLimit {
 		_ = ed.Write("memory.max", "max")
 	} else {
 		_ = ed.Write("memory.max", strconv.FormatInt(memHard, 10))

--- a/drivers/shared/executor/executor_universal_linux_test.go
+++ b/drivers/shared/executor/executor_universal_linux_test.go
@@ -17,63 +17,8 @@ import (
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/helper/testlog"
-	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/shoenig/test/must"
 )
-
-func Test_computeMemory(t *testing.T) {
-	cases := []struct {
-		memory    int64
-		memoryMax int64
-		expSoft   int64
-		expHard   int64
-	}{
-		{
-			// typical case; only 'memory' is set and that is used as the hard
-			// memory limit
-			memory:    100,
-			memoryMax: 0,
-			expSoft:   0,
-			expHard:   mbToBytes(100),
-		},
-		{
-			// oversub case; both 'memory' and 'memory_max' are set and used as
-			// the soft and hard memory limits
-			memory:    100,
-			memoryMax: 200,
-			expSoft:   mbToBytes(100),
-			expHard:   mbToBytes(200),
-		},
-		{
-			// special oversub case; 'memory' is set and 'memory_max' is set to
-			// -1; which indicates there should be no hard limit (i.e. -1 / max)
-			memory:    100,
-			memoryMax: memoryNoLimit,
-			expSoft:   mbToBytes(100),
-			expHard:   memoryNoLimit,
-		},
-	}
-
-	for _, tc := range cases {
-		name := fmt.Sprintf("(%d,%d)", tc.memory, tc.memoryMax)
-		t.Run(name, func(t *testing.T) {
-			command := &ExecCommand{
-				Resources: &drivers.Resources{
-					NomadResources: &structs.AllocatedTaskResources{
-						Memory: structs.AllocatedMemoryResources{
-							MemoryMB:    tc.memory,
-							MemoryMaxMB: tc.memoryMax,
-						},
-					},
-				},
-			}
-			hard, soft := (*UniversalExecutor)(nil).computeMemory(command)
-			must.Eq(t, tc.expSoft, soft)
-			must.Eq(t, tc.expHard, hard)
-		})
-	}
-}
 
 func TestExecutor_InvalidCgroup(t *testing.T) {
 	ci.Parallel(t)

--- a/drivers/shared/executor/utils.go
+++ b/drivers/shared/executor/utils.go
@@ -159,9 +159,12 @@ func IsolationMode(plugin, task string) string {
 }
 
 const (
-	// memoryNoLimit is a sentinel value for memory_max that indicates the
-	// driver should not enforce a maximum memory limit
-	memoryNoLimit = -1
+	// MemoryNoLimit is a sentinel value for resources.memory_max that indicates
+	// the driver should not enforce a maximum memory limit and treat
+	// resources.memory as a reservation. For Linux drivers that implement
+	// memory allocation via cgroups, this means setting `memory.max = max` and
+	// `memory.low` to the value of resources.memory (multiplied to bytes)
+	MemoryNoLimit = -1
 )
 
 func mbToBytes(n int64) int64 {
@@ -179,7 +182,7 @@ func mbToBytes(n int64) int64 {
 func memoryLimits(memory structs.AllocatedMemoryResources) (int64, int64) {
 	memHard, memReserved := memory.MemoryMaxMB, memory.MemoryMB
 
-	if memHard == memoryNoLimit {
+	if memHard == MemoryNoLimit {
 		// special oversub case where 'memory' is soft limit and there is no
 		// hard limit
 		return -1, mbToBytes(memReserved)

--- a/drivers/shared/executor/utils_test.go
+++ b/drivers/shared/executor/utils_test.go
@@ -107,9 +107,9 @@ func Test_memoryLimits(t *testing.T) {
 			// special oversub case; 'memory' is set and 'memory_max' is set to
 			// -1; which indicates there should be no hard limit (i.e. -1 / max)
 			memory:      100,
-			memoryMax:   memoryNoLimit,
+			memoryMax:   MemoryNoLimit,
 			expReserved: mbToBytes(100),
-			expHard:     memoryNoLimit,
+			expHard:     MemoryNoLimit,
 		},
 	}
 


### PR DESCRIPTION
Implement driver-side support in the `exec` and `docker` drivers for `resource.memory_max = -1`, which allows a reserve-only memory request without a hard limit for clusters with oversubscription enabled. This was already allowed by the server, but undocumented and unevenly supported by the built-in drivers.

Fixes: https://github.com/hashicorp/nomad/issues/25939
Ref: https://hashicorp.atlassian.net/browse/NMD-911
Docs: https://github.com/hashicorp/web-unified-docs/pull/1629
Ref: https://github.com/hashicorp/nomad-driver-podman/pull/488

### Testing & Reproduction steps

Configure the server to allow oversubscription:

```
$ nomad operator scheduler set-config -memory-oversubscription=true
```

Run the tests shown below:
* `docker`: https://github.com/hashicorp/nomad/pull/27354#issuecomment-3751271524
* `exec`: https://github.com/hashicorp/nomad/pull/27354#issuecomment-3751273777
* `raw_exec`: https://github.com/hashicorp/nomad/pull/27354#issuecomment-3751276460
* `podman` is missing support ([ref](https://github.com/hashicorp/nomad-driver-podman/blob/2ea4c5900477c3cf1570eed1d6a8af15e11340a2/driver.go#L1037-L1063)), which I've addressed in https://github.com/hashicorp/nomad-driver-podman/pull/488

The values shown for the resulting cgroups are described in the [kernel docs](https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html) but in brief:
* `memory.max`: the hard limit at which the task will get OOM'd
* `memory.low`: the "best-effort" soft limit 
* `memory.high`: the throttling limit (not supported today in Nomad)


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
  * https://github.com/hashicorp/web-unified-docs/pull/1629

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
