### PR TITLE
artifact: fix file mode artifact inspection

### DIFF
--- a/.changelog/27552.txt
+++ b/.changelog/27552.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+artifact: Fix artifact inspection when using `file` mode
+```

--- a/client/allocrunner/taskrunner/getter/util.go
+++ b/client/allocrunner/taskrunner/getter/util.go
@@ -313,9 +313,21 @@ func (s *Sandbox) runCmd(env *parameters) error {
 		return err
 	}
 
-	// merge the artifact contents into the real destination
-	if err := mergeDirectories(at, atTemporaryDest, atFinalDest); err != nil {
-		return err
+	// if in file mode, simply move the file into place. otherwise
+	// merge the directories.
+	if env.Mode == getter.ClientModeFile {
+		if err := at.MkdirAll(filepath.Dir(atFinalDest), 0755); err != nil {
+			return err
+		}
+
+		if err := at.Rename(atTemporaryDest, atFinalDest); err != nil {
+			return err
+		}
+	} else {
+		// merge the artifact contents into the real destination
+		if err := mergeDirectories(at, atTemporaryDest, atFinalDest); err != nil {
+			return err
+		}
 	}
 
 	// the artifact contents will have the owner set correctly


### PR DESCRIPTION
### Description

When the artifact is configured for file mode, the destination will be a file, not the parent directory. Detect when in file mode and move the file to the destination.

Test coverage includes basic file mode usage with inspection as well as tests for behavior parity with go-getter.

### Testing & Reproduction steps

Can be reproduced by fetching an artifact in "file" mode with filesystem isolation disabled.

### Links

#27530

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](../web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](../web-unified-docs/tree/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
