### PR TITLE
CI: group dependabot updates and reduce interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,74 +7,44 @@ updates:
     directory: "/"
     labels:
       - "theme/dependencies"
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 15 * *" # once a month, mid-month
     groups:
-      go-updates:
+      go:
         patterns:
           - "*"
-        applies-to: "version-updates"
-        schedule:
-          interval: "cron"
-          cronjob: "0 9 15 * *" # once a month, mid-month
-      go-security:
-        patterns:
-          - "*"
-        applies-to: "security-updates"
-        schedule:
-          interval: "weekly"
-          day: "sunday"
-          time: "09:00"
 
   - package-ecosystem: gomod
     directory: "/api"
     labels:
       - "theme/dependencies"
       - "theme/api"
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 15 * *" # once a month, mid-month
     groups:
-      go-updates-api:
+      go-api:
         patterns:
           - "*"
-        applies-to: "version-updates"
-        schedule:
-          interval: "cron"
-          cronjob: "0 9 15 * *" # once a month, mid-month
-      go-security-api:
-        patterns:
-          - "*"
-        applies-to: "security-updates"
-        schedule:
-          interval: "weekly"
-          day: "sunday"
-          time: "09:00"
 
   - package-ecosystem: npm
     directory: "/ui"
     labels:
       - "theme/dependencies"
       - "theme/ui"
+    schedule:
+      interval: "cron"
+      cronjob: "0 9 15 * *" # once a month, mid-month
     groups:
       ui-dev:
-        schedule:
-          interval: "cron"
-          cronjob: "0 9 15 * *" # once a month, mid-month
          patterns:
            - "*"
          dependency-type: "development"
       ui-prod:
-        schedule:
-          interval: "cron"
-          cronjob: "0 9 15 * *" # once a month, mid-month
          patterns:
            - "*"
          dependency-type: "production"
-      ui-security:
-        schedule:
-          interval: "weekly"
-          day: "sunday"
-          time: "09:00"
-        patterns:
-          - "*"
-        applies-to: "security-updates"
-        dependency-type: "production"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
As the number of backport branches we have to manage has increased and compliance process requirements have increased, the toil of doing dependency updates has increased as well. Our original thinking was that we should split out updates because it would make picking apart individual PRs easier, and maximize the amount of time that dependency updates would be tested. But it's time to make some adjustments.

In order to balance those desires with reducing toil, this changeset proposes:
* Group up dependency updates into a single PR for Go (+ 1 for the `api` package), and dev vs prod PRs for Node
* All version updates are posted monthly. The timing of this is intended to fall shortly after we ship our monthly patch release. This maximizes the amount of time that a dependency update is in our nightly E2E tests.
* Add GitHub Actions configuration, also updated monthly.
* Security vulnerabilities will get flagged via our nightly scan, outside of dependabot.

Advantages:
* We'll have a consolidated backport PR for all the dependency updates, which some of us have been building manually anyways.
* Less CI minutes burned.
* Less time looking at trivial PRs and getting them backported.
* We keep internal SLAs for security issues but mess with non-security dependency updates far less often.

Drawbacks include:
* There'll be increased pain for backporting if we decide _not_ to backport a dependency update to a given release (ex. the Docker API client for 1.9.x that doesn't exist in 1.8.) This is rare.
* If a dependency update causes a problem, it'll be slightly harder to pick apart which one introduced the issue. This seems like a bigger problem in theory than in practice.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
