### PR TITLE
cli: fix nomad ui namespace URL for jobs

### DIFF
--- a/command/ui.go
+++ b/command/ui.go
@@ -191,7 +191,12 @@ func (c *UiCommand) Run(args []string) int {
 		case contexts.Allocs:
 			url.Path = fmt.Sprintf("ui/allocations/%s", fullID)
 		case contexts.Jobs:
-			url.Path = fmt.Sprintf("ui/jobs/%s", fullID)
+			ns := c.clientConfig().Namespace
+			if ns != "" {
+				url.Path = fmt.Sprintf("ui/jobs/%s@%s", fullID, ns)
+			} else {
+				url.Path = fmt.Sprintf("ui/jobs/%s", fullID)
+			}
 		default:
 			c.Ui.Error(fmt.Sprintf("Unable to resolve ID: %q", id))
 			return 1


### PR DESCRIPTION
### Description

The `nomad ui` command builds job URLs with `?namespace=X` query params. The UI stopped reading that format for job detail pages. Now it expects `/ui/jobs/name@namespace`.

This change updates the `contexts.Jobs` case in `command/ui.go` to append `@namespace` to the job path when a namespace is configured. Nodes and allocs are unaffected since they don't use namespace in their URL paths.

Before: `nomad ui -namespace prod example` -> `/ui/jobs/example?namespace=prod` (404)
After: `nomad ui -namespace prod example` -> `/ui/jobs/example@prod` (resolves correctly)

The base URL namespace query param is preserved for the initial redirect, which still works.

### Testing & Reproduction steps

1. `nomad ui -show-url -namespace prod example` now outputs a URL with `example@prod` in the path
2. `go build ./command/` passes

### Links

Fixes #27758

Per @tgross's diagnosis in the issue: the UI changed to use `@namespace` in job paths (see `ui/app/models/job.js:346`), but the CLI was not updated.

### Contributor Checklist
- [ ] **Changelog Entry** 
- [x] **Testing** Existing tests pass. The identifier-based tests require a running server so can't be added to the unit test file.
- [ ] **Documentation**

This contribution was developed with AI assistance (Codex).