### PR TITLE
ci: actionlint allow "ondemand" runners

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -4,6 +4,7 @@
 self-hosted-runner:
   # Labels of self-hosted runner in array of string
   labels:
+    - ondemand
     - custom-windows-medium
     - windows-2022-16core
     - custom-linux-xxl-nomad-20.04


### PR DESCRIPTION
The absence of this is masked in some workflows by e.g.

```yaml
runs-on: ${{ endsWith(github.repository, '-enterprise') && fromJSON('["self-hosted", "ondemand", "macos"]') || 'macos-latest' }}
```

`actionlint` doesn't flag that, either due to the conditional, or the list being stashed in a single fromJSON string `'["self-hosted", "ondemand", "macos"]'`.