### PR TITLE
Remove unused parameter from scheduler/utils/setStatus

### DIFF
--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -129,7 +129,7 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) (err error) {
 	default:
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason",
 			eval.TriggeredBy)
-		return setStatus(s.logger, s.planner, s.eval, nil, s.blocked,
+		return setStatus(s.logger, s.planner, s.eval, s.blocked,
 			s.failedTGAllocs, s.planAnnotations, structs.EvalStatusFailed, desc, s.queuedAllocs,
 			s.deployment.GetID())
 	}
@@ -148,7 +148,7 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) (err error) {
 			if err := s.createBlockedEval(true); err != nil {
 				mErr.Errors = append(mErr.Errors, err)
 			}
-			if err := setStatus(s.logger, s.planner, s.eval, nil, s.blocked,
+			if err := setStatus(s.logger, s.planner, s.eval, s.blocked,
 				s.failedTGAllocs, s.planAnnotations, statusErr.EvalStatus, err.Error(),
 				s.queuedAllocs, s.deployment.GetID()); err != nil {
 				mErr.Errors = append(mErr.Errors, err)
@@ -170,7 +170,7 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) (err error) {
 	}
 
 	// Update the status to complete
-	return setStatus(s.logger, s.planner, s.eval, nil, s.blocked,
+	return setStatus(s.logger, s.planner, s.eval, s.blocked,
 		s.failedTGAllocs, s.planAnnotations, structs.EvalStatusComplete, "", s.queuedAllocs,
 		s.deployment.GetID())
 }

--- a/scheduler/scheduler_sysbatch.go
+++ b/scheduler/scheduler_sysbatch.go
@@ -78,7 +78,7 @@ func (s *SysBatchScheduler) Process(eval *structs.Evaluation) (err error) {
 	// Verify the evaluation trigger reason is understood
 	if !s.canHandle(eval.TriggeredBy) {
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason", eval.TriggeredBy)
-		return setStatus(s.logger, s.planner, s.eval, nil, nil,
+		return setStatus(s.logger, s.planner, s.eval, nil,
 			s.failedTGAllocs, s.planAnnotations, structs.EvalStatusFailed, desc,
 			s.queuedAllocs, "")
 	}
@@ -89,7 +89,7 @@ func (s *SysBatchScheduler) Process(eval *structs.Evaluation) (err error) {
 	progress := func() bool { return progressMade(s.planResult) }
 	if err := retryMax(limit, s.process, progress); err != nil {
 		if statusErr, ok := err.(*SetStatusError); ok {
-			return setStatus(s.logger, s.planner, s.eval, nil, nil,
+			return setStatus(s.logger, s.planner, s.eval, nil,
 				s.failedTGAllocs, s.planAnnotations, statusErr.EvalStatus, err.Error(),
 				s.queuedAllocs, "")
 		}
@@ -97,7 +97,7 @@ func (s *SysBatchScheduler) Process(eval *structs.Evaluation) (err error) {
 	}
 
 	// Update the status to complete
-	return setStatus(s.logger, s.planner, s.eval, nil, nil,
+	return setStatus(s.logger, s.planner, s.eval, nil,
 		s.failedTGAllocs, s.planAnnotations, structs.EvalStatusComplete, "",
 		s.queuedAllocs, "")
 }

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -87,7 +87,7 @@ func (s *SystemScheduler) Process(eval *structs.Evaluation) (err error) {
 	// Verify the evaluation trigger reason is understood
 	if !s.canHandle(eval.TriggeredBy) {
 		desc := fmt.Sprintf("scheduler cannot handle '%s' evaluation reason", eval.TriggeredBy)
-		return setStatus(s.logger, s.planner, s.eval, nil, nil,
+		return setStatus(s.logger, s.planner, s.eval, nil,
 			s.failedTGAllocs, s.planAnnotations, structs.EvalStatusFailed, desc,
 			s.queuedAllocs, s.deployment.GetID())
 	}
@@ -98,7 +98,7 @@ func (s *SystemScheduler) Process(eval *structs.Evaluation) (err error) {
 	progress := func() bool { return progressMade(s.planResult) }
 	if err := retryMax(limit, s.process, progress); err != nil {
 		if statusErr, ok := err.(*SetStatusError); ok {
-			return setStatus(s.logger, s.planner, s.eval, nil, nil,
+			return setStatus(s.logger, s.planner, s.eval, nil,
 				s.failedTGAllocs, s.planAnnotations, statusErr.EvalStatus, err.Error(),
 				s.queuedAllocs, s.deployment.GetID())
 		}
@@ -106,7 +106,7 @@ func (s *SystemScheduler) Process(eval *structs.Evaluation) (err error) {
 	}
 
 	// Update the status to complete
-	return setStatus(s.logger, s.planner, s.eval, nil, nil,
+	return setStatus(s.logger, s.planner, s.eval, nil,
 		s.failedTGAllocs, s.planAnnotations, structs.EvalStatusComplete, "",
 		s.queuedAllocs, s.deployment.GetID())
 }

--- a/scheduler/util.go
+++ b/scheduler/util.go
@@ -542,7 +542,7 @@ func renderTemplatesUpdated(a, b *structs.RestartPolicy, msg string) comparison 
 
 // setStatus is used to update the status of the evaluation
 func setStatus(logger log.Logger, planner sstructs.Planner,
-	eval, nextEval, spawnedBlocked *structs.Evaluation,
+	eval, spawnedBlocked *structs.Evaluation,
 	tgMetrics map[string]*structs.AllocMetric,
 	annotations *structs.PlanAnnotations,
 	status, desc string,
@@ -554,9 +554,7 @@ func setStatus(logger log.Logger, planner sstructs.Planner,
 	newEval.StatusDescription = desc
 	newEval.DeploymentID = deploymentID
 	newEval.FailedTGAllocs = tgMetrics
-	if nextEval != nil {
-		newEval.NextEval = nextEval.ID
-	}
+
 	if spawnedBlocked != nil {
 		newEval.BlockedEval = spawnedBlocked.ID
 	}

--- a/scheduler/util_test.go
+++ b/scheduler/util_test.go
@@ -613,26 +613,17 @@ func TestSetStatus(t *testing.T) {
 	eval := mock.Eval()
 	status := "a"
 	desc := "b"
-	must.NoError(t, setStatus(logger, h, eval, nil, nil, nil, nil, status, desc, nil, ""))
+	must.NoError(t, setStatus(logger, h, eval, nil, nil, nil, status, desc, nil, ""))
 	must.Eq(t, 1, len(h.Evals), must.Sprintf("setStatus() didn't update plan: %v", h.Evals))
 
 	newEval := h.Evals[0]
 	must.True(t, newEval.ID == eval.ID && newEval.Status == status && newEval.StatusDescription == desc,
 		must.Sprintf("setStatus() submited invalid eval: %v", newEval))
 
-	// Test next evals
-	h = tests.NewHarness(t)
-	next := mock.Eval()
-	must.NoError(t, setStatus(logger, h, eval, next, nil, nil, nil, status, desc, nil, ""))
-	must.Eq(t, 1, len(h.Evals), must.Sprintf("setStatus() didn't update plan: %v", h.Evals))
-
-	newEval = h.Evals[0]
-	must.Eq(t, next.ID, newEval.NextEval, must.Sprintf("setStatus() didn't set nextEval correctly: %v", newEval))
-
 	// Test blocked evals
 	h = tests.NewHarness(t)
 	blocked := mock.Eval()
-	must.NoError(t, setStatus(logger, h, eval, nil, blocked, nil, nil, status, desc, nil, ""))
+	must.NoError(t, setStatus(logger, h, eval, blocked, nil, nil, status, desc, nil, ""))
 	must.Eq(t, 1, len(h.Evals), must.Sprintf("setStatus() didn't update plan: %v", h.Evals))
 
 	newEval = h.Evals[0]
@@ -641,7 +632,7 @@ func TestSetStatus(t *testing.T) {
 	// Test metrics
 	h = tests.NewHarness(t)
 	metrics := map[string]*structs.AllocMetric{"foo": nil}
-	must.NoError(t, setStatus(logger, h, eval, nil, nil, metrics, nil, status, desc, nil, ""))
+	must.NoError(t, setStatus(logger, h, eval, nil, metrics, nil, status, desc, nil, ""))
 	must.Eq(t, 1, len(h.Evals), must.Sprintf("setStatus() didn't update plan: %v", h.Evals))
 
 	newEval = h.Evals[0]
@@ -652,7 +643,7 @@ func TestSetStatus(t *testing.T) {
 	h = tests.NewHarness(t)
 	queuedAllocs := map[string]int{"web": 1}
 
-	must.NoError(t, setStatus(logger, h, eval, nil, nil, metrics, nil, status, desc, queuedAllocs, ""))
+	must.NoError(t, setStatus(logger, h, eval, nil, metrics, nil, status, desc, queuedAllocs, ""))
 	must.Eq(t, 1, len(h.Evals), must.Sprintf("setStatus() didn't update plan: %v", h.Evals))
 
 	// Test annotations
@@ -662,7 +653,7 @@ func TestSetStatus(t *testing.T) {
 		PreemptedAllocs:  []*structs.AllocListStub{{ID: uuid.Generate()}},
 	}
 
-	must.NoError(t, setStatus(logger, h, eval, nil, nil, metrics, annotations, status, desc, queuedAllocs, ""))
+	must.NoError(t, setStatus(logger, h, eval, nil, metrics, annotations, status, desc, queuedAllocs, ""))
 	must.Eq(t, 1, len(h.Evals), must.Sprintf("setStatus() didn't update plan: %v", h.Evals))
 
 	newEval = h.Evals[0]
@@ -670,7 +661,7 @@ func TestSetStatus(t *testing.T) {
 
 	h = tests.NewHarness(t)
 	dID := uuid.Generate()
-	must.NoError(t, setStatus(logger, h, eval, nil, nil, metrics, nil, status, desc, queuedAllocs, dID))
+	must.NoError(t, setStatus(logger, h, eval, nil, metrics, nil, status, desc, queuedAllocs, dID))
 	must.Eq(t, 1, len(h.Evals), must.Sprintf("setStatus() didn't update plan: %v", h.Evals))
 
 	newEval = h.Evals[0]


### PR DESCRIPTION
### Description
This PR removes the `nextEval` parameter from the function `setStatus` because it is not being used anywhere.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
