### PR TITLE
client: task-level max_run_duration

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -774,6 +774,7 @@ type Task struct {
 	RestartPolicy   *RestartPolicy         `hcl:"restart,block"`
 	Meta            map[string]string      `hcl:"meta,block"`
 	KillTimeout     *time.Duration         `mapstructure:"kill_timeout" hcl:"kill_timeout,optional"`
+	MaxRunDuration  *time.Duration         `mapstructure:"max_run_duration" hcl:"max_run_duration,optional"`
 	LogConfig       *LogConfig             `mapstructure:"logs" hcl:"logs,block"`
 	Artifacts       []*TaskArtifact        `hcl:"artifact,block"`
 	Vault           *Vault                 `hcl:"vault,block"`

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -723,6 +723,10 @@ func hasSidecarTasks(tasks map[string]*taskrunner.TaskRunner) bool {
 // logged except taskrunner.ErrTaskNotRunning which is ignored. Task states
 // after Kill has been called are returned.
 func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
+	return ar.killTasksWithFilter(nil)
+}
+
+func (ar *allocRunner) killTasksWithFilter(shouldKill func(*taskrunner.TaskRunner) bool) map[string]*structs.TaskState {
 	var mu sync.Mutex
 	states := make(map[string]*structs.TaskState, len(ar.tasks))
 
@@ -747,21 +751,34 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 		return event
 	}
 
-	// Kill leader first, synchronously
-	for name, tr := range ar.tasks {
-		if !tr.IsLeader() {
-			continue
+	shouldKillTask := func(tr *taskrunner.TaskRunner) bool {
+		if shouldKill == nil {
+			return true
 		}
+		return shouldKill(tr)
+	}
 
+	killRunner := func(name string, tr *taskrunner.TaskRunner, warnMsg string) {
 		taskEvent := taskEventFn(tr)
 
 		err := tr.Kill(context.TODO(), taskEvent)
 		if err != nil && err != taskrunner.ErrTaskNotRunning {
-			ar.logger.Warn("error stopping leader task", "error", err, "task_name", name)
+			ar.logger.Warn(warnMsg, "error", err, "task_name", name)
 		}
 
 		taskState := tr.TaskState()
+		mu.Lock()
 		states[name] = taskState
+		mu.Unlock()
+	}
+
+	// Kill leader first, synchronously
+	for name, tr := range ar.tasks {
+		if !tr.IsLeader() || !shouldKillTask(tr) {
+			continue
+		}
+
+		killRunner(name, tr, "error stopping leader task")
 		break
 	}
 
@@ -769,48 +786,28 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 	wg := sync.WaitGroup{}
 	for name, tr := range ar.tasks {
 		// Filter out poststop and sidecar tasks so that they stop after all the other tasks are killed
-		if tr.IsLeader() || tr.IsPoststopTask() || tr.IsSidecarTask() {
+		if tr.IsLeader() || tr.IsPoststopTask() || tr.IsSidecarTask() || !shouldKillTask(tr) {
 			continue
 		}
 
 		wg.Add(1)
 		go func(name string, tr *taskrunner.TaskRunner) {
 			defer wg.Done()
-			taskEvent := taskEventFn(tr)
-
-			err := tr.Kill(context.TODO(), taskEvent)
-			if err != nil && err != taskrunner.ErrTaskNotRunning {
-				ar.logger.Warn("error stopping task", "error", err, "task_name", name)
-			}
-
-			taskState := tr.TaskState()
-			mu.Lock()
-			states[name] = taskState
-			mu.Unlock()
+			killRunner(name, tr, "error stopping task")
 		}(name, tr)
 	}
 	wg.Wait()
 
 	// Kill the sidecar tasks last.
 	for name, tr := range ar.tasks {
-		if !tr.IsSidecarTask() || tr.IsLeader() || tr.IsPoststopTask() {
+		if !tr.IsSidecarTask() || tr.IsLeader() || tr.IsPoststopTask() || !shouldKillTask(tr) {
 			continue
 		}
 
 		wg.Add(1)
 		go func(name string, tr *taskrunner.TaskRunner) {
 			defer wg.Done()
-			taskEvent := taskEventFn(tr)
-
-			err := tr.Kill(context.TODO(), taskEvent)
-			if err != nil && err != taskrunner.ErrTaskNotRunning {
-				ar.logger.Warn("error stopping sidecar task", "error", err, "task_name", name)
-			}
-
-			taskState := tr.TaskState()
-			mu.Lock()
-			states[name] = taskState
-			mu.Unlock()
+			killRunner(name, tr, "error stopping sidecar task")
 		}(name, tr)
 	}
 	wg.Wait()

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -723,10 +723,6 @@ func hasSidecarTasks(tasks map[string]*taskrunner.TaskRunner) bool {
 // logged except taskrunner.ErrTaskNotRunning which is ignored. Task states
 // after Kill has been called are returned.
 func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
-	return ar.killTasksWithFilter(nil)
-}
-
-func (ar *allocRunner) killTasksWithFilter(shouldKill func(*taskrunner.TaskRunner) bool) map[string]*structs.TaskState {
 	var mu sync.Mutex
 	states := make(map[string]*structs.TaskState, len(ar.tasks))
 
@@ -751,34 +747,21 @@ func (ar *allocRunner) killTasksWithFilter(shouldKill func(*taskrunner.TaskRunne
 		return event
 	}
 
-	shouldKillTask := func(tr *taskrunner.TaskRunner) bool {
-		if shouldKill == nil {
-			return true
+	// Kill leader first, synchronously
+	for name, tr := range ar.tasks {
+		if !tr.IsLeader() {
+			continue
 		}
-		return shouldKill(tr)
-	}
 
-	killRunner := func(name string, tr *taskrunner.TaskRunner, warnMsg string) {
 		taskEvent := taskEventFn(tr)
 
 		err := tr.Kill(context.TODO(), taskEvent)
 		if err != nil && err != taskrunner.ErrTaskNotRunning {
-			ar.logger.Warn(warnMsg, "error", err, "task_name", name)
+			ar.logger.Warn("error stopping leader task", "error", err, "task_name", name)
 		}
 
 		taskState := tr.TaskState()
-		mu.Lock()
 		states[name] = taskState
-		mu.Unlock()
-	}
-
-	// Kill leader first, synchronously
-	for name, tr := range ar.tasks {
-		if !tr.IsLeader() || !shouldKillTask(tr) {
-			continue
-		}
-
-		killRunner(name, tr, "error stopping leader task")
 		break
 	}
 
@@ -786,28 +769,48 @@ func (ar *allocRunner) killTasksWithFilter(shouldKill func(*taskrunner.TaskRunne
 	wg := sync.WaitGroup{}
 	for name, tr := range ar.tasks {
 		// Filter out poststop and sidecar tasks so that they stop after all the other tasks are killed
-		if tr.IsLeader() || tr.IsPoststopTask() || tr.IsSidecarTask() || !shouldKillTask(tr) {
+		if tr.IsLeader() || tr.IsPoststopTask() || tr.IsSidecarTask() {
 			continue
 		}
 
 		wg.Add(1)
 		go func(name string, tr *taskrunner.TaskRunner) {
 			defer wg.Done()
-			killRunner(name, tr, "error stopping task")
+			taskEvent := taskEventFn(tr)
+
+			err := tr.Kill(context.TODO(), taskEvent)
+			if err != nil && err != taskrunner.ErrTaskNotRunning {
+				ar.logger.Warn("error stopping task", "error", err, "task_name", name)
+			}
+
+			taskState := tr.TaskState()
+			mu.Lock()
+			states[name] = taskState
+			mu.Unlock()
 		}(name, tr)
 	}
 	wg.Wait()
 
 	// Kill the sidecar tasks last.
 	for name, tr := range ar.tasks {
-		if !tr.IsSidecarTask() || tr.IsLeader() || tr.IsPoststopTask() || !shouldKillTask(tr) {
+		if !tr.IsSidecarTask() || tr.IsLeader() || tr.IsPoststopTask() {
 			continue
 		}
 
 		wg.Add(1)
 		go func(name string, tr *taskrunner.TaskRunner) {
 			defer wg.Done()
-			killRunner(name, tr, "error stopping sidecar task")
+			taskEvent := taskEventFn(tr)
+
+			err := tr.Kill(context.TODO(), taskEvent)
+			if err != nil && err != taskrunner.ErrTaskNotRunning {
+				ar.logger.Warn("error stopping sidecar task", "error", err, "task_name", name)
+			}
+
+			taskState := tr.TaskState()
+			mu.Lock()
+			states[name] = taskState
+			mu.Unlock()
 		}(name, tr)
 	}
 	wg.Wait()

--- a/client/allocrunner/max_run_duration_hook_test.go
+++ b/client/allocrunner/max_run_duration_hook_test.go
@@ -116,6 +116,60 @@ func TestMaxRunDurationHook_Update_RearmsOnDurationChange(t *testing.T) {
 	}
 }
 
+func TestMaxRunDurationHook_TaskLevelOverride_DisablesAllocTimer(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	groupMaxRunDuration := 25 * time.Millisecond
+	taskMaxRunDuration := 50 * time.Millisecond
+	alloc.Job.Type = structs.JobTypeBatch
+	alloc.Job.TaskGroups[0].MaxRunDuration = &groupMaxRunDuration
+	alloc.Job.TaskGroups[0].Tasks[0].MaxRunDuration = &taskMaxRunDuration
+
+	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
+	hook := newTestMaxRunDurationHook(alloc, onTimeout)
+
+	err := hook.Prerun((*taskenv.TaskEnv)(nil))
+	must.NoError(t, err)
+
+	select {
+	case deadline := <-deadlines:
+		t.Fatalf("unexpected alloc-level deadline fired with task-level override: %v", deadline)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestMaxRunDurationHook_TaskLevelOverride_DisablesAllocTimerWithMultipleTaskOverrides(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	groupMaxRunDuration := 25 * time.Millisecond
+	taskOneMaxRunDuration := 50 * time.Millisecond
+	taskTwoMaxRunDuration := 60 * time.Millisecond
+
+	mainTask := alloc.Job.TaskGroups[0].Tasks[0]
+	secondTask := mainTask.Copy()
+	secondTask.Name = "worker"
+
+	alloc.Job.Type = structs.JobTypeBatch
+	alloc.Job.TaskGroups[0].MaxRunDuration = &groupMaxRunDuration
+	mainTask.MaxRunDuration = &taskOneMaxRunDuration
+	secondTask.MaxRunDuration = &taskTwoMaxRunDuration
+	alloc.Job.TaskGroups[0].Tasks = []*structs.Task{mainTask, secondTask}
+
+	onTimeout, deadlines := newTestMaxRunDurationHookCallback()
+	hook := newTestMaxRunDurationHook(alloc, onTimeout)
+
+	err := hook.Prerun((*taskenv.TaskEnv)(nil))
+	must.NoError(t, err)
+
+	select {
+	case deadline := <-deadlines:
+		t.Fatalf("unexpected alloc-level deadline fired with multiple task-level overrides: %v", deadline)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
 func TestMaxRunDurationHook_DoesNotFireWhenAllocNotEligible(t *testing.T) {
 	ci.Parallel(t)
 

--- a/client/allocrunner/taskrunner/task_max_run_duration_hook.go
+++ b/client/allocrunner/taskrunner/task_max_run_duration_hook.go
@@ -1,0 +1,189 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+package taskrunner
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+var (
+	_ interfaces.TaskPrestartHook = (*taskMaxRunDurationHook)(nil)
+	_ interfaces.TaskUpdateHook   = (*taskMaxRunDurationHook)(nil)
+	_ interfaces.TaskExitedHook   = (*taskMaxRunDurationHook)(nil)
+)
+
+type taskMaxRunDurationHook struct {
+	tr *TaskRunner
+
+	mu sync.Mutex
+
+	timer             *time.Timer
+	deadline          time.Time
+	maxRunDuration    time.Duration
+	hasMaxRunDuration bool
+
+	logger log.Logger
+}
+
+func newTaskMaxRunDurationHook(tr *TaskRunner, logger log.Logger) interfaces.TaskHook {
+	return &taskMaxRunDurationHook{
+		tr:     tr,
+		logger: logger.Named("task_max_run_duration"),
+	}
+}
+
+func (h *taskMaxRunDurationHook) Name() string {
+	return "task_max_run_duration"
+}
+
+func (h *taskMaxRunDurationHook) Prestart(context.Context, *interfaces.TaskPrestartRequest, *interfaces.TaskPrestartResponse) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.resetTimer()
+	return nil
+}
+
+func (h *taskMaxRunDurationHook) Update(_ context.Context, req *interfaces.TaskUpdateRequest, _ *interfaces.TaskUpdateResponse) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if req != nil && req.Alloc != nil {
+		task := req.Alloc.LookupTask(h.tr.taskName)
+		if task != nil {
+			h.tr.setAlloc(req.Alloc, task)
+		}
+	}
+
+	h.resetTimer()
+	return nil
+}
+
+func (h *taskMaxRunDurationHook) Exited(context.Context, *interfaces.TaskExitedRequest, *interfaces.TaskExitedResponse) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.stopTimer()
+	return nil
+}
+
+func (h *taskMaxRunDurationHook) resetTimer() {
+	deadline, maxRunDuration, ok := h.currentDeadline()
+	if !ok {
+		h.stopTimer()
+		h.deadline = time.Time{}
+		h.maxRunDuration = 0
+		h.hasMaxRunDuration = false
+		return
+	}
+
+	if h.hasMaxRunDuration && h.maxRunDuration == maxRunDuration && h.deadline.Equal(deadline) {
+		return
+	}
+
+	h.stopTimer()
+
+	h.deadline = deadline
+	h.maxRunDuration = maxRunDuration
+	h.hasMaxRunDuration = true
+
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		h.logger.Debug("task exceeded max_run_duration, enforcing immediately", "task", h.tr.taskName, "deadline", deadline)
+		go h.enforce(deadline)
+		return
+	}
+
+	timer := time.NewTimer(remaining)
+	h.timer = timer
+
+	h.logger.Trace("armed task max_run_duration timer", "task", h.tr.taskName, "deadline", deadline, "remaining", remaining)
+
+	go func(t *time.Timer, deadline time.Time) {
+		<-t.C
+
+		h.mu.Lock()
+		if h.timer != t {
+			h.mu.Unlock()
+			return
+		}
+		h.timer = nil
+		h.mu.Unlock()
+
+		h.enforce(deadline)
+	}(timer, deadline)
+}
+
+func (h *taskMaxRunDurationHook) stopTimer() {
+	if h.timer == nil {
+		return
+	}
+
+	if !h.timer.Stop() {
+		select {
+		case <-h.timer.C:
+		default:
+		}
+	}
+
+	h.timer = nil
+}
+
+func (h *taskMaxRunDurationHook) currentDeadline() (time.Time, time.Duration, bool) {
+	task := h.tr.Task()
+	if task == nil || task.MaxRunDuration == nil || *task.MaxRunDuration <= 0 {
+		return time.Time{}, 0, false
+	}
+
+	alloc := h.tr.Alloc()
+	if alloc == nil || alloc.TerminalStatus() {
+		return time.Time{}, 0, false
+	}
+
+	if alloc.DesiredStatus != "" && alloc.DesiredStatus != structs.AllocDesiredStatusRun {
+		return time.Time{}, 0, false
+	}
+
+	state := h.tr.TaskState()
+	if state == nil || state.State != structs.TaskStateRunning || state.StartedAt.IsZero() {
+		return time.Time{}, 0, false
+	}
+
+	return state.StartedAt.Add(*task.MaxRunDuration), *task.MaxRunDuration, true
+}
+
+func (h *taskMaxRunDurationHook) enforce(deadline time.Time) {
+	now := time.Now()
+	if now.Before(deadline) {
+		return
+	}
+
+	task := h.tr.Task()
+	if task == nil || task.MaxRunDuration == nil || *task.MaxRunDuration <= 0 {
+		return
+	}
+
+	state := h.tr.TaskState()
+	if state == nil || state.State != structs.TaskStateRunning || state.StartedAt.IsZero() {
+		return
+	}
+
+	if state.StartedAt.Add(*task.MaxRunDuration).After(now) {
+		return
+	}
+
+	h.logger.Debug("task exceeded max_run_duration, killing task", "task", h.tr.taskName, "deadline", deadline)
+
+	event := structs.NewTaskEvent(structs.TaskKilling).
+		SetKillTimeout(task.KillTimeout, h.tr.clientConfig.MaxKillTimeout).
+		SetDisplayMessage(structs.AllocTimeoutReasonMaxRunDuration)
+
+	_ = h.tr.Kill(context.Background(), event)
+}

--- a/client/allocrunner/taskrunner/task_max_run_duration_hook.go
+++ b/client/allocrunner/taskrunner/task_max_run_duration_hook.go
@@ -122,18 +122,20 @@ func (h *taskMaxRunDurationHook) resetTimer() {
 }
 
 func (h *taskMaxRunDurationHook) stopTimer() {
-	if h.timer == nil {
-		return
-	}
-
-	if !h.timer.Stop() {
-		select {
-		case <-h.timer.C:
-		default:
+	if h.timer != nil {
+		if !h.timer.Stop() {
+			select {
+			case <-h.timer.C:
+			default:
+			}
 		}
+
+		h.timer = nil
 	}
 
-	h.timer = nil
+	h.deadline = time.Time{}
+	h.maxRunDuration = 0
+	h.hasMaxRunDuration = false
 }
 
 func (h *taskMaxRunDurationHook) currentDeadline() (time.Time, time.Duration, bool) {

--- a/client/allocrunner/taskrunner/task_max_run_duration_hook_test.go
+++ b/client/allocrunner/taskrunner/task_max_run_duration_hook_test.go
@@ -1,0 +1,285 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+package taskrunner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	log "github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/ci"
+	arinterfaces "github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	"github.com/hashicorp/nomad/client/config"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+func newTestTaskMaxRunDurationHook(tr *TaskRunner) *taskMaxRunDurationHook {
+	hook := newTaskMaxRunDurationHook(tr, log.NewNullLogger())
+
+	h, ok := hook.(*taskMaxRunDurationHook)
+	if !ok {
+		panic("newTaskMaxRunDurationHook returned unexpected hook type")
+	}
+
+	return h
+}
+
+func newTestTaskRunnerForMaxRunDurationHook(alloc *structs.Allocation, taskName string) *TaskRunner {
+	task := alloc.LookupTask(taskName)
+	if task == nil {
+		panic("allocation missing task")
+	}
+
+	return &TaskRunner{
+		allocID:  taskName + "-alloc",
+		taskName: taskName,
+		alloc:    alloc,
+		task:     task,
+		state:    &structs.TaskState{},
+		clientConfig: &config.Config{
+			MaxKillTimeout: 30 * time.Second,
+		},
+		killCtx: context.Background(),
+		waitCh:  make(chan struct{}),
+		logger:  log.NewNullLogger(),
+	}
+}
+
+func TestTaskMaxRunDurationHook_Prestart_DoesNotArmBeforeTaskStarts(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	maxRunDuration := 40 * time.Millisecond
+	task.MaxRunDuration = &maxRunDuration
+
+	tr := newTestTaskRunnerForMaxRunDurationHook(alloc, task.Name)
+	hook := newTestTaskMaxRunDurationHook(tr)
+
+	err := hook.Prestart(context.Background(), &arinterfaces.TaskPrestartRequest{}, &arinterfaces.TaskPrestartResponse{})
+	must.NoError(t, err)
+
+	hook.mu.Lock()
+	defer hook.mu.Unlock()
+
+	must.Nil(t, hook.timer)
+	must.False(t, hook.hasMaxRunDuration)
+	must.True(t, hook.deadline.IsZero())
+}
+
+func TestTaskMaxRunDurationHook_Update_ArmsWhenTaskStartsRunning(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	maxRunDuration := 200 * time.Millisecond
+	task.MaxRunDuration = &maxRunDuration
+
+	tr := newTestTaskRunnerForMaxRunDurationHook(alloc, task.Name)
+	hook := newTestTaskMaxRunDurationHook(tr)
+
+	err := hook.Prestart(context.Background(), &arinterfaces.TaskPrestartRequest{}, &arinterfaces.TaskPrestartResponse{})
+	must.NoError(t, err)
+
+	startedAt := time.Now()
+	tr.state = &structs.TaskState{
+		State:     structs.TaskStateRunning,
+		StartedAt: startedAt,
+	}
+
+	updated := alloc.Copy()
+	err = hook.Update(context.Background(), &arinterfaces.TaskUpdateRequest{Alloc: updated}, &arinterfaces.TaskUpdateResponse{})
+	must.NoError(t, err)
+
+	hook.mu.Lock()
+	defer hook.mu.Unlock()
+
+	must.NotNil(t, hook.timer)
+	must.True(t, hook.hasMaxRunDuration)
+	must.Eq(t, maxRunDuration, hook.maxRunDuration)
+	must.False(t, hook.deadline.IsZero())
+	must.True(t, hook.deadline.After(startedAt))
+}
+
+func TestTaskMaxRunDurationHook_Update_RearmsOnDurationChange(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	initial := 200 * time.Millisecond
+	task.MaxRunDuration = &initial
+
+	tr := newTestTaskRunnerForMaxRunDurationHook(alloc, task.Name)
+	hook := newTestTaskMaxRunDurationHook(tr)
+
+	startedAt := time.Now()
+	tr.state = &structs.TaskState{
+		State:     structs.TaskStateRunning,
+		StartedAt: startedAt,
+	}
+
+	err := hook.Prestart(context.Background(), &arinterfaces.TaskPrestartRequest{}, &arinterfaces.TaskPrestartResponse{})
+	must.NoError(t, err)
+
+	hook.mu.Lock()
+	initialDeadline := hook.deadline
+	hook.mu.Unlock()
+
+	updated := alloc.Copy()
+	latest := 50 * time.Millisecond
+	updated.LookupTask(task.Name).MaxRunDuration = &latest
+
+	err = hook.Update(context.Background(), &arinterfaces.TaskUpdateRequest{Alloc: updated}, &arinterfaces.TaskUpdateResponse{})
+	must.NoError(t, err)
+
+	hook.mu.Lock()
+	defer hook.mu.Unlock()
+
+	must.NotNil(t, hook.timer)
+	must.Eq(t, latest, hook.maxRunDuration)
+	must.True(t, hook.deadline.Before(initialDeadline))
+}
+
+func TestTaskMaxRunDurationHook_Update_DoesNotRearmOnUnrelatedAllocChange(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	maxRunDuration := 200 * time.Millisecond
+	task.MaxRunDuration = &maxRunDuration
+
+	tr := newTestTaskRunnerForMaxRunDurationHook(alloc, task.Name)
+	hook := newTestTaskMaxRunDurationHook(tr)
+
+	startedAt := time.Now()
+	tr.state = &structs.TaskState{
+		State:     structs.TaskStateRunning,
+		StartedAt: startedAt,
+	}
+
+	err := hook.Prestart(context.Background(), &arinterfaces.TaskPrestartRequest{}, &arinterfaces.TaskPrestartResponse{})
+	must.NoError(t, err)
+
+	hook.mu.Lock()
+	initialTimer := hook.timer
+	initialDeadline := hook.deadline
+	hook.mu.Unlock()
+
+	updated := alloc.Copy()
+	updated.ClientDescription = "unrelated alloc update"
+
+	err = hook.Update(context.Background(), &arinterfaces.TaskUpdateRequest{Alloc: updated}, &arinterfaces.TaskUpdateResponse{})
+	must.NoError(t, err)
+
+	hook.mu.Lock()
+	defer hook.mu.Unlock()
+
+	must.Eq(t, initialTimer, hook.timer)
+	must.Eq(t, initialDeadline, hook.deadline)
+	must.Eq(t, maxRunDuration, hook.maxRunDuration)
+}
+
+func TestTaskMaxRunDurationHook_Exited_CancelsTimer(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	maxRunDuration := 150 * time.Millisecond
+	task.MaxRunDuration = &maxRunDuration
+
+	tr := newTestTaskRunnerForMaxRunDurationHook(alloc, task.Name)
+	hook := newTestTaskMaxRunDurationHook(tr)
+
+	tr.state = &structs.TaskState{
+		State:     structs.TaskStateRunning,
+		StartedAt: time.Now(),
+	}
+
+	err := hook.Prestart(context.Background(), &arinterfaces.TaskPrestartRequest{}, &arinterfaces.TaskPrestartResponse{})
+	must.NoError(t, err)
+
+	hook.mu.Lock()
+	must.NotNil(t, hook.timer)
+	hook.mu.Unlock()
+
+	err = hook.Exited(context.Background(), &arinterfaces.TaskExitedRequest{}, &arinterfaces.TaskExitedResponse{})
+	must.NoError(t, err)
+
+	hook.mu.Lock()
+	defer hook.mu.Unlock()
+
+	must.Nil(t, hook.timer)
+}
+
+func TestTaskMaxRunDurationHook_CurrentDeadline_IgnoresNonRunningTask(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	maxRunDuration := 100 * time.Millisecond
+	task.MaxRunDuration = &maxRunDuration
+
+	tr := newTestTaskRunnerForMaxRunDurationHook(alloc, task.Name)
+	tr.state = &structs.TaskState{
+		State: structs.TaskStatePending,
+	}
+
+	hook := newTestTaskMaxRunDurationHook(tr)
+
+	deadline, duration, ok := hook.currentDeadline()
+	must.False(t, ok)
+	must.True(t, deadline.IsZero())
+	must.Zero(t, duration)
+}
+
+func TestTaskMaxRunDurationHook_CurrentDeadline_UsesTaskStartedAt(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	maxRunDuration := 100 * time.Millisecond
+	task.MaxRunDuration = &maxRunDuration
+
+	startedAt := time.Now().Add(-25 * time.Millisecond)
+
+	tr := newTestTaskRunnerForMaxRunDurationHook(alloc, task.Name)
+	tr.state = &structs.TaskState{
+		State:     structs.TaskStateRunning,
+		StartedAt: startedAt,
+	}
+
+	hook := newTestTaskMaxRunDurationHook(tr)
+
+	deadline, duration, ok := hook.currentDeadline()
+	must.True(t, ok)
+	must.Eq(t, maxRunDuration, duration)
+	must.Eq(t, startedAt.Add(maxRunDuration), deadline)
+}
+
+func TestTaskMaxRunDurationHook_CurrentDeadline_IgnoresTerminalAlloc(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	alloc.ClientStatus = structs.AllocClientStatusComplete
+
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	maxRunDuration := 100 * time.Millisecond
+	task.MaxRunDuration = &maxRunDuration
+
+	tr := newTestTaskRunnerForMaxRunDurationHook(alloc, task.Name)
+	tr.state = &structs.TaskState{
+		State:     structs.TaskStateRunning,
+		StartedAt: time.Now(),
+	}
+
+	hook := newTestTaskMaxRunDurationHook(tr)
+
+	deadline, duration, ok := hook.currentDeadline()
+	must.False(t, ok)
+	must.True(t, deadline.IsZero())
+	must.Zero(t, duration)
+}

--- a/client/allocrunner/taskrunner/task_max_run_duration_hook_test.go
+++ b/client/allocrunner/taskrunner/task_max_run_duration_hook_test.go
@@ -102,7 +102,7 @@ func TestTaskMaxRunDurationHook_Update_ArmsWhenTaskStartsRunning(t *testing.T) {
 	must.True(t, hook.hasMaxRunDuration)
 	must.Eq(t, maxRunDuration, hook.maxRunDuration)
 	must.False(t, hook.deadline.IsZero())
-	must.True(t, hook.deadline.After(startedAt))
+	must.Eq(t, startedAt.Add(maxRunDuration), hook.deadline)
 }
 
 func TestTaskMaxRunDurationHook_Update_RearmsOnDurationChange(t *testing.T) {
@@ -141,6 +141,7 @@ func TestTaskMaxRunDurationHook_Update_RearmsOnDurationChange(t *testing.T) {
 
 	must.NotNil(t, hook.timer)
 	must.Eq(t, latest, hook.maxRunDuration)
+	must.Eq(t, startedAt.Add(latest), hook.deadline)
 	must.True(t, hook.deadline.Before(initialDeadline))
 }
 
@@ -213,6 +214,9 @@ func TestTaskMaxRunDurationHook_Exited_CancelsTimer(t *testing.T) {
 	defer hook.mu.Unlock()
 
 	must.Nil(t, hook.timer)
+	must.True(t, hook.deadline.IsZero())
+	must.Zero(t, hook.maxRunDuration)
+	must.False(t, hook.hasMaxRunDuration)
 }
 
 func TestTaskMaxRunDurationHook_CurrentDeadline_IgnoresNonRunningTask(t *testing.T) {

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -63,6 +63,7 @@ func (tr *TaskRunner) initHooks() {
 		newDynamicUsersHook(tr.killCtx, tr.driverCapabilities.DynamicWorkloadUsers, tr.logger, tr.users),
 		newTaskDirHook(tr, hookLogger),
 		newIdentityHook(tr, hookLogger),
+		newTaskMaxRunDurationHook(tr, hookLogger),
 		newConsulHook(hookLogger, tr),
 	}
 	// If Vault is enabled, add the hook
@@ -493,6 +494,7 @@ func (tr *TaskRunner) stop() error {
 			end := time.Now()
 			tr.logger.Trace("finished stop hook", "name", name, "end", end, "duration", end.Sub(start))
 		}
+
 	}
 
 	return merr.ErrorOrNil()

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -362,7 +362,9 @@ func (a *Allocation) TerminalStatus() bool {
 }
 
 // MaxRunDuration returns the configured max_run_duration for the allocation's
-// task group, if any.
+// task group, if any. If any task in the group has a task-level
+// max_run_duration configured, the task-group timer is disabled and task-level
+// timers are expected to enforce the timeout instead.
 func (a *Allocation) MaxRunDuration() (time.Duration, bool) {
 	if a == nil || a.Job == nil {
 		return 0, false
@@ -371,6 +373,12 @@ func (a *Allocation) MaxRunDuration() (time.Duration, bool) {
 	tg := a.Job.LookupTaskGroup(a.TaskGroup)
 	if tg == nil || tg.MaxRunDuration == nil || *tg.MaxRunDuration <= 0 {
 		return 0, false
+	}
+
+	for _, task := range tg.Tasks {
+		if task != nil && task.MaxRunDuration != nil && *task.MaxRunDuration > 0 {
+			return 0, false
+		}
 	}
 
 	switch a.Job.Type {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -8179,6 +8179,9 @@ func (t *Task) Validate(jobType string, tg *TaskGroup) error {
 		default:
 			mErr.Errors = append(mErr.Errors, fmt.Errorf("Job type %q does not allow max_run_duration", jobType))
 		}
+		if t.Lifecycle != nil {
+			mErr.Errors = append(mErr.Errors, errors.New("Lifecycle tasks may not have max_run_duration"))
+		}
 	}
 
 	// Validate the resources.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6868,8 +6868,9 @@ type TaskGroup struct {
 	ShutdownDelay *time.Duration
 
 	// MaxRunDuration is the maximum amount of time a batch or sysbatch task
-	// group allocation may run after entering the running state before Nomad
-	// stops it.
+	// group allocation may run after allocation creation before Nomad stops it.
+	// Task-level max_run_duration overrides this setting for the individual task
+	// and is timed from the task's own running state.
 	MaxRunDuration *time.Duration
 
 	// StopAfterClientDisconnect, if set, configures the client to stop the task group
@@ -7879,6 +7880,11 @@ type Task struct {
 	// task from Consul and sending it a signal to shutdown. See #2441
 	ShutdownDelay time.Duration
 
+	// MaxRunDuration is the maximum amount of time a batch or sysbatch task
+	// may run after the actual task enters the running state before Nomad
+	// stops it. This overrides the task group's MaxRunDuration for this task.
+	MaxRunDuration *time.Duration
+
 	// VolumeMounts is a list of Volume name <-> mount configurations that will be
 	// attached to this task.
 	VolumeMounts []*VolumeMount
@@ -8002,6 +8008,10 @@ func (t *Task) Copy() *Task {
 	nt.Meta = maps.Clone(nt.Meta)
 	nt.DispatchPayload = nt.DispatchPayload.Copy()
 	nt.Lifecycle = nt.Lifecycle.Copy()
+	if nt.MaxRunDuration != nil {
+		maxRunDuration := *nt.MaxRunDuration
+		nt.MaxRunDuration = &maxRunDuration
+	}
 	nt.Identity = nt.Identity.Copy()
 	nt.Identities = helper.CopySlice(nt.Identities)
 	nt.Actions = helper.CopySlice(nt.Actions)
@@ -8159,6 +8169,16 @@ func (t *Task) Validate(jobType string, tg *TaskGroup) error {
 	}
 	if t.ShutdownDelay < 0 {
 		mErr.Errors = append(mErr.Errors, errors.New("ShutdownDelay must be a positive value"))
+	}
+	if t.MaxRunDuration != nil {
+		if *t.MaxRunDuration <= 0 {
+			mErr.Errors = append(mErr.Errors, errors.New("MaxRunDuration must be greater than zero"))
+		}
+		switch jobType {
+		case JobTypeBatch, JobTypeSysBatch:
+		default:
+			mErr.Errors = append(mErr.Errors, fmt.Errorf("Job type %q does not allow max_run_duration", jobType))
+		}
 	}
 
 	// Validate the resources.

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1619,6 +1619,96 @@ func TestTaskGroup_Validate(t *testing.T) {
 			jobType: JobTypeSysBatch,
 		},
 		{
+			name: "valid task max run duration for batch job",
+			tg: &TaskGroup{
+				Name:  "web",
+				Count: 1,
+				Tasks: []*Task{
+					{
+						Name:           "web",
+						Driver:         "mock_driver",
+						Resources:      DefaultResources(),
+						LogConfig:      DefaultLogConfig(),
+						MaxRunDuration: pointer.Of(5 * time.Minute),
+					},
+				},
+				RestartPolicy:    NewRestartPolicy(JobTypeBatch),
+				ReschedulePolicy: NewReschedulePolicy(JobTypeBatch),
+				EphemeralDisk:    DefaultEphemeralDisk(),
+			},
+			jobType: JobTypeBatch,
+		},
+		{
+			name: "valid task max run duration for sysbatch job",
+			tg: &TaskGroup{
+				Name:  "web",
+				Count: 1,
+				Tasks: []*Task{
+					{
+						Name:           "web",
+						Driver:         "mock_driver",
+						Resources:      DefaultResources(),
+						LogConfig:      DefaultLogConfig(),
+						MaxRunDuration: pointer.Of(5 * time.Minute),
+					},
+				},
+				RestartPolicy: &RestartPolicy{
+					Attempts:        0,
+					Interval:        5 * time.Second,
+					Delay:           5 * time.Second,
+					Mode:            RestartPolicyModeFail,
+					RenderTemplates: false,
+				},
+				EphemeralDisk: DefaultEphemeralDisk(),
+			},
+			jobType: JobTypeSysBatch,
+		},
+		{
+			name: "invalid task max run duration for service job",
+			tg: &TaskGroup{
+				Name:  "web",
+				Count: 1,
+				Tasks: []*Task{
+					{
+						Name:           "web",
+						Driver:         "mock_driver",
+						Resources:      DefaultResources(),
+						LogConfig:      DefaultLogConfig(),
+						MaxRunDuration: pointer.Of(5 * time.Minute),
+					},
+				},
+				RestartPolicy: NewRestartPolicy(JobTypeService),
+				EphemeralDisk: DefaultEphemeralDisk(),
+			},
+			expErr: []string{
+				`Job type "service" does not allow max_run_duration`,
+			},
+			jobType: JobTypeService,
+		},
+		{
+			name: "invalid non-positive task max run duration for batch job",
+			tg: &TaskGroup{
+				Name:  "web",
+				Count: 1,
+				Tasks: []*Task{
+					{
+						Name:           "web",
+						Driver:         "mock_driver",
+						Resources:      DefaultResources(),
+						LogConfig:      DefaultLogConfig(),
+						MaxRunDuration: pointer.Of(time.Duration(0)),
+					},
+				},
+				RestartPolicy:    NewRestartPolicy(JobTypeBatch),
+				ReschedulePolicy: NewReschedulePolicy(JobTypeBatch),
+				EphemeralDisk:    DefaultEphemeralDisk(),
+			},
+			expErr: []string{
+				"MaxRunDuration must be greater than zero",
+			},
+			jobType: JobTypeBatch,
+		},
+		{
 			name: "duplicated por label",
 			tg: &TaskGroup{
 				Networks: []*NetworkResource{

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1709,6 +1709,32 @@ func TestTaskGroup_Validate(t *testing.T) {
 			jobType: JobTypeBatch,
 		},
 		{
+			name: "invalid task max run duration for lifecycle task",
+			tg: &TaskGroup{
+				Name:  "web",
+				Count: 1,
+				Tasks: []*Task{
+					{
+						Name:           "web",
+						Driver:         "mock_driver",
+						Resources:      DefaultResources(),
+						LogConfig:      DefaultLogConfig(),
+						MaxRunDuration: pointer.Of(5 * time.Minute),
+						Lifecycle: &TaskLifecycleConfig{
+							Hook: TaskLifecycleHookPrestart,
+						},
+					},
+				},
+				RestartPolicy:    NewRestartPolicy(JobTypeBatch),
+				ReschedulePolicy: NewReschedulePolicy(JobTypeBatch),
+				EphemeralDisk:    DefaultEphemeralDisk(),
+			},
+			expErr: []string{
+				"Lifecycle tasks may not have max_run_duration",
+			},
+			jobType: JobTypeBatch,
+		},
+		{
 			name: "duplicated por label",
 			tg: &TaskGroup{
 				Networks: []*NetworkResource{


### PR DESCRIPTION
This implements taskrunner counterpart to allocrunner logic introduced in #27827. We now have 2 types of timeouts: 

- tg-level `max_run_duration` which acts independently of task state, and is contained within allocrunner. 
- task-level `max_run_duration` which can be defined per-task and overrides the tg-level setting. These timers only get started once the task starts running, and ignore `prestart`, `poststart` and `poststop` hooks, i.e., `max_runner` cannot be defined to lifecycle tasks. 