### PR TITLE
Scheduler: Add configurable NodeLimitForFeasibilityChecks

### DIFF
--- a/.changelog/27650.txt
+++ b/.changelog/27650.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+scheduler: Add a configuration field for the number of nodes that the scheduler considers when spread or affinity is in use. This can improve scheduler performance for some cluster shapes.
+```

--- a/api/operator.go
+++ b/api/operator.go
@@ -185,6 +185,13 @@ type SchedulerConfiguration struct {
 	// until the configuration is updated and written to the Nomad servers.
 	PauseEvalBroker bool
 
+	// NodeLimitForFeasibilityChecks limits the number of feasible nodes to consider when
+	// scheduling a job that specifies spread and/or affinity. Defaults to 100 nodes if
+	// unset. Lower numbers result in better scheduler performance and more randomization
+	// of jobs across nodes. Higher numbers result in more deterministic application of
+	// spread and/or affinity.
+	NodeLimitForFeasibilityChecks uint
+
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
 	ModifyIndex uint64

--- a/api/operator_test.go
+++ b/api/operator_test.go
@@ -64,6 +64,7 @@ func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 		MemoryOversubscriptionEnabled: true,
 		RejectJobRegistration:         true,
 		PauseEvalBroker:               true,
+		NodeLimitForFeasibilityChecks: 123,
 	}
 
 	schedulerConfigUpdateResp, _, err := c.Operator().SchedulerSetConfiguration(&newSchedulerConfig, nil)
@@ -78,6 +79,7 @@ func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 	must.True(t, schedulerConfig.SchedulerConfig.RejectJobRegistration)
 	must.True(t, schedulerConfig.SchedulerConfig.MemoryOversubscriptionEnabled)
 	must.Eq(t, schedulerConfig.SchedulerConfig.PreemptionConfig, newSchedulerConfig.PreemptionConfig)
+	must.Eq(t, schedulerConfig.SchedulerConfig.NodeLimitForFeasibilityChecks, newSchedulerConfig.NodeLimitForFeasibilityChecks)
 }
 
 func TestOperator_AutopilotState(t *testing.T) {

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -311,6 +311,7 @@ func (s *HTTPServer) schedulerUpdateConfig(resp http.ResponseWriter, req *http.R
 		MemoryOversubscriptionEnabled: conf.MemoryOversubscriptionEnabled,
 		RejectJobRegistration:         conf.RejectJobRegistration,
 		PauseEvalBroker:               conf.PauseEvalBroker,
+		NodeLimitForFeasibilityChecks: conf.NodeLimitForFeasibilityChecks,
 		PreemptionConfig: structs.PreemptionConfig{
 			SystemSchedulerEnabled:   conf.PreemptionConfig.SystemSchedulerEnabled,
 			SysBatchSchedulerEnabled: conf.PreemptionConfig.SysBatchSchedulerEnabled,

--- a/command/agent/operator_endpoint_test.go
+++ b/command/agent/operator_endpoint_test.go
@@ -496,6 +496,7 @@ func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 {
   "MemoryOversubscriptionEnabled": true,
   "PauseEvalBroker": true,
+  "NodeLimitForFeasibilityChecks": 123,
   "PreemptionConfig": {
     "SystemSchedulerEnabled": true,
     "ServiceSchedulerEnabled": true
@@ -525,6 +526,7 @@ func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 		require.True(t, reply.SchedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
 		require.True(t, reply.SchedulerConfig.MemoryOversubscriptionEnabled)
 		require.True(t, reply.SchedulerConfig.PauseEvalBroker)
+		require.Equal(t, reply.SchedulerConfig.GetNodeLimitForFeasibilityChecks(), uint(123))
 	})
 }
 

--- a/command/operator_scheduler_get_config.go
+++ b/command/operator_scheduler_get_config.go
@@ -86,6 +86,7 @@ func (o *OperatorSchedulerGetConfig) Run(args []string) int {
 		fmt.Sprintf("Preemption Service Scheduler|%v", schedConfig.PreemptionConfig.ServiceSchedulerEnabled),
 		fmt.Sprintf("Preemption Batch Scheduler|%v", schedConfig.PreemptionConfig.BatchSchedulerEnabled),
 		fmt.Sprintf("Preemption SysBatch Scheduler|%v", schedConfig.PreemptionConfig.SysBatchSchedulerEnabled),
+		fmt.Sprintf("Node Limit For Feasibility Checks|%v", schedConfig.NodeLimitForFeasibilityChecks),
 		fmt.Sprintf("Modify Index|%v", resp.SchedulerConfig.ModifyIndex),
 	}))
 	return 0

--- a/command/operator_scheduler_get_config_test.go
+++ b/command/operator_scheduler_get_config_test.go
@@ -25,8 +25,8 @@ func TestOperatorSchedulerGetConfig_Run(t *testing.T) {
 	// Run the command, so we get the default output and test this.
 	must.Zero(t, c.Run([]string{"-address=" + addr}))
 	s := ui.OutputWriter.String()
-	must.StrContains(t, s, "Scheduler Algorithm           = binpack")
-	must.StrContains(t, s, "Preemption SysBatch Scheduler = false")
+	must.StrContains(t, s, "Scheduler Algorithm               = binpack")
+	must.StrContains(t, s, "Preemption SysBatch Scheduler     = false")
 	ui.ErrorWriter.Reset()
 	ui.OutputWriter.Reset()
 

--- a/command/operator_scheduler_set_config.go
+++ b/command/operator_scheduler_set_config.go
@@ -22,15 +22,16 @@ type OperatorSchedulerSetConfig struct {
 	// The scheduler configuration flags allow us to tell whether the user set
 	// a value or not. This means we can safely merge the current configuration
 	// with user supplied, selective updates.
-	checkIndex               string
-	schedulerAlgorithm       string
-	memoryOversubscription   flagHelper.BoolValue
-	rejectJobRegistration    flagHelper.BoolValue
-	pauseEvalBroker          flagHelper.BoolValue
-	preemptBatchScheduler    flagHelper.BoolValue
-	preemptServiceScheduler  flagHelper.BoolValue
-	preemptSysBatchScheduler flagHelper.BoolValue
-	preemptSystemScheduler   flagHelper.BoolValue
+	checkIndex                    string
+	schedulerAlgorithm            string
+	memoryOversubscription        flagHelper.BoolValue
+	rejectJobRegistration         flagHelper.BoolValue
+	pauseEvalBroker               flagHelper.BoolValue
+	preemptBatchScheduler         flagHelper.BoolValue
+	preemptServiceScheduler       flagHelper.BoolValue
+	preemptSysBatchScheduler      flagHelper.BoolValue
+	preemptSystemScheduler        flagHelper.BoolValue
+	nodeLimitForFeasibilityChecks flagHelper.UintValue
 }
 
 func (o *OperatorSchedulerSetConfig) AutocompleteFlags() complete.Flags {
@@ -41,13 +42,14 @@ func (o *OperatorSchedulerSetConfig) AutocompleteFlags() complete.Flags {
 				string(api.SchedulerAlgorithmBinpack),
 				string(api.SchedulerAlgorithmSpread),
 			),
-			"-memory-oversubscription":    complete.PredictSet("true", "false"),
-			"-reject-job-registration":    complete.PredictSet("true", "false"),
-			"-pause-eval-broker":          complete.PredictSet("true", "false"),
-			"-preempt-batch-scheduler":    complete.PredictSet("true", "false"),
-			"-preempt-service-scheduler":  complete.PredictSet("true", "false"),
-			"-preempt-sysbatch-scheduler": complete.PredictSet("true", "false"),
-			"-preempt-system-scheduler":   complete.PredictSet("true", "false"),
+			"-memory-oversubscription":           complete.PredictSet("true", "false"),
+			"-reject-job-registration":           complete.PredictSet("true", "false"),
+			"-pause-eval-broker":                 complete.PredictSet("true", "false"),
+			"-preempt-batch-scheduler":           complete.PredictSet("true", "false"),
+			"-preempt-service-scheduler":         complete.PredictSet("true", "false"),
+			"-preempt-sysbatch-scheduler":        complete.PredictSet("true", "false"),
+			"-preempt-system-scheduler":          complete.PredictSet("true", "false"),
+			"-node-limit-for-feasibility-checks": complete.PredictAnything,
 		},
 	)
 }
@@ -72,6 +74,7 @@ func (o *OperatorSchedulerSetConfig) Run(args []string) int {
 	flags.Var(&o.preemptServiceScheduler, "preempt-service-scheduler", "")
 	flags.Var(&o.preemptSysBatchScheduler, "preempt-sysbatch-scheduler", "")
 	flags.Var(&o.preemptSystemScheduler, "preempt-system-scheduler", "")
+	flags.Var(&o.nodeLimitForFeasibilityChecks, "node-limit-for-feasibility-checks", "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -134,6 +137,7 @@ func (o *OperatorSchedulerSetConfig) Run(args []string) int {
 	o.preemptServiceScheduler.Merge(&schedulerConfig.PreemptionConfig.ServiceSchedulerEnabled)
 	o.preemptSysBatchScheduler.Merge(&schedulerConfig.PreemptionConfig.SysBatchSchedulerEnabled)
 	o.preemptSystemScheduler.Merge(&schedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
+	o.nodeLimitForFeasibilityChecks.Merge(&schedulerConfig.NodeLimitForFeasibilityChecks)
 
 	// Check-and-set the new configuration.
 	result, _, err := client.Operator().SchedulerCASConfiguration(schedulerConfig, nil)
@@ -208,6 +212,13 @@ Scheduler Set Config Options:
   -preempt-system-scheduler=[true|false]
     Specifies whether preemption for system jobs is enabled. Note that if this
     is set to true, then system jobs can preempt any other jobs.
+
+  -node-limit-for-feasibility-checks=<count>
+    Limits the number of feasible nodes to consider when scheduling a job that
+	specifies spread and/or affinity. Defaults to 100 nodes if unset. Lower
+	numbers result in better scheduler performance and more randomization of jobs
+	across nodes. Higher numbers result in more deterministic application of
+	feasibility checks.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/operator_scheduler_set_config_test.go
+++ b/command/operator_scheduler_set_config_test.go
@@ -51,6 +51,7 @@ func TestOperatorSchedulerSetConfig_Run(t *testing.T) {
 		"-preempt-service-scheduler=true",
 		"-preempt-sysbatch-scheduler=true",
 		"-preempt-system-scheduler=false",
+		"-node-limit-for-feasibility-checks=200",
 	}
 	must.Zero(t, c.Run(modifyingArgs))
 	s := ui.OutputWriter.String()
@@ -69,6 +70,7 @@ func TestOperatorSchedulerSetConfig_Run(t *testing.T) {
 		MemoryOversubscriptionEnabled: true,
 		RejectJobRegistration:         true,
 		PauseEvalBroker:               true,
+		NodeLimitForFeasibilityChecks: 200,
 	}, modifiedConfig.SchedulerConfig)
 
 	ui.ErrorWriter.Reset()
@@ -108,4 +110,5 @@ func schedulerConfigEquals(t *testing.T, expected, actual *api.SchedulerConfigur
 	must.Eq(t, expected.MemoryOversubscriptionEnabled, actual.MemoryOversubscriptionEnabled)
 	must.Eq(t, expected.PauseEvalBroker, actual.PauseEvalBroker)
 	must.Eq(t, expected.PreemptionConfig, actual.PreemptionConfig)
+	must.Eq(t, expected.NodeLimitForFeasibilityChecks, actual.NodeLimitForFeasibilityChecks)
 }

--- a/nomad/operator_endpoint_test.go
+++ b/nomad/operator_endpoint_test.go
@@ -551,13 +551,14 @@ func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 	rpcCodec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
 
-	// Disable preemption and pause the eval broker.
+	// Disable preemption, pause the eval broker, and set a custom node limit.
 	arg := structs.SchedulerSetConfigRequest{
 		Config: structs.SchedulerConfiguration{
 			PreemptionConfig: structs.PreemptionConfig{
 				SystemSchedulerEnabled: false,
 			},
-			PauseEvalBroker: true,
+			PauseEvalBroker:               true,
+			NodeLimitForFeasibilityChecks: 200,
 		},
 	}
 	arg.Region = s1.config.Region
@@ -581,6 +582,7 @@ func TestOperator_SchedulerSetConfiguration(t *testing.T) {
 	require.NotZero(t, reply.Index)
 	require.False(t, reply.SchedulerConfig.PreemptionConfig.SystemSchedulerEnabled)
 	require.True(t, reply.SchedulerConfig.PauseEvalBroker)
+	require.Equal(t, uint(200), reply.SchedulerConfig.GetNodeLimitForFeasibilityChecks())
 
 	require.False(t, s1.evalBroker.Enabled())
 	require.False(t, s1.blockedEvals.Enabled())

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -209,6 +209,10 @@ const (
 	// SchedulerAlgorithmSpread indicates that the scheduler should spread
 	// allocations as evenly as possible over the available hardware.
 	SchedulerAlgorithmSpread SchedulerAlgorithm = "spread"
+
+	// DefaultNodeLimitForFeasibilityChecks is the default value of
+	// NodeLimitForFeasibilityChecks if not specified
+	DefaultNodeLimitForFeasibilityChecks = 100
 )
 
 // SchedulerConfiguration is the config for controlling scheduler behavior
@@ -233,6 +237,13 @@ type SchedulerConfiguration struct {
 	// during leadership transitions.
 	PauseEvalBroker bool `hcl:"pause_eval_broker"`
 
+	// NodeLimitForFeasibilityChecks limits the number of randomly selected feasible nodes
+	// to consider when scheduling a job that specifies spread and/or affinity. Defaults
+	// to 100 nodes if unset. Lower numbers result in better scheduler performance and
+	// more randomization of jobs across nodes. Higher numbers result in more
+	// deterministic application of spread and/or affinity.
+	NodeLimitForFeasibilityChecks uint `hcl:"node_limit_for_feasibility_checks"`
+
 	// CreateIndex/ModifyIndex store the create/modify indexes of this configuration.
 	CreateIndex uint64
 	ModifyIndex uint64
@@ -253,6 +264,13 @@ func (s *SchedulerConfiguration) EffectiveSchedulerAlgorithm() SchedulerAlgorith
 	}
 
 	return s.SchedulerAlgorithm
+}
+
+func (s *SchedulerConfiguration) GetNodeLimitForFeasibilityChecks() uint {
+	if s == nil || s.NodeLimitForFeasibilityChecks == 0 {
+		return DefaultNodeLimitForFeasibilityChecks
+	}
+	return s.NodeLimitForFeasibilityChecks
 }
 
 // WithNodePool returns a new SchedulerConfiguration with the node pool

--- a/nomad/structs/operator_test.go
+++ b/nomad/structs/operator_test.go
@@ -11,6 +11,40 @@ import (
 	"github.com/shoenig/test/must"
 )
 
+func TestSchedulerConfiguration_GetNodeLimitForFeasibilityChecks(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name     string
+		config   *SchedulerConfiguration
+		expected uint
+	}{
+		{
+			name:     "nil config returns default",
+			config:   nil,
+			expected: DefaultNodeLimitForFeasibilityChecks,
+		},
+		{
+			name:     "zero value returns default",
+			config:   &SchedulerConfiguration{},
+			expected: DefaultNodeLimitForFeasibilityChecks,
+		},
+		{
+			name: "positive value is returned",
+			config: &SchedulerConfiguration{
+				NodeLimitForFeasibilityChecks: 42,
+			},
+			expected: 42,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			must.Eq(t, tc.expected, tc.config.GetNodeLimitForFeasibilityChecks())
+		})
+	}
+}
+
 func TestSchedulerConfiguration_WithNodePool(t *testing.T) {
 	ci.Parallel(t)
 

--- a/scheduler/feasible/stack.go
+++ b/scheduler/feasible/stack.go
@@ -63,16 +63,17 @@ type GenericStack struct {
 	taskGroupNetwork     *NetworkChecker
 	taskGroupSecrets     *SecretsProviderChecker
 
-	distinctHostsConstraint    *DistinctHostsIterator
-	distinctPropertyConstraint *DistinctPropertyIterator
-	binPack                    *BinPackIterator
-	jobAntiAff                 *JobAntiAffinityIterator
-	nodeReschedulingPenalty    *NodeReschedulingPenaltyIterator
-	limit                      *LimitIterator
-	maxScore                   *MaxScoreIterator
-	nodeAffinity               *NodeAffinityIterator
-	spread                     *SpreadIterator
-	scoreNorm                  *ScoreNormalizationIterator
+	distinctHostsConstraint       *DistinctHostsIterator
+	distinctPropertyConstraint    *DistinctPropertyIterator
+	binPack                       *BinPackIterator
+	jobAntiAff                    *JobAntiAffinityIterator
+	nodeReschedulingPenalty       *NodeReschedulingPenaltyIterator
+	limit                         *LimitIterator
+	maxScore                      *MaxScoreIterator
+	nodeAffinity                  *NodeAffinityIterator
+	spread                        *SpreadIterator
+	scoreNorm                     *ScoreNormalizationIterator
+	nodeLimitForFeasibilityChecks int
 }
 
 func (s *GenericStack) SetNodes(baseNodes []*structs.Node) {
@@ -129,6 +130,7 @@ func (s *GenericStack) SetJob(job *structs.Job) {
 // on the node pool being used.
 func (s *GenericStack) SetSchedulerConfiguration(schedConfig *structs.SchedulerConfiguration) {
 	s.binPack.SetSchedulerConfiguration(schedConfig)
+	s.nodeLimitForFeasibilityChecks = int(schedConfig.GetNodeLimitForFeasibilityChecks())
 }
 
 func (s *GenericStack) Select(tg *structs.TaskGroup, options *SelectOptions) *RankedNode {
@@ -183,11 +185,11 @@ func (s *GenericStack) Select(tg *structs.TaskGroup, options *SelectOptions) *Ra
 	if s.nodeAffinity.hasAffinities() || s.spread.hasSpreads() {
 		// scoring spread across all nodes has quadratic behavior, so
 		// we need to consider a subset of nodes to keep evaluaton times
-		// reasonable but enough to ensure spread is correct. this
-		// value was empirically determined.
-		s.limit.SetLimit(tg.Count)
-		if tg.Count < 100 {
-			s.limit.SetLimit(100)
+		// reasonable but enough to ensure spread is statistically correct.
+		if tg.Count < s.nodeLimitForFeasibilityChecks {
+			s.limit.SetLimit(s.nodeLimitForFeasibilityChecks)
+		} else {
+			s.limit.SetLimit(tg.Count)
 		}
 	}
 

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -997,6 +997,49 @@ func TestServiceSched_Spread(t *testing.T) {
 	}
 }
 
+// TestServiceSched_Spread_NodeLimitForFeasibilityChecks verifies that the
+// NodeLimitForFeasibilityChecks scheduler configuration limits the number of
+// nodes evaluated when scheduling a job with spreads.
+func TestServiceSched_Spread_NodeLimitForFeasibilityChecks(t *testing.T) {
+	ci.Parallel(t)
+
+	h := tests.NewHarness(t)
+
+	const nodeLimit uint = 5
+	h.State.SchedulerSetConfig(h.NextIndex(), &structs.SchedulerConfiguration{
+		NodeLimitForFeasibilityChecks: nodeLimit,
+	})
+
+	job := mock.Job()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Spreads = append(job.TaskGroups[0].Spreads,
+		&structs.Spread{Attribute: "${node.datacenter}", Weight: 100})
+	must.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
+
+	for i := 0; i < 20; i++ {
+		must.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), mock.Node()))
+	}
+
+	eval := &structs.Evaluation{
+		Namespace:   structs.DefaultNamespace,
+		ID:          uuid.Generate(),
+		Priority:    job.Priority,
+		TriggeredBy: structs.EvalTriggerJobRegister,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+	must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
+	must.NoError(t, h.Process(NewServiceScheduler, eval))
+
+	// With 20 feasible nodes but a limit of 5, only 5 should be evaluated.
+	var planned []*structs.Allocation
+	for _, allocList := range h.Plans[0].NodeAllocation {
+		planned = append(planned, allocList...)
+	}
+	must.Len(t, 1, planned)
+	must.Eq(t, int(nodeLimit), planned[0].Metrics.NodesEvaluated)
+}
+
 // TestServiceSched_JobRegister_Datacenter_Downgrade tests the case where an
 // allocation fails during a deployment with canaries, an the job changes its
 // datacenter. The replacement for the failed alloc should be placed in the


### PR DESCRIPTION
Add a configuration field for the number of nodes that the scheduler considers when spread or affinity is in use.

### Description
For jobs without spread nor affinity, Nomad's scheduler uses a randomized sampling approach and typically considers 2 feasible nodes, an approach that has been shown to both work and perform well[^1]. When spread and/or affinity is in use, Nomad considers 100 feasible nodes based on a hardcoded constant. In some scenarios, considering 100 nodes causes undesirable behavior. This PR makes this constant configurable.

As background to describing undesirable behavior I'll first discuss interaction between binpack scoring and affinities. Because affinity score is divided by total possible affinity and then compared directly with binpack score, when using even just a few possible affinities the influence of any given affinity on scheduling will be small in absolute terms compared to the binpack score. Because of this, we find that in practice affinity often serves mostly as a tiebreaker between empty nodes. This is actually fine for similar reasons as to why randomized sampling works in the first place.

Now, to illustrate undesirable behavior, consider a cluster of 100 nodes where the resource requirements of jobs are small compared to the nodes they are scheduled on. Using current generation physical hosts this may actually be a cluster of appreciable size. In this scenario there is no randomization of the nodes considered for scheduling: that is, all feasible nodes are always considered. Combined with the previously discussed behavior of affinities with binpack, and given many jobs having the same affinity specification, we find that a single "hot" node will be selected and then will be continuously scheduled until it is full, and that this will then repeat for the empty host selected next.

One undesirable effect this causes is scheduler contention. For a node that is nearly full it is observable that parallel scheduler evaluations will all evaluate to, and contend for, placement on the same node. This will happen not only during initial packing of a empty node, but more notably, any time a small amount of space becomes available on an otherwise nearly full node.

A second order effect this causes is that jobs submitted close together in time tend to be scheduled on a small amount of hardware. In real world scenarios it is likely that jobs submitted at the same time have both a similar purpose and similar load characteristics. This can concentrate the risk of a node failure for a single logical application that has submitted many jobs at the same time. This can also cause like jobs to compete for specific resources they may need (for example, if a series of jobs does a lot of disk IO). While there is no contract violation by the scheduler here and constructs in the job spec exist to mitigate much of this, it is generally more desirable to spread such jobs across a larger number of nodes.

We have found that when using affinity and spread, configuring the number of nodes considered to be smaller than the size of the cluster allows randomized sampling to work as intended. As expected, this results in significantly better scheduler performance and behavior while still allowing affinity and spread to be statistically correct in aggregate.

[^1]: [Ousterhout et al., "Sparrow: Distributed, Low Latency Scheduling," SOSP 2013](https://doi.org/10.1145/2517349.2522716)

### Testing & Reproduction steps
Included tests show the desired behavior.

### Contributor Checklist

- [X] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [X] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls
None

