### PR TITLE
artifact: fix directory merging on Windows

### DIFF
--- a/.changelog/27398.txt
+++ b/.changelog/27398.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+artifact: Fixed a bug that prevented the sandbox from moving downloaded files to the target directory on Windows
+```


### PR DESCRIPTION
In #26892 we corrected the behavior of artifact inspection to account for the `raw_exec` driver's root filesystem being the host filesystem and therefore including symlinks. Part of this work was to merge a temporary directory with the final directory, and that work used the `os.Root` capability to ensure that we weren't chasing symlinks out of the temporary directory.

But on Windows, the `ReadDir` call is apparently quite finicky when using the `os.Root` capability and if you cast the root to `fs.ReadDirFS` this will compile fine but fail at runtime when you call `ReadDir` with the unhelpful error message "invalid argument". Instead, we'll open the rooted directory file and call `ReadDir` on that.

Ref: https://github.com/hashicorp/nomad/pull/26892

### Testing & Reproduction steps

Using the test job found at [`e2e/artifact/input/artifact_windows.nomad`](https://github.com/hashicorp/nomad/blob/main/e2e/artifact/input/artifact_windows.nomad). I've also verified this doesn't break Linux in the process :grin: 

Before:

```
$ nomad alloc status 4dc13748
...
Recent Events:
Time                       Type                      Description
2026-01-22T14:54:19-05:00  Restarting                Task restarting in 18.592693126s
2026-01-22T14:54:19-05:00  Failed Artifact Download  failed to download artifact "https://github.com/hashicorp/go-set/archive/refs/heads/main.zip": fell back to fs.ReadDir but that failed too "artifact-3912642489\\artifact": readdir artifact-3912642489\artifact: invalid argument
2026-01-22T14:54:18-05:00  Downloading Artifacts     Client is downloading artifacts
2026-01-22T14:54:17-05:00  Task Setup                Building Task Directory
2026-01-22T14:54:17-05:00  Received                  Task received by client
```

After:

```
$ nomad alloc status f02f915e
...
Recent Events:
Time                       Type                   Description
2026-01-22T15:36:36-05:00  Terminated             Exit Code: 0
2026-01-22T15:36:36-05:00  Started                Task started by client
2026-01-22T15:36:34-05:00  Downloading Artifacts  Client is downloading artifacts
2026-01-22T15:36:32-05:00  Task Setup             Building Task Directory
2026-01-22T15:36:32-05:00  Received               Task received by client
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
