### PR TITLE
system deployments: fix write skew mitigation

### DIFF
--- a/.changelog/27604.txt
+++ b/.changelog/27604.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+deployments: Fixed a bug where a task group dropped from a system job could cause deployment state to be overwritten incorrectly
+```

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -402,10 +402,11 @@ func (s *StateStore) UpsertPlanResults(msgType structs.MessageType, index uint64
 			return fmt.Errorf("deployment lookup failed: %v", err)
 		}
 		if existing != nil {
-			for tgName, dstate := range results.Deployment.TaskGroups {
-				existDstate := existing.TaskGroups[tgName]
-				if existDstate != nil {
+			for tgName, existDstate := range existing.TaskGroups {
+				if dstate := results.Deployment.TaskGroups[tgName]; dstate != nil {
 					dstate.MergeClientValues(existDstate)
+				} else {
+					results.Deployment.TaskGroups[tgName] = existDstate
 				}
 			}
 		}

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -5630,6 +5630,15 @@ func TestStateStore_UpdateAllocsFromClient_DeploymentStateMerges(t *testing.T) {
 	must.NotNil(t, out)
 	must.True(t, out.DeploymentStatus.Canary)
 
+	// Drop the task group
+
+	deployment, err = state.DeploymentByID(nil, deployment.ID)
+	must.NoError(t, err)
+	deployment = deployment.Copy()
+	deployment.TaskGroups[alloc.TaskGroup] = nil
+	must.NoError(t, state.UpsertPlanResults(structs.MsgTypeTestSetup, 1005,
+		&structs.ApplyPlanResultsRequest{Deployment: deployment}))
+
 	update = update.Copy()
 	update.DeploymentStatus = &structs.AllocDeploymentStatus{
 		Healthy: pointer.Of(true), // should update


### PR DESCRIPTION
In #27497 we added write skew protection against the scheduler overwriting deployment state written by the clients. But there's a potential edge case where if a deployment were to drop the task group dstate entirely, we would overwrite the existing one.  It doesn't appear possible to actually hit this case in the scheduler without hitting the panic described in #27571 but this is belt-and-suspenders.

Ref: https://github.com/hashicorp/nomad/pull/27497
Ref: https://github.com/hashicorp/nomad/issues/27382
Ref: https://github.com/hashicorp/nomad/pull/27571

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
