### PR TITLE
ui: fix client detail page error

### DIFF
--- a/ui/app/adapters/token.js
+++ b/ui/app/adapters/token.js
@@ -47,13 +47,18 @@ export default class TokenAdapter extends ApplicationAdapter {
     return `${this.buildURL()}/${singularize(modelName)}/${identifier}`;
   }
 
-  async findSelf() {
+  async findSelf(regionOverride = null) {
     // the application adapter automatically adds the region parameter to all requests,
     // but only if the /regions endpoint has been resolved first. Since this request is async,
     // we can ensure that the regions are loaded before making the token/self request.
     await this.system.regions;
 
-    const response = await this.ajax(`${this.buildURL()}/token/self`, 'GET');
+    const options = regionOverride ? { regionOverride } : {};
+    const response = await this.ajax(
+      `${this.buildURL()}/token/self`,
+      'GET',
+      options
+    );
     const normalized = this.store.normalize('token', response);
     const tokenRecord = this.store.push(normalized);
     return tokenRecord;

--- a/ui/app/components/primary-metric/node.js
+++ b/ui/app/components/primary-metric/node.js
@@ -74,7 +74,11 @@ export default class NodePrimaryMetric extends Component {
 
   @task(function* () {
     do {
-      this.tracker.poll.perform();
+      const tracker = this.tracker;
+      const nodeId = tracker && get(tracker, 'node.id');
+      if (tracker && nodeId) {
+        tracker.poll.perform();
+      }
       yield timeout(100);
     } while (!Ember.testing);
   })
@@ -88,6 +92,8 @@ export default class NodePrimaryMetric extends Component {
   willDestroy() {
     super.willDestroy(...arguments);
     this.poller.cancelAll();
-    this.tracker.signalPause.perform();
+    if (this.tracker) {
+      this.tracker.signalPause.perform();
+    }
   }
 }

--- a/ui/app/components/region-switcher.js
+++ b/ui/app/components/region-switcher.js
@@ -21,10 +21,8 @@ export default class RegionSwitcher extends Component {
   }
 
   async gotoRegion(region) {
-    // Note: redundant but as long as we're using PowerSelect, the implicit set('activeRegion')
-    // is not something we can await, so we do it explicitly here.
-    this.system.set('activeRegion', region);
-    await this.get('token.fetchSelfTokenAndPolicies').perform().catch();
+    // Fetch token for the new region before transitioning
+    await this.get('token.fetchSelfTokenAndPolicies').perform(region).catch();
 
     this.router.transitionTo({ queryParams: { region } });
   }

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -10,7 +10,7 @@ import {
   fragmentArray,
   fragmentOwner,
 } from 'ember-data-model-fragments/attributes';
-import { computed } from '@ember/object';
+import { computed, notifyPropertyChange } from '@ember/object';
 
 export default class Task extends Fragment {
   @fragmentOwner() taskGroup;
@@ -84,7 +84,7 @@ export default class Task extends Fragment {
     this._job = job;
     await this._job.variables;
     // pathLinkedVariable is consumed by a sync template condition, so notify after async load.
-    this.notifyPropertyChange('pathLinkedVariable');
+    notifyPropertyChange(this, 'pathLinkedVariable');
   }
 
   get pathLinkedVariable() {

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -10,7 +10,7 @@ import {
   fragmentArray,
   fragmentOwner,
 } from 'ember-data-model-fragments/attributes';
-import { computed } from '@ember/object';
+import { computed, notifyPropertyChange } from '@ember/object';
 
 export default class Task extends Fragment {
   @fragmentOwner() taskGroup;
@@ -61,6 +61,19 @@ export default class Task extends Fragment {
 
   @fragmentArray('volume-mount', { defaultValue: () => [] }) volumeMounts;
 
+  _pathLinkedVariableJobID() {
+    let jobID = this._job.plainId;
+    const parentID = this._job.belongsTo('parent').id()
+      ? JSON.parse(this._job.belongsTo('parent').id())[0]
+      : null;
+
+    if (parentID) {
+      jobID = parentID;
+    }
+
+    return jobID;
+  }
+
   async _fetchParentJob() {
     let job = this.store.peekRecord('job', this.taskGroup.job.id);
     if (!job) {
@@ -69,6 +82,9 @@ export default class Task extends Fragment {
       });
     }
     this._job = job;
+    await this._job.variables;
+    // pathLinkedVariable is consumed by a sync template condition, so notify after async load.
+    notifyPropertyChange(this, 'pathLinkedVariable');
   }
 
   get pathLinkedVariable() {
@@ -76,10 +92,7 @@ export default class Task extends Fragment {
       this._fetchParentJob();
       return null;
     } else {
-      let jobID = this._job.plainId;
-      if (this._job.parent.get('plainId')) {
-        jobID = this._job.parent.get('plainId');
-      }
+      let jobID = this._pathLinkedVariableJobID();
       return this._job.variables?.findBy(
         'path',
         `nomad/jobs/${jobID}/${this.taskGroup.name}/${this.name}`
@@ -93,14 +106,7 @@ export default class Task extends Fragment {
       await this._fetchParentJob();
     }
     await this._job.variables;
-    let jobID = this._job.plainId;
-    // not getting plainID because we dont know the resolution status of the task's job's parent yet
-    let parentID = this._job.belongsTo('parent').id()
-      ? JSON.parse(this._job.belongsTo('parent').id())[0]
-      : null;
-    if (parentID) {
-      jobID = parentID;
-    }
+    let jobID = this._pathLinkedVariableJobID();
     return await this._job.variables?.findBy(
       'path',
       `nomad/jobs/${jobID}/${this.taskGroup.name}/${this.name}`

--- a/ui/app/models/task.js
+++ b/ui/app/models/task.js
@@ -61,6 +61,19 @@ export default class Task extends Fragment {
 
   @fragmentArray('volume-mount', { defaultValue: () => [] }) volumeMounts;
 
+  _pathLinkedVariableJobID() {
+    let jobID = this._job.plainId;
+    const parentID = this._job.belongsTo('parent').id()
+      ? JSON.parse(this._job.belongsTo('parent').id())[0]
+      : null;
+
+    if (parentID) {
+      jobID = parentID;
+    }
+
+    return jobID;
+  }
+
   async _fetchParentJob() {
     let job = this.store.peekRecord('job', this.taskGroup.job.id);
     if (!job) {
@@ -69,6 +82,9 @@ export default class Task extends Fragment {
       });
     }
     this._job = job;
+    await this._job.variables;
+    // pathLinkedVariable is consumed by a sync template condition, so notify after async load.
+    this.notifyPropertyChange('pathLinkedVariable');
   }
 
   get pathLinkedVariable() {
@@ -76,10 +92,7 @@ export default class Task extends Fragment {
       this._fetchParentJob();
       return null;
     } else {
-      let jobID = this._job.plainId;
-      if (this._job.parent.get('plainId')) {
-        jobID = this._job.parent.get('plainId');
-      }
+      let jobID = this._pathLinkedVariableJobID();
       return this._job.variables?.findBy(
         'path',
         `nomad/jobs/${jobID}/${this.taskGroup.name}/${this.name}`
@@ -93,14 +106,7 @@ export default class Task extends Fragment {
       await this._fetchParentJob();
     }
     await this._job.variables;
-    let jobID = this._job.plainId;
-    // not getting plainID because we dont know the resolution status of the task's job's parent yet
-    let parentID = this._job.belongsTo('parent').id()
-      ? JSON.parse(this._job.belongsTo('parent').id())[0]
-      : null;
-    if (parentID) {
-      jobID = parentID;
-    }
+    let jobID = this._pathLinkedVariableJobID();
     return await this._job.variables?.findBy(
       'path',
       `nomad/jobs/${jobID}/${this.taskGroup.name}/${this.name}`

--- a/ui/app/routes/allocations/allocation.js
+++ b/ui/app/routes/allocations/allocation.js
@@ -54,7 +54,7 @@ export default class AllocationRoute extends Route.extend(WithWatchers) {
         await allocation.reload();
       }
       const jobId = allocation.belongsTo('job').id();
-      await this.store.findRecord('job', jobId);
+      await this.store.findRecord('job', jobId, { reload: true });
       return allocation;
     } catch (e) {
       const [allocId, transition] = arguments;

--- a/ui/app/routes/allocations/allocation/task.js
+++ b/ui/app/routes/allocations/allocation/task.js
@@ -30,11 +30,4 @@ export default class TaskRoute extends Route {
 
     return task;
   }
-
-  async afterModel(model) {
-    if (model && model.task) {
-      // Preload the job's variables so pathLinkedVariable can work synchronously
-      await model.task.getPathLinkedVariable();
-    }
-  }
 }

--- a/ui/app/routes/allocations/allocation/task.js
+++ b/ui/app/routes/allocations/allocation/task.js
@@ -30,4 +30,11 @@ export default class TaskRoute extends Route {
 
     return task;
   }
+
+  async afterModel(model) {
+    if (model && model.task) {
+      // Preload the job's variables so pathLinkedVariable can work synchronously
+      await model.task.getPathLinkedVariable();
+    }
+  }
 }

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -111,6 +111,9 @@ export default class ApplicationRoute extends Route {
           currentRoute.handler.cancelAllWatchers
         ) {
           currentRoute.handler.cancelAllWatchers();
+
+          // Cancel all stats trackers as well
+          this.get('stats-trackers-registry').cancelAll();
         }
 
         // Clear the store to remove stale data

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -92,15 +92,34 @@ export default class ApplicationRoute extends Route {
     const defaultRegion = this.get('system.defaultRegion.region');
     const currentRegion = this.get('system.activeRegion') || defaultRegion;
 
-    // Only reset the store if the region actually changed
-    if (
+    // Check if region actually changed
+    const regionChanged =
       (queryParam && queryParam !== currentRegion) ||
-      (!queryParam && currentRegion !== defaultRegion)
-    ) {
-      this.store.unloadAll();
-    }
+      (!queryParam && currentRegion !== defaultRegion);
 
+    // Update the active region - the adapter will use this for all API requests
     this.set('system.activeRegion', queryParam || defaultRegion);
+
+    // If region changed, cancel watchers, clear store, and refresh
+    if (regionChanged) {
+      later(() => {
+        // Cancel all watchers on the current route to prevent polling old region
+        const currentRoute = this.router.currentRoute;
+        if (
+          currentRoute &&
+          currentRoute.handler &&
+          currentRoute.handler.cancelAllWatchers
+        ) {
+          currentRoute.handler.cancelAllWatchers();
+        }
+
+        // Clear the store to remove stale data
+        this.store.unloadAll();
+
+        // Refresh to reload with new region data
+        this.refresh();
+      }, 0);
+    }
 
     return promises;
   }

--- a/ui/app/routes/application.js
+++ b/ui/app/routes/application.js
@@ -19,7 +19,6 @@ import { handleRouteRedirects } from '../utils/route-redirector';
 export default class ApplicationRoute extends Route {
   @service config;
   @service system;
-  @service store;
   @service token;
   @service router;
 
@@ -91,35 +90,15 @@ export default class ApplicationRoute extends Route {
     const queryParam = transition.to.queryParams.region;
     const defaultRegion = this.get('system.defaultRegion.region');
     const currentRegion = this.get('system.activeRegion') || defaultRegion;
-
-    // Check if region actually changed
-    const regionChanged =
-      (queryParam && queryParam !== currentRegion) ||
-      (!queryParam && currentRegion !== defaultRegion);
+    const nextRegion = queryParam || defaultRegion;
+    const regionChanged = nextRegion !== currentRegion;
 
     // Update the active region - the adapter will use this for all API requests
-    this.set('system.activeRegion', queryParam || defaultRegion);
+    this.set('system.activeRegion', nextRegion);
 
-    // If region changed, cancel watchers, clear store, and refresh
-    if (regionChanged) {
+    // Refresh for child routes if region changes and only if query-param-only transitions
+    if (regionChanged && transition.queryParamsOnly) {
       later(() => {
-        // Cancel all watchers on the current route to prevent polling old region
-        const currentRoute = this.router.currentRoute;
-        if (
-          currentRoute &&
-          currentRoute.handler &&
-          currentRoute.handler.cancelAllWatchers
-        ) {
-          currentRoute.handler.cancelAllWatchers();
-
-          // Cancel all stats trackers as well
-          this.get('stats-trackers-registry').cancelAll();
-        }
-
-        // Clear the store to remove stale data
-        this.store.unloadAll();
-
-        // Refresh to reload with new region data
         this.refresh();
       }, 0);
     }

--- a/ui/app/routes/jobs/job.js
+++ b/ui/app/routes/jobs/job.js
@@ -42,8 +42,8 @@ export default class JobRoute extends Route.extend(WithWatchers) {
       .findRecord('job', fullId, { reload: true })
       .then((job) => {
         const relatedModelsQueries = [
-          job.get('allocations'),
-          job.get('evaluations'),
+          job.hasMany('allocations').reload(),
+          job.hasMany('evaluations').reload(),
           this.store.findAll('namespace'),
         ];
 

--- a/ui/app/services/stats-trackers-registry.js
+++ b/ui/app/services/stats-trackers-registry.js
@@ -67,7 +67,10 @@ export default class StatsTrackersRegistryService extends Service {
 
       // Replace stale/mismatched trackers instead of mutating an already-used
       // tracker during render.
-      if (cachedTracker.poll && typeof cachedTracker.poll.cancelAll === 'function') {
+      if (
+        cachedTracker.poll &&
+        typeof cachedTracker.poll.cancelAll === 'function'
+      ) {
         cachedTracker.poll.cancelAll();
       }
       if (

--- a/ui/app/services/stats-trackers-registry.js
+++ b/ui/app/services/stats-trackers-registry.js
@@ -67,4 +67,21 @@ export default class StatsTrackersRegistryService extends Service {
 
     return tracker;
   }
+
+  // utility method to cancel all active stats polling tasks across all trackers in the registry.
+  cancelAll() {
+    registry.forEach((tracker) => {
+      // Cancel the poll task if it exists and is running
+      if (tracker.poll && typeof tracker.poll.cancelAll === 'function') {
+        tracker.poll.cancelAll();
+      }
+      // Cancel the signalPause task if it exists
+      if (
+        tracker.signalPause &&
+        typeof tracker.signalPause.cancelAll === 'function'
+      ) {
+        tracker.signalPause.cancelAll();
+      }
+    });
+  }
 }

--- a/ui/app/services/stats-trackers-registry.js
+++ b/ui/app/services/stats-trackers-registry.js
@@ -44,18 +44,46 @@ export default class StatsTrackersRegistryService extends Service {
     if (!resource) return;
 
     const type = resource && resource.constructor.modelName;
-    const key = `${type}:${resource.get('id')}`;
+    const resourceId = resource.get('id');
+
+    if (!resourceId) {
+      return;
+    }
+
+    const key = `${type}:${resourceId}`;
     const Constructor =
       type === 'node' ? NodeStatsTracker : AllocationStatsTracker;
     const resourceProp = type === 'node' ? 'node' : 'allocation';
 
     const cachedTracker = registry.get(key);
     if (cachedTracker) {
-      // It's possible for the resource on a cachedTracker to have been
-      // deleted. Rebind it if that's the case.
-      if (!exists(cachedTracker, resourceProp))
-        cachedTracker.set(resourceProp, resource);
-      return cachedTracker;
+      const cachedResource = cachedTracker.get(resourceProp);
+      const shouldReuse =
+        exists(cachedTracker, resourceProp) && cachedResource === resource;
+
+      if (shouldReuse) {
+        return cachedTracker;
+      }
+
+      // Replace stale/mismatched trackers instead of mutating an already-used
+      // tracker during render.
+      if (cachedTracker.poll && typeof cachedTracker.poll.cancelAll === 'function') {
+        cachedTracker.poll.cancelAll();
+      }
+      if (
+        cachedTracker.signalPause &&
+        typeof cachedTracker.signalPause.cancelAll === 'function'
+      ) {
+        cachedTracker.signalPause.cancelAll();
+      }
+
+      const replacementTracker = Constructor.create({
+        fetch: (url) => this.token.authorizedRequest(url),
+        [resourceProp]: resource,
+      });
+
+      registry.set(key, replacementTracker);
+      return replacementTracker;
     }
 
     const tracker = Constructor.create({

--- a/ui/app/services/stats-trackers-registry.js
+++ b/ui/app/services/stats-trackers-registry.js
@@ -67,21 +67,4 @@ export default class StatsTrackersRegistryService extends Service {
 
     return tracker;
   }
-
-  // utility method to cancel all active stats polling tasks across all trackers in the registry.
-  cancelAll() {
-    registry.forEach((tracker) => {
-      // Cancel the poll task if it exists and is running
-      if (tracker.poll && typeof tracker.poll.cancelAll === 'function') {
-        tracker.poll.cancelAll();
-      }
-      // Cancel the signalPause task if it exists
-      if (
-        tracker.signalPause &&
-        typeof tracker.signalPause.cancelAll === 'function'
-      ) {
-        tracker.signalPause.cancelAll();
-      }
-    });
-  }
 }

--- a/ui/app/services/stats-trackers-registry.js
+++ b/ui/app/services/stats-trackers-registry.js
@@ -95,21 +95,4 @@ export default class StatsTrackersRegistryService extends Service {
 
     return tracker;
   }
-
-  // utility method to cancel all active stats polling tasks across all trackers in the registry.
-  cancelAll() {
-    registry.forEach((tracker) => {
-      // Cancel the poll task if it exists and is running
-      if (tracker.poll && typeof tracker.poll.cancelAll === 'function') {
-        tracker.poll.cancelAll();
-      }
-      // Cancel the signalPause task if it exists
-      if (
-        tracker.signalPause &&
-        typeof tracker.signalPause.cancelAll === 'function'
-      ) {
-        tracker.signalPause.cancelAll();
-      }
-    });
-  }
 }

--- a/ui/app/services/token.js
+++ b/ui/app/services/token.js
@@ -40,10 +40,10 @@ export default class TokenService extends Service {
     }
   }
 
-  @task(function* () {
+  @task(function* (regionOverride = null) {
     const TokenAdapter = getOwner(this).lookup('adapter:token');
     try {
-      var token = yield TokenAdapter.findSelf();
+      var token = yield TokenAdapter.findSelf(regionOverride);
       if (token.accessor === 'acls-disabled') {
         this.set('aclEnabled', false);
         return null;
@@ -102,8 +102,8 @@ export default class TokenService extends Service {
 
   @alias('fetchSelfTokenPolicies.lastSuccessful.value') selfTokenPolicies;
 
-  @task(function* () {
-    yield this.fetchSelfToken.perform();
+  @task(function* (regionOverride = null) {
+    yield this.fetchSelfToken.perform(regionOverride);
     this.kickoffTokenTTLMonitoring();
     if (this.aclEnabled) {
       yield this.fetchSelfTokenPolicies.perform();

--- a/ui/tests/acceptance/job-definition-test.js
+++ b/ui/tests/acceptance/job-definition-test.js
@@ -12,7 +12,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import setupCodeMirror from 'nomad-ui/tests/helpers/codemirror';
 import Definition from 'nomad-ui/tests/pages/jobs/job/definition';
-import { JOB_JSON } from 'nomad-ui/tests/utils/generate-raw-json-job';
 
 let job;
 
@@ -154,7 +153,7 @@ module('Acceptance | job definition | full specification', function (hooks) {
   });
 
   test('it allows users to select between full specification and JSON definition', async function (assert) {
-    assert.expect(3);
+    assert.expect(7);
     const specification_response = {
       Format: 'hcl2',
       JobID: 'example',
@@ -166,7 +165,7 @@ module('Acceptance | job definition | full specification', function (hooks) {
       Variables: '',
       Version: 0,
     };
-    server.get('/job/:id', () => JOB_JSON);
+
     server.get('/job/:id/submission', () => specification_response);
 
     await Definition.visit({ id: job.id });
@@ -174,7 +173,7 @@ module('Acceptance | job definition | full specification', function (hooks) {
 
     assert
       .dom('[data-test-select="job-spec"]')
-      .exists('A select button exists and defaults to full definition');
+      .exists('A select button exists and defaults to job spec');
     let codeMirror = getCodeMirrorInstance('[data-test-editor]');
     assert.equal(
       codeMirror.getValue(),
@@ -184,6 +183,31 @@ module('Acceptance | job definition | full specification', function (hooks) {
 
     await click('[data-test-select-full]');
     codeMirror = getCodeMirrorInstance('[data-test-editor]');
-    assert.propContains(JSON.parse(codeMirror.getValue()), JOB_JSON);
+    const fullDefinition = JSON.parse(codeMirror.getValue());
+    assert
+      .dom('[data-test-select="full-definition"]')
+      .exists('View switches to full definition mode');
+    assert.equal(
+      fullDefinition.ID,
+      job.id,
+      'Full definition shows the correct job ID'
+    );
+    assert.equal(
+      fullDefinition.Name,
+      job.name,
+      'Full definition shows the correct job name'
+    );
+    assert.ok(
+      fullDefinition.TaskGroups,
+      'Full definition includes task groups'
+    );
+
+    await click('[data-test-select="full-definition"] button:first-child');
+    codeMirror = getCodeMirrorInstance('[data-test-editor]');
+    assert.equal(
+      codeMirror.getValue(),
+      specification_response.Source,
+      'Switching back to job spec restores the original specification source'
+    );
   });
 });

--- a/ui/tests/acceptance/job-definition-test.js
+++ b/ui/tests/acceptance/job-definition-test.js
@@ -12,7 +12,6 @@ import { setupMirage } from 'ember-cli-mirage/test-support';
 import a11yAudit from 'nomad-ui/tests/helpers/a11y-audit';
 import setupCodeMirror from 'nomad-ui/tests/helpers/codemirror';
 import Definition from 'nomad-ui/tests/pages/jobs/job/definition';
-import { JOB_JSON } from 'nomad-ui/tests/utils/generate-raw-json-job';
 
 let job;
 
@@ -154,7 +153,7 @@ module('Acceptance | job definition | full specification', function (hooks) {
   });
 
   test('it allows users to select between full specification and JSON definition', async function (assert) {
-    assert.expect(3);
+    assert.expect(5);
     const specification_response = {
       Format: 'hcl2',
       JobID: 'example',
@@ -166,7 +165,7 @@ module('Acceptance | job definition | full specification', function (hooks) {
       Variables: '',
       Version: 0,
     };
-    server.get('/job/:id', () => JOB_JSON);
+
     server.get('/job/:id/submission', () => specification_response);
 
     await Definition.visit({ id: job.id });
@@ -184,6 +183,20 @@ module('Acceptance | job definition | full specification', function (hooks) {
 
     await click('[data-test-select-full]');
     codeMirror = getCodeMirrorInstance('[data-test-editor]');
-    assert.propContains(JSON.parse(codeMirror.getValue()), JOB_JSON);
+    const fullDefinition = JSON.parse(codeMirror.getValue());
+    assert.equal(
+      fullDefinition.ID,
+      job.id,
+      'Full definition shows the correct job ID'
+    );
+    assert.equal(
+      fullDefinition.Name,
+      job.name,
+      'Full definition shows the correct job name'
+    );
+    assert.ok(
+      fullDefinition.TaskGroups,
+      'Full definition includes task groups'
+    );
   });
 });

--- a/ui/tests/acceptance/regions-test.js
+++ b/ui/tests/acceptance/regions-test.js
@@ -22,6 +22,7 @@ module('Acceptance | regions (only one)', function (hooks) {
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
+    window.localStorage.clear();
     server.create('agent');
     server.create('node-pool');
     server.create('node');
@@ -106,7 +107,11 @@ module('Acceptance | regions (many)', function (hooks) {
   });
 
   test('the region switcher is rendered in the nav bar and the region is in the page title', async function (assert) {
+    let managementToken = server.create('token');
+    window.localStorage.nomadTokenSecret = managementToken.secretId;
+
     await JobsList.visit();
+    await settled();
 
     assert.ok(
       Layout.navbar.regionSwitcher.isPresent,
@@ -144,6 +149,110 @@ module('Acceptance | regions (many)', function (hooks) {
       window.localStorage.nomadActiveRegion,
       newRegion,
       'New region in localStorage'
+    );
+  });
+
+  test('switching regions on a query-param-only transition refreshes the active route model', async function (assert) {
+    const newRegion = server.db.regions[1].id;
+
+    await JobsList.visit();
+
+    const jobsRequestsBeforeSwitch = server.pretender.handledRequests.filter(
+      (request) => request.url.includes('/v1/jobs')
+    ).length;
+
+    await selectChoose('[data-test-region-switcher-parent]', newRegion);
+    await settled();
+
+    const jobsRequestsAfterSwitch = server.pretender.handledRequests.filter(
+      (request) => request.url.includes('/v1/jobs')
+    );
+
+    assert.ok(
+      jobsRequestsAfterSwitch.length > jobsRequestsBeforeSwitch,
+      'Jobs model request is issued again after region query-param switch'
+    );
+
+    assert.ok(
+      jobsRequestsAfterSwitch
+        .slice(jobsRequestsBeforeSwitch)
+        .some((request) => request.url.includes(`region=${newRegion}`)),
+      'Refreshed jobs request uses the selected region'
+    );
+  });
+
+  test('switching regions on job detail reloads job, allocations, and evaluations', async function (assert) {
+    const newRegion = server.db.regions[1].id;
+
+    await JobsList.visit();
+    const jobId = JobsList.jobs.objectAt(0).id;
+    await JobsList.jobs.objectAt(0).clickRow();
+    await settled();
+
+    const isForJobPath = (request, path) => {
+      const url = new URL(request.url, window.location.origin);
+      return url.pathname === `/v1/job/${jobId}${path}`;
+    };
+
+    const jobRequestsBeforeSwitch = server.pretender.handledRequests.filter(
+      (request) => isForJobPath(request, '')
+    ).length;
+
+    const allocationRequestsBeforeSwitch =
+      server.pretender.handledRequests.filter((request) =>
+        isForJobPath(request, '/allocations')
+      ).length;
+
+    const evaluationRequestsBeforeSwitch =
+      server.pretender.handledRequests.filter((request) =>
+        isForJobPath(request, '/evaluations')
+      ).length;
+
+    await selectChoose('[data-test-region-switcher-parent]', newRegion);
+    await settled();
+
+    const jobRequestsAfterSwitch = server.pretender.handledRequests.filter(
+      (request) => isForJobPath(request, '')
+    );
+    const allocationRequestsAfterSwitch =
+      server.pretender.handledRequests.filter((request) =>
+        isForJobPath(request, '/allocations')
+      );
+    const evaluationRequestsAfterSwitch =
+      server.pretender.handledRequests.filter((request) =>
+        isForJobPath(request, '/evaluations')
+      );
+
+    assert.ok(
+      jobRequestsAfterSwitch.length > jobRequestsBeforeSwitch,
+      'Job record is fetched again after switching regions on job detail'
+    );
+    assert.ok(
+      allocationRequestsAfterSwitch.length > allocationRequestsBeforeSwitch,
+      'Job allocations are fetched again after switching regions on job detail'
+    );
+    assert.ok(
+      evaluationRequestsAfterSwitch.length > evaluationRequestsBeforeSwitch,
+      'Job evaluations are fetched again after switching regions on job detail'
+    );
+
+    assert.ok(
+      jobRequestsAfterSwitch
+        .slice(jobRequestsBeforeSwitch)
+        .some((request) => request.url.includes(`region=${newRegion}`)),
+      'Refetched job request includes selected region'
+    );
+    assert.ok(
+      allocationRequestsAfterSwitch
+        .slice(allocationRequestsBeforeSwitch)
+        .some((request) => request.url.includes(`region=${newRegion}`)),
+      'Refetched allocations request includes selected region'
+    );
+    assert.ok(
+      evaluationRequestsAfterSwitch
+        .slice(evaluationRequestsBeforeSwitch)
+        .some((request) => request.url.includes(`region=${newRegion}`)),
+      'Refetched evaluations request includes selected region'
     );
   });
 

--- a/ui/tests/integration/components/primary-metric/primary-metric.js
+++ b/ui/tests/integration/components/primary-metric/primary-metric.js
@@ -17,6 +17,9 @@ export function setupPrimaryMetricMocks(hooks, tasks = []) {
     const trackerSignalPauseSpy = (this.trackerSignalPauseSpy = sinon.spy());
 
     const MockTracker = EmberObject.extend({
+      node: computed(function () {
+        return { id: 'test-node-id' };
+      }),
       poll: task(function* () {
         yield trackerPollSpy();
       }),

--- a/ui/tests/unit/services/stats-trackers-registry-test.js
+++ b/ui/tests/unit/services/stats-trackers-registry-test.js
@@ -107,7 +107,7 @@ module('Unit | Service | Stats Trackers Registry', function (hooks) {
     );
   });
 
-  test('Registry does not depend on persistent object references', function (assert) {
+  test('Registry replaces cached tracker when resource reference changes for same id', function (assert) {
     const registry = this.subject();
     const id = 'some-id';
 
@@ -122,10 +122,18 @@ module('Unit | Service | Stats Trackers Registry', function (hooks) {
       'And the same className'
     );
 
+    const tracker1 = registry.getTracker(node1);
+    const tracker2 = registry.getTracker(node2);
+
+    assert.notEqual(
+      tracker1,
+      tracker2,
+      'Returns a replacement tracker for a different resource reference with same id'
+    );
     assert.equal(
-      registry.getTracker(node1),
-      registry.getTracker(node2),
-      'Return the same tracker'
+      tracker2.get('node'),
+      node2,
+      'The replacement tracker is bound to the latest resource reference'
     );
     assert.equal(
       registry.get('registryRef').size,


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
This PR fixes the issue when allocations view is not updated when switching region. This leads to user seeing incorrect data and further errors when they try to interact with it - for eg. trying to access a job not existing in the newly switched region.

The changes in the PR are as below:
- The region change was not being detected correctly in the application router when comparing active region and region from query params 
  - Updated region switcher to not set the active region and let it be updated by application router after comparing with query params
- Removed global `store.unloadAll` which was causing rendering errors and replaced it with `route.refresh` to reload active route models for the selected region
- Updated child detail routes (job and allocation) to explicitly reload related region data, avoiding reuse of stale cache after switching regions
- Also noticed an issue in clients details page when switching regions, where repeated calls to fetch node metrics were made. Fixed it by adding necessary guards and removing stale trackers

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
To reproduce the issue, set up Nomad instances with two regions and deploy a job to the federated cluster.
- Start instance for region 1
```bash
bin/nomad agent -dev -config=india-dev.hcl
```
- Start instance for region 2
```bash
bin/nomad agent -dev -config=us-dev.hcl
```
- Join the instances and deploy a sample job in both instances
```bash
bin/nomad server join -address=http://127.0.0.1:5646 127.0.0.1:4648
bin/nomad job run -region=india minimal-job.nomad
bin/nomad job run -region=us minimal-job.nomad
```
- Launch UI and navigate to jobs view [http://localhost:4646/ui/jobs/example](http://localhost:4646/ui/jobs/example)
- Switch between regions and observe the recent allocations data does not refresh
- Also click on an allocation id after switching initial region to observe object not found error

To verify the fix, please make another build with the PR branch and repeat the above steps

```bash
make dev-ui
```
You should see updated data for relevant region without any errors

Including the files mentioned above for reference:
[NMD917-test-files.zip](https://github.com/user-attachments/files/26661988/NMD917-test-files.zip)


### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
[JIRA](https://hashicorp.atlassian.net/browse/NMD-917)

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
