### PR TITLE
NMD-789 - Nomad UI Clients view issue in federated clusters configuration

### DIFF
--- a/ui/app/components/client-node-row.js
+++ b/ui/app/components/client-node-row.js
@@ -6,7 +6,6 @@
 import { inject as service } from '@ember/service';
 import Component from '@ember/component';
 import { lazyClick } from '../helpers/lazy-click';
-import { watchRelationship } from 'nomad-ui/utils/properties/watch';
 import WithVisibilityDetection from 'nomad-ui/mixins/with-component-visibility-detection';
 import { computed } from '@ember/object';
 import { classNames, tagName } from '@ember-decorators/component';
@@ -33,29 +32,9 @@ export default class ClientNodeRow extends Component.extend(
     // Reload the node in order to get detail information
     const node = this.node;
     if (node) {
-      node.reload().then(() => {
-        this.watch.perform(node, 100);
-      });
+      node.reload();
     }
   }
-
-  visibilityHandler() {
-    if (document.hidden) {
-      this.watch.cancelAll();
-    } else {
-      const node = this.node;
-      if (node) {
-        this.watch.perform(node, 100);
-      }
-    }
-  }
-
-  willDestroy() {
-    this.watch.cancelAll();
-    super.willDestroy(...arguments);
-  }
-
-  @watchRelationship('allocations') watch;
 
   @computed('node.status')
   get nodeStatusColor() {

--- a/ui/app/routes/clients/client/index.js
+++ b/ui/app/routes/clients/client/index.js
@@ -21,7 +21,12 @@ export default class ClientRoute extends Route.extend(WithWatchers) {
     return super.setupController(...arguments);
   }
 
-  resetController(controller) {
+  resetController(controller, isExiting) {
+    if (isExiting) {
+      controller.set('watchModel', null);
+      controller.set('watchAllocations', null);
+    }
+
     controller.setProperties({
       eligibilityError: null,
       stopDrainError: null,
@@ -34,10 +39,12 @@ export default class ClientRoute extends Route.extend(WithWatchers) {
   }
 
   startWatchers(controller, model) {
-    if (model) {
-      controller.set('watchModel', this.watch.perform(model));
-      controller.set('watchAllocations', this.watchAllocations.perform(model));
+    if (!model) {
+      return;
     }
+
+    controller.set('watchModel', this.watch.perform(model));
+    controller.set('watchAllocations', this.watchAllocations.perform(model));
   }
 
   @watchRecord('node') watch;

--- a/ui/app/routes/clients/index.js
+++ b/ui/app/routes/clients/index.js
@@ -11,12 +11,6 @@ import { inject as service } from '@ember/service';
 
 export default class IndexRoute extends Route.extend(WithWatchers) {
   @service store;
-
-  deactivate() {
-    this.cancelAllWatchers();
-    super.deactivate(...arguments);
-  }
-
   startWatchers(controller) {
     controller.set('watcher', this.watch.perform());
   }

--- a/ui/app/routes/clients/index.js
+++ b/ui/app/routes/clients/index.js
@@ -13,15 +13,8 @@ export default class IndexRoute extends Route.extend(WithWatchers) {
   @service store;
 
   deactivate() {
-    const startTime = performance.now();
-    console.log('Route deactivating at', new Date().toISOString());
-
     this.cancelAllWatchers();
-
     super.deactivate(...arguments);
-
-    const duration = performance.now() - startTime;
-    console.log(`Deactivate completed in ${duration.toFixed(2)}ms`);
   }
 
   startWatchers(controller) {

--- a/ui/app/routes/clients/index.js
+++ b/ui/app/routes/clients/index.js
@@ -11,6 +11,7 @@ import { inject as service } from '@ember/service';
 
 export default class IndexRoute extends Route.extend(WithWatchers) {
   @service store;
+
   startWatchers(controller) {
     controller.set('watcher', this.watch.perform());
   }

--- a/ui/app/routes/clients/index.js
+++ b/ui/app/routes/clients/index.js
@@ -14,16 +14,14 @@ export default class IndexRoute extends Route.extend(WithWatchers) {
 
   deactivate() {
     const startTime = performance.now();
-    console.log('🔴 [CLIENTS] Route deactivating at', new Date().toISOString());
+    console.log('Route deactivating at', new Date().toISOString());
 
     this.cancelAllWatchers();
 
     super.deactivate(...arguments);
 
     const duration = performance.now() - startTime;
-    console.log(
-      `🔴 [CLIENTS] Deactivate completed in ${duration.toFixed(2)}ms`
-    );
+    console.log(`Deactivate completed in ${duration.toFixed(2)}ms`);
   }
 
   startWatchers(controller) {

--- a/ui/app/routes/clients/index.js
+++ b/ui/app/routes/clients/index.js
@@ -12,6 +12,20 @@ import { inject as service } from '@ember/service';
 export default class IndexRoute extends Route.extend(WithWatchers) {
   @service store;
 
+  deactivate() {
+    const startTime = performance.now();
+    console.log('🔴 [CLIENTS] Route deactivating at', new Date().toISOString());
+
+    this.cancelAllWatchers();
+
+    super.deactivate(...arguments);
+
+    const duration = performance.now() - startTime;
+    console.log(
+      `🔴 [CLIENTS] Deactivate completed in ${duration.toFixed(2)}ms`
+    );
+  }
+
   startWatchers(controller) {
     controller.set('watcher', this.watch.perform());
   }


### PR DESCRIPTION
### Description
This PR fixes performance issues in the Nomad UI Clients page that caused slow loading, stalled navigation, and unresponsive behavior across the UI.

Previously, when navigating away from the Clients page, in-flight browser requests were not being cancelled. These stale pending requests continued occupying browser resources, which blocked new requests and degraded navigation performance.

While testing the short-term fix in PR #27679 using nomad-nodesim, another source of the slow and pending request issue was identified.

The client-node-row component was independently watching allocations for every row in the Clients list. As a result, for N clients, the UI triggered N long-polling requests to:

/v1/allocations?index=X

These requests remained open and eventually exhausted the browser’s available connection pool, causing the UI to become slow, navigation to stall, and region switching in federated clusters to break.

**Root Cause**

Before the fix:

- Each client row component independently watched for allocation updates
- The component used the @watchRelationship('allocations') decorator
- Every row called this.watch.perform(node, 100) to start long-polling
- This created N concurrent long-polling allocation requests for N clients
- Requests remained open and consumed browser connections
- Browser connection exhaustion caused slow UI performance and blocked navigation


**Solution**

The per-row allocation watching logic was removed from the client-node-row component.

Instead of continuously watching allocations for every row, each row now reloads its node data only once, eliminating the large number of concurrent long-polling requests.

Impact:

- Eliminates N concurrent allocation watch requests
- Reduces browser connection exhaustion
- Improves Clients page responsiveness
- Prevents stalled navigation and region switching issues

**Files Changed**
ui/app/components/client-node-row.js

Changes:

- Removed individual allocation watching logic from each row component
- Removed long-polling behavior triggered via watch.perform(node, 100)
- Updated row behavior to reload node data once instead of continuously watching allocations

**Testing & Reproduction Steps**

Use the following files for reproduction:

[NMD-789.zip](https://github.com/user-attachments/files/27648861/NMD-789.zip)

1. Start Servers :

nomad agent -config=india-server-federated.hcl

nomad agent -config=us-server-federated.hcl

2. Start Simulated Clients:

../nomad-nodesim/nomad-nodesim -config=india-nodesim-config.hcl

../nomad-nodesim/nomad-nodesim -config=us-nodesim-config.hcl

3. Wait for clients to register (~2 minutes), then submit jobs:

chmod +x submit-india-jobs.sh submit-us-jobs.sh
./submit-india-jobs.sh
./submit-us-jobs.sh

4. Restart UI
cd ui
USE_MIRAGE=false ember server --proxy http://127.0.0.1:4646

**Results**

**Before:**

https://github.com/user-attachments/assets/b0796aa2-951d-4845-8cee-126e41b1bbe2


100 clients → 100 concurrent requests
Navigation blocked

**After:**

https://github.com/user-attachments/assets/f4ddc53d-e5fd-4636-816b-887c65d22359

100 clients → 1 request
Smooth navigation
Files Updated
client-node-row.js – removed per-row watching
clients/index.js – added route-level watching

### Links
https://hashicorp.atlassian.net/browse/NMD-789

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.



