### PR TITLE
cli: improve autocompletions for various commands

### DIFF
--- a/.changelog/27506.txt
+++ b/.changelog/27506.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Improved options autocompletions for various commands
+```

--- a/command/alloc_pause.go
+++ b/command/alloc_pause.go
@@ -182,6 +182,9 @@ func (c *AllocPauseCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
 			"-mode":    complete.PredictNothing,
+			"-state":   complete.PredictSet("pause", "run", "scheduled"),
+			"-status":  complete.PredictNothing,
+			"-task":    complete.PredictAnything,
 			"-verbose": complete.PredictNothing,
 		},
 	)

--- a/command/alloc_restart.go
+++ b/command/alloc_restart.go
@@ -183,6 +183,15 @@ func (c *AllocRestartCommand) Synopsis() string {
 	return "Restart a running allocation"
 }
 
+func (c *AllocRestartCommand) AutocompleteFlags() complete.Flags {
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-all-tasks": complete.PredictNothing,
+			"-verbose":   complete.PredictNothing,
+			"-task":      complete.PredictAnything,
+		})
+}
+
 func (c *AllocRestartCommand) AutocompleteArgs() complete.Predictor {
 	// Here we attempt to autocomplete allocations for any position of arg.
 	// We should eventually try to auto complete the task name if the arg is

--- a/command/alloc_signal.go
+++ b/command/alloc_signal.go
@@ -153,6 +153,7 @@ func (c *AllocSignalCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{
 			"-s":       complete.PredictNothing,
 			"-verbose": complete.PredictNothing,
+			"-task":    complete.PredictAnything,
 		})
 }
 func (c *AllocSignalCommand) AutocompleteArgs() complete.Predictor {

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -74,6 +74,7 @@ func (c *AllocStatusCommand) AutocompleteFlags() complete.Flags {
 			"-json":    complete.PredictNothing,
 			"-t":       complete.PredictAnything,
 			"-ui":      complete.PredictNothing,
+			"-stats":   complete.PredictNothing,
 		})
 }
 

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -76,6 +76,7 @@ func (c *DeploymentStatusCommand) AutocompleteFlags() complete.Flags {
 			"-monitor": complete.PredictNothing,
 			"-t":       complete.PredictAnything,
 			"-ui":      complete.PredictNothing,
+			"-wait":    complete.PredictAnything,
 		})
 }
 

--- a/command/eval_list.go
+++ b/command/eval_list.go
@@ -97,13 +97,12 @@ func (c *EvalListCommand) AutocompleteArgs() complete.Predictor {
 func (c *EvalListCommand) Name() string { return "eval list" }
 
 func (c *EvalListCommand) Run(args []string) int {
-	var monitor, verbose, json, openURL bool
+	var verbose, json, openURL bool
 	var perPage int
 	var tmpl, pageToken, filter, filterJobID, filterStatus string
 
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
-	flags.BoolVar(&monitor, "monitor", false, "")
 	flags.BoolVar(&verbose, "verbose", false, "")
 	flags.BoolVar(&json, "json", false, "")
 	flags.StringVar(&tmpl, "t", "", "")

--- a/command/job_allocs.go
+++ b/command/job_allocs.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
 
@@ -63,18 +62,7 @@ func (c *JobAllocsCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *JobAllocsCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := c.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Jobs]
-	})
+	return JobPredictor(c.Meta.Client)
 }
 
 func (c *JobAllocsCommand) Name() string { return "job allocs" }

--- a/command/job_deployments.go
+++ b/command/job_deployments.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
 
@@ -67,18 +66,7 @@ func (c *JobDeploymentsCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *JobDeploymentsCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := c.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Jobs]
-	})
+	return JobPredictor(c.Meta.Client)
 }
 
 func (c *JobDeploymentsCommand) Name() string { return "job deployments" }

--- a/command/job_dispatch.go
+++ b/command/job_dispatch.go
@@ -83,11 +83,13 @@ func (c *JobDispatchCommand) Synopsis() string {
 func (c *JobDispatchCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
-			"-meta":              complete.PredictAnything,
-			"-detach":            complete.PredictNothing,
-			"-idempotency-token": complete.PredictAnything,
-			"-verbose":           complete.PredictNothing,
-			"-ui":                complete.PredictNothing,
+			"-meta":               complete.PredictAnything,
+			"-detach":             complete.PredictNothing,
+			"-idempotency-token":  complete.PredictAnything,
+			"-verbose":            complete.PredictNothing,
+			"-ui":                 complete.PredictNothing,
+			"-id-prefix-template": complete.PredictAnything,
+			"-priority":           complete.PredictAnything,
 		})
 }
 

--- a/command/job_eval.go
+++ b/command/job_eval.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
 
@@ -67,18 +66,7 @@ func (c *JobEvalCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *JobEvalCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := c.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Jobs]
-	})
+	return JobPredictor(c.Meta.Client)
 }
 
 func (c *JobEvalCommand) Name() string { return "job eval" }

--- a/command/job_history.go
+++ b/command/job_history.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 	"github.com/ryanuber/columnize"
 )
@@ -86,18 +85,7 @@ func (c *JobHistoryCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *JobHistoryCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := c.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Jobs]
-	})
+	return JobPredictor(c.Meta.Client)
 }
 
 func (c *JobHistoryCommand) Name() string { return "job history" }

--- a/command/job_init.go
+++ b/command/job_init.go
@@ -59,7 +59,10 @@ func (c *JobInitCommand) Synopsis() string {
 func (c *JobInitCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
-			"-short": complete.PredictNothing,
+			"-short":          complete.PredictNothing,
+			"-connect":        complete.PredictNothing,
+			"-list-templates": complete.PredictNothing,
+			"-template":       complete.PredictAnything,
 		})
 }
 

--- a/command/job_inspect.go
+++ b/command/job_inspect.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
 
@@ -69,18 +68,7 @@ func (c *JobInspectCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *JobInspectCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := c.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Jobs]
-	})
+	return JobPredictor(c.Meta.Client)
 }
 
 func (c *JobInspectCommand) Name() string { return "job inspect" }

--- a/command/job_promote.go
+++ b/command/job_promote.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/api/contexts"
 	flaghelper "github.com/hashicorp/nomad/helper/flags"
 	"github.com/posener/complete"
 )
@@ -70,18 +69,7 @@ func (c *JobPromoteCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *JobPromoteCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := c.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Jobs]
-	})
+	return JobPredictor(c.Meta.Client)
 }
 
 func (c *JobPromoteCommand) Name() string { return "job promote" }

--- a/command/job_restart.go
+++ b/command/job_restart.go
@@ -20,7 +20,6 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/mitchellh/colorstring"
 	"github.com/posener/complete"
 )
@@ -233,18 +232,7 @@ func (c *JobRestartCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *JobRestartCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := c.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Jobs]
-	})
+	return JobPredictor(c.Meta.Client)
 }
 
 func (c *JobRestartCommand) Name() string { return "job restart" }

--- a/command/job_start.go
+++ b/command/job_start.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/hashicorp/nomad/jobspec2"
 	"github.com/posener/complete"
 )
@@ -33,7 +32,7 @@ Alias: nomad start
 
  When ACLs are enabled, this command requires a token with either the
  'submit-job' or 'register-job' capability for the job's namespace.
- 
+
 General Options:
 
  ` + generalOptionsUsage(usageOptsDefault) + `
@@ -65,19 +64,9 @@ func (c *JobStartCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *JobStartCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := c.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Jobs]
-	})
+	return JobPredictor(c.Meta.Client)
 }
+
 func (c *JobStartCommand) Name() string { return "job start" }
 
 func (c *JobStartCommand) Run(args []string) int {

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
 
@@ -61,22 +60,29 @@ General Options:
 
 Status Options:
 
-  -short
-    Display short output. Used only when a single job is being
-    queried, and drops verbose information about allocations.
-
-  -evals
-    Display the evaluations associated with the job.
-
   -all-allocs
     Display all allocations matching the job ID, including those from an older
     instance of the job.
 
-  -verbose
-    Display full information.
+  -evals
+    Display the evaluations associated with the job.
+
+  -json
+    Output the job status in JSON format.
+
+  -short
+    Display short output. Used only when a single job is being
+    queried, and drops verbose information about allocations.
+
+  -t
+    Format and display the job status using a Go template.
 
   -ui
     Open the job status page in the browser.
+
+  -verbose
+    Display full information.
+
 `
 	return strings.TrimSpace(helpText)
 }
