### PR TITLE
ci: pass secrets to build.yml on push

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -20,5 +20,6 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yml
+    secrets: inherit
     with:
       build-ref: ${{ github.ref }}


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/27370 unwittingly broke enterprise builds by neglecting to pass github secrets when using `build.yml` as a reusable workflow.