### PR TITLE
test: Fix Docker test due to inspect image mismatch.

### DIFF
--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1025,14 +1025,9 @@ func TestDockerDriver_ForcePull_RepoDigest(t *testing.T) {
 	container, err := client.ContainerInspect(context.Background(), handle.containerID)
 	must.NoError(t, err)
 
-	switch runtime.GOARCH {
-	case "amd64":
-		must.Eq(t, "sha256:8ac48589692a53a9b8c2d1ceaa6b402665aa7fe667ba51ccc03002300856d8c7", container.Image)
-	case "arm64":
-		must.Eq(t, "sha256:ba3a78826904c625e65a2eed1f247bbab59898f043490e7113e88907bf7c6b3b", container.Image)
-	default:
-		t.Fatalf("unsupported test architecture: %s", runtime.GOARCH)
-	}
+	// Docker returns the image field as the manifest/repo digest rather than
+	// the platform-specific image config hash.
+	must.StrEqFold(t, "sha256:58ac43b2cc92c687a32c8be6278e50a063579655fe3090125dcb2af0ff9e1a64", container.Image)
 }
 
 func TestDockerDriver_SecurityOptUnconfined(t *testing.T) {


### PR DESCRIPTION
What I do know:
- The inspect API will return the image SHA with the manifest/repo digest rather than the platform-specific image config hash

What I don't know:
- Why this just started failing

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

