### PR TITLE
events: add field to job events to detect deregister vs delete

### DIFF
--- a/.changelog/27614.txt
+++ b/.changelog/27614.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-events: Added a Purge flag to JobDeregistered event type to differentiate between stopped and deleted jobs
+events: Added a Deleted flag to JobDeregistered event type to differentiate between stopped and deleted jobs
 ```

--- a/api/event_stream.go
+++ b/api/event_stream.go
@@ -90,6 +90,17 @@ func (e *Event) Job() (*Job, error) {
 	return out.Job, nil
 }
 
+// DeregisteredJob returns a Job struct from a given event payload. If the Event
+// Topic is Job this will return a valid Job and whether that job was deleted
+// (purged).
+func (e *Event) DeregisteredJob() (*Job, bool, error) {
+	out, err := e.decodePayload()
+	if err != nil {
+		return nil, false, err
+	}
+	return out.Job, out.Deleted, nil
+}
+
 // Node returns a Node struct from a given event payload. If the
 // Event Topic is Node this will return a valid Node.
 func (e *Event) Node() (*Node, error) {
@@ -125,6 +136,7 @@ type eventPayload struct {
 	Deployment *Deployment          `mapstructure:"Deployment"`
 	Evaluation *Evaluation          `mapstructure:"Evaluation"`
 	Job        *Job                 `mapstructure:"Job"`
+	Deleted    bool                 `mapstructure:"Deleted"`
 	Node       *Node                `mapstructure:"Node"`
 	NodePool   *NodePool            `mapstructure:"NodePool"`
 	Service    *ServiceRegistration `mapstructure:"Service"`

--- a/api/event_stream_test.go
+++ b/api/event_stream_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/go-viper/mapstructure/v2"
+	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/shoenig/test/must"
 )
 
@@ -338,11 +338,26 @@ func TestEventStream_PayloadValueHelpers(t *testing.T) {
 			},
 		},
 		{
+			desc:  "job",
 			input: []byte(`{"Topic": "Job", "Payload": {"Job":{"ID":"some-id","Namespace":"some-namespace-id"}}}`),
 			expectFn: func(t *testing.T, event Event) {
 				must.Eq(t, TopicJob, event.Topic)
 				j, err := event.Job()
 				must.NoError(t, err)
+				must.Eq(t, &Job{
+					ID:        pointerOf("some-id"),
+					Namespace: pointerOf("some-namespace-id"),
+				}, j)
+			},
+		},
+		{
+			desc:  "deregistered job",
+			input: []byte(`{"Topic": "Job", "Payload": {"Job":{"ID":"some-id","Namespace":"some-namespace-id"}, "Deleted": true}}`),
+			expectFn: func(t *testing.T, event Event) {
+				must.Eq(t, TopicJob, event.Topic)
+				j, deleted, err := event.DeregisteredJob()
+				must.NoError(t, err)
+				must.True(t, deleted, must.Sprint("did not populated Deleted value"))
 				must.Eq(t, &Job{
 					ID:        pointerOf("some-id"),
 					Namespace: pointerOf("some-namespace-id"),

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -144,8 +144,8 @@ func eventFromChange(change memdb.Change) (structs.Event, bool) {
 				Key:       before.ID,
 				Namespace: before.Namespace,
 				Payload: &structs.JobEvent{
-					Job:   before,
-					Purge: true,
+					Job:     before,
+					Deleted: true,
 				},
 			}, true
 		case "nodes":

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -715,7 +715,7 @@ func TestEventsFromChanges_WithDeletion(t *testing.T) {
 			{
 				Table:  "jobs",
 				Before: purgedJob,
-				After:  nil, // deleted (purged)
+				After:  nil, // deleted (or purged)
 			},
 		},
 		MsgType: structs.JobDeregisterRequestType,
@@ -725,17 +725,17 @@ func TestEventsFromChanges_WithDeletion(t *testing.T) {
 	must.NotNil(t, events)
 	must.Len(t, 2, events.Events)
 
-	// first event: upserted job (stop) — Purge should be false
+	// first event: upserted job (stop) — Deleted should be false
 	upsertEvent := events.Events[0]
 	upsertPayload, ok := upsertEvent.Payload.(*structs.JobEvent)
 	must.True(t, ok)
-	must.False(t, upsertPayload.Purge)
+	must.False(t, upsertPayload.Deleted)
 
-	// second event: deleted job (purge) — Purge should be true
+	// second event: deleted job (purge) — Deleted should be true
 	purgeEvent := events.Events[1]
 	purgePayload, ok := purgeEvent.Payload.(*structs.JobEvent)
 	must.True(t, ok)
-	must.True(t, purgePayload.Purge)
+	must.True(t, purgePayload.Deleted)
 }
 
 func TestEventsFromChanges_WithNodeDeregistration(t *testing.T) {

--- a/nomad/structs/event.go
+++ b/nomad/structs/event.go
@@ -124,9 +124,9 @@ func (j *EventJson) Copy() *EventJson {
 type JobEvent struct {
 	Job *Job
 
-	// Purge indicates whether the job was deleted from the state store. This
+	// Deleted indicates whether the job was deleted from the state store. This
 	// field is only set for JobDeregistered events.
-	Purge bool `json:",omitempty"`
+	Deleted bool `json:",omitempty"`
 }
 
 // EvaluationEvent holds a newly updated Eval.


### PR DESCRIPTION
Most objects are simply deleted from the state store once the user deletes them or they're GC'd, but jobs can be either deregistered (stopped) or deleted (purged). Because both happen with the same Raft log type, we emit identical events to the event stream for both. Add a `Purge` flag to the job event to differentiate between the two.

Ref: https://hashicorp.atlassian.net/browse/NMD-366
Fixes: https://github.com/hashicorp/nomad/issues/24618

Generative AI disclosure: I used IBM Bob to generate much of this changeset. All code has been reviewed by me and tested end-to-end on a real cluster. Commit message by humans for humans, of course.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
