### PR TITLE
sentinel: allow opt-in to `http` and add support for `nomad_var`

### DIFF
--- a/.changelog/_3568.txt
+++ b/.changelog/_3568.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+sentinel: Added opt-in support for the `http` module via the `sentinel.additional_enabled_modules` configuration
+```
+
+```release-note:improvement
+sentinel: Added a new `nomad_var` built-in import for fetching Nomad variables under the `nomad/sentinel` path for use in policy evaluation
+```

--- a/nomad/structs/config/sentinel.go
+++ b/nomad/structs/config/sentinel.go
@@ -11,8 +11,14 @@ import (
 
 // SentinelConfig is configuration specific to Sentinel
 type SentinelConfig struct {
-	// Imports are the configured imports
+	// Imports are configured external imports
 	Imports []*SentinelImport `hcl:"import,expand"`
+
+	// AdditionalEnabledModules specifies allowing "stdlib" imports that are
+	// normally disallowed. We currently enable all Sentinel's standard imports
+	// except "http". In the future if any new imports aren't automatically
+	// enabled, users can override that here
+	AdditionalEnabledModules []string `hcl:"additional_enabled_modules"`
 }
 
 func (s *SentinelConfig) Copy() *SentinelConfig {
@@ -22,6 +28,7 @@ func (s *SentinelConfig) Copy() *SentinelConfig {
 
 	ns := *s
 	ns.Imports = helper.CopySlice(s.Imports)
+	ns.AdditionalEnabledModules = slices.Clone(s.AdditionalEnabledModules)
 	return &ns
 }
 
@@ -42,11 +49,16 @@ func (s *SentinelImport) Copy() *SentinelImport {
 	return &ns
 }
 
-// Merge is used to merge two Sentinel configs together. The settings from the input always take precedence.
+// Merge is used to merge two Sentinel configs together. All slice fields are
+// combined.
 func (s *SentinelConfig) Merge(b *SentinelConfig) *SentinelConfig {
 	result := *s
 	if len(b.Imports) > 0 {
 		result.Imports = append(result.Imports, b.Imports...)
+	}
+	if len(b.AdditionalEnabledModules) > 0 {
+		result.AdditionalEnabledModules = append(
+			result.AdditionalEnabledModules, b.AdditionalEnabledModules...)
 	}
 	return &result
 }

--- a/nomad/structs/variables.go
+++ b/nomad/structs/variables.go
@@ -427,12 +427,12 @@ func ValidatePath(path string) error {
 
 	// Don't allow a variable with path "nomad"
 	if len(parts) == 1 {
-		return fmt.Errorf("\"nomad\" is a reserved top-level directory path, but you may write variables to \"nomad/jobs\", \"nomad/job-templates\", or below")
+		return fmt.Errorf(`"nomad" is a reserved top-level directory path, but you may write variables to "nomad/jobs", "nomad/job-templates", "nomad/sentinel", or below`)
 	}
 
 	switch {
-	case parts[1] == "jobs":
-		// Any path including "nomad/jobs" is valid
+	case parts[1] == "jobs" || parts[1] == "sentinel":
+		// Any path including "nomad/jobs" or "nomad/sentinel" is valid
 		return nil
 	case parts[1] == "job-templates" && len(parts) == 3:
 		// Paths including "nomad/job-templates" is valid, provided they have single further path part


### PR DESCRIPTION
Nomad's Sentinel implementation has long disallowed the use of the built-in `http` import, but we'll now allow access for policies on an opt-in basis. Cluster administrators can grant access by adding it to the `sentinel.additional_enabled_modules` configuration, which matches the configuration used for this purpose by Vault.

In order to provide credentials to the `http` module, the Nomad Enterprise code base implements a new built-in `nomad_var` import. Policy authors can use this to fetch variables under the `nomad/sentinel` path and expose them as a map of strings. The policy can use these values for credentials or any other purpose in the policy. Job authors and workloads do not have access to these credentials unless the policy author exposes them via the `print` or `error` functions in the Sentinel policy document. This CE code needs to include some minor changes around Variables validation to allow for this.

Ref: https://hashicorp.atlassian.net/browse/NMD-861
Ref: https://go.hashi.co/rfc/nmd-219
Ref: https://github.com/hashicorp/nomad-enterprise/pull/3568
Docs PR: https://github.com/hashicorp/web-unified-docs/pull/1607

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
  * Tests in https://github.com/hashicorp/nomad-enterprise/pull/3568
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
  * https://github.com/hashicorp/web-unified-docs/pull/1607

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
