### PR TITLE
artifact: fix failing tests for sandbox inspection

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -92,6 +92,7 @@ jobs:
             github.com/hashicorp/nomad/client/lib/fifo \
             github.com/hashicorp/nomad/client/logmon \
             github.com/hashicorp/nomad/client/allocrunner/taskrunner/template \
+            github.com/hashicorp/nomad/client/allocrunner/taskrunner/getter \
             github.com/hashicorp/nomad/client/allocdir \
             github.com/hashicorp/nomad/plugins/base
       - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1

--- a/client/allocrunner/taskrunner/getter/sandbox_default_test.go
+++ b/client/allocrunner/taskrunner/getter/sandbox_default_test.go
@@ -1,0 +1,90 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !windows
+
+package getter
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/nomad/client/interfaces"
+	"github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+func TestSandbox_Get_chown(t *testing.T) {
+	testutil.RequireRoot(t) // NOTE: required for chown call
+	logger := testlog.HCLogger(t)
+
+	ac := artifactConfig(10 * time.Second)
+	sbox := New(ac, logger)
+
+	_, taskDir := SetupDir(t)
+	env := noopTaskEnv(taskDir)
+
+	artifact := &structs.TaskArtifact{
+		GetterSource: "https://raw.githubusercontent.com/hashicorp/go-set/main/go.mod",
+		RelativeDest: "local/downloads",
+		Chown:        true,
+	}
+
+	err := sbox.Get(env, artifact, "nobody")
+	must.NoError(t, err)
+
+	info, err := os.Stat(filepath.Join(taskDir, "local", "downloads"))
+	must.NoError(t, err)
+
+	uid := info.Sys().(*syscall.Stat_t).Uid
+	must.Eq(t, 65534, uid) // nobody's conventional uid
+}
+
+func TestSandbox_Get_inspection_NonWindows(t *testing.T) {
+	// These tests disable filesystem isolation as the
+	// artifact inspection is what is being tested.
+	testutil.RequireRoot(t) // NOTE: required for chown call
+
+	sandboxSetup := func() (string, *Sandbox, interfaces.EnvReplacer) {
+		logger := testlog.HCLogger(t)
+		ac := artifactConfig(10 * time.Second)
+		sbox := New(ac, logger)
+		_, taskDir := SetupDir(t)
+		env := noopTaskEnv(taskDir)
+		sbox.ac.DisableFilesystemIsolation = true
+
+		return taskDir, sbox, env
+	}
+
+	t.Run("properly chowns destination", func(t *testing.T) {
+		taskDir, sbox, env := sandboxSetup()
+		src, _ := servTestFile(t, "test-file")
+
+		artifact := &structs.TaskArtifact{
+			GetterSource: src,
+			RelativeDest: "local/downloads",
+			Chown:        true,
+		}
+
+		err := sbox.Get(env, artifact, "nobody")
+		must.NoError(t, err)
+
+		info, err := os.Stat(filepath.Join(taskDir, "local", "downloads"))
+		must.NoError(t, err)
+
+		uid := info.Sys().(*syscall.Stat_t).Uid
+		must.Eq(t, 65534, uid) // nobody's conventional uid
+
+		info, err = os.Stat(filepath.Join(taskDir, "local", "downloads", "test-file"))
+		must.NoError(t, err)
+
+		uid = info.Sys().(*syscall.Stat_t).Uid
+		must.Eq(t, 65534, uid) // nobody's conventional uid
+	})
+
+}

--- a/client/allocrunner/taskrunner/getter/util_test.go
+++ b/client/allocrunner/taskrunner/getter/util_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/hashicorp/go-getter"
@@ -79,7 +80,7 @@ func TestUtil_getDestination(t *testing.T) {
 			RelativeDest: "local/downloads",
 		})
 		must.NoError(t, err)
-		must.Eq(t, "/path/to/task/local/downloads", result)
+		must.Eq(t, "/path/to/task/local/downloads", filepath.ToSlash(result))
 	})
 
 	t.Run("escapes", func(t *testing.T) {
@@ -143,8 +144,8 @@ func TestUtil_getTaskDir(t *testing.T) {
 
 	env := noopTaskEnv("/path/to/alloc/task")
 	allocDir, taskDir := getWritableDirs(env)
-	must.Eq(t, "/path/to/alloc", allocDir)
-	must.Eq(t, "/path/to/alloc/task", taskDir)
+	must.Eq(t, "/path/to/alloc", filepath.ToSlash(allocDir))
+	must.Eq(t, "/path/to/alloc/task", filepath.ToSlash(taskDir))
 }
 
 func TestUtil_environment(t *testing.T) {
@@ -283,7 +284,11 @@ func TestUtil_isPathWithin(t *testing.T) {
 		check := filepath.Join(root, "unknown")
 		result, err := isPathWithin(root, check)
 
-		must.ErrorContains(t, err, "no such file or directory")
+		if runtime.GOOS != "windows" {
+			must.ErrorContains(t, err, "no such file or directory")
+		} else {
+			must.ErrorContains(t, err, "cannot find the file")
+		}
 		must.False(t, result)
 	})
 


### PR DESCRIPTION
In #27398 we changed the way we used `os.Root` to protect the client when merging artifact directories to fix failing tests on Windows where this approach would always fail with "invalid argument". But this has now started failing on unit tests in CI, but only on Linux (where we'll usually have Landlock anyways), specifically on AMD64. While we try to investigate, let's revert #27398 but only on non-Windows.

Because we'll want to make sure we're running the tests on Windows, this changeset also splits out some tests that can't run on Windows because they use OS-specific structs. We'll also tweak a few test assertions to make sure the tests can tolerate being run on either Unix or Windows.

Ref: https://github.com/hashicorp/nomad/pull/27398

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
