### PR TITLE
ci: windows tests should run on every PR

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,9 +1,6 @@
 name: test-windows
 on:
   pull_request:
-    branches:
-      - main
-      - release/**
     paths-ignore:
       - 'README.md'
       - 'CHANGELOG.md'


### PR DESCRIPTION
For some reason windows would only run on PRs against `main` or release branches unlike other unit tests. 