### PR TITLE
ACLs: add fine-grained ACLs for Sentinel CRUD operations

### DIFF
--- a/.changelog/27556.txt
+++ b/.changelog/27556.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+acl (Enterprise): Added `sentinel` policy block to allow managing Sentinel policies without a management token
+```

--- a/acl/policy_test.go
+++ b/acl/policy_test.go
@@ -99,6 +99,10 @@ func TestParse(t *testing.T) {
 			operator {
 				policy = "deny"
 			}
+			sentinel {
+				policy = "read"
+				capabilities = ["sentinel-delete"]
+			}
 			quota {
 				policy = "read"
 			}
@@ -231,6 +235,13 @@ func TestParse(t *testing.T) {
 				Operator: &OperatorPolicy{
 					Policy:       PolicyDeny,
 					Capabilities: []string{"deny"},
+				},
+				Sentinel: &SentinelPolicy{
+					Policy: PolicyRead,
+					Capabilities: []string{
+						SentinelCapabilityDelete,
+						SentinelCapabilityRead,
+					},
 				},
 				Quota: &QuotaPolicy{
 					Policy: PolicyRead,
@@ -938,6 +949,16 @@ func TestParse(t *testing.T) {
 			}
 			`,
 			"Invalid plugin policy",
+			nil,
+		},
+		{
+			`sentinel {	policy = "invalid" }`,
+			"Invalid sentinel policy",
+			nil,
+		},
+		{
+			`sentinel { capabilities = ["invalid-capability"] }`,
+			"Invalid sentinel capability",
 			nil,
 		},
 	}

--- a/command/sentinel_apply.go
+++ b/command/sentinel_apply.go
@@ -26,7 +26,7 @@ Usage: nomad sentinel apply [options] <name> <file>
   from stdin by specifying "-".
 
   Sentinel commands are only available when ACLs are enabled. This command
-  requires a management token.
+  requires a token with the sentinel-submit capability.
 
 General Options:
 

--- a/command/sentinel_delete.go
+++ b/command/sentinel_delete.go
@@ -21,7 +21,7 @@ Usage: nomad sentinel delete [options] <name>
   Delete is used to delete an existing Sentinel policy.
 
   Sentinel commands are only available when ACLs are enabled. This command
-  requires a management token.
+  requires a token with the sentinel-delete capability.
 
 General Options:
 

--- a/command/sentinel_list.go
+++ b/command/sentinel_list.go
@@ -21,7 +21,7 @@ Usage: nomad sentinel list [options]
   List is used to display all the installed Sentinel policies.
 
   Sentinel commands are only available when ACLs are enabled. This command
-  requires a management token.
+  requires a token with the sentinel-read capability.
 
 General Options:
 

--- a/command/sentinel_read.go
+++ b/command/sentinel_read.go
@@ -21,7 +21,7 @@ Usage: nomad sentinel read [options] <name>
   Read is used to inspect a Sentinel policy.
 
   Sentinel commands are only available when ACLs are enabled. This command
-  requires a management token.
+  requires a token with the sentinel-read capability.
 
 General Options:
 


### PR DESCRIPTION
Updating Sentinel policies currently requires a management token. We'd like to break up the management token capabilities so that users can provide less-privileged tokens to services for specific purposes. For example, one might want to run testing on Sentinel policies and not allow that test pipeline to have full management access.

Add support for fine-grained ACLs on Sentinel CRUD operations. Note that unlike most ACLs, Sentinel is disabled when ACLs are disabled.

This is the CE portion of the work. The Sentinel RPC handlers are in the Enterprise PR.

Ref: https://github.com/hashicorp/nomad-enterprise/pull/3700
Ref: https://hashicorp.atlassian.net/browse/NMD-512
Fixes: https://github.com/hashicorp/nomad/issues/24225

Generative AI disclosure: these ACL package code changes were substantially generated via IBM Bob (with heavy hand-holding), while the RPC handler code and its test updates in the ENT PR were done solely by me. Fully reviewed and tested by me before marking ready for review.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** https://github.com/hashicorp/web-unified-docs/pull/1853

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
