### PR TITLE
acls: handle nil claims safely in `GetClaimPolicies` RPC

### DIFF
--- a/.changelog/27550.txt
+++ b/.changelog/27550.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+acl: Fixed a bug where a bearer-token authenticated request could panic the handler for checking claims
+```

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -411,7 +411,7 @@ func (a *ACL) GetClaimPolicies(args *structs.GenericRequest, reply *structs.ACLP
 	defer metrics.MeasureSince([]string{"nomad", "acl", "get_claim_policies"}, time.Now())
 
 	// Should only be called using a workload identity
-	claims := args.GetIdentity().Claims
+	claims := args.GetIdentity().GetClaims()
 	if claims == nil {
 		// Calling this RPC without a workload identity is either a bug or an
 		// attacker as this RPC is not exposed to users directly.


### PR DESCRIPTION
The `ACL.GetClaimPolicies` RPC reads claims from the authenticated identity. But if the RPC were to be authenticated via a bearer token, `GetIdentity` would return nil and we'd panic. The HTTP handler routes the RPC based on the shape of the token it gets to avoid this problem in practice. It's only possible to hit this panic if someone were to obtain a bearer token (either from the cluster admin, Vault, or logging in via OIDC), get a client or server mTLS certificate, and craft an messagepack RPC request directly and send it to the server.

Fixes: https://hashicorp.atlassian.net/browse/SECVULN-29933 ("informational" finding)

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
