### PR TITLE
csi: fix check of StagePublishBaseDir being subdirectory of MountDir

### DIFF
--- a/.changelog/27717.txt
+++ b/.changelog/27717.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: improve check of StagePublishBaseDir being subdirectory of MountDir
+```

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -568,3 +568,12 @@ func FindExecutableFiles(path string) (map[string]string, error) {
 	}
 	return executables, nil
 }
+
+// IsSubdirectory returns true if potentialParent is equal to or a parent directory of path.
+func IsSubdirectory(potentialParent, path string) bool {
+	rel, err := filepath.Rel(potentialParent, path)
+	if err != nil {
+		return false
+	}
+	return !strings.HasPrefix(rel, "..")
+}

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -528,3 +528,23 @@ func TestFlattenMultiError(t *testing.T) {
 
 `, err.Error())
 }
+
+func TestIsSubdirectory(t *testing.T) {
+	cases := []struct {
+		potentialParent string
+		path            string
+		expected        bool
+	}{
+		{potentialParent: "/dir", path: "/dir/local", expected: true},
+		{potentialParent: "/dir", path: "/other", expected: false},
+		{potentialParent: "/dir", path: "/directory", expected: false},
+		{potentialParent: "/dir", path: "/directory/../dir/local", expected: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("parent=%q path=%q", tc.potentialParent, tc.path), func(t *testing.T) {
+			result := IsSubdirectory(tc.potentialParent, tc.path)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8287,7 +8287,7 @@ func (t *Task) Validate(jobType string, tg *TaskGroup) error {
 		}
 
 		if t.CSIPluginConfig.StagePublishBaseDir != "" && t.CSIPluginConfig.MountDir != "" &&
-			strings.HasPrefix(t.CSIPluginConfig.StagePublishBaseDir, t.CSIPluginConfig.MountDir) {
+			helper.IsSubdirectory(t.CSIPluginConfig.MountDir, t.CSIPluginConfig.StagePublishBaseDir) {
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("CSIPluginConfig StagePublishBaseDir must not be a subdirectory of MountDir, got: StagePublishBaseDir=\"%s\" MountDir=\"%s\"", t.CSIPluginConfig.StagePublishBaseDir, t.CSIPluginConfig.MountDir))
 		}
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -3262,6 +3262,15 @@ func TestTask_Validate_CSIPluginConfig(t *testing.T) {
 			},
 			expectedErr: "CSIPluginConfig StagePublishBaseDir must not be a subdirectory of MountDir, got: StagePublishBaseDir=\"/csi/local\" MountDir=\"/csi\"",
 		},
+		{
+			name: "handles valid staging publish base dir",
+			pc: &TaskCSIPluginConfig{
+				ID:                  "com.hashicorp.csi",
+				Type:                "monolith",
+				MountDir:            "/csi",
+				StagePublishBaseDir: "/csilocal",
+			},
+		},
 	}
 
 	for _, tt := range table {


### PR DESCRIPTION
### Description
Small fix, adds an `IsSubdirectory` helper that checks if a path is a subdirectory of another using the `filepath.Rel`, instead of only checking for a prefix match of two strings. Prevents an error being thrown if the StagePublishBaseDir and MountDir are given as separate directories that still start with the same characters (like `/csi` and `/csilocal`)

### Testing & Reproduction steps
Bug was found when using a `csi_plugin` block such as: 
```
csi_plugin {
  ...
  mount_dir              = "/csi"
  stage_publish_base_dir = "/csilocal"
}
```
returned  the error`CSIPluginConfig StagePublishBaseDir must not be a subdirectory of MountDir`, now it does not error. Tests have been added/updated. 

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
