### PR TITLE
OIDC: eliminate race condition in request cache

### DIFF
--- a/.changelog/27747.txt
+++ b/.changelog/27747.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+oidc: Fixed a bug where the request cache could be corrupted by concurrent requests with the same nonce
+```

--- a/lib/auth/oidc/request.go
+++ b/lib/auth/oidc/request.go
@@ -5,6 +5,8 @@ package oidc
 
 import (
 	"errors"
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/cap/oidc"
@@ -34,12 +36,19 @@ func NewRequestCache(timeout time.Duration) *RequestCache {
 }
 
 type RequestCache struct {
-	c *expirable.LRU[string, *oidc.Req]
+	c    *expirable.LRU[string, *oidc.Req]
+	lock sync.Mutex
 }
 
-// Store saves the request, to be Loaded later with its Nonce.
-// If LoadAndDelete is not called, the stale request will be auto-deleted.
-func (rc *RequestCache) Store(req *oidc.Req) error {
+// store saves the request, to be Loaded later with its Nonce. This is only used
+// in testing.
+func (rc *RequestCache) store(req *oidc.Req) error {
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	return rc.storeLocked(req)
+}
+
+func (rc *RequestCache) storeLocked(req *oidc.Req) error {
 	if rc.c.Len() >= MaxRequests {
 		return ErrTooManyRequests
 	}
@@ -54,14 +63,48 @@ func (rc *RequestCache) Store(req *oidc.Req) error {
 	return nil
 }
 
+// Load fetches a previously cached oidc.Req. You should only use this for test
+// assertions, as the workflows require atomic load-or-set and atomic
+// load-or-delete.
 func (rc *RequestCache) Load(nonce string) *oidc.Req {
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	return rc.loadLocked(nonce)
+}
+
+func (rc *RequestCache) loadLocked(nonce string) *oidc.Req {
 	if req, ok := rc.c.Get(nonce); ok {
 		return req
 	}
 	return nil
 }
 
+// LoadOrAdd atomically fetches a previously cached oidc.Req or creates once
+// using the provided function and stores it before returning it. If
+// LoadAndDelete is not called later, the stale request will eventually expire
+// and be auto-deleted.
+func (rc *RequestCache) LoadOrAdd(clientNonce string, create func() (*oidc.Req, error)) (*oidc.Req, error) {
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
+	var err error
+	oidcReq := rc.loadLocked(clientNonce)
+	if oidcReq == nil {
+		oidcReq, err = create()
+		if err != nil {
+			return nil, err
+		}
+		if err = rc.storeLocked(oidcReq); err != nil {
+			return nil, fmt.Errorf("error storing OIDC request: %w", err)
+		}
+	}
+	return oidcReq, nil
+}
+
+// LoadAndDelete atomically loads a previously-cache oidc.Req and clears it from
+// the cache
 func (rc *RequestCache) LoadAndDelete(nonce string) *oidc.Req {
+	rc.lock.Lock()
+	defer rc.lock.Unlock()
 	if req, ok := rc.c.Get(nonce); ok {
 		rc.c.Remove(nonce)
 		return req

--- a/lib/auth/oidc/request_test.go
+++ b/lib/auth/oidc/request_test.go
@@ -22,21 +22,48 @@ func TestRequestCache(t *testing.T) {
 		t.Parallel()
 		req := getRequest(t)
 
-		must.NoError(t, rc.Store(req))
-		must.ErrorIs(t, rc.Store(req), ErrNonceReuse)
+		must.NoError(t, rc.store(req))
+		must.ErrorIs(t, rc.store(req), ErrNonceReuse)
 	})
 
 	t.Run("load and delete", func(t *testing.T) {
 		t.Parallel()
 		req := getRequest(t)
 
-		must.NoError(t, rc.Store(req))
+		must.NoError(t, rc.store(req))
 		must.Eq(t, req, rc.Load(req.Nonce()))
 
 		must.Eq(t, req, rc.LoadAndDelete(req.Nonce()))
 
 		waitUntilGone(t, rc, req.Nonce())
 		must.Nil(t, rc.LoadAndDelete(req.Nonce()))
+	})
+
+	t.Run("load or add", func(t *testing.T) {
+		t.Parallel()
+		nonce := t.Name()
+		fn := func() (*oidc.Req, error) {
+			return oidc.NewRequest(time.Millisecond, "test-redirect-url",
+				oidc.WithNonce(nonce))
+		}
+
+		// create new
+		req, err := rc.LoadOrAdd(nonce, fn)
+		must.NoError(t, err)
+		must.Eq(t, nonce, req.Nonce())
+
+		// fetch from cache
+		req, err = rc.LoadOrAdd(nonce, fn)
+		must.NoError(t, err)
+		must.Eq(t, nonce, req.Nonce())
+
+		// clear the cache
+		must.NotNil(t, rc.LoadAndDelete(req.Nonce()))
+
+		// create new again
+		req, err = rc.LoadOrAdd(nonce, fn)
+		must.NoError(t, err)
+		must.Eq(t, nonce, req.Nonce())
 	})
 
 	t.Run("timeout", func(t *testing.T) {
@@ -46,7 +73,7 @@ func TestRequestCache(t *testing.T) {
 
 		req := getRequest(t)
 
-		must.NoError(t, rc.Store(req))
+		must.NoError(t, rc.store(req))
 
 		// timeout triggers delete behind the scenes
 		waitUntilGone(t, rc, req.Nonce())
@@ -62,7 +89,7 @@ func TestRequestCache(t *testing.T) {
 				oidc.WithNonce(fmt.Sprintf("too-many-cooks-%d", i)))
 			must.NoError(t, err)
 
-			if err := rc.Store(req); err != nil {
+			if err := rc.store(req); err != nil {
 				gotErr = err
 				break
 			}

--- a/nomad/acl_endpoint.go
+++ b/nomad/acl_endpoint.go
@@ -2659,16 +2659,11 @@ func (a *ACL) OIDCAuthURL(args *structs.ACLOIDCAuthURLRequest, reply *structs.AC
 		}
 	}
 
-	// Generate our OIDC request.
-	oidcReq := a.oidcRequestCache.Load(args.ClientNonce)
-	if oidcReq == nil {
-		oidcReq, err = a.oidcRequest(args.ClientNonce, args.RedirectURI, authMethod.Config)
-		if err != nil {
-			return err
-		}
-		if err = a.oidcRequestCache.Store(oidcReq); err != nil {
-			return fmt.Errorf("error storing OIDC request: %w", err)
-		}
+	oidcReq, err := a.oidcRequestCache.LoadOrAdd(args.ClientNonce, func() (*capOIDC.Req, error) {
+		return a.oidcRequest(args.ClientNonce, args.RedirectURI, authMethod.Config)
+	})
+	if err != nil {
+		return err
 	}
 
 	// Use the cache to provide us with an OIDC provider for the auth method

--- a/nomad/acl_endpoint_test.go
+++ b/nomad/acl_endpoint_test.go
@@ -4410,6 +4410,9 @@ func TestACL_Login(t *testing.T) {
 // to prepare for a subsequent OIDCCompleteAuth call.
 func cacheOIDCRequest(t *testing.T, cache *oidc.RequestCache, req structs.ACLOIDCCompleteAuthRequest, opts ...capOIDC.Option) {
 	t.Helper()
+	// make sure the cache is clean first
+	cache.LoadAndDelete(req.ClientNonce)
+
 	opts = append(opts,
 		capOIDC.WithNonce(req.ClientNonce),
 		capOIDC.WithState(req.State),
@@ -4417,14 +4420,13 @@ func cacheOIDCRequest(t *testing.T, cache *oidc.RequestCache, req structs.ACLOID
 			return time.Now().Add(time.Minute) // expire in the future
 		}),
 	)
-	oidcReq, err := capOIDC.NewRequest(
-		time.Second, "http://127.0.0.1:4649/oidc/callback",
-		opts...,
-	)
+	_, err := cache.LoadOrAdd(req.ClientNonce, func() (*capOIDC.Req, error) {
+		return capOIDC.NewRequest(
+			time.Second, "http://127.0.0.1:4649/oidc/callback",
+			opts...,
+		)
+	})
 	must.NoError(t, err)
-	// make sure the cache is clean first
-	cache.LoadAndDelete(req.ClientNonce)
-	must.NoError(t, cache.Store(oidcReq))
 }
 
 func TestACL_ClientIntroductionToken(t *testing.T) {


### PR DESCRIPTION
The cache we use for in-flight OIDC requests uses `go-lrucache`, which has mutexes on its internal state. But the RPC handlers that use it perform multiple non-atomic operations in a single request. Concurrent requests with the same nonce can cause data races here. Authorization state is owned by the server, which prevents this data race from being used to fixate or observe this state.

But better safe than sorry, so update the request cache to perform load-or-store operations atomically.

Ref: https://hashicorp.atlassian.net/browse/SECVULN-29932


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
