### PR TITLE
ci: correct slack incoming webhook syntax for new slack-github-action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -93,7 +93,7 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_FEED_NOMAD || secrets.BACKPORT_ASSISTANT_FAILURE_SLACK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_WEBHOOK_TYPE: incoming-webhook
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
see https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0