### PR TITLE
RFC: Admission controller proof of concept

### DIFF
--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -679,6 +679,14 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		}
 	}
 
+	for _, c := range agentConfig.Server.AdmissionControllers.External {
+		conf.AdmissionControllers.External = append(conf.AdmissionControllers.External, config.ExternalController{
+			Name:     c.Name,
+			Endpoint: c.Endpoint,
+			NodePool: c.NodePool,
+		})
+	}
+
 	if err := conf.NodeIntroductionConfig.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid server.client_introduction configuration: %w", err)
 	}

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -532,10 +532,30 @@ func (a *ACLConfig) Copy() *ACLConfig {
 	return &na
 }
 
+type BuiltinController struct {
+	Enabled bool `hcl:"enabled"`
+}
+
+type ExternalController struct {
+	Name     string `hcl:",key"`
+	Endpoint string `hcl:"endpoint"`
+	NodePool string `hcl:"node_pool"`
+}
+
+type AdmissionControllers struct {
+	// In-tree controllers would be added here
+
+	// Out-of-tree controllers
+	External []ExternalController `hcl:"external,block"`
+}
+
 // ServerConfig is configuration specific to the server mode
 type ServerConfig struct {
 	// Enabled controls if we are a server
 	Enabled bool `hcl:"enabled"`
+
+	// AdmissionControllers are used for custom job mutation
+	AdmissionControllers *AdmissionControllers `hcl:"admission_controllers"`
 
 	// AuthoritativeRegion is used to control which region is treated as
 	// the source of truth for global tokens and ACL policies.
@@ -2509,6 +2529,9 @@ func (a *ACLConfig) Merge(b *ACLConfig) *ACLConfig {
 func (s *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 	result := *s
 
+	if b.AdmissionControllers != nil {
+		result.AdmissionControllers = b.AdmissionControllers
+	}
 	if b.Enabled {
 		result.Enabled = true
 	}

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -57,6 +57,7 @@ func ParseConfigFile(path string) (*Config, error) {
 			ClientIntroduction:   &ClientIntroduction{},
 			PlanRejectionTracker: &PlanRejectionTracker{},
 			ServerJoin:           &ServerJoin{},
+			AdmissionControllers: &AdmissionControllers{},
 		},
 		ACL:       &ACLConfig{},
 		RPC:       &RPCConfig{},

--- a/nomad/admissioncontrollers/controller.go
+++ b/nomad/admissioncontrollers/controller.go
@@ -1,0 +1,12 @@
+package admission
+
+import (
+	"context"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+type AdmissionController interface {
+	Start(context.Context)
+	AdmitJob(*structs.Job) ([]error, error)
+}

--- a/nomad/admissioncontrollers/external_controller.go
+++ b/nomad/admissioncontrollers/external_controller.go
@@ -1,0 +1,77 @@
+package admission
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+type External struct {
+	name     string
+	endpoint string
+	nodePool string
+}
+
+func NewExternalController(name, endpoint, nodePool string) *External {
+	return &External{
+		name:     name,
+		endpoint: endpoint,
+		nodePool: nodePool,
+	}
+}
+
+// Start is a noop for external controllers
+func (c *External) Start(ctx context.Context) {}
+
+func (c *External) Name() string {
+	return c.name
+}
+
+// AdmitJob is used to send the job to an external process for processing.
+//
+// This is a basic implementation for proof of concept.
+func (c *External) AdmitJob(job *structs.Job) (warnings []error, err error) {
+	if job.NodePool != c.nodePool {
+		return nil, nil
+	}
+
+	data, err := json.Marshal(job)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", c.endpoint, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received bad response code, %d", res.StatusCode)
+	}
+
+	newJob := &structs.Job{}
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(b, newJob)
+	if err != nil {
+		return nil, err
+	}
+
+	job = newJob
+
+	return nil, nil
+}

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -457,6 +457,10 @@ type Config struct {
 	// requests and perform the appropriate enforcement actions.
 	NodeIntroductionConfig *structs.NodeIntroductionConfig
 
+	// AdmissionControllers are the set of configured controllers to
+	// be invoked during job registration.
+	AdmissionControllers *config.AdmissionControllers
+
 	// LogFile is used by MonitorExport to stream a server's log file
 	LogFile string `hcl:"log_file"`
 }
@@ -586,6 +590,7 @@ func DefaultConfig() *Config {
 	}
 
 	c := &Config{
+		AdmissionControllers:             &config.AdmissionControllers{},
 		Region:                           DefaultRegion,
 		AuthoritativeRegion:              DefaultRegion,
 		Datacenter:                       DefaultDC,

--- a/nomad/structs/config/admission_controller.go
+++ b/nomad/structs/config/admission_controller.go
@@ -1,0 +1,18 @@
+package config
+
+type BuiltinController struct {
+	Enabled bool
+}
+
+type ExternalController struct {
+	Name     string
+	Endpoint string
+	NodePool string
+}
+
+type AdmissionControllers struct {
+	// In-tree controllers
+
+	// Out-of-tree controllers
+	External []ExternalController
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4489,6 +4489,13 @@ type Job struct {
 	// used to register this version of the job. Used by deploymentwatcher.
 	NomadTokenID string
 
+	// SkipEvalCreation is used to signify that an evaluation should not be
+	// created for this job during registration. This field could be used for
+	// parameterized/periodic jobs, or for external processes like admission
+	// controllers to use Nomad to store jobs via Raft, but still control when
+	// they are run.
+	SkipEvalCreation bool
+
 	// Job status
 	Status string
 


### PR DESCRIPTION
### Description
DO NOT MERGE

As a part of some investigative work around Nomad fair scheduling in resource constrained clusters, we decided to take a look at what fair resource sharing would look like as an implementation of a generic admission controller. Our initial implementation of this admission controller pushed jobs to a queue and kept track of reserved cpu and memory at the namespace level (although we had plans for more configurable tenancy models). When resources for the configured node pool became constrained, and jobs begin to queue, a simple fairsharing algorithm would decide which one to run next (Using the `SkipEvalCreation` flag, a controller could mutate the job so it was stored in Raft but not run until the controller forces an evaluation).

Using a configuration like the below would configure the nomad server to forward job
```
server {
  admission_controllers {
    external "fairshare" {
      endpoint  = "http://127.0.0.1:8000/v1/jobs"
      node_pool = "some_nodepool"
    }
  }
}
```

Fairsharing algorithms are inherently stateful which complicated the controller enough that it did not seem to provide much more benefit than submitting jobs directly to a queue (which is what most users do with this use case).

We are currently investigating other places in Nomad where this type of logic might fit better, but wanted to push up these changes in the event others may have a good use case or ideas for external admission controllers.

### Request for comments

Please share if you could use admission controllers and if you have feedback on this design. While we do not have admission controllers on the roadmap yet, we have long intended to make admission-controller-like patterns easier to implement.

Feedback welcome!