### PR TITLE
api: Allow tagging latest version of a job

### DIFF
--- a/.changelog/27764.txt
+++ b/.changelog/27764.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Add "latest" flag for tagging the latest version of a job
+```

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1701,18 +1701,22 @@ type JobStatusesRequest struct {
 }
 
 type TagVersionRequest struct {
-	Version     uint64
-	Description string
+	Version     uint64 // numeric version of the job to tag
+	Latest      bool   // tag the latest version of the job, if Version if zero/unset
+	Description string // description to add to the tag
 	WriteRequest
 }
 
+func (j *Jobs) TagVersionOpts(jobID, name string, req *TagVersionRequest, q *WriteOptions) (*WriteMeta, error) {
+	return j.client.put("/v1/job/"+url.PathEscape(jobID)+"/versions/"+name+"/tag", req, nil, q)
+}
+
 func (j *Jobs) TagVersion(jobID string, version uint64, name string, description string, q *WriteOptions) (*WriteMeta, error) {
-	var tagRequest = &TagVersionRequest{
+	var req = &TagVersionRequest{
 		Version:     version,
 		Description: description,
 	}
-
-	return j.client.put("/v1/job/"+url.PathEscape(jobID)+"/versions/"+name+"/tag", tagRequest, nil, q)
+	return j.TagVersionOpts(jobID, name, req, q)
 }
 
 func (j *Jobs) UntagVersion(jobID string, name string, q *WriteOptions) (*WriteMeta, error) {

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -435,6 +435,7 @@ func (s *HTTPServer) jobVersionApplyTag(resp http.ResponseWriter, req *http.Requ
 	rpcArgs := structs.JobApplyTagRequest{
 		JobID:   jobID,
 		Version: args.Version,
+		Latest:  args.Latest,
 		Name:    name,
 		Tag: &structs.JobVersionTag{
 			Name:        name,

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -2425,6 +2425,9 @@ func (j *Job) TagVersion(args *structs.JobApplyTagRequest, reply *structs.JobTag
 		return structs.ErrPermissionDenied
 	}
 
+	if args.Latest && args.Version > 0 {
+		return fmt.Errorf("version cannot be non-zero when tagging latest")
+	}
 	if args.Tag != nil {
 		args.Tag.TaggedTime = time.Now().UnixNano()
 	}

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -2426,7 +2426,7 @@ func (j *Job) TagVersion(args *structs.JobApplyTagRequest, reply *structs.JobTag
 	}
 
 	if args.Latest && args.Version > 0 {
-		return fmt.Errorf("version cannot be non-zero when tagging latest")
+		return fmt.Errorf("version must be zero when tagging latest, got: %d", args.Version)
 	}
 	if args.Tag != nil {
 		args.Tag.TaggedTime = time.Now().UnixNano()

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -8641,11 +8641,11 @@ func TestJob_TagVersion(t *testing.T) {
 	defer cleanupS1()
 	codec := rpcClient(t, s1)
 	testutil.WaitForLeader(t, s1.RPC)
-	state := s1.fsm.State()
+	store := s1.fsm.State()
 
 	job := mock.Job()
-	err := state.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
-	must.Nil(t, err)
+	err := store.UpsertJob(structs.MsgTypeTestSetup, 1000, nil, job)
+	must.NoError(t, err)
 
 	// Tag the job version
 	tagVersionReq := &structs.JobApplyTagRequest{
@@ -8661,40 +8661,59 @@ func TestJob_TagVersion(t *testing.T) {
 	}
 
 	// Expect failure for request with an invalid token
-	invalidToken := mock.CreatePolicyAndToken(t, state, 1003, "test-invalid",
+	invalidToken := mock.CreatePolicyAndToken(t, store, 1003, "test-invalid",
 		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityReadJob}))
 
 	tagVersionReq.AuthToken = invalidToken.SecretID
 	var invalidResp structs.JobTagResponse
 	err = msgpackrpc.CallWithCodec(codec, "Job.TagVersion", tagVersionReq, &invalidResp)
-	must.NotNil(t, err)
-	must.StrContains(t, err.Error(), "Permission denied")
+	must.ErrorContains(t, err, "Permission denied")
 
 	// Tagging a job with a management token should succeed
 	tagVersionReq.AuthToken = root.SecretID
 	var resp structs.JobTagResponse
 	err = msgpackrpc.CallWithCodec(codec, "Job.TagVersion", tagVersionReq, &resp)
-	must.Nil(t, err)
+	must.NoError(t, err)
 
-	// Looking up the job with a valid token should succeed
-	validToken := mock.CreatePolicyAndToken(t, state, 1005, "test-valid",
+	// Tagging the job with a valid token should succeed
+	validToken := mock.CreatePolicyAndToken(t, store, 1005, "test-valid",
 		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilitySubmitJob}))
 	tagVersionReq.AuthToken = validToken.SecretID
 	var resp2 structs.JobTagResponse
 	err = msgpackrpc.CallWithCodec(codec, "Job.TagVersion", tagVersionReq, &resp2)
-	must.Nil(t, err)
+	must.NoError(t, err)
 
-	// Looking up the job with a valid fine-grain token should succeed
-	validFineGrainToken := mock.CreatePolicyAndToken(t, state, 1005, "test-valid",
+	// Tagging the job with a valid fine-grain token should succeed
+	validFineGrainToken := mock.CreatePolicyAndToken(t, store, 1005, "test-valid",
 		mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityTagJobVersion}))
 	tagVersionReq.AuthToken = validFineGrainToken.SecretID
 	var resp3 structs.JobTagResponse
 	err = msgpackrpc.CallWithCodec(codec, "Job.TagVersion", tagVersionReq, &resp3)
-	must.Nil(t, err)
+	must.NoError(t, err)
 
 	must.Eq(t, "release", resp3.Name)
 	must.Eq(t, "Release version tag", resp3.Description)
 	must.NotNil(t, resp3.TaggedTime)
+
+	// update the job
+	job, _ = store.JobByID(nil, job.Namespace, job.ID)
+	job = job.Copy()
+	job.TaskGroups[0].Tasks[0].Resources.CPU++
+	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, 1100, nil, job))
+
+	// Tag again, this time for the latest version
+	tagVersionReq.Latest = true
+	tagVersionReq.Tag.Name = "next release"
+
+	var resp4 structs.JobTagResponse
+	err = msgpackrpc.CallWithCodec(codec, "Job.TagVersion", tagVersionReq, &resp4)
+	must.NoError(t, err)
+	must.Eq(t, "next release", resp4.Name)
+	must.Eq(t, "Release version tag", resp4.Description)
+	must.NotNil(t, resp4.TaggedTime)
+
+	job, _ = store.JobVersionByTagName(nil, job.Namespace, job.ID, resp4.Name)
+	must.Eq(t, uint64(1), job.Version)
 }
 
 func TestIntegration_SystemDeploymentHealth(t *testing.T) {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4848,6 +4848,14 @@ func (s *StateStore) updateJobStabilityImpl(index uint64, namespace, jobID strin
 func (s *StateStore) UpdateJobVersionTag(index uint64, namespace string, req *structs.JobApplyTagRequest) error {
 	jobID := req.JobID
 	jobVersion := req.Version
+	if jobVersion == 0 && req.Latest {
+		job, err := s.JobByID(nil, namespace, jobID)
+		if err != nil {
+			return err
+		}
+		jobVersion = job.Version
+	}
+
 	tag := req.Tag
 	name := req.Name
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -4536,6 +4536,7 @@ type JobApplyTagRequest struct {
 	Name    string
 	Tag     *JobVersionTag
 	Version uint64
+	Latest  bool
 	WriteRequest
 }
 


### PR DESCRIPTION
The Create Job Version Tag API is documented to tag the latest version if the version flag is omitted. Unfortunately this is only a property of the CLI, which queries the job first to get the latest version (also note this is racy with concurrent job registrations anyways). The struct we use for the API uses a uint64 and not a pointer, so we can't use the zero value of the version field to indicate the latest version either.

Add a `Latest` field on the struct which indicates that we should ignore the zero value of the `Version` field and tag the latest version instead. For backwards compatibility in the CLI, we'll keep the existing approach there for another Nomad major version.

Fixes: https://github.com/hashicorp/nomad/issues/27759

### Testing & Reproduction steps

Deploy a job, update it and deploy it again so there are two versions. Then tag the latest version:

```
$ echo '{"Latest": true, "Description": "something something"}' \
    | nomad operator api /v1/job/example/versions/foo/tag
````

Review the history:

```
$ nomad job history example
Version         = 1
Stable          = false
Submit Date     = 2026-03-26T12:28:14-04:00
Tag Name        = foo
Tag Description = something something

Version     = 0
Stable      = false
Submit Date = 2026-03-26T12:28:05-04:00
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** need to update the API docs. TBD

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
