### PR TITLE
dependabot: remove actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -45,16 +45,3 @@ updates:
          patterns:
            - "*"
          dependency-type: "production"
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "cron"
-      cronjob: "0 9 15 * *" # once a month, mid-month
-    labels:
-      - "theme/dependencies"
-      - "theme/build-infrastructure"
-    groups:
-      actions:
-        patterns:
-          - "*"


### PR DESCRIPTION
Removing GitHub Actions updates recently added to the dependabot configuration. If we have critical security updates, we'll get notifications on this elsewhere, and keeping on the treadmill is going to create a lot of toil we were trying to avoid.

Note: we can't backport this automatically to the ENT repo, as the dependabot config is different there.

---

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
