### PR TITLE
E2E: migrate instances to HC base image

### DIFF
--- a/e2e/terraform/packer/ubuntu-jammy-amd64.pkr.hcl
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64.pkr.hcl
@@ -8,7 +8,6 @@ variable "build_sha" {
 
 locals {
   timestamp = regex_replace(timestamp(), "[- TZ:]", "")
-  distro    = "ubuntu-jammy-22.04-amd64-server-*"
   version   = "v3"
 }
 
@@ -20,16 +19,17 @@ source "amazon-ebs" "latest_ubuntu_jammy" {
   ssh_username         = "ubuntu"
   ssh_interface        = "public_ip"
 
+  # note: this is an internal baseline image and not available for use outside
+  # of HashiCorp AWS environments. You'll need to use an Ubuntu base image from
+  # Canonical if building outside that environment
   source_ami_filter {
     filters = {
-      architecture                       = "x86_64"
-      "block-device-mapping.volume-type" = "gp2"
-      name                               = "ubuntu/images/hvm-ssd/${local.distro}"
-      root-device-type                   = "ebs"
-      virtualization-type                = "hvm"
+      architecture = "x86_64"
+      name         = "hc-base-ubuntu-2404-amd64-*"
+      state        = "available"
     }
     most_recent = true
-    owners      = ["099720109477"] // Canonical
+    owners      = ["888995627335"] # hc-ami_prod
   }
 
   tags = {


### PR DESCRIPTION
This updates our Packer build for the end-to-end tests to use the internally-managed base image which meets all the security and compliance team requirements. The goal here is to avoid having to work through exception process, and I've verified that it's acceptable to have this AMI ID exposed because access is controlled by-account. Note this base image build is on Ubuntu 24.04 instead of 22.04, so we'll be using newer kernels.

Ref: https://github.com/hashicorp/nomad-enterprise/pull/3768

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