@@ -90,25 +96,16 @@ func (c *JobStatusCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{
 			"-all-allocs": complete.PredictNothing,
 			"-evals":      complete.PredictNothing,
+			"-json":       complete.PredictNothing,
 			"-short":      complete.PredictNothing,
+			"-t":          complete.PredictAnything,
 			"-verbose":    complete.PredictNothing,
 			"-ui":         complete.PredictNothing,
 		})
 }
 
 func (c *JobStatusCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := c.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Jobs]
-	})
+	return JobPredictor(c.Meta.Client)
 }
 
 func (c *JobStatusCommand) Name() string { return "status" }

--- a/command/job_stop.go
+++ b/command/job_stop.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	"github.com/hashicorp/nomad/api"
-	"github.com/hashicorp/nomad/api/contexts"
 	"github.com/posener/complete"
 )
 
@@ -90,18 +89,7 @@ func (c *JobStopCommand) AutocompleteFlags() complete.Flags {
 }
 
 func (c *JobStopCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictFunc(func(a complete.Args) []string {
-		client, err := c.Meta.Client()
-		if err != nil {
-			return nil
-		}
-
-		resp, _, err := client.Search().PrefixSearch(a.Last, contexts.Jobs, nil)
-		if err != nil {
-			return []string{}
-		}
-		return resp.Matches[contexts.Jobs]
-	})
+	return JobPredictor(c.Meta.Client)
 }
 
 func (c *JobStopCommand) Name() string { return "job stop" }

