### PR TITLE
fix potential state store corruption in scheduler and deploymentwatcher

### DIFF
--- a/.changelog/27548.txt
+++ b/.changelog/27548.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+state: Fixed a potential state store corruption bug in the service/batch scheduler and deployment watcher
+```

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -214,6 +214,7 @@ func (w *deploymentWatcher) setAllocHealth(
 	}
 
 	// Canonicalize the job in case it doesn't have namespace set
+	j = j.Copy()
 	j.Canonicalize()
 
 	// Create the request

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -226,6 +226,7 @@ func (s *GenericScheduler) process() (bool, error) {
 		if err != nil {
 			return false, fmt.Errorf("failed to get job deployment %q: %v", s.eval.JobID, err)
 		}
+		s.deployment = s.deployment.Copy() // may mutate in reconciler
 	}
 
 	// Reset the failed allocations


### PR DESCRIPTION
During investigation of another bug, we discovered two potential but unreported state store corruption bugs where an object is mutated without first being copied:

* Deployments can be mutated in the reconciler for service and batch jobs. It's unlikely this can cause a bug because the deployment would have to have been created without a group dstate, but testing with `-race` hit this case. (cc @tehut who discovered this)
* Jobs can be mutated via a call to `Canonicalize` in the deployment watcher when checking to see if we need to do a rollback. It's unlikely this can cause a bug because the fields mutated aren't going to be those mutated once we've committed a version of the job to state, but it's a data race nonetheless.

Ref: https://github.com/hashicorp/nomad/blob/main/contributing/architecture-state-store.md

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
