### PR TITLE
event endpoint: heartbeat for EventStream handler

### DIFF
--- a/.changelog/27397.txt
+++ b/.changelog/27397.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-event endpoint: added a heartbeat to the EventStream handler to cancel blocking io.Copy operations
+event stream: Fixed a bug where the HTTP handler can block forever and cause high memory usage if an API client reads too slowly from the stream
 ```

--- a/.changelog/27397.txt
+++ b/.changelog/27397.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+event endpoint: added a heartbeat to the EventStream handler to cancel blocking io.Copy operations
+```

--- a/command/agent/event_endpoint.go
+++ b/command/agent/event_endpoint.go
@@ -77,7 +77,7 @@ func (s *HTTPServer) EventStream(resp http.ResponseWriter, req *http.Request) (i
 
 	// Create a heartbeat that is just a bit longer than NewJsonStream and close the
 	// connection when it ticks
-	writeTimeout := 31 * time.Second
+	writeTimeout := 40 * time.Second
 	heartbeat := time.NewTicker(writeTimeout)
 	defer heartbeat.Stop()
 

--- a/lib/lang/ctxreader.go
+++ b/lib/lang/ctxreader.go
@@ -1,0 +1,27 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+package lang
+
+import (
+	"context"
+	"io"
+)
+
+// CtxReader is a context-aware io.Reader, see
+// https://pace.dev/blog/2020/02/03/context-aware-ioreader-for-golang-by-mat-ryer.html
+type CtxReader struct {
+	ctx context.Context
+	r   io.Reader
+}
+
+func (r *CtxReader) Read(p []byte) (n int, err error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.r.Read(p)
+}
+
+func NewCtxReader(ctx context.Context, r io.Reader) io.Reader {
+	return &CtxReader{ctx: ctx, r: r}
+}


### PR DESCRIPTION
In situations where we have a very slow client that subscribes to events and at the same time have a lot of events, the Linux kernel's send-q buffer fills up and creates a backpressure on the EventStream http endpoint. This leads to our io.Copy goroutine blocking. This changeset introduces a heartbeat that cancels the handler context and wraps our io.Reader in it. 

Resolves https://hashicorp.atlassian.net/browse/NMD-1105