### PR TITLE
autorelease: delete/re-create release branch

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -122,7 +122,9 @@ jobs:
           branch="$(git branch --show-current)"
           sha="$(git rev-parse HEAD)"
 
-          git push origin --force "$branch"
+          # force-push is forbidden, so instead we delete and re-create the branch
+          git push origin "$branch" --delete || true
+          git push origin "$branch"
 
           # summarize and output
 


### PR DESCRIPTION
The branch protection rule forbidding force-push to `release/**` is binary: on or off. We can't make exceptions for our bot user.

But we can delete and re-create it.