### PR TITLE
make `make changelog` better for humans

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Update changelog
         id: changelog # output: contents, file
         env:
+          CI: true
           NEW_VERSION: ${{ inputs.version }}
           ALLOW_DIRTY_WORKTREE: true
           DEBUG: ${{ runner.debug }}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -234,8 +234,16 @@ proto: ## Generate protobuf bindings
 	@echo "==> Generating proto bindings..."
 	@buf --config tools/buf/buf.yaml --template tools/buf/buf.gen.yaml generate
 
+# the update-changelog script mutates the local git filesystem,
+# so clone into a temp dir for a fresh worktree.
+.PHONY: changelog
+changelog: tmp := $(shell mktemp -d /tmp/nomad-changelog-XXXXX)
+changelog: script := $(PWD)/scripts/release/update-changelog
 changelog: ## Generate changelog from entries
-	./scripts/release/update-changelog
+	@git clone $(PWD) $(tmp)
+	@echo "==> Running changelog script"
+	@cd $(tmp) && $(script)
+	@rm -rf $(tmp)
 
 ## We skip the terraform directory as there are templated hcl configurations
 ## that do not successfully compile without rendering

--- a/scripts/release/update-changelog
+++ b/scripts/release/update-changelog
@@ -16,8 +16,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/shared"
 # -> https://github.com/go-git/go-git/issues/1812
 
 echo 'Checking variables'
+  CI="${CI:-false}"
   # NEW_VERSION is only for display, e.g. in changelog header, not functional
-  NEW_VERSION="${NEW_VERSION:-$(make version)}"
+  NEW_VERSION="${NEW_VERSION:-$(make --no-print-directory version)}"
   SOURCE_BRANCH="${SOURCE_BRANCH:-$(git branch --show-current)}"
   # LAST_RELEASE is the last released GA or backport version.
   # main branch should have the latest published release, and
@@ -25,6 +26,7 @@ echo 'Checking variables'
   LAST_RELEASE="${LAST_RELEASE:-$(grep -v '^#' scripts/release/previous.version)}"
   # vars displayed this way for easier troubleshooting
   cat <<VARS
+export CI='$CI'
 export NEW_VERSION='$NEW_VERSION'
 export SOURCE_BRANCH='$SOURCE_BRANCH'
 export LAST_RELEASE='$LAST_RELEASE'
@@ -40,7 +42,7 @@ echo 'Ensuring source branch'
   git switch "$SOURCE_BRANCH"
 echo
 
-cl_file="$(mktemp -t changelog-XXXXX-$NEW_VERSION.md)"
+cl_file="$(mktemp -t "changelog-XXXXX-$NEW_VERSION.md")"
 
 echo "Generating the changelog from v$LAST_RELEASE to HEAD ($(git rev-parse HEAD))"
   changelog-build \
@@ -60,6 +62,12 @@ echo "Generating the changelog from v$LAST_RELEASE to HEAD ($(git rev-parse HEAD
     exit 1
   fi
 echo
+
+# if not CI, just display the changelog contents
+case $CI in
+  1|true|yes) ;; # continue below
+  *) echo "========="; cat "$cl_file" ; exit ;;
+esac
 
 echo 'Updating CHANGELOG.md'
   {


### PR DESCRIPTION
In making changelog management automatic for releases, I made it worse for humans to generate (such as when drafting a release announcement _before_ the release).

This makes `make changelog` Just Work* more like it did before (but still way faster now and without eating all your ram)

\* I have not tried it on mac. If someone will try it on mac for me, that'd be swell.

@jrasell since you're running the release tomorrow, note: This is _not_ a blocker to running the beta; it's just nice to have.