### PR TITLE
E2E: fix test flake in service discovery test

### DIFF
--- a/e2e/servicediscovery/input/checks_task_restart_helper.nomad
+++ b/e2e/servicediscovery/input/checks_task_restart_helper.nomad
@@ -13,9 +13,12 @@ variable "delay" {
   type = string
 }
 
+variable "filename" {
+  type = string
+}
+
 job "checks_task_restart_helper" {
-  datacenters = ["dc1"]
-  type        = "batch"
+  type = "batch"
 
   group "group" {
 
@@ -38,7 +41,7 @@ job "checks_task_restart_helper" {
       driver = "raw_exec"
       config {
         command = "bash"
-        args    = ["-c", "sleep ${var.delay} && ${var.cmd} /tmp/nsd-checks-task-restart-test.txt"]
+        args    = ["-c", "sleep ${var.delay} && ${var.cmd} /tmp/${var.filename}"]
       }
       resources {
         cpu    = 50

--- a/e2e/servicediscovery/input/checks_task_restart_main.nomad
+++ b/e2e/servicediscovery/input/checks_task_restart_main.nomad
@@ -1,9 +1,12 @@
 # Copyright IBM Corp. 2015, 2025
 # SPDX-License-Identifier: BUSL-1.1
 
+variable "filename" {
+  type = string
+}
+
 job "checks_task_restart" {
-  datacenters = ["dc1"]
-  type        = "service"
+  type = "service"
 
   constraint {
     attribute = "${attr.kernel.name}"
@@ -23,7 +26,7 @@ job "checks_task_restart" {
       check {
         name     = "alive"
         type     = "http"
-        path     = "/nsd-checks-task-restart-test.txt"
+        path     = "/${var.filename}"
         interval = "2s"
         timeout  = "1s"
         check_restart {

--- a/e2e/servicediscovery/nomad_checks_test.go
+++ b/e2e/servicediscovery/nomad_checks_test.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/e2e/e2eutil"
+	"github.com/hashicorp/nomad/e2e/v3/jobs3"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
 	"github.com/stretchr/testify/require"
@@ -108,38 +108,23 @@ func testChecksSad(t *testing.T) {
 }
 
 func testChecksServiceReRegisterAfterCheckRestart(t *testing.T) {
-	const (
-		jobChecksAfterRestartMain   = "./input/checks_task_restart_main.nomad"
-		jobChecksAfterRestartHelper = "./input/checks_task_restart_helper.nomad"
-	)
-
 	nomadClient := e2eutil.NomadClient(t)
 
-	idJobMain := "nsd-check-restart-services-" + uuid.Short()
-	idJobHelper := "nsd-check-restart-services-helper-" + uuid.Short()
-	jobIDs := []string{idJobMain, idJobHelper}
-
-	// Defer a cleanup function to remove the job. This will trigger if the
-	// test fails, unless the cancel function is called.
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	defer e2eutil.CleanupJobsAndGCWithContext(t, ctx, &jobIDs)
-
-	// register the main job
-	allocStubs := e2eutil.RegisterAndWaitForAllocs(t, nomadClient, jobChecksAfterRestartMain, idJobMain, "")
-	must.Len(t, 1, allocStubs)
+	filename := uuid.Generate() + ".txt"
+	mainJob, mainCleanup := jobs3.Submit(t,
+		"./input/checks_task_restart_main.nomad",
+		jobs3.Var("filename", filename),
+		jobs3.Detach(),
+	)
+	t.Cleanup(mainCleanup)
 
 	// wait for task restart due to failing health check
 	must.Wait(t, wait.InitialSuccess(
 		wait.BoolFunc(func() bool {
-			allocEvents, err := e2eutil.AllocTaskEventsForJob(idJobMain, "")
-			if err != nil {
-				t.Log("failed to get task events for job", idJobMain, err)
-				return false
-			}
+			allocEvents := mainJob.AllocEvents()
 			for _, events := range allocEvents {
-				for _, event := range events {
-					if event["Type"] == "Restarting" {
+				for _, event := range events.Events {
+					if event.Type == "Restarting" {
 						return true
 					}
 				}
@@ -150,20 +135,21 @@ func testChecksServiceReRegisterAfterCheckRestart(t *testing.T) {
 		wait.Gap(3*time.Second),
 	))
 
-	runHelper := func(command string) {
-		vars := []string{"-var", "nodeID=" + allocStubs[0].NodeID, "-var", "cmd=touch", "-var", "delay=3s"}
-		err := e2eutil.RegisterWithArgs(idJobHelper, jobChecksAfterRestartHelper, vars...)
-		test.NoError(t, err)
-	}
+	alloc := mainJob.Allocs()[0]
 
 	// register helper job, triggering check to start passing
-	runHelper("touch")
-	defer func() {
-		runHelper("rm")
-	}()
+	_, helperCleanup := jobs3.Submit(t,
+		"./input/checks_task_restart_helper.nomad",
+		jobs3.Var("filename", filename),
+		jobs3.Var("cmd", "touch"),
+		jobs3.Var("delay", "3s"),
+		jobs3.Var("nodeID", alloc.NodeID),
+		jobs3.WaitComplete("group"),
+	)
+	t.Cleanup(helperCleanup)
 
 	// wait for main task to become healthy
-	e2eutil.WaitForAllocStatus(t, nomadClient, allocStubs[0].ID, structs.AllocClientStatusRunning)
+	e2eutil.WaitForAllocStatus(t, nomadClient, alloc.ID, structs.AllocClientStatusRunning)
 
 	// finally assert we have services
 	services := nomadClient.Services()


### PR DESCRIPTION
The E2E test for Nomad native service discovery includes a test for check restarts. This test runs a job that needs a file to exist on disk in order to pass its HTTP check. The task restarts and then we run a helper job that writes the file to disk so the restarted main task passes checks. This was flaky because we were not waiting for the helper job to complete. Running the same test multiple times (during test debugging) would also often fail because the file had already been written to disk and the job would now fail to fail checks.

Update the test case to use the improved `job3` helpers which include fine-grained control over waiting. Update the jobspecs to read/write a unique file per test run.

### Testing & Reproduction steps

before:

```
=== RUN   TestServiceDiscovery/TestServiceDiscovery_ServiceRegisterAfterCheckRestart
    nomad_checks_test.go:135:
        nomad_checks_test.go:135: expected condition to pass within wait context
        ↪ error: wait: timeout exceeded
    job.go:272:
        job.go:272: expected nil error
        ↪ error: command nomad [job stop -purge -detach nsd-check-restart-services-helper-9fcd8718] failed: exit status 1
        Output: No job(s) with prefix or ID "nsd-check-restart-services-helper-9fcd8718" found
--- FAIL: TestServiceDiscovery (31.56s)
    --- FAIL: TestServiceDiscovery/TestServiceDiscovery_ServiceRegisterAfterCheckRestart (31.35s)
FAIL
FAIL    github.com/hashicorp/nomad/e2e/servicediscovery 31.570s
FAIL
```

after:

```
$ go test -v -count=1 ./servicediscovery -run TestServiceDiscovery
=== RUN   TestServiceDiscovery
=== RUN   TestServiceDiscovery/TestServiceDiscovery_MultiProvider
=== RUN   TestServiceDiscovery/TestServiceDiscovery_UpdateProvider
=== RUN   TestServiceDiscovery/TestServiceDiscovery_SimpleLoadBalancing
=== RUN   TestServiceDiscovery/TestServiceDiscovery_ChecksHappy
=== RUN   TestServiceDiscovery/TestServiceDiscovery_ChecksSad
=== RUN   TestServiceDiscovery/TestServiceDiscovery_ServiceRegisterAfterCheckRestart
    nomad_checks_test.go:116: submitting job: "./input/checks_task_restart_main.nomad"
    nomad_checks_test.go:143: submitting job: "./input/checks_task_restart_helper.nomad"
--- PASS: TestServiceDiscovery (50.78s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_MultiProvider (2.78s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_UpdateProvider (4.30s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_SimpleLoadBalancing (5.31s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_ChecksHappy (1.55s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_ChecksSad (1.57s)
    --- PASS: TestServiceDiscovery/TestServiceDiscovery_ServiceRegisterAfterCheckRestart (35.09s)
PASS
ok      github.com/hashicorp/nomad/e2e/servicediscovery 50.796s
```

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** n/a
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
