### PR TITLE
core: timeouts for batch jobs

### DIFF
--- a/.changelog/27803.txt
+++ b/.changelog/27803.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: timeouts for batch jobs
+```

--- a/.changelog/27803.txt
+++ b/.changelog/27803.txt
@@ -1,3 +1,3 @@
-```release-note:improvement
+```release-note:feature
 core: timeouts for batch jobs
 ```

--- a/.changelog/27913.txt
+++ b/.changelog/27913.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-cli: display job deadline if present
-```

--- a/.changelog/27913.txt
+++ b/.changelog/27913.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: display job deadline if present
+```

--- a/.changelog/27914.txt
+++ b/.changelog/27914.txt
@@ -1,3 +1,0 @@
-```release-note:improvement
-ui: display job deadline if present
-```

--- a/.changelog/27914.txt
+++ b/.changelog/27914.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+ui: display job deadline if present
+```

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -507,6 +507,7 @@ type TaskGroup struct {
 	Meta             map[string]string         `hcl:"meta,block"`
 	Services         []*Service                `hcl:"service,block"`
 	ShutdownDelay    *time.Duration            `mapstructure:"shutdown_delay" hcl:"shutdown_delay,optional"`
+	MaxRunDuration   *time.Duration            `mapstructure:"max_run_duration" hcl:"max_run_duration,optional"`
 	// Deprecated: StopAfterClientDisconnect is deprecated in Nomad 1.8 and ignored in Nomad 1.10. Use Disconnect.StopOnClientAfter.
 	StopAfterClientDisconnect *time.Duration `mapstructure:"stop_after_client_disconnect" hcl:"stop_after_client_disconnect,optional"`
 	// Deprecated: MaxClientDisconnect is deprecated in Nomad 1.8.0 and ignored in Nomad 1.10. Use Disconnect.LostAfter.

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -737,8 +737,14 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 			return nil
 		}
 
-		return structs.NewTaskEvent(structs.TaskKilling).
+		event := structs.NewTaskEvent(structs.TaskKilling).
 			SetKillTimeout(tr.Task().KillTimeout, ar.clientConfig.MaxKillTimeout)
+
+		if ar.state.MaxRunDurationExceeded {
+			event.SetDisplayMessage(structs.AllocTimeoutReasonMaxRunDuration)
+		}
+
+		return event
 	}
 
 	// Kill leader first, synchronously
@@ -809,6 +815,23 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 	}
 	wg.Wait()
 
+	// Skip poststop tasks entirely when max_run_duration has been exceeded so
+	// they are not started after the allocation has timed out.
+	if ar.state.MaxRunDurationExceeded {
+		for name, tr := range ar.tasks {
+			if !tr.IsPoststopTask() {
+				continue
+			}
+
+			state := tr.TaskState()
+			if state != nil {
+				states[name] = state
+			}
+		}
+
+		return states
+	}
+
 	// Perform no action on post stop tasks, but retain their states if they exist. This
 	// commonly happens at the time of alloc GC from the client node.
 	for name, tr := range ar.tasks {
@@ -845,7 +868,10 @@ func (ar *allocRunner) clientAlloc(taskStates map[string]*structs.TaskState) *st
 	}
 
 	// Compute the ClientStatus
-	if ar.state.ClientStatus != "" {
+	if ar.state.MaxRunDurationExceeded {
+		a.ClientStatus = structs.AllocClientStatusComplete
+		a.ClientDescription = structs.AllocTimeoutReasonMaxRunDuration
+	} else if ar.state.ClientStatus != "" {
 		// The client status is being forced
 		a.ClientStatus, a.ClientDescription = ar.state.ClientStatus, ar.state.ClientDescription
 	} else {
@@ -983,7 +1009,7 @@ func (ar *allocRunner) AllocState() *state.State {
 	// If TaskStateUpdated has not been called yet, ar.state.TaskStates
 	// won't be set as it is not the canonical source of TaskStates.
 	if len(state.TaskStates) == 0 {
-		ar.state.TaskStates = make(map[string]*structs.TaskState, len(ar.tasks))
+		state.TaskStates = make(map[string]*structs.TaskState, len(ar.tasks))
 		for k, tr := range ar.tasks {
 			state.TaskStates[k] = tr.TaskState()
 		}
@@ -1079,6 +1105,27 @@ func (ar *allocRunner) handleAllocUpdate(update *structs.Allocation) {
 
 func (ar *allocRunner) Listener() *cstructs.AllocListener {
 	return ar.allocBroadcaster.Listen()
+}
+
+func (ar *allocRunner) EnforceMaxRunDurationTimeout(deadline time.Time) {
+	now := time.Now()
+
+	if ar.isShuttingDown() {
+		return
+	}
+
+	if now.Before(deadline) {
+		return
+	}
+
+	ar.stateLock.Lock()
+	ar.state.MaxRunDurationExceeded = true
+	ar.state.ClientStatus = structs.AllocClientStatusComplete
+	ar.state.ClientDescription = structs.AllocTimeoutReasonMaxRunDuration
+	ar.stateLock.Unlock()
+
+	ar.logger.Debug("allocation exceeded max_run_duration, killing tasks", "deadline", deadline)
+	ar.killTasks()
 }
 
 func (ar *allocRunner) destroyImpl() {
@@ -1255,8 +1302,8 @@ func (ar *allocRunner) Shutdown() {
 	go func() {
 		ar.logger.Trace("shutting down")
 
-		// Shutdown tasks gracefully if they were run
-		wg := sync.WaitGroup{}
+		// Shutdown task runners
+		var wg sync.WaitGroup
 		for _, tr := range ar.tasks {
 			wg.Add(1)
 			go func(tr *taskrunner.TaskRunner) {

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -111,13 +111,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 	ar.runnerHooks = []interfaces.RunnerHook{
 		newIdentityHook(hookLogger, ar.widmgr),
 		newAllocDirHook(hookLogger, ar.allocDir),
-		newMaxRunDurationHook(hookLogger, alloc, ar.clientBaseLabels, ar.EnforceMaxRunDurationTimeout, func() map[string]*structs.TaskState {
-			states := make(map[string]*structs.TaskState, len(ar.tasks))
-			for name, tr := range ar.tasks {
-				states[name] = tr.TaskState()
-			}
-			return states
-		}),
+		newMaxRunDurationHook(hookLogger, alloc, ar.clientBaseLabels, ar.EnforceMaxRunDurationTimeout),
 		newConsulHook(consulHookConfig{
 			alloc:                   ar.alloc,
 			allocdir:                ar.allocDir,

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -111,7 +111,13 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 	ar.runnerHooks = []interfaces.RunnerHook{
 		newIdentityHook(hookLogger, ar.widmgr),
 		newAllocDirHook(hookLogger, ar.allocDir),
-		newMaxRunDurationHook(hookLogger, alloc, ar.clientBaseLabels, ar.EnforceMaxRunDurationTimeout),
+		newMaxRunDurationHook(hookLogger, alloc, ar.clientBaseLabels, ar.EnforceMaxRunDurationTimeout, func() map[string]*structs.TaskState {
+			states := make(map[string]*structs.TaskState, len(ar.tasks))
+			for name, tr := range ar.tasks {
+				states[name] = tr.TaskState()
+			}
+			return states
+		}),
 		newConsulHook(consulHookConfig{
 			alloc:                   ar.alloc,
 			allocdir:                ar.allocDir,

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -111,6 +111,7 @@ func (ar *allocRunner) initRunnerHooks(config *clientconfig.Config) error {
 	ar.runnerHooks = []interfaces.RunnerHook{
 		newIdentityHook(hookLogger, ar.widmgr),
 		newAllocDirHook(hookLogger, ar.allocDir),
+		newMaxRunDurationHook(hookLogger, alloc, ar.clientBaseLabels, ar.EnforceMaxRunDurationTimeout),
 		newConsulHook(consulHookConfig{
 			alloc:                   ar.alloc,
 			allocdir:                ar.allocDir,

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -501,6 +501,7 @@ func TestAllocRunner_MaxRunDuration_SkipsPoststopTasks(t *testing.T) {
 	ci.Parallel(t)
 
 	alloc := mock.LifecycleAlloc()
+	alloc.CreateTime = time.Now().UnixNano()
 	tr := alloc.AllocatedResources.Tasks[alloc.Job.TaskGroups[0].Tasks[0].Name]
 
 	alloc.Job.Type = structs.JobTypeBatch
@@ -2769,6 +2770,7 @@ func TestAllocRunner_MaxRunDuration_StopsExpiredAlloc(t *testing.T) {
 	ci.Parallel(t)
 
 	alloc := mock.BatchAlloc()
+	alloc.CreateTime = time.Now().UnixNano()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
 	task.Config = map[string]interface{}{
@@ -2813,6 +2815,7 @@ func TestAllocRunner_MaxRunDuration_UpdateExtendsRunningAlloc(t *testing.T) {
 	ci.Parallel(t)
 
 	alloc := mock.BatchAlloc()
+	alloc.CreateTime = time.Now().UnixNano()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
 	task.Config = map[string]interface{}{
@@ -2820,7 +2823,11 @@ func TestAllocRunner_MaxRunDuration_UpdateExtendsRunningAlloc(t *testing.T) {
 	}
 	task.KillTimeout = 10 * time.Millisecond
 
-	initialMaxRunDuration := 75 * time.Millisecond
+	// Scale timings with TestMultiplier so the test is reliable on slow CI
+	// environments. The deadline is anchored to CreateTime (set above), so we
+	// need the update to land well before the initial deadline fires.
+	m := time.Duration(testutil.TestMultiplier())
+	initialMaxRunDuration := m * 250 * time.Millisecond
 	alloc.Job.TaskGroups[0].MaxRunDuration = &initialMaxRunDuration
 
 	conf, cleanup := testAllocRunnerConfig(t, alloc)
@@ -2847,15 +2854,18 @@ func TestAllocRunner_MaxRunDuration_UpdateExtendsRunningAlloc(t *testing.T) {
 		t.Fatalf("timed out waiting for alloc runner to start: %v; state=%#v", err, state)
 	})
 
-	time.Sleep(40 * time.Millisecond)
+	// Apply the update well before initialMaxRunDuration elapses from CreateTime.
+	time.Sleep(m * 100 * time.Millisecond)
 
 	updatedAlloc := ar.Alloc().Copy()
 	updatedAlloc.AllocModifyIndex++
-	updatedMaxRunDuration := 200 * time.Millisecond
+	updatedMaxRunDuration := initialMaxRunDuration * 4
 	updatedAlloc.Job.TaskGroups[0].MaxRunDuration = &updatedMaxRunDuration
 	ar.Update(updatedAlloc)
 
-	time.Sleep(60 * time.Millisecond)
+	// Sleep past the original deadline. The alloc should still be running
+	// because the update extended the deadline to initialMaxRunDuration*4.
+	time.Sleep(initialMaxRunDuration)
 
 	state := ar.AllocState()
 	must.NotNil(t, state)

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -497,6 +497,95 @@ func TestAllocRunner_Lifecycle_Poststop(t *testing.T) {
 
 }
 
+func TestAllocRunner_MaxRunDuration_SkipsPoststopTasks(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.LifecycleAlloc()
+	tr := alloc.AllocatedResources.Tasks[alloc.Job.TaskGroups[0].Tasks[0].Name]
+
+	alloc.Job.Type = structs.JobTypeBatch
+	maxRunDuration := 50 * time.Millisecond
+	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+
+	mainTask := alloc.Job.TaskGroups[0].Tasks[0]
+	mainTask.Config["run_for"] = "100s"
+	mainTask.KillTimeout = 10 * time.Millisecond
+
+	poststopTask := alloc.Job.TaskGroups[0].Tasks[1]
+	poststopTask.Name = "poststop"
+	poststopTask.Lifecycle.Hook = structs.TaskLifecycleHookPoststop
+	poststopTask.Config["run_for"] = "10s"
+
+	alloc.Job.TaskGroups[0].Tasks = []*structs.Task{mainTask, poststopTask}
+	alloc.AllocatedResources.Tasks = map[string]*structs.AllocatedTaskResources{
+		mainTask.Name:     tr,
+		poststopTask.Name: tr,
+	}
+
+	conf, cleanup := testAllocRunnerConfig(t, alloc)
+	defer cleanup()
+
+	arIface, err := NewAllocRunner(conf)
+	must.NoError(t, err)
+	ar := arIface.(*allocRunner)
+
+	go ar.Run()
+	defer destroy(ar)
+
+	upd := conf.StateUpdater.(*MockStateUpdater)
+
+	testutil.WaitForResult(func() (bool, error) {
+		last := upd.Last()
+		if last == nil {
+			return false, fmt.Errorf("no updates")
+		}
+
+		if last.ClientStatus != structs.AllocClientStatusRunning {
+			return false, fmt.Errorf("expected alloc to be running not %s", last.ClientStatus)
+		}
+
+		if s := last.TaskStates[mainTask.Name].State; s != structs.TaskStateRunning {
+			return false, fmt.Errorf("expected main task to be running not %s", s)
+		}
+
+		if s := last.TaskStates[poststopTask.Name].State; s != structs.TaskStatePending {
+			return false, fmt.Errorf("expected poststop task to be pending not %s", s)
+		}
+
+		return true, nil
+	}, func(err error) {
+		t.Fatalf("error waiting for initial state:\n%v", err)
+	})
+
+	testutil.WaitForResult(func() (bool, error) {
+		last := upd.Last()
+		if last == nil {
+			return false, fmt.Errorf("no updates")
+		}
+
+		if last.ClientStatus != structs.AllocClientStatusComplete {
+			return false, fmt.Errorf("expected alloc to be complete not %s", last.ClientStatus)
+		}
+
+		if last.ClientDescription != structs.AllocTimeoutReasonMaxRunDuration {
+			return false, fmt.Errorf("expected alloc description %q not %q", structs.AllocTimeoutReasonMaxRunDuration, last.ClientDescription)
+		}
+
+		if s := last.TaskStates[mainTask.Name].State; s != structs.TaskStateDead {
+			return false, fmt.Errorf("expected main task to be dead not %s", s)
+		}
+
+		if s := last.TaskStates[poststopTask.Name].State; s != structs.TaskStatePending {
+			return false, fmt.Errorf("expected poststop task to remain pending not %s", s)
+		}
+
+		return true, nil
+	}, func(err error) {
+		last := upd.Last()
+		t.Fatalf("error waiting for max_run_duration state:\n%v\nlast=%#v", err, last)
+	})
+}
+
 func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 	ci.Parallel(t)
 
@@ -2674,6 +2763,124 @@ func TestAllocRunner_GetUpdatePriority(t *testing.T) {
 	ar.SetClientStatus(structs.AllocClientStatusFailed)
 	calloc = ar.clientAlloc(map[string]*structs.TaskState{})
 	must.Eq(t, cstructs.AllocUpdatePriorityUrgent, ar.GetUpdatePriority(calloc))
+}
+
+func TestAllocRunner_MaxRunDuration_StopsExpiredAlloc(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Driver = "mock_driver"
+	task.Config = map[string]interface{}{
+		"run_for": "10s",
+	}
+	task.KillTimeout = 10 * time.Millisecond
+	maxRunDuration := 50 * time.Millisecond
+	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+
+	conf, cleanup := testAllocRunnerConfig(t, alloc)
+	defer cleanup()
+
+	arIface, err := NewAllocRunner(conf)
+	must.NoError(t, err)
+	ar := arIface.(*allocRunner)
+
+	go ar.Run()
+	defer destroy(ar)
+
+	testutil.WaitForResult(func() (bool, error) {
+		state := ar.AllocState()
+		if state == nil {
+			return false, fmt.Errorf("no alloc state")
+		}
+		if state.ClientStatus != structs.AllocClientStatusComplete {
+			return false, fmt.Errorf("got status %v; want %v", state.ClientStatus, structs.AllocClientStatusComplete)
+		}
+		if state.ClientDescription != structs.AllocTimeoutReasonMaxRunDuration {
+			return false, fmt.Errorf("got description %q; want %q", state.ClientDescription, structs.AllocTimeoutReasonMaxRunDuration)
+		}
+		if !state.MaxRunDurationExceeded {
+			return false, fmt.Errorf("max run duration was not marked exceeded")
+		}
+		return true, nil
+	}, func(err error) {
+		state := ar.AllocState()
+		t.Fatalf("timed out waiting for alloc runner max_run_duration enforcement: %v; state=%#v", err, state)
+	})
+}
+
+func TestAllocRunner_MaxRunDuration_UpdateExtendsRunningAlloc(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Driver = "mock_driver"
+	task.Config = map[string]interface{}{
+		"run_for": "10s",
+	}
+	task.KillTimeout = 10 * time.Millisecond
+
+	initialMaxRunDuration := 75 * time.Millisecond
+	alloc.Job.TaskGroups[0].MaxRunDuration = &initialMaxRunDuration
+
+	conf, cleanup := testAllocRunnerConfig(t, alloc)
+	defer cleanup()
+
+	arIface, err := NewAllocRunner(conf)
+	must.NoError(t, err)
+	ar := arIface.(*allocRunner)
+
+	go ar.Run()
+	defer destroy(ar)
+
+	testutil.WaitForResult(func() (bool, error) {
+		state := ar.AllocState()
+		if state == nil {
+			return false, fmt.Errorf("no alloc state")
+		}
+		if state.ClientStatus != structs.AllocClientStatusRunning {
+			return false, fmt.Errorf("got status %v; want %v", state.ClientStatus, structs.AllocClientStatusRunning)
+		}
+		return true, nil
+	}, func(err error) {
+		state := ar.AllocState()
+		t.Fatalf("timed out waiting for alloc runner to start: %v; state=%#v", err, state)
+	})
+
+	time.Sleep(40 * time.Millisecond)
+
+	updatedAlloc := ar.Alloc().Copy()
+	updatedAlloc.AllocModifyIndex++
+	updatedMaxRunDuration := 200 * time.Millisecond
+	updatedAlloc.Job.TaskGroups[0].MaxRunDuration = &updatedMaxRunDuration
+	ar.Update(updatedAlloc)
+
+	time.Sleep(60 * time.Millisecond)
+
+	state := ar.AllocState()
+	must.NotNil(t, state)
+	must.False(t, state.MaxRunDurationExceeded)
+	must.Eq(t, structs.AllocClientStatusRunning, state.ClientStatus)
+
+	testutil.WaitForResult(func() (bool, error) {
+		state := ar.AllocState()
+		if state == nil {
+			return false, fmt.Errorf("no alloc state")
+		}
+		if state.ClientStatus != structs.AllocClientStatusComplete {
+			return false, fmt.Errorf("got status %v; want %v", state.ClientStatus, structs.AllocClientStatusComplete)
+		}
+		if state.ClientDescription != structs.AllocTimeoutReasonMaxRunDuration {
+			return false, fmt.Errorf("got description %q; want %q", state.ClientDescription, structs.AllocTimeoutReasonMaxRunDuration)
+		}
+		if !state.MaxRunDurationExceeded {
+			return false, fmt.Errorf("max run duration was not marked exceeded")
+		}
+		return true, nil
+	}, func(err error) {
+		state := ar.AllocState()
+		t.Fatalf("timed out waiting for alloc runner max_run_duration enforcement after update: %v; state=%#v", err, state)
+	})
 }
 
 func TestAllocRunner_setHookStatsHandler(t *testing.T) {

--- a/client/allocrunner/max_run_duration_hook.go
+++ b/client/allocrunner/max_run_duration_hook.go
@@ -96,6 +96,7 @@ func (h *maxRunDurationHook) resetTimer() {
 		return
 	}
 
+	// Only reset timer if the max run duration has changed
 	if h.hasMaxRunDuration && h.maxRunDuration == maxRunDuration && h.deadline.Equal(deadline) {
 		return
 	}

--- a/client/allocrunner/max_run_duration_hook.go
+++ b/client/allocrunner/max_run_duration_hook.go
@@ -1,0 +1,213 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+package allocrunner
+
+import (
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	metrics "github.com/hashicorp/go-metrics/compat"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/client/taskenv"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+var (
+	_ interfaces.RunnerPrerunHook  = (*maxRunDurationHook)(nil)
+	_ interfaces.RunnerPostrunHook = (*maxRunDurationHook)(nil)
+	_ interfaces.RunnerUpdateHook  = (*maxRunDurationHook)(nil)
+	_ interfaces.ShutdownHook      = (*maxRunDurationHook)(nil)
+)
+
+type maxRunDurationHook struct {
+	mu sync.Mutex
+
+	alloc *structs.Allocation
+
+	timer             *time.Timer
+	deadline          time.Time
+	maxRunDuration    time.Duration
+	hasMaxRunDuration bool
+
+	onTimeout  func(time.Time)
+	logger     hclog.Logger
+	baseLabels []metrics.Label
+}
+
+func newMaxRunDurationHook(
+	logger hclog.Logger,
+	alloc *structs.Allocation,
+	baseLabels []metrics.Label,
+	onTimeout func(time.Time),
+) interfaces.RunnerHook {
+	return &maxRunDurationHook{
+		alloc:      alloc,
+		onTimeout:  onTimeout,
+		logger:     logger.Named("max_run_duration"),
+		baseLabels: baseLabels,
+	}
+}
+
+func (h *maxRunDurationHook) Name() string {
+	return "max_run_duration"
+}
+
+func (h *maxRunDurationHook) Prerun(*taskenv.TaskEnv) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.resetTimer()
+	return nil
+}
+
+func (h *maxRunDurationHook) Update(req *interfaces.RunnerUpdateRequest) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.alloc = req.Alloc
+	h.resetTimer()
+	return nil
+}
+
+func (h *maxRunDurationHook) Postrun() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.stopTimer()
+	return nil
+}
+
+func (h *maxRunDurationHook) Shutdown() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.stopTimer()
+}
+
+func (h *maxRunDurationHook) resetTimer() {
+	deadline, maxRunDuration, ok := h.currentDeadline()
+	if !ok {
+		h.stopTimer()
+		h.deadline = time.Time{}
+		h.maxRunDuration = 0
+		h.hasMaxRunDuration = false
+		return
+	}
+
+	if h.hasMaxRunDuration && h.maxRunDuration == maxRunDuration && h.deadline.Equal(deadline) {
+		return
+	}
+
+	prevMaxRunDuration := h.maxRunDuration
+	prevDeadline := h.deadline
+	hadMaxRunDuration := h.hasMaxRunDuration
+
+	h.stopTimer()
+
+	h.maxRunDuration = maxRunDuration
+	h.hasMaxRunDuration = true
+	h.deadline = deadline
+	h.emitMetrics(maxRunDuration, deadline)
+
+	remaining := time.Until(deadline)
+
+	if hadMaxRunDuration {
+		h.logger.Debug("updated max_run_duration",
+			"task_group", h.alloc.TaskGroup,
+			"old_configured", prevMaxRunDuration,
+			"new_configured", maxRunDuration,
+			"old_deadline", prevDeadline,
+			"new_deadline", deadline,
+			"remaining", remaining,
+		)
+	}
+
+	if remaining <= 0 {
+		h.logger.Debug("allocation exceeded max_run_duration, enforcing immediately",
+			"task_group", h.alloc.TaskGroup,
+			"configured", maxRunDuration,
+			"remaining", remaining,
+			"deadline", deadline,
+		)
+		go h.onTimeout(deadline)
+		return
+	}
+
+	timer := time.NewTimer(remaining)
+	h.timer = timer
+
+	h.logger.Trace("armed max_run_duration timer",
+		"task_group", h.alloc.TaskGroup,
+		"configured", maxRunDuration,
+		"remaining", remaining,
+		"deadline", deadline,
+	)
+
+	go func(t *time.Timer, deadline time.Time) {
+		<-t.C
+
+		h.mu.Lock()
+		if h.timer != t {
+			h.mu.Unlock()
+			return
+		}
+		h.timer = nil
+		h.mu.Unlock()
+
+		h.onTimeout(deadline)
+	}(timer, deadline)
+}
+
+func (h *maxRunDurationHook) stopTimer() {
+	if h.timer == nil {
+		return
+	}
+
+	if !h.timer.Stop() {
+		select {
+		case <-h.timer.C:
+		default:
+		}
+	}
+
+	h.timer = nil
+}
+
+func (h *maxRunDurationHook) emitMetrics(maxRunDuration time.Duration, deadline time.Time) {
+	labels := h.baseLabels
+	labels = append(labels, metrics.Label{Name: "task_group", Value: h.alloc.TaskGroup})
+
+	metrics.SetGaugeWithLabels(
+		[]string{"client", "allocs", "max_run_duration", "configured_seconds"},
+		float32(maxRunDuration.Seconds()),
+		labels,
+	)
+	metrics.SetGaugeWithLabels(
+		[]string{"client", "allocs", "max_run_duration", "remaining_seconds"},
+		float32(time.Until(deadline).Seconds()),
+		labels,
+	)
+}
+
+func (h *maxRunDurationHook) currentDeadline() (time.Time, time.Duration, bool) {
+	if h.alloc.TerminalStatus() {
+		return time.Time{}, 0, false
+	}
+
+	if h.alloc.DesiredStatus != "" && h.alloc.DesiredStatus != structs.AllocDesiredStatusRun {
+		return time.Time{}, 0, false
+	}
+
+	maxRunDuration, ok := h.alloc.MaxRunDuration()
+	if !ok {
+		return time.Time{}, 0, false
+	}
+
+	if deadline, ok := h.alloc.MaxRunDurationDeadline(); ok {
+		return deadline, maxRunDuration, true
+	}
+
+	return time.Now().Add(maxRunDuration), maxRunDuration, true
+}

--- a/client/allocrunner/max_run_duration_hook.go
+++ b/client/allocrunner/max_run_duration_hook.go
@@ -31,9 +31,16 @@ type maxRunDurationHook struct {
 	maxRunDuration    time.Duration
 	hasMaxRunDuration bool
 
-	onTimeout  func(time.Time)
-	logger     hclog.Logger
+	onTimeout func(time.Time)
+	logger    hclog.Logger
+
 	baseLabels []metrics.Label
+
+	// taskStatesFn returns task states directly from the task runners.
+	// It is used to reconstruct the countdown deadline after a client restart,
+	// when the server-side allocation's TaskStates may be absent or stale but
+	// each task runner's persisted state still holds the original StartedAt.
+	taskStatesFn func() map[string]*structs.TaskState
 }
 
 func newMaxRunDurationHook(
@@ -41,12 +48,14 @@ func newMaxRunDurationHook(
 	alloc *structs.Allocation,
 	baseLabels []metrics.Label,
 	onTimeout func(time.Time),
+	taskStatesFn func() map[string]*structs.TaskState,
 ) interfaces.RunnerHook {
 	return &maxRunDurationHook{
-		alloc:      alloc,
-		onTimeout:  onTimeout,
-		logger:     logger.Named("max_run_duration"),
-		baseLabels: baseLabels,
+		alloc:        alloc,
+		onTimeout:    onTimeout,
+		logger:       logger.Named("max_run_duration"),
+		baseLabels:   baseLabels,
+		taskStatesFn: taskStatesFn,
 	}
 }
 
@@ -96,8 +105,10 @@ func (h *maxRunDurationHook) resetTimer() {
 		return
 	}
 
-	// Only reset timer if the max run duration has changed
-	if h.hasMaxRunDuration && h.maxRunDuration == maxRunDuration && h.deadline.Equal(deadline) {
+	// if the duration hasn't changed the timer is already correctly armed —
+	// skip it. The deadline can never move earlier with the same duration
+	// (StartedAt only advances, and time.Now() only advances).
+	if h.hasMaxRunDuration && h.maxRunDuration == maxRunDuration {
 		return
 	}
 
@@ -206,9 +217,19 @@ func (h *maxRunDurationHook) currentDeadline() (time.Time, time.Duration, bool) 
 		return time.Time{}, 0, false
 	}
 
-	if deadline, ok := h.alloc.MaxRunDurationDeadline(); ok {
-		return deadline, maxRunDuration, true
+	// if task runners report that every task has started at least once, use
+	// their StartedAt timestamps to reconstruct the original deadline.
+	//
+	// Note: the resetTimer guard above ensures this can never *extend* a
+	// deadline that was already established, so a slow-starting task cannot
+	// gain extra time by eventually setting StartedAt.
+	if h.taskStatesFn != nil {
+		if startedAt, ok := structs.FullyStartedSince(h.taskStatesFn()); ok {
+			return startedAt.Add(maxRunDuration), maxRunDuration, true
+		}
 	}
 
+	// No task has started yet (fresh alloc). Anchor the deadline to now so
+	// that pre-start time counts against the budget.
 	return time.Now().Add(maxRunDuration), maxRunDuration, true
 }

--- a/client/allocrunner/max_run_duration_hook.go
+++ b/client/allocrunner/max_run_duration_hook.go
@@ -35,12 +35,6 @@ type maxRunDurationHook struct {
 	logger    hclog.Logger
 
 	baseLabels []metrics.Label
-
-	// taskStatesFn returns task states directly from the task runners.
-	// It is used to reconstruct the countdown deadline after a client restart,
-	// when the server-side allocation's TaskStates may be absent or stale but
-	// each task runner's persisted state still holds the original StartedAt.
-	taskStatesFn func() map[string]*structs.TaskState
 }
 
 func newMaxRunDurationHook(
@@ -48,14 +42,12 @@ func newMaxRunDurationHook(
 	alloc *structs.Allocation,
 	baseLabels []metrics.Label,
 	onTimeout func(time.Time),
-	taskStatesFn func() map[string]*structs.TaskState,
 ) interfaces.RunnerHook {
 	return &maxRunDurationHook{
-		alloc:        alloc,
-		onTimeout:    onTimeout,
-		logger:       logger.Named("max_run_duration"),
-		baseLabels:   baseLabels,
-		taskStatesFn: taskStatesFn,
+		alloc:      alloc,
+		onTimeout:  onTimeout,
+		logger:     logger.Named("max_run_duration"),
+		baseLabels: baseLabels,
 	}
 }
 
@@ -106,8 +98,8 @@ func (h *maxRunDurationHook) resetTimer() {
 	}
 
 	// if the duration hasn't changed the timer is already correctly armed —
-	// skip it. The deadline can never move earlier with the same duration
-	// (StartedAt only advances, and time.Now() only advances).
+	// skip it. The deadline is deterministically CreateTime + duration, so it
+	// cannot change as long as the configured duration hasn't changed.
 	if h.hasMaxRunDuration && h.maxRunDuration == maxRunDuration {
 		return
 	}
@@ -217,19 +209,12 @@ func (h *maxRunDurationHook) currentDeadline() (time.Time, time.Duration, bool) 
 		return time.Time{}, 0, false
 	}
 
-	// if task runners report that every task has started at least once, use
-	// their StartedAt timestamps to reconstruct the original deadline.
-	//
-	// Note: the resetTimer guard above ensures this can never *extend* a
-	// deadline that was already established, so a slow-starting task cannot
-	// gain extra time by eventually setting StartedAt.
-	if h.taskStatesFn != nil {
-		if startedAt, ok := structs.FullyStartedSince(h.taskStatesFn()); ok {
-			return startedAt.Add(maxRunDuration), maxRunDuration, true
-		}
+	// The deadline is always anchored to the allocation's CreateTime. This is
+	// stable across client restarts, task retries, and any other events that
+	// would change individual task-level timestamps such as StartedAt.
+	if h.alloc.CreateTime == 0 {
+		return time.Time{}, 0, false
 	}
 
-	// No task has started yet (fresh alloc). Anchor the deadline to now so
-	// that pre-start time counts against the budget.
-	return time.Now().Add(maxRunDuration), maxRunDuration, true
+	return time.Unix(0, h.alloc.CreateTime).Add(maxRunDuration), maxRunDuration, true
 }

--- a/client/allocrunner/max_run_duration_hook_test.go
+++ b/client/allocrunner/max_run_duration_hook_test.go
@@ -30,7 +30,7 @@ func newTestMaxRunDurationHook(
 	baseLabels []metrics.Label,
 	onTimeout func(time.Time),
 ) *maxRunDurationHook {
-	hook := newMaxRunDurationHook(log.NewNullLogger(), alloc, baseLabels, onTimeout)
+	hook := newMaxRunDurationHook(log.NewNullLogger(), alloc, baseLabels, onTimeout, nil)
 
 	h, ok := hook.(*maxRunDurationHook)
 	if !ok {
@@ -88,6 +88,65 @@ func TestMaxRunDurationHook_Update_DoesNotExtendDeadlineOnUnrelatedAllocChange(t
 	case <-deadlines:
 	case <-time.After(200 * time.Millisecond):
 		t.Fatal("timed out waiting for original max_run_duration deadline after unrelated update")
+	}
+}
+
+// TestMaxRunDurationHook_Update_DoesNotExtendDeadlineWhenTasksStart verifies
+// that once the deadline is established at Prerun() time, a subsequent Update()
+// that carries task-state timestamps (i.e. tasks have now started running and
+// the server has echoed their StartedAt back) cannot push the deadline later.
+// Without this guard a slow-starting task could effectively earn extra budget
+// time beyond the configured max_run_duration.
+func TestMaxRunDurationHook_Update_DoesNotExtendDeadlineWhenTasksStart(t *testing.T) {
+	ci.Parallel(t)
+
+	maxRunDuration := 200 * time.Millisecond
+
+	alloc := mock.BatchAlloc()
+	alloc.Job.Type = structs.JobTypeBatch
+	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+
+	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
+	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
+
+	// Prerun arms the timer anchored to now.
+	err := hook.Prerun((*taskenv.TaskEnv)(nil))
+	must.NoError(t, err)
+	deadlineAfterPrerun := hook.deadline
+
+	// Simulate a slow task: it only starts 75 ms into the countdown.
+	time.Sleep(75 * time.Millisecond)
+
+	// The server has now echoed back the alloc with the task's StartedAt set.
+	// If the hook were to use this as the new deadline anchor it would compute
+	// StartedAt + maxRunDuration, which is ~75ms later than the original
+	// deadline — giving the task extra time it should not have.
+	taskName := alloc.Job.TaskGroups[0].Tasks[0].Name
+	updatedAlloc := alloc.Copy()
+	updatedAlloc.TaskStates = map[string]*structs.TaskState{
+		taskName: {
+			State:     structs.TaskStateRunning,
+			StartedAt: time.Now(), // tasks just started, 75ms into the countdown
+		},
+	}
+
+	err = hook.Update(&interfaces.RunnerUpdateRequest{Alloc: updatedAlloc})
+	must.NoError(t, err)
+
+	// The deadline must not have moved later.
+	must.True(t,
+		!hook.deadline.After(deadlineAfterPrerun),
+		must.Sprintf("deadline was extended from %v to %v after tasks started running",
+			deadlineAfterPrerun, hook.deadline),
+	)
+
+	// And the timer must still fire at roughly the original deadline, not the
+	// extended one (i.e. within the remaining ~125ms, not ~200ms from now).
+	select {
+	case deadline := <-deadlines:
+		must.False(t, deadline.IsZero())
+	case <-time.After(maxRunDuration):
+		t.Fatal("timer did not fire before original deadline: deadline was incorrectly extended")
 	}
 }
 
@@ -233,6 +292,69 @@ func TestMaxRunDurationHook_Shutdown_CancelsTimer(t *testing.T) {
 	case deadline := <-deadlines:
 		t.Fatalf("unexpected deadline fired after shutdown: %v", deadline)
 	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+// TestMaxRunDurationHook_Prerun_PreservesDeadlineAfterClientRestart verifies
+// that when a client restarts mid-countdown the hook does not reset the timer
+// to the full max_run_duration. Instead it should reconstruct the original
+// deadline from the StartedAt timestamps stored in the task runners, so the
+// remaining time is maxRunDuration minus the time already elapsed.
+func TestMaxRunDurationHook_Prerun_PreservesDeadlineAfterClientRestart(t *testing.T) {
+	ci.Parallel(t)
+
+	maxRunDuration := 200 * time.Millisecond
+
+	// Simulate a task that has already been running for half the budget.
+	elapsed := maxRunDuration / 2
+	originalStartedAt := time.Now().Add(-elapsed)
+
+	alloc := mock.BatchAlloc()
+	alloc.Job.Type = structs.JobTypeBatch
+	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+	// The server-side alloc carries no task states (as is typical on restart).
+	alloc.TaskStates = nil
+
+	taskName := alloc.Job.TaskGroups[0].Tasks[0].Name
+
+	// taskStatesFn mimics task runners that have been restored from local state
+	// with the original StartedAt preserved, but may be in Pending state
+	// because the process handle could not be reattached.
+	taskStatesFn := func() map[string]*structs.TaskState {
+		return map[string]*structs.TaskState{
+			taskName: {
+				State:     structs.TaskStatePending,
+				StartedAt: originalStartedAt,
+			},
+		}
+	}
+
+	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
+	hookIface := newMaxRunDurationHook(log.NewNullLogger(), alloc, nil, onTimeout, taskStatesFn)
+	hook := hookIface.(*maxRunDurationHook)
+
+	err := hook.Prerun((*taskenv.TaskEnv)(nil))
+	must.NoError(t, err)
+
+	// The deadline should fire after approximately the remaining half of the
+	// budget (maxRunDuration/2), not after the full maxRunDuration. We allow
+	// some slack for slow test environments, but the key invariant is that it
+	// fires well before the full duration would have elapsed.
+	remaining := maxRunDuration - elapsed
+	grace := remaining * 3 // generous upper bound
+
+	select {
+	case deadline := <-deadlines:
+		must.False(t, deadline.IsZero())
+		// Confirm the deadline is anchored to the original start, not time.Now().
+		must.True(t,
+			deadline.Before(time.Now().Add(grace)),
+			must.Sprintf("deadline %v is too far in the future; expected it near %v",
+				deadline, originalStartedAt.Add(maxRunDuration)),
+		)
+	case <-time.After(maxRunDuration * 2):
+		t.Fatal("timed out: hook did not fire within 2x maxRunDuration, " +
+			"suggesting the clock was reset to the full duration on restart")
 	}
 }
 

--- a/client/allocrunner/max_run_duration_hook_test.go
+++ b/client/allocrunner/max_run_duration_hook_test.go
@@ -30,7 +30,7 @@ func newTestMaxRunDurationHook(
 	baseLabels []metrics.Label,
 	onTimeout func(time.Time),
 ) *maxRunDurationHook {
-	hook := newMaxRunDurationHook(log.NewNullLogger(), alloc, baseLabels, onTimeout, nil)
+	hook := newMaxRunDurationHook(log.NewNullLogger(), alloc, baseLabels, onTimeout)
 
 	h, ok := hook.(*maxRunDurationHook)
 	if !ok {
@@ -40,6 +40,9 @@ func newTestMaxRunDurationHook(
 	return h
 }
 
+// TestMaxRunDurationHook_Prerun_ArmsTimerImmediately verifies that a timer is
+// armed when Prerun is called on an eligible allocation and fires after the
+// configured max_run_duration.
 func TestMaxRunDurationHook_Prerun_ArmsTimerImmediately(t *testing.T) {
 	ci.Parallel(t)
 
@@ -47,6 +50,7 @@ func TestMaxRunDurationHook_Prerun_ArmsTimerImmediately(t *testing.T) {
 	maxRunDuration := 50 * time.Millisecond
 	alloc.Job.Type = structs.JobTypeBatch
 	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+	alloc.CreateTime = time.Now().UnixNano()
 
 	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
 	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
@@ -69,6 +73,7 @@ func TestMaxRunDurationHook_Update_DoesNotExtendDeadlineOnUnrelatedAllocChange(t
 	maxRunDuration := 50 * time.Millisecond
 	alloc.Job.Type = structs.JobTypeBatch
 	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+	alloc.CreateTime = time.Now().UnixNano()
 
 	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
 	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
@@ -91,13 +96,10 @@ func TestMaxRunDurationHook_Update_DoesNotExtendDeadlineOnUnrelatedAllocChange(t
 	}
 }
 
-// TestMaxRunDurationHook_Update_DoesNotExtendDeadlineWhenTasksStart verifies
-// that once the deadline is established at Prerun() time, a subsequent Update()
-// that carries task-state timestamps (i.e. tasks have now started running and
-// the server has echoed their StartedAt back) cannot push the deadline later.
-// Without this guard a slow-starting task could effectively earn extra budget
-// time beyond the configured max_run_duration.
-func TestMaxRunDurationHook_Update_DoesNotExtendDeadlineWhenTasksStart(t *testing.T) {
+// TestMaxRunDurationHook_Update_DoesNotExtendDeadlineWhenAllocUpdated verifies
+// that the deadline remains fixed at CreateTime + maxRunDuration and cannot be
+// shifted by an alloc update (e.g. one that carries task-state timestamps).
+func TestMaxRunDurationHook_Update_DoesNotExtendDeadlineWhenAllocUpdated(t *testing.T) {
 	ci.Parallel(t)
 
 	maxRunDuration := 200 * time.Millisecond
@@ -105,48 +107,46 @@ func TestMaxRunDurationHook_Update_DoesNotExtendDeadlineWhenTasksStart(t *testin
 	alloc := mock.BatchAlloc()
 	alloc.Job.Type = structs.JobTypeBatch
 	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+	alloc.CreateTime = time.Now().UnixNano()
 
 	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
 	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
 
-	// Prerun arms the timer anchored to now.
+	// Prerun arms the timer anchored to CreateTime.
 	err := hook.Prerun((*taskenv.TaskEnv)(nil))
 	must.NoError(t, err)
 	deadlineAfterPrerun := hook.deadline
 
-	// Simulate a slow task: it only starts 75 ms into the countdown.
+	// Simulate an alloc update that arrives after some time has passed.
 	time.Sleep(75 * time.Millisecond)
 
-	// The server has now echoed back the alloc with the task's StartedAt set.
-	// If the hook were to use this as the new deadline anchor it would compute
-	// StartedAt + maxRunDuration, which is ~75ms later than the original
-	// deadline — giving the task extra time it should not have.
+	// An update with new task states should not move the deadline, because the
+	// deadline is always CreateTime + maxRunDuration regardless of task state.
 	taskName := alloc.Job.TaskGroups[0].Tasks[0].Name
 	updatedAlloc := alloc.Copy()
 	updatedAlloc.TaskStates = map[string]*structs.TaskState{
 		taskName: {
 			State:     structs.TaskStateRunning,
-			StartedAt: time.Now(), // tasks just started, 75ms into the countdown
+			StartedAt: time.Now(),
 		},
 	}
 
 	err = hook.Update(&interfaces.RunnerUpdateRequest{Alloc: updatedAlloc})
 	must.NoError(t, err)
 
-	// The deadline must not have moved later.
+	// The deadline must not have changed.
 	must.True(t,
 		!hook.deadline.After(deadlineAfterPrerun),
-		must.Sprintf("deadline was extended from %v to %v after tasks started running",
+		must.Sprintf("deadline was extended from %v to %v after alloc update",
 			deadlineAfterPrerun, hook.deadline),
 	)
 
-	// And the timer must still fire at roughly the original deadline, not the
-	// extended one (i.e. within the remaining ~125ms, not ~200ms from now).
+	// Timer must still fire within the original deadline.
 	select {
 	case deadline := <-deadlines:
 		must.False(t, deadline.IsZero())
 	case <-time.After(maxRunDuration):
-		t.Fatal("timer did not fire before original deadline: deadline was incorrectly extended")
+		t.Fatal("timer did not fire before original deadline")
 	}
 }
 
@@ -157,6 +157,7 @@ func TestMaxRunDurationHook_Update_RearmsOnDurationChange(t *testing.T) {
 	initial := 200 * time.Millisecond
 	alloc.Job.Type = structs.JobTypeBatch
 	alloc.Job.TaskGroups[0].MaxRunDuration = &initial
+	alloc.CreateTime = time.Now().UnixNano()
 
 	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
 	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
@@ -255,6 +256,7 @@ func TestMaxRunDurationHook_Postrun_CancelsTimer(t *testing.T) {
 	maxRunDuration := 150 * time.Millisecond
 	alloc.Job.Type = structs.JobTypeBatch
 	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+	alloc.CreateTime = time.Now().UnixNano()
 
 	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
 	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
@@ -279,6 +281,7 @@ func TestMaxRunDurationHook_Shutdown_CancelsTimer(t *testing.T) {
 	maxRunDuration := 150 * time.Millisecond
 	alloc.Job.Type = structs.JobTypeBatch
 	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+	alloc.CreateTime = time.Now().UnixNano()
 
 	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
 	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
@@ -296,61 +299,46 @@ func TestMaxRunDurationHook_Shutdown_CancelsTimer(t *testing.T) {
 }
 
 // TestMaxRunDurationHook_Prerun_PreservesDeadlineAfterClientRestart verifies
-// that when a client restarts mid-countdown the hook does not reset the timer
-// to the full max_run_duration. Instead it should reconstruct the original
-// deadline from the StartedAt timestamps stored in the task runners, so the
-// remaining time is maxRunDuration minus the time already elapsed.
+// that when a client restarts mid-countdown, the hook correctly reconstructs the
+// original deadline from the allocation's CreateTime rather than resetting the
+// full budget. CreateTime is a durable server-assigned property that survives
+// client restarts, so the remaining budget is automatically correct.
 func TestMaxRunDurationHook_Prerun_PreservesDeadlineAfterClientRestart(t *testing.T) {
 	ci.Parallel(t)
 
 	maxRunDuration := 200 * time.Millisecond
 
-	// Simulate a task that has already been running for half the budget.
+	// Simulate an alloc that has already consumed half of its budget.
 	elapsed := maxRunDuration / 2
-	originalStartedAt := time.Now().Add(-elapsed)
 
 	alloc := mock.BatchAlloc()
 	alloc.Job.Type = structs.JobTypeBatch
 	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+	alloc.CreateTime = time.Now().Add(-elapsed).UnixNano()
 	// The server-side alloc carries no task states (as is typical on restart).
 	alloc.TaskStates = nil
 
-	taskName := alloc.Job.TaskGroups[0].Tasks[0].Name
-
-	// taskStatesFn mimics task runners that have been restored from local state
-	// with the original StartedAt preserved, but may be in Pending state
-	// because the process handle could not be reattached.
-	taskStatesFn := func() map[string]*structs.TaskState {
-		return map[string]*structs.TaskState{
-			taskName: {
-				State:     structs.TaskStatePending,
-				StartedAt: originalStartedAt,
-			},
-		}
-	}
-
 	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
-	hookIface := newMaxRunDurationHook(log.NewNullLogger(), alloc, nil, onTimeout, taskStatesFn)
-	hook := hookIface.(*maxRunDurationHook)
+	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
 
 	err := hook.Prerun((*taskenv.TaskEnv)(nil))
 	must.NoError(t, err)
 
 	// The deadline should fire after approximately the remaining half of the
 	// budget (maxRunDuration/2), not after the full maxRunDuration. We allow
-	// some slack for slow test environments, but the key invariant is that it
-	// fires well before the full duration would have elapsed.
+	// generous slack for slow test environments, but the key invariant is that
+	// it fires well before the full duration would have elapsed from now.
 	remaining := maxRunDuration - elapsed
 	grace := remaining * 3 // generous upper bound
 
 	select {
 	case deadline := <-deadlines:
 		must.False(t, deadline.IsZero())
-		// Confirm the deadline is anchored to the original start, not time.Now().
+		// Confirm the deadline is anchored to CreateTime, not time.Now().
 		must.True(t,
 			deadline.Before(time.Now().Add(grace)),
 			must.Sprintf("deadline %v is too far in the future; expected it near %v",
-				deadline, originalStartedAt.Add(maxRunDuration)),
+				deadline, time.Unix(0, alloc.CreateTime).Add(maxRunDuration)),
 		)
 	case <-time.After(maxRunDuration * 2):
 		t.Fatal("timed out: hook did not fire within 2x maxRunDuration, " +
@@ -358,21 +346,19 @@ func TestMaxRunDurationHook_Prerun_PreservesDeadlineAfterClientRestart(t *testin
 	}
 }
 
-func TestMaxRunDurationHook_Prerun_ArmsTimerBeforeTasksAreFullyRunning(t *testing.T) {
+// TestMaxRunDurationHook_Prerun_ArmsTimerWithoutTaskStates verifies that the
+// hook arms the timer correctly even when no task state is present — e.g. at
+// initial Prerun before any tasks have started. The deadline is determined
+// purely from CreateTime, so task state is never required.
+func TestMaxRunDurationHook_Prerun_ArmsTimerWithoutTaskStates(t *testing.T) {
 	ci.Parallel(t)
 
 	alloc := mock.BatchAlloc()
 	maxRunDuration := 50 * time.Millisecond
 	alloc.Job.Type = structs.JobTypeBatch
 	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
-
-	// Simulate the initial prerun state where tasks have not yet started and
-	// therefore no StartedAt timestamps are available to compute a fully-running
-	// deadline from task state.
-	for _, ts := range alloc.TaskStates {
-		ts.State = structs.TaskStatePending
-		ts.StartedAt = time.Time{}
-	}
+	alloc.CreateTime = time.Now().UnixNano()
+	alloc.TaskStates = nil
 
 	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
 	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
@@ -384,7 +370,7 @@ func TestMaxRunDurationHook_Prerun_ArmsTimerBeforeTasksAreFullyRunning(t *testin
 	case deadline := <-deadlines:
 		must.False(t, deadline.IsZero())
 	case <-time.After(500 * time.Millisecond):
-		t.Fatal("timed out waiting for max_run_duration deadline before tasks were fully running")
+		t.Fatal("timed out waiting for max_run_duration deadline")
 	}
 }
 
@@ -399,6 +385,7 @@ func TestMaxRunDurationHook_EmitMetrics(t *testing.T) {
 	maxRunDuration := 2 * time.Minute
 	alloc.Job.Type = structs.JobTypeBatch
 	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+	alloc.CreateTime = time.Now().UnixNano()
 
 	baseLabels := []metrics.Label{
 		{Name: "node_id", Value: "node-123"},

--- a/client/allocrunner/max_run_duration_hook_test.go
+++ b/client/allocrunner/max_run_duration_hook_test.go
@@ -1,0 +1,315 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+package allocrunner
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	log "github.com/hashicorp/go-hclog"
+	metrics "github.com/hashicorp/go-metrics/compat"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/client/taskenv"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+func newTestMaxRunDurationHookCallback() (func(time.Time), chan time.Time) {
+	deadlines := make(chan time.Time, 8)
+	return func(deadline time.Time) {
+		deadlines <- deadline
+	}, deadlines
+}
+
+func newTestMaxRunDurationHook(
+	alloc *structs.Allocation,
+	baseLabels []metrics.Label,
+	onTimeout func(time.Time),
+) *maxRunDurationHook {
+	hook := newMaxRunDurationHook(log.NewNullLogger(), alloc, baseLabels, onTimeout)
+
+	h, ok := hook.(*maxRunDurationHook)
+	if !ok {
+		panic("newMaxRunDurationHook returned unexpected hook type")
+	}
+
+	return h
+}
+
+func TestMaxRunDurationHook_Prerun_ArmsTimerImmediately(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	maxRunDuration := 50 * time.Millisecond
+	alloc.Job.Type = structs.JobTypeBatch
+	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+
+	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
+	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
+
+	err := hook.Prerun((*taskenv.TaskEnv)(nil))
+	must.NoError(t, err)
+
+	select {
+	case deadline := <-deadlines:
+		must.False(t, deadline.IsZero())
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for max_run_duration deadline")
+	}
+}
+
+func TestMaxRunDurationHook_Update_DoesNotExtendDeadlineOnUnrelatedAllocChange(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	maxRunDuration := 50 * time.Millisecond
+	alloc.Job.Type = structs.JobTypeBatch
+	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+
+	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
+	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
+
+	err := hook.Prerun((*taskenv.TaskEnv)(nil))
+	must.NoError(t, err)
+
+	updated := alloc.Copy()
+	updated.ClientDescription = "unrelated alloc update"
+
+	time.Sleep(20 * time.Millisecond)
+
+	err = hook.Update(&interfaces.RunnerUpdateRequest{Alloc: updated})
+	must.NoError(t, err)
+
+	select {
+	case <-deadlines:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for original max_run_duration deadline after unrelated update")
+	}
+}
+
+func TestMaxRunDurationHook_Update_RearmsOnDurationChange(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	initial := 200 * time.Millisecond
+	alloc.Job.Type = structs.JobTypeBatch
+	alloc.Job.TaskGroups[0].MaxRunDuration = &initial
+
+	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
+	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
+
+	err := hook.Prerun((*taskenv.TaskEnv)(nil))
+	must.NoError(t, err)
+
+	updated := alloc.Copy()
+	latest := 40 * time.Millisecond
+	updated.Job.TaskGroups[0].MaxRunDuration = &latest
+
+	err = hook.Update(&interfaces.RunnerUpdateRequest{Alloc: updated})
+	must.NoError(t, err)
+
+	select {
+	case <-deadlines:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for updated max_run_duration deadline")
+	}
+}
+
+func TestMaxRunDurationHook_DoesNotFireWhenAllocNotEligible(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name  string
+		alloc *structs.Allocation
+	}{
+		{
+			name: "non-batch job",
+			alloc: func() *structs.Allocation {
+				alloc := mock.BatchAlloc()
+				maxRunDuration := 25 * time.Millisecond
+				alloc.Job.Type = structs.JobTypeService
+				alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+				return alloc
+			}(),
+		},
+		{
+			name: "desired status not run",
+			alloc: func() *structs.Allocation {
+				alloc := mock.BatchAlloc()
+				maxRunDuration := 25 * time.Millisecond
+				alloc.Job.Type = structs.JobTypeBatch
+				alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+				alloc.DesiredStatus = structs.AllocDesiredStatusStop
+				return alloc
+			}(),
+		},
+		{
+			name: "terminal alloc",
+			alloc: func() *structs.Allocation {
+				alloc := mock.BatchAlloc()
+				maxRunDuration := 25 * time.Millisecond
+				alloc.Job.Type = structs.JobTypeBatch
+				alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+				alloc.ClientStatus = structs.AllocClientStatusComplete
+				return alloc
+			}(),
+		},
+		{
+			name: "no max run duration",
+			alloc: func() *structs.Allocation {
+				alloc := mock.BatchAlloc()
+				alloc.Job.Type = structs.JobTypeBatch
+				alloc.Job.TaskGroups[0].MaxRunDuration = nil
+				return alloc
+			}(),
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			onTimeout, deadlines := newTestMaxRunDurationHookCallback()
+			hook := newTestMaxRunDurationHook(tc.alloc, nil, onTimeout)
+
+			err := hook.Prerun((*taskenv.TaskEnv)(nil))
+			must.NoError(t, err)
+
+			select {
+			case deadline := <-deadlines:
+				t.Fatalf("unexpected deadline fired: %v", deadline)
+			case <-time.After(100 * time.Millisecond):
+			}
+		})
+	}
+}
+
+func TestMaxRunDurationHook_Postrun_CancelsTimer(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	maxRunDuration := 150 * time.Millisecond
+	alloc.Job.Type = structs.JobTypeBatch
+	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+
+	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
+	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
+
+	err := hook.Prerun((*taskenv.TaskEnv)(nil))
+	must.NoError(t, err)
+
+	err = hook.Postrun()
+	must.NoError(t, err)
+
+	select {
+	case deadline := <-deadlines:
+		t.Fatalf("unexpected deadline fired after postrun: %v", deadline)
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+func TestMaxRunDurationHook_Shutdown_CancelsTimer(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	maxRunDuration := 150 * time.Millisecond
+	alloc.Job.Type = structs.JobTypeBatch
+	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+
+	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
+	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
+
+	err := hook.Prerun((*taskenv.TaskEnv)(nil))
+	must.NoError(t, err)
+
+	hook.Shutdown()
+
+	select {
+	case deadline := <-deadlines:
+		t.Fatalf("unexpected deadline fired after shutdown: %v", deadline)
+	case <-time.After(250 * time.Millisecond):
+	}
+}
+
+func TestMaxRunDurationHook_Prerun_ArmsTimerBeforeTasksAreFullyRunning(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	maxRunDuration := 50 * time.Millisecond
+	alloc.Job.Type = structs.JobTypeBatch
+	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+
+	// Simulate the initial prerun state where tasks have not yet started and
+	// therefore no StartedAt timestamps are available to compute a fully-running
+	// deadline from task state.
+	for _, ts := range alloc.TaskStates {
+		ts.State = structs.TaskStatePending
+		ts.StartedAt = time.Time{}
+	}
+
+	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
+	hook := newTestMaxRunDurationHook(alloc, nil, onTimeout)
+
+	err := hook.Prerun((*taskenv.TaskEnv)(nil))
+	must.NoError(t, err)
+
+	select {
+	case deadline := <-deadlines:
+		must.False(t, deadline.IsZero())
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for max_run_duration deadline before tasks were fully running")
+	}
+}
+
+func TestMaxRunDurationHook_EmitMetrics(t *testing.T) {
+	ci.Parallel(t)
+
+	inMemorySink := metrics.NewInmemSink(10*time.Millisecond, 50*time.Millisecond)
+	_, err := metrics.NewGlobal(metrics.DefaultConfig("nomad_test"), inMemorySink)
+	must.NoError(t, err)
+
+	alloc := mock.BatchAlloc()
+	maxRunDuration := 2 * time.Minute
+	alloc.Job.Type = structs.JobTypeBatch
+	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+
+	baseLabels := []metrics.Label{
+		{Name: "node_id", Value: "node-123"},
+	}
+
+	onTimeout, _ := newTestMaxRunDurationHookCallback()
+	hook := newTestMaxRunDurationHook(alloc, baseLabels, onTimeout)
+
+	err = hook.Prerun((*taskenv.TaskEnv)(nil))
+	must.NoError(t, err)
+
+	data := inMemorySink.Data()
+	must.Len(t, 1, data)
+
+	configuredSuffix := "client.allocs.max_run_duration.configured_seconds;node_id=node-123;task_group=" + alloc.TaskGroup
+	remainingSuffix := "client.allocs.max_run_duration.remaining_seconds;node_id=node-123;task_group=" + alloc.TaskGroup
+
+	var configuredFound bool
+	var remainingFound bool
+
+	for key, gauge := range data[0].Gauges {
+		if strings.HasSuffix(key, configuredSuffix) {
+			must.Eq(t, float32(maxRunDuration.Seconds()), gauge.Value)
+			configuredFound = true
+		}
+
+		if strings.HasSuffix(key, remainingSuffix) {
+			must.Positive(t, gauge.Value)
+			must.True(t, gauge.Value <= float32(maxRunDuration.Seconds()))
+			remainingFound = true
+		}
+	}
+
+	must.True(t, configuredFound)
+	must.True(t, remainingFound)
+}

--- a/client/allocrunner/state/state.go
+++ b/client/allocrunner/state/state.go
@@ -19,6 +19,11 @@ type State struct {
 	// allocations client state
 	ClientDescription string
 
+	// MaxRunDurationExceeded indicates the allocation exceeded its configured
+	// max_run_duration and should be reported as complete with a timeout reason
+	// regardless of task exit status.
+	MaxRunDurationExceeded bool
+
 	// DeploymentStatus captures the status of the deployment
 	DeploymentStatus *structs.AllocDeploymentStatus
 
@@ -60,11 +65,12 @@ func (s *State) Copy() *State {
 		taskStates[k] = v.Copy()
 	}
 	return &State{
-		ClientStatus:      s.ClientStatus,
-		ClientDescription: s.ClientDescription,
-		DeploymentStatus:  s.DeploymentStatus.Copy(),
-		TaskStates:        taskStates,
-		NetworkStatus:     s.NetworkStatus.Copy(),
+		ClientStatus:           s.ClientStatus,
+		ClientDescription:      s.ClientDescription,
+		MaxRunDurationExceeded: s.MaxRunDurationExceeded,
+		DeploymentStatus:       s.DeploymentStatus.Copy(),
+		TaskStates:             taskStates,
+		NetworkStatus:          s.NetworkStatus.Copy(),
 	}
 }
 

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -1254,6 +1254,10 @@ func ApiTgToStructsTG(job *structs.Job, taskGroup *api.TaskGroup, tg *structs.Ta
 		tg.ShutdownDelay = taskGroup.ShutdownDelay
 	}
 
+	if taskGroup.MaxRunDuration != nil {
+		tg.MaxRunDuration = taskGroup.MaxRunDuration
+	}
+
 	if taskGroup.ReschedulePolicy != nil {
 		tg.ReschedulePolicy = &structs.ReschedulePolicy{
 			Attempts:      *taskGroup.ReschedulePolicy.Attempts,

--- a/command/agent/job_endpoint_test.go
+++ b/command/agent/job_endpoint_test.go
@@ -2834,6 +2834,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 					ProgressDeadline: pointer.Of(5 * time.Minute),
 					AutoRevert:       pointer.Of(true),
 				},
+				MaxRunDuration: pointer.Of(10 * time.Second),
 				Meta: map[string]string{
 					"key": "value",
 				},
@@ -3275,6 +3276,7 @@ func TestJobs_ApiJobToStructsJob(t *testing.T) {
 					AutoPromote:      false,
 					Canary:           1,
 				},
+				MaxRunDuration: pointer.Of(10 * time.Second),
 				Meta: map[string]string{
 					"key": "value",
 				},

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -198,7 +198,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 
 	// Format the allocation data
 	if short {
-		c.Ui.Output(formatAllocShortInfo(alloc, client))
+		c.Ui.Output(formatAllocShortInfo(alloc))
 	} else {
 		output, err := formatAllocBasicInfo(alloc, client, length, verbose)
 		if err != nil {
@@ -256,7 +256,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	return 0
 }
 
-func formatAllocShortInfo(alloc *api.Allocation, client *api.Client) string {
+func formatAllocShortInfo(alloc *api.Allocation) string {
 	formattedCreateTime := prettyTimeDiff(time.Unix(0, alloc.CreateTime), time.Now())
 	formattedModifyTime := prettyTimeDiff(time.Unix(0, alloc.ModifyTime), time.Now())
 
@@ -265,6 +265,10 @@ func formatAllocShortInfo(alloc *api.Allocation, client *api.Client) string {
 		fmt.Sprintf("Name|%s", alloc.Name),
 		fmt.Sprintf("Created|%s", formattedCreateTime),
 		fmt.Sprintf("Modified|%s", formattedModifyTime),
+	}
+
+	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates); ok {
+		basic = append(basic, fmt.Sprintf("Max Run Deadline|%s", formatMaxRunDeadline(deadline, false)))
 	}
 
 	return formatKV(basic)
@@ -295,6 +299,10 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 		fmt.Sprintf("Desired Description|%s", alloc.DesiredDescription),
 		fmt.Sprintf("Created|%s", formattedCreateTime),
 		fmt.Sprintf("Modified|%s", formattedModifyTime),
+	}
+
+	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates); ok {
+		basic = append(basic, fmt.Sprintf("Max Run Deadline|%s", formatMaxRunDeadline(deadline, verbose)))
 	}
 
 	if alloc.DeploymentID != "" {

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -267,7 +267,7 @@ func formatAllocShortInfo(alloc *api.Allocation) string {
 		fmt.Sprintf("Modified|%s", formattedModifyTime),
 	}
 
-	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates, alloc.CreateTime); ok {
+	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.CreateTime); ok {
 		basic = append(basic, fmt.Sprintf("Max Run Deadline|%s", formatMaxRunDeadline(deadline, false)))
 	}
 
@@ -301,7 +301,7 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 		fmt.Sprintf("Modified|%s", formattedModifyTime),
 	}
 
-	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates, alloc.CreateTime); ok {
+	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.CreateTime); ok {
 		basic = append(basic, fmt.Sprintf("Max Run Deadline|%s", formatMaxRunDeadline(deadline, verbose)))
 	}
 

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -267,7 +267,7 @@ func formatAllocShortInfo(alloc *api.Allocation) string {
 		fmt.Sprintf("Modified|%s", formattedModifyTime),
 	}
 
-	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates); ok {
+	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates, alloc.CreateTime); ok {
 		basic = append(basic, fmt.Sprintf("Max Run Deadline|%s", formatMaxRunDeadline(deadline, false)))
 	}
 
@@ -301,7 +301,7 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 		fmt.Sprintf("Modified|%s", formattedModifyTime),
 	}
 
-	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates); ok {
+	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates, alloc.CreateTime); ok {
 		basic = append(basic, fmt.Sprintf("Max Run Deadline|%s", formatMaxRunDeadline(deadline, verbose)))
 	}
 

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/cli"
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -201,6 +202,65 @@ func TestAllocStatusCommand_Run(t *testing.T) {
 
 	// make sure nsd checks status output is elided if none exist
 	must.StrNotContains(t, out, `Nomad Service Checks:`)
+}
+
+func TestFormatAllocBasicInfo_MaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeBatch
+	version := uint64(1)
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := startedAt.Add(maxRunDuration)
+
+	alloc := &api.Allocation{
+		ID:                 "alloc-id",
+		EvalID:             "eval-id",
+		Name:               "alloc-name",
+		NodeID:             "node-id",
+		NodeName:           "node-name",
+		JobID:              "job-id",
+		Job:                &api.Job{Type: &jobType, Version: &version, TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}}},
+		TaskGroup:          groupName,
+		ClientStatus:       "running",
+		ClientDescription:  "running",
+		DesiredStatus:      "run",
+		DesiredDescription: "run",
+		TaskStates: map[string]*api.TaskState{
+			"task-a": {State: "running", StartedAt: startedAt.Add(-1 * time.Minute)},
+			"task-b": {State: "dead", StartedAt: startedAt},
+		},
+		Metrics: &api.AllocationMetric{},
+	}
+
+	out, err := formatAllocBasicInfo(alloc, nil, fullId, true)
+	must.NoError(t, err)
+	must.StrContains(t, out, "Max Run Deadline")
+	must.StrContains(t, out, formatTime(deadline))
+}
+
+func TestFormatAllocShortInfo_MaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeBatch
+	version := uint64(1)
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+	startedAt := time.Now().Add(-5 * time.Minute)
+
+	alloc := &api.Allocation{
+		ID:        "alloc-id",
+		Name:      "alloc-name",
+		Job:       &api.Job{Type: &jobType, Version: &version, TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}}},
+		TaskGroup: groupName,
+		TaskStates: map[string]*api.TaskState{
+			"task-a": {State: "running", StartedAt: startedAt},
+		},
+	}
+
+	out := formatAllocShortInfo(alloc)
+	must.StrContains(t, out, "Max Run Deadline")
 }
 
 func TestAllocStatusCommand_RescheduleInfo(t *testing.T) {

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -211,8 +211,8 @@ func TestFormatAllocBasicInfo_MaxRunDeadline(t *testing.T) {
 	version := uint64(1)
 	groupName := "group"
 	maxRunDuration := 10 * time.Minute
-	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
-	deadline := startedAt.Add(maxRunDuration)
+	createtime := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := createtime.Add(maxRunDuration)
 
 	alloc := &api.Allocation{
 		ID:                 "alloc-id",
@@ -223,13 +223,14 @@ func TestFormatAllocBasicInfo_MaxRunDeadline(t *testing.T) {
 		JobID:              "job-id",
 		Job:                &api.Job{Type: &jobType, Version: &version, TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}}},
 		TaskGroup:          groupName,
+		CreateTime:         createtime.UnixNano(),
 		ClientStatus:       "running",
 		ClientDescription:  "running",
 		DesiredStatus:      "run",
 		DesiredDescription: "run",
 		TaskStates: map[string]*api.TaskState{
-			"task-a": {State: "running", StartedAt: startedAt.Add(-1 * time.Minute)},
-			"task-b": {State: "dead", StartedAt: startedAt},
+			"task-a": {State: "running", StartedAt: createtime.Add(-1 * time.Minute)},
+			"task-b": {State: "dead", StartedAt: createtime},
 		},
 		Metrics: &api.AllocationMetric{},
 	}
@@ -247,16 +248,14 @@ func TestFormatAllocShortInfo_MaxRunDeadline(t *testing.T) {
 	version := uint64(1)
 	groupName := "group"
 	maxRunDuration := 10 * time.Minute
-	startedAt := time.Now().Add(-5 * time.Minute)
+	createtime := time.Now().Add(-5 * time.Minute).UnixNano()
 
 	alloc := &api.Allocation{
-		ID:        "alloc-id",
-		Name:      "alloc-name",
-		Job:       &api.Job{Type: &jobType, Version: &version, TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}}},
-		TaskGroup: groupName,
-		TaskStates: map[string]*api.TaskState{
-			"task-a": {State: "running", StartedAt: startedAt},
-		},
+		ID:         "alloc-id",
+		Name:       "alloc-name",
+		Job:        &api.Job{Type: &jobType, Version: &version, TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}}},
+		TaskGroup:  groupName,
+		CreateTime: createtime,
 	}
 
 	out := formatAllocShortInfo(alloc)

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -130,38 +130,17 @@ func formatMaxRunDeadline(deadline time.Time, verbose bool) string {
 	return prettyTimeDiff(deadline, time.Now())
 }
 
-func jobTaskGroupMaxRunDeadline(job *api.Job, taskGroupName string, taskStates map[string]*api.TaskState, createTime int64) (time.Time, bool) {
+func jobTaskGroupMaxRunDeadline(job *api.Job, taskGroupName string, createTime int64) (time.Time, bool) {
 	maxRunDuration, ok := jobTaskGroupMaxRunDuration(job, taskGroupName)
 	if !ok {
 		return time.Time{}, false
 	}
 
-	// If any task has restarted, its StartedAt reflects the most recent
-	// restart time rather than the original start. The client anchors the
-	// deadline to Prerun() time (which is close to alloc creation), so fall
-	// back to CreateTime as the best available proxy.
-	if anyTaskRestarted(taskStates) {
-		if createTime == 0 {
-			return time.Time{}, false
-		}
-		return time.Unix(0, createTime).Add(maxRunDuration), true
-	}
-
-	startedAt, ok := taskStatesFullyStartedSince(taskStates)
-	if !ok {
+	if createTime == 0 {
 		return time.Time{}, false
 	}
 
-	return startedAt.Add(maxRunDuration), true
-}
-
-func anyTaskRestarted(taskStates map[string]*api.TaskState) bool {
-	for _, ts := range taskStates {
-		if ts != nil && ts.Restarts > 0 {
-			return true
-		}
-	}
-	return false
+	return time.Unix(0, createTime).Add(maxRunDuration), true
 }
 
 func jobTaskGroupMaxRunDuration(job *api.Job, taskGroupName string) (time.Duration, bool) {
@@ -180,28 +159,6 @@ func jobTaskGroupMaxRunDuration(job *api.Job, taskGroupName string) (time.Durati
 	default:
 		return 0, false
 	}
-}
-
-func taskStatesFullyStartedSince(taskStates map[string]*api.TaskState) (time.Time, bool) {
-	if len(taskStates) == 0 {
-		return time.Time{}, false
-	}
-
-	var latest time.Time
-	for _, ts := range taskStates {
-		if ts == nil || ts.StartedAt.IsZero() {
-			return time.Time{}, false
-		}
-		if ts.StartedAt.After(latest) {
-			latest = ts.StartedAt
-		}
-	}
-
-	if latest.IsZero() {
-		return time.Time{}, false
-	}
-
-	return latest.Local(), true
 }
 
 // fmtInt formats v into the tail of buf.

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -122,6 +122,68 @@ func formatTimeDifference(first, second time.Time, d time.Duration) string {
 	return second.Truncate(d).Sub(first.Truncate(d)).String()
 }
 
+func formatMaxRunDeadline(deadline time.Time, verbose bool) string {
+	if verbose {
+		return formatTime(deadline)
+	}
+
+	return prettyTimeDiff(deadline, time.Now())
+}
+
+func jobTaskGroupMaxRunDeadline(job *api.Job, taskGroupName string, taskStates map[string]*api.TaskState) (time.Time, bool) {
+	maxRunDuration, ok := jobTaskGroupMaxRunDuration(job, taskGroupName)
+	if !ok {
+		return time.Time{}, false
+	}
+
+	startedAt, ok := taskStatesFullyStartedSince(taskStates)
+	if !ok {
+		return time.Time{}, false
+	}
+
+	return startedAt.Add(maxRunDuration), true
+}
+
+func jobTaskGroupMaxRunDuration(job *api.Job, taskGroupName string) (time.Duration, bool) {
+	if job == nil || job.Type == nil {
+		return 0, false
+	}
+
+	tg := job.LookupTaskGroup(taskGroupName)
+	if tg == nil || tg.MaxRunDuration == nil || *tg.MaxRunDuration <= 0 {
+		return 0, false
+	}
+
+	switch *job.Type {
+	case api.JobTypeBatch, api.JobTypeSysbatch:
+		return *tg.MaxRunDuration, true
+	default:
+		return 0, false
+	}
+}
+
+func taskStatesFullyStartedSince(taskStates map[string]*api.TaskState) (time.Time, bool) {
+	if len(taskStates) == 0 {
+		return time.Time{}, false
+	}
+
+	var latest time.Time
+	for _, ts := range taskStates {
+		if ts == nil || ts.StartedAt.IsZero() {
+			return time.Time{}, false
+		}
+		if ts.StartedAt.After(latest) {
+			latest = ts.StartedAt
+		}
+	}
+
+	if latest.IsZero() {
+		return time.Time{}, false
+	}
+
+	return latest.Local(), true
+}
+
 // fmtInt formats v into the tail of buf.
 // It returns the index where the output begins.
 func fmtInt(buf []byte, v uint64) int {

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -130,10 +130,21 @@ func formatMaxRunDeadline(deadline time.Time, verbose bool) string {
 	return prettyTimeDiff(deadline, time.Now())
 }
 
-func jobTaskGroupMaxRunDeadline(job *api.Job, taskGroupName string, taskStates map[string]*api.TaskState) (time.Time, bool) {
+func jobTaskGroupMaxRunDeadline(job *api.Job, taskGroupName string, taskStates map[string]*api.TaskState, createTime int64) (time.Time, bool) {
 	maxRunDuration, ok := jobTaskGroupMaxRunDuration(job, taskGroupName)
 	if !ok {
 		return time.Time{}, false
+	}
+
+	// If any task has restarted, its StartedAt reflects the most recent
+	// restart time rather than the original start. The client anchors the
+	// deadline to Prerun() time (which is close to alloc creation), so fall
+	// back to CreateTime as the best available proxy.
+	if anyTaskRestarted(taskStates) {
+		if createTime == 0 {
+			return time.Time{}, false
+		}
+		return time.Unix(0, createTime).Add(maxRunDuration), true
 	}
 
 	startedAt, ok := taskStatesFullyStartedSince(taskStates)
@@ -142,6 +153,15 @@ func jobTaskGroupMaxRunDeadline(job *api.Job, taskGroupName string, taskStates m
 	}
 
 	return startedAt.Add(maxRunDuration), true
+}
+
+func anyTaskRestarted(taskStates map[string]*api.TaskState) bool {
+	for _, ts := range taskStates {
+		if ts != nil && ts.Restarts > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func jobTaskGroupMaxRunDuration(job *api.Job, taskGroupName string) (time.Duration, bool) {

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -463,6 +463,64 @@ func TestJobGetter_Validate(t *testing.T) {
 	}
 }
 
+func TestJobTaskGroupMaxRunDeadline_NoRestarts(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeBatch
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
+
+	job := &api.Job{
+		Type:       &jobType,
+		TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}},
+	}
+	taskStates := map[string]*api.TaskState{
+		"task-a": {StartedAt: startedAt, Restarts: 0},
+	}
+
+	deadline, ok := jobTaskGroupMaxRunDeadline(job, groupName, taskStates, 0)
+	must.True(t, ok)
+	must.Eq(t, startedAt.Add(maxRunDuration).UTC(), deadline.UTC())
+}
+
+// TestJobTaskGroupMaxRunDeadline_AfterRestart verifies that when a task has
+// restarted, the CLI anchors the deadline to the alloc's CreateTime rather than
+// the (updated) StartedAt. Using StartedAt after a restart would produce a
+// deadline later than what the client actually enforces, because StartedAt is
+// overwritten with the restart timestamp while the client holds the original
+// Prerun()-time deadline.
+func TestJobTaskGroupMaxRunDeadline_AfterRestart(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeBatch
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+
+	// The alloc was created (and Prerun() called) 20 minutes ago.
+	createTime := time.Now().Add(-20 * time.Minute).Round(time.Second)
+	expectedDeadline := createTime.Add(maxRunDuration) // already exceeded
+
+	// The task restarted 2 minutes ago — its StartedAt was overwritten.
+	// Using this as the anchor would give a deadline 8 minutes in the future,
+	// which is wrong.
+	restartedAt := time.Now().Add(-2 * time.Minute)
+
+	job := &api.Job{
+		Type:       &jobType,
+		TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}},
+	}
+	taskStates := map[string]*api.TaskState{
+		"task-a": {StartedAt: restartedAt, Restarts: 1},
+	}
+
+	deadline, ok := jobTaskGroupMaxRunDeadline(job, groupName, taskStates, createTime.UnixNano())
+	must.True(t, ok)
+	must.Eq(t, expectedDeadline.UTC(), deadline.UTC())
+	// Confirm it is NOT anchored to the restart time.
+	must.NotEq(t, restartedAt.Add(maxRunDuration).UTC(), deadline.UTC())
+}
+
 func TestPrettyTimeDiff(t *testing.T) {
 	// Grab the time and truncate to the nearest second. This allows our tests
 	// to be deterministic since we don't have to worry about rounding.

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -463,62 +463,43 @@ func TestJobGetter_Validate(t *testing.T) {
 	}
 }
 
-func TestJobTaskGroupMaxRunDeadline_NoRestarts(t *testing.T) {
-	ci.Parallel(t)
-
-	jobType := api.JobTypeBatch
-	groupName := "group"
-	maxRunDuration := 10 * time.Minute
-	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
-
-	job := &api.Job{
-		Type:       &jobType,
-		TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}},
-	}
-	taskStates := map[string]*api.TaskState{
-		"task-a": {StartedAt: startedAt, Restarts: 0},
-	}
-
-	deadline, ok := jobTaskGroupMaxRunDeadline(job, groupName, taskStates, 0)
-	must.True(t, ok)
-	must.Eq(t, startedAt.Add(maxRunDuration).UTC(), deadline.UTC())
-}
-
-// TestJobTaskGroupMaxRunDeadline_AfterRestart verifies that when a task has
-// restarted, the CLI anchors the deadline to the alloc's CreateTime rather than
-// the (updated) StartedAt. Using StartedAt after a restart would produce a
-// deadline later than what the client actually enforces, because StartedAt is
-// overwritten with the restart timestamp while the client holds the original
-// Prerun()-time deadline.
-func TestJobTaskGroupMaxRunDeadline_AfterRestart(t *testing.T) {
+func TestJobTaskGroupMaxRunDeadline(t *testing.T) {
 	ci.Parallel(t)
 
 	jobType := api.JobTypeBatch
 	groupName := "group"
 	maxRunDuration := 10 * time.Minute
 
-	// The alloc was created (and Prerun() called) 20 minutes ago.
-	createTime := time.Now().Add(-20 * time.Minute).Round(time.Second)
-	expectedDeadline := createTime.Add(maxRunDuration) // already exceeded
-
-	// The task restarted 2 minutes ago — its StartedAt was overwritten.
-	// Using this as the anchor would give a deadline 8 minutes in the future,
-	// which is wrong.
-	restartedAt := time.Now().Add(-2 * time.Minute)
+	// The alloc was created 5 minutes ago.
+	createtime := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	expectedDeadline := createtime.Add(maxRunDuration)
 
 	job := &api.Job{
 		Type:       &jobType,
 		TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}},
 	}
-	taskStates := map[string]*api.TaskState{
-		"task-a": {StartedAt: restartedAt, Restarts: 1},
-	}
 
-	deadline, ok := jobTaskGroupMaxRunDeadline(job, groupName, taskStates, createTime.UnixNano())
+	deadline, ok := jobTaskGroupMaxRunDeadline(job, groupName, createtime.UnixNano())
 	must.True(t, ok)
 	must.Eq(t, expectedDeadline.UTC(), deadline.UTC())
-	// Confirm it is NOT anchored to the restart time.
-	must.NotEq(t, restartedAt.Add(maxRunDuration).UTC(), deadline.UTC())
+}
+
+// TestJobTaskGroupMaxRunDeadline_ZeroCreateTime verifies that a zero CreateTime
+// (alloc not yet scheduled) produces no deadline.
+func TestJobTaskGroupMaxRunDeadline_ZeroCreateTime(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeBatch
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+
+	job := &api.Job{
+		Type:       &jobType,
+		TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}},
+	}
+
+	_, ok := jobTaskGroupMaxRunDeadline(job, groupName, 0)
+	must.False(t, ok)
 }
 
 func TestPrettyTimeDiff(t *testing.T) {

--- a/command/job_allocs.go
+++ b/command/job_allocs.go
@@ -107,6 +107,17 @@ func (c *JobAllocsCommand) Run(args []string) int {
 
 	q := &api.QueryOptions{Namespace: namespace}
 
+	// Fetch job info to enrich allocations output (e.g. Max Run Deadline
+	// column). This is best-effort: when the jobID was returned as a raw
+	// prefix by JobIDByPrefix (e.g. because the token lacks list-jobs), the
+	// Info call may fail. In that case we continue with a nil job so that
+	// formatJobAllocListStubs still works — it omits the deadline column.
+	job, _, err := client.Jobs().Info(jobID, q)
+	if err != nil && strings.Contains(err.Error(), api.PermissionDeniedErrorContent) {
+		c.Ui.Error(fmt.Sprintf("Error querying job: %s", err))
+		return 1
+	}
+
 	allocs, _, err := client.Jobs().Allocations(jobID, all, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving allocations: %s", err))
@@ -130,6 +141,6 @@ func (c *JobAllocsCommand) Run(args []string) int {
 		length = fullId
 	}
 
-	c.Ui.Output(formatAllocListStubs(allocs, verbose, length))
+	c.Ui.Output(formatJobAllocListStubs(allocs, job, verbose, length))
 	return 0
 }

--- a/command/job_allocs_test.go
+++ b/command/job_allocs_test.go
@@ -112,8 +112,8 @@ func TestJobAllocsCommand_MaxRunDeadline(t *testing.T) {
 	job.TaskGroups[0].MaxRunDuration = &maxRunDuration
 	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job))
 
-	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
-	deadline := startedAt.Add(maxRunDuration)
+	createtime := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := createtime.Add(maxRunDuration)
 
 	a := mock.Alloc()
 	a.Job = job
@@ -122,9 +122,7 @@ func TestJobAllocsCommand_MaxRunDeadline(t *testing.T) {
 	a.Metrics = &structs.AllocMetric{}
 	a.DesiredStatus = structs.AllocDesiredStatusRun
 	a.ClientStatus = structs.AllocClientStatusRunning
-	a.TaskStates = map[string]*structs.TaskState{
-		"web": {State: "running", StartedAt: startedAt},
-	}
+	a.CreateTime = createtime.UnixNano()
 	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{a}))
 
 	code := cmd.Run([]string{"-address=" + url, "-verbose", job.ID})

--- a/command/job_allocs_test.go
+++ b/command/job_allocs_test.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/nomad/api"
@@ -95,6 +96,45 @@ func TestJobAllocsCommand_Run(t *testing.T) {
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()
+}
+
+func TestJobAllocsCommand_MaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := cli.NewMockUi()
+	cmd := &JobAllocsCommand{Meta: Meta{Ui: ui}}
+	state := srv.Agent.Server().State()
+
+	job := mock.BatchJob()
+	maxRunDuration := 10 * time.Minute
+	job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job))
+
+	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := startedAt.Add(maxRunDuration)
+
+	a := mock.Alloc()
+	a.Job = job
+	a.JobID = job.ID
+	a.TaskGroup = job.TaskGroups[0].Name
+	a.Metrics = &structs.AllocMetric{}
+	a.DesiredStatus = structs.AllocDesiredStatusRun
+	a.ClientStatus = structs.AllocClientStatusRunning
+	a.TaskStates = map[string]*structs.TaskState{
+		"web": {State: "running", StartedAt: startedAt},
+	}
+	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{a}))
+
+	code := cmd.Run([]string{"-address=" + url, "-verbose", job.ID})
+	out := ui.OutputWriter.String()
+	outerr := ui.ErrorWriter.String()
+
+	must.Zero(t, code)
+	must.Eq(t, "", outerr)
+	must.StrContains(t, out, "Max Run Deadline")
+	must.StrContains(t, out, formatTime(deadline))
 }
 
 func TestJobAllocsCommand_Template(t *testing.T) {

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -577,7 +577,7 @@ func formatJobActions(actions []map[string]string) string {
 func formatJobAllocListStubs(stubs []*api.AllocationListStub, job *api.Job, verbose bool, uuidLength int) string {
 	deadlines := make([]string, len(stubs))
 	for i, alloc := range stubs {
-		deadline, ok := jobTaskGroupMaxRunDeadline(job, alloc.TaskGroup, alloc.TaskStates, alloc.CreateTime)
+		deadline, ok := jobTaskGroupMaxRunDeadline(job, alloc.TaskGroup, alloc.CreateTime)
 		if !ok {
 			continue
 		}
@@ -666,7 +666,7 @@ func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int
 
 	deadlines := make([]string, len(allocations))
 	for i, alloc := range allocations {
-		deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates, alloc.CreateTime)
+		deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.CreateTime)
 		if !ok {
 			continue
 		}

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -577,7 +577,7 @@ func formatJobActions(actions []map[string]string) string {
 func formatJobAllocListStubs(stubs []*api.AllocationListStub, job *api.Job, verbose bool, uuidLength int) string {
 	deadlines := make([]string, len(stubs))
 	for i, alloc := range stubs {
-		deadline, ok := jobTaskGroupMaxRunDeadline(job, alloc.TaskGroup, alloc.TaskStates)
+		deadline, ok := jobTaskGroupMaxRunDeadline(job, alloc.TaskGroup, alloc.TaskStates, alloc.CreateTime)
 		if !ok {
 			continue
 		}
@@ -666,7 +666,7 @@ func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int
 
 	deadlines := make([]string, len(allocations))
 	for i, alloc := range allocations {
-		deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates)
+		deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates, alloc.CreateTime)
 		if !ok {
 			continue
 		}

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -519,7 +519,7 @@ func (c *JobStatusCommand) outputJobInfo(client *api.Client, job *api.Job) error
 
 	// Format the allocs
 	c.Ui.Output(c.Colorize().Color("\n[bold]Allocations[reset]"))
-	c.Ui.Output(formatAllocListStubs(jobAllocs, c.verbose, c.length))
+	c.Ui.Output(formatJobAllocListStubs(jobAllocs, job, c.verbose, c.length))
 	return nil
 }
 
@@ -574,16 +574,38 @@ func formatJobActions(actions []map[string]string) string {
 	return formatList(actionsOut)
 }
 
+func formatJobAllocListStubs(stubs []*api.AllocationListStub, job *api.Job, verbose bool, uuidLength int) string {
+	deadlines := make([]string, len(stubs))
+	for i, alloc := range stubs {
+		deadline, ok := jobTaskGroupMaxRunDeadline(job, alloc.TaskGroup, alloc.TaskStates)
+		if !ok {
+			continue
+		}
+
+		deadlines[i] = formatMaxRunDeadline(deadline, verbose)
+	}
+
+	return formatAllocListStubsWithDeadlines(stubs, verbose, uuidLength, deadlines)
+}
+
 func formatAllocListStubs(stubs []*api.AllocationListStub, verbose bool, uuidLength int) string {
+	return formatAllocListStubsWithDeadlines(stubs, verbose, uuidLength, nil)
+}
+
+func formatAllocListStubsWithDeadlines(stubs []*api.AllocationListStub, verbose bool, uuidLength int, deadlines []string) string {
 	if len(stubs) == 0 {
 		return "No allocations placed"
 	}
 
+	showDeadline := allocationDeadlineColumnVisible(deadlines)
 	allocs := make([]string, len(stubs)+1)
 	if verbose {
 		allocs[0] = "ID|Eval ID|Node ID|Node Name|Task Group|Version|Desired|Status|Created|Modified"
+		if showDeadline {
+			allocs[0] += "|Max Run Deadline"
+		}
 		for i, alloc := range stubs {
-			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%d|%s|%s|%s|%s",
+			row := fmt.Sprintf("%s|%s|%s|%s|%s|%d|%s|%s|%s|%s",
 				limit(alloc.ID, uuidLength),
 				limit(alloc.EvalID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
@@ -594,14 +616,21 @@ func formatAllocListStubs(stubs []*api.AllocationListStub, verbose bool, uuidLen
 				alloc.ClientStatus,
 				formatUnixNanoTime(alloc.CreateTime),
 				formatUnixNanoTime(alloc.ModifyTime))
+			if showDeadline {
+				row += fmt.Sprintf("|%s", deadlines[i])
+			}
+			allocs[i+1] = row
 		}
 	} else {
 		allocs[0] = "ID|Node ID|Task Group|Version|Desired|Status|Created|Modified"
+		if showDeadline {
+			allocs[0] += "|Max Run Deadline"
+		}
+		now := time.Now()
 		for i, alloc := range stubs {
-			now := time.Now()
 			createTimePretty := prettyTimeDiff(time.Unix(0, alloc.CreateTime), now)
 			modTimePretty := prettyTimeDiff(time.Unix(0, alloc.ModifyTime), now)
-			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%d|%s|%s|%s|%s",
+			row := fmt.Sprintf("%s|%s|%s|%d|%s|%s|%s|%s",
 				limit(alloc.ID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
 				alloc.TaskGroup,
@@ -610,10 +639,24 @@ func formatAllocListStubs(stubs []*api.AllocationListStub, verbose bool, uuidLen
 				alloc.ClientStatus,
 				createTimePretty,
 				modTimePretty)
+			if showDeadline {
+				row += fmt.Sprintf("|%s", deadlines[i])
+			}
+			allocs[i+1] = row
 		}
 	}
 
 	return formatList(allocs)
+}
+
+func allocationDeadlineColumnVisible(deadlines []string) bool {
+	for _, deadline := range deadlines {
+		if deadline != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int) string {
@@ -621,11 +664,25 @@ func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int
 		return "No allocations placed"
 	}
 
+	deadlines := make([]string, len(allocations))
+	for i, alloc := range allocations {
+		deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates)
+		if !ok {
+			continue
+		}
+
+		deadlines[i] = formatMaxRunDeadline(deadline, verbose)
+	}
+	showDeadline := allocationDeadlineColumnVisible(deadlines)
+
 	allocs := make([]string, len(allocations)+1)
 	if verbose {
 		allocs[0] = "ID|Eval ID|Node ID|Task Group|Version|Desired|Status|Created|Modified"
+		if showDeadline {
+			allocs[0] += "|Max Run Deadline"
+		}
 		for i, alloc := range allocations {
-			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%d|%s|%s|%s|%s",
+			row := fmt.Sprintf("%s|%s|%s|%s|%d|%s|%s|%s|%s",
 				limit(alloc.ID, uuidLength),
 				limit(alloc.EvalID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
@@ -635,14 +692,21 @@ func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int
 				alloc.ClientStatus,
 				formatUnixNanoTime(alloc.CreateTime),
 				formatUnixNanoTime(alloc.ModifyTime))
+			if showDeadline {
+				row += fmt.Sprintf("|%s", deadlines[i])
+			}
+			allocs[i+1] = row
 		}
 	} else {
 		allocs[0] = "ID|Node ID|Task Group|Version|Desired|Status|Created|Modified"
+		if showDeadline {
+			allocs[0] += "|Max Run Deadline"
+		}
+		now := time.Now()
 		for i, alloc := range allocations {
-			now := time.Now()
 			createTimePretty := prettyTimeDiff(time.Unix(0, alloc.CreateTime), now)
 			modTimePretty := prettyTimeDiff(time.Unix(0, alloc.ModifyTime), now)
-			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%d|%s|%s|%s|%s",
+			row := fmt.Sprintf("%s|%s|%s|%d|%s|%s|%s|%s",
 				limit(alloc.ID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
 				alloc.TaskGroup,
@@ -651,6 +715,10 @@ func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int
 				alloc.ClientStatus,
 				createTimePretty,
 				modTimePretty)
+			if showDeadline {
+				row += fmt.Sprintf("|%s", deadlines[i])
+			}
+			allocs[i+1] = row
 		}
 	}
 

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -256,8 +256,8 @@ func TestFormatJobAllocListStubs_MaxRunDeadline(t *testing.T) {
 	jobType := api.JobTypeBatch
 	groupName := "group"
 	maxRunDuration := 10 * time.Minute
-	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
-	deadline := startedAt.Add(maxRunDuration)
+	createtime := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := createtime.Add(maxRunDuration)
 
 	job := &api.Job{
 		Type: &jobType,
@@ -276,10 +276,7 @@ func TestFormatJobAllocListStubs_MaxRunDeadline(t *testing.T) {
 		JobVersion:    1,
 		DesiredStatus: "run",
 		ClientStatus:  "running",
-		TaskStates: map[string]*api.TaskState{
-			"task-a": {State: "running", StartedAt: startedAt.Add(-1 * time.Minute)},
-			"task-b": {State: "complete", StartedAt: startedAt},
-		},
+		CreateTime:    createtime.UnixNano(),
 	}}
 
 	out := formatJobAllocListStubs(allocs, job, true, fullId)
@@ -326,8 +323,8 @@ func TestFormatAllocList_MaxRunDeadline(t *testing.T) {
 	version := uint64(1)
 	groupName := "group"
 	maxRunDuration := 10 * time.Minute
-	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
-	deadline := startedAt.Add(maxRunDuration)
+	createtime := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := createtime.Add(maxRunDuration)
 
 	allocs := []*api.Allocation{{
 		ID:            "alloc-id",
@@ -337,10 +334,7 @@ func TestFormatAllocList_MaxRunDeadline(t *testing.T) {
 		Job:           &api.Job{Type: &jobType, Version: &version, TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}}},
 		DesiredStatus: "run",
 		ClientStatus:  "running",
-		TaskStates: map[string]*api.TaskState{
-			"task-a": {State: "running", StartedAt: startedAt.Add(-1 * time.Minute)},
-			"task-b": {State: "complete", StartedAt: startedAt},
-		},
+		CreateTime:    createtime.UnixNano(),
 	}}
 
 	out := formatAllocList(allocs, true, fullId)

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -250,6 +250,104 @@ func TestJobStatusCommand_Fails(t *testing.T) {
 	}
 }
 
+func TestFormatJobAllocListStubs_MaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeBatch
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := startedAt.Add(maxRunDuration)
+
+	job := &api.Job{
+		Type: &jobType,
+		TaskGroups: []*api.TaskGroup{{
+			Name:           &groupName,
+			MaxRunDuration: &maxRunDuration,
+		}},
+	}
+
+	allocs := []*api.AllocationListStub{{
+		ID:            "alloc-id",
+		EvalID:        "eval-id",
+		NodeID:        "node-id",
+		NodeName:      "node-name",
+		TaskGroup:     groupName,
+		JobVersion:    1,
+		DesiredStatus: "run",
+		ClientStatus:  "running",
+		TaskStates: map[string]*api.TaskState{
+			"task-a": {State: "running", StartedAt: startedAt.Add(-1 * time.Minute)},
+			"task-b": {State: "complete", StartedAt: startedAt},
+		},
+	}}
+
+	out := formatJobAllocListStubs(allocs, job, true, fullId)
+	must.StrContains(t, out, "Max Run Deadline")
+	must.StrContains(t, out, formatTime(deadline))
+}
+
+func TestFormatJobAllocListStubs_NoMaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeService
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+	startedAt := time.Now().Add(-5 * time.Minute)
+
+	job := &api.Job{
+		Type: &jobType,
+		TaskGroups: []*api.TaskGroup{{
+			Name:           &groupName,
+			MaxRunDuration: &maxRunDuration,
+		}},
+	}
+
+	allocs := []*api.AllocationListStub{{
+		ID:            "alloc-id",
+		NodeID:        "node-id",
+		TaskGroup:     groupName,
+		JobVersion:    1,
+		DesiredStatus: "run",
+		ClientStatus:  "running",
+		TaskStates: map[string]*api.TaskState{
+			"task-a": {State: "running", StartedAt: startedAt},
+		},
+	}}
+
+	out := formatJobAllocListStubs(allocs, job, false, fullId)
+	must.StrNotContains(t, out, "Max Run Deadline")
+}
+
+func TestFormatAllocList_MaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeBatch
+	version := uint64(1)
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := startedAt.Add(maxRunDuration)
+
+	allocs := []*api.Allocation{{
+		ID:            "alloc-id",
+		EvalID:        "eval-id",
+		NodeID:        "node-id",
+		TaskGroup:     groupName,
+		Job:           &api.Job{Type: &jobType, Version: &version, TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}}},
+		DesiredStatus: "run",
+		ClientStatus:  "running",
+		TaskStates: map[string]*api.TaskState{
+			"task-a": {State: "running", StartedAt: startedAt.Add(-1 * time.Minute)},
+			"task-b": {State: "complete", StartedAt: startedAt},
+		},
+	}}
+
+	out := formatAllocList(allocs, true, fullId)
+	must.StrContains(t, out, "Max Run Deadline")
+	must.StrContains(t, out, formatTime(deadline))
+}
+
 func TestJobStatusCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
 

--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -357,12 +357,19 @@ func eventFromChange(change memdb.Change) (structs.Event, bool) {
 		// remove job info to help keep size of alloc event down
 		alloc.Job = nil
 
+		allocEvent := &structs.AllocationEvent{Allocation: alloc}
+		if alloc.ClientStatus == structs.AllocClientStatusComplete &&
+			alloc.ClientDescription == structs.AllocTimeoutReasonMaxRunDuration {
+			allocEvent.Timeout = true
+			allocEvent.TimeoutReason = alloc.ClientDescription
+		}
+
 		return structs.Event{
 			Topic:      structs.TopicAllocation,
 			Key:        after.ID,
 			FilterKeys: filterKeys,
 			Namespace:  after.Namespace,
-			Payload:    &structs.AllocationEvent{Allocation: alloc},
+			Payload:    allocEvent,
 		}, true
 	case "jobs":
 		after, ok := change.After.(*structs.Job)

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -538,6 +538,54 @@ func TestEventsFromChanges_ApplyPlanResultsRequestType(t *testing.T) {
 	must.Len(t, 1, evals)
 	must.Len(t, 1, jobs)
 	must.Len(t, 1, deploys)
+
+	for _, e := range allocs {
+		allocEvent := e.Payload.(*structs.AllocationEvent)
+		must.False(t, allocEvent.Timeout)
+		must.Eq(t, "", allocEvent.TimeoutReason)
+	}
+}
+
+func TestEventFromChange_AllocationTimeoutFields(t *testing.T) {
+	ci.Parallel(t)
+	s := TestStateStoreCfg(t, TestStateStorePublisher(t))
+	defer s.StopEventBroker()
+
+	timeoutAlloc := mock.Alloc()
+	timeoutAlloc.ClientStatus = structs.AllocClientStatusComplete
+	timeoutAlloc.ClientDescription = structs.AllocTimeoutReasonMaxRunDuration
+
+	timeoutEvent, ok := eventFromChange(memdb.Change{
+		Table:  "allocs",
+		Before: nil,
+		After:  timeoutAlloc,
+	})
+	must.True(t, ok)
+
+	timeoutPayload, ok := timeoutEvent.Payload.(*structs.AllocationEvent)
+	must.True(t, ok)
+	must.True(t, timeoutPayload.Timeout)
+	must.Eq(t, structs.AllocTimeoutReasonMaxRunDuration, timeoutPayload.TimeoutReason)
+	must.Eq(t, structs.AllocClientStatusComplete, timeoutPayload.Allocation.ClientStatus)
+	must.Eq(t, structs.AllocTimeoutReasonMaxRunDuration, timeoutPayload.Allocation.ClientDescription)
+
+	nonTimeoutAlloc := mock.Alloc()
+	nonTimeoutAlloc.ClientStatus = structs.AllocClientStatusFailed
+	nonTimeoutAlloc.ClientDescription = structs.AllocTimeoutReasonMaxRunDuration
+
+	nonTimeoutEvent, ok := eventFromChange(memdb.Change{
+		Table:  "allocs",
+		Before: nil,
+		After:  nonTimeoutAlloc,
+	})
+	must.True(t, ok)
+
+	nonTimeoutPayload, ok := nonTimeoutEvent.Payload.(*structs.AllocationEvent)
+	must.True(t, ok)
+	must.False(t, nonTimeoutPayload.Timeout)
+	must.Eq(t, "", nonTimeoutPayload.TimeoutReason)
+	must.Eq(t, structs.AllocClientStatusFailed, nonTimeoutPayload.Allocation.ClientStatus)
+	must.Eq(t, structs.AllocTimeoutReasonMaxRunDuration, nonTimeoutPayload.Allocation.ClientDescription)
 }
 
 func TestEventsFromChanges_BatchNodeUpdateDrainRequestType(t *testing.T) {

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -381,10 +381,13 @@ func (a *Allocation) MaxRunDuration() (time.Duration, bool) {
 	}
 }
 
-// FullyRunningSince returns the latest StartedAt timestamp across all task
-// states, but only when every known task state is running with a non-zero start
-// time.
-func FullyRunningSince(taskStates map[string]*TaskState) (time.Time, bool) {
+// FullyStartedSince returns the latest StartedAt timestamp across all task
+// states, but only when every known task state has a non-zero StartedAt time,
+// meaning each task has started at least once. Unlike a stricter check that
+// also requires State == Running, this works correctly both during normal
+// operation and after a client restart when tasks may be temporarily Pending
+// while re-attaching to (or restarting) their processes.
+func FullyStartedSince(taskStates map[string]*TaskState) (time.Time, bool) {
 	if len(taskStates) == 0 {
 		return time.Time{}, false
 	}
@@ -392,7 +395,7 @@ func FullyRunningSince(taskStates map[string]*TaskState) (time.Time, bool) {
 	var latest time.Time
 
 	for _, ts := range taskStates {
-		if ts == nil || ts.State != TaskStateRunning || ts.StartedAt.IsZero() {
+		if ts == nil || ts.StartedAt.IsZero() {
 			return time.Time{}, false
 		}
 		if ts.StartedAt.After(latest) {
@@ -407,23 +410,19 @@ func FullyRunningSince(taskStates map[string]*TaskState) (time.Time, bool) {
 	return latest, true
 }
 
-func (a *Allocation) fullyRunningSince() (time.Time, bool) {
+// MaxRunDurationDeadline returns the deadline at which the allocation should be
+// considered timed out based on max_run_duration.
+func (a *Allocation) MaxRunDurationDeadline() (time.Time, bool) {
 	if a == nil {
 		return time.Time{}, false
 	}
 
-	return FullyRunningSince(a.TaskStates)
-}
-
-// MaxRunDurationDeadline returns the deadline at which the allocation should be
-// considered timed out based on max_run_duration.
-func (a *Allocation) MaxRunDurationDeadline() (time.Time, bool) {
 	maxRunDuration, ok := a.MaxRunDuration()
 	if !ok {
 		return time.Time{}, false
 	}
 
-	startedAt, ok := a.fullyRunningSince()
+	startedAt, ok := FullyStartedSince(a.TaskStates)
 	if !ok {
 		return time.Time{}, false
 	}

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -20,6 +20,10 @@ const (
 	AllocDesiredStatusRun   = "run"   // Allocation should run
 	AllocDesiredStatusStop  = "stop"  // Allocation should stop
 	AllocDesiredStatusEvict = "evict" // Allocation should stop, and was evicted
+
+	// AllocTimeoutReasonMaxRunDuration is the reason used when an allocation is
+	// stopped because it exceeded its configured max_run_duration.
+	AllocTimeoutReasonMaxRunDuration = "allocation exceeded max_run_duration"
 )
 
 const (
@@ -355,6 +359,95 @@ func (a *Allocation) TerminalStatus() bool {
 	// First check the desired state and if that isn't terminal, check client
 	// state.
 	return a.ServerTerminalStatus() || a.ClientTerminalStatus()
+}
+
+// MaxRunDuration returns the configured max_run_duration for the allocation's
+// task group, if any.
+func (a *Allocation) MaxRunDuration() (time.Duration, bool) {
+	if a == nil || a.Job == nil {
+		return 0, false
+	}
+
+	tg := a.Job.LookupTaskGroup(a.TaskGroup)
+	if tg == nil || tg.MaxRunDuration == nil || *tg.MaxRunDuration <= 0 {
+		return 0, false
+	}
+
+	switch a.Job.Type {
+	case JobTypeBatch, JobTypeSysBatch:
+		return *tg.MaxRunDuration, true
+	default:
+		return 0, false
+	}
+}
+
+// FullyRunningSince returns the latest StartedAt timestamp across all task
+// states, but only when every known task state is running with a non-zero start
+// time.
+func FullyRunningSince(taskStates map[string]*TaskState) (time.Time, bool) {
+	if len(taskStates) == 0 {
+		return time.Time{}, false
+	}
+
+	var latest time.Time
+
+	for _, ts := range taskStates {
+		if ts == nil || ts.State != TaskStateRunning || ts.StartedAt.IsZero() {
+			return time.Time{}, false
+		}
+		if ts.StartedAt.After(latest) {
+			latest = ts.StartedAt
+		}
+	}
+
+	if latest.IsZero() {
+		return time.Time{}, false
+	}
+
+	return latest, true
+}
+
+func (a *Allocation) fullyRunningSince() (time.Time, bool) {
+	if a == nil {
+		return time.Time{}, false
+	}
+
+	return FullyRunningSince(a.TaskStates)
+}
+
+// MaxRunDurationDeadline returns the deadline at which the allocation should be
+// considered timed out based on max_run_duration.
+func (a *Allocation) MaxRunDurationDeadline() (time.Time, bool) {
+	maxRunDuration, ok := a.MaxRunDuration()
+	if !ok {
+		return time.Time{}, false
+	}
+
+	startedAt, ok := a.fullyRunningSince()
+	if !ok {
+		return time.Time{}, false
+	}
+
+	return startedAt.Add(maxRunDuration), true
+}
+
+// MaxRunDurationExpired returns whether the allocation has exceeded its
+// configured max_run_duration.
+func (a *Allocation) MaxRunDurationExpired(now time.Time) bool {
+	if a == nil || a.DesiredStatus != AllocDesiredStatusRun || a.ClientStatus != AllocClientStatusRunning {
+		return false
+	}
+
+	if a.ClientTerminalStatus() || a.ServerTerminalStatus() {
+		return false
+	}
+
+	deadline, ok := a.MaxRunDurationDeadline()
+	if !ok {
+		return false
+	}
+
+	return !deadline.After(now)
 }
 
 // ServerTerminalStatus returns true if the desired state of the allocation is terminal

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -381,37 +381,10 @@ func (a *Allocation) MaxRunDuration() (time.Duration, bool) {
 	}
 }
 
-// FullyStartedSince returns the latest StartedAt timestamp across all task
-// states, but only when every known task state has a non-zero StartedAt time,
-// meaning each task has started at least once. Unlike a stricter check that
-// also requires State == Running, this works correctly both during normal
-// operation and after a client restart when tasks may be temporarily Pending
-// while re-attaching to (or restarting) their processes.
-func FullyStartedSince(taskStates map[string]*TaskState) (time.Time, bool) {
-	if len(taskStates) == 0 {
-		return time.Time{}, false
-	}
-
-	var latest time.Time
-
-	for _, ts := range taskStates {
-		if ts == nil || ts.StartedAt.IsZero() {
-			return time.Time{}, false
-		}
-		if ts.StartedAt.After(latest) {
-			latest = ts.StartedAt
-		}
-	}
-
-	if latest.IsZero() {
-		return time.Time{}, false
-	}
-
-	return latest, true
-}
-
 // MaxRunDurationDeadline returns the deadline at which the allocation should be
-// considered timed out based on max_run_duration.
+// considered timed out based on max_run_duration. The deadline is always
+// anchored to the allocation's CreateTime, which is stable across restarts and
+// task-level events such as retries that update individual task StartedAt times.
 func (a *Allocation) MaxRunDurationDeadline() (time.Time, bool) {
 	if a == nil {
 		return time.Time{}, false
@@ -422,12 +395,11 @@ func (a *Allocation) MaxRunDurationDeadline() (time.Time, bool) {
 		return time.Time{}, false
 	}
 
-	startedAt, ok := FullyStartedSince(a.TaskStates)
-	if !ok {
+	if a.CreateTime == 0 {
 		return time.Time{}, false
 	}
 
-	return startedAt.Add(maxRunDuration), true
+	return time.Unix(0, a.CreateTime).Add(maxRunDuration), true
 }
 
 // MaxRunDurationExpired returns whether the allocation has exceeded its

--- a/nomad/structs/event.go
+++ b/nomad/structs/event.go
@@ -141,6 +141,14 @@ type EvaluationEvent struct {
 // Allocs embedded Job has been removed to reduce size.
 type AllocationEvent struct {
 	Allocation *Allocation
+
+	// Timeout indicates the allocation was stopped because it exceeded its
+	// configured max_run_duration.
+	Timeout bool `json:",omitempty"`
+
+	// TimeoutReason is a human-readable explanation for timeout-triggered
+	// allocation stops.
+	TimeoutReason string `json:",omitempty"`
 }
 
 // DeploymentEvent holds a newly updated Deployment.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6937,6 +6937,11 @@ type TaskGroup struct {
 	// group services in consul and stopping tasks.
 	ShutdownDelay *time.Duration
 
+	// MaxRunDuration is the maximum amount of time a batch or sysbatch task
+	// group allocation may run after entering the running state before Nomad
+	// stops it.
+	MaxRunDuration *time.Duration
+
 	// StopAfterClientDisconnect, if set, configures the client to stop the task group
 	// after this duration since the last known good heartbeat
 	// To be deprecated after 1.8.0 infavor of Disconnect.StopOnClientAfter
@@ -7003,6 +7008,10 @@ func (tg *TaskGroup) Copy() *TaskGroup {
 
 	if tg.ShutdownDelay != nil {
 		ntg.ShutdownDelay = tg.ShutdownDelay
+	}
+
+	if tg.MaxRunDuration != nil {
+		ntg.MaxRunDuration = tg.MaxRunDuration
 	}
 
 	return ntg
@@ -7121,6 +7130,18 @@ func (tg *TaskGroup) Validate(j *Job) error {
 	if tg.Disconnect != nil {
 		if err := tg.Disconnect.Validate(j); err != nil {
 			mErr = multierror.Append(mErr, err)
+		}
+	}
+
+	if tg.MaxRunDuration != nil {
+		if *tg.MaxRunDuration <= 0 {
+			mErr = multierror.Append(mErr, errors.New("MaxRunDuration must be greater than zero"))
+		}
+
+		switch j.Type {
+		case JobTypeBatch, JobTypeSysBatch:
+		default:
+			mErr = multierror.Append(mErr, fmt.Errorf("Job type %q does not allow max_run_duration", j.Type))
 		}
 	}
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1651,6 +1651,81 @@ func TestTaskGroup_Validate(t *testing.T) {
 			jobType: JobTypeSystem,
 		},
 		{
+			name: "invalid max run duration for service job",
+			tg: &TaskGroup{
+				Name:           "web",
+				Count:          1,
+				MaxRunDuration: pointer.Of(5 * time.Minute),
+				Tasks: []*Task{
+					{Name: "web"},
+				},
+			},
+			expErr: []string{
+				`Job type "service" does not allow max_run_duration`,
+			},
+			jobType: JobTypeService,
+		},
+		{
+			name: "invalid non-positive max run duration for batch job",
+			tg: &TaskGroup{
+				Name:           "web",
+				Count:          1,
+				MaxRunDuration: pointer.Of(time.Duration(0)),
+				Tasks: []*Task{
+					{Name: "web"},
+				},
+			},
+			expErr: []string{
+				"MaxRunDuration must be greater than zero",
+			},
+			jobType: JobTypeBatch,
+		},
+		{
+			name: "valid max run duration for batch job",
+			tg: &TaskGroup{
+				Name:           "web",
+				Count:          1,
+				MaxRunDuration: pointer.Of(5 * time.Minute),
+				Tasks: []*Task{
+					{
+						Name:      "web",
+						Driver:    "mock_driver",
+						Resources: DefaultResources(),
+						LogConfig: DefaultLogConfig(),
+					},
+				},
+				RestartPolicy:    NewRestartPolicy(JobTypeBatch),
+				ReschedulePolicy: NewReschedulePolicy(JobTypeBatch),
+				EphemeralDisk:    DefaultEphemeralDisk(),
+			},
+			jobType: JobTypeBatch,
+		},
+		{
+			name: "valid max run duration for sysbatch job",
+			tg: &TaskGroup{
+				Name:           "web",
+				Count:          1,
+				MaxRunDuration: pointer.Of(5 * time.Minute),
+				Tasks: []*Task{
+					{
+						Name:      "web",
+						Driver:    "mock_driver",
+						Resources: DefaultResources(),
+						LogConfig: DefaultLogConfig(),
+					},
+				},
+				RestartPolicy: &RestartPolicy{
+					Attempts:        0,
+					Interval:        5 * time.Second,
+					Delay:           5 * time.Second,
+					Mode:            RestartPolicyModeFail,
+					RenderTemplates: false,
+				},
+				EphemeralDisk: DefaultEphemeralDisk(),
+			},
+			jobType: JobTypeSysBatch,
+		},
+		{
 			name: "duplicated por label",
 			tg: &TaskGroup{
 				Networks: []*NetworkResource{

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -3423,6 +3423,93 @@ func TestServiceSched_JobModify_InPlace08(t *testing.T) {
 	must.NotNil(t, newAlloc.AllocatedResources)
 }
 
+func TestServiceSched_JobModify_MaxRunDuration_InPlace(t *testing.T) {
+	ci.Parallel(t)
+
+	h := tests.NewHarness(t)
+
+	// Create a node
+	node := mock.Node()
+	must.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
+
+	// Create a batch job with a running allocation
+	job := mock.BatchJob()
+	job.TaskGroups[0].Count = 1
+	initialMaxRunDuration := 1 * time.Hour
+	job.TaskGroups[0].MaxRunDuration = &initialMaxRunDuration
+	must.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
+
+	alloc := mock.BatchAlloc()
+	alloc.Job = job
+	alloc.JobID = job.ID
+	alloc.NodeID = node.ID
+	alloc.Name = fmt.Sprintf("%s.%s[%d]", job.ID, job.TaskGroups[0].Name, 0)
+	must.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
+
+	// Update only max_run_duration
+	job2 := job.Copy()
+	updatedMaxRunDuration := 4 * time.Hour
+	job2.TaskGroups[0].MaxRunDuration = &updatedMaxRunDuration
+	must.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job2))
+
+	// Create a mock evaluation
+	eval := &structs.Evaluation{
+		Namespace:    structs.DefaultNamespace,
+		ID:           uuid.Generate(),
+		Priority:     50,
+		TriggeredBy:  structs.EvalTriggerJobRegister,
+		JobID:        job.ID,
+		Status:       structs.EvalStatusPending,
+		AnnotatePlan: true,
+	}
+	must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
+
+	// Process the evaluation
+	err := h.Process(NewBatchScheduler, eval)
+	must.NoError(t, err)
+
+	// Ensure a single plan
+	must.SliceLen(t, 1, h.Plans)
+	plan := h.Plans[0]
+
+	// Ensure the plan did not evict any allocs
+	var update []*structs.Allocation
+	for _, updateList := range plan.NodeUpdate {
+		update = append(update, updateList...)
+	}
+	must.SliceLen(t, 0, update)
+
+	// Ensure the plan updated the existing alloc in place
+	var planned []*structs.Allocation
+	for _, allocList := range plan.NodeAllocation {
+		planned = append(planned, allocList...)
+	}
+	must.SliceLen(t, 1, planned)
+	must.Eq(t, job2, planned[0].Job)
+	must.NotNil(t, plan.Annotations)
+	must.NotNil(t, plan.Annotations.DesiredTGUpdates)
+	must.NotNil(t, plan.Annotations.DesiredTGUpdates[job.TaskGroups[0].Name])
+	must.Eq(t, uint64(1), plan.Annotations.DesiredTGUpdates[job.TaskGroups[0].Name].InPlaceUpdate)
+	must.Eq(t, uint64(0), plan.Annotations.DesiredTGUpdates[job.TaskGroups[0].Name].DestructiveUpdate)
+	must.Eq(t, uint64(0), plan.Annotations.DesiredTGUpdates[job.TaskGroups[0].Name].Place)
+	must.Eq(t, uint64(0), plan.Annotations.DesiredTGUpdates[job.TaskGroups[0].Name].Stop)
+
+	// Lookup the allocations by JobID
+	ws := memdb.NewWatchSet()
+	out, err := h.State.AllocsByJob(ws, job.Namespace, job.ID, false)
+	must.NoError(t, err)
+	must.Len(t, 1, out)
+
+	updatedAlloc := out[0]
+	maxRunDuration, ok := updatedAlloc.MaxRunDuration()
+	must.True(t, ok)
+	must.Eq(t, updatedMaxRunDuration, maxRunDuration)
+	must.Eq(t, alloc.ID, planned[0].ID)
+	must.Eq(t, updatedAlloc.ID, planned[0].ID)
+
+	h.AssertEvalStatus(t, structs.EvalStatusComplete)
+}
+
 func TestServiceSched_JobModify_DistinctProperty(t *testing.T) {
 	ci.Parallel(t)
 

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -842,6 +842,22 @@ func genericAllocUpdateFn(ctx feasible.Context, stack feasible.Stack, evalID str
 			return false, true, nil
 		}
 
+		// max_run_duration-only updates. This field does not affect placement
+		// or allocated resources, so we can update the alloc in place without
+		// re-running feasibility.
+		if existingTG := existing.Job.LookupTaskGroup(newTG.Name); existingTG != nil {
+			oldMax, oldOK := existing.MaxRunDuration()
+			newAlloc := existing.Copy()
+			newAlloc.EvalID = evalID
+			newAlloc.Job = nil
+			newAlloc.Resources = nil
+
+			newMax, newOK := newAlloc.MaxRunDuration()
+			if oldOK != newOK || oldMax != newMax {
+				return false, false, newAlloc
+			}
+		}
+
 		// Set the existing node as the base set
 		stack.SetNodes([]*structs.Node{node})
 

--- a/ui/app/components/allocation-row.hbs
+++ b/ui/app/components/allocation-row.hbs
@@ -72,6 +72,18 @@
     {{moment-from-now this.allocation.modifyTime}}
   </span>
 </td>
+{{#if @showMaxRunDeadline}}
+  <td data-test-max-run-deadline>
+    {{#if this.allocation.maxRunDeadline}}
+      <span
+        class="tooltip"
+        aria-label="{{format-ts this.allocation.maxRunDeadline}}"
+      >
+        {{moment-from-now this.allocation.maxRunDeadline}}
+      </span>
+    {{/if}}
+  </td>
+{{/if}}
 <td data-test-client-status class="is-one-line">
   <span class="color-swatch {{this.allocation.clientStatus}}"></span>
   {{this.allocation.clientStatus}}

--- a/ui/app/components/job-deployment/deployment-allocations.hbs
+++ b/ui/app/components/job-deployment/deployment-allocations.hbs
@@ -24,6 +24,9 @@
           <th>Task Group</th>
           <th>Created</th>
           <th>Modified</th>
+          {{#if @deployment.job.isBatchOrSysbatch}}
+            <th>Max Run Deadline</th>
+          {{/if}}
           <th>Status</th>
           <th>Version</th>
           <th>Node</th>
@@ -36,6 +39,7 @@
             data-test-deployment-allocation
             @allocation={{row.model}}
             @context="job"
+            @showMaxRunDeadline={{@deployment.job.isBatchOrSysbatch}}
           />
         </t.body>
       </ListTable>

--- a/ui/app/components/job-editor/review.hbs
+++ b/ui/app/components/job-editor/review.hbs
@@ -67,6 +67,9 @@
           <th>Task Group</th>
           <th>Created</th>
           <th>Modified</th>
+          {{#if @data.job.isBatchOrSysbatch}}
+            <th>Max Run Deadline</th>
+          {{/if}}
           <th>Status</th>
           <th>Version</th>
           <th>Node</th>
@@ -75,7 +78,11 @@
           <th>Memory</th>
         </t.head>
         <t.body as |row|>
-          <AllocationRow @allocation={{row.model}} @context="job" />
+          <AllocationRow
+            @allocation={{row.model}}
+            @context="job"
+            @showMaxRunDeadline={{@data.job.isBatchOrSysbatch}}
+          />
         </t.body>
       </ListTable>
     </div>

--- a/ui/app/components/job-page/parts/recent-allocations.hbs
+++ b/ui/app/components/job-page/parts/recent-allocations.hbs
@@ -41,6 +41,11 @@
           <th>
             Modified
           </th>
+          {{#if this.job.isBatchOrSysbatch}}
+            <th>
+              Max Run Deadline
+            </th>
+          {{/if}}
           <th>
             Status
           </th>
@@ -69,6 +74,7 @@
             @allocation={{row.model}}
             @context="job"
             @onClick={{fn this.gotoAllocation row.model}}
+            @showMaxRunDeadline={{this.job.isBatchOrSysbatch}}
             @showSubTasks={{this.showSubTasks}}
             {{keyboard-shortcut
               enumerated=true
@@ -78,16 +84,29 @@
 
           {{#if this.showSubTasks}}
             {{#each row.model.states as |task|}}
-              <TaskSubRow
-                @namespan="9"
-                @taskState={{task}}
-                @active={{eq
-                  @activeTask
-                  (concat task.allocation.id "-" task.name)
-                }}
-                @onSetActiveTask={{@setActiveTaskQueryParam}}
-                @jobHasActions={{this.job.actions.length}}
-              />
+              {{#if this.job.isBatchOrSysbatch}}
+                <TaskSubRow
+                  @namespan="10"
+                  @taskState={{task}}
+                  @active={{eq
+                    @activeTask
+                    (concat task.allocation.id "-" task.name)
+                  }}
+                  @onSetActiveTask={{@setActiveTaskQueryParam}}
+                  @jobHasActions={{this.job.actions.length}}
+                />
+              {{else}}
+                <TaskSubRow
+                  @namespan="9"
+                  @taskState={{task}}
+                  @active={{eq
+                    @activeTask
+                    (concat task.allocation.id "-" task.name)
+                  }}
+                  @onSetActiveTask={{@setActiveTaskQueryParam}}
+                  @jobHasActions={{this.job.actions.length}}
+                />
+              {{/if}}
             {{/each}}
           {{/if}}
         </t.body>

--- a/ui/app/models/allocation.js
+++ b/ui/app/models/allocation.js
@@ -23,6 +23,8 @@ const STATUS_ORDER = {
   lost: 6,
 };
 
+const NANOSECONDS_IN_MILLISECOND = 1000000;
+
 @classic
 export default class Allocation extends Model {
   @service token;
@@ -170,6 +172,48 @@ export default class Allocation extends Model {
   }
 
   @fragment('task-group', { defaultValue: null }) allocationTaskGroup;
+
+  @computed('taskGroup.{hasMaxRunDeadline,maxRunDuration}')
+  get maxRunDuration() {
+    if (!this.taskGroup?.hasMaxRunDeadline) {
+      return null;
+    }
+
+    return this.taskGroup.maxRunDuration;
+  }
+
+  @computed('states.@each.startedAt')
+  get fullyStartedAt() {
+    const states = this.states?.toArray?.() || this.states || [];
+    if (!states.length) {
+      return null;
+    }
+
+    let latest = null;
+    for (const taskState of states) {
+      if (!taskState.startedAt) {
+        return null;
+      }
+
+      if (!latest || taskState.startedAt > latest) {
+        latest = taskState.startedAt;
+      }
+    }
+
+    return latest;
+  }
+
+  @computed('maxRunDuration', 'fullyStartedAt')
+  get maxRunDeadline() {
+    if (!this.maxRunDuration || !this.fullyStartedAt) {
+      return null;
+    }
+
+    return new Date(
+      this.fullyStartedAt.getTime() +
+        this.maxRunDuration / NANOSECONDS_IN_MILLISECOND
+    );
+  }
 
   @computed('taskGroup.drivers.[]', 'node.unhealthyDriverNames.[]')
   get unhealthyDrivers() {

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -449,6 +449,17 @@ export default class Job extends Model {
 
   @attr() datacenters;
   @fragmentArray('task-group', { defaultValue: () => [] }) taskGroups;
+  @computed('taskGroups.@each.hasMaxRunDeadline')
+  get hasMaxRunDeadline() {
+    return (this.taskGroups?.toArray?.() || this.taskGroups || []).some(
+      (taskGroup) => taskGroup.hasMaxRunDeadline,
+    );
+  }
+
+  get isBatchOrSysbatch() {
+    return this.type === 'batch' || this.type === 'sysbatch';
+  }
+
   @belongsTo('job-summary', { async: true, inverse: 'job' }) summary;
 
   // A job model created from the jobs list response will be lacking

--- a/ui/app/models/task-group.js
+++ b/ui/app/models/task-group.js
@@ -15,6 +15,7 @@ import sumAggregation from '../utils/properties/sum-aggregation';
 import classic from 'ember-classic-decorator';
 
 const maybe = (arr) => arr || [];
+const JOB_TYPES_WITH_MAX_RUN_DEADLINE = ['batch', 'sysbatch'];
 
 @classic
 export default class TaskGroup extends Fragment {
@@ -22,6 +23,27 @@ export default class TaskGroup extends Fragment {
 
   @attr('string') name;
   @attr('number') count;
+  @attr('number') maxRunDuration;
+
+  @computed('job.type')
+  get ownerJobType() {
+    return this.job?.type;
+  }
+
+  @computed('job.job.type')
+  get allocationOwnerJobType() {
+    return this.job?.job?.type;
+  }
+
+  @computed('ownerJobType', 'allocationOwnerJobType', 'maxRunDuration')
+  get hasMaxRunDeadline() {
+    const jobType = this.ownerJobType || this.allocationOwnerJobType;
+
+    return (
+      JOB_TYPES_WITH_MAX_RUN_DEADLINE.includes(jobType) &&
+      this.maxRunDuration > 0
+    );
+  }
 
   @computed('job.{variables,parent,plainId}', 'name')
   get pathLinkedVariable() {

--- a/ui/app/templates/allocations/allocation/index.hbs
+++ b/ui/app/templates/allocations/allocation/index.hbs
@@ -137,6 +137,19 @@
           {{this.model.job.namespace.name}}
         </span>
       </span>
+      {{#if this.model.maxRunDeadline}}
+        <span class="pair" data-test-max-run-deadline>
+          <span class="term">
+            Max Run Deadline
+          </span>
+          <span
+            class="tooltip"
+            aria-label="{{format-ts this.model.maxRunDeadline}}"
+          >
+            {{moment-from-now this.model.maxRunDeadline}}
+          </span>
+        </span>
+      {{/if}}
     </div>
   </div>
   <div class="boxed-section">
@@ -496,6 +509,11 @@
             <th>
               Modified
             </th>
+            {{#if this.model.job.isBatchOrSysbatch}}
+              <th>
+                Max Run Deadline
+              </th>
+            {{/if}}
             <th>
               Status
             </th>
@@ -517,6 +535,7 @@
               @allocation={{row.model}}
               @context="job"
               @data-test-allocation={{row.model.id}}
+              @showMaxRunDeadline={{this.model.job.isBatchOrSysbatch}}
             />
           </t.body>
         </ListTable>

--- a/ui/app/templates/clients/client/index.hbs
+++ b/ui/app/templates/clients/client/index.hbs
@@ -569,6 +569,9 @@
               <t.sort-by @prop="modifyIndex" @title="Modify Index">
                 Modified
               </t.sort-by>
+              <t.sort-by @prop="maxRunDeadline">
+                Max Run Deadline
+              </t.sort-by>
               <t.sort-by @prop="statusIndex">
                 Status
               </t.sort-by>
@@ -599,19 +602,20 @@
                 @context="node"
                 @onClick={{fn this.gotoAllocation row.model}}
                 @data-test-allocation={{row.model.id}}
+                @showMaxRunDeadline={{true}}
               />
               {{#if this.showSubTasks}}
                 {{#each row.model.states as |task|}}
                   <TaskSubRow
-                    @namespan="8"
-                    @taskState={{task}}
-                    @active={{eq
-                      this.activeTask
-                      (concat task.allocation.id "-" task.name)
-                    }}
-                    @onSetActiveTask={{this.setActiveTaskQueryParam}}
-                    @jobHasActions={{true}}
-                  />
+                      @namespan="9"
+                      @taskState={{task}}
+                      @active={{eq
+                        this.activeTask
+                        (concat task.allocation.id "-" task.name)
+                      }}
+                      @onSetActiveTask={{this.setActiveTaskQueryParam}}
+                      @jobHasActions={{true}}
+                    />
                 {{/each}}
               {{/if}}
             </t.body>

--- a/ui/app/templates/jobs/job/allocations.hbs
+++ b/ui/app/templates/jobs/job/allocations.hbs
@@ -83,6 +83,9 @@
               @prop="modifyIndex"
               @title="Modify Index"
             >Modified</t.sort-by>
+            {{#if this.job.isBatchOrSysbatch}}
+              <t.sort-by @prop="maxRunDeadline">Max Run Deadline</t.sort-by>
+            {{/if}}
             <t.sort-by @prop="statusIndex">Status</t.sort-by>
             <t.sort-by @prop="jobVersion">Version</t.sort-by>
             <t.sort-by @prop="node.shortId">Client</t.sort-by>
@@ -102,19 +105,33 @@
               @data-test-allocation={{row.model.id}}
               @allocation={{row.model}}
               @context="job"
+              @showMaxRunDeadline={{this.job.isBatchOrSysbatch}}
               @onClick={{fn this.gotoAllocation row.model}}
             />
             {{#each row.model.states as |task|}}
-              <TaskSubRow
-                @active={{eq
-                  this.activeTask
-                  (concat task.allocation.id "-" task.name)
-                }}
-                @onSetActiveTask={{this.setActiveTaskQueryParam}}
-                @namespan="9"
-                @taskState={{task}}
-                @jobHasActions={{this.job.actions.length}}
-              />
+              {{#if this.job.isBatchOrSysbatch}}
+                <TaskSubRow
+                  @active={{eq
+                    this.activeTask
+                    (concat task.allocation.id "-" task.name)
+                  }}
+                  @onSetActiveTask={{this.setActiveTaskQueryParam}}
+                  @namespan="10"
+                  @taskState={{task}}
+                  @jobHasActions={{this.job.actions.length}}
+                />
+              {{else}}
+                <TaskSubRow
+                  @active={{eq
+                    this.activeTask
+                    (concat task.allocation.id "-" task.name)
+                  }}
+                  @onSetActiveTask={{this.setActiveTaskQueryParam}}
+                  @namespan="9"
+                  @taskState={{task}}
+                  @jobHasActions={{this.job.actions.length}}
+                />
+              {{/if}}
             {{/each}}
 
           </t.body>

--- a/ui/app/templates/jobs/job/task-group.hbs
+++ b/ui/app/templates/jobs/job/task-group.hbs
@@ -207,6 +207,11 @@
               <t.sort-by @prop="modifyIndex" @title="Modify Index">
                 Modified
               </t.sort-by>
+              {{#if this.model.job.isBatchOrSysbatch}}
+                <t.sort-by @prop="maxRunDeadline">
+                  Max Run Deadline
+                </t.sort-by>
+              {{/if}}
               <t.sort-by @prop="statusIndex">
                 Status
               </t.sort-by>
@@ -238,20 +243,34 @@
                 @data-test-allocation={{row.model.id}}
                 @allocation={{row.model}}
                 @context="taskGroup"
+                @showMaxRunDeadline={{this.model.job.isBatchOrSysbatch}}
                 @onClick={{fn this.gotoAllocation row.model}}
               />
               {{#if this.showSubTasks}}
                 {{#each row.model.states as |task|}}
-                  <TaskSubRow
-                    @namespan="8"
-                    @taskState={{task}}
-                    @active={{eq
-                      this.activeTask
-                      (concat task.allocation.id "-" task.name)
-                    }}
-                    @onSetActiveTask={{this.setActiveTaskQueryParam}}
-                    @jobHasActions={{this.model.job.actions.length}}
-                  />
+                  {{#if this.model.job.isBatchOrSysbatch}}
+                    <TaskSubRow
+                      @namespan="9"
+                      @taskState={{task}}
+                      @active={{eq
+                        this.activeTask
+                        (concat task.allocation.id "-" task.name)
+                      }}
+                      @onSetActiveTask={{this.setActiveTaskQueryParam}}
+                      @jobHasActions={{this.model.job.actions.length}}
+                    />
+                  {{else}}
+                    <TaskSubRow
+                      @namespan="8"
+                      @taskState={{task}}
+                      @active={{eq
+                        this.activeTask
+                        (concat task.allocation.id "-" task.name)
+                      }}
+                      @onSetActiveTask={{this.setActiveTaskQueryParam}}
+                      @jobHasActions={{this.model.job.actions.length}}
+                    />
+                  {{/if}}
                 {{/each}}
               {{/if}}
             </t.body>

--- a/ui/app/templates/storage/volumes/dynamic-host-volume.hbs
+++ b/ui/app/templates/storage/volumes/dynamic-host-volume.hbs
@@ -74,6 +74,7 @@
             <th>ID</th>
             <th>Created</th>
             <th>Modified</th>
+            <th>Max Run Deadline</th>
             <th>Status</th>
             <th>Client</th>
             <th>Job</th>
@@ -90,6 +91,7 @@
               @data-test-allocation={{row.model.id}}
               @allocation={{row.model}}
               @context="volume"
+              @showMaxRunDeadline={{true}}
               @onClick={{fn this.gotoAllocation row.model}}
             />
           </t.body>

--- a/ui/app/templates/storage/volumes/volume.hbs
+++ b/ui/app/templates/storage/volumes/volume.hbs
@@ -55,6 +55,7 @@
             <th>ID</th>
             <th>Created</th>
             <th>Modified</th>
+              <th>Max Run Deadline</th>
             <th>Status</th>
             <th>Client</th>
             <th>Job</th>
@@ -71,6 +72,7 @@
               @data-test-write-allocation={{row.model.id}}
               @allocation={{row.model}}
               @context="volume"
+              @showMaxRunDeadline={{true}}
               @onClick={{fn this.gotoAllocation row.model}}
             />
           </t.body>
@@ -110,6 +112,7 @@
             <th>ID</th>
             <th>Modified</th>
             <th>Created</th>
+              <th>Max Run Deadline</th>
             <th>Status</th>
             <th>Client</th>
             <th>Job</th>
@@ -126,6 +129,7 @@
               @data-test-read-allocation={{row.model.id}}
               @allocation={{row.model}}
               @context="volume"
+              @showMaxRunDeadline={{true}}
               @onClick={{fn this.gotoAllocation row.model}}
             />
           </t.body>

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -102,6 +102,50 @@ module('Acceptance | allocation detail', function (hooks) {
     );
   });
 
+  test('/allocation/:id shows max run deadline for batch allocations that have one configured', async function (assert) {
+    const maxRunDuration = 10 * 60 * 1000000000;
+    const startedAt = new Date('2025-01-02T03:04:05Z');
+    const expectedDeadline = new Date(
+      startedAt.getTime() + maxRunDuration / 1000000,
+    );
+
+    const batchJob = this.server.create('job', {
+      groupsCount: 1,
+      withGroupServices: true,
+      createAllocations: false,
+      type: 'batch',
+    });
+    const taskGroup = this.server.db.taskGroups.findBy({ jobId: batchJob.id });
+    this.server.db.taskGroups.update(taskGroup.id, { maxRunDuration });
+
+    const batchAllocation = this.server.create(
+      'allocation',
+      'withTaskWithPorts',
+      {
+        clientStatus: 'running',
+        jobId: batchJob.id,
+        taskGroup: taskGroup.name,
+      },
+    );
+
+    this.server.db.taskStates
+      .where({ allocationId: batchAllocation.id })
+      .forEach((taskState) => {
+        this.server.db.taskStates.update(taskState.id, {
+          state: 'running',
+          startedAt,
+        });
+      });
+
+    await Allocation.visit({ id: batchAllocation.id });
+
+    assert.equal(
+      Allocation.details.maxRunDeadlineTooltip,
+      moment(expectedDeadline).format("MMM DD, 'YY HH:mm:ss ZZ"),
+      'Allocation details show the computed max run deadline',
+    );
+  });
+
   test('/allocation/:id should include resource utilization graphs', async function (assert) {
     assert.deepEqual(
       Allocation.resourceCharts.length,

--- a/ui/tests/acceptance/client-detail-test.js
+++ b/ui/tests/acceptance/client-detail-test.js
@@ -180,6 +180,46 @@ module('Acceptance | client detail', function (hooks) {
     assert.deepEqual(ClientDetail.emptyAllocations.headline, 'No Allocations');
   });
 
+  test('client allocations show max run deadline when configured', async function (assert) {
+    const maxRunDuration = 10 * 60 * 1000000000;
+    const startedAt = new Date('2025-01-02T03:04:05Z');
+    const expectedDeadline = new Date(
+      startedAt.getTime() + maxRunDuration / 1000000
+    );
+
+    const batchJob = this.server.create('job', {
+      type: 'batch',
+      createAllocations: false,
+    });
+    const taskGroup = this.server.db.taskGroups.findBy({ jobId: batchJob.id });
+    this.server.db.taskGroups.update(taskGroup.id, { maxRunDuration });
+
+    const allocation = this.server.create('allocation', {
+      nodeId: node.id,
+      jobId: batchJob.id,
+      taskGroup: taskGroup.name,
+      clientStatus: 'running',
+      modifyIndex: 999999,
+    });
+
+    this.server.db.taskStates
+      .where({ allocationId: allocation.id })
+      .forEach((taskState) => {
+        this.server.db.taskStates.update(taskState.id, {
+          state: 'running',
+          startedAt,
+        });
+      });
+
+    await ClientDetail.visit({ id: node.id });
+
+    assert.equal(
+      ClientDetail.allocationFor(allocation.id).maxRunDeadlineTooltip,
+      moment(expectedDeadline).format("MMM DD, 'YY HH:mm:ss ZZ"),
+      'The client allocations table shows the computed max run deadline'
+    );
+  });
+
   test('each allocation should have high-level details for the allocation', async function (assert) {
     const allocation = this.server.db.allocations
       .where({ nodeId: node.id })

--- a/ui/tests/acceptance/dynamic-host-volume-detail-test.js
+++ b/ui/tests/acceptance/dynamic-host-volume-detail-test.js
@@ -127,6 +127,46 @@ module('Acceptance | dynamic host volume detail', function (hooks) {
     }
   });
 
+  test('allocations show max run deadline when configured', async function (assert) {
+    const maxRunDuration = 10 * 60 * 1000000000;
+    const startedAt = new Date('2025-01-02T03:04:05Z');
+    const expectedDeadline = new Date(
+      startedAt.getTime() + maxRunDuration / 1000000
+    );
+
+    const batchJob = this.server.create('job', {
+      type: 'batch',
+      createAllocations: false,
+    });
+    const taskGroup = this.server.db.taskGroups.findBy({ jobId: batchJob.id });
+    this.server.db.taskGroups.update(taskGroup.id, { maxRunDuration });
+
+    const allocation = this.server.create('allocation', {
+      clientStatus: 'running',
+      jobId: batchJob.id,
+      taskGroup: taskGroup.name,
+      modifyIndex: 999999,
+    });
+    assignAlloc(volume, allocation);
+
+    this.server.db.taskStates
+      .where({ allocationId: allocation.id })
+      .forEach((taskState) => {
+        this.server.db.taskStates.update(taskState.id, {
+          state: 'running',
+          startedAt,
+        });
+      });
+
+    await VolumeDetail.visit({ id: `${volume.id}@default` });
+
+    assert.equal(
+      VolumeDetail.allocationFor(allocation.id).maxRunDeadlineTooltip,
+      moment(expectedDeadline).format("MMM DD, 'YY HH:mm:ss ZZ"),
+      'The allocations table shows the computed max run deadline'
+    );
+  });
+
   test('each allocation should have high-level details for the allocation', async function (assert) {
     const allocation = this.server.create('allocation', {
       clientStatus: 'running',

--- a/ui/tests/acceptance/job-allocations-test.js
+++ b/ui/tests/acceptance/job-allocations-test.js
@@ -10,6 +10,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import Allocations from 'nomad-ui/tests/pages/jobs/job/allocations';
+import moment from 'moment';
 
 let job;
 let allocations;
@@ -79,6 +80,42 @@ module('Acceptance | job allocations', function (hooks) {
     });
 
     assert.deepEqual(getPageTitle(), `Job ${job.name} allocations - Nomad`);
+  });
+
+
+  test('allocations show max run deadline for batch jobs that have one configured', async function (assert) {
+    const maxRunDuration = 10 * 60 * 1000000000;
+    const startedAt = new Date('2025-01-02T03:04:05Z');
+    const taskGroup = this.server.db.taskGroups.where({ jobId: job.id })[0];
+    const expectedDeadline = new Date(
+      startedAt.getTime() + maxRunDuration / 1000000
+    );
+
+    job.update({ type: 'batch' });
+    this.server.db.taskGroups.update(taskGroup.id, { maxRunDuration });
+
+    const allocation = this.server.create('allocation', {
+      jobId: job.id,
+      taskGroup: taskGroup.name,
+      clientStatus: 'running',
+    });
+
+    this.server.db.taskStates
+      .where({ allocationId: allocation.id })
+      .forEach((taskState) => {
+        this.server.db.taskStates.update(taskState.id, {
+          state: 'running',
+          startedAt,
+        });
+      });
+
+    await Allocations.visit({ id: job.id });
+
+    assert.equal(
+      Allocations.allocations[0].maxRunDeadlineTooltip,
+      moment(expectedDeadline).format("MMM DD, 'YY HH:mm:ss ZZ"),
+      'The allocations table shows the computed max run deadline',
+    );
   });
 
   test('clicking an allocation results in the correct endpoint being hit', async function (assert) {

--- a/ui/tests/acceptance/job-detail-test.js
+++ b/ui/tests/acceptance/job-detail-test.js
@@ -357,6 +357,59 @@ moduleForJob(
   },
 );
 
+module('Acceptance | job detail max run deadline', function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+
+  let job;
+
+  hooks.beforeEach(async function () {
+    const maxRunDuration = 10 * 60 * 1000000000;
+    const startedAt = new Date('2025-01-02T03:04:05Z');
+    this.server.create('node-pool');
+    this.server.create('node');
+
+    job = this.server.create('job', {
+      type: 'batch',
+      createAllocations: false,
+      noActiveDeployment: true,
+      withPreviousStableVersion: true,
+    });
+
+    const taskGroup = this.server.db.taskGroups.where({ jobId: job.id })[0];
+    this.server.db.taskGroups.update(taskGroup.id, { maxRunDuration });
+
+    const allocation = this.server.create('allocation', {
+      jobId: job.id,
+      taskGroup: taskGroup.name,
+      clientStatus: 'running',
+    });
+
+    this.server.db.taskStates
+      .where({ allocationId: allocation.id })
+      .forEach((taskState) => {
+        this.server.db.taskStates.update(taskState.id, {
+          state: 'running',
+          startedAt,
+        });
+      });
+
+    await JobDetail.visit({ id: job.id });
+  });
+
+  test('recent allocations show max run deadline when configured', async function (assert) {
+    const expectedDeadline = moment('2025-01-02T03:14:05Z').format(
+      "MMM DD, 'YY HH:mm:ss ZZ"
+    );
+
+    assert.equal(
+      JobDetail.allocations[0].maxRunDeadlineTooltip,
+      expectedDeadline,
+      'The recent allocations table shows the computed max run deadline'
+    );
+  });
+});
+
 module('Acceptance | ui block', function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);

--- a/ui/tests/acceptance/task-group-detail-test.js
+++ b/ui/tests/acceptance/task-group-detail-test.js
@@ -86,6 +86,36 @@ module('Acceptance | task group detail', function (hooks) {
     await a11yAudit(assert);
   });
 
+  test('task group allocations show max run deadline when configured', async function (assert) {
+    const maxRunDuration = 10 * 60 * 1000000000;
+    const startedAt = new Date('2025-01-02T03:04:05Z');
+    const expectedDeadline = new Date(
+      startedAt.getTime() + maxRunDuration / 1000000
+    );
+
+    job.update({ type: 'batch' });
+    this.server.db.taskGroups.update(taskGroup.id, { maxRunDuration });
+
+    allocations.forEach((allocation) => {
+      this.server.db.taskStates
+        .where({ allocationId: allocation.id })
+        .forEach((taskState) => {
+          this.server.db.taskStates.update(taskState.id, {
+            state: 'running',
+            startedAt,
+          });
+        });
+    });
+
+    await TaskGroup.visit({ id: job.id, name: taskGroup.name });
+
+    assert.equal(
+      TaskGroup.allocations[0].maxRunDeadlineTooltip,
+      moment(expectedDeadline).format("MMM DD, 'YY HH:mm:ss ZZ"),
+      'The task group allocations table shows the computed max run deadline'
+    );
+  });
+
   test('/jobs/:id/:task-group should list high-level metrics for the allocation', async function (assert) {
     const totalCPU = tasks.mapBy('resources.CPU').reduce(sum, 0);
     const totalMemory = tasks.mapBy('resources.MemoryMB').reduce(sum, 0);

--- a/ui/tests/acceptance/volume-detail-test.js
+++ b/ui/tests/acceptance/volume-detail-test.js
@@ -127,6 +127,46 @@ module('Acceptance | volume detail', function (hooks) {
       });
   });
 
+  test('write allocations show max run deadline when configured', async function (assert) {
+    const maxRunDuration = 10 * 60 * 1000000000;
+    const startedAt = new Date('2025-01-02T03:04:05Z');
+    const expectedDeadline = new Date(
+      startedAt.getTime() + maxRunDuration / 1000000
+    );
+
+    const batchJob = this.server.create('job', {
+      type: 'batch',
+      createAllocations: false,
+    });
+    const taskGroup = this.server.db.taskGroups.findBy({ jobId: batchJob.id });
+    this.server.db.taskGroups.update(taskGroup.id, { maxRunDuration });
+
+    const allocation = this.server.create('allocation', {
+      clientStatus: 'running',
+      jobId: batchJob.id,
+      taskGroup: taskGroup.name,
+      modifyIndex: 999999,
+    });
+    assignWriteAlloc(volume, allocation);
+
+    this.server.db.taskStates
+      .where({ allocationId: allocation.id })
+      .forEach((taskState) => {
+        this.server.db.taskStates.update(taskState.id, {
+          state: 'running',
+          startedAt,
+        });
+      });
+
+    await VolumeDetail.visit({ id: `${volume.id}@default` });
+
+    assert.equal(
+      VolumeDetail.writeAllocationFor(allocation.id).maxRunDeadlineTooltip,
+      moment(expectedDeadline).format("MMM DD, 'YY HH:mm:ss ZZ"),
+      'The write allocations table shows the computed max run deadline'
+    );
+  });
+
   test('each allocation should have high-level details for the allocation', async function (assert) {
     const allocation = this.server.create('allocation', {
       clientStatus: 'running',

--- a/ui/tests/helpers/module-for-job.js
+++ b/ui/tests/helpers/module-for-job.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: BUSL-1.1
  */
 
-import { currentRouteName, currentURL, visit } from '@ember/test-helpers';
+import { currentRouteName, currentURL, visit, waitUntil } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { setupMirage } from 'ember-cli-mirage/test-support';
@@ -90,6 +90,14 @@ export default function moduleForJob(
     });
 
     test('the title buttons are dependent on job status', async function (assert) {
+      await waitUntil(
+        () =>
+          JobDetail.stop.isPresent ||
+          JobDetail.start.isPresent ||
+          JobDetail.purge.isPresent ||
+          JobDetail.revert.isPresent
+      );
+
       if (job.status === 'dead') {
         if (job.stopped) {
           assert.ok(JobDetail.start.isPresent);

--- a/ui/tests/pages/allocations/detail.js
+++ b/ui/tests/pages/allocations/detail.js
@@ -38,6 +38,11 @@ export default create({
 
     client: text('[data-test-client-link]'),
     visitClient: clickable('[data-test-client-link]'),
+    maxRunDeadline: text('[data-test-max-run-deadline]'),
+    maxRunDeadlineTooltip: attribute(
+      'aria-label',
+      '[data-test-max-run-deadline] .tooltip',
+    ),
   },
 
   resourceCharts: collection('[data-test-primary-metric]', {

--- a/ui/tests/pages/components/allocations.js
+++ b/ui/tests/pages/components/allocations.js
@@ -30,6 +30,11 @@ export default function (
         '[data-test-create-time] .tooltip',
       ),
       modifyTime: text('[data-test-modify-time]'),
+      maxRunDeadline: text('[data-test-max-run-deadline]'),
+      maxRunDeadlineTooltip: attribute(
+        'aria-label',
+        '[data-test-max-run-deadline] .tooltip'
+      ),
       health: text('[data-test-health]'),
       status: text('[data-test-client-status]'),
       job: text('[data-test-job]'),

--- a/ui/tests/unit/models/allocation-test.js
+++ b/ui/tests/unit/models/allocation-test.js
@@ -104,4 +104,118 @@ module('Unit | Model | allocation', function (hooks) {
       'taskGroup.name is null when no allocation task group is present',
     );
   });
+
+  test('batch allocations expose a max run deadline when every task has started', function (assert) {
+    const startedAt = new Date('2025-01-02T03:04:05Z');
+    const maxRunDuration = 10 * 60 * 1000000000;
+    const job = run(() =>
+      this.store.createRecord('job', {
+        name: 'batch-job',
+        type: 'batch',
+        version: 1,
+        taskGroups: [
+          {
+            name: 'web',
+            count: 1,
+            maxRunDuration,
+            tasks: [],
+          },
+        ],
+      })
+    );
+
+    const allocation = run(() =>
+      this.store.createRecord('allocation', {
+        job,
+        jobVersion: 1,
+        taskGroupName: 'web',
+        states: [
+          { name: 'task-a', state: 'running', startedAt },
+          {
+            name: 'task-b',
+            state: 'complete',
+            startedAt: new Date('2025-01-02T03:05:05Z'),
+          },
+        ],
+      })
+    );
+
+    assert.strictEqual(
+      allocation.maxRunDeadline.getTime(),
+      new Date('2025-01-02T03:15:05Z').getTime()
+    );
+  });
+
+  test('service allocations do not expose a max run deadline', function (assert) {
+    const maxRunDuration = 10 * 60 * 1000000000;
+    const job = run(() =>
+      this.store.createRecord('job', {
+        name: 'service-job',
+        type: 'service',
+        version: 1,
+        taskGroups: [
+          {
+            name: 'web',
+            count: 1,
+            maxRunDuration,
+            tasks: [],
+          },
+        ],
+      })
+    );
+
+    const allocation = run(() =>
+      this.store.createRecord('allocation', {
+        job,
+        jobVersion: 1,
+        taskGroupName: 'web',
+        states: [
+          {
+            name: 'task-a',
+            state: 'running',
+            startedAt: new Date('2025-01-02T03:04:05Z'),
+          },
+        ],
+      })
+    );
+
+    assert.strictEqual(allocation.maxRunDeadline, null);
+  });
+
+  test('allocations do not expose a max run deadline until every task has started', function (assert) {
+    const maxRunDuration = 10 * 60 * 1000000000;
+    const job = run(() =>
+      this.store.createRecord('job', {
+        name: 'batch-job',
+        type: 'batch',
+        version: 1,
+        taskGroups: [
+          {
+            name: 'web',
+            count: 1,
+            maxRunDuration,
+            tasks: [],
+          },
+        ],
+      })
+    );
+
+    const allocation = run(() =>
+      this.store.createRecord('allocation', {
+        job,
+        jobVersion: 1,
+        taskGroupName: 'web',
+        states: [
+          {
+            name: 'task-a',
+            state: 'running',
+            startedAt: new Date('2025-01-02T03:04:05Z'),
+          },
+          { name: 'task-b', state: 'pending', startedAt: null },
+        ],
+      })
+    );
+
+    assert.strictEqual(allocation.maxRunDeadline, null);
+  });
 });


### PR DESCRIPTION
This changeset introduces `max_run_duration` task group configuration variable
for `batch` and `sysbatch` jobs. It's enforced in the alloc runner by a max run
hook. If the timer is up: 

- tasks are killed
- allocation is marked as `complete` and with:
```
  Client Status       = complete
  Client Description  = allocation exceeded max_run_duration
```

The `max_run_duration` timer starts in the allocation runner regardless of task
states. That is, tasks that take longer to start than the timeout get
terminated. This is to avoid long-starting tasks to run too long. 

Lifecycle tasks count to the `max_run_duration` timer. `prestart`, `poststart`
tasks runtime count into the overall run time of the taskgroup, and `poststop`
tasks will _not_ be started if the task was terminated due to running out of its
allocated time. 

Two new metrics are emitted:
- `client.allocs.max_run_duration.configured_seconds`
- `client.allocs.max_run_duration.remaining_seconds`


Resolves #1782
Supersedes #18456
Internal ref: https://hashicorp.atlassian.net/browse/NMD-551