### PR TITLE
csi: remove obsolete CSISecrets.Sanitize() method

### DIFF
--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -234,15 +234,6 @@ func (s *CSISecrets) GoString() string {
 	return s.String()
 }
 
-// Sanitize returns a copy of the CSISecrets with sensitive data redacted
-func (s *CSISecrets) Sanitize() *CSISecrets {
-	redacted := CSISecrets{}
-	for k := range *s {
-		redacted[k] = "[REDACTED]"
-	}
-	return &redacted
-}
-
 type CSIVolumeClaim struct {
 	AllocationID   string
 	NodeID         string

--- a/nomad/structs/csi_test.go
+++ b/nomad/structs/csi_test.go
@@ -1117,22 +1117,6 @@ func TestCSIVolumeSanitize(t *testing.T) {
 	must.Eq(t, "unchanged", sanitized.Parameters["example"])
 }
 
-func TestCSISecretsSanitize(t *testing.T) {
-	ci.Parallel(t)
-
-	orig := &CSISecrets{
-		"foo": "bar",
-		"baz": "qux",
-	}
-
-	sanitized := orig.Sanitize()
-	must.NotEq(t, orig, sanitized)
-
-	for _, v := range *sanitized {
-		must.Eq(t, v, "[REDACTED]")
-	}
-}
-
 func TestCSIMountOptionsSanitize(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
CE component of https://github.com/hashicorp/nomad-enterprise/pull/3649