### PR TITLE
job: Validate the constraint attribute.

### DIFF
--- a/.changelog/27355.txt
+++ b/.changelog/27355.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+job: Correctly validate any constraint attributes to ensure they conform to known formats
+```

--- a/nomad/host_volume_endpoint_test.go
+++ b/nomad/host_volume_endpoint_test.go
@@ -119,7 +119,7 @@ func TestHostVolumeEndpoint_CreateRegisterGetDelete(t *testing.T) {
 	* capacity_max (100000) must be larger than capacity_min (200000)
 	* invalid attachment mode: "bad"
 	* invalid constraint: 1 error occurred:
-	* No LTarget provided but is required by constraint
+	* no attribute provided but is required by operator
 
 
 

--- a/nomad/structs/constraint.go
+++ b/nomad/structs/constraint.go
@@ -1,0 +1,67 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+package structs
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+var (
+	// validConstraintExactTargets are the exact targets that can be used within
+	// a job specification constraint target.
+	validConstraintExactTargets = []string{
+		"node.unique.id",
+		"node.datacenter",
+		"node.unique.name",
+		"node.class",
+		"node.pool",
+	}
+
+	// validConstraintPrefixTargets are the valid prefixes on constraint targets
+	// used within a job specification constraint.
+	validConstraintPrefixTargets = []string{
+		"attr.",
+		"meta.",
+	}
+)
+
+// validateConstraintAttribute ensures the constraint attribute is valid. It
+// does this by ensuring any interpolated field can be handled by the
+// resolveTarget function.
+func validateConstraintAttribute(target string) error {
+
+	// If no prefix delimieter is included, we assume this is a literal value
+	// and is therefore valid.
+	if !strings.HasPrefix(target, "${") {
+		return nil
+	}
+
+	// Must have closing brace
+	if !strings.HasSuffix(target, "}") {
+		return fmt.Errorf("attribute %q is missing a closing brace", target)
+	}
+
+	// Extract the interpolatable content between the delimiters.
+	interior := strings.TrimSuffix(strings.TrimPrefix(target, "${"), "}")
+
+	// Perform our exact target matching first. If the target does not hit this
+	// exact match, we will fall through to the prefix match check.
+	if slices.Contains(validConstraintExactTargets, interior) {
+		return nil
+	}
+
+	// Check the target against our valid prefixes.
+	for _, prefix := range validConstraintPrefixTargets {
+		if strings.HasPrefix(interior, prefix) {
+			return nil
+		}
+	}
+
+	// If we have reached this point, the target has not matched any valid
+	// options. Return an error that includes the target string, so it is
+	// immediately clear what constraint failed as job specifications can
+	// include many constraint blocks.
+	return fmt.Errorf("unsupported attribute %q", target)
+}

--- a/nomad/structs/constraint.go
+++ b/nomad/structs/constraint.go
@@ -12,18 +12,18 @@ var (
 	// validConstraintExactTargets are the exact targets that can be used within
 	// a job specification constraint target.
 	validConstraintExactTargets = []string{
-		"node.unique.id",
-		"node.datacenter",
-		"node.unique.name",
-		"node.class",
-		"node.pool",
+		"${node.unique.id}",
+		"${node.datacenter}",
+		"${node.unique.name}",
+		"${node.class}",
+		"${node.pool}",
 	}
 
 	// validConstraintPrefixTargets are the valid prefixes on constraint targets
 	// used within a job specification constraint.
 	validConstraintPrefixTargets = []string{
-		"attr.",
-		"meta.",
+		"${attr.",
+		"${meta.",
 	}
 )
 
@@ -34,27 +34,27 @@ func validateConstraintAttribute(target string) error {
 
 	// If no prefix delimieter is included, we assume this is a literal value
 	// and is therefore valid.
-	if !strings.HasPrefix(target, "${") {
+	if !strings.HasPrefix(target, "$") {
 		return nil
 	}
 
-	// Must have closing brace
+	// Must have the correct opening and closing delimeters.
+	if !strings.HasPrefix(target, "${") {
+		return fmt.Errorf("attribute %q is missing an opening brace", target)
+	}
 	if !strings.HasSuffix(target, "}") {
 		return fmt.Errorf("attribute %q is missing a closing brace", target)
 	}
 
-	// Extract the interpolatable content between the delimiters.
-	interior := strings.TrimSuffix(strings.TrimPrefix(target, "${"), "}")
-
 	// Perform our exact target matching first. If the target does not hit this
 	// exact match, we will fall through to the prefix match check.
-	if slices.Contains(validConstraintExactTargets, interior) {
+	if slices.Contains(validConstraintExactTargets, target) {
 		return nil
 	}
 
 	// Check the target against our valid prefixes.
 	for _, prefix := range validConstraintPrefixTargets {
-		if strings.HasPrefix(interior, prefix) {
+		if strings.HasPrefix(target, prefix) {
 			return nil
 		}
 	}

--- a/nomad/structs/constraint_test.go
+++ b/nomad/structs/constraint_test.go
@@ -1,0 +1,112 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+package structs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
+)
+
+func TestValidateConstraintTarget(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name             string
+		inputTarget      string
+		expectedErrorMsg string
+	}{
+		{
+			name:             "literal value",
+			inputTarget:      "literal-value",
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "literal empty",
+			inputTarget:      "",
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "valid node.unique.id",
+			inputTarget:      "${node.unique.id}",
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "valid node.datacenter",
+			inputTarget:      "${node.datacenter}",
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "valid node.unique.name",
+			inputTarget:      "${node.unique.name}",
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "valid node.class",
+			inputTarget:      "${node.class}",
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "valid node.pool",
+			inputTarget:      "${node.pool}",
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "valid attr.kernel.name",
+			inputTarget:      "${attr.kernel.name}",
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "valid attr.cpu.arch",
+			inputTarget:      "${attr.cpu.arch}",
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "invalid exact with suffix",
+			inputTarget:      "${node.pool.}",
+			expectedErrorMsg: `unsupported attribute "${node.pool.}"`,
+		},
+		{
+			name:             "valid meta.team",
+			inputTarget:      "${meta.team}",
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "valid meta.environment",
+			inputTarget:      "${meta.environment}",
+			expectedErrorMsg: "",
+		},
+		{
+			name:             "missing closing brace",
+			inputTarget:      "${node.datacenter",
+			expectedErrorMsg: `attribute "${node.datacenter" is missing a closing brace`,
+		},
+		{
+			name:             "unsupported interpolated value",
+			inputTarget:      "${env.PATH}",
+			expectedErrorMsg: `unsupported attribute "${env.PATH}"`,
+		},
+		{
+			name:             "invalid node attribute",
+			inputTarget:      "${node.invalid}",
+			expectedErrorMsg: `unsupported attribute "${node.invalid}"`,
+		},
+		{
+			name:             "empty interpolation",
+			inputTarget:      "${}",
+			expectedErrorMsg: `unsupported attribute "${}"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualErr := validateConstraintAttribute(tc.inputTarget)
+			if tc.expectedErrorMsg != "" {
+				must.ErrorContains(t, actualErr, tc.expectedErrorMsg)
+			} else {
+				must.NoError(t, actualErr)
+			}
+		})
+	}
+}

