### PR TITLE
system deployments: don't create deploy for older clients

### DIFF
--- a/.changelog/27605.txt
+++ b/.changelog/27605.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fixed a bug where system deployments would not complete on clusters with pre-1.11.0 nodes
+```

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
+	nomadVersion "github.com/hashicorp/nomad/version"
 	"github.com/hashicorp/raft"
 	"github.com/kr/pretty"
 	"github.com/shoenig/test/must"
@@ -8701,6 +8702,7 @@ func TestIntegration_SystemDeploymentHealth(t *testing.T) {
 
 	for range 4 {
 		node := mock.Node()
+		node.Attributes["nomad.version"] = nomadVersion.Version
 		req := &structs.NodeRegisterRequest{
 			Node:         node,
 			WriteRequest: structs.WriteRequest{Region: region},


### PR DESCRIPTION
Clients from before 1.11.0 will not send deployment health status for system job allocations, but 1.11.0+ servers are expecting this information to mark a deployment healthy. Don't create a deployment if any of the nodes in the eligible set are pre-1.11.0.

Fixes: https://github.com/hashicorp/nomad/issues/27382
See also: https://github.com/hashicorp/nomad/pull/27604
See also: https://github.com/hashicorp/nomad/pull/27571

### Testing & Reproduction steps

See comment below: https://github.com/hashicorp/nomad/pull/27605#issuecomment-3967615550

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
