### PR TITLE
services: update check IDs from group service hook on update

### DIFF
--- a/client/allocrunner/group_service_hook.go
+++ b/client/allocrunner/group_service_hook.go
@@ -155,17 +155,7 @@ func (h *groupServiceHook) preRunLocked(env *taskenv.TaskEnv) error {
 	}
 
 	services := h.getWorkloadServicesLocked()
-
-	checkIDs := make([][]string, len(services.Services))
-	for i, svc := range services.Services {
-		svcID := serviceregistration.MakeAllocServiceID(h.allocID, services.Name(), svc)
-		checkIDs[i] = make([]string, len(svc.Checks))
-		for j, check := range svc.Checks {
-			checkIDs[i][j] = consul.MakeCheckID(svcID, check)
-		}
-	}
-	h.hookResources.SetConsulCheckIDs(checkIDs)
-
+	h.setCheckIDs(services)
 	return h.serviceRegWrapper.RegisterWorkload(services)
 }
 
@@ -215,6 +205,7 @@ func (h *groupServiceHook) Update(req *interfaces.RunnerUpdateRequest) error {
 		return nil
 	}
 
+	h.setCheckIDs(newWorkloadServices)
 	return h.serviceRegWrapper.UpdateWorkload(oldWorkloadServices, newWorkloadServices)
 }
 
@@ -328,4 +319,16 @@ func (h *groupServiceHook) getWorkloadServicesLocked() *serviceregistration.Work
 		Canary:            h.canary,
 		Tokens:            tokens,
 	}
+}
+
+func (h *groupServiceHook) setCheckIDs(services *serviceregistration.WorkloadServices) {
+	checkIDs := make([][]string, len(services.Services))
+	for i, svc := range services.Services {
+		svcID := serviceregistration.MakeAllocServiceID(h.allocID, services.Name(), svc)
+		checkIDs[i] = make([]string, len(svc.Checks))
+		for j, check := range svc.Checks {
+			checkIDs[i][j] = consul.MakeCheckID(svcID, check)
+		}
+	}
+	h.hookResources.SetConsulCheckIDs(checkIDs)
 }


### PR DESCRIPTION
In #27453 we fixed a bug in script check hook interpolation by recording the check IDs for each check in the group service hook and then passing that to the script check hook via alloc hook resources. But this change did not account for checks being updated in-place, so the script check hook reads the old check IDs and fails. This was caught by nightly E2E testing.

Record the updated check IDs in the group service hook as well. Expand the group service tests to include updating the checks.

Ref: https://github.com/hashicorp/nomad/pull/27453
Ref: https://hashicorp.atlassian.net/browse/NMD-1054
Ref: https://github.com/hashicorp/nomad-e2e/actions/runs/21699934682/job/62586402991

### Testing & Reproduction steps

In addition to the unit tests above, you can exercise this code with the jobs in [the E2E test](https://github.com/hashicorp/nomad/tree/main/e2e/consul/input):
* `nomad job run ./checks_group.nomad`
* (see checks 2 and 3 failing)
* nomad alloc exec -job group_check /bin/sh -c 'touch /tmp/${NOMAD_ALLOC_ID}-alive-2b`
* (see check 2 start passing; 3 is intended to never pass)
* `nomad job run ./checks_group_update.nomad`
* (see check 1 and 2 still passing)

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
  * no changelog because #27453 has not yet shipped
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
