### PR TITLE
Backport of: system deployments: fix scheduler write skew from stale snapshot (#27497)

### DIFF
--- a/.changelog/27497.txt
+++ b/.changelog/27497.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+deployments: Fixed a bug where system job deployments would not be marked healthy even though all allocations were healthy
+```
+
+```release-note:bug
+deployments: Fixed a bug where system job canary state could be incorrectly changed after a promotion
+```

--- a/nomad/structs/deployment.go
+++ b/nomad/structs/deployment.go
@@ -312,6 +312,13 @@ func (d *DeploymentState) Copy() *DeploymentState {
 	return c
 }
 
+func (d *DeploymentState) MergeClientValues(c *DeploymentState) {
+	d.HealthyAllocs = c.HealthyAllocs
+	d.UnhealthyAllocs = c.UnhealthyAllocs
+	d.PlacedAllocs = c.PlacedAllocs
+	d.RequireProgressBy = c.RequireProgressBy
+}
+
 // DeploymentStatusUpdate is used to update the status of a given deployment
 type DeploymentStatusUpdate struct {
 	// DeploymentID is the ID of the deployment to update


### PR DESCRIPTION
_Manual backport of #27497_

During a system deployment, if a client update marking an allocation healthy happens after a scheduler worker has taken a snapshot, the plan will overwrite the `HealthyAllocs` count on the deployment. The client never writes another health update, so the deployment gets stuck even though all allocations are marked healthy.

Likewise, if a scheduler worker takes a snapshot and the deployment is promoted before the plan is submitted, the number of canaries will be mutated and the promotion flag potentially removed.

Break the `DeploymentState` into "client owned" vs "server owned" fields, and have the update that comes from upserting a plan treat the client owned fields as authoritative for that data. Enforce in the FSM that flipping `Promoted` to true for the deployment state is a one-way operation.

Fixes: https://github.com/hashicorp/nomad/issues/27382


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
