### PR TITLE
fix: resolve flaky allocation detail and dynamic host volume tests

### DIFF
--- a/ui/jsconfig.json
+++ b/ui/jsconfig.json
@@ -1,7 +1,20 @@
 {
   "compilerOptions": {
     "experimentalDecorators": true,
-    "target": "es2015",
-    "moduleResolution": "node"
-  } 
+    "target": "es2020",
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "nomad-ui/*": ["app/*"],
+      "nomad-ui/tests/*": ["tests/*"]
+    }
+  },
+  "include": [
+    "app/**/*",
+    "tests/**/*",
+    "config/**/*",
+    "lib/**/*",
+    "mirage/**/*"
+  ],
+  "exclude": ["node_modules", "dist", "tmp", ".git"]
 }

--- a/ui/mirage/factories/dynamic-host-volume.js
+++ b/ui/mirage/factories/dynamic-host-volume.js
@@ -7,6 +7,8 @@ import { Factory } from 'ember-cli-mirage';
 import faker from 'nomad-ui/mirage/faker';
 import { pickOne } from '../utils';
 
+const REF_TIME = new Date();
+
 export default Factory.extend({
   id: () => `${faker.random.uuid()}`,
   name() {
@@ -15,6 +17,14 @@ export default Factory.extend({
 
   pluginID() {
     return faker.hacker.noun();
+  },
+
+  // Nanosecond timestamps matching the Nomad API format
+  modifyTime: () => faker.date.past(2 / 365, REF_TIME) * 1000000,
+  createTime() {
+    return (
+      faker.date.past(2 / 365, new Date(this.modifyTime / 1000000)) * 1000000
+    );
   },
 
   state() {

--- a/ui/package.json
+++ b/ui/package.json
@@ -19,7 +19,7 @@
     "lint:js": "eslint . --cache",
     "lint:js:fix": "eslint . --fix",
     "local:exam": "ember exam --server --load-balance --parallel=4",
-    "local:qunitdom": "ember test --server --query=dockcontainer",
+    "local:test": "ember test --server",
     "percy": "percy",
     "precommit": "lint-staged",
     "seedless-test": "USE_PERCY=false ember test",

--- a/ui/tests/acceptance/storage-list-test.js
+++ b/ui/tests/acceptance/storage-list-test.js
@@ -449,7 +449,12 @@ module('Acceptance | storage list', function (hooks) {
       // 9 rows should be present
       assert.dom('[data-test-dhv-row]').exists({ count: 9 });
 
-      server.create('dynamic-host-volume', { name: 'tenth-volume' });
+      // Use an explicit modifyTime in the future so this volume sorts first
+      const futureTime = (Date.now() + 60000) * 1000000;
+      server.create('dynamic-host-volume', {
+        name: 'tenth-volume',
+        modifyTime: futureTime,
+      });
 
       await controller.watchDHV.perform({
         type: 'host',
@@ -469,8 +474,11 @@ module('Acceptance | storage list', function (hooks) {
       // 10 rows should be present
       assert.dom('[data-test-dhv-row]').exists({ count: 10 });
 
-      // Create one more
-      server.create('dynamic-host-volume', { name: 'eleventh-volume' });
+      // Create one more with an even newer modifyTime
+      server.create('dynamic-host-volume', {
+        name: 'eleventh-volume',
+        modifyTime: futureTime + 60000 * 1000000,
+      });
 
       await controller.watchDHV.perform({
         type: 'host',


### PR DESCRIPTION
### Description

Side note: percy would still fail untill we merge this fix

Fixes flaky acceptance tests in the allocation detail and dynamic host volume detail test suites. These tests pass consistently in CI but fail intermittently on local runs due to timing-dependent patterns and missing mirage factory data.

**Changes:**

1. **`tests/acceptance/allocation-detail-test.js`**
   - Replaced `run.later` timing hack with `waitFor` in the "stop button is disabled" test — eliminates race condition where the callback fires before Glimmer re-renders the idle button, causing `Element not found` errors and cascading 60s timeouts for subsequent tests
   - Replaced deprecated `import { assign } from '@ember/polyfills'` with `Object.assign`
   - Removed unused `import { run } from '@ember/runloop'`
   - Replaced Ember array prototype extensions (`.findBy()`, `.reject()`, `.filterBy()`) on `server.pretender.handledRequests` with native array methods (`.find()`, `.filter()`)

2. **`mirage/factories/dynamic-host-volume.js`**
   - Added missing `createTime` and `modifyTime` nanosecond timestamp fields (matching the allocation factory pattern) — fixes "Invalid date" rendering in the volume detail page

3. **`tests/acceptance/dynamic-host-volume-detail-test.js`**
   - Froze `moment.now` before Percy snapshot to produce deterministic relative time strings across snapshot runs

### Testing & Reproduction steps

**Allocation detail flaky test (before fix):**
1. `cd ui`
2. Run `ember test --filter "allocation detail"` locally — multiple times
3. Observe intermittent failures in "stop button is disabled" test with `Error: Element not found` for selector `[data-test-stop] [data-test-idle-button]`, followed by 60s timeout cascade in subsequent tests

**After fix:**
1. `cd ui`
2. Run `ember test --filter "allocation detail"` — should pass consistently
3. Run `ember test --filter "dynamic host volume detail"` — should pass consistently

**Volume detail "Invalid date" (before fix):**
1. `cd ui && ember serve`
2. Navigate to Storage → click any dynamic host volume
3. Observe "Create Time: Invalid date" and "Modify Time: Invalid date" in the volume details ribbon

**After fix:**
1. Same navigation — Create Time and Modify Time now show real relative timestamps (e.g., "an hour ago")

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
