### PR TITLE
E2E: update service discovery test assertion

### DIFF
--- a/e2e/servicediscovery/nomad_checks_test.go
+++ b/e2e/servicediscovery/nomad_checks_test.go
@@ -103,7 +103,7 @@ func testChecksSad(t *testing.T) {
 		}
 
 		// assert output contains error output from python http.server
-		return strings.Contains(output, `<p>Error code explanation: HTTPStatus.NOT_IMPLEMENTED - Server does not support this operation.</p>`)
+		return strings.Contains(output, `<p>Error code explanation: 501 - Server does not support this operation.</p>`)
 	}, 5*time.Second, 200*time.Millisecond)
 }
 


### PR DESCRIPTION
After updating our base image for E2E in #27661, the `checks_sad` job used in the service discovery test started failing. This is because the test looks for strings from the error message of the Python web server it's using for testing, which have changed in the version of Python on the new base image. Correct the text of the error message.

Ref: https://github.com/hashicorp/nomad/pull/27661

### Testing & Reproduction steps

before:

```
=== RUN   TestServiceDiscovery/TestServiceDiscovery_ChecksSad
    nomad_checks_test.go:87: 
        	Error Trace:	/home/runner/actions-runner/_work/nomad-e2e/nomad-e2e/nomad/e2e/servicediscovery/nomad_checks_test.go:87
        	Error:      	Condition never satisfied
        	Test:       	TestServiceDiscovery/TestServiceDiscovery_ChecksSad
--- FAIL: TestServiceDiscovery/TestServiceDiscovery_ChecksSad (7.10s)
```

after:

```
$ go test -v -count=1 ./servicediscovery -run TestServiceDiscovery
=== RUN   TestServiceDiscovery
=== RUN   TestServiceDiscovery/TestServiceDiscovery_MultiProvider
=== RUN   TestServiceDiscovery/TestServiceDiscovery_UpdateProvider
=== RUN   TestServiceDiscovery/TestServiceDiscovery_SimpleLoadBalancing
=== RUN   TestServiceDiscovery/TestServiceDiscovery_ChecksHappy
=== RUN   TestServiceDiscovery/TestServiceDiscovery_ChecksSad
=== RUN   TestServiceDiscovery/TestServiceDiscovery_ServiceRegisterAfterCheckRestart
--- PASS: TestServiceDiscovery (51.69s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_MultiProvider (3.13s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_UpdateProvider (4.07s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_SimpleLoadBalancing (5.70s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_ChecksHappy (1.46s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_ChecksSad (1.48s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_ServiceRegisterAfterCheckRestart (35.66s)
PASS
ok      github.com/hashicorp/nomad/e2e/servicediscovery 51.702s
```

There may be additional issues with this test as some of the other subtests appear to be racy, but this subtest will always fail.

### Contributor Checklist
- [x] **Changelog Entry** n/a
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
