### PR TITLE
ACLs: add fine-grained capabilities for keyring rotation

### DIFF
--- a/.changelog/27526.txt
+++ b/.changelog/27526.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl: Added fine-grained ACL capability for rotating the keyring
+```

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -1113,15 +1113,51 @@ func TestAllowOperatorOperation(t *testing.T) {
 			expect:    true,
 		},
 		{
+			name:      "policy write allows keyring-rotate",
+			policy:    `operator { policy = "write" }`,
+			operation: OperatorCapabilityKeyringRotate,
+			expect:    true,
+		},
+		{
+			name:      "policy write allows keyring-read",
+			policy:    `operator { policy = "write" }`,
+			operation: OperatorCapabilityKeyringRead,
+			expect:    true,
+		},
+		{
+			name:      "policy write allows keyring-delete",
+			policy:    `operator { policy = "write" }`,
+			operation: OperatorCapabilityKeyringDelete,
+			expect:    true,
+		},
+		{
 			name:      "policy read allows license-read",
 			policy:    `operator { policy = "read" }`,
 			operation: OperatorCapabilityLicenseRead,
 			expect:    true,
 		},
 		{
+			name:      "policy read allows keyring-read",
+			policy:    `operator { policy = "read" }`,
+			operation: OperatorCapabilityKeyringRead,
+			expect:    true,
+		},
+		{
 			name:      "policy read denies snapshot-save",
 			policy:    `operator { policy = "read" }`,
 			operation: OperatorCapabilitySnapshotSave,
+			expect:    false,
+		},
+		{
+			name:      "policy read denies keyring-rotate",
+			policy:    `operator { policy = "read" }`,
+			operation: OperatorCapabilityKeyringRotate,
+			expect:    false,
+		},
+		{
+			name:      "policy read denies keyring-delete",
+			policy:    `operator { policy = "read" }`,
+			operation: OperatorCapabilityKeyringDelete,
 			expect:    false,
 		},
 		{
@@ -1145,10 +1181,34 @@ func TestAllowOperatorOperation(t *testing.T) {
 			expect:    true,
 		},
 		{
+			name:      "capability keyring-rotate allows keyring-rotate",
+			policy:    `operator { capabilities = ["keyring-rotate"] }`,
+			operation: OperatorCapabilityKeyringRotate,
+			expect:    true,
+		},
+		{
+			name:      "capability keyring-read allows keyring-read",
+			policy:    `operator { capabilities = ["keyring-read"] }`,
+			operation: OperatorCapabilityKeyringRead,
+			expect:    true,
+		},
+		{
+			name:      "capability keyring-delete allows keyring-delete",
+			policy:    `operator { capabilities = ["keyring-delete"] }`,
+			operation: OperatorCapabilityKeyringDelete,
+			expect:    true,
+		},
+		{
 			name:      "multiple capabilities allow respective operations",
 			policy:    `operator { capabilities = ["snapshot-save", "license-read"] }`,
 			operation: OperatorCapabilitySnapshotSave,
 			expect:    true,
+		},
+		{
+			name:      "capability snapshot-save does not permit keyring-rotate",
+			policy:    `operator { capabilities = ["snapshot-save"] }`,
+			operation: OperatorCapabilityKeyringRotate,
+			expect:    false,
 		},
 		{
 			name:      "capability deny denies all operations",
@@ -1193,11 +1253,13 @@ func TestAllowOperatorOperation(t *testing.T) {
 		must.NoError(t, err)
 		must.True(t, acl.AllowOperatorOperation(OperatorCapabilitySnapshotSave))
 		must.True(t, acl.AllowOperatorOperation(OperatorCapabilityLicenseRead))
+		must.True(t, acl.AllowOperatorOperation(OperatorCapabilityKeyringRotate))
 	})
 
 	t.Run("ACLs disabled allows all operations", func(t *testing.T) {
 		acl := &ACL{aclsDisabled: true}
 		must.True(t, acl.AllowOperatorOperation(OperatorCapabilitySnapshotSave))
 		must.True(t, acl.AllowOperatorOperation(OperatorCapabilityLicenseRead))
+		must.True(t, acl.AllowOperatorOperation(OperatorCapabilityKeyringRotate))
 	})
 }

--- a/acl/policy.go
+++ b/acl/policy.go
@@ -136,9 +136,12 @@ const (
 	// The following are the fine-grained capabilities that can be granted for
 	// operator-level operations. Deny takes precedence and overwrites all other
 	// capabilities.
-	OperatorCapabilityDeny         = "deny"
-	OperatorCapabilitySnapshotSave = "snapshot-save"
-	OperatorCapabilityLicenseRead  = "license-read"
+	OperatorCapabilityDeny          = "deny"
+	OperatorCapabilitySnapshotSave  = "snapshot-save"
+	OperatorCapabilityLicenseRead   = "license-read"
+	OperatorCapabilityKeyringRotate = "keyring-rotate"
+	OperatorCapabilityKeyringRead   = "keyring-read"
+	OperatorCapabilityKeyringDelete = "keyring-delete"
 )
 
 // Policy represents a parsed HCL or JSON policy.
@@ -393,7 +396,9 @@ func isNodePoolCapabilityValid(cap string) bool {
 // isOperatorCapabilityValid ensures the given capability is valid for an operator policy
 func isOperatorCapabilityValid(cap string) bool {
 	switch cap {
-	case OperatorCapabilityDeny, OperatorCapabilitySnapshotSave, OperatorCapabilityLicenseRead:
+	case OperatorCapabilityDeny, OperatorCapabilitySnapshotSave, OperatorCapabilityKeyringRotate,
+		OperatorCapabilityKeyringRead, OperatorCapabilityKeyringDelete,
+		OperatorCapabilityLicenseRead:
 		return true
 	default:
 		return false
@@ -424,9 +429,12 @@ func expandOperatorPolicy(policy string) []string {
 	case PolicyDeny:
 		return []string{OperatorCapabilityDeny}
 	case PolicyRead:
-		return []string{OperatorCapabilityLicenseRead}
+		return []string{OperatorCapabilityLicenseRead, OperatorCapabilityKeyringRead}
 	case PolicyWrite:
-		return []string{OperatorCapabilitySnapshotSave, OperatorCapabilityLicenseRead}
+		return []string{
+			OperatorCapabilitySnapshotSave, OperatorCapabilityLicenseRead,
+			OperatorCapabilityKeyringRotate, OperatorCapabilityKeyringRead,
+			OperatorCapabilityKeyringDelete}
 	default:
 		return nil
 	}

--- a/command/operator_root_keyring_list.go
+++ b/command/operator_root_keyring_list.go
@@ -23,7 +23,8 @@ Usage: nomad operator root keyring list [options]
   List the currently installed keys. This list returns key metadata and not
   sensitive key material.
 
-  If ACLs are enabled, this command requires a management token.
+  If ACLs are enabled, this command requires a token with the operator:read
+  policy or the operator:keyring-read capability.
 
 General Options:
 

--- a/command/operator_root_keyring_remove.go
+++ b/command/operator_root_keyring_remove.go
@@ -25,7 +25,8 @@ Usage: nomad operator root keyring remove [options] <key ID>
   Remove an encryption key from the cluster. This operation may only be
   performed on keys that are not the active key.
 
-  If ACLs are enabled, this command requires a management token.
+  If ACLs are enabled, this command requires a token with the operator:write
+  policy or the operator:keyring-delete capability.
 
 General Options:
 

--- a/command/operator_root_keyring_rotate.go
+++ b/command/operator_root_keyring_rotate.go
@@ -24,7 +24,8 @@ Usage: nomad operator root keyring rotate [options]
 
   Generate a new encryption key for all future variables.
 
-  If ACLs are enabled, this command requires a management token.
+  If ACLs are enabled, this command requires a token with the operator:write
+  policy or the operator:keyring-rotate capability.
 
 General Options:
 

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/go-memdb"
 	metrics "github.com/hashicorp/go-metrics/compat"
 
+	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -44,7 +45,7 @@ func (k *Keyring) Rotate(args *structs.KeyringRotateRootKeyRequest, reply *struc
 
 	if aclObj, err := k.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.IsManagement() {
+	} else if !aclObj.AllowOperatorOperation(acl.OperatorCapabilityKeyringRotate) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -135,7 +136,7 @@ func (k *Keyring) List(args *structs.KeyringListRootKeyMetaRequest, reply *struc
 
 	if aclObj, err := k.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.IsManagement() {
+	} else if !aclObj.AllowOperatorOperation(acl.OperatorCapabilityKeyringRead) {
 		return structs.ErrPermissionDenied
 	}
 
@@ -326,7 +327,7 @@ func (k *Keyring) Delete(args *structs.KeyringDeleteRootKeyRequest, reply *struc
 
 	if aclObj, err := k.srv.ResolveACL(args); err != nil {
 		return err
-	} else if !aclObj.IsManagement() {
+	} else if !aclObj.AllowOperatorOperation(acl.OperatorCapabilityKeyringDelete) {
 		return structs.ErrPermissionDenied
 	}
 


### PR DESCRIPTION
Rotating the keyring currently requires a management token, which we'd like to break up into less powerful privileges. Add a fine-grained ACL capability to the `operator` policy block for rotating the keyring.

Ref: https://github.com/hashicorp/nomad/issues/23614#issuecomment-2237676025
Ref: https://hashicorp.atlassian.net/browse/NMD-356

Generative AI disclosure: this changeset was substantially generated via IBM Bob, with edits to improve test clarity and remove some overly-chatty comments. Fully reviewed and tested by me before marking ready for review.

### Testing

```
$ nomad acl policy self
Name      Job ID         Group Name     Task Name
operator  <unavailable>  <unavailable>  <unavailable>

$ nomad acl policy info operator
Name        = operator
Description = <none>
CreateIndex = 14
ModifyIndex = 31

Rules

# ACL policy for operator
operator {
  policy = "read"
  capabilities = ["snapshot-save"]
}

$ nomad operator root keyring rotate -now
Key       State   Create Time                Publish Time
d68e7771  active  2026-02-16T16:12:29-05:00  <none>
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** https://github.com/hashicorp/web-unified-docs/pull/1853

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
