### PR TITLE
batch queue: add config parameters to scheduler_configuration

### DIFF
--- a/api/operator.go
+++ b/api/operator.go
@@ -174,6 +174,13 @@ type SchedulerConfiguration struct {
 	// priority jobs to place higher priority jobs.
 	PreemptionConfig PreemptionConfig
 
+	// BatchQueue specifies the configuration of the batch jobs queue
+	// use to control queueing and scheduling of batch jobs.
+	//
+	// "Scheduling" in this context refers to releasing evaluations
+	// to the eval broker for scheduling with a worker.
+	BatchQueue BatchQueue
+
 	// MemoryOversubscriptionEnabled specifies whether memory oversubscription is enabled
 	MemoryOversubscriptionEnabled bool
 
@@ -231,6 +238,15 @@ type PreemptionConfig struct {
 	SysBatchSchedulerEnabled bool
 	BatchSchedulerEnabled    bool
 	ServiceSchedulerEnabled  bool
+}
+
+// BatchQueue is the configuration for a batch job queue used to control scheduling
+// of batch jobs.
+type BatchQueue struct {
+	Type        string
+	TenantType  string
+	MetadataKey string
+	Config      map[string]any
 }
 
 // SchedulerGetConfiguration is used to query the current Scheduler configuration.

--- a/api/operator.go
+++ b/api/operator.go
@@ -237,8 +237,8 @@ const (
 
 	BatchQueueTypeDynamic BatchQueueType = "dynamicPriority"
 
-	TenantMetadata  BatchQueueTenant = "metadata"
-	TenantNamespace BatchQueueTenant = "namespace"
+	TenantTypeMetadata  BatchQueueTenant = "metadata"
+	TenantTypeNamespace BatchQueueTenant = "namespace"
 )
 
 // PreemptionConfig specifies whether preemption is enabled based on scheduler type

--- a/api/operator.go
+++ b/api/operator.go
@@ -237,8 +237,8 @@ const (
 
 	BatchQueueTypeDynamic BatchQueueType = "dynamicPriority"
 
-	BatchQueueTenantMetadata  BatchQueueTenant = "metadata"
-	BatchQueueTenantNamespace BatchQueueTenant = "namespace"
+	TenantMetadata  BatchQueueTenant = "metadata"
+	TenantNamespace BatchQueueTenant = "namespace"
 )
 
 // PreemptionConfig specifies whether preemption is enabled based on scheduler type

--- a/api/operator.go
+++ b/api/operator.go
@@ -222,14 +222,23 @@ type SchedulerSetConfigurationResponse struct {
 	WriteMeta
 }
 
-// SchedulerAlgorithm is an enum string that encapsulates the valid options for a
-// SchedulerConfiguration block's SchedulerAlgorithm. These modes will allow the
-// scheduler to be user-selectable.
-type SchedulerAlgorithm string
+// Enum strings that encapsulate the valid options for a
+// their respective scheduler configuration blocks. These modes
+// allow the config to be user-selectable.
+type (
+	SchedulerAlgorithm string
+	BatchQueueTenant   string
+	BatchQueueType     string
+)
 
 const (
 	SchedulerAlgorithmBinpack SchedulerAlgorithm = "binpack"
 	SchedulerAlgorithmSpread  SchedulerAlgorithm = "spread"
+
+	BatchQueueTypeDynamic BatchQueueType = "dynamicPriority"
+
+	BatchQueueTenantMetadata  BatchQueueTenant = "metadata"
+	BatchQueueTenantNamespace BatchQueueTenant = "namespace"
 )
 
 // PreemptionConfig specifies whether preemption is enabled based on scheduler type
@@ -243,8 +252,8 @@ type PreemptionConfig struct {
 // BatchQueue is the configuration for a batch job queue used to control scheduling
 // of batch jobs.
 type BatchQueue struct {
-	Type        string
-	TenantType  string
+	Type        BatchQueueType
+	TenantType  BatchQueueTenant
 	MetadataKey string
 	Config      map[string]any
 }

--- a/api/operator.go
+++ b/api/operator.go
@@ -174,6 +174,13 @@ type SchedulerConfiguration struct {
 	// priority jobs to place higher priority jobs.
 	PreemptionConfig PreemptionConfig
 
+	// BatchQueue specifies the configuration of the batch jobs queue
+	// use to control queueing and scheduling of batch jobs.
+	//
+	// "Scheduling" in this context refers to releasing evaluations
+	// to the eval broker for scheduling with a worker.
+	BatchQueue BatchQueue
+
 	// MemoryOversubscriptionEnabled specifies whether memory oversubscription is enabled
 	MemoryOversubscriptionEnabled bool
 
@@ -224,6 +231,15 @@ type PreemptionConfig struct {
 	SysBatchSchedulerEnabled bool
 	BatchSchedulerEnabled    bool
 	ServiceSchedulerEnabled  bool
+}
+
+// BatchQueue is the configuration for a batch job queue used to control scheduling
+// of batch jobs.
+type BatchQueue struct {
+	Type        string
+	TenantType  string
+	MetadataKey string
+	Config      map[string]any
 }
 
 // SchedulerGetConfiguration is used to query the current Scheduler configuration.

--- a/command/operator_scheduler_get_config.go
+++ b/command/operator_scheduler_get_config.go
@@ -87,7 +87,6 @@ func (o *OperatorSchedulerGetConfig) Run(args []string) int {
 		fmt.Sprintf("Preemption SysBatch Scheduler|%v", schedConfig.PreemptionConfig.SysBatchSchedulerEnabled),
 		fmt.Sprintf("Node Limit For Feasibility Checks|%v", schedConfig.NodeLimitForFeasibilityChecks),
 		fmt.Sprintf("Batch Queue Type|%v", schedConfig.BatchQueue.Type),
-		fmt.Sprintf("Modify Index|%v", resp.SchedulerConfig.ModifyIndex),
 	}
 
 	if schedConfig.BatchQueue.Type != "" {

--- a/command/operator_scheduler_get_config.go
+++ b/command/operator_scheduler_get_config.go
@@ -76,8 +76,7 @@ func (o *OperatorSchedulerGetConfig) Run(args []string) int {
 
 	schedConfig := resp.SchedulerConfig
 
-	// Output the information.
-	o.Ui.Output(formatKV([]string{
+	out := []string{
 		fmt.Sprintf("Scheduler Algorithm|%s", schedConfig.SchedulerAlgorithm),
 		fmt.Sprintf("Memory Oversubscription|%v", schedConfig.MemoryOversubscriptionEnabled),
 		fmt.Sprintf("Reject Job Registration|%v", schedConfig.RejectJobRegistration),
@@ -87,8 +86,29 @@ func (o *OperatorSchedulerGetConfig) Run(args []string) int {
 		fmt.Sprintf("Preemption Batch Scheduler|%v", schedConfig.PreemptionConfig.BatchSchedulerEnabled),
 		fmt.Sprintf("Preemption SysBatch Scheduler|%v", schedConfig.PreemptionConfig.SysBatchSchedulerEnabled),
 		fmt.Sprintf("Node Limit For Feasibility Checks|%v", schedConfig.NodeLimitForFeasibilityChecks),
+		fmt.Sprintf("Batch Queue Type|%v", schedConfig.BatchQueue.Type),
 		fmt.Sprintf("Modify Index|%v", resp.SchedulerConfig.ModifyIndex),
-	}))
+	}
+
+	if schedConfig.BatchQueue.Type != "" {
+		out = append(out, fmt.Sprintf("Batch Queue Tenant Type|%v", schedConfig.BatchQueue.TenantType))
+
+		// only append metadata key if it's set
+		if schedConfig.BatchQueue.TenantType == "metadata" {
+			out = append(out, fmt.Sprintf("Batch Queue Metadata Key|%v", schedConfig.BatchQueue.MetadataKey))
+		}
+
+		conf := ""
+		for k, v := range schedConfig.BatchQueue.Config {
+			conf = fmt.Sprintf("%s%s", conf, fmt.Sprintf("%v:%v ", k, v))
+		}
+		out = append(out, fmt.Sprintf("Batch Queue Config|%v", conf))
+	}
+
+	out = append(out, fmt.Sprintf("Modify Index|%v", resp.SchedulerConfig.ModifyIndex))
+
+	// Output the information.
+	o.Ui.Output(formatKV(out))
 	return 0
 }
 

--- a/command/operator_scheduler_get_config.go
+++ b/command/operator_scheduler_get_config.go
@@ -76,8 +76,7 @@ func (o *OperatorSchedulerGetConfig) Run(args []string) int {
 
 	schedConfig := resp.SchedulerConfig
 
-	// Output the information.
-	o.Ui.Output(formatKV([]string{
+	out := []string{
 		fmt.Sprintf("Scheduler Algorithm|%s", schedConfig.SchedulerAlgorithm),
 		fmt.Sprintf("Memory Oversubscription|%v", schedConfig.MemoryOversubscriptionEnabled),
 		fmt.Sprintf("Reject Job Registration|%v", schedConfig.RejectJobRegistration),
@@ -86,8 +85,28 @@ func (o *OperatorSchedulerGetConfig) Run(args []string) int {
 		fmt.Sprintf("Preemption Service Scheduler|%v", schedConfig.PreemptionConfig.ServiceSchedulerEnabled),
 		fmt.Sprintf("Preemption Batch Scheduler|%v", schedConfig.PreemptionConfig.BatchSchedulerEnabled),
 		fmt.Sprintf("Preemption SysBatch Scheduler|%v", schedConfig.PreemptionConfig.SysBatchSchedulerEnabled),
-		fmt.Sprintf("Modify Index|%v", resp.SchedulerConfig.ModifyIndex),
-	}))
+		fmt.Sprintf("Batch Queue Type|%v", schedConfig.BatchQueue.Type),
+	}
+
+	if schedConfig.BatchQueue.Type != "" {
+		out = append(out, fmt.Sprintf("Batch Queue Tenant Type|%v", schedConfig.BatchQueue.TenantType))
+
+		// only append metadata key if it's set
+		if schedConfig.BatchQueue.TenantType == "metadata" {
+			out = append(out, fmt.Sprintf("Batch Queue Metadata Key|%v", schedConfig.BatchQueue.MetadataKey))
+		}
+
+		conf := ""
+		for k, v := range schedConfig.BatchQueue.Config {
+			conf = fmt.Sprintf("%s%s", conf, fmt.Sprintf("%v:%v ", k, v))
+		}
+		out = append(out, fmt.Sprintf("Batch Queue Config|%v", conf))
+	}
+
+	out = append(out, fmt.Sprintf("Modify Index|%v", resp.SchedulerConfig.ModifyIndex))
+
+	// Output the information.
+	o.Ui.Output(formatKV(out))
 	return 0
 }
 

--- a/command/operator_scheduler_get_config_test.go
+++ b/command/operator_scheduler_get_config_test.go
@@ -27,6 +27,10 @@ func TestOperatorSchedulerGetConfig_Run(t *testing.T) {
 	s := ui.OutputWriter.String()
 	must.StrContains(t, s, "Scheduler Algorithm               = binpack")
 	must.StrContains(t, s, "Preemption SysBatch Scheduler     = false")
+	must.StrContains(t, s, "Scheduler Algorithm               = binpack")
+	must.StrContains(t, s, "Preemption SysBatch Scheduler     = false")
+	must.StrContains(t, s, "Node Limit For Feasibility Checks = 0")
+	must.StrContains(t, s, "Batch Queue Type                  =")
 	ui.ErrorWriter.Reset()
 	ui.OutputWriter.Reset()
 

--- a/command/operator_scheduler_get_config_test.go
+++ b/command/operator_scheduler_get_config_test.go
@@ -27,6 +27,7 @@ func TestOperatorSchedulerGetConfig_Run(t *testing.T) {
 	s := ui.OutputWriter.String()
 	must.StrContains(t, s, "Scheduler Algorithm           = binpack")
 	must.StrContains(t, s, "Preemption SysBatch Scheduler = false")
+	must.StrContains(t, s, "Batch Queue Type              =")
 	ui.ErrorWriter.Reset()
 	ui.OutputWriter.Reset()
 

--- a/nomad/structs/node_pool.go
+++ b/nomad/structs/node_pool.go
@@ -249,6 +249,10 @@ type NodePoolSchedulerConfiguration struct {
 	// If not defined, the global cluster scheduling algorithm is used.
 	SchedulerAlgorithm SchedulerAlgorithm `hcl:"scheduler_algorithm"`
 
+	// BatchQueue defines the batch job queue configuration used
+	// to control scheduling of batch jobs.
+	BatchQueue BatchQueue `hcl:"batch_queue"`
+
 	// MemoryOversubscriptionEnabled specifies whether memory oversubscription
 	// is enabled. If not defined, the global cluster configuration is used.
 	MemoryOversubscriptionEnabled *bool `hcl:"memory_oversubscription_enabled"`

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -359,18 +359,26 @@ type PreemptionConfig struct {
 	ServiceSchedulerEnabled bool `hcl:"service_scheduler_enabled"`
 }
 
+type (
+	BatchQueueType   string
+	BatchQueueTenant string
+)
+
 const (
-	QueueTypeDynamicPriority = "dynamicPriority"
+	BatchQueueTypeDynamic BatchQueueType = "dynamicPriorty"
+
+	TenantTypeMetadata  BatchQueueTenant = "metadata"
+	TenantTypeNamespace BatchQueueTenant = "namespace"
 
 	DynamicCalcInterval = "calc_interval"
 	DynamicMaxAge       = "max_age"
 )
 
 type BatchQueue struct {
-	Type        string         `hcl:"type"`
-	TenantType  string         `hcl:"tenant_type"`
-	MetadataKey string         `hcl:"metadata_key"`
-	Config      map[string]any `hcl:"config"`
+	Type        BatchQueueType   `hcl:"type"`
+	TenantType  BatchQueueTenant `hcl:"tenant_type"`
+	MetadataKey string           `hcl:"metadata_key"`
+	Config      map[string]any   `hcl:"config"`
 }
 
 type DynamicQueueConfig struct {
@@ -407,7 +415,7 @@ func (b *BatchQueue) Validate() error {
 	}
 
 	switch b.Type {
-	case QueueTypeDynamicPriority:
+	case BatchQueueTypeDynamic:
 		if err := validateDuration(b.Config[DynamicCalcInterval]); err != nil {
 			return fmt.Errorf("failed to parse calc_interval: %v", err)
 		}
@@ -418,12 +426,14 @@ func (b *BatchQueue) Validate() error {
 		return fmt.Errorf("unsupported batch queue type: %q", b.Type)
 	}
 
-	if b.TenantType != "namespace" && b.TenantType != "metadata" {
+	switch b.TenantType {
+	case TenantTypeNamespace:
+	case TenantTypeMetadata:
+		if b.MetadataKey == "" {
+			return fmt.Errorf("metadata key must be specified if using metadata tenency")
+		}
+	default:
 		return fmt.Errorf("unsupported tenant type: %q", b.TenantType)
-	}
-
-	if b.TenantType == "metadata" && b.MetadataKey == "" {
-		return fmt.Errorf("metadata key must be specified if using metadata tenency")
 	}
 
 	return nil

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -224,6 +224,10 @@ type SchedulerConfiguration struct {
 	// priority jobs to place higher priority jobs.
 	PreemptionConfig PreemptionConfig `hcl:"preemption_config"`
 
+	// BatchQueue specifies the batch queue for this scheduler configuration
+	// which defines the behavior for scheduling batch job evaluations.
+	BatchQueue BatchQueue `hcl:"batch_queue"`
+
 	// MemoryOversubscriptionEnabled specifies whether memory oversubscription is enabled
 	MemoryOversubscriptionEnabled bool `hcl:"memory_oversubscription_enabled"`
 
@@ -286,6 +290,11 @@ func (s *SchedulerConfiguration) WithNodePool(pool *NodePool) *SchedulerConfigur
 	if poolConfig.SchedulerAlgorithm != "" {
 		schedConfig.SchedulerAlgorithm = poolConfig.SchedulerAlgorithm
 	}
+
+	if poolConfig.BatchQueue.Type != "" {
+		schedConfig.BatchQueue = poolConfig.BatchQueue
+	}
+
 	if poolConfig.MemoryOversubscriptionEnabled != nil {
 		schedConfig.MemoryOversubscriptionEnabled = *poolConfig.MemoryOversubscriptionEnabled
 	}
@@ -308,6 +317,10 @@ func (s *SchedulerConfiguration) Validate() error {
 	case "", SchedulerAlgorithmBinpack, SchedulerAlgorithmSpread:
 	default:
 		return fmt.Errorf("invalid scheduler algorithm: %v", s.SchedulerAlgorithm)
+	}
+
+	if err := s.BatchQueue.Validate(); err != nil {
+		return err
 	}
 
 	return nil
@@ -344,6 +357,65 @@ type PreemptionConfig struct {
 
 	// ServiceSchedulerEnabled specifies if preemption is enabled for service jobs
 	ServiceSchedulerEnabled bool `hcl:"service_scheduler_enabled"`
+}
+
+type BatchQueue struct {
+	Type        string         `hcl:"type"`
+	TenantType  string         `hcl:"tenant_type"`
+	MetadataKey string         `hcl:"metadata_key"`
+	Config      map[string]any `hcl:"config"` // TODO: not sure yet how to handle this any blob
+}
+
+type DynamicQueueConfig struct {
+	CalcInterval time.Duration
+	MaxAge       time.Duration
+	MaxSize      int
+	AgeWeight    int
+	UsageWeight  int
+	SizeWeight   int
+}
+
+func validateDuration(val any) error {
+	switch t := val.(type) {
+	case string:
+		if _, err := time.ParseDuration(t); err != nil {
+			return err
+		}
+	case int, nil:
+	default:
+		return fmt.Errorf("value not a duration: %v", val)
+	}
+
+	return nil
+}
+
+func (b *BatchQueue) Validate() error {
+	if b.Type == "" {
+		return nil
+	}
+
+	// TODO: lots of magic strings here
+	switch b.Type {
+	case "dynamicPriority":
+		if err := validateDuration(b.Config["calc_interval"]); err != nil {
+			return fmt.Errorf("failed to parse calc_interval: %v", err)
+		}
+		if err := validateDuration(b.Config["max_age"]); err != nil {
+			return fmt.Errorf("failed to parse max_age: %v", err)
+		}
+	default:
+		return fmt.Errorf("unsupported batch queue type: %s", b.Type)
+	}
+
+	if b.TenantType != "namespace" && b.TenantType != "metadata" {
+		return fmt.Errorf("unsupported tenant type: %s", b.TenantType)
+	}
+
+	if b.TenantType == "metadata" && b.MetadataKey == "" {
+		return fmt.Errorf("metadata key must be specified if using metadata tenency")
+	}
+
+	return nil
 }
 
 // SchedulerSetConfigRequest is used by the Operator endpoint to update the

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -359,6 +359,13 @@ type PreemptionConfig struct {
 	ServiceSchedulerEnabled bool `hcl:"service_scheduler_enabled"`
 }
 
+const (
+	QueueTypeDynamicPriority = "dynamicPriority"
+
+	DynamicCalcInterval = "calc_interval"
+	DynamicMaxAge       = "max_age"
+)
+
 type BatchQueue struct {
 	Type        string         `hcl:"type"`
 	TenantType  string         `hcl:"tenant_type"`
@@ -394,13 +401,12 @@ func (b *BatchQueue) Validate() error {
 		return nil
 	}
 
-	// TODO: lots of magic strings here
 	switch b.Type {
-	case "dynamicPriority":
-		if err := validateDuration(b.Config["calc_interval"]); err != nil {
+	case QueueTypeDynamicPriority:
+		if err := validateDuration(b.Config[DynamicCalcInterval]); err != nil {
 			return fmt.Errorf("failed to parse calc_interval: %v", err)
 		}
-		if err := validateDuration(b.Config["max_age"]); err != nil {
+		if err := validateDuration(b.Config[DynamicMaxAge]); err != nil {
 			return fmt.Errorf("failed to parse max_age: %v", err)
 		}
 	default:

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -398,6 +398,11 @@ func validateDuration(val any) error {
 
 func (b *BatchQueue) Validate() error {
 	if b.Type == "" {
+		switch {
+		case b.TenantType != "", b.MetadataKey != "", b.Config != nil:
+			return errors.New("batch queue configuration found but no type specified")
+		}
+
 		return nil
 	}
 
@@ -410,11 +415,11 @@ func (b *BatchQueue) Validate() error {
 			return fmt.Errorf("failed to parse max_age: %v", err)
 		}
 	default:
-		return fmt.Errorf("unsupported batch queue type: %s", b.Type)
+		return fmt.Errorf("unsupported batch queue type: %q", b.Type)
 	}
 
 	if b.TenantType != "namespace" && b.TenantType != "metadata" {
-		return fmt.Errorf("unsupported tenant type: %s", b.TenantType)
+		return fmt.Errorf("unsupported tenant type: %q", b.TenantType)
 	}
 
 	if b.TenantType == "metadata" && b.MetadataKey == "" {

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -363,7 +363,7 @@ type BatchQueue struct {
 	Type        string         `hcl:"type"`
 	TenantType  string         `hcl:"tenant_type"`
 	MetadataKey string         `hcl:"metadata_key"`
-	Config      map[string]any `hcl:"config"` // TODO: not sure yet how to handle this any blob
+	Config      map[string]any `hcl:"config"`
 }
 
 type DynamicQueueConfig struct {

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -220,6 +220,10 @@ type SchedulerConfiguration struct {
 	// priority jobs to place higher priority jobs.
 	PreemptionConfig PreemptionConfig `hcl:"preemption_config"`
 
+	// BatchQueue specifies the batch queue for this scheduler configuration
+	// which defines the behavior for scheduling batch job evaluations.
+	BatchQueue BatchQueue `hcl:"batch_queue"`
+
 	// MemoryOversubscriptionEnabled specifies whether memory oversubscription is enabled
 	MemoryOversubscriptionEnabled bool `hcl:"memory_oversubscription_enabled"`
 
@@ -268,6 +272,11 @@ func (s *SchedulerConfiguration) WithNodePool(pool *NodePool) *SchedulerConfigur
 	if poolConfig.SchedulerAlgorithm != "" {
 		schedConfig.SchedulerAlgorithm = poolConfig.SchedulerAlgorithm
 	}
+
+	if poolConfig.BatchQueue.Type != "" {
+		schedConfig.BatchQueue = poolConfig.BatchQueue
+	}
+
 	if poolConfig.MemoryOversubscriptionEnabled != nil {
 		schedConfig.MemoryOversubscriptionEnabled = *poolConfig.MemoryOversubscriptionEnabled
 	}
@@ -290,6 +299,10 @@ func (s *SchedulerConfiguration) Validate() error {
 	case "", SchedulerAlgorithmBinpack, SchedulerAlgorithmSpread:
 	default:
 		return fmt.Errorf("invalid scheduler algorithm: %v", s.SchedulerAlgorithm)
+	}
+
+	if err := s.BatchQueue.Validate(); err != nil {
+		return err
 	}
 
 	return nil
@@ -326,6 +339,65 @@ type PreemptionConfig struct {
 
 	// ServiceSchedulerEnabled specifies if preemption is enabled for service jobs
 	ServiceSchedulerEnabled bool `hcl:"service_scheduler_enabled"`
+}
+
+type BatchQueue struct {
+	Type        string         `hcl:"type"`
+	TenantType  string         `hcl:"tenant_type"`
+	MetadataKey string         `hcl:"metadata_key"`
+	Config      map[string]any `hcl:"config"` // TODO: not sure yet how to handle this any blob
+}
+
+type DynamicQueueConfig struct {
+	CalcInterval time.Duration
+	MaxAge       time.Duration
+	MaxSize      int
+	AgeWeight    int
+	UsageWeight  int
+	SizeWeight   int
+}
+
+func validateDuration(val any) error {
+	switch t := val.(type) {
+	case string:
+		if _, err := time.ParseDuration(t); err != nil {
+			return err
+		}
+	case int, nil:
+	default:
+		return fmt.Errorf("value not a duration: %v", val)
+	}
+
+	return nil
+}
+
+func (b *BatchQueue) Validate() error {
+	if b.Type == "" {
+		return nil
+	}
+
+	// TODO: lots of magic strings here
+	switch b.Type {
+	case "dynamicPriority":
+		if err := validateDuration(b.Config["calc_interval"]); err != nil {
+			return fmt.Errorf("failed to parse calc_interval: %v", err)
+		}
+		if err := validateDuration(b.Config["max_age"]); err != nil {
+			return fmt.Errorf("failed to parse max_age: %v", err)
+		}
+	default:
+		return fmt.Errorf("unsupported batch queue type: %s", b.Type)
+	}
+
+	if b.TenantType != "namespace" && b.TenantType != "metadata" {
+		return fmt.Errorf("unsupported tenant type: %s", b.TenantType)
+	}
+
+	if b.TenantType == "metadata" && b.MetadataKey == "" {
+		return fmt.Errorf("metadata key must be specified if using metadata tenency")
+	}
+
+	return nil
 }
 
 // SchedulerSetConfigRequest is used by the Operator endpoint to update the

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -345,7 +345,7 @@ type BatchQueue struct {
 	Type        string         `hcl:"type"`
 	TenantType  string         `hcl:"tenant_type"`
 	MetadataKey string         `hcl:"metadata_key"`
-	Config      map[string]any `hcl:"config"` // TODO: not sure yet how to handle this any blob
+	Config      map[string]any `hcl:"config"`
 }
 
 type DynamicQueueConfig struct {

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -341,6 +341,13 @@ type PreemptionConfig struct {
 	ServiceSchedulerEnabled bool `hcl:"service_scheduler_enabled"`
 }
 
+const (
+	QueueTypeDynamicPriority = "dynamicPriority"
+
+	DynamicCalcInterval = "calc_interval"
+	DynamicMaxAge       = "max_age"
+)
+
 type BatchQueue struct {
 	Type        string         `hcl:"type"`
 	TenantType  string         `hcl:"tenant_type"`
@@ -376,13 +383,12 @@ func (b *BatchQueue) Validate() error {
 		return nil
 	}
 
-	// TODO: lots of magic strings here
 	switch b.Type {
-	case "dynamicPriority":
-		if err := validateDuration(b.Config["calc_interval"]); err != nil {
+	case QueueTypeDynamicPriority:
+		if err := validateDuration(b.Config[DynamicCalcInterval]); err != nil {
 			return fmt.Errorf("failed to parse calc_interval: %v", err)
 		}
-		if err := validateDuration(b.Config["max_age"]); err != nil {
+		if err := validateDuration(b.Config[DynamicMaxAge]); err != nil {
 			return fmt.Errorf("failed to parse max_age: %v", err)
 		}
 	default:

--- a/nomad/structs/operator_test.go
+++ b/nomad/structs/operator_test.go
@@ -210,7 +210,7 @@ func TestBatchQueue_Validate(t *testing.T) {
 				Type:       "",
 				TenantType: "metadata",
 			},
-			err: "batch queue config found but no type specified",
+			err: "batch queue configuration found but no type specified",
 		},
 		{
 			name: "empty metadata key errors",

--- a/nomad/structs/operator_test.go
+++ b/nomad/structs/operator_test.go
@@ -205,6 +205,14 @@ func TestBatchQueue_Validate(t *testing.T) {
 			err: "unsupported tenant type",
 		},
 		{
+			name: "batch config with no type",
+			batchConfig: BatchQueue{
+				Type:       "",
+				TenantType: "metadata",
+			},
+			err: "batch queue config found but no type specified",
+		},
+		{
 			name: "empty metadata key errors",
 			batchConfig: BatchQueue{
 				Type:       "dynamicPriority",

--- a/nomad/structs/operator_test.go
+++ b/nomad/structs/operator_test.go
@@ -86,10 +86,16 @@ func TestSchedulerConfiguration_WithNodePool(t *testing.T) {
 			pool: &NodePool{
 				SchedulerConfiguration: &NodePoolSchedulerConfiguration{
 					MemoryOversubscriptionEnabled: pointer.Of(true),
+					BatchQueue: BatchQueue{
+						Type: "test",
+					},
 				},
 			},
 			expected: &SchedulerConfiguration{
 				MemoryOversubscriptionEnabled: true,
+				BatchQueue: BatchQueue{
+					Type: "test",
+				},
 			},
 		},
 		{
@@ -137,6 +143,118 @@ func TestSchedulerConfiguration_WithNodePool(t *testing.T) {
 			got := tc.schedConfig.WithNodePool(tc.pool)
 			must.Eq(t, tc.expected, got)
 			must.NotEqOp(t, tc.schedConfig, got)
+		})
+	}
+}
+
+func TestSchedulerConfiguration_Validate(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		schedConfig *SchedulerConfiguration
+		err         string
+	}{
+		{
+			name: "invalid scheduler algorithm",
+			schedConfig: &SchedulerConfiguration{
+				SchedulerAlgorithm: "not-good",
+			},
+			err: "invalid scheduler algorithm: not-good",
+		},
+		{
+			name: "valid scheduler algorithm",
+			schedConfig: &SchedulerConfiguration{
+				SchedulerAlgorithm: SchedulerAlgorithmBinpack,
+			},
+			err: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.schedConfig.Validate()
+			if tc.err != "" {
+				must.ErrorContains(t, err, tc.err)
+			} else {
+				must.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBatchQueue_Validate(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		batchConfig BatchQueue
+		err         string
+	}{
+		{
+			name: "invalid queue type",
+			batchConfig: BatchQueue{
+				Type: "foo",
+			},
+			err: "unsupported batch queue type",
+		},
+		{
+			name: "invalid metadata type",
+			batchConfig: BatchQueue{
+				Type:       "dynamicPriority",
+				TenantType: "foo",
+			},
+			err: "unsupported tenant type",
+		},
+		{
+			name: "empty metadata key errors",
+			batchConfig: BatchQueue{
+				Type:       "dynamicPriority",
+				TenantType: "metadata",
+			},
+			err: "metadata key must be specified",
+		},
+		{
+			name: "dynamicPriority - invalid interval",
+			batchConfig: BatchQueue{
+				Type:       "dynamicPriority",
+				TenantType: "namespace",
+				Config: map[string]any{
+					"calc_interval": "hello",
+				},
+			},
+			err: "failed to parse",
+		},
+		{
+			name: "dynamicPriority - valid string interval",
+			batchConfig: BatchQueue{
+				Type:       "dynamicPriority",
+				TenantType: "namespace",
+				Config: map[string]any{
+					"calc_interval": "1h",
+				},
+			},
+			err: "",
+		},
+		{
+			name: "dynamicPriority - valid int interval",
+			batchConfig: BatchQueue{
+				Type:       "dynamicPriority",
+				TenantType: "namespace",
+				Config: map[string]any{
+					"calc_interval": 1000,
+				},
+			},
+			err: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.batchConfig.Validate()
+			if tc.err != "" {
+				must.ErrorContains(t, err, tc.err)
+			} else {
+				must.NoError(t, err)
+			}
 		})
 	}
 }

--- a/nomad/structs/operator_test.go
+++ b/nomad/structs/operator_test.go
@@ -199,7 +199,7 @@ func TestBatchQueue_Validate(t *testing.T) {
 		{
 			name: "invalid metadata type",
 			batchConfig: BatchQueue{
-				Type:       "dynamicPriority",
+				Type:       BatchQueueTypeDynamic,
 				TenantType: "foo",
 			},
 			err: "unsupported tenant type",
@@ -208,23 +208,23 @@ func TestBatchQueue_Validate(t *testing.T) {
 			name: "batch config with no type",
 			batchConfig: BatchQueue{
 				Type:       "",
-				TenantType: "metadata",
+				TenantType: TenantTypeNamespace,
 			},
 			err: "batch queue configuration found but no type specified",
 		},
 		{
 			name: "empty metadata key errors",
 			batchConfig: BatchQueue{
-				Type:       "dynamicPriority",
-				TenantType: "metadata",
+				Type:       BatchQueueTypeDynamic,
+				TenantType: TenantTypeMetadata,
 			},
 			err: "metadata key must be specified",
 		},
 		{
 			name: "dynamicPriority - invalid interval",
 			batchConfig: BatchQueue{
-				Type:       "dynamicPriority",
-				TenantType: "namespace",
+				Type:       BatchQueueTypeDynamic,
+				TenantType: TenantTypeNamespace,
 				Config: map[string]any{
 					"calc_interval": "hello",
 				},
@@ -234,8 +234,8 @@ func TestBatchQueue_Validate(t *testing.T) {
 		{
 			name: "dynamicPriority - valid string interval",
 			batchConfig: BatchQueue{
-				Type:       "dynamicPriority",
-				TenantType: "namespace",
+				Type:       BatchQueueTypeDynamic,
+				TenantType: TenantTypeNamespace,
 				Config: map[string]any{
 					"calc_interval": "1h",
 				},
@@ -245,8 +245,8 @@ func TestBatchQueue_Validate(t *testing.T) {
 		{
 			name: "dynamicPriority - valid int interval",
 			batchConfig: BatchQueue{
-				Type:       "dynamicPriority",
-				TenantType: "namespace",
+				Type:       BatchQueueTypeDynamic,
+				TenantType: TenantTypeNamespace,
 				Config: map[string]any{
 					"calc_interval": 1000,
 				},

--- a/nomad/structs/operator_test.go
+++ b/nomad/structs/operator_test.go
@@ -52,10 +52,16 @@ func TestSchedulerConfiguration_WithNodePool(t *testing.T) {
 			pool: &NodePool{
 				SchedulerConfiguration: &NodePoolSchedulerConfiguration{
 					MemoryOversubscriptionEnabled: pointer.Of(true),
+					BatchQueue: BatchQueue{
+						Type: "test",
+					},
 				},
 			},
 			expected: &SchedulerConfiguration{
 				MemoryOversubscriptionEnabled: true,
+				BatchQueue: BatchQueue{
+					Type: "test",
+				},
 			},
 		},
 		{
@@ -103,6 +109,118 @@ func TestSchedulerConfiguration_WithNodePool(t *testing.T) {
 			got := tc.schedConfig.WithNodePool(tc.pool)
 			must.Eq(t, tc.expected, got)
 			must.NotEqOp(t, tc.schedConfig, got)
+		})
+	}
+}
+
+func TestSchedulerConfiguration_Validate(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		schedConfig *SchedulerConfiguration
+		err         string
+	}{
+		{
+			name: "invalid scheduler algorithm",
+			schedConfig: &SchedulerConfiguration{
+				SchedulerAlgorithm: "not-good",
+			},
+			err: "invalid scheduler algorithm: not-good",
+		},
+		{
+			name: "valid scheduler algorithm",
+			schedConfig: &SchedulerConfiguration{
+				SchedulerAlgorithm: SchedulerAlgorithmBinpack,
+			},
+			err: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.schedConfig.Validate()
+			if tc.err != "" {
+				must.ErrorContains(t, err, tc.err)
+			} else {
+				must.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestBatchQueue_Validate(t *testing.T) {
+
+	testCases := []struct {
+		name        string
+		batchConfig BatchQueue
+		err         string
+	}{
+		{
+			name: "invalid queue type",
+			batchConfig: BatchQueue{
+				Type: "foo",
+			},
+			err: "unsupported batch queue type",
+		},
+		{
+			name: "invalid metadata type",
+			batchConfig: BatchQueue{
+				Type:       "dynamicPriority",
+				TenantType: "foo",
+			},
+			err: "unsupported tenant type",
+		},
+		{
+			name: "empty metadata key errors",
+			batchConfig: BatchQueue{
+				Type:       "dynamicPriority",
+				TenantType: "metadata",
+			},
+			err: "metadata key must be specified",
+		},
+		{
+			name: "dynamicPriority - invalid interval",
+			batchConfig: BatchQueue{
+				Type:       "dynamicPriority",
+				TenantType: "namespace",
+				Config: map[string]any{
+					"calc_interval": "hello",
+				},
+			},
+			err: "failed to parse",
+		},
+		{
+			name: "dynamicPriority - valid string interval",
+			batchConfig: BatchQueue{
+				Type:       "dynamicPriority",
+				TenantType: "namespace",
+				Config: map[string]any{
+					"calc_interval": "1h",
+				},
+			},
+			err: "",
+		},
+		{
+			name: "dynamicPriority - valid int interval",
+			batchConfig: BatchQueue{
+				Type:       "dynamicPriority",
+				TenantType: "namespace",
+				Config: map[string]any{
+					"calc_interval": 1000,
+				},
+			},
+			err: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.batchConfig.Validate()
+			if tc.err != "" {
+				must.ErrorContains(t, err, tc.err)
+			} else {
+				must.NoError(t, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes introduce scheduler configuration parameters to configure a batch job queue.

An example of `nomad operator scheduler get-config` using these changes:
<img width="969" height="229" alt="image" src="https://github.com/user-attachments/assets/32576c69-b9c6-4220-ad9d-ba996fc1c835" />

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
