### PR TITLE
bug fix: paused deployments failing progress deadline

### DIFF
--- a/.changelog/27804.txt
+++ b/.changelog/27804.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+deployments: reset ProgressDeadline after pausing and do not fail while paused
+```

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -888,11 +888,16 @@ func (w *deploymentWatcher) getEval() *structs.Evaluation {
 
 // getDeploymentStatusUpdate returns a deployment status update
 func (w *deploymentWatcher) getDeploymentStatusUpdate(status, desc string) *structs.DeploymentStatusUpdate {
+	// only pass UpdatedAt value for paused deployments
+	var updatedAt int64
+	if status == structs.DeploymentStatusPaused || status == structs.DeploymentStatusRunning {
+		updatedAt = time.Now().UTC().UnixNano()
+	}
 	return &structs.DeploymentStatusUpdate{
 		DeploymentID:      w.deploymentID,
 		Status:            status,
 		StatusDescription: desc,
-		UpdatedAt:         time.Now().UTC().UnixNano(),
+		UpdatedAt:         updatedAt,
 	}
 }
 

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -669,6 +669,9 @@ func (w *deploymentWatcher) shouldFail() (fail, rollback bool, err error) {
 	}
 
 	fail = false
+	if d.Status == structs.DeploymentStatusPaused {
+		return fail, false, nil
+	}
 	for tg, dstate := range d.TaskGroups {
 		// If we are in a canary state we fail if there aren't enough healthy
 		// allocs to satisfy DesiredCanaries
@@ -889,6 +892,7 @@ func (w *deploymentWatcher) getDeploymentStatusUpdate(status, desc string) *stru
 		DeploymentID:      w.deploymentID,
 		Status:            status,
 		StatusDescription: desc,
+		UpdatedAt:         time.Now().UTC().UnixNano(),
 	}
 }
 

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -670,7 +670,7 @@ func (w *deploymentWatcher) shouldFail() (fail, rollback bool, err error) {
 
 	fail = false
 	if d.Status == structs.DeploymentStatusPaused {
-		return fail, false, nil
+		return false, false, nil
 	}
 	for tg, dstate := range d.TaskGroups {
 		// If we are in a canary state we fail if there aren't enough healthy

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -791,7 +791,7 @@ func TestWatcher_PauseDeployment_IgnoreProgressDeadline(t *testing.T) {
 // is reset
 func TestWatcher_PauseDeployment_Unpause_Paused(t *testing.T) {
 	ci.Parallel(t)
-	w, m, getLogs := logRecorderTestDeploymentWatcher(t)
+	w, m := defaultTestDeploymentWatcher(t)
 
 	// Create a job and a deployment
 	j := mock.Job()

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -4,11 +4,14 @@
 package deploymentwatcher
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/pointer"
@@ -17,6 +20,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
 )
@@ -29,6 +33,28 @@ func testDeploymentWatcher(t *testing.T, qps float64, batchDur time.Duration) (*
 
 func defaultTestDeploymentWatcher(t *testing.T) (*Watcher, *mockBackend) {
 	return testDeploymentWatcher(t, LimitStateQueriesPerSecond, CrossDeploymentUpdateBatchDuration)
+}
+
+// logRecorder is a modification of the logRecorder pattern from hostvolumemanager
+// and added to the TestDeploymentWatcher so we can assert that stdout/stderr
+// appear in logs
+func logRecorderTestDeploymentWatcher(t *testing.T) (*Watcher, *mockBackend, func() string) {
+	buf := &bytes.Buffer{}
+	logger := hclog.New(&hclog.LoggerOptions{
+		Name:            "log-recorder",
+		Output:          buf,
+		Level:           hclog.Debug,
+		IncludeLocation: true,
+		DisableTime:     true,
+	})
+	m := newMockBackend(t)
+	w := NewDeploymentsWatcher(logger, m, nil, nil, LimitStateQueriesPerSecond, CrossDeploymentUpdateBatchDuration)
+	return w, m, func() string {
+		bts, err := io.ReadAll(buf)
+		test.NoError(t, err)
+		buf.Reset()
+		return string(bts)
+	}
 }
 
 // Tests that the watcher properly watches for deployments and reconciles them
@@ -701,10 +727,71 @@ func TestWatcher_PauseDeployment_Pause_Paused(t *testing.T) {
 	must.Eq(t, structs.DeploymentStatusDescriptionPaused, d.StatusDescription)
 }
 
-// Test unpausing a deployment that is paused
+// Test that the timeline check is skipped for paused deployment
+func TestWatcher_PauseDeployment_IgnoreProgressDeadline(t *testing.T) {
+	ci.Parallel(t)
+	w, m, getLogs := logRecorderTestDeploymentWatcher(t)
+
+	// Create a job and a deployment
+	j := mock.Job()
+	j.TaskGroups[0].Count = 1
+	j.TaskGroups[0].Update = structs.DefaultUpdateStrategy.Copy()
+	j.TaskGroups[0].Update.ProgressDeadline = 50 * time.Millisecond
+	d := mock.Deployment()
+	d.JobID = j.ID
+	d.TaskGroups["web"].DesiredTotal = 1
+	d.TaskGroups["web"].ProgressDeadline = 50 * time.Millisecond
+
+	a := mock.Alloc()
+	now := time.Now()
+	a.CreateTime = now.UnixNano()
+	a.ModifyTime = now.UnixNano()
+	a.DeploymentID = d.ID
+	a.Job = j
+	a.JobID = j.ID
+	must.NoError(t, m.state.UpsertJob(structs.MsgTypeTestSetup, m.nextIndex(), nil, j))
+	must.NoError(t, m.state.UpsertDeployment(m.nextIndex(), d))
+	must.NoError(t, m.state.UpsertAllocs(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a}))
+	w.SetEnabled(true, m.state)
+	waitForWatchers(t, w, 1)
+
+	// manually pause
+	req := &structs.DeploymentPauseRequest{
+		DeploymentID: d.ID,
+		Pause:        true,
+	}
+	var resp structs.DeploymentUpdateResponse
+	must.NoError(t, w.PauseDeployment(req, &resp))
+	must.Eq(t, 1, watchersCount(w), must.Sprint("watcher should still be active"))
+
+	d1, err := m.state.DeploymentByID(nil, d.ID)
+
+	state := d1.TaskGroups["web"]
+	must.NoError(t, err)
+	must.Eq(t, structs.DeploymentStatusPaused, d1.Status)
+	must.Eq(t, structs.DeploymentStatusDescriptionPaused, d1.StatusDescription)
+
+	watcher, err := w.getOrCreateWatcher(d1.ID)
+	must.NoError(t, err)
+	must.NotNil(t, watcher)
+
+	time.Sleep(time.Until(state.RequireProgressBy.Add(time.Second)))
+	cutoff1 := watcher.getDeploymentProgressCutoff(d1)
+	must.False(t, cutoff1.IsZero())
+
+	// confirm deadline was skipped
+	must.StrContains(t, getLogs(), "skipping deadline")
+	// confirm RequireProgressBy was set to UpdateTime + ProgressDeadline
+	modifiedTime := time.Unix(0, d1.ModifyTime)
+	must.Eq(t, modifiedTime.Add(d1.TaskGroups["web"].ProgressDeadline), d1.TaskGroups["web"].RequireProgressBy)
+
+}
+
+// Test unpausing a deployment that is paused and ensure timeout
+// is reset
 func TestWatcher_PauseDeployment_Unpause_Paused(t *testing.T) {
 	ci.Parallel(t)
-	w, m := defaultTestDeploymentWatcher(t)
+	w, m, getLogs := logRecorderTestDeploymentWatcher(t)
 
 	// Create a job and a deployment
 	j := mock.Job()

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4773,13 +4773,15 @@ func (s *StateStore) updateDeploymentStatusImpl(index uint64, u *structs.Deploym
 	copy.ModifyTime = u.UpdatedAt
 
 	// check each TaskGroup for ProgressDeadline and reset RequireProgressBy
-	// to u.UpdatedAt + ProgressDeadline
+	// to u.UpdatedAt + ProgressDeadline if neither equal 0
 	for _, dState := range copy.TaskGroups {
 		if dState == nil {
 			continue
 		}
-		updateTime := time.Unix(0, u.UpdatedAt)
-		dState.RequireProgressBy = updateTime.Add(dState.ProgressDeadline)
+		if u.UpdatedAt != 0 && dState.ProgressDeadline != 0 {
+			updateTime := time.Unix(0, u.UpdatedAt)
+			dState.RequireProgressBy = updateTime.Add(dState.ProgressDeadline)
+		}
 	}
 	// Insert the deployment
 	if err := txn.Insert("deployment", copy); err != nil {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4772,6 +4772,15 @@ func (s *StateStore) updateDeploymentStatusImpl(index uint64, u *structs.Deploym
 	copy.ModifyIndex = index
 	copy.ModifyTime = u.UpdatedAt
 
+	// check each TaskGroup for ProgressDeadline and reset RequireProgressBy
+	// to u.UpdatedAt + ProgressDeadline
+	for _, dState := range copy.TaskGroups {
+		if dState == nil {
+			continue
+		}
+		updateTime := time.Unix(0, u.UpdatedAt)
+		dState.RequireProgressBy = updateTime.Add(dState.ProgressDeadline)
+	}
 	// Insert the deployment
 	if err := txn.Insert("deployment", copy); err != nil {
 		return err


### PR DESCRIPTION
Bug: 
Support informed us of customers running into counterintuitive behavior where deployments were failing their progress deadline while paused.

Fix: 
- Updated the [deploymentwatcher.shouldFail](https://github.com/hashicorp/nomad/blob/main/nomad/deploymentwatcher/deployment_watcher.go#L656) function not to fail deployments if their status is "paused"


The changes below are intended make sure deployments don't fail as soon as they're un-paused 
- Updated the [deploymentwatcher.getDeploymentStatusUpdate](https://github.com/hashicorp/nomad/blob/main/nomad/deploymentwatcher/deployment_watcher.go#L890)  function to set an UpdatedAt time if the new deployment status is "paused" or "running" (might make sense to only reset on `running` instead of both)
- Update the state store's [updateDeploymentStatusImpl](https://github.com/hashicorp/nomad/blob/main/nomad/state/state_store.go#L4756) function to overwrite the deployment's ProgressDeadline with the UpdatedAt time + ProgressDeadline duration if neither u.UpdatedAt nor u.ProgressDeadline are 0.


### Testing & Reproduction steps
- Added an additional test case to deployments_watcher_test.go to assert:
      - that a paused deployment past its progress deadline will not fail
      - that the deployment's progress deadline == UpdatedAt + ProgressDeadline

### Links
ref: https://hashicorp.atlassian.net/browse/NMD-1080?atlOrigin=eyJpIjoiMDI5YTFlZjZiMGM2NGQ4MWIwMDU1NjBhZDFjNzFiNjciLCJwIjoiaiJ9

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
