### PR TITLE
E2E: show errors when assertions fail to read from files

### DIFF
--- a/e2e/volume_mounts/volumes_test.go
+++ b/e2e/volume_mounts/volumes_test.go
@@ -35,10 +35,10 @@ func TestVolumeMounts(t *testing.T) {
 
 	oldPath := fmt.Sprintf("/tmp/foo/%s", allocID0)
 	logs := sub.Exec("group", "docker_task", []string{"cat", oldPath})
-	must.StrContains(t, logs.Stdout, allocID0)
+	must.StrContains(t, logs.Stdout, allocID0, must.Sprint(logs.Stderr))
 
 	logs = sub.Exec("group", "exec_task", []string{"cat", oldPath})
-	must.StrContains(t, logs.Stdout, allocID0)
+	must.StrContains(t, logs.Stdout, allocID0, must.Sprint(logs.Stderr))
 
 	stop()
 
@@ -57,17 +57,17 @@ func TestVolumeMounts(t *testing.T) {
 
 	logs = sub.Exec("group", "docker_task", []string{"cat", newPath})
 	must.StrContains(t, logs.Stdout, allocID1,
-		must.Sprintf("new alloc data is missing from docker_task, got: %s", logs.Stdout))
+		must.Sprintf("new alloc data is missing from docker_task. error=%s", logs.Stderr))
 
 	logs = sub.Exec("group", "docker_task", []string{"cat", oldPath})
 	must.StrContains(t, logs.Stdout, allocID0,
-		must.Sprintf("previous alloc data is missing from docker_task, got: %s", logs.Stdout))
+		must.Sprintf("previous alloc data is missing from docker_task. error=%s", logs.Stderr))
 
 	logs = sub.Exec("group", "exec_task", []string{"cat", newPath})
 	must.StrContains(t, logs.Stdout, allocID1,
-		must.Sprintf("new alloc data is missing from exec_task, got: %s", logs.Stdout))
+		must.Sprintf("new alloc data is missing from exec_task. error=%s", logs.Stderr))
 
 	logs = sub.Exec("group", "exec_task", []string{"cat", oldPath})
 	must.StrContains(t, logs.Stdout, allocID0,
-		must.Sprintf("previous alloc data is missing from exec_task, got: %s", logs.Stdout))
+		must.Sprintf("previous alloc data is missing from exec_task. error=%s", logs.Stderr))
 }


### PR DESCRIPTION
A recent flake in the E2E tests for volume mounts hasn't been reproducible. But the outputs of the test assertions don't help debug this. The assertion already will show the difference between stdout and the expected value, and typically if the assertion fails its because stdout is empty. So the annotations should include stderr instead.

Ref: https://github.com/hashicorp/nomad-e2e/actions/runs/21699934682/job/62586402991

(Note that I've looked at the client logs here for that run and as far as I can tell everything was working correctly. The tasks start and there's no problem with the `exec` call either.)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
