### PR TITLE
E2E: fix failing Task API test

### DIFF
--- a/e2e/workload_id/input/api-nomad-cli.nomad.hcl
+++ b/e2e/workload_id/input/api-nomad-cli.nomad.hcl
@@ -16,10 +16,7 @@ job "task-api-nomad-cli" {
       driver = "raw_exec"
       config {
         command = "bash"
-        // "|| true" because failure to get a var makes nomad cli exit 1,
-        // but for this test, "Variable not found" actually indicates successful
-        // API connection.
-        args = ["-xc", "echo $NOMAD_ADDR; nomad var get nothing || true"]
+        args    = ["-xc", "echo $NOMAD_ADDR; nomad var get nomad/jobs/task-api-nomad-cli"]
       }
       env {
         NOMAD_ADDR = "${NOMAD_UNIX_ADDR}"


### PR DESCRIPTION
In #27269 we improved the Go SDK's treatment of the variables API to correctly return 403. An E2E test of the CLI was expected a "not found" response instead, so this causes the test to fail. But the test also poorly exercised the Task API socket by not ensuring that authentication was working. Update the test to get a variable that exists and that the test has access to.

Ref: https://github.com/hashicorp/nomad/pull/27269

### Testing & Reproduction steps

Before:

```
=== RUN   TestTaskAPI
=== RUN   TestTaskAPI/testTaskAPI_NomadCLI
    taskapi_test.go:140: submitting job: "./input/api-nomad-cli.nomad.hcl"
    taskapi_test.go:152:
        taskapi_test.go:152: expected string to contain substring; it does not
        ↪ substring: Variable not found
        ↪    string: + echo unix:///var/nomad/dev/data/alloc/4cf3a1e2-7e0e-50fa-6ead-65ec0e983d95/tsk/secrets/api.sock
        + nomad var get nothing
        Error retrieving variable: Unexpected response code: 403 (Permission denied)
        + true
    jobs3.go:678: tg 'grp' alloc status 'complete': All tasks have completed
    jobs3.go:684: tg 'grp' task 'tsk' event: Task received by client
    jobs3.go:684: tg 'grp' task 'tsk' event: Building Task Directory
    jobs3.go:684: tg 'grp' task 'tsk' event: Task started by client
    jobs3.go:684: tg 'grp' task 'tsk' event: Exit Code: 0
--- FAIL: TestTaskAPI (1.15s)
    --- FAIL: TestTaskAPI/testTaskAPI_NomadCLI (1.03s)
FAIL
FAIL    github.com/hashicorp/nomad/e2e/workload_id      1.164s
FAIL
```

After:

```
=== RUN   TestTaskAPI
=== RUN   TestTaskAPI/testTaskAPI_NomadCLI
    taskapi_test.go:156: submitting job: "./input/api-nomad-cli.nomad.hcl"
--- PASS: TestTaskAPI (1.15s)
    --- PASS: TestTaskAPI/testTaskAPI_NomadCLI (1.03s)
PASS
ok      github.com/hashicorp/nomad/e2e/workload_id      1.164s
```


### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
