### PR TITLE
ci: avoid mergeflicts during release finalize main

### DIFF
--- a/.github/workflows/release-finalize.yml
+++ b/.github/workflows/release-finalize.yml
@@ -9,8 +9,12 @@ on:
       gh-token:
         required: true
     inputs:
+      org:
+        description: "GitHub org"
+        type: string
+        default: "hashicorp"
       repo:
-        description: "GitHub repository, e.g. hashicorp/nomad"
+        description: "GitHub repository, e.g. nomad or nomad-enterprise"
         type: string
         required: true
       version:
@@ -44,7 +48,7 @@ jobs:
       - name: Checkout nomad
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: ${{ inputs.repo }}
+          repository: ${{ inputs.org }}/${{ inputs.repo }}
           ref: ${{ inputs.merge-from }}
           fetch-depth: 0 # need history to merge
           token: ${{ secrets.gh-token }}
@@ -66,9 +70,9 @@ jobs:
         run: |-
           msg="release: Prepare for next release after ${{ inputs.version }}"
           if [ "${{ inputs.merge-into }}" == "${{ inputs.main-branch }}" ]; then
-            msg="release: ${{ inputs.version }}"
+            msg="release: Copy files after ${{ inputs.version }}"
           fi
           set -x
-          git switch ${{ inputs.merge-into }}
+          git status
           git commit -m "$msg"
           git push origin ${{ inputs.merge-into }}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -9,8 +9,12 @@ on:
       gh-token:
         required: true
     inputs:
+      org:
+        description: "GitHub org"
+        type: string
+        default: "hashicorp"
       repo:
-        description: "GitHub repository, e.g. hashicorp/nomad"
+        description: "GitHub repository, e.g. nomad or nomad-enterprise"
         type: string
         required: true
       version:
@@ -56,7 +60,7 @@ jobs:
       - name: Checkout nomad
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: ${{ inputs.repo }}
+          repository: ${{ inputs.org }}/${{ inputs.repo }}
           ref: ${{ inputs.source-branch }}
           fetch-depth: 0
           fetch-tags: true # for changelog
@@ -122,9 +126,10 @@ jobs:
 
           # summarize and output
 
+          base_url="https://github.com/${{ inputs.org }}/${{ inputs.repo }}"
           cat <<SUMM >> "$GITHUB_STEP_SUMMARY"
-          Release branch: [$branch](https://github.com/${{ inputs.repo }}/tree/$branch)
-          Build sha: [\`$sha\`](https://github.com/${{ inputs.repo }}/commit/$sha)
+          Release branch: [$branch]($base_url/tree/$branch)
+          Build sha: [\`$sha\`]($base_url/commit/$sha)
           SUMM
 
           cat <<OUT >> "$GITHUB_OUTPUT"

--- a/scripts/release/finalize
+++ b/scripts/release/finalize
@@ -35,28 +35,25 @@ echo 'Ensuring branches'
   done
 echo
 
-# if the target is main, we cherry-pick from the source and call it a day.
+# if the target is main, grab select files from the source branch,
+# which during a release will be the latest version's .x branch
 if [ "$MERGE_INTO" == "${MAIN_BRANCH:-main}" ]; then
-  echo 'Target branch is main; squashing release commits'
+  echo "Target branch is main; checking out files from '$MERGE_FROM'"
 
-  # find commits for this release in source branch.
-  # commit messages in release-{prepare,finalize}.yml workflows match this format.
-  msg="^release:.* ${NEW_VERSION}$"
-  commits="$(git log --grep "$msg" --reverse --pretty='%H' "$MERGE_FROM")"
-  [ -n "$commits" ] || { echo "::error::found no commits for '$msg'"; exit 1; }
-  echo -e "commits:\n$commits"
-
-  # squash (--no-commit) to exclude the generated files from git history;
-  # they're huge, and remain in other branches for posterity.
-  if ! echo "$commits" | xargs git cherry-pick --no-commit; then
-    echo "::error::failed to cherry-pick release commits"
-    exit 1
-  fi
+  # using a simple `checkout` to bypass merge conflicts
+  # excluding files: *.generated.go, CHANGELOG.md
+  git checkout "$MERGE_FROM" \
+    version/version.go \
+    scripts/release/previous.version \
+    command/agent/bindata_assetfs.go \
+    ;
 
   exit # nothing else to do
 fi
 
 echo "Merging changes from '$MERGE_FROM' into '$MERGE_INTO'"
+  # there should never be a merge conflict, because MERGE_FROM
+  # was originally created from MERGE_INTO (a .x branch) during prepare.
   if ! git merge --no-edit "$MERGE_FROM"; then
     echo "::error::failed to merge $MERGE_FROM into $MERGE_INTO"
     exit 1


### PR DESCRIPTION
Copy files from source (`.x`) branch instead of cherry-picking commits to squash. And exclude CHANGELOG.md; we'll handle that separately, because it refers to multiple different versions.

Also, consistent org/repo inputs in workflows for consistency with nomad-releases.

The result of this new finalize `main` logic can be seen here: [1.11.x+ent](https://github.com/hashicorp/nomad-enterprise/commits/db-testing/1.11.x+ent) => [main](https://github.com/hashicorp/nomad-enterprise/commits/db-testing/main)