--- a/nomad/structs/constraint_test.go
+++ b/nomad/structs/constraint_test.go
@@ -97,6 +97,11 @@ func TestValidateConstraintTarget(t *testing.T) {
 			inputTarget:      "${}",
 			expectedErrorMsg: `unsupported attribute "${}"`,
 		},
+		{
+			name:             "missing starting brace",
+			inputTarget:      "$node.datacenter}",
+			expectedErrorMsg: `attribute "$node.datacenter}" is missing an opening brace`,
+		},
 	}
 
 	for _, tc := range cases {

--- a/nomad/structs/host_volumes_test.go
+++ b/nomad/structs/host_volumes_test.go
@@ -99,7 +99,7 @@ func TestHostVolume_Validate(t *testing.T) {
 	* capacity_max (100000) must be larger than capacity_min (200000)
 	* invalid attachment mode: "bad"
 	* invalid constraint: 1 error occurred:
-	* No LTarget provided but is required by constraint
+	* no attribute provided but is required by operator
 
 
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9955,9 +9955,17 @@ func (c *Constraint) Validate() error {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("Unknown constraint type %q", c.Operand))
 	}
 
-	// Ensure we have an LTarget for the constraints that need one
-	if requireLtarget && c.LTarget == "" {
-		mErr.Errors = append(mErr.Errors, fmt.Errorf("No LTarget provided but is required by constraint"))
+	// If the constraint must have a "LTarget" (attribute in the job spec), then
+	// ensure it is not an empty string and is valid.
+	if requireLtarget {
+		if c.LTarget == "" {
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("No LTarget provided but is required by constraint"))
+		} else {
+			if err := validateConstraintAttribute(c.LTarget); err != nil {
+				mErr.Errors = append(mErr.Errors, err)
+			}
+		}
+
 	}
 
 	return mErr.ErrorOrNil()

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9959,7 +9959,7 @@ func (c *Constraint) Validate() error {
 	// ensure it is not an empty string and is valid.
 	if requireLtarget {
 		if c.LTarget == "" {
-			mErr.Errors = append(mErr.Errors, fmt.Errorf("No LTarget provided but is required by constraint"))
+			mErr.Errors = append(mErr.Errors, errors.New("no attribute provided but is required by operator"))
 		} else {
 			if err := validateConstraintAttribute(c.LTarget); err != nil {
 				mErr.Errors = append(mErr.Errors, err)

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -735,7 +735,7 @@ func testJob() *Job {
 		},
 		Constraints: []*Constraint{
 			{
-				LTarget: "$attr.kernel.name",
+				LTarget: "${attr.kernel.name}",
 				RTarget: "linux",
 				Operand: "=",
 			},

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -3658,7 +3658,7 @@ func TestConstraint_Validate(t *testing.T) {
 		{
 			name: "valid",
 			inputConstraint: &Constraint{
-				LTarget: "$attr.kernel.name",
+				LTarget: "${attr.kernel.name}",
 				RTarget: "linux",
 				Operand: "=",
 			},
@@ -3667,7 +3667,7 @@ func TestConstraint_Validate(t *testing.T) {
 		{
 			name: "invalid regex",
 			inputConstraint: &Constraint{
-				LTarget: "$attr.kernel.name",
+				LTarget: "${attr.kernel.name}",
 				RTarget: "(foo",
 				Operand: ConstraintRegex,
 			},
@@ -3694,7 +3694,7 @@ func TestConstraint_Validate(t *testing.T) {
 		{
 			name: "valid semver",
 			inputConstraint: &Constraint{
-				LTarget: "$attr.kernel.name",
+				LTarget: "${attr.kernel.name}",
 				RTarget: ">= 0.6.1",
 				Operand: ConstraintSemver,
 			},
@@ -3761,7 +3761,7 @@ func TestConstraint_Validate(t *testing.T) {
 				RTarget: "foo",
 				Operand: ConstraintRegex,
 			},
-			expectedErrorMsg: "No LTarget",
+			expectedErrorMsg: "no attribute provided but is required by operator",
 		},
 		{
 			name: "invalid operand",

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -3645,75 +3645,154 @@ func TestTaskWaitConfig_Equals(t *testing.T) {
 func TestConstraint_Validate(t *testing.T) {
 	ci.Parallel(t)
 
-	c := &Constraint{}
-	err := c.Validate()
-	require.Error(t, err, "Missing constraint operand")
-
-	c = &Constraint{
-		LTarget: "$attr.kernel.name",
-		RTarget: "linux",
-		Operand: "=",
+	testCases := []struct {
+		name             string
+		inputConstraint  *Constraint
+		expectedErrorMsg string
+	}{
+		{
+			name:             "missing operand",
+			inputConstraint:  &Constraint{},
+			expectedErrorMsg: "Missing constraint operand",
+		},
+		{
+			name: "valid",
+			inputConstraint: &Constraint{
+				LTarget: "$attr.kernel.name",
+				RTarget: "linux",
+				Operand: "=",
+			},
+			expectedErrorMsg: "",
+		},
+		{
+			name: "invalid regex",
+			inputConstraint: &Constraint{
+				LTarget: "$attr.kernel.name",
+				RTarget: "(foo",
+				Operand: ConstraintRegex,
+			},
+			expectedErrorMsg: "missing closing",
+		},
+		{
+			name: "invalid version",
+			inputConstraint: &Constraint{
+				LTarget: "$attr.kernel.name",
+				RTarget: "~> foo",
+				Operand: ConstraintVersion,
+			},
+			expectedErrorMsg: "malformed constraint",
+		},
+		{
+			name: "invalid semver",
+			inputConstraint: &Constraint{
+				LTarget: "$attr.kernel.name",
+				RTarget: "~> foo",
+				Operand: ConstraintSemver,
+			},
+			expectedErrorMsg: "Malformed constraint",
+		},
+		{
+			name: "valid semver",
+			inputConstraint: &Constraint{
+				LTarget: "$attr.kernel.name",
+				RTarget: ">= 0.6.1",
+				Operand: ConstraintSemver,
+			},
+			expectedErrorMsg: "",
+		},
+		{
+			name: "invalid zero distinct",
+			inputConstraint: &Constraint{
+				LTarget: "$attr.kernel.name",
+				RTarget: "0",
+				Operand: ConstraintDistinctProperty,
+			},
+			expectedErrorMsg: "count of 1 or greater",
+		},
+		{
+			name: "invalid negative distinct",
+			inputConstraint: &Constraint{
+				LTarget: "$attr.kernel.name",
+				RTarget: "-1",
+				Operand: ConstraintDistinctProperty,
+			},
+			expectedErrorMsg: "to uint64",
+		},
+		{
+			name: "valid distinct hosts",
+			inputConstraint: &Constraint{
+				LTarget: "",
+				RTarget: "",
+				Operand: ConstraintDistinctHosts,
+			},
+			expectedErrorMsg: "",
+		},
+		{
+			name: "invalid set contains",
+			inputConstraint: &Constraint{
+				LTarget: "",
+				RTarget: "",
+				Operand: ConstraintSetContains,
+			},
+			expectedErrorMsg: "requires an RTarget",
+		},
+		{
+			name: "invalid set contains all",
+			inputConstraint: &Constraint{
+				LTarget: "",
+				RTarget: "",
+				Operand: ConstraintSetContainsAll,
+			},
+			expectedErrorMsg: "requires an RTarget",
+		},
+		{
+			name: "invalid set contains any",
+			inputConstraint: &Constraint{
+				LTarget: "",
+				RTarget: "",
+				Operand: ConstraintSetContainsAny,
+			},
+			expectedErrorMsg: "requires an RTarget",
+		},
+		{
+			name: "invalid regex",
+			inputConstraint: &Constraint{
+				LTarget: "",
+				RTarget: "foo",
+				Operand: ConstraintRegex,
+			},
+			expectedErrorMsg: "No LTarget",
+		},
+		{
+			name: "invalid operand",
+			inputConstraint: &Constraint{
+				LTarget: "",
+				RTarget: "",
+				Operand: "foo",
+			},
+			expectedErrorMsg: "Unknown constraint type",
+		},
+		{
+			name: "invalid constraint attribure",
+			inputConstraint: &Constraint{
+				LTarget: "${platform.aws.placement.availability-zone}",
+				RTarget: "3",
+				Operand: ">",
+			},
+			expectedErrorMsg: "unsupported attribute",
+		},
 	}
-	err = c.Validate()
-	require.NoError(t, err)
 
-	// Perform additional regexp validation
-	c.Operand = ConstraintRegex
-	c.RTarget = "(foo"
-	err = c.Validate()
-	require.Error(t, err, "missing closing")
-
-	// Perform version validation
-	c.Operand = ConstraintVersion
-	c.RTarget = "~> foo"
-	err = c.Validate()
-	require.Error(t, err, "Malformed constraint")
-
-	// Perform semver validation
-	c.Operand = ConstraintSemver
-	err = c.Validate()
-	require.Error(t, err, "Malformed constraint")
-
-	c.RTarget = ">= 0.6.1"
-	require.NoError(t, c.Validate())
-
-	// Perform distinct_property validation
-	c.Operand = ConstraintDistinctProperty
-	c.RTarget = "0"
-	err = c.Validate()
-	require.Error(t, err, "count of 1 or greater")
-
-	c.RTarget = "-1"
-	err = c.Validate()
-	require.Error(t, err, "to uint64")
-
-	// Perform distinct_hosts validation
-	c.Operand = ConstraintDistinctHosts
-	c.LTarget = ""
-	c.RTarget = ""
-	if err := c.Validate(); err != nil {
-		t.Fatalf("expected valid constraint: %v", err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualError := tc.inputConstraint.Validate()
+			if tc.expectedErrorMsg != "" {
+				must.ErrorContains(t, actualError, tc.expectedErrorMsg)
+			} else {
+				must.NoError(t, actualError)
+			}
+		})
 	}
-
-	// Perform set_contains* validation
-	c.RTarget = ""
-	for _, o := range []string{ConstraintSetContains, ConstraintSetContainsAll, ConstraintSetContainsAny} {
-		c.Operand = o
-		err = c.Validate()
-		require.Error(t, err, "requires an RTarget")
-	}
-
-	// Perform LTarget validation
-	c.Operand = ConstraintRegex
-	c.RTarget = "foo"
-	c.LTarget = ""
-	err = c.Validate()
-	require.Error(t, err, "No LTarget")
-
-	// Perform constraint type validation
-	c.Operand = "foo"
-	err = c.Validate()
-	require.Error(t, err, "Unknown constraint type")
 }
 
 func TestAffinity_Validate(t *testing.T) {


### PR DESCRIPTION
This change adds better validation of the job specification constraint block attribute parameter. The parameter has a well defined set of possible formats, meaning we can catch these before submitting the job to the scheduler. This validation is returned to the job submitter who can make adjustments to any errors.

Before this change, no validation of the parameter contents was conducted, meaning a job could be submitted to the scheduler that would never be placable.

I took the opportunity to update the existing constraint validation test to be table driven and use the `must` library.

### Testing & Reproduction steps
Tested using this example job:
```hcl
job "example" {
  constraint {
    attribute = "${platform.aws.placement.availability-zone}"
    operator  = ">"
    value     = "3"
  }

  group "cache" {
    network {
      port "db" {
        to = 6379
      }
    }

    task "redis" {
      driver = "docker"

      config {
        image          = "redis:7"
        ports          = ["db"]
        auth_soft_fail = true
      }

      identity {
        env  = true
        file = true
      }

      resources {
        cpu    = 500
        memory = 256
      }
    }
  }
}
```

### Links
Closes #17435
Jira https://hashicorp.atlassian.net/browse/NMD-1022

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

