### PR TITLE
fix(ui): guard against undefined task in getTaskSortPrefix

### DIFF
--- a/ui/app/components/lifecycle-chart.js
+++ b/ui/app/components/lifecycle-chart.js
@@ -86,5 +86,6 @@ const lifecycleNameSortPrefix = {
 };
 
 function getTaskSortPrefix(task) {
+  if (!task) return '';
   return `${lifecycleNameSortPrefix[task.lifecycleName]}-${task.name}`;
 }


### PR DESCRIPTION
## Summary
- Add null check in `getTaskSortPrefix` to handle undefined tasks
- Prevents `TypeError: task is undefined` on allocation details page for rescheduled allocations

## Root Cause
When an allocation is rescheduled, some tasks may be undefined in the UI state. `getTaskSortPrefix` is called without checking for this, causing a TypeError.

## Testing
- Verified the fix handles undefined tasks gracefully
- Existing test suite passes

Fixes #11996

Made with [Cursor](https://cursor.com)