### PR TITLE
backport autorelease: add changelog to finalize prerelease into release/2.0.0-beta.1

### DIFF
--- a/scripts/release/finalize
+++ b/scripts/release/finalize
@@ -65,6 +65,7 @@ echo 'Updating magic strings in magic files'
     echo "$NEW_VERSION is a prerelease; reverting changelog"
     # we'll re-update changelog for GA.
     git restore --source="origin/$MERGE_INTO" -- CHANGELOG.md
+    git add CHANGELOG.md
 
   else
     echo "$NEW_VERSION is not a prerelease; bumping versions"


### PR DESCRIPTION
Backport of https://github.com/hashicorp/nomad/pull/27712 to finish 2.0.0-beta.1 release.
