### PR TITLE
devices: add support for first_available device priotisation

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -114,6 +114,15 @@ endif
 pkg/windows_%/nomad: GO_OUT = $@.exe
 pkg/windows_%/nomad: GO_TAGS += timetzdata
 
+# Build the example device plugin for e2e device tests
+pkg/%/nomad-device-example: GO_OUT ?= $@
+pkg/%/nomad-device-example: ## Build the example device plugin for GOOS_GOARCH
+	@echo "==> Building $@..."
+	@CGO_ENABLED=0 \
+		GOOS=$(firstword $(subst _, ,$*)) \
+		GOARCH=$(lastword $(subst _, ,$*)) \
+		go build -trimpath -o $(GO_OUT) ./plugins/device/cmd/example/cmd
+
 # Define package targets for each of the build targets we actually have on this system
 define makePackageTarget
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1627,12 +1627,28 @@ func ApiResourcesToStructs(in *api.Resources) *structs.Resources {
 	if len(in.Devices) > 0 {
 		out.Devices = []*structs.RequestedDevice{}
 		for _, d := range in.Devices {
-			out.Devices = append(out.Devices, &structs.RequestedDevice{
+			rd := &structs.RequestedDevice{
 				Name:        d.Name,
-				Count:       *d.Count,
 				Constraints: ApiConstraintsToStructs(d.Constraints),
 				Affinities:  ApiAffinitiesToStructs(d.Affinities),
-			})
+			}
+			// Only set Count if not using FirstAvailable
+			if d.Count != nil {
+				rd.Count = *d.Count
+			}
+			// Convert FirstAvailable options
+			if len(d.FirstAvailable) > 0 {
+				rd.FirstAvailable = make([]*structs.DeviceOption, len(d.FirstAvailable))
+				for i, opt := range d.FirstAvailable {
+					rd.FirstAvailable[i] = &structs.DeviceOption{
+						Constraints: ApiConstraintsToStructs(opt.Constraints),
+					}
+					if opt.Count != nil {
+						rd.FirstAvailable[i].Count = *opt.Count
+					}
+				}
+			}
+			out.Devices = append(out.Devices, rd)
 		}
 	}
 

--- a/e2e/devices/basic_test.go
+++ b/e2e/devices/basic_test.go
@@ -1,0 +1,327 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+package devices
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
+)
+
+// TestDeviceScheduling runs end-to-end tests for traditional device scheduling
+// (count, constraint, affinity without first_available). These tests require:
+// - A Nomad cluster with at least one Linux client
+// - The example device plugin (nomad/file/mock) installed and configured
+// - Mock device files created in the configured directory
+//
+// See plugins/device/cmd/example/README.md for setup instructions.
+func TestDeviceScheduling(t *testing.T) {
+	nomadClient := e2eutil.NomadClient(t)
+	e2eutil.WaitForLeader(t, nomadClient)
+	e2eutil.WaitForNodesReady(t, nomadClient, 1)
+
+	// Check if any nodes have mock devices available
+	if !hasDevicePlugin(t, nomadClient, "nomad/file/mock") {
+		t.Skip("skipping: no nodes with nomad/file/mock device plugin")
+	}
+
+	t.Run("testDeviceCountOnly", testDeviceCountOnly)
+	t.Run("testDeviceWithConstraint", testDeviceWithConstraint)
+	t.Run("testDeviceWithAffinity", testDeviceWithAffinity)
+	t.Run("testDeviceWithConstraintAndAffinity", testDeviceWithConstraintAndAffinity)
+	t.Run("testDeviceConstraintNoMatch", testDeviceConstraintNoMatch)
+}
+
+// hasDevicePlugin checks if any node in the cluster has the specified device
+// plugin available.
+func hasDevicePlugin(t *testing.T, client *api.Client, deviceName string) bool {
+	t.Helper()
+
+	nodes, _, err := client.Nodes().List(nil)
+	must.NoError(t, err)
+
+	for _, nodeStub := range nodes {
+		node, _, err := client.Nodes().Info(nodeStub.ID, nil)
+		must.NoError(t, err)
+
+		if node.NodeResources != nil && node.NodeResources.Devices != nil {
+			for _, device := range node.NodeResources.Devices {
+				fullName := device.Vendor + "/" + device.Type + "/" + device.Name
+				if strings.Contains(fullName, deviceName) ||
+					strings.Contains(device.Name, deviceName) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// testDeviceCountOnly tests that a job with only device count specified
+// can be successfully scheduled.
+func testDeviceCountOnly(t *testing.T) {
+	nomadClient := e2eutil.NomadClient(t)
+
+	jobID := "device-count-" + uuid.Short()
+	jobIDs := []string{jobID}
+	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
+
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient, "./input/device_count_only.hcl", jobID, "")
+	must.Len(t, 1, allocs, must.Sprint("expected 1 allocation"))
+
+	alloc, _, err := nomadClient.Allocations().Info(allocs[0].ID, nil)
+	must.NoError(t, err)
+	must.Eq(t, api.AllocClientStatusRunning, alloc.ClientStatus,
+		must.Sprintf("allocation status: %s, description: %s",
+			alloc.ClientStatus, alloc.ClientDescription))
+
+	// Verify device was allocated
+	must.NotNil(t, alloc.AllocatedResources)
+	taskResources := alloc.AllocatedResources.Tasks["sleep"]
+	must.NotNil(t, taskResources)
+	must.SliceNotEmpty(t, taskResources.Devices,
+		must.Sprint("expected devices to be allocated"))
+
+	// Verify exactly 1 device
+	totalDevices := 0
+	for _, deviceResource := range taskResources.Devices {
+		totalDevices += len(deviceResource.DeviceIDs)
+	}
+	must.Eq(t, 1, totalDevices, must.Sprint("expected exactly 1 device"))
+}
+
+// testDeviceWithConstraint tests that a job with device count and constraint
+// can be successfully scheduled when the constraint is satisfied.
+func testDeviceWithConstraint(t *testing.T) {
+	nomadClient := e2eutil.NomadClient(t)
+
+	jobID := "device-constraint-" + uuid.Short()
+	jobIDs := []string{jobID}
+	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
+
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient, "./input/device_with_constraint.hcl", jobID, "")
+	must.Len(t, 1, allocs, must.Sprint("expected 1 allocation"))
+
+	alloc, _, err := nomadClient.Allocations().Info(allocs[0].ID, nil)
+	must.NoError(t, err)
+	must.Eq(t, api.AllocClientStatusRunning, alloc.ClientStatus,
+		must.Sprintf("allocation status: %s, description: %s",
+			alloc.ClientStatus, alloc.ClientDescription))
+
+	// Verify device was allocated
+	must.NotNil(t, alloc.AllocatedResources)
+	taskResources := alloc.AllocatedResources.Tasks["sleep"]
+	must.NotNil(t, taskResources)
+	must.SliceNotEmpty(t, taskResources.Devices,
+		must.Sprint("expected devices to be allocated"))
+}
+
+// testDeviceWithAffinity tests that a job with device count and affinity
+// can be successfully scheduled.
+func testDeviceWithAffinity(t *testing.T) {
+	nomadClient := e2eutil.NomadClient(t)
+
+	jobID := "device-affinity-" + uuid.Short()
+	jobIDs := []string{jobID}
+	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
+
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient, "./input/device_with_affinity.hcl", jobID, "")
+	must.Len(t, 1, allocs, must.Sprint("expected 1 allocation"))
+
+	alloc, _, err := nomadClient.Allocations().Info(allocs[0].ID, nil)
+	must.NoError(t, err)
+	must.Eq(t, api.AllocClientStatusRunning, alloc.ClientStatus,
+		must.Sprintf("allocation status: %s, description: %s",
+			alloc.ClientStatus, alloc.ClientDescription))
+
+	// Verify device was allocated
+	must.NotNil(t, alloc.AllocatedResources)
+	taskResources := alloc.AllocatedResources.Tasks["sleep"]
+	must.NotNil(t, taskResources)
+	must.SliceNotEmpty(t, taskResources.Devices,
+		must.Sprint("expected devices to be allocated"))
+}
+
+// testDeviceWithConstraintAndAffinity tests that a job with device count,
+// constraint, and affinity can be successfully scheduled.
+func testDeviceWithConstraintAndAffinity(t *testing.T) {
+	nomadClient := e2eutil.NomadClient(t)
+
+	jobID := "device-both-" + uuid.Short()
+	jobIDs := []string{jobID}
+	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
+
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient, "./input/device_with_constraint_and_affinity.hcl", jobID, "")
+	must.Len(t, 1, allocs, must.Sprint("expected 1 allocation"))
+
+	alloc, _, err := nomadClient.Allocations().Info(allocs[0].ID, nil)
+	must.NoError(t, err)
+	must.Eq(t, api.AllocClientStatusRunning, alloc.ClientStatus,
+		must.Sprintf("allocation status: %s, description: %s",
+			alloc.ClientStatus, alloc.ClientDescription))
+
+	// Verify devices were allocated
+	must.NotNil(t, alloc.AllocatedResources)
+	taskResources := alloc.AllocatedResources.Tasks["sleep"]
+	must.NotNil(t, taskResources)
+	must.SliceNotEmpty(t, taskResources.Devices,
+		must.Sprint("expected devices to be allocated"))
+
+	// Verify 2 devices were allocated
+	totalDevices := 0
+	for _, deviceResource := range taskResources.Devices {
+		totalDevices += len(deviceResource.DeviceIDs)
+	}
+	must.Eq(t, 2, totalDevices, must.Sprint("expected exactly 2 devices"))
+}
+
+// testDeviceConstraintNoMatch tests that when a device constraint cannot be
+// satisfied, the job fails to schedule with appropriate error messages.
+func testDeviceConstraintNoMatch(t *testing.T) {
+	nomadClient := e2eutil.NomadClient(t)
+
+	jobID := "device-nomatch-" + uuid.Short()
+	jobIDs := []string{jobID}
+	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
+
+	// Parse and register the job
+	job, err := e2eutil.Parse2(t, "./input/device_constraint_no_match.hcl")
+	must.NoError(t, err)
+	job.ID = &jobID
+
+	resp, _, err := nomadClient.Jobs().Register(job, nil)
+	must.NoError(t, err)
+
+	evalID := resp.EvalID
+
+	// Wait for the evaluation to complete (it should fail to place)
+	var eval *api.Evaluation
+	testutil.WaitForResultRetries(30, func() (bool, error) {
+		time.Sleep(500 * time.Millisecond)
+		eval, _, err = nomadClient.Evaluations().Info(evalID, nil)
+		if err != nil {
+			return false, err
+		}
+		if eval.Status == api.EvalStatusComplete || eval.Status == api.EvalStatusBlocked {
+			return true, nil
+		}
+		return false, fmt.Errorf("eval status: %s", eval.Status)
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+
+	// The evaluation should have failed task group allocations
+	must.MapNotEmpty(t, eval.FailedTGAllocs,
+		must.Sprint("expected failed task group allocations"))
+
+	// Check that the failure is due to device exhaustion or constraint filtering
+	for _, metrics := range eval.FailedTGAllocs {
+		exhausted := metrics.NodesExhausted > 0 ||
+			len(metrics.DimensionExhausted) > 0 ||
+			len(metrics.ConstraintFiltered) > 0
+		must.True(t, exhausted,
+			must.Sprintf("expected device exhaustion, got metrics: %+v", metrics))
+	}
+}
+
+// TestDeviceParsing tests that traditional device configurations (count,
+// constraint, affinity) are parsed correctly. These are unit-style tests
+// that don't require a running Nomad cluster.
+func TestDeviceParsing(t *testing.T) {
+	t.Run("testParseDeviceCountOnly", testParseDeviceCountOnly)
+	t.Run("testParseDeviceWithConstraint", testParseDeviceWithConstraint)
+	t.Run("testParseDeviceWithAffinity", testParseDeviceWithAffinity)
+	t.Run("testParseDeviceWithConstraintAndAffinity", testParseDeviceWithConstraintAndAffinity)
+}
+
+// testParseDeviceCountOnly verifies parsing of a device with only count.
+func testParseDeviceCountOnly(t *testing.T) {
+	job, err := e2eutil.Parse2(t, "./input/device_count_only.hcl")
+	must.NoError(t, err)
+	must.NotNil(t, job)
+
+	must.Len(t, 1, job.TaskGroups)
+	task := job.TaskGroups[0].Tasks[0]
+	must.NotNil(t, task.Resources)
+	must.Len(t, 1, task.Resources.Devices)
+
+	device := task.Resources.Devices[0]
+	must.Eq(t, "nomad/file/mock", device.Name)
+	must.Eq(t, uint64(1), *device.Count)
+	must.Len(t, 0, device.Constraints)
+	must.Len(t, 0, device.Affinities)
+	must.Len(t, 0, device.FirstAvailable)
+}
+
+// testParseDeviceWithConstraint verifies parsing of a device with count and constraint.
+func testParseDeviceWithConstraint(t *testing.T) {
+	job, err := e2eutil.Parse2(t, "./input/device_with_constraint.hcl")
+	must.NoError(t, err)
+	must.NotNil(t, job)
+
+	task := job.TaskGroups[0].Tasks[0]
+	device := task.Resources.Devices[0]
+
+	must.Eq(t, "nomad/file/mock", device.Name)
+	must.Eq(t, uint64(1), *device.Count)
+	must.Len(t, 1, device.Constraints)
+	must.Eq(t, "${device.attr.type}", device.Constraints[0].LTarget)
+	must.Eq(t, "file", device.Constraints[0].RTarget)
+	must.Len(t, 0, device.Affinities)
+	must.Len(t, 0, device.FirstAvailable)
+}
+
+// testParseDeviceWithAffinity verifies parsing of a device with count and affinity.
+func testParseDeviceWithAffinity(t *testing.T) {
+	job, err := e2eutil.Parse2(t, "./input/device_with_affinity.hcl")
+	must.NoError(t, err)
+	must.NotNil(t, job)
+
+	task := job.TaskGroups[0].Tasks[0]
+	device := task.Resources.Devices[0]
+
+	must.Eq(t, "nomad/file/mock", device.Name)
+	must.Eq(t, uint64(1), *device.Count)
+	must.Len(t, 0, device.Constraints)
+	must.Len(t, 1, device.Affinities)
+	must.Eq(t, "${device.attr.priority}", device.Affinities[0].LTarget)
+	must.Eq(t, "high", device.Affinities[0].RTarget)
+	must.Eq(t, int8(100), *device.Affinities[0].Weight)
+	must.Len(t, 0, device.FirstAvailable)
+}
+
+// testParseDeviceWithConstraintAndAffinity verifies parsing of a device with
+// count, constraint, and affinity.
+func testParseDeviceWithConstraintAndAffinity(t *testing.T) {
+	job, err := e2eutil.Parse2(t, "./input/device_with_constraint_and_affinity.hcl")
+	must.NoError(t, err)
+	must.NotNil(t, job)
+
+	task := job.TaskGroups[0].Tasks[0]
+	device := task.Resources.Devices[0]
+
+	must.Eq(t, "nomad/file/mock", device.Name)
+	must.Eq(t, uint64(2), *device.Count)
+
+	// Verify constraint
+	must.Len(t, 1, device.Constraints)
+	must.Eq(t, "${device.attr.type}", device.Constraints[0].LTarget)
+	must.Eq(t, "file", device.Constraints[0].RTarget)
+
+	// Verify affinity
+	must.Len(t, 1, device.Affinities)
+	must.Eq(t, "${device.attr.priority}", device.Affinities[0].LTarget)
+	must.Eq(t, "high", device.Affinities[0].RTarget)
+	must.Eq(t, int8(50), *device.Affinities[0].Weight)
+
+	// No first_available
+	must.Len(t, 0, device.FirstAvailable)
+}

--- a/e2e/devices/doc.go
+++ b/e2e/devices/doc.go
@@ -1,0 +1,7 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package devices provides end-to-end tests for Nomad's device scheduling
+// functionality, including the first_available feature for flexible device
+// selection.
+package devices

--- a/e2e/devices/first_available_test.go
+++ b/e2e/devices/first_available_test.go
@@ -1,0 +1,193 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+package devices
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
+)
+
+// TestDeviceFirstAvailable runs end-to-end tests for the first_available
+// device scheduling feature. These tests require:
+// - A Nomad cluster with at least one Linux client
+// - The example device plugin (nomad/file/mock) installed and configured
+// - Mock device files created in the configured directory
+//
+// See plugins/device/cmd/example/README.md for setup instructions.
+func TestDeviceFirstAvailable(t *testing.T) {
+	nomadClient := e2eutil.NomadClient(t)
+	e2eutil.WaitForLeader(t, nomadClient)
+	e2eutil.WaitForNodesReady(t, nomadClient, 1)
+
+	// Check if any nodes have mock devices available
+	if !hasDevicePlugin(t, nomadClient, "nomad/file/mock") {
+		t.Skip("skipping: no nodes with nomad/file/mock device plugin")
+	}
+
+	t.Run("testFirstAvailableSelectsCorrectOption", testFirstAvailableSelectsCorrectOption)
+	t.Run("testFirstAvailableNoMatch", testFirstAvailableNoMatch)
+}
+
+// testFirstAvailableSelectsCorrectOption tests that first_available correctly
+// evaluates options in order and selects the appropriate one. The first option
+// has an impossible constraint (should fail), so the scheduler must fall back
+// to the second option. We verify by checking that exactly 2 devices were
+// allocated (second option's count), not 1 (first option's count) or 3 (third
+// option's count).
+func testFirstAvailableSelectsCorrectOption(t *testing.T) {
+	nomadClient := e2eutil.NomadClient(t)
+
+	jobID := "device-fa-second-" + uuid.Short()
+	jobIDs := []string{jobID}
+	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
+
+	// Register the job - first option has impossible constraint (should fail),
+	// second option requests 2 devices (should be selected)
+	allocs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient, "./input/first_available_with_basic.hcl", jobID, "")
+	must.Len(t, 1, allocs, must.Sprint("expected 1 allocation"))
+
+	// Verify the allocation is running (fallback to second option succeeded)
+	alloc, _, err := nomadClient.Allocations().Info(allocs[0].ID, nil)
+	must.NoError(t, err)
+	must.Eq(t, api.AllocClientStatusRunning, alloc.ClientStatus,
+		must.Sprintf("allocation status: %s, description: %s",
+			alloc.ClientStatus, alloc.ClientDescription))
+
+	// Verify devices were allocated
+	must.NotNil(t, alloc.AllocatedResources)
+	taskResources := alloc.AllocatedResources.Tasks["sleep"]
+	must.NotNil(t, taskResources)
+	must.SliceNotEmpty(t, taskResources.Devices,
+		must.Sprint("expected devices to be allocated"))
+
+	// Count total devices allocated - should be 2 (second option), not 1 (first option)
+	totalDevices := 0
+	for _, deviceResource := range taskResources.Devices {
+		totalDevices += len(deviceResource.DeviceIDs)
+	}
+	must.Eq(t, 2, totalDevices,
+		must.Sprint("expected exactly 2 devices from SECOND option, got different count indicating wrong option selected"))
+}
+
+// testFirstAvailableNoMatch tests that when no first_available options can be
+// satisfied, the job fails to schedule with appropriate error messages.
+func testFirstAvailableNoMatch(t *testing.T) {
+	nomadClient := e2eutil.NomadClient(t)
+
+	jobID := "device-fa-nomatch-" + uuid.Short()
+	jobIDs := []string{jobID}
+	t.Cleanup(e2eutil.CleanupJobsAndGC(t, &jobIDs))
+
+	// Parse and register the job
+	job, err := e2eutil.Parse2(t, "./input/first_available_no_match.hcl")
+	must.NoError(t, err)
+	job.ID = &jobID
+
+	resp, _, err := nomadClient.Jobs().Register(job, nil)
+	must.NoError(t, err)
+
+	evalID := resp.EvalID
+
+	// Wait for the evaluation to complete (it should fail to place)
+	var eval *api.Evaluation
+	testutil.WaitForResultRetries(30, func() (bool, error) {
+		time.Sleep(500 * time.Millisecond)
+		eval, _, err = nomadClient.Evaluations().Info(evalID, nil)
+		if err != nil {
+			return false, err
+		}
+		// Wait until eval is complete or blocked
+		if eval.Status == api.EvalStatusComplete || eval.Status == api.EvalStatusBlocked {
+			return true, nil
+		}
+		return false, fmt.Errorf("eval status: %s", eval.Status)
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+
+	// The evaluation should have failed task group allocations
+	must.MapNotEmpty(t, eval.FailedTGAllocs,
+		must.Sprint("expected failed task group allocations"))
+
+	// Check that the failure is due to device exhaustion
+	for _, metrics := range eval.FailedTGAllocs {
+		// Should see nodes exhausted or constraint filtered
+		exhausted := metrics.NodesExhausted > 0 ||
+			len(metrics.DimensionExhausted) > 0 ||
+			len(metrics.ConstraintFiltered) > 0
+		must.True(t, exhausted,
+			must.Sprintf("expected device exhaustion, got metrics: %+v", metrics))
+	}
+}
+
+// TestDeviceFirstAvailableParsing tests that jobs with first_available blocks
+// are parsed correctly. These are unit-style tests that don't require a
+// running Nomad cluster.
+func TestDeviceFirstAvailableParsing(t *testing.T) {
+	t.Run("testParseFirstAvailable", testParseFirstAvailable)
+	t.Run("testParseWithBaseConstraint", testParseWithBaseConstraint)
+}
+
+// testParseFirstAvailable verifies parsing of first_available with multiple
+// options including constraints.
+func testParseFirstAvailable(t *testing.T) {
+	job, err := e2eutil.Parse2(t, "./input/first_available_with_basic.hcl")
+	must.NoError(t, err)
+	must.NotNil(t, job)
+
+	// Verify the structure was parsed correctly
+	must.Len(t, 1, job.TaskGroups)
+	task := job.TaskGroups[0].Tasks[0]
+	must.NotNil(t, task.Resources)
+	must.Len(t, 1, task.Resources.Devices)
+
+	device := task.Resources.Devices[0]
+	must.Eq(t, "nomad/file/mock", device.Name)
+	must.Len(t, 3, device.FirstAvailable,
+		must.Sprint("expected 3 first_available options"))
+
+	// Verify first option: count=1, with impossible constraint
+	opt1 := device.FirstAvailable[0]
+	must.Eq(t, uint64(1), *opt1.Count)
+	must.Len(t, 1, opt1.Constraints)
+	must.Eq(t, "${device.attr.impossible_attr}", opt1.Constraints[0].LTarget)
+	must.Eq(t, "impossible_value", opt1.Constraints[0].RTarget)
+
+	// Verify second option: count=2, no constraints
+	opt2 := device.FirstAvailable[1]
+	must.Eq(t, uint64(2), *opt2.Count)
+	must.Len(t, 0, opt2.Constraints)
+
+	// Verify third option: count=3, no constraints
+	opt3 := device.FirstAvailable[2]
+	must.Eq(t, uint64(3), *opt3.Count)
+	must.Len(t, 0, opt3.Constraints)
+}
+
+// testParseWithBaseConstraint verifies parsing with base and option constraints.
+func testParseWithBaseConstraint(t *testing.T) {
+	job, err := e2eutil.Parse2(t, "./input/first_available_with_base_constraint.hcl")
+	must.NoError(t, err)
+	must.NotNil(t, job)
+
+	task := job.TaskGroups[0].Tasks[0]
+	device := task.Resources.Devices[0]
+
+	// Verify base constraint exists
+	must.Len(t, 1, device.Constraints,
+		must.Sprint("expected 1 base constraint"))
+	must.Eq(t, "${device.attr.cool-attribute}", device.Constraints[0].LTarget)
+
+	// Verify first_available options also have their own constraints
+	must.Len(t, 2, device.FirstAvailable)
+	must.Len(t, 1, device.FirstAvailable[0].Constraints)
+	must.Len(t, 1, device.FirstAvailable[1].Constraints)
+}

--- a/e2e/devices/input/device_constraint_no_match.hcl
+++ b/e2e/devices/input/device_constraint_no_match.hcl
@@ -1,0 +1,36 @@
+# Copyright IBM Corp. 2015, 2025
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test for device constraint that cannot be satisfied.
+# The job should fail to schedule because no device matches the constraint.
+
+job "device-constraint-nomatch" {
+  type = "batch"
+
+  group "test" {
+    count = 1
+
+    task "sleep" {
+      driver = "raw_exec"
+
+      config {
+        command = "sleep"
+        args    = ["30"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 64
+
+        device "nomad/file/mock" {
+          count = 1
+
+          constraint {
+            attribute = "${device.attr.cool-attribute}"
+            value     = "impossible-value-that-will-never-match"
+          }
+        }
+      }
+    }
+  }
+}

--- a/e2e/devices/input/device_count_only.hcl
+++ b/e2e/devices/input/device_count_only.hcl
@@ -1,0 +1,30 @@
+# Copyright IBM Corp. 2015, 2025
+# SPDX-License-Identifier: BUSL-1.1
+
+# Basic test for device scheduling with only count specified.
+
+job "device-count-only" {
+  type = "batch"
+
+  group "test" {
+    count = 1
+
+    task "sleep" {
+      driver = "raw_exec"
+
+      config {
+        command = "sleep"
+        args    = ["30"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 64
+
+        device "nomad/file/mock" {
+          count = 1
+        }
+      }
+    }
+  }
+}

--- a/e2e/devices/input/device_with_affinity.hcl
+++ b/e2e/devices/input/device_with_affinity.hcl
@@ -1,0 +1,36 @@
+# Copyright IBM Corp. 2015, 2025
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test for device scheduling with count and affinity.
+
+job "device-with-affinity" {
+  type = "batch"
+
+  group "test" {
+    count = 1
+
+    task "sleep" {
+      driver = "raw_exec"
+
+      config {
+        command = "sleep"
+        args    = ["30"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 64
+
+        device "nomad/file/mock" {
+          count = 1
+
+          affinity {
+            attribute = "${device.attr.cool-attribute}"
+            value     = "high"
+            weight    = 100
+          }
+        }
+      }
+    }
+  }
+}

--- a/e2e/devices/input/device_with_constraint.hcl
+++ b/e2e/devices/input/device_with_constraint.hcl
@@ -1,0 +1,35 @@
+# Copyright IBM Corp. 2015, 2025
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test for device scheduling with count and constraint.
+
+job "device-with-constraint" {
+  type = "batch"
+
+  group "test" {
+    count = 1
+
+    task "sleep" {
+      driver = "raw_exec"
+
+      config {
+        command = "sleep"
+        args    = ["30"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 64
+
+        device "nomad/file/mock" {
+          count = 1
+
+          constraint {
+            attribute = "${device.attr.cool-attribute}"
+            value     = "attribute-wearing-sunglasses"
+          }
+        }
+      }
+    }
+  }
+}

--- a/e2e/devices/input/device_with_constraint_and_affinity.hcl
+++ b/e2e/devices/input/device_with_constraint_and_affinity.hcl
@@ -1,0 +1,41 @@
+# Copyright IBM Corp. 2015, 2025
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test for device scheduling with count, constraint, and affinity combined.
+
+job "device-constraint-affinity" {
+  type = "batch"
+
+  group "test" {
+    count = 1
+
+    task "sleep" {
+      driver = "raw_exec"
+
+      config {
+        command = "sleep"
+        args    = ["30"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 64
+
+        device "nomad/file/mock" {
+          count = 2
+
+          constraint {
+            attribute = "${device.attr.cool-attribute}"
+            value     = "attribute-wearing-sunglasses"
+          }
+
+          affinity {
+            attribute = "${device.attr.priority}"
+            value     = "high"
+            weight    = 50
+          }
+        }
+      }
+    }
+  }
+}

--- a/e2e/devices/input/first_available_no_match.hcl
+++ b/e2e/devices/input/first_available_no_match.hcl
@@ -1,0 +1,44 @@
+# Copyright IBM Corp. 2015, 2025
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test for first_available when no options can be satisfied.
+# All options have impossible constraints, so the job should fail to schedule.
+
+job "device-first-available-nomatch" {
+  type = "batch"
+
+  group "test" {
+    count = 1
+
+    task "sleep" {
+      driver = "raw_exec"
+
+      config {
+        command = "sleep"
+        args    = ["30"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 64
+
+        device "nomad/file/mock" {
+          first_available {
+            count = 100
+            constraint {
+              attribute = "${device.attr.nonexistent1}"
+              value     = "impossible1"
+            }
+          }
+          first_available {
+            count = 100
+            constraint {
+              attribute = "${device.attr.nonexistent2}"
+              value     = "impossible2"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/e2e/devices/input/first_available_with_base_constraint.hcl
+++ b/e2e/devices/input/first_available_with_base_constraint.hcl
@@ -1,0 +1,51 @@
+# Copyright IBM Corp. 2015, 2025
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test for first_available with base constraints.
+# The device block has a base constraint that all options must satisfy,
+# plus each first_available option can have additional constraints.
+
+job "device-first-available-base" {
+  type = "batch"
+
+  group "test" {
+    count = 1
+
+    task "sleep" {
+      driver = "raw_exec"
+
+      config {
+        command = "sleep"
+        args    = ["30"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 64
+
+        device "nomad/file/mock" {
+          # Base constraint applied to all first_available options
+          constraint {
+            attribute = "${device.attr.cool-attribute}"
+            value     = "attribute-wearing-sunglasses"
+          }
+
+          first_available {
+            count = 2
+            constraint {
+              attribute = "${device.attr.type}"
+              value     = "premium"
+            }
+          }
+          first_available {
+            count = 1
+            constraint {
+              attribute = "${device.attr.type}"
+              value     = "standard"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/e2e/devices/input/first_available_with_basic.hcl
+++ b/e2e/devices/input/first_available_with_basic.hcl
@@ -1,0 +1,49 @@
+# Copyright IBM Corp. 2015, 2025
+# SPDX-License-Identifier: BUSL-1.1
+
+# Test that the SECOND option is selected when the first cannot be satisfied.
+# Option 1: 1 device with impossible constraint (should fail)
+# Option 2: 2 devices with no constraints (should be selected)
+#
+# We verify by checking that exactly 2 devices were allocated.
+
+job "device-first-available-second" {
+  type = "batch"
+
+  group "test" {
+    count = 1
+
+    task "sleep" {
+      driver = "raw_exec"
+
+      config {
+        command = "sleep"
+        args    = ["30"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 64
+
+        device "nomad/file/mock" {
+          # First option: impossible constraint (should fail)
+          first_available {
+            count = 1
+            constraint {
+              attribute = "${device.attr.impossible_attr}"
+              value     = "impossible_value"
+            }
+          }
+          # Second option: request 2 devices (should be selected)
+          first_available {
+            count = 2
+          }
+          # Second option: request 3 devices (should not be selected)
+          first_available {
+            count = 3
+          }
+        }
+      }
+    }
+  }
+}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/hashicorp/nomad/e2e/consul"
 	_ "github.com/hashicorp/nomad/e2e/csi"
 	_ "github.com/hashicorp/nomad/e2e/deployment"
+	_ "github.com/hashicorp/nomad/e2e/devices"
 	_ "github.com/hashicorp/nomad/e2e/eval_priority"
 	_ "github.com/hashicorp/nomad/e2e/events"
 	_ "github.com/hashicorp/nomad/e2e/lifecycle"

--- a/e2e/terraform/main.tf
+++ b/e2e/terraform/main.tf
@@ -16,6 +16,7 @@ module "provision-infra" {
   nomad_local_binary                     = var.nomad_local_binary
   nomad_local_binary_client_ubuntu_jammy = var.nomad_local_binary_client_ubuntu_jammy
   nomad_local_binary_client_windows_2022 = var.nomad_local_binary_client_windows_2022
+  device_plugin_local_binary             = var.device_plugin_local_binary
   nomad_license                          = var.nomad_license
   consul_license                         = var.consul_license
   nomad_region                           = var.nomad_region

--- a/e2e/terraform/provision-infra/nomad.tf
+++ b/e2e/terraform/provision-infra/nomad.tf
@@ -55,6 +55,8 @@ module "nomad_client_ubuntu_jammy" {
   nomad_region       = var.nomad_region
   nomad_local_binary = local.linux_binary
 
+  device_plugin_local_binary = var.device_plugin_local_binary
+
   tls_ca_key  = tls_private_key.ca.private_key_pem
   tls_ca_cert = tls_self_signed_cert.ca.cert_pem
 

--- a/e2e/terraform/provision-infra/provision-nomad/etc/nomad.d/client-linux.hcl
+++ b/e2e/terraform/provision-infra/provision-nomad/etc/nomad.d/client-linux.hcl
@@ -51,3 +51,11 @@ plugin "nomad-driver-exec2" {
     unveil_paths    = ["r:/etc/mime.types"]
   }
 }
+
+plugin "nomad-device-example" {
+  config {
+    dir            = "/tmp/nomad-device"
+    list_period    = "1s"
+    unhealthy_perm = "-rwxrwxrwx"
+  }
+}

--- a/e2e/terraform/provision-infra/provision-nomad/variables.tf
+++ b/e2e/terraform/provision-infra/provision-nomad/variables.tf
@@ -99,3 +99,9 @@ variable "keys_dir" {
   description = "Directory where all the configuration TLS and SSH keys and certificates will be stored for provisioning"
   default     = ""
 }
+
+variable "device_plugin_local_binary" {
+  type        = string
+  description = "Path to the example device plugin binary for e2e device tests"
+  default     = ""
+}

--- a/e2e/terraform/provision-infra/variables.tf
+++ b/e2e/terraform/provision-infra/variables.tf
@@ -125,3 +125,9 @@ variable "nomad_local_binary_client_windows_2022" {
   type        = string
   default     = ""
 }
+
+variable "device_plugin_local_binary" {
+  description = "Path to the example device plugin binary for e2e device tests"
+  type        = string
+  default     = ""
+}

--- a/e2e/terraform/terraform.tfvars
+++ b/e2e/terraform/terraform.tfvars
@@ -5,6 +5,10 @@
 # with `make dev` or similar (../../ = this repository root)
 # before running `terraform apply` and created the /pkg/goos_goarch/binary
 # folder
+#
+# For the device e2e tests, also build the example device plugin:
+#   make pkg/linux_amd64/nomad-device-example
 
 nomad_local_binary                     = "../../pkg/linux_amd64/nomad"
 nomad_local_binary_client_windows_2022 = "../../pkg/windows_amd64/nomad.exe"
+device_plugin_local_binary             = "../../pkg/linux_amd64/nomad-device-example"

--- a/e2e/terraform/variables.tf
+++ b/e2e/terraform/variables.tf
@@ -122,3 +122,9 @@ variable "nomad_local_binary_client_windows_2022" {
   type        = string
   default     = ""
 }
+
+variable "device_plugin_local_binary" {
+  description = "Path to the example device plugin binary for e2e device tests"
+  type        = string
+  default     = ""
+}

--- a/nomad/structs/constraint.go
+++ b/nomad/structs/constraint.go
@@ -24,6 +24,7 @@ var (
 	validConstraintPrefixTargets = []string{
 		"${attr.",
 		"${meta.",
+		"${device.attr.",
 	}
 )
 

--- a/scheduler/feasible/feasible_test.go
+++ b/scheduler/feasible/feasible_test.go
@@ -3494,6 +3494,157 @@ func TestDeviceChecker(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:        "first_available first option satisfied",
+			Result:      true,
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_A},
+			RequestedDevices: []*structs.RequestedDevice{
+				{
+					Name: "nvidia/gpu",
+					FirstAvailable: []*structs.DeviceOption{
+						{
+							Count: 1,
+							Constraints: []*structs.Constraint{
+								{
+									Operand: "=",
+									LTarget: "${device.model}",
+									RTarget: "1080ti",
+								},
+							},
+						},
+						{
+							Count: 1,
+							Constraints: []*structs.Constraint{
+								{
+									Operand: "=",
+									LTarget: "${device.model}",
+									RTarget: "2080ti",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "first_available fallback to second option",
+			Result:      true,
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_B}, // only has 2080ti
+			RequestedDevices: []*structs.RequestedDevice{
+				{
+					Name: "nvidia/gpu",
+					FirstAvailable: []*structs.DeviceOption{
+						{
+							Count: 1,
+							Constraints: []*structs.Constraint{
+								{
+									Operand: "=",
+									LTarget: "${device.model}",
+									RTarget: "1080ti", // not available
+								},
+							},
+						},
+						{
+							Count: 1,
+							Constraints: []*structs.Constraint{
+								{
+									Operand: "=",
+									LTarget: "${device.model}",
+									RTarget: "2080ti", // available
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "first_available no options satisfy",
+			Result:      false,
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_A},
+			RequestedDevices: []*structs.RequestedDevice{
+				{
+					Name: "nvidia/gpu",
+					FirstAvailable: []*structs.DeviceOption{
+						{
+							Count: 1,
+							Constraints: []*structs.Constraint{
+								{
+									Operand: "=",
+									LTarget: "${device.model}",
+									RTarget: "H100", // not available
+								},
+							},
+						},
+						{
+							Count: 1,
+							Constraints: []*structs.Constraint{
+								{
+									Operand: "=",
+									LTarget: "${device.model}",
+									RTarget: "GH200", // not available
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "first_available with base constraint applied",
+			Result:      true,
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_A, nvidia_B},
+			RequestedDevices: []*structs.RequestedDevice{
+				{
+					Name: "nvidia/gpu",
+					// Base constraint that must be satisfied
+					Constraints: []*structs.Constraint{
+						{
+							Operand: ">",
+							LTarget: "${device.attr.memory}",
+							RTarget: "3 GiB",
+						},
+					},
+					FirstAvailable: []*structs.DeviceOption{
+						{
+							Count: 2, // need 2 devices
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:        "first_available count not satisfiable falls back",
+			Result:      true,
+			NodeDevices: []*structs.NodeDeviceResource{nvidia_A}, // only has 2 instances
+			RequestedDevices: []*structs.RequestedDevice{
+				{
+					Name: "nvidia/gpu",
+					FirstAvailable: []*structs.DeviceOption{
+						{
+							Count: 4, // can't satisfy - need 4 but only 2 available
+							Constraints: []*structs.Constraint{
+								{
+									Operand: "=",
+									LTarget: "${device.model}",
+									RTarget: "1080ti",
+								},
+							},
+						},
+						{
+							Count: 1, // can satisfy
+							Constraints: []*structs.Constraint{
+								{
+									Operand: "=",
+									LTarget: "${device.model}",
+									RTarget: "1080ti",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
_(note: this is in a bit of a draft state right now - that said, I'd love feedback from HashiCorp on the chances of having something like this incorporated and how to best align it to y'alls design goals - a rough first pass at the design would be amazing -- don't spend a lot of time on the changes themselves until we're happy with the design and I've done more of my own homework)_

This PR introduces a new `first_available` block for device requests in Nomad job specifications. This enables more flexible device scheduling by allowing you to specify a prioritized list of device reservation sizes, where the scheduler attempts each option in order and selects the first one that can be fulfilled.

This is particularly useful in heterogeneous clusters with varying device types (such as a bunch of different GPU models) where you want to prioritize one type of GPU over another, but to carry the workload you need to reserve a different number of devices (GPUs).

A concrete example: I've got a workload which fits on a single 96GB GH200, but if I don't have that available I can also carry it on two H100s with 80GB memory each. I want to be able to do this in one job, and have Nomad figure out what the resource reservation should be. Today, this needs multiple jobs or multiple task groups, because `device` only accepts a single reservation size (`count`).

To support this, the following is introduced:

```hcl
device "nvidia/gpu" {
  # i would prefer this workload to land on a GH200 and if it does, it needs one GPU
  first_available {
    count = 1
    constraint {
      attribute = "${device.attr.model}"
      value = "GH200"
    }
  }
  # otherwise, i'll take a pair of H100s
  first_available {
    count = 2
    constraint {
      attribute = "${device.attr.model}"
      value = "H100"
    }
  }
}
```

With a job configuration like this, Nomad will first try to schedule the workload on a GH200. If that's not available, it will then try to schedule on two H100 SDMs. If that's not available, it will fail the job.

`count`, `affinity`, and `constraint` without `first_available` are supported as before.

## Implementation Notes

I'm open to feedback on the implementation of this -- this was just the first take that came to mind.

`first_available` is an ordered list of options where the first match wins. Inside `first_available`, `constraint` is supported, which lets you perform the additional filtering.

`first_available` and `count` are mutually exclusive at the `device` level. 

### Alternative Approach

Would it make sense to have a syntax like this instead, where the constraints are specified inline instead of in their own `constraint` block?

```hcl
device "nvidia/gpu" {
  first_available {
    count = 1
    attribute = "${device.attr.model}"
    value = "GH200"
  }
}
```

## Testing Notes

I've gone in and added a bunch of E2E tests for this as a first pass - these cover the existing device scheduling functionality and the new `first_available` functionality.

I've only run these tests locally - I've not used the Terraform E2E test suite, and am mostly certain (given I let Claude do the work almost exclusively for the tests) that at least the TF test setup needs some work.. but otherwise, the tests themselves are passing and seem to do the right thing.

## AI Use

I noticed a new callout for this in the contributing guidelines, so to call it out: 

* A bunch of the initial scaffolding I implemented myself. For work around the scheduler (especially the feasibility checks), I asked for help from Opus 4.5 w/ CC -- mostly because I've not navigated that part of Nomad much before. On review, it _looks_ like the right things are happening - these are design decisions I'd probably make myself.. but I still need to do a more exhaustive review before I'm willing to say I'm happy with the approach.
* CC was used to generate the bulk of the tests, especially in the E2E suites -- I'm pretty happy with these