### PR TITLE
DHV: fix unmet claims handling for terminal allocations

### DIFF
--- a/.changelog/27613.txt
+++ b/.changelog/27613.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+dynamic host volumes: Fixed a bug with sticky volumes where replacement allocations would not use the previous volume claim
+```

--- a/e2e/dynamic_host_volumes/dynamic_host_volumes_test.go
+++ b/e2e/dynamic_host_volumes/dynamic_host_volumes_test.go
@@ -194,14 +194,20 @@ func TestDynamicHostVolumes_StickyVolumes(t *testing.T) {
 	selectedVolID := nodeToVolMap[selectedNodeID]
 
 	t.Logf("[%v] volume %q on node %q was selected",
-		time.Since(start), selectedVolID, selectedNodeID)
+		time.Since(start), selectedVolID[:8], selectedNodeID[:8])
+
+	claims, _, err := nomad.TaskGroupHostVolumeClaims().List(
+		&nomadapi.TaskGroupHostVolumeClaimsListRequest{JobID: jobSub.JobID()}, nil)
+	must.NoError(t, err)
+	must.Len(t, 1, claims)
+	must.Eq(t, allocID1, claims[0].AllocID)
 
 	// Test: force reschedule
 
 	_, err = nomad.Allocations().Stop(alloc, nil)
 	must.NoError(t, err)
 
-	t.Logf("[%v] stopped allocation %q", time.Since(start), alloc.ID)
+	t.Logf("[%v] stopped allocation %q", time.Since(start), alloc.ID[:8])
 
 	var allocID2 string
 
@@ -229,11 +235,18 @@ func TestDynamicHostVolumes_StickyVolumes(t *testing.T) {
 	newAlloc, _, err := nomad.Allocations().Info(allocID2, nil)
 	must.NoError(t, err)
 	must.Eq(t, selectedNodeID, newAlloc.NodeID)
-	t.Logf("[%v] replacement alloc %q is running", time.Since(start), newAlloc.ID)
+	t.Logf("[%v] replacement alloc %q is running on %q",
+		time.Since(start), newAlloc.ID[:8], newAlloc.NodeID[:8])
+
+	claims, _, err = nomad.TaskGroupHostVolumeClaims().List(
+		&nomadapi.TaskGroupHostVolumeClaimsListRequest{JobID: jobSub.JobID()}, nil)
+	must.NoError(t, err)
+	must.Len(t, 1, claims)
+	must.Eq(t, allocID2, claims[0].AllocID)
 
 	// Test: drain node
 
-	t.Logf("[%v] draining node %q", time.Since(start), selectedNodeID)
+	t.Logf("[%v] draining node %q", time.Since(start), selectedNodeID[:8])
 	cleanup, err := drainNode(nomad, selectedNodeID, time.Second*20)
 	t.Cleanup(cleanup)
 	must.NoError(t, err)
@@ -245,10 +258,10 @@ func TestDynamicHostVolumes_StickyVolumes(t *testing.T) {
 				return err
 			}
 
-			got := map[string]string{}
-
+			got := ""
 			for _, eval := range evals {
-				got[eval.ID[:8]] = fmt.Sprintf("status=%q trigger=%q create_index=%d",
+				got += fmt.Sprintf("eval=%s status=%s trigger=%s create_index=%d\n",
+					eval.ID[:8],
 					eval.Status,
 					eval.TriggeredBy,
 					eval.CreateIndex,
@@ -258,13 +271,24 @@ func TestDynamicHostVolumes_StickyVolumes(t *testing.T) {
 				}
 			}
 
-			return fmt.Errorf("expected blocked eval, got evals => %#v", got)
+			allocs, _, err := nomad.Jobs().Allocations(jobSub.JobID(), true, nil)
+			if err != nil {
+				return err
+			}
+			if len(allocs) > 2 {
+				for _, alloc := range allocs {
+					got += fmt.Sprintf("alloc=%s status=%s\n", alloc.ID[:8], alloc.ClientStatus)
+				}
+				return fmt.Errorf("alloc should not have started, got:\n%s", got)
+			}
+
+			return fmt.Errorf("expected blocked eval, got:\n%s", got)
 		}),
 		wait.Timeout(10*time.Second),
 		wait.Gap(50*time.Millisecond),
 	))
 
-	t.Logf("[%v] undraining node %q", time.Since(start), selectedNodeID)
+	t.Logf("[%v] undraining node %q", time.Since(start), selectedNodeID[:8])
 	cleanup()
 
 	var allocID3 string
@@ -279,7 +303,7 @@ func TestDynamicHostVolumes_StickyVolumes(t *testing.T) {
 				if a.ID != allocID1 && a.ID != allocID2 {
 					allocID3 = a.ID
 					if a.ClientStatus != api.AllocClientStatusRunning {
-						return fmt.Errorf("replacement alloc %q not running", allocID3)
+						return fmt.Errorf("replacement alloc %q not running", allocID3[:8])
 					}
 				}
 			}
@@ -291,9 +315,8 @@ func TestDynamicHostVolumes_StickyVolumes(t *testing.T) {
 
 	newAlloc, _, err = nomad.Allocations().Info(allocID3, nil)
 	must.NoError(t, err)
-	must.Eq(t, selectedNodeID, newAlloc.NodeID)
-	t.Logf("[%v] replacement alloc %q is running", time.Since(start), newAlloc.ID)
-
+	must.Eq(t, selectedNodeID, newAlloc.NodeID, must.Sprint("started on wrong node"))
+	t.Logf("[%v] replacement alloc %q is running", time.Since(start), newAlloc.ID[:8])
 }
 
 func drainNode(nomad *nomadapi.Client, nodeID string, timeout time.Duration) (func(), error) {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
-	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/lib/lang"
 	"github.com/hashicorp/nomad/nomad/stream"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -4272,50 +4271,9 @@ func (s *StateStore) upsertAllocsImpl(index uint64, allocs []*structs.Allocation
 			// Check if the alloc requires sticky volumes. If yes, find a node
 			// that has the right volume and update the task group volume
 			// claims table
-			for _, tg := range alloc.Job.TaskGroups {
-				for _, v := range tg.Volumes {
-					if !v.Sticky {
-						continue
-					}
-					sv := &structs.TaskGroupHostVolumeClaim{
-						ID:            uuid.Generate(),
-						Namespace:     alloc.Namespace,
-						JobID:         alloc.JobID,
-						TaskGroupName: tg.Name,
-						AllocID:       alloc.ID,
-						VolumeName:    v.Source,
-					}
-
-					allocNode, err := s.NodeByID(nil, alloc.NodeID)
-					if err != nil {
-						return err
-					}
-
-					// since there's no existing claim, find a volume and register a claim
-					for _, v := range allocNode.HostVolumes {
-						if v.Name != sv.VolumeName {
-							continue
-						}
-
-						sv.VolumeID = v.ID
-
-						// has this volume been claimed already?
-						existingClaim, err := s.GetTaskGroupHostVolumeClaim(nil, sv.Namespace, sv.JobID, sv.TaskGroupName, v.ID)
-						if err != nil {
-							return err
-						}
-
-						// if the volume has already been claimed, we don't have to do anything. The
-						// feasibility checker in the scheduler will verify alloc placement.
-						if existingClaim != nil {
-							continue
-						}
-
-						if err := s.upsertTaskGroupHostVolumeClaimImpl(index, sv, txn); err != nil {
-							return err
-						}
-					}
-				}
+			err = s.updateStickyVolumeClaimsFromAlloc(txn, index, alloc)
+			if err != nil {
+				return err
 			}
 		} else {
 			alloc.CreateIndex = exist.CreateIndex

--- a/nomad/state/state_store_task_group_volume_claims.go
+++ b/nomad/state/state_store_task_group_volume_claims.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -186,4 +187,78 @@ func (s *StateStore) DeleteTaskGroupHostVolumeClaim(index uint64, claimID string
 	}
 
 	return txn.Commit()
+}
+
+func (s *StateStore) updateStickyVolumeClaimsFromAlloc(txn *txn, index uint64, alloc *structs.Allocation) error {
+	var node *structs.Node
+	var err error
+	tg := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
+	if tg != nil {
+		for _, req := range tg.Volumes {
+			if !req.Sticky {
+				continue
+			}
+			if node == nil {
+				node, err = s.NodeByID(nil, alloc.NodeID)
+				if err != nil {
+					return err
+				}
+			}
+			for _, v := range node.HostVolumes {
+				if v.Name != req.Source {
+					continue
+				}
+				claim, err := s.claimToUpsertForAlloc(txn, alloc, req.Source, v)
+				if err != nil {
+					return err
+				}
+				if claim == nil {
+					continue
+				}
+				if err := s.upsertTaskGroupHostVolumeClaimImpl(index, claim, txn); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// claimToUpsertForAlloc returns any claim that needs to be upserted for the allocation
+func (s *StateStore) claimToUpsertForAlloc(txn *txn, alloc *structs.Allocation, source string, chv *structs.ClientHostVolumeConfig) (*structs.TaskGroupHostVolumeClaim, error) {
+
+	claim := &structs.TaskGroupHostVolumeClaim{
+		ID:            uuid.Generate(),
+		Namespace:     alloc.Namespace,
+		JobID:         alloc.JobID,
+		TaskGroupName: alloc.TaskGroup,
+		AllocID:       alloc.ID,
+		VolumeName:    source,
+		VolumeID:      chv.ID,
+	}
+
+	raw, err := txn.First(TableTaskGroupHostVolumeClaim,
+		indexID, alloc.Namespace, alloc.JobID, alloc.TaskGroup, chv.ID)
+	if err != nil {
+		return nil, err
+	}
+	if raw == nil {
+		return claim, nil
+	}
+	existingClaim := raw.(*structs.TaskGroupHostVolumeClaim)
+	if existingClaim.AllocID == alloc.ID {
+		return nil, nil // this is our claim already, nothing to do
+	}
+	if existingClaim.AllocID != "" {
+		existingAlloc, err := s.allocByIDImpl(txn, nil, existingClaim.AllocID)
+		if err != nil {
+			return nil, err
+		}
+		if existingAlloc != nil && existingAlloc.TerminalStatus() {
+			// this allocation is a replacement for the claim
+			claim.ID = existingClaim.ID
+			return claim, nil
+		}
+	}
+	return claim, nil
 }

--- a/nomad/state/state_store_task_group_volume_claims_test.go
+++ b/nomad/state/state_store_task_group_volume_claims_test.go
@@ -186,3 +186,137 @@ func TestStateStore_TaskGroupHostVolumeClaimsByFields(t *testing.T) {
 	}
 	must.SliceLen(t, 3, foundClaims)
 }
+
+func TestStateStore_claimUpsertForAlloc(t *testing.T) {
+	ci.Parallel(t)
+	store := testStateStore(t)
+
+	job := mock.Job()
+	node := mock.Node()
+	volumeID := uuid.Generate()
+	chv := &structs.ClientHostVolumeConfig{
+		Name:     "test-volume",
+		Path:     "/data",
+		ReadOnly: false,
+		ID:       volumeID,
+	}
+
+	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, 10, nil, job))
+	must.NoError(t, store.UpsertNode(structs.MsgTypeTestSetup, 11, node))
+
+	makeAlloc := func() *structs.Allocation {
+		alloc := mock.Alloc()
+		alloc.JobID = job.ID
+		alloc.Job = job
+		alloc.NodeID = node.ID
+		alloc.TaskGroup = "web"
+		alloc.Namespace = structs.DefaultNamespace
+		return alloc
+	}
+
+	t.Run("no existing claim creates new claim", func(t *testing.T) {
+		txn := store.db.WriteTxn(100)
+		t.Cleanup(func() { txn.Abort() })
+
+		alloc := makeAlloc()
+		claim, err := store.claimToUpsertForAlloc(txn, alloc, "test-volume", chv)
+		must.NoError(t, err)
+		must.NotNil(t, claim)
+		must.Eq(t, alloc.ID, claim.AllocID)
+		must.Eq(t, alloc.JobID, claim.JobID)
+		must.Eq(t, alloc.TaskGroup, claim.TaskGroupName)
+		must.Eq(t, alloc.Namespace, claim.Namespace)
+		must.Eq(t, "test-volume", claim.VolumeName)
+		must.Eq(t, volumeID, claim.VolumeID)
+	})
+
+	t.Run("existing claim for same alloc is no-op", func(t *testing.T) {
+		alloc := makeAlloc()
+		existingClaim := &structs.TaskGroupHostVolumeClaim{
+			ID:            uuid.Generate(),
+			Namespace:     alloc.Namespace,
+			JobID:         alloc.JobID,
+			TaskGroupName: alloc.TaskGroup,
+			AllocID:       alloc.ID,
+			VolumeName:    "test-volume",
+			VolumeID:      volumeID,
+		}
+
+		must.NoError(t, store.UpsertTaskGroupHostVolumeClaim(
+			structs.MsgTypeTestSetup, 200, existingClaim))
+
+		txn := store.db.WriteTxn(201)
+		t.Cleanup(func() { txn.Abort() })
+
+		claim, err := store.claimToUpsertForAlloc(txn, alloc, "test-volume", chv)
+		must.NoError(t, err)
+		must.Nil(t, claim) // alloc already owns this claim
+	})
+
+	t.Run("existing claim with terminal alloc gets updated for new alloc", func(t *testing.T) {
+		oldAlloc := makeAlloc()
+		oldAlloc.ClientStatus = structs.AllocClientStatusComplete
+		must.NoError(t, store.UpsertAllocs(
+			structs.MsgTypeTestSetup, 300, []*structs.Allocation{oldAlloc}))
+
+		existingClaim := &structs.TaskGroupHostVolumeClaim{
+			ID:            uuid.Generate(),
+			Namespace:     oldAlloc.Namespace,
+			JobID:         oldAlloc.JobID,
+			TaskGroupName: oldAlloc.TaskGroup,
+			AllocID:       oldAlloc.ID,
+			VolumeName:    "test-volume",
+			VolumeID:      volumeID,
+		}
+
+		must.NoError(t, store.UpsertTaskGroupHostVolumeClaim(
+			structs.MsgTypeTestSetup, 301, existingClaim))
+
+		newAlloc := makeAlloc()
+		newAlloc.ClientStatus = structs.AllocClientStatusRunning
+
+		txn := store.db.WriteTxn(302)
+		t.Cleanup(func() { txn.Abort() })
+
+		claim, err := store.claimToUpsertForAlloc(txn, newAlloc, "test-volume", chv)
+		must.NoError(t, err)
+		must.NotNil(t, claim)
+		must.Eq(t, existingClaim.ID, claim.ID) // reuse the existing claim ID
+		must.Eq(t, newAlloc.ID, claim.AllocID) // update to new alloc ID
+		must.Eq(t, newAlloc.JobID, claim.JobID)
+		must.Eq(t, newAlloc.TaskGroup, claim.TaskGroupName)
+	})
+
+	t.Run("existing claim with running alloc gets new claim for new alloc", func(t *testing.T) {
+		existingAlloc := makeAlloc()
+		existingAlloc.ClientStatus = structs.AllocClientStatusRunning
+		must.NoError(t, store.UpsertAllocs(
+			structs.MsgTypeTestSetup, 400, []*structs.Allocation{existingAlloc}))
+
+		existingClaim := &structs.TaskGroupHostVolumeClaim{
+			ID:            uuid.Generate(),
+			Namespace:     existingAlloc.Namespace,
+			JobID:         existingAlloc.JobID,
+			TaskGroupName: existingAlloc.TaskGroup,
+			AllocID:       existingAlloc.ID,
+			VolumeName:    "test-volume",
+			VolumeID:      volumeID,
+		}
+		must.NoError(t, store.UpsertTaskGroupHostVolumeClaim(
+			structs.MsgTypeTestSetup, 401, existingClaim))
+
+		newAlloc := makeAlloc()
+		newAlloc.ClientStatus = structs.AllocClientStatusRunning
+
+		txn := store.db.WriteTxn(402)
+		t.Cleanup(func() { txn.Abort() })
+
+		claim, err := store.claimToUpsertForAlloc(txn, newAlloc, "test-volume", chv)
+		must.NoError(t, err)
+		must.NotNil(t, claim)
+		must.NotEq(t, existingClaim.ID, claim.ID) // must be new claim ID
+		must.Eq(t, newAlloc.ID, claim.AllocID)
+		must.Eq(t, newAlloc.JobID, claim.JobID)
+		must.Eq(t, newAlloc.TaskGroup, claim.TaskGroupName)
+	})
+}

--- a/scheduler/feasible/feasible.go
+++ b/scheduler/feasible/feasible.go
@@ -258,13 +258,10 @@ NEXT:
 
 		// the proposed alloc might be the exact same alloc or it could be an
 		// alloc from earlier in this eval that we've successfully placed
-		proposed, err := h.ctx.ProposedAllocs(alloc.NodeID)
+		proposed, err := h.ctx.ProposedAllocs(vol.NodeID)
 		if err == nil {
 			for _, proposedAlloc := range proposed {
-				if proposedAlloc.ID == claim.AllocID ||
-					(proposedAlloc.TaskGroup == taskGroupName &&
-						vol.NodeID == alloc.NodeID &&
-						vol.ID == claim.VolumeID) {
+				if proposedAllocMeetsClaim(proposedAlloc, claim, vol, alloc.NodeID) {
 					continue NEXT
 				}
 			}
@@ -288,6 +285,28 @@ NEXT:
 			h.volumeReqs = append(h.volumeReqs, req)
 		}
 	}
+}
+
+// proposedAllocMeetsClaim determines if a proposed alloc (existing non-terminal
+// or newly proposed this eval) satisfies a volume claim
+func proposedAllocMeetsClaim(
+	proposed *structs.Allocation,
+	claim *structs.TaskGroupHostVolumeClaim,
+	vol *structs.HostVolume,
+	nodeID string, // node ID of the alloc in the claim, should always match volume
+) bool {
+	if proposed.TerminalStatus() {
+		return false // evicted or being replaced
+	}
+	if proposed.ID == claim.AllocID {
+		return true // exact match
+	}
+
+	return proposed.Namespace == claim.Namespace &&
+		proposed.JobID == claim.JobID &&
+		proposed.TaskGroup == claim.TaskGroupName &&
+		proposed.NodeID == nodeID &&
+		vol.ID == claim.VolumeID
 }
 
 func (h *HostVolumeChecker) Feasible(candidate *structs.Node) bool {

--- a/scheduler/feasible/feasible_test.go
+++ b/scheduler/feasible/feasible_test.go
@@ -3712,3 +3712,128 @@ func TestCheckAttributeConstraint(t *testing.T) {
 		}
 	}
 }
+
+func TestHostVolume_ProposedAllocMeetsClaim(t *testing.T) {
+	ci.Parallel(t)
+
+	allocID := uuid.Generate()
+	volID0, volID1 := uuid.Generate(), uuid.Generate()
+	nodeID0, nodeID1 := uuid.Generate(), uuid.Generate()
+
+	makeAlloc := func(id, job, tg, desiredStatus, clientStatus string) *structs.Allocation {
+		alloc := &structs.Allocation{
+			Namespace:     structs.DefaultNamespace,
+			ID:            id,
+			JobID:         job,
+			TaskGroup:     tg,
+			DesiredStatus: desiredStatus,
+			ClientStatus:  clientStatus,
+			NodeID:        nodeID0,
+		}
+		return alloc
+	}
+
+	makeClaim := func(allocID, volID string) *structs.TaskGroupHostVolumeClaim {
+		return &structs.TaskGroupHostVolumeClaim{
+			ID:            uuid.Generate(),
+			AllocID:       allocID,
+			VolumeID:      volID,
+			Namespace:     structs.DefaultNamespace,
+			JobID:         "job0",
+			TaskGroupName: "tg0",
+			VolumeName:    "database",
+		}
+	}
+
+	vol0 := &structs.HostVolume{Namespace: structs.DefaultNamespace, ID: volID0, NodeID: nodeID0}
+	vol1 := &structs.HostVolume{Namespace: structs.DefaultNamespace, ID: volID1, NodeID: nodeID1}
+
+	testCases := []struct {
+		name     string
+		proposed *structs.Allocation
+		claim    *structs.TaskGroupHostVolumeClaim
+		vol      *structs.HostVolume
+		nodeID   string
+		expect   bool
+	}{
+		{
+			name: "terminal alloc fails claim",
+			proposed: makeAlloc(allocID, "job0", "tg0",
+				structs.AllocDesiredStatusStop, structs.AllocClientStatusComplete),
+			claim:  makeClaim(allocID, volID0),
+			vol:    vol0,
+			nodeID: nodeID0,
+			expect: false,
+		},
+		{
+			name: "exact alloc ID matches claim",
+			proposed: makeAlloc(allocID, "job0", "tg0",
+				structs.AllocDesiredStatusRun, structs.AllocClientStatusRunning),
+			claim:  makeClaim(allocID, volID0),
+			vol:    vol0,
+			nodeID: nodeID0,
+			expect: true,
+		},
+		{
+			name: "different alloc for task group matches claim",
+			proposed: makeAlloc("different-alloc", "job0", "tg0",
+				structs.AllocDesiredStatusRun, structs.AllocClientStatusRunning),
+			claim:  makeClaim(allocID, volID0),
+			vol:    vol0,
+			nodeID: nodeID0,
+			expect: true,
+		},
+		{
+			name: "job mismatch fails claim",
+			proposed: makeAlloc("different-alloc", "job1", "tg0",
+				structs.AllocDesiredStatusRun, structs.AllocClientStatusRunning),
+			claim:  makeClaim(allocID, volID0),
+			vol:    vol0,
+			nodeID: nodeID0,
+			expect: false,
+		},
+		{
+			name: "volume mismatch fails claim",
+			proposed: makeAlloc("different-alloc", "job0", "tg0",
+				structs.AllocDesiredStatusRun, structs.AllocClientStatusRunning),
+			claim:  makeClaim(allocID, volID0),
+			vol:    vol1,
+			nodeID: nodeID1,
+			expect: false,
+		},
+		{
+			name: "node-volume mismatch fails claim",
+			proposed: makeAlloc("different-alloc", "job0", "tg0",
+				structs.AllocDesiredStatusRun, structs.AllocClientStatusRunning),
+			claim:  makeClaim(allocID, volID0),
+			vol:    vol0,
+			nodeID: nodeID1, // note: should be impossible
+			expect: false,
+		},
+		{
+			name: "pending alloc with exact ID match returns true",
+			proposed: makeAlloc(allocID, "job0", "tg0",
+				structs.AllocDesiredStatusRun, structs.AllocClientStatusPending),
+			claim:  makeClaim(allocID, volID0),
+			vol:    vol0,
+			nodeID: nodeID0,
+			expect: true,
+		},
+		{
+			name: "running alloc with all conditions matched returns true",
+			proposed: makeAlloc("new-alloc", "job0", "tg0",
+				structs.AllocDesiredStatusRun, structs.AllocClientStatusRunning),
+			claim:  makeClaim("old-alloc", volID0),
+			vol:    vol0,
+			nodeID: nodeID0,
+			expect: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := proposedAllocMeetsClaim(tc.proposed, tc.claim, tc.vol, tc.nodeID)
+			must.Eq(t, tc.expect, result)
+		})
+	}
+}


### PR DESCRIPTION
When we feasibility check dynamic host volume claims for "sticky" volumes, we need to ensure that new allocations are preferentially places on nodes that the job has previously been on. In #27470 we fixed a bug where we were incorrectly handling proposed allocations for the eval, but this fix missed handling of terminal allocations. If an allocation is terminal (server or client), we don't want to count it among the allocations that match a claim, so that we free the claim up for allocations that are replacing it.

Add a check for terminal allocations in the feasibility check. Extract this check out to a function so that it can be tested, and add tests.

While debugging this issue, I discovered that the claims upsert read existing claims out of a read transaction in the middle of the write transaction. This makes it possible for the read to see a stale version that doesn't include any changes from the current write (because `go-memdb` does not permit dirty reads). Correct this, and extract the claims upsert logic to a method we can test.

Improve logging and assertions for the E2E test to make this bug easier to understand as well.

Ref: https://github.com/hashicorp/nomad/pull/27470
Ref: https://hashicorp.atlassian.net/browse/NMD-1267

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
