### PR TITLE
E2E: use `exec2` instead of `pledge` for metrics cpustress job

### DIFF
--- a/e2e/metrics/input/cpustress.hcl
+++ b/e2e/metrics/input/cpustress.hcl
@@ -28,12 +28,11 @@ job "cpustress" {
     }
 
     task "cpustress" {
-      driver = "pledge"
+      driver = "exec2"
 
       config {
-        command  = "stress"
-        args     = ["--cpu", "1"]
-        promises = "stdio rpath proc"
+        command = "stress"
+        args    = ["--cpu", "1"]
       }
 
       resources {
@@ -43,4 +42,3 @@ job "cpustress" {
     }
   }
 }
-


### PR DESCRIPTION
After updating our base image for E2E in #27661, the `cpustress` job used in the metrics test started failing. The error appears to be an incompatibility with the `shoenig/pledge` driver we're using for this test, or more properly with the `jart/pledge` utility that it uses under the hood. Neither have been updated in some time, so rather than sinking time into debugging this, let's switch this test over to `exec2` for now.

Ref: https://github.com/hashicorp/nomad/pull/27661
Ref: https://github.com/shoenig/nomad-pledge-driver
Ref: https://justine.lol/pledge/

### Testing & Reproduction steps

before:

```
=== RUN   TestMetrics
    metrics_test.go:52: tweaking podman registry auth files ...
    metrics_test.go:53: submitting job: "./input/setup.hcl"
    metrics_test.go:56: running metrics job cpustress ...
    metrics_test.go:57: submitting job: "./input/cpustress.hcl"
    jobs3.go:469: 
        jobs3.go:469: expected not to execute this code path
        ↪ PostScript | annotation ↷
        	deployment is failed
    jobs3.go:684: tg 'cpustress' alloc status 'pending': 
    jobs3.go:684: tg 'cpustress' alloc status 'failed': Failed tasks
    jobs3.go:684: tg 'cpustress' alloc status 'failed': Failed tasks
    jobs3.go:684: tg 'cpustress' alloc status 'failed': Failed tasks
    jobs3.go:684: tg 'cpustress' alloc status 'failed': Failed tasks
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Task received by client
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Building Task Directory
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Task started by client
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Exit Code: 0
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Policy allows no restarts
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Unhealthy because of failed task
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Task received by client
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Building Task Directory
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Task started by client
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Exit Code: 0
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Policy allows no restarts
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Unhealthy because of failed task
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Task received by client
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Building Task Directory
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Task started by client
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Exit Code: 0
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Policy allows no restarts
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Unhealthy because of failed task
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Task received by client
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Building Task Directory
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Task started by client
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Exit Code: 0
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Policy allows no restarts
    jobs3.go:690: tg 'cpustress' task 'cpustress' event: Unhealthy because of failed task
--- FAIL: TestMetrics (5.66s)
FAIL
FAIL	github.com/hashicorp/nomad/e2e/metrics	5.735s
```

after (edited to remove Windows tests b/c I didn't feel like waiting for a Windows host to come up):

```
$ go test -v -count=1 ./metrics
=== RUN   TestMetrics
    metrics_test.go:52: tweaking podman registry auth files ...
    metrics_test.go:53: submitting job: "./input/setup.hcl"
    metrics_test.go:56: running metrics job cpustress ...
    metrics_test.go:57: submitting job: "./input/cpustress.hcl"
    metrics_test.go:60: running metrics job nomadagent ...
    metrics_test.go:61: submitting job: "./input/nomadagent.hcl"
    metrics_test.go:64: running metrics job prometheus ...
    metrics_test.go:65: submitting job: "./input/prometheus.hcl"
    metrics_test.go:68: running metrics job pythonhttp ...
    metrics_test.go:69: submitting job: "./input/pythonhttp.hcl"
    metrics_test.go:72: running metrics job caddy ...
    metrics_test.go:73: submitting job: "./input/caddy.hcl"
    metrics_test.go:80: let the metrics collect for a bit (10s) ...
    metrics_test.go:83: measuring alloc metrics ...
    metrics_test.go:163: expose prometheus http address http://13.217.167.73:9999
    metrics_test.go:184: query for metric nomad_client_allocs_memory_usage{exported_job="nomadagent-776"}
    metrics_test.go:184: query for metric nomad_client_allocs_cpu_user{exported_job="cpustress-543"}
    metrics_test.go:184: query for metric nomad_client_allocs_cpu_allocated{exported_job="pythonhttp-898"}
    metrics_test.go:104: measuring client metrics ...
    metrics_test.go:163: expose prometheus http address http://13.217.167.73:9999
    metrics_test.go:184: query for metric nomad_client_allocated_memory{node_id="9245556a-25aa-9c48-c97f-67a0a400a36f"}
    metrics_test.go:184: query for metric sum(nomad_client_host_cpu_user{node_id="9245556a-25aa-9c48-c97f-67a0a400a36f"})
    metrics_test.go:184: query for metric nomad_client_host_memory_used{node_id="9245556a-25aa-9c48-c97f-67a0a400a36f"}
    metrics_test.go:184: query for metric nomad_client_uptime{node_id="9245556a-25aa-9c48-c97f-67a0a400a36f"}
    metrics_test.go:184: query for metric nomad_client_allocated_memory{node_id="4999f7a5-f427-221d-bc68-5e1755537826"}
    metrics_test.go:184: query for metric sum(nomad_client_host_cpu_user{node_id="4999f7a5-f427-221d-bc68-5e1755537826"})
    metrics_test.go:184: query for metric nomad_client_host_memory_used{node_id="4999f7a5-f427-221d-bc68-5e1755537826"}
    metrics_test.go:184: query for metric nomad_client_uptime{node_id="4999f7a5-f427-221d-bc68-5e1755537826"}
--- PASS: TestMetrics (71.83s)
PASS
ok      github.com/hashicorp/nomad/e2e/metrics  71.839s

```

### Contributor Checklist
- [x] **Changelog Entry** n/a
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
