### PR TITLE
agent: remove systemd notification env var reset

### DIFF
--- a/.changelog/27746.txt
+++ b/.changelog/27746.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fixed a potential panic in agents using systemd notification
+```

--- a/command/agent/sdnotify_linux.go
+++ b/command/agent/sdnotify_linux.go
@@ -19,16 +19,17 @@ const sdNotifySocketEnvVar = "NOTIFY_SOCKET"
 
 // openNotify opens the systemd notify socket only if the expected env var has
 // been set, because the systemd unit file is Type=notify or Type=notify-reload
-// (systemd 253+). It then unsets the env var in the agent process so that child
-// processes can't accidentally inherit it. This function returns (nil, nil) if
-// the env var isn't set.
+// (systemd 253+). This function returns (nil, nil) if the env var isn't set.
 func openNotify() (io.WriteCloser, error) {
 	socketPath := os.Getenv(sdNotifySocketEnvVar)
 	if socketPath == "" {
 		return nil, nil
 	}
 
-	defer os.Unsetenv(sdNotifySocketEnvVar)
+	// note we can't safely unset the env var as recommended by systemd because
+	// the Go runtime will have spawned threads by this point. It's up to the
+	// client code to ensure that child processes are not accidentally
+	// inheriting it in their environment.
 	conn, err := net.DialTimeout("unixgram", socketPath, time.Second)
 	return conn, err
 }


### PR DESCRIPTION
In #20528 we added support for the sdnotify protocol on Linux, so that the agent can notify systemd that its ready for work. A code audit has pointed out that unsetting the `NOTIFY_SOCKET` environment variable could potentially cause a panic in concurrent threads where CGO is calling into glibc routines like `getaddrinfo`. And we can't simply read the value and clear it at the start of the application, because the runtime will have spun up threads before Nomad ever starts and then any goroutine that could subsequently call into glibc could be moved to one of those threads.

In practice this isn't going to hurt us, and really we should be handling this by allowlisting any environment that's getting passed on to child processes anyways. Fixing this will quiet down some static analysis and future audits.

Ref: https://github.com/hashicorp/nomad/pull/20528
Ref: https://hashicorp.atlassian.net/browse/SECVULN-29925

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
