### PR TITLE
refactor(ui): replace dynamic component invocations with explicit conditionals

### DIFF
--- a/ui/app/components/app-breadcrumbs.hbs
+++ b/ui/app/components/app-breadcrumbs.hbs
@@ -6,7 +6,11 @@
 <Breadcrumbs as |breadcrumbs|>
   {{#each breadcrumbs as |crumb iter|}}
     {{#let crumb.args.crumb as |c|}}
-      {{component (concat "breadcrumbs/" (or c.type "default")) crumb=c isOneCrumbUp=(action this.isOneCrumbUp iter breadcrumbs.length)}}
+      {{#if (eq c.type "job")}}
+        <Breadcrumbs::Job @crumb={{c}} @isOneCrumbUp={{fn this.isOneCrumbUp iter breadcrumbs.length}} />
+      {{else}}
+        <Breadcrumbs::Default @crumb={{c}} @isOneCrumbUp={{fn this.isOneCrumbUp iter breadcrumbs.length}} />
+      {{/if}}
     {{/let}}
   {{/each}}
 </Breadcrumbs>

--- a/ui/app/components/breadcrumbs/default.hbs
+++ b/ui/app/components/breadcrumbs/default.hbs
@@ -3,20 +3,20 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-{{! template-lint-disable no-unknown-arguments-for-builtin-components }}
 <li data-test-breadcrumb-default
   {{(modifier
     this.maybeKeyboardShortcut
     label="Go up a level"
     pattern=(array "u")
     menuLevel=true
-    action=(action this.traverseUpALevel @crumb.args)
+    action=this.traverseUpALevel
     exclusive=true
   )}}
 >
   <LinkTo
-    @params={{@crumb.args}}
-    data-test-breadcrumb={{@crumb.args.firstObject}}>
+    @route={{this.route}}
+    @models={{this.models}}
+    data-test-breadcrumb={{this.route}}>
     {{#if @crumb.title}}
       <dl>
         <dt>

--- a/ui/app/components/breadcrumbs/default.js
+++ b/ui/app/components/breadcrumbs/default.js
@@ -11,10 +11,25 @@ import { inject as service } from '@ember/service';
 export default class BreadcrumbsTemplate extends Component {
   @service router;
 
+  /**
+   * The route name extracted from the crumb args array.
+   * @returns {string}
+   */
+  get route() {
+    return this.args.crumb?.args?.[0];
+  }
+
+  /**
+   * The dynamic segments (models) for the route, extracted from the crumb args array.
+   * @returns {Array}
+   */
+  get models() {
+    return this.args.crumb?.args?.slice(1) ?? [];
+  }
+
   @action
-  traverseUpALevel(args) {
-    const [path, ...rest] = args;
-    this.router.transitionTo(path, ...rest);
+  traverseUpALevel() {
+    this.router.transitionTo(this.route, ...this.models);
   }
 
   get maybeKeyboardShortcut() {

--- a/ui/app/components/breadcrumbs/job.hbs
+++ b/ui/app/components/breadcrumbs/job.hbs
@@ -3,7 +3,7 @@
   SPDX-License-Identifier: BUSL-1.1
 ~}}
 
-<Trigger @onError={{action this.onError}} @do={{this.fetchParent}} as |trigger|>
+<Trigger @onError={{this.onError}} @do={{this.fetchParent}} as |trigger|>
   {{did-insert trigger.fns.do}}
   {{#if trigger.data.isBusy}}
     <li>
@@ -18,7 +18,7 @@
         <LinkTo
           @route="jobs.job.index"
           @model={{trigger.data.result}}
-          data-test-breadcrumb={{"jobs.job.index"}}
+          data-test-breadcrumb="jobs.job.index"
         >
           <dl>
             <dt>
@@ -37,14 +37,14 @@
         label="Go up a level"
         pattern=(array "u")
         menuLevel=true
-        action=(action this.traverseUpALevel (array "jobs.job" this.job.idWithNamespace))
+        action=this.traverseUpALevel
         exclusive=true
       )}}
     >
       <LinkTo
         @route="jobs.job.index"
         @model={{this.job}}
-        data-test-breadcrumb={{"jobs.job.index"}}
+        data-test-breadcrumb="jobs.job.index"
         data-test-job-breadcrumb
       >
         <dl>

--- a/ui/app/components/breadcrumbs/job.js
+++ b/ui/app/components/breadcrumbs/job.js
@@ -17,6 +17,11 @@ export default class BreadcrumbsJob extends BreadcrumbsTemplate {
   }
 
   @action
+  traverseUpALevel() {
+    this.router.transitionTo('jobs.job', this.job.idWithNamespace);
+  }
+
+  @action
   onError(err) {
     assert(`Error:  ${err.message}`);
   }

--- a/ui/app/components/job-editor.hbs
+++ b/ui/app/components/job-editor.hbs
@@ -4,7 +4,7 @@
 ~}}
 
 <div>
-  <JobEditor::Alert 
+  <JobEditor::Alert
     @data={{merge (hash error=this.error stage=this.stage) this.data}}
     @fns={{this.fns}}
   />
@@ -22,7 +22,7 @@
             <div class="hds-button__text">Upload file</div>
             <input
             type="file"
-              onchange={{action this.fns.onUpload}}
+              {{on "change" this.fns.onUpload}}
               accept=".hcl,.json,.nomad"
             />
           </label>
@@ -38,5 +38,11 @@
       </header>
     {{/if}}
     {{did-update this.setDefinitionOnModel this.definition}}
-    {{component (concat 'job-editor/' this.stage) data=this.data fns=this.fns}}
+    {{#if (eq this.stage "review")}}
+      <JobEditor::Review @data={{this.data}} @fns={{this.fns}} />
+    {{else if (eq this.stage "edit")}}
+      <JobEditor::Edit @data={{this.data}} @fns={{this.fns}} />
+    {{else}}
+      <JobEditor::Read @data={{this.data}} @fns={{this.fns}} />
+    {{/if}}
 </div>

--- a/ui/app/components/job-editor/edit.hbs
+++ b/ui/app/components/job-editor/edit.hbs
@@ -10,7 +10,7 @@
     <div class="pull-right" style="display: flex">
       <span class="header-toggle">
         <Hds::Form::Toggle::Field
-          {{keyboard-shortcut label="Toggle word wrap" action=(action @fns.onToggleWrap) pattern=(array "w" "w") menuLevel=true }}
+          {{keyboard-shortcut label="Toggle word wrap" action=@fns.onToggleWrap pattern=(array "w" "w") menuLevel=true }}
           checked={{@data.shouldWrap}}
           {{on "change" @fns.onToggleWrap}}
         as |F|>

--- a/ui/app/components/job-editor/read.hbs
+++ b/ui/app/components/job-editor/read.hbs
@@ -9,7 +9,7 @@
     <div class="pull-right" style="display: flex">
         <span class="header-toggle">
           <Hds::Form::Toggle::Field
-            {{keyboard-shortcut label="Toggle word wrap" action=(action @fns.onToggleWrap) pattern=(array "w" "w") menuLevel=true }}
+            {{keyboard-shortcut label="Toggle word wrap" action=@fns.onToggleWrap pattern=(array "w" "w") menuLevel=true }}
             checked={{@data.shouldWrap}}
             {{on "change" @fns.onToggleWrap}}
           as |F|>
@@ -19,14 +19,14 @@
 
         <Tooltip @condition={{unless @data.hasSpecification true false}} @isFullText={{true}} @text="A jobspec file was not submitted when this job was run. You can still view and edit the expanded JSON format.">
             <div class="job-definition-select {{unless @data.hasSpecification " disabled"}}" data-test-select={{@data.view}}>
-                <button 
+                <button
                     class="button is-small is-borderless {{if (eq @data.view "job-spec") "is-active"}}"
                     type="button"
                     {{on "click" (fn @fns.onSelect "job-spec")}}
                 >
                     Job Spec
                 </button>
-                <button 
+                <button
                     class="button is-small is-borderless {{if (eq @data.view "full-definition") "is-active"}}"
                     type="button"
                     {{on "click" (fn @fns.onSelect "full-definition")}}
@@ -34,7 +34,7 @@
                 >
                     Full Definition
                 </button>
-            </div>        
+            </div>
         </Tooltip>
 
         <button
@@ -50,16 +50,16 @@
     </div>
     <div class="boxed-section-body is-full-bleed">
     {{#if (eq @data.view "job-spec")}}
-        <div 
+        <div
             data-test-job-spec-view
             {{code-mirror
             content=@data.definition
             mode=(if (eq @data.format "json") "javascript" "ruby")
             readOnly=true
-            screenReaderLabel="Job specification"          
+            screenReaderLabel="Job specification"
             theme="hashi-read-only"
             lineWrapping=@data.shouldWrap
-            }} 
+            }}
         />
     {{else}}
         <div

--- a/ui/tests/integration/components/app-breadcrumbs-test.js
+++ b/ui/tests/integration/components/app-breadcrumbs-test.js
@@ -4,8 +4,6 @@
  */
 
 /* eslint-disable ember-a11y-testing/a11y-audit-called */
-import { setComponentTemplate } from '@ember/component';
-import templateOnlyComponent from '@ember/component/template-only';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { findAll, render } from '@ember/test-helpers';
@@ -46,38 +44,24 @@ module('Integration | Component | app breadcrumbs', function (hooks) {
     });
   });
 
-  test('when we register a crumb with a type property, a dedicated breadcrumb/<type> component renders', async function (assert) {
-    const crumbs = [
+  test('crumbs without a type default to the default breadcrumb component', async function (assert) {
+    this.set('crumbs', [
       { label: 'Jobs', args: ['jobs.index'] },
-      { type: 'special', label: 'Job', args: ['jobs.job.index'] },
-    ];
-    this.set('crumbs', crumbs);
-
-    this.owner.register(
-      'component:breadcrumbs/special',
-      setComponentTemplate(
-        hbs`
-        <div data-test-breadcrumb-special>Test</div>
-      `,
-        templateOnlyComponent()
-      )
-    );
+      { label: 'Job', args: ['jobs.job.index'] },
+    ]);
 
     await render(hbs`
-    <AppBreadcrumbs />
-    {{#each this.crumbs as |crumb|}}
-      <Breadcrumb @crumb={{hash type=crumb.type label=crumb.label args=crumb.args }} />
-    {{/each}}
-  `);
-
-    assert
-      .dom('[data-test-breadcrumb-special]')
-      .exists(
-        'We can create a new type of breadcrumb component and AppBreadcrumbs will handle rendering by type'
-      );
+      <AppBreadcrumbs />
+      {{#each this.crumbs as |crumb|}}
+        <Breadcrumb @crumb={{hash label=crumb.label args=crumb.args}} />
+      {{/each}}
+    `);
 
     assert
       .dom('[data-test-breadcrumb-default]')
-      .exists('Default breadcrumb registers if no type is specified');
+      .exists(
+        { count: 2 },
+        'All crumbs without a type render as default breadcrumbs'
+      );
   });
 });

--- a/ui/tests/integration/components/breadcrumbs-test.js
+++ b/ui/tests/integration/components/breadcrumbs-test.js
@@ -23,10 +23,10 @@ module('Integration | Component | breadcrumbs', function (hooks) {
           {{/each}}
         </ul>
       </Breadcrumbs>
-      <button data-test-button type="button" {{on "click" toggleCrumb}}>Toggle</button>
-      <Breadcrumb @crumb={{'Zoey'}} />
+      <button data-test-button type="button" {{on "click" this.toggleCrumb}}>Toggle</button>
+      <Breadcrumb @crumb="Zoey" />
       {{#if this.isRegistered}}
-        <Breadcrumb @crumb={{'Tomster'}} />
+        <Breadcrumb @crumb="Tomster" />
       {{/if}}
     `);
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

Phase 0.10 of the Ember upgrade plan — remove Embroider-incompatible patterns:

- Replace `{{component (concat ...)}}` in app-breadcrumbs and job-editor with explicit `{{#if (eq ...)}}` and angle bracket component invocations
- Replace deprecated `<LinkTo @params>` with `@route`/`@models` in breadcrumbs/default
- Replace `(action ...)` helper with direct references and `{{fn}}`
- Remove `.firstObject` array prototype extension usage
- Replace `onchange={{action ...}}` with `{{on "change" ...}}` modifier
- Fix implicit `this` fallback and unnecessary curly braces in tests
- Modernize `run.later` import to `later` in allocation-detail-test
- Update jsconfig.json with proper paths and include/exclude
- Replace broken local:qunitdom script with local:test

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

[FF-565](https://hashicorp.atlassian.net/browse/FF-565)

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


[FF-565]: https://hashicorp.atlassian.net/browse/FF-565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