### PR TITLE
E2E: upgrade podman driver

### DIFF
--- a/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
@@ -122,7 +122,7 @@ echo "Installing Podman"
 sudo apt-get -y install podman catatonit
 
 echo "Installing Podman Driver"
-sudo hc-install install --path ${NOMAD_PLUGIN_DIR} --version 0.5.0 nomad-driver-podman
+sudo hc-install install --path ${NOMAD_PLUGIN_DIR} --version 0.6.4 nomad-driver-podman
 
 # Pledge
 echo "Installing Pledge Driver"


### PR DESCRIPTION
After updating our base image for E2E, the version of podman on the instances is no longer compatible with the older version of the podman driver we have installed. This causes the client to never get informed when task exit, which results in failing tests when we're waiting on batch workloads. Upgrade the podman driver to fix this.

### Testing & Reproduction steps

before:

```
=== RUN   TestPodman
    podman_test.go:44: submitting job: "../docker_registry/registry.hcl"
    podman_test.go:55: submitting job: "../docker_registry/registry-auths.hcl"
=== RUN   TestPodman/testRedis
    podman_test.go:68: submitting job: "./input/redis.hcl"
--- PASS: TestPodman/testRedis (19.89s)
=== RUN   TestPodman/testAuthBasic
    podman_test.go:80: submitting job: "./input/auth_basic.hcl"
    jobs3.go:506: 
        jobs3.go:506: expected not to execute this code path
        ↪ PostScript | annotation ↷
        	timeout reached waiting for alloc
    jobs3.go:684: tg 'basic' alloc status 'running': Tasks are running
    jobs3.go:690: tg 'basic' task 'echo' event: Task received by client
    jobs3.go:690: tg 'basic' task 'echo' event: Building Task Directory
    jobs3.go:690: tg 'basic' task 'echo' event: Pulling image 172.31.92.170:31856/docker.io/library/bash_auth_basic:private
    jobs3.go:690: tg 'basic' task 'echo' event: Task started by client
--- FAIL: TestPodman/testAuthBasic (22.07s)
=== RUN   TestPodman/testAuthFileStatic
    podman_test.go:95: submitting job: "./input/auth_static.hcl"
    jobs3.go:506: 
        jobs3.go:506: expected not to execute this code path
        ↪ PostScript | annotation ↷
        	timeout reached waiting for alloc
    jobs3.go:684: tg 'static' alloc status 'running': Tasks are running
    jobs3.go:690: tg 'static' task 'echo' event: Task received by client
    jobs3.go:690: tg 'static' task 'echo' event: Building Task Directory
    jobs3.go:690: tg 'static' task 'echo' event: Pulling image 172.31.92.170:31856/docker.io/library/bash_auth_static:private
    jobs3.go:690: tg 'static' task 'echo' event: Task started by client
--- FAIL: TestPodman/testAuthFileStatic (22.06s)
=== RUN   TestPodman/testAuthHelper
    podman_test.go:109: registry 172.31.92.170 31856
    podman_test.go:112: submitting job: "./input/auth_helper.hcl"
    jobs3.go:506: 
        jobs3.go:506: expected not to execute this code path
        ↪ PostScript | annotation ↷
        	timeout reached waiting for alloc
    jobs3.go:684: tg 'helper' alloc status 'running': Tasks are running
    jobs3.go:690: tg 'helper' task 'echo' event: Task received by client
    jobs3.go:690: tg 'helper' task 'echo' event: Building Task Directory
    jobs3.go:690: tg 'helper' task 'echo' event: Pulling image 172.31.92.170:31856/docker.io/library/bash_auth_helper:private
    jobs3.go:690: tg 'helper' task 'echo' event: Task started by client
--- FAIL: TestPodman/testAuthHelper (22.09s)
--- FAIL: TestPodman (105.21s)
FAIL
FAIL	github.com/hashicorp/nomad/e2e/podman	105.286s
```

after:

```
$ go test -v -count=1 ./podman
=== RUN   TestPodman
    podman_test.go:44: submitting job: "../docker_registry/registry.hcl"
    podman_test.go:55: submitting job: "../docker_registry/registry-auths.hcl"
=== RUN   TestPodman/testRedis
    podman_test.go:68: submitting job: "./input/redis.hcl"
=== RUN   TestPodman/testAuthBasic
    podman_test.go:80: submitting job: "./input/auth_basic.hcl"
=== RUN   TestPodman/testAuthFileStatic
    podman_test.go:96: submitting job: "./input/auth_static.hcl"
=== RUN   TestPodman/testAuthHelper
    podman_test.go:110: registry 172.31.89.64 27585
    podman_test.go:113: submitting job: "./input/auth_helper.hcl"
--- PASS: TestPodman (63.00s)
    --- PASS: TestPodman/testRedis (19.42s)
    --- PASS: TestPodman/testAuthBasic (9.32s)
    --- PASS: TestPodman/testAuthFileStatic (8.39s)
    --- PASS: TestPodman/testAuthHelper (8.34s)
PASS
ok      github.com/hashicorp/nomad/e2e/podman   63.012s
```


### Contributor Checklist
- [ ] **Changelog Entry** n/a
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
