### PR TITLE
release automation: enable monitoring build.yml dispatch

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -1,0 +1,24 @@
+name: Build push
+
+# This being a separate workflow from build.yml allows the build logic
+# to be exercised on push without also triggering CRT prepare workflow
+# every time. It also allows runs for this workflow to keep their default
+# default run name (auto-truncated commit message).
+
+on:
+  push:
+    branches:
+      # 'main' is our forever branch where all changes get merged.
+      # It should always be buildable.
+      - main
+      # 'release/[0-9].[0-9]+.x*' matches our long-lived release lines such as
+      # '1.10.x' and '1.10.x+ent', but excludes specific release branches like
+      # '1.10.0' and '1.10.0+ent' (they are instead built via workflow_dispatch
+      # to build.yml directly during a release).
+      - 'release/[0-9].[0-9]+.x*'
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      build-ref: ${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,42 +1,52 @@
 # The build workflow is responsible for building Nomad on all our supported
-# platforms. The compiled artifacts are then uploaded to GitHub. This upload
-# triggers the CRT prepare workflow, which downloads the artifacts and then
-# uploads them to our internal store.
+# platforms. The compiled artifacts are then uploaded to GitHub.
+#
+# The completion of this workflow (specifically "build.yml") triggers the
+# CRT prepare workflow, which downloads the GitHub artifacts produced here
+# and uploads them to our internal store (Artifactory).
 #
 # The workflow can be triggered in two ways:
-#  - pushes to main or long-lived release line branches (eg. 1.10.x)
-#  - dispatched via the release workflow (release.yml).
-#
-# The workflow should not be triggered from short-lived release branches;
-# branches that are cut from the long-lived ones in order to release Nomad. The
-# release workflow should be the only process responsible for triggering the
-# build workflow. This is because the release workflow performs a commit and
-# push of updated generated assets to the release branch. If this push triggers
-# a build, it will conflict with the release build process which shares the same
-# Git SHA and result in a last-write-wins to our internal store.
+#  - push to main or long-lived release line branches (eg. 1.10.x)
+#    via build-on-push.yml
+#  - dispatched during a release
+
 name: build
 
+# special identifier set only on workflow dispatch,
+# so the release automation can watch for a specific run.
+run-name: ${{ inputs.run-name || 'Build' }}
+
 on:
-  push:
-    branches:
-      # 'main' is our forever branch where all changes get merged.
-      # 'release/[0-9].[0-9]+.x*' matches our long-lived release lines such as
-      # '1.10.x' and '1.10.x+ent' but excludes short-lived release branches such
-      # as '1.10.0' and '1.10.0+ent'.
-      - main
-      - 'release/[0-9].[0-9]+.x*'
-  workflow_dispatch:
+  # build-on-push.yml uses this as a reusable workflow on:push
+  workflow_call:
     inputs:
       build-ref:
         description: 'The git ref to build from'
         type: string
-        default: ''
-        required: false
+        required: true # gets set to github.ref on:push
       make-prerelease:
-        description: "Run prerelease to generate files"
-        type: "boolean"
+        description: 'Run prerelease to generate files'
+        type: boolean
         required: false
-        default: true
+        default: true # run `make prerelease` here when triggered on:push
+
+  # we call `gh workflow run` during releases
+  workflow_dispatch:
+    inputs:
+      run-name:
+        description: "Value to specify as the workflow's run-name"
+        type: string
+        required: false
+        default: ''
+      build-ref:
+        description: 'The git ref to build'
+        type: string
+        required: true # must specify what to build during a release
+      make-prerelease:
+        description: 'Run prerelease to generate files'
+        type: boolean
+        required: false
+        default: false # `make prerelease` run in advance by release-prepare.yml
 
 env:
   PKG_NAME: "nomad"


### PR DESCRIPTION
This PR does two things:
1. Enable waiting for a specific dispatch of `build.yml` during releases
2. Bonus: Do not trigger CRT prepare on every push to `main` / `release/*.x`

In our internal release system, the CRT prepare workflow is triggered by the completion of `build.yml`, so we can't just `workflow_call` it as a reusable workflow, but we need it to block the release process until it's done.

It would be nice if `gh workflow run` or the API had some option for this, but [alas](https://github.com/orgs/community/discussions/9752). Instead, the common way to do this is to specify some unique value in the workflow's `run-name`, then filter `gh run list` results based on that.

E.g.

```shell
name="Release $(git rev-parse HEAD) $(date +%s)"

gh workflow run --field "run-name=$name" build.yml

# loop this until the run registers
gh run list --workflow build.yml \
  --json 'databaseId,displayTitle,status,conclusion,url' \
  --jq "[ .[] | select(.displayTitle == \"$name\") ]"

gh run watch '<< that databaseId >>'
```

Splitting `on:push` out to a separate workflow isn't strictly necessary, but I left a comment on there about why I chose to do that. I thiiiink it will also allow us to remove the slack-channel-changing business during a release, since this should cut way down on the noise in #feed-nomad-releases 

---

Internal ticket: https://hashicorp.atlassian.net/browse/NMD-1112