### PR TITLE
E2E: fix invalid constraint in service discovery test job

### DIFF
--- a/e2e/servicediscovery/input/checks_task_restart_helper.nomad
+++ b/e2e/servicediscovery/input/checks_task_restart_helper.nomad
@@ -25,7 +25,7 @@ job "checks_task_restart_helper" {
     }
 
     constraint {
-      attribute = "${node.unique_id}"
+      attribute = "${node.unique.id}"
       value     = "${var.nodeID}"
     }
 


### PR DESCRIPTION
In #27355 we added validation to constraints. One of the E2E tests had an invalid constraint on `node.unique_id` instead of `node.unique.id` which causes the test setup to fail.

Ref: https://github.com/hashicorp/nomad/pull/27355

### Testing & Reproduction steps

Before:

```
=== RUN   TestServiceDiscovery
=== RUN   TestServiceDiscovery/TestServiceDiscovery_ServiceRegisterAfterCheckRestart
    nomad_checks_test.go:133:
        nomad_checks_test.go:133: expected condition to pass within wait context
        ↪ error: wait: timeout exceeded
    job.go:272:
        job.go:272: expected nil error
        ↪ error: command nomad [job stop -purge -detach nsd-check-restart-services-helper-8a4da16a] failed: exit status 1
        Output: No job(s) with prefix or ID "nsd-check-restart-services-helper-8a4da16a" found
--- FAIL: TestServiceDiscovery (31.30s)
    --- FAIL: TestServiceDiscovery/TestServiceDiscovery_ServiceRegisterAfterCheckRestart (31.17s)
FAIL
FAIL    github.com/hashicorp/nomad/e2e/servicediscovery 31.316s
FAIL
```

After:

```
=== RUN   TestServiceDiscovery
=== RUN   TestServiceDiscovery/TestServiceDiscovery_ServiceRegisterAfterCheckRestart
--- PASS: TestServiceDiscovery (36.29s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_ServiceRegisterAfterCheckRestart (36.17s)
PASS
ok      github.com/hashicorp/nomad/e2e/servicediscovery 36.312s
```

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
