### PR TITLE
test: fix alloc pause tests for enterprise

### DIFF
--- a/client/alloc_endpoint_test.go
+++ b/client/alloc_endpoint_test.go
@@ -541,6 +541,11 @@ func TestAllocations_SetPauseState(t *testing.T) {
 		must.ErrorContains(t, err, nstructs.ErrPermissionDenied.Error())
 	}
 
+	successfulError := "Enterprise only" // we got past the ACL check
+	if server.EnterpriseState.Features() > 0 {
+		successfulError = "Could not find task runner for task"
+	}
+
 	// Try request with a valid token
 	{
 		token := mock.CreatePolicyAndToken(t, server.State(), 1007, "test-valid",
@@ -552,7 +557,7 @@ func TestAllocations_SetPauseState(t *testing.T) {
 
 		var resp nstructs.GenericResponse
 		err := client.ClientRPC("Allocations.SetPauseState", &req, &resp)
-		must.ErrorContains(t, err, "Enterprise only")
+		must.ErrorContains(t, err, successfulError)
 	}
 
 	// Try request with a valid fine grain token
@@ -566,7 +571,7 @@ func TestAllocations_SetPauseState(t *testing.T) {
 
 		var resp nstructs.GenericResponse
 		err := client.ClientRPC("Allocations.SetPauseState", &req, &resp)
-		must.ErrorContains(t, err, "Enterprise only")
+		must.ErrorContains(t, err, successfulError)
 	}
 
 	// Try request with a management token
@@ -577,7 +582,7 @@ func TestAllocations_SetPauseState(t *testing.T) {
 
 		var resp nstructs.GenericResponse
 		err := client.ClientRPC("Allocations.SetPauseState", &req, &resp)
-		must.ErrorContains(t, err, "Enterprise only")
+		must.ErrorContains(t, err, successfulError)
 	}
 }
 

--- a/nomad/client_alloc_endpoint_test.go
+++ b/nomad/client_alloc_endpoint_test.go
@@ -1189,6 +1189,11 @@ func TestClientAllocations_SetPauseState(t *testing.T) {
 		must.ErrorContains(t, err, nstructs.ErrPermissionDenied.Error())
 	}
 
+	successfulError := "Enterprise only" // we got past the ACL check
+	if s.EnterpriseState.Features() > 0 {
+		successfulError = "Could not find task runner for task"
+	}
+
 	// Request with an valid token
 	{
 		token := mock.CreatePolicyAndToken(t, s.State(), 1005, "valid-token", mock.NamespacePolicy(nstructs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
@@ -1202,7 +1207,7 @@ func TestClientAllocations_SetPauseState(t *testing.T) {
 		var resp nstructs.GenericResponse
 		err := msgpackrpc.CallWithCodec(codec, "ClientAllocations.SetPauseState", req, &resp)
 		must.NotNil(t, err)
-		must.ErrorContains(t, err, "Enterprise only")
+		must.ErrorContains(t, err, successfulError)
 	}
 
 	// Request with an valid fine grain token
@@ -1218,7 +1223,7 @@ func TestClientAllocations_SetPauseState(t *testing.T) {
 		var resp nstructs.GenericResponse
 		err := msgpackrpc.CallWithCodec(codec, "ClientAllocations.SetPauseState", req, &resp)
 		must.NotNil(t, err)
-		must.ErrorContains(t, err, "Enterprise only")
+		must.ErrorContains(t, err, successfulError)
 	}
 
 	// Request with an management token
@@ -1233,7 +1238,7 @@ func TestClientAllocations_SetPauseState(t *testing.T) {
 		var resp nstructs.GenericResponse
 		err := msgpackrpc.CallWithCodec(codec, "ClientAllocations.SetPauseState", req, &resp)
 		must.NotNil(t, err)
-		must.ErrorContains(t, err, "Enterprise only")
+		must.ErrorContains(t, err, successfulError)
 	}
 }
 


### PR DESCRIPTION
These tests added in https://github.com/hashicorp/nomad/pull/27287 fail in nomad-enterprise by expecting "Enterprise only" errors.

Tests run in ent: 

```
$ NOMAD_TEST_LOG_LEVEL=off go test -v -tags=ent ./{client,nomad} -run SetPauseState
=== RUN   TestAllocations_SetPauseState
=== PAUSE TestAllocations_SetPauseState
=== CONT  TestAllocations_SetPauseState
    wait.go:295: Job "mock-batch-128e56a5-c27d-3a0f-50c6-15976fdae0ec" registered
--- PASS: TestAllocations_SetPauseState (1.26s)
PASS
ok      github.com/hashicorp/nomad/client       1.327s
=== RUN   TestClientAllocations_SetPauseState
=== PAUSE TestClientAllocations_SetPauseState
=== CONT  TestClientAllocations_SetPauseState
--- PASS: TestClientAllocations_SetPauseState (1.50s)
PASS
ok      github.com/hashicorp/nomad/nomad        1.553s
```

full test suite: https://github.com/hashicorp/nomad-enterprise/actions/runs/21487658246