--- a/command/job_tag_apply.go
+++ b/command/job_tag_apply.go
@@ -22,9 +22,9 @@ Usage: nomad job tag apply [options] <jobname>
 
   Save a job version to prevent it from being garbage-collected and allow it to
   be diffed and reverted by name.
-  
+
   Example usage:
- 
+
     nomad job tag apply -name "My Golden Version" \
 		-description "The version we can roll back to if needed" <jobname>
 
@@ -62,12 +62,12 @@ func (c *JobTagApplyCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{
 			"-name":        complete.PredictAnything,
 			"-description": complete.PredictAnything,
-			"-version":     complete.PredictNothing,
+			"-version":     complete.PredictAnything,
 		})
 }
 
 func (c *JobTagApplyCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return JobPredictor(c.Meta.Client)
 }
 
 func (c *JobTagApplyCommand) Name() string { return "job tag apply" }

--- a/command/job_tag_unset.go
+++ b/command/job_tag_unset.go
@@ -39,11 +39,13 @@ func (c *JobTagUnsetCommand) Synopsis() string {
 
 func (c *JobTagUnsetCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
-		complete.Flags{})
+		complete.Flags{
+			"-name": complete.PredictAnything,
+		})
 }
 
 func (c *JobTagUnsetCommand) AutocompleteArgs() complete.Predictor {
-	return complete.PredictNothing
+	return JobPredictor(c.Meta.Client)
 }
 
 func (c *JobTagUnsetCommand) Name() string { return "job tag unset" }

--- a/command/login.go
+++ b/command/login.go
@@ -58,7 +58,7 @@ Login Options:
 
   -login-token
     Login token used for authentication that will be exchanged for a Nomad ACL
-    Token. It is only required if using auth method type other than OIDC. 
+    Token. It is only required if using auth method type other than OIDC.
 
   -json
     Output the ACL token in JSON format.

--- a/command/service_list.go
+++ b/command/service_list.go
@@ -57,6 +57,7 @@ func (s *ServiceListCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{
 			"-json": complete.PredictNothing,
 			"-t":    complete.PredictAnything,
+			"-name": complete.PredictAnything,
 		})
 }
 


### PR DESCRIPTION
Some commands are missing autocompletion flags for specific fields, have completions for flags that are deprecated or no longer exist, have the wrong predictor, or don't perform searches for argument completions for objects from state.

This is one of three batches of work to improve autocompletions, focusing on a miscellaneous set of commands.

Generative AI disclosure: as part of an ongoing pilot, this changeset was partially generated via Claude Code with the exception of the code reuse refactoring and minor touch-ups. Reviewed and tested manually, with commit description written by human for humans.

Ref: https://github.com/hashicorp/nomad/pull/27507
Ref: https://github.com/hashicorp/nomad/pull/27505

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
  * as this is a UX improvement, this was tested manually
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
