### PR TITLE
backport of autorelease: add changelog to finalize prerelease into release/1.11.x

### DIFF
--- a/scripts/release/finalize
+++ b/scripts/release/finalize
@@ -65,6 +65,7 @@ echo 'Updating magic strings in magic files'
     echo "$NEW_VERSION is a prerelease; reverting changelog"
     # we'll re-update changelog for GA.
     git restore --source="origin/$MERGE_INTO" -- CHANGELOG.md
+    git add CHANGELOG.md
 
   else
     echo "$NEW_VERSION is not a prerelease; bumping versions"


### PR DESCRIPTION
Backport of https://github.com/hashicorp/nomad/pull/27712 -- mainly to keep `release/1.11.x` easily releasable, if we want to. I at least don't want to leave it in a known-bad state.