### PR TITLE
ACLs: add fine-grained capabilities to support snapshot agent

### DIFF
--- a/.changelog/27525.txt
+++ b/.changelog/27525.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: Added fine-grained ACL capabilities for saving snapshots and reading the Enterprise license
+```

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -229,7 +229,8 @@ func TestParse(t *testing.T) {
 					Policy: PolicyWrite,
 				},
 				Operator: &OperatorPolicy{
-					Policy: PolicyDeny,
+					Policy:       PolicyDeny,
+					Capabilities: []string{"deny"},
 				},
 				Quota: &QuotaPolicy{
 					Policy: PolicyRead,
@@ -455,7 +456,8 @@ func TestParse(t *testing.T) {
 					Policy: PolicyWrite,
 				},
 				Operator: &OperatorPolicy{
-					Policy: PolicyDeny,
+					Policy:       PolicyDeny,
+					Capabilities: []string{"deny"},
 				},
 				Quota: &QuotaPolicy{
 					Policy: PolicyRead,

--- a/command/operator_snapshot_save.go
+++ b/command/operator_snapshot_save.go
@@ -26,8 +26,8 @@ Usage: nomad operator snapshot save [options] <file>
   Retrieves an atomic, point-in-time snapshot of the state of the Nomad servers
   which includes jobs, nodes, allocations, periodic jobs, and ACLs.
 
-  If ACLs are enabled, a management token must be supplied in order to perform
-  snapshot operations.
+  If ACLs are enabled, a token with operator:write or the operator:snapshot-save
+  capability must be supplied in order to perform snapshot operations.
 
   To create a snapshot from the leader server and save it to "backup.snap":
 

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/raft"
 	"github.com/hashicorp/serf/serf"
 
+	"github.com/hashicorp/nomad/acl"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper/snapshot"
 	"github.com/hashicorp/nomad/nomad/peers"
@@ -596,7 +597,7 @@ func (op *Operator) snapshotSave(conn io.ReadWriteCloser) {
 		}
 		handleFailure(code, err)
 		return
-	} else if !aclObj.IsManagement() {
+	} else if !aclObj.AllowOperatorOperation(acl.OperatorCapabilitySnapshotSave) {
 		handleFailure(403, structs.ErrPermissionDenied)
 		return
 	}

--- a/nomad/operator_endpoint_test.go
+++ b/nomad/operator_endpoint_test.go
@@ -806,6 +806,9 @@ func TestOperator_SnapshotSave_ACL(t *testing.T) {
 
 	deniedToken := mock.CreatePolicyAndToken(t, s.fsm.State(), 1001, "test-invalid", mock.NodePolicy(acl.PolicyWrite))
 
+	snapshotSavePolicy := `operator { capabilities = ["snapshot-save"] }`
+	snapshotSaveToken := mock.CreatePolicyAndToken(t, s.fsm.State(), 1002, "test-snapshot-save", snapshotSavePolicy)
+
 	/////////  Actually run query now
 	cases := []struct {
 		name    string
@@ -814,6 +817,7 @@ func TestOperator_SnapshotSave_ACL(t *testing.T) {
 		err     error
 	}{
 		{"root", root.SecretID, 0, nil},
+		{"snapshot_save_capability", snapshotSaveToken.SecretID, 0, nil},
 		{"no_permission_token", deniedToken.SecretID, 403, structs.ErrPermissionDenied},
 		{"invalid token", uuid.Generate(), 403, structs.ErrPermissionDenied},
 		{"unauthenticated", "", 403, structs.ErrPermissionDenied},


### PR DESCRIPTION
The Nomad snapshot agent needs to save snapshots and check the Enterprise license for Enterprise features. Currently saving snapshots requires a management token, which gives the snapshot agent far more privilege than it should have. Add fine-grained ACL capabilities to the `operator` policy block for saving a snapshot and reading the license.

(Note this PR will need another PR to the Enterprise repository for the `License.Get` RPC handler. The original #23614 also mentioned expanding to cover `keyring-rotate`, but I'll do that under a separate PR to keep review size reasonable.)

Fixes: https://github.com/hashicorp/nomad/issues/23614
Ref: https://hashicorp.atlassian.net/browse/NMD-356

Generative AI disclosure: this changeset was substantially generated via IBM Bob, with edits to improve test clarity and remove some overly-chatty comments. Fully reviewed and tested by me before marking ready for review.

### Testing

```
$ nomad acl policy self
Name      Job ID         Group Name     Task Name
operator  <unavailable>  <unavailable>  <unavailable>

$ nomad acl policy info operator
Name        = operator
Description = <none>
CreateIndex = 14
ModifyIndex = 25

Rules

# ACL policy for operator
operator {
  policy = "read"
  capabilities = ["snapshot-save"]
}

$ nomad operator snapshot save /tmp/backup.snap
State file written to /tmp/backup.snap

$ nomad operator snapshot inspect /tmp/backup.snap
Created = 2026-02-16T15:53:14-05:00
ID      = 2-25-1771275194934
Size    = 11 KiB
Index   = 25
Term    = 2
Version = 1

Type             Count  Size
ACLPolicy        4      5.8 KiB
WrappedRootKeys  1      2.0 KiB
ACLToken         5      1.4 KiB
Namespace        5      941 B
NodePool         2      286 B
SchedulerConfig  1      242 B
Index            6      152 B
ClusterMetadata  1      71 B

Total            25     11 KiB
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** 
  - https://github.com/hashicorp/web-unified-docs/pull/1853

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
