### PR TITLE
drivers: improve error message when executor process crashes

### DIFF
--- a/drivers/exec/driver.go
+++ b/drivers/exec/driver.go
@@ -592,14 +592,18 @@ func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *dr
 	var result *drivers.ExitResult
 	ps, err := handle.exec.Wait(ctx)
 	if err != nil {
-		result = &drivers.ExitResult{
-			Err: fmt.Errorf("executor: error waiting on process: %v", err),
-		}
-		// if process state is nil, we've probably been killed, so return a reasonable
-		// exit state to the handlers
+		// if process state is nil, the executor process likely crashed or was
+		// killed (e.g. OOM). Wrap the raw RPC error with a clearer message.
 		if ps == nil {
-			result.ExitCode = -1
-			result.OOMKilled = false
+			result = &drivers.ExitResult{
+				Err:       fmt.Errorf("executor: the executor process terminated unexpectedly: %v", err),
+				ExitCode:  -1,
+				OOMKilled: false,
+			}
+		} else {
+			result = &drivers.ExitResult{
+				Err: fmt.Errorf("executor: error waiting on process: %v", err),
+			}
 		}
 	} else {
 		result = &drivers.ExitResult{

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -601,14 +601,18 @@ func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *dr
 	var result *drivers.ExitResult
 	ps, err := handle.exec.Wait(ctx)
 	if err != nil {
-		result = &drivers.ExitResult{
-			Err: fmt.Errorf("executor: error waiting on process: %v", err),
-		}
-		// if process state is nil, we've probably been killed, so return a reasonable
-		// exit state to the handlers
+		// if process state is nil, the executor process likely crashed or was
+		// killed (e.g. OOM). Wrap the raw RPC error with a clearer message.
 		if ps == nil {
-			result.ExitCode = -1
-			result.OOMKilled = false
+			result = &drivers.ExitResult{
+				Err:       fmt.Errorf("executor: the executor process terminated unexpectedly: %v", err),
+				ExitCode:  -1,
+				OOMKilled: false,
+			}
+		} else {
+			result = &drivers.ExitResult{
+				Err: fmt.Errorf("executor: error waiting on process: %v", err),
+			}
 		}
 	} else {
 		result = &drivers.ExitResult{

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -831,14 +831,18 @@ func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *dr
 	var result *drivers.ExitResult
 	ps, err := handle.exec.Wait(ctx)
 	if err != nil {
-		result = &drivers.ExitResult{
-			Err: fmt.Errorf("executor: error waiting on process: %v", err),
-		}
-		// if process state is nil, we've probably been killed, so return a reasonable
-		// exit state to the handlers
+		// if process state is nil, the executor process likely crashed or was
+		// killed (e.g. OOM). Wrap the raw RPC error with a clearer message.
 		if ps == nil {
-			result.ExitCode = -1
-			result.OOMKilled = false
+			result = &drivers.ExitResult{
+				Err:       fmt.Errorf("executor: the executor process terminated unexpectedly: %v", err),
+				ExitCode:  -1,
+				OOMKilled: false,
+			}
+		} else {
+			result = &drivers.ExitResult{
+				Err: fmt.Errorf("executor: error waiting on process: %v", err),
+			}
 		}
 	} else {
 		result = &drivers.ExitResult{

--- a/drivers/rawexec/driver.go
+++ b/drivers/rawexec/driver.go
@@ -498,14 +498,18 @@ func (d *Driver) handleWait(ctx context.Context, handle *taskHandle, ch chan *dr
 	var result *drivers.ExitResult
 	ps, err := handle.exec.Wait(ctx)
 	if err != nil {
-		result = &drivers.ExitResult{
-			Err: fmt.Errorf("executor: error waiting on process: %v", err),
-		}
-		// if process state is nil, we've probably been killed, so return a reasonable
-		// exit state to the handlers
+		// if process state is nil, the executor process likely crashed or was
+		// killed (e.g. OOM). Wrap the raw RPC error with a clearer message.
 		if ps == nil {
-			result.ExitCode = -1
-			result.OOMKilled = false
+			result = &drivers.ExitResult{
+				Err:       fmt.Errorf("executor: the executor process terminated unexpectedly: %v", err),
+				ExitCode:  -1,
+				OOMKilled: false,
+			}
+		} else {
+			result = &drivers.ExitResult{
+				Err: fmt.Errorf("executor: error waiting on process: %v", err),
+			}
 		}
 	} else {
 		result = &drivers.ExitResult{


### PR DESCRIPTION
## Summary

When the executor process terminates unexpectedly (OOM killed, crash, etc.), the task event shows a raw gRPC error that's confusing for operators. This changes the error message to clearly indicate the executor crashed.

## Changes

Updated `handleWait` in all four task drivers (`exec`, `rawexec`, `java`, `qemu`) to provide different error messages depending on whether the executor process returned a process state:

- **Process state is nil** (executor crashed): "executor: the executor process terminated unexpectedly: ..."
- **Process state available** (normal error): "executor: error waiting on process: ..." (unchanged)

Before:
```
Exit Message: "executor: error waiting on process: rpc error: code = Unavailable desc = error reading from server: read tcp 127.0.0.1:50900->127.0.0.1:14000: wsarecv: An existing connection was forcibly closed by the remote host."
```

After:
```
Exit Message: "executor: the executor process terminated unexpectedly: rpc error: code = Unavailable desc = ..."
```

The raw error is still included for debugging, but the prefix now tells operators what actually happened instead of exposing internal RPC details as the primary message.

## Testing

The logic change is a conditional branch on the existing `ps == nil` check (which was already there for setting exit code). The error wrapping is unchanged, just the message prefix when the executor is confirmed dead.

Fixes #24220

This contribution was developed with AI assistance (Claude Code).