### PR TITLE
cli: improve autocompletions for ACL commands

### DIFF
--- a/.changelog/27505.txt
+++ b/.changelog/27505.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added autocompletions for ACL auth method, binding rule, policy, and token subcommands
+```

--- a/command/acl_auth_method_delete.go
+++ b/command/acl_auth_method_delete.go
@@ -41,7 +41,7 @@ func (a *ACLAuthMethodDeleteCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (a *ACLAuthMethodDeleteCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return ACLAuthMethodPredictor(a.Meta.Client)
 }
 
 // Synopsis satisfies the cli.Command Synopsis function.

--- a/command/acl_auth_method_info.go
+++ b/command/acl_auth_method_info.go
@@ -55,7 +55,7 @@ func (a *ACLAuthMethodInfoCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (a *ACLAuthMethodInfoCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return ACLAuthMethodPredictor(a.Meta.Client)
 }
 
 // Synopsis satisfies the cli.Command Synopsis function.

--- a/command/acl_auth_method_update.go
+++ b/command/acl_auth_method_update.go
@@ -98,7 +98,7 @@ func (a *ACLAuthMethodUpdateCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (a *ACLAuthMethodUpdateCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return ACLAuthMethodPredictor(a.Meta.Client)
 }
 
 // Synopsis satisfies the cli.Command Synopsis function.

--- a/command/acl_binding_rule_delete.go
+++ b/command/acl_binding_rule_delete.go
@@ -40,7 +40,7 @@ func (a *ACLBindingRuleDeleteCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (a *ACLBindingRuleDeleteCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return ACLBindingRulePredictor(a.Meta.Client)
 }
 
 // Synopsis satisfies the cli.Command Synopsis function.

--- a/command/acl_binding_rule_info.go
+++ b/command/acl_binding_rule_info.go
@@ -55,7 +55,7 @@ func (a *ACLBindingRuleInfoCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (a *ACLBindingRuleInfoCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return ACLBindingRulePredictor(a.Meta.Client)
 }
 
 // Synopsis satisfies the cli.Command Synopsis function.

--- a/command/acl_binding_rule_update.go
+++ b/command/acl_binding_rule_update.go
@@ -85,12 +85,13 @@ func (a *ACLBindingRuleUpdateCommand) AutocompleteFlags() complete.Flags {
 			),
 			"-bind-name": complete.PredictAnything,
 			"-json":      complete.PredictNothing,
+			"-no-merge":  complete.PredictNothing,
 			"-t":         complete.PredictAnything,
 		})
 }
 
 func (a *ACLBindingRuleUpdateCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return ACLBindingRulePredictor(a.Meta.Client)
 }
 
 // Synopsis satisfies the cli.Command Synopsis function.

--- a/command/acl_policy_apply.go
+++ b/command/acl_policy_apply.go
@@ -55,7 +55,12 @@ Apply Options:
 
 func (c *ACLPolicyApplyCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
-		complete.Flags{})
+		complete.Flags{
+			"-description": complete.PredictAnything,
+			"-group":       complete.PredictAnything,
+			"-job":         complete.PredictAnything,
+			"-task":        complete.PredictAnything,
+		})
 }
 
 func (c *ACLPolicyApplyCommand) AutocompleteArgs() complete.Predictor {

--- a/command/acl_policy_delete.go
+++ b/command/acl_policy_delete.go
@@ -35,7 +35,7 @@ func (c *ACLPolicyDeleteCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *ACLPolicyDeleteCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return ACLPolicyPredictor(c.Meta.Client)
 }
 
 func (c *ACLPolicyDeleteCommand) Synopsis() string {

--- a/command/acl_policy_info.go
+++ b/command/acl_policy_info.go
@@ -36,7 +36,7 @@ func (c *ACLPolicyInfoCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *ACLPolicyInfoCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return ACLPolicyPredictor(c.Meta.Client)
 }
 
 func (c *ACLPolicyInfoCommand) Synopsis() string {

--- a/command/acl_role_delete.go
+++ b/command/acl_role_delete.go
@@ -39,7 +39,9 @@ func (a *ACLRoleDeleteCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{})
 }
 
-func (a *ACLRoleDeleteCommand) AutocompleteArgs() complete.Predictor { return complete.PredictNothing }
+func (a *ACLRoleDeleteCommand) AutocompleteArgs() complete.Predictor {
+	return ACLRolePredictor(a.Meta.Client)
+}
 
 // Synopsis satisfies the cli.Command Synopsis function.
 func (a *ACLRoleDeleteCommand) Synopsis() string { return "Delete an existing ACL role" }

--- a/command/acl_role_info.go
+++ b/command/acl_role_info.go
@@ -61,7 +61,9 @@ func (a *ACLRoleInfoCommand) AutocompleteFlags() complete.Flags {
 		})
 }
 
-func (a *ACLRoleInfoCommand) AutocompleteArgs() complete.Predictor { return complete.PredictNothing }
+func (a *ACLRoleInfoCommand) AutocompleteArgs() complete.Predictor {
+	return ACLRolePredictor(a.Meta.Client)
+}
 
 // Synopsis satisfies the cli.Command Synopsis function.
 func (a *ACLRoleInfoCommand) Synopsis() string { return "Fetch information on an existing ACL role" }

--- a/command/acl_role_update.go
+++ b/command/acl_role_update.go
@@ -79,7 +79,9 @@ func (a *ACLRoleUpdateCommand) AutocompleteFlags() complete.Flags {
 		})
 }
 
-func (a *ACLRoleUpdateCommand) AutocompleteArgs() complete.Predictor { return complete.PredictNothing }
+func (a *ACLRoleUpdateCommand) AutocompleteArgs() complete.Predictor {
+	return ACLRolePredictor(a.Meta.Client)
+}
 
 // Synopsis satisfies the cli.Command Synopsis function.
 func (a *ACLRoleUpdateCommand) Synopsis() string { return "Update an existing ACL role" }

--- a/command/acl_token_delete.go
+++ b/command/acl_token_delete.go
@@ -33,7 +33,7 @@ func (c *ACLTokenDeleteCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *ACLTokenDeleteCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return ACLTokenPredictor(c.Meta.Client)
 }
 
 func (c *ACLTokenDeleteCommand) Synopsis() string {

--- a/command/acl_token_info.go
+++ b/command/acl_token_info.go
@@ -33,7 +33,7 @@ func (c *ACLTokenInfoCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *ACLTokenInfoCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return ACLTokenPredictor(c.Meta.Client)
 }
 
 func (c *ACLTokenInfoCommand) Synopsis() string {

--- a/command/acl_token_update.go
+++ b/command/acl_token_update.go
@@ -66,7 +66,7 @@ func (c *ACLTokenUpdateCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *ACLTokenUpdateCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return ACLTokenPredictor(c.Meta.Client)
 }
 
 func (c *ACLTokenUpdateCommand) Synopsis() string {


### PR DESCRIPTION
Some commands are missing autocompletion flags for specific fields, have completions for flags that are deprecated or no longer exist, have the wrong predictor, or don't perform searches for argument completions for objects from state.

This is one of three batches of work to improve autocompletions, focusing on a set of ACL-related commands.

Generative AI disclosure: as part of an ongoing pilot, this changeset was mostly generated via Claude Code with the exception of touch-ups to use existing helper methods and clean up its terrible docstrings. Reviewed and tested manually, with commit description written by human for humans.

Ref: https://github.com/hashicorp/nomad/pull/27507
Ref: https://github.com/hashicorp/nomad/pull/27506

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
  * as this is a UX improvement, this was tested manually
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
