### PR TITLE
UI: fix variable formatting for jobs submitted with non-string var flags

### DIFF
--- a/ui/app/utils/json-to-hcl.js
+++ b/ui/app/utils/json-to-hcl.js
@@ -33,7 +33,7 @@ export default function jsonToHcl(obj) {
       hclValue = JSON.stringify(value);
     }
 
-    hclLines.push(`${key}=${hclValue}`);
+    hclLines.push(`${key}=${hclValue}\n`);
   }
 
   return hclLines.join('\n');

--- a/ui/app/utils/json-to-hcl.js
+++ b/ui/app/utils/json-to-hcl.js
@@ -19,14 +19,18 @@ export default function jsonToHcl(obj) {
     let hclValue;
 
     if (typeof value === 'string') {
-      // Check if it's a JSON array or object (starts with [ or {)
-      if (
-        (value.startsWith('[') && value.endsWith(']')) ||
-        (value.startsWith('{') && value.endsWith('}'))
-      ) {
-        hclValue = value; // Keep it as a JSON string
-      } else {
-        // Escape double quotes and backslashes
+      // Try to parse as JSON to validate it's actually valid JSON
+      try {
+        const parsed = JSON.parse(value);
+        // Only preserve as JSON if it's an array or object
+        if (typeof parsed === 'object' && parsed !== null) {
+          hclValue = value; // Keep it as valid JSON
+        } else {
+          // Parsed to a primitive (string, number, boolean, null)
+          hclValue = JSON.stringify(value);
+        }
+      } catch {
+        // Not valid JSON, treat as a regular string
         hclValue = JSON.stringify(value);
       }
     } else {

--- a/ui/app/utils/json-to-hcl.js
+++ b/ui/app/utils/json-to-hcl.js
@@ -22,11 +22,9 @@ export default function jsonToHcl(obj) {
       // Try to parse as JSON to validate it's actually valid JSON
       try {
         const parsed = JSON.parse(value);
-        // Only preserve as JSON if it's an array or object
         if (typeof parsed === 'object' && parsed !== null) {
-          hclValue = value; // Keep it as valid JSON
+          hclValue = value;
         } else {
-          // Parsed to a primitive (string, number, boolean, null)
           hclValue = JSON.stringify(value);
         }
       } catch {

--- a/ui/app/utils/json-to-hcl.js
+++ b/ui/app/utils/json-to-hcl.js
@@ -12,8 +12,6 @@
  * @returns {string} The HCL string representation of the JSON object.
  */
 export default function jsonToHcl(obj) {
-  if (!obj) return '';
-
   const hclLines = [];
 
   for (const key in obj) {
@@ -21,6 +19,7 @@ export default function jsonToHcl(obj) {
     let hclValue;
 
     if (typeof value === 'string') {
+      // Check if it's a JSON array or object (starts with [ or {)
       if (
         (value.startsWith('[') && value.endsWith(']')) ||
         (value.startsWith('{') && value.endsWith('}'))

--- a/ui/app/utils/json-to-hcl.js
+++ b/ui/app/utils/json-to-hcl.js
@@ -24,9 +24,7 @@ export default function jsonToHcl(obj) {
     .map(([key, value]) => {
       // All values from the API are strings, but some contain JSON
       const hclValue =
-        typeof value === 'string'
-          ? convertStringValue(value)
-          : JSON.stringify(value); // Defensive: handle non-string values
+        typeof value === 'string' ? convertStringValue(value) : value; // Defensive: handle non-string values
 
       return `${key}=${hclValue}`;
     });

--- a/ui/app/utils/json-to-hcl.js
+++ b/ui/app/utils/json-to-hcl.js
@@ -21,7 +21,6 @@ export default function jsonToHcl(obj) {
     let hclValue;
 
     if (typeof value === 'string') {
-      //
       if (
         (value.startsWith('[') && value.endsWith(']')) ||
         (value.startsWith('{') && value.endsWith('}'))

--- a/ui/app/utils/json-to-hcl.js
+++ b/ui/app/utils/json-to-hcl.js
@@ -12,12 +12,30 @@
  * @returns {string} The HCL string representation of the JSON object.
  */
 export default function jsonToHcl(obj) {
+  if (!obj) return '';
+
   const hclLines = [];
 
   for (const key in obj) {
     const value = obj[key];
-    const hclValue = typeof value === 'string' ? value : JSON.stringify(value);
-    hclLines.push(`${key}=${hclValue}\n`);
+    let hclValue;
+
+    if (typeof value === 'string') {
+      //
+      if (
+        (value.startsWith('[') && value.endsWith(']')) ||
+        (value.startsWith('{') && value.endsWith('}'))
+      ) {
+        hclValue = value; // Keep it as a JSON string
+      } else {
+        // Escape double quotes and backslashes
+        hclValue = JSON.stringify(value);
+      }
+    } else {
+      hclValue = JSON.stringify(value);
+    }
+
+    hclLines.push(`${key}=${hclValue}`);
   }
 
   return hclLines.join('\n');

--- a/ui/app/utils/json-to-hcl.js
+++ b/ui/app/utils/json-to-hcl.js
@@ -20,9 +20,8 @@ export default function jsonToHcl(obj) {
   }
 
   const hclLines = Object.entries(obj)
-    .filter(([, value]) => value != null) // Skip undefined/null values
+    .filter(([, value]) => value != null)
     .map(([key, value]) => {
-      // All values from the API are strings, but some contain JSON
       const hclValue =
         typeof value === 'string' ? convertStringValue(value) : value; // Defensive: handle non-string values
 
@@ -41,9 +40,8 @@ function convertStringValue(value) {
   try {
     const parsed = JSON.parse(value);
     // Only preserve objects and arrays
-    // Arrays are objects in JavaScript: typeof [] === 'object'
     if (typeof parsed === 'object' && parsed !== null) {
-      return value; // Keep JSON objects/arrays as-is
+      return value;
     }
     // For JSON primitives (numbers, booleans, null), quote them
     return JSON.stringify(value);

--- a/ui/app/utils/json-to-hcl.js
+++ b/ui/app/utils/json-to-hcl.js
@@ -16,8 +16,7 @@ export default function jsonToHcl(obj) {
 
   for (const key in obj) {
     const value = obj[key];
-    const hclValue = typeof value === 'string' ? JSON.stringify(value) : value;
-
+    const hclValue = typeof value === 'string' ? value : JSON.stringify(value);
     hclLines.push(`${key}=${hclValue}\n`);
   }
 

--- a/ui/app/utils/json-to-hcl.js
+++ b/ui/app/utils/json-to-hcl.js
@@ -7,36 +7,50 @@
 
 /**
  * Convert a JSON object to an HCL string.
- *
+ * The Nomad API returns VariableFlags as an object where all values are strings.
+ * Some strings contain JSON-encoded arrays/objects (e.g., '["dc1"]'), while others are plain strings (e.g., 'my-app'). This function converts them to HCL format:
+ * - JSON arrays/objects: preserved as-is (e.g., datacenters=["dc1"])
+ * - Everything else: quoted (e.g., app_name="my-app")
  * @param {Object} obj - The JSON object to convert.
  * @returns {string} The HCL string representation of the JSON object.
  */
 export default function jsonToHcl(obj) {
-  const hclLines = [];
-
-  for (const key in obj) {
-    const value = obj[key];
-    let hclValue;
-
-    if (typeof value === 'string') {
-      // Try to parse as JSON to validate it's actually valid JSON
-      try {
-        const parsed = JSON.parse(value);
-        if (typeof parsed === 'object' && parsed !== null) {
-          hclValue = value;
-        } else {
-          hclValue = JSON.stringify(value);
-        }
-      } catch {
-        // Not valid JSON, treat as a regular string
-        hclValue = JSON.stringify(value);
-      }
-    } else {
-      hclValue = JSON.stringify(value);
-    }
-
-    hclLines.push(`${key}=${hclValue}\n`);
+  if (!obj || typeof obj !== 'object') {
+    return '';
   }
 
-  return hclLines.join('\n');
+  const hclLines = Object.entries(obj)
+    .filter(([, value]) => value != null) // Skip undefined/null values
+    .map(([key, value]) => {
+      // All values from the API are strings, but some contain JSON
+      const hclValue =
+        typeof value === 'string'
+          ? convertStringValue(value)
+          : JSON.stringify(value); // Defensive: handle non-string values
+
+      return `${key}=${hclValue}`;
+    });
+
+  return hclLines.length > 0 ? hclLines.join('\n') + '\n' : '';
+}
+
+/**
+ * Convert a string value to HCL format.
+ * - If it's a valid JSON object/array, keep as-is
+ * - Otherwise, quote it
+ */
+function convertStringValue(value) {
+  try {
+    const parsed = JSON.parse(value);
+    // Only preserve objects and arrays
+    // Arrays are objects in JavaScript: typeof [] === 'object'
+    if (typeof parsed === 'object' && parsed !== null) {
+      return value; // Keep JSON objects/arrays as-is
+    }
+    // For JSON primitives (numbers, booleans, null), quote them
+    return JSON.stringify(value);
+  } catch {
+    // Not valid JSON, treat as plain string and quote it
+    return JSON.stringify(value);
+  }
 }

--- a/ui/tests/unit/utils/json-to-hcl-test.js
+++ b/ui/tests/unit/utils/json-to-hcl-test.js
@@ -57,9 +57,7 @@ module('Unit | Utility | json-to-hcl', function () {
   });
 
   test('it handles the case where a string variable contains invalid JSON-like syntax from CLI', function (assert) {
-    // Real-world scenario: nomad job run -var="example=[dc1,dc2]" test-string-var.hcl
     // When variable has type=string, HCL2 treats it as literal string
-    // The string "[dc1,dc2]" reaches the UI and must be quoted correctly
     const input = { example: '[dc1,dc2]' };
     const result = jsonToHcl(input);
 

--- a/ui/tests/unit/utils/json-to-hcl-test.js
+++ b/ui/tests/unit/utils/json-to-hcl-test.js
@@ -55,4 +55,15 @@ module('Unit | Utility | json-to-hcl', function () {
     // Should be treated as a regular string and quoted
     assert.equal(result, 'text="[incomplete"\n');
   });
+
+  test('it handles the case where a string variable contains invalid JSON-like syntax from CLI', function (assert) {
+    // Real-world scenario: nomad job run -var="example=[dc1,dc2]" test-string-var.hcl
+    // When variable has type=string, HCL2 treats it as literal string
+    // The string "[dc1,dc2]" reaches the UI and must be quoted correctly
+    const input = { example: '[dc1,dc2]' };
+    const result = jsonToHcl(input);
+
+    // Should be quoted as a string since it's not valid JSON
+    assert.equal(result, 'example="[dc1,dc2]"\n');
+  });
 });

--- a/ui/tests/unit/utils/json-to-hcl-test.js
+++ b/ui/tests/unit/utils/json-to-hcl-test.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright IBM Corp. 2015, 2025
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import jsonToHcl from 'nomad-ui/utils/json-to-hcl';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | json-to-hcl', function () {
+  test('it preserves strings that look like JSON arrays without adding extra quotes', function (assert) {
+    // This tests the scenario where a variable with type=string
+    // has a default value that looks like below:
+    // variable "example" {
+    //   type    = string
+    //   default = "[\"dc1\"]"
+    // }
+    const input = { example: '["dc1"]' };
+    const result = jsonToHcl(input);
+
+    assert.equal(result, 'example=["dc1"]\n');
+  });
+
+  test('it converts regular string values to quoted HCL', function (assert) {
+    const input = { name: 'my-job' };
+    const result = jsonToHcl(input);
+
+    assert.equal(result, 'name="my-job"\n');
+  });
+
+  test('it converts numeric values to HCL', function (assert) {
+    const input = { count: 3 };
+    const result = jsonToHcl(input);
+
+    assert.equal(result, 'count=3\n');
+  });
+
+  test('it converts boolean values to HCL', function (assert) {
+    const input = { enabled: true };
+    const result = jsonToHcl(input);
+
+    assert.equal(result, 'enabled=true\n');
+  });
+
+  test('it preserves JSON object strings', function (assert) {
+    const input = { config: '{"key": "value"}' };
+    const result = jsonToHcl(input);
+
+    assert.equal(result, 'config={"key": "value"}\n');
+  });
+
+  test('it handles strings that look like incomplete JSON arrays', function (assert) {
+    const input = { text: '[incomplete' };
+    const result = jsonToHcl(input);
+
+    // Should be treated as a regular string and quoted
+    assert.equal(result, 'text="[incomplete"\n');
+  });
+});


### PR DESCRIPTION
### Description
This pr fixes variable formatting in UI for jobs submitted with list/map types via -var flags

Fix added : 

- Added logic to detect string values that are already JSON arrays or objects(by checking if they start with [ or { and end with ] or }). 

- These values are now preserved as it is without additional stringification, while regular string values still get properly quoted.This ensures that variable values maintain correct HCL syntax.

### Testing & Reproduction steps

**Reproduction  steps:**
 Submit a job with a -var  containing a variable of type list(string). Open the UI, edit the HCL Variable Values and click on plan. Below error is dispalyed.
<img width="2364" height="328" alt="Screenshot 2026-03-16 at 9 03 00 PM" src="https://github.com/user-attachments/assets/57d0194b-7b61-4bae-8a41-bd73e5a40d52" />


**Testing**
Scenario 1
- Submit a job with a **-var** containing a variable of type list(string). Open the UI, edit the HCL Variable Values and click on plan.

https://github.com/user-attachments/assets/bc910191-eba9-45e6-aa80-81b8820dfcd9

Scenario 2
- Submit a job with a **-var-file**  containing a variable of type list(string). Open the UI, edit the HCL Variable Values and click on plan.

https://github.com/user-attachments/assets/002c8ea0-7e93-4465-af8a-9f643ada3225

Scenario 3 
Edit other type(number, boolean) fields and validate it if it works correctly

https://github.com/user-attachments/assets/dbc232ef-263a-4a18-b6ac-5b702d3cbba5

The UI displays variables as strings (e.g., instance_count="3"), and HCL type system handles the conversion based on the variable's declared type(Number). 
If the value ( instance_count="3a") cannot be converted to the declared type, Nomad returns a error message during plan. I hope this is the expected behavior—just wanted to confirm.

### Links

Fixes: #23462
Ref: https://hashicorp.atlassian.net/browse/NMD-531

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
