### PR TITLE
ci: enable 2.0.x CE backports

### DIFF
--- a/.release/versions.hcl
+++ b/.release/versions.hcl
@@ -7,7 +7,8 @@
 schema = 1
 active_versions {
   version "2.0.x" {
-    lts = true
+    lts       = true
+    ce_active = true
   }
   version "1.11.x" {
     lts = true


### PR DESCRIPTION
https://github.com/hashicorp/nomad/pull/27702 was a little overzealous dropping `ce_active` from our latest release version.

I'm tempted to also set it on `1.11.x`, since at the moment it would be easy to continue supporting that version in CE, but we can decide that separately.
