### PR TITLE
fix(ui): initiate OIDC login flow from 'Not Authorized' page

### DIFF
--- a/ui/app/components/forbidden-message.hbs
+++ b/ui/app/components/forbidden-message.hbs
@@ -18,7 +18,7 @@
       {{#if this.authMethods}}
         Sign in with
         {{#each this.authMethods as |authMethod|}}
-          <LinkTo @route="settings.tokens">{{authMethod.name}}</LinkTo>,
+          <a href="#" {{on "click" (fn this.redirectToSSO authMethod)}}>{{authMethod.name}}</a>{{if (not-eq authMethod this.authMethods.lastObject) "," ""}}
         {{/each}}
         or
       {{/if}}

--- a/ui/app/components/forbidden-message.js
+++ b/ui/app/components/forbidden-message.js
@@ -6,6 +6,8 @@
 import Component from '@ember/component';
 import { tagName } from '@ember-decorators/component';
 import { inject as service } from '@ember/service';
+import { action } from '@ember/object';
+import Ember from 'ember';
 
 @tagName('')
 export default class ForbiddenMessage extends Component {
@@ -15,5 +17,44 @@ export default class ForbiddenMessage extends Component {
 
   get authMethods() {
     return this.store.findAll('auth-method');
+  }
+
+  generateNonce() {
+    let randomArray = new Uint32Array(10);
+    crypto.getRandomValues(randomArray);
+    return randomArray.join('').slice(0, 20);
+  }
+
+  @action
+  redirectToSSO(method, event) {
+    event?.preventDefault();
+    const provider = method.name;
+    const nonce = this.generateNonce();
+
+    window.localStorage.setItem('nomadOIDCNonce', nonce);
+    window.localStorage.setItem('nomadOIDCAuthMethod', provider);
+
+    let redirectURL;
+    if (Ember.testing) {
+      redirectURL = this.router.currentURL;
+    } else {
+      redirectURL = new URL(window.location.toString());
+      redirectURL.search = '';
+      redirectURL = redirectURL.href;
+    }
+
+    method
+      .getAuthURL({
+        AuthMethodName: provider,
+        ClientNonce: nonce,
+        RedirectUri: redirectURL,
+      })
+      .then(({ AuthURL }) => {
+        if (Ember.testing) {
+          this.router.transitionTo(AuthURL.split('/ui')[1]);
+        } else {
+          window.location = AuthURL;
+        }
+      });
   }
 }


### PR DESCRIPTION
## Summary

Fixes #27475

When ACLs are enabled and OIDC SSO is configured, an unauthenticated user navigating to the Nomad UI sees a "Not Authorized" page with a "Sign in with [IdP]" link. Previously, clicking the IdP link navigated to `/ui/settings/tokens` instead of initiating the OIDC login flow.

The user had to first click "Sign Out" to end the anonymous session, then click the "Sign in with Okta" button to actually start the OIDC flow. This was confusing UX.

## Changes

- Modified `forbidden-message.hbs` to use an anchor tag with an `onclick` handler instead of `<LinkTo>` for auth method links
- Added `redirectToSSO` action to `forbidden-message.js` that initiates the OIDC login flow directly
- The fix mirrors the existing behavior of the sign-in buttons on the tokens settings page

## Expected Behavior

Clicking an IdP link (e.g., "Okta") on the "Not Authorized" page now initiates the OIDC login flow directly, redirecting the user to their identity provider's login page.

## Testing

1. Set up a Nomad cluster with ACLs enabled and OIDC SSO configured
2. Navigate to the Nomad UI as an unauthenticated user
3. Observe the "Not Authorized" page with "Sign in with [IdP name]" message
4. Click the IdP link
5. Verify that the OIDC login flow starts immediately