### PR TITLE
leader: do not emit follow-up for failed but orphaned evals

### DIFF
--- a/.changelog/27367.txt
+++ b/.changelog/27367.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed a bug where follow-up evals could be created for failed evaluations of garbage collected jobs
+```


### PR DESCRIPTION
An evaluation that's in-flight in the scheduler when the job is garbage collected, will fail and eventually reach the delivery limit. When the leader is pulling failed evals off the eval broker, it creates a new follow-up eval which will meet the same fate and this will continue forever (albeit slowly due to backoff) until the evals are manually deleted.

Update the failed evals reaper to check the state for the evaluation being "orphaned": no job in the state store. It appears that we can't check this unconditionally on all eval upserts in the FSM because there are many cases where we want to update evals where the job has already been deleted.

It appears that we can't check this unconditionally on upsert in the FSM because there are many cases where we want to update evals where the job has already been deleted.

Ref: https://hashicorp.atlassian.net/browse/NMD-1012
Fixes: https://github.com/hashicorp/nomad/issues/16877

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/docs/contribute.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
