### PR TITLE
api: fix incorrect assertion in `TestJobs_ScaleInvalidAction`

### DIFF
--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1555,9 +1555,9 @@ func TestJobs_ScaleInvalidAction(t *testing.T) {
 		value int
 		want  string
 	}{
-		{"", "", 1, "404"},
+		{"", "", 1, "400"},
 		{"i-dont-exist", "", 1, "400"},
-		{"", "i-dont-exist", 1, "404"},
+		{"", "i-dont-exist", 1, "400"},
 		{"i-dont-exist", "me-neither", 1, "404"},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
In #27685 the upgrade to 1.26 uncovered an interesting bug in our API package unit test. The test expected 404 while `PUT`ting to `/v1/job/{$jobID}/scale` with an empty `jobID`. This would lead to a request with a malformed URL path (`/v1/job//scale`) that would never reach the correct handler, and [by sheer luck](https://github.com/hashicorp/nomad/blob/da8b688a9e7a32f681ca0b64f0ce9b73553e01b0/command/agent/job_endpoint.go?plain=1#L520) would actually respond with 404 because its method would be transformed from `PUT` to `GET`. 

The reason this happened was because of a bug in pre-1.26 Go, fixed here: https://go-review.googlesource.com/c/go/+/720820 Go's `net/http` `findHandler` method incorrectly used 301 instead of 307 redirects when it corrected URL paths. 

_note to reviewers:_ API unit tests will fail on this PR until #27685 gets merged and vice versa, its unit tests will fail until this gets merged. local test below:
```
$ go version
go version go1.26.1 darwin/arm64
$ cd api && go test -v -count=1 -run 'TestJobs_ScaleInvalidAction' .
==> Formatting HCL
==> Removing old development build...
==> Building pkg/darwin_arm64/nomad with tags ui hashicorpmetrics  ...
=== RUN   TestJobs_ScaleInvalidAction
=== PAUSE TestJobs_ScaleInvalidAction
=== CONT  TestJobs_ScaleInvalidAction
==> WARNING: mTLS is not configured - Nomad is not secure without mTLS!
==> WARNING: Bootstrap mode enabled! Potentially unsafe operation.
==> Loaded configuration from /var/folders/nz/7h3n1b9d2p1b95jn71rh6q1h0000gq/T/nomad960070035/nomad913136739
==> Starting Nomad agent...
==> Nomad agent configuration:

       Advertise Addrs: HTTP: 192.168.0.140:51242; RPC: 192.168.0.140:51243; Serf: 192.168.0.140:51244
            Bind Addrs: HTTP: [0.0.0.0:51242]; RPC: 0.0.0.0:51243; Serf: 0.0.0.0:51244
                Client: false
             Log Level: ERROR
               Node Id: ab769e7c-348d-9cfb-742f-a00669a0ec19
                Region: global (DC: dc1)
                Server: true
               Version: 1.11.4-dev

==> Nomad agent started! Log data will stream in below:

==> Caught signal: interrupt
    2026-03-17T20:08:30.308+0100 [ERROR] worker: error invoking scheduler: worker_id=1d7dc558-ef53-93d9-6a62-1f5de1c15d3f error="failed to process evaluation: shutdown while planning"
    2026-03-17T20:08:30.308+0100 [ERROR] worker: failed to nack evaluation: worker_id=1d7dc558-ef53-93d9-6a62-1f5de1c15d3f eval_id=de82cad1-116b-1855-fc38-0b7635cb9edb error="Not ready to serve consistent reads"
--- PASS: TestJobs_ScaleInvalidAction (4.75s)
PASS
ok  	github.com/hashicorp/nomad/api	5.294s
```