### PR TITLE
job register: remove backcompat logic and remove duplicate logic

### DIFF
--- a/.changelog/27386.txt
+++ b/.changelog/27386.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+multiregion: fixes a bug where resubmitting an unchanged job would cause server handler to hang
+```

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -335,7 +335,9 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 	if !specChanged {
 		reply.JobModifyIndex = existingJob.ModifyIndex
 
-		// Force an eval for service/batch jobs
+		// Force an eval for service/batch jobs. This is intentional
+		// behavior to allow triggering of evaluations via re-registering
+		// similar to `nomad job eval`.
 		if args.Eval != nil {
 			update := &structs.EvalUpdateRequest{
 				Evals:        []*structs.Evaluation{args.Eval},

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -338,28 +338,23 @@ func (j *Job) Register(args *structs.JobRegisterRequest, reply *structs.JobRegis
 		return nil
 	}
 
-	if existingJob == nil {
-		// Pre-register a deployment if necessary.
-		args.Deployment = j.multiregionCreateDeployment(job, args.Eval)
+	// Pre-register a deployment if necessary.
+	args.Deployment = j.multiregionCreateDeployment(job, args.Eval)
 
-		// Commit this update via Raft
-		_, index, err := j.srv.raftApply(structs.JobRegisterRequestType, args)
-		if err != nil {
-			j.logger.Error("registering job failed", "error", err)
-			return err
-		}
+	// Commit this update via Raft
+	_, index, err := j.srv.raftApply(structs.JobRegisterRequestType, args)
+	if err != nil {
+		j.logger.Error("registering job failed", "error", err)
+		return err
+	}
 
-		// Populate the reply with job information
-		reply.JobModifyIndex = index
-		reply.Index = index
+	// Populate the reply with job information
+	reply.JobModifyIndex = index
+	reply.Index = index
 
-		if args.Eval != nil {
-			reply.EvalCreateIndex = index
-			reply.EvalID = args.Eval.ID
-		}
-
-	} else {
-		reply.JobModifyIndex = existingJob.JobModifyIndex
+	if args.Eval != nil {
+		reply.EvalCreateIndex = index
+		reply.EvalID = args.Eval.ID
 	}
 
 	// used for multiregion start


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Removes some backward compatibility logic in the `Job.Register` RPC handle, along with refactoring some multi-region code to reduce duplicate logic. This has the added benefit of fixing a bug where the CLI was getting hanging when redeploying the same multiregion jobs.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
