### PR TITLE
client: fix unchanged devices causing node updates

### DIFF
--- a/.changelog/27363.txt
+++ b/.changelog/27363.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fix unchanged devices causing extraneous node updates
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3552,7 +3552,8 @@ func (n *NodeDeviceResource) Equal(o *NodeDeviceResource) bool {
 		return false
 	}
 	for k, v := range n.Attributes {
-		if otherV, ok := o.Attributes[k]; !ok || v != otherV {
+		otherV, ok := o.Attributes[k]
+		if !ok || !v.Equal(otherV) {
 			return false
 		}
 	}
@@ -3610,7 +3611,7 @@ func (n *NodeDevice) Equal(o *NodeDevice) bool {
 		return false
 	}
 
-	return false
+	return true
 }
 
 func (n *NodeDevice) Copy() *NodeDevice {

--- a/plugins/device/cmd/example/device.go
+++ b/plugins/device/cmd/example/device.go
@@ -249,6 +249,11 @@ func getDeviceGroup(devices []*device.Device) *device.DeviceGroup {
 		Type:    deviceType,
 		Name:    deviceName,
 		Devices: devices,
+		Attributes: map[string]*structs.Attribute{
+			"cool-attribute": {
+				String: pointer.Of("attribute-wearing-sunglasses"),
+			},
+		},
 	}
 }
 

--- a/plugins/shared/structs/attribute.go
+++ b/plugins/shared/structs/attribute.go
@@ -322,6 +322,12 @@ func (a *Attribute) Compare(b *Attribute) (int, bool) {
 	return a.comparator()(b)
 }
 
+// Equal returns true if two Attributes are comparable and have equal values.
+func (a *Attribute) Equal(b *Attribute) bool {
+	val, isComparable := a.Compare(b)
+	return isComparable && val == 0
+}
+
 // comparator returns the comparator function for the attribute
 func (a *Attribute) comparator() compareFn {
 	if a.Bool != nil {


### PR DESCRIPTION
### Description

When a device plugin fingerprints, Nomad should only register a node update if a device has been added, removed, or changed.

Currently, if a plugin sends a fingerprint with no actual changes (which ostensibly it should not do, but I digress), we still think something has changed, for two reasons:

* For device attributes, we're comparing pointers rather than values.
* For device instances, we can only get `Equal() == true` if they're both `nil`.

This repairs both scenarios.

### Testing & Reproduction steps

This was reported by our lovely support team ~using the `nvidia` device plugin (which needs a separate investigation)~ (edit: it was a custom plugin, not nvidia), but can be reproduced with a modified version of [our `example` plugin](https://github.com/hashicorp/nomad/tree/v1.11.1/plugins/device/cmd/example).

<details><summary>This causes it to always send a fingerprint, even if nothing has changed:</summary>

```diff
diff --git a/plugins/device/cmd/example/device.go b/plugins/device/cmd/example/device.go
index 5e3000c66f..7c4618647c 100644
--- a/plugins/device/cmd/example/device.go
+++ b/plugins/device/cmd/example/device.go
@@ -170,9 +170,6 @@ func (d *FsDevice) fingerprint(ctx context.Context, devices chan *device.Fingerp
                }

                detected := d.diffFiles(files)
-               if len(detected) == 0 {
-                       continue
-               }

                devices <- device.NewFingerprint(getDeviceGroup(detected))

@@ -202,10 +199,6 @@ func (d *FsDevice) diffFiles(files []os.FileInfo) []*device.Device {
                d.logger.Trace("checking health", "file perm", perms, "unhealthy perms", d.unhealthyPerm, "healthy", healthy)

                // See if we alreay have the device
-               oldHealth, ok := d.devices[name]
-               if ok && oldHealth == healthy {
-                       continue
-               }

                // Health has changed or we have a new object
                changes = true
```
</details>

And the change in this PR adds an Attribute to hit that part of the bug.

### Links

Internal ref: https://hashicorp.atlassian.net/browse/NMD-1124

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.