### PR TITLE
increase default SecretsCmdTimeout

### DIFF
--- a/.changelog/27779.txt
+++ b/.changelog/27779.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+secrets: increase secrets plugin execution timeout to 60s
+```

--- a/client/commonplugins/secrets_plugin.go
+++ b/client/commonplugins/secrets_plugin.go
@@ -21,7 +21,7 @@ const (
 	SecretsPluginDir = "secrets"
 
 	// The timeout for the plugin command before it is send SIGTERM
-	SecretsCmdTimeout = 10 * time.Second
+	SecretsCmdTimeout = 60 * time.Second
 
 	// The timeout before the command is sent SIGKILL after being SIGTERM'd
 	SecretsKillTimeout = 2 * time.Second


### PR DESCRIPTION
 #27618 prompted me to share a small design memo around implementing the configuration options proposed in our internal CPI RFC (NMD-02).  The decision to increase the default timeout instead of implementing configuration was an option that grew out of our discussion of that memo.

This PR just increases the default time from 10s -> 60s.



refs:
jira: https://hashicorp.atlassian.net/browse/NMD-1276
gh issue: https://github.com/hashicorp/nomad/issues/27618
docs pr: https://github.com/hashicorp/web-unified-docs/pull/2119

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
