### PR TITLE
Fix accidental job revert after scaling

### DIFF
--- a/.changelog/27832.txt
+++ b/.changelog/27832.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-scaling: fix issue where it would revert a job
+api: Fix a bug where the Create Job, Update Job, and Scale Job APIs could fail to respect EnforceIndex under concurrent requests
 ```

--- a/.changelog/27832.txt
+++ b/.changelog/27832.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scaling: fix issue where it would revert a job
+```

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -224,16 +224,8 @@ func (j *Job) doRegister(aclObj *acl.ACL, additionalAllowedPermissions []string,
 
 	// If EnforceIndex set, check it before trying to apply
 	if args.EnforceIndex {
-		jmi := args.JobModifyIndex
-		if existingJob != nil {
-			if jmi == 0 {
-				return fmt.Errorf("%s 0: job already exists", state.RegisterEnforceIndexErrPrefix)
-			} else if jmi != existingJob.JobModifyIndex {
-				return fmt.Errorf("%s %d: job exists with conflicting job modify index: %d",
-					state.RegisterEnforceIndexErrPrefix, jmi, existingJob.JobModifyIndex)
-			}
-		} else if jmi != 0 {
-			return fmt.Errorf("%s %d: job does not exist", state.RegisterEnforceIndexErrPrefix, jmi)
+		if err := existingJob.EnforceIndex(args.JobModifyIndex); err != nil {
+			return err
 		}
 	}
 
@@ -1077,7 +1069,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		if args.JobModifyIndex > 0 {
 			if args.JobModifyIndex != job.JobModifyIndex {
 				return fmt.Errorf("%s %d: job exists with conflicting job modify index: %d",
-					state.RegisterEnforceIndexErrPrefix, args.JobModifyIndex, job.JobModifyIndex)
+					structs.RegisterEnforceIndexErrPrefix, args.JobModifyIndex, job.JobModifyIndex)
 			}
 		}
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -30,10 +30,6 @@ import (
 )
 
 const (
-	// RegisterEnforceIndexErrPrefix is the prefix to use in errors caused by
-	// enforcing the job modify index during registers.
-	RegisterEnforceIndexErrPrefix = "Enforcing job modify index"
-
 	// DispatchPayloadSizeLimit is the maximum size of the uncompressed input
 	// data payload.
 	DispatchPayloadSizeLimit = 16 * 1024
@@ -231,13 +227,13 @@ func (j *Job) doRegister(aclObj *acl.ACL, additionalAllowedPermissions []string,
 		jmi := args.JobModifyIndex
 		if existingJob != nil {
 			if jmi == 0 {
-				return fmt.Errorf("%s 0: job already exists", RegisterEnforceIndexErrPrefix)
+				return fmt.Errorf("%s 0: job already exists", state.RegisterEnforceIndexErrPrefix)
 			} else if jmi != existingJob.JobModifyIndex {
 				return fmt.Errorf("%s %d: job exists with conflicting job modify index: %d",
-					RegisterEnforceIndexErrPrefix, jmi, existingJob.JobModifyIndex)
+					state.RegisterEnforceIndexErrPrefix, jmi, existingJob.JobModifyIndex)
 			}
 		} else if jmi != 0 {
-			return fmt.Errorf("%s %d: job does not exist", RegisterEnforceIndexErrPrefix, jmi)
+			return fmt.Errorf("%s %d: job does not exist", state.RegisterEnforceIndexErrPrefix, jmi)
 		}
 	}
 
@@ -1081,7 +1077,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 		if args.JobModifyIndex > 0 {
 			if args.JobModifyIndex != job.JobModifyIndex {
 				return fmt.Errorf("%s %d: job exists with conflicting job modify index: %d",
-					RegisterEnforceIndexErrPrefix, args.JobModifyIndex, job.JobModifyIndex)
+					state.RegisterEnforceIndexErrPrefix, args.JobModifyIndex, job.JobModifyIndex)
 			}
 		}
 

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1091,7 +1091,7 @@ func (j *Job) Scale(args *structs.JobScaleRequest, reply *structs.JobRegisterRes
 			structs.JobRegisterRequest{
 				Job:            job,
 				EnforceIndex:   true,
-				JobModifyIndex: job.ModifyIndex,
+				JobModifyIndex: job.JobModifyIndex,
 				PolicyOverride: args.PolicyOverride,
 				WriteRequest:   args.WriteRequest,
 			},

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
-	nomadState "github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	nomadVersion "github.com/hashicorp/nomad/version"
@@ -1519,7 +1518,7 @@ func TestJobEndpoint_Register_EnforceIndex(t *testing.T) {
 	// Fetch the response
 	var resp structs.JobRegisterResponse
 	err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
-	if err == nil || !strings.Contains(err.Error(), nomadState.RegisterEnforceIndexErrPrefix) {
+	if err == nil || !strings.Contains(err.Error(), structs.RegisterEnforceIndexErrPrefix) {
 		t.Fatalf("expected enforcement error")
 	}
 
@@ -1571,7 +1570,7 @@ func TestJobEndpoint_Register_EnforceIndex(t *testing.T) {
 
 	// Fetch the response
 	err = msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
-	if err == nil || !strings.Contains(err.Error(), nomadState.RegisterEnforceIndexErrPrefix) {
+	if err == nil || !strings.Contains(err.Error(), structs.RegisterEnforceIndexErrPrefix) {
 		t.Fatalf("expected enforcement error")
 	}
 
@@ -1588,7 +1587,7 @@ func TestJobEndpoint_Register_EnforceIndex(t *testing.T) {
 
 	// Fetch the response
 	err = msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
-	if err == nil || !strings.Contains(err.Error(), nomadState.RegisterEnforceIndexErrPrefix) {
+	if err == nil || !strings.Contains(err.Error(), structs.RegisterEnforceIndexErrPrefix) {
 		t.Fatalf("expected enforcement error")
 	}
 

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -8147,6 +8147,70 @@ func TestJobEndpoint_InvalidCount(t *testing.T) {
 	require.Error(err)
 }
 
+// Regression test to make sure the Job.Scale endpoint doesn't accidentally
+// cause a job to revert to a previous version.
+func TestJobEndpoint_Scale_StaleSnapshotClobbersDeployment(t *testing.T) {
+	ci.Parallel(t)
+
+	s1, cleanupS1 := TestServer(t, func(c *Config) { c.NumSchedulers = 0 })
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+	state := s1.fsm.State()
+
+	// This is the initial job. Set `meta.version` to a known value to later
+	// check whether it was incorrectly reverted.
+	job := mock.Job()
+	job.Meta["version"] = "v0"
+
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, "Job.Register", &structs.JobRegisterRequest{
+		Job:          job,
+		WriteRequest: structs.WriteRequest{Region: "global", Namespace: job.Namespace},
+	}, &structs.JobRegisterResponse{}))
+
+	jobV0, err := state.JobByID(nil, job.Namespace, job.ID)
+	must.NoError(t, err)
+	must.Eq(t, 0, jobV0.Version)
+	must.Eq(t, 10, jobV0.TaskGroups[0].Count)
+	v0ModifyIndex := jobV0.ModifyIndex
+
+	// The autoscaler calls Job.Scale via the public API. Internally, the
+	// Job.Scale handler snapshots the current job, modifies the count, and
+	// commits the full job spec via raftApply. Capture what that stale commit
+	// would look like: a copy of v0 with a new count.
+	staleScaledJob := jobV0.Copy()
+	staleScaledJob.TaskGroups[0].Count = 15
+
+	// Before the Job.Scale handler's raftApply commits, someone deploys a new
+	// version of the service via Job.Register.
+	jobV1Spec := jobV0.Copy()
+	jobV1Spec.Meta["version"] = "v1"
+
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, "Job.Register", &structs.JobRegisterRequest{
+		Job:          jobV1Spec,
+		WriteRequest: structs.WriteRequest{Region: "global", Namespace: job.Namespace},
+	}, &structs.JobRegisterResponse{}))
+
+	jobV1, err := state.JobByID(nil, job.Namespace, job.ID)
+	must.NoError(t, err)
+	must.Eq(t, 1, jobV1.Version)
+	must.Eq(t, 10, jobV1.TaskGroups[0].Count)
+	must.Eq(t, "v1", jobV1.Meta["version"])
+
+	// Showing the race via goroutines would be flaky. Instead, replay exactly
+	// what the Job.Scale handler does internally: commit the stale job spec via
+	// raftApply with EnforceIndex=true and the ModifyIndex from the snapshot.
+	// This must be rejected because v1 has since superseded v0.
+	_, _, raftErr := s1.raftApply(structs.JobRegisterRequestType, structs.JobRegisterRequest{
+		Job:            staleScaledJob,
+		EnforceIndex:   true,
+		JobModifyIndex: v0ModifyIndex, // stale: v1 has a higher ModifyIndex
+		WriteRequest:   structs.WriteRequest{Region: "global", Namespace: job.Namespace},
+	})
+
+	must.Error(t, raftErr, must.Sprint("expected stale scale to be rejected but it overwrote a later deployment"))
+}
+
 func TestJobEndpoint_GetScaleStatus(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
+	nomadState "github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	nomadVersion "github.com/hashicorp/nomad/version"
@@ -1518,7 +1519,7 @@ func TestJobEndpoint_Register_EnforceIndex(t *testing.T) {
 	// Fetch the response
 	var resp structs.JobRegisterResponse
 	err := msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
-	if err == nil || !strings.Contains(err.Error(), RegisterEnforceIndexErrPrefix) {
+	if err == nil || !strings.Contains(err.Error(), nomadState.RegisterEnforceIndexErrPrefix) {
 		t.Fatalf("expected enforcement error")
 	}
 
@@ -1570,7 +1571,7 @@ func TestJobEndpoint_Register_EnforceIndex(t *testing.T) {
 
 	// Fetch the response
 	err = msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
-	if err == nil || !strings.Contains(err.Error(), RegisterEnforceIndexErrPrefix) {
+	if err == nil || !strings.Contains(err.Error(), nomadState.RegisterEnforceIndexErrPrefix) {
 		t.Fatalf("expected enforcement error")
 	}
 
@@ -1587,7 +1588,7 @@ func TestJobEndpoint_Register_EnforceIndex(t *testing.T) {
 
 	// Fetch the response
 	err = msgpackrpc.CallWithCodec(codec, "Job.Register", req, &resp)
-	if err == nil || !strings.Contains(err.Error(), RegisterEnforceIndexErrPrefix) {
+	if err == nil || !strings.Contains(err.Error(), nomadState.RegisterEnforceIndexErrPrefix) {
 		t.Fatalf("expected enforcement error")
 	}
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -39,6 +39,12 @@ const (
 )
 
 const (
+	// RegisterEnforceIndexErrPrefix is the prefix to use in errors caused by
+	// enforcing the job modify index during registers.
+	RegisterEnforceIndexErrPrefix = "Enforcing job modify index"
+)
+
+const (
 	// NodeEligibilityEventPlanRejectThreshold is the message used when the node
 	// is set to ineligible due to multiple plan failures.
 	// This is a preventive measure to signal scheduler workers to not consider
@@ -1801,17 +1807,33 @@ func (s *StateStore) upsertJobImpl(index uint64, sub *structs.JobSubmission, job
 
 	// Check if the job already exists
 	existing, err := txn.First("jobs", "id", job.Namespace, job.ID)
-	var existingJob *structs.Job
 	if err != nil {
 		return fmt.Errorf("job lookup failed: %v", err)
 	}
 
-	// Setup the indexes correctly
+	var existingJob *structs.Job
 	if existing != nil {
-		job.CreateIndex = existing.(*structs.Job).CreateIndex
-		job.ModifyIndex = index
-
 		existingJob = existing.(*structs.Job)
+	}
+
+	if req != nil && req.EnforceIndex {
+		jmi := req.JobModifyIndex
+		if existingJob != nil {
+			if jmi == 0 {
+				return fmt.Errorf("%s 0: job already exists", RegisterEnforceIndexErrPrefix)
+			} else if jmi != existingJob.JobModifyIndex {
+				return fmt.Errorf("%s %d: job exists with conflicting job modify index: %d",
+					RegisterEnforceIndexErrPrefix, jmi, existingJob.JobModifyIndex)
+			}
+		} else if jmi != 0 {
+			return fmt.Errorf("%s %d: job does not exist", RegisterEnforceIndexErrPrefix, jmi)
+		}
+	}
+
+	// Setup the indexes correctly
+	if existingJob != nil {
+		job.CreateIndex = existingJob.CreateIndex
+		job.ModifyIndex = index
 
 		// Bump the version unless asked to keep it. This should only be done
 		// when changing an internal field such as Stable. A spec change should

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -39,12 +39,6 @@ const (
 )
 
 const (
-	// RegisterEnforceIndexErrPrefix is the prefix to use in errors caused by
-	// enforcing the job modify index during registers.
-	RegisterEnforceIndexErrPrefix = "Enforcing job modify index"
-)
-
-const (
 	// NodeEligibilityEventPlanRejectThreshold is the message used when the node
 	// is set to ineligible due to multiple plan failures.
 	// This is a preventive measure to signal scheduler workers to not consider
@@ -1817,16 +1811,8 @@ func (s *StateStore) upsertJobImpl(index uint64, sub *structs.JobSubmission, job
 	}
 
 	if req != nil && req.EnforceIndex {
-		jmi := req.JobModifyIndex
-		if existingJob != nil {
-			if jmi == 0 {
-				return fmt.Errorf("%s 0: job already exists", RegisterEnforceIndexErrPrefix)
-			} else if jmi != existingJob.JobModifyIndex {
-				return fmt.Errorf("%s %d: job exists with conflicting job modify index: %d",
-					RegisterEnforceIndexErrPrefix, jmi, existingJob.JobModifyIndex)
-			}
-		} else if jmi != 0 {
-			return fmt.Errorf("%s %d: job does not exist", RegisterEnforceIndexErrPrefix, jmi)
+		if err := existingJob.EnforceIndex(req.JobModifyIndex); err != nil {
+			return err
 		}
 	}
 

--- a/nomad/structs/job.go
+++ b/nomad/structs/job.go
@@ -303,7 +303,8 @@ func (j *Job) RequiredScheduleTask() set.Collection[string] {
 	return result
 }
 
-// Checks the
+// EnforceIndex checks the `EnforceIndex` logic: if the job exists (not `nil`)
+// it must match the `index` argument and if `index == 0` the job must be `nil`.
 func (j *Job) EnforceIndex(index uint64) error {
 	if j != nil {
 		if index == 0 {

--- a/nomad/structs/job.go
+++ b/nomad/structs/job.go
@@ -4,6 +4,8 @@
 package structs
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-set/v3"
 )
 
@@ -22,6 +24,12 @@ const (
 	// Args: JobServiceRegistrationsRequest
 	// Reply: JobServiceRegistrationsResponse
 	JobServiceRegistrationsRPCMethod = "Job.GetServiceRegistrations"
+)
+
+const (
+	// RegisterEnforceIndexErrPrefix is the prefix to use in errors caused by
+	// enforcing the job modify index during registers.
+	RegisterEnforceIndexErrPrefix = "Enforcing job modify index"
 )
 
 // JobBatchDeregisterRequest is used to batch deregister jobs and upsert
@@ -293,4 +301,19 @@ func (j *Job) RequiredScheduleTask() set.Collection[string] {
 		}
 	}
 	return result
+}
+
+// Checks the
+func (j *Job) EnforceIndex(index uint64) error {
+	if j != nil {
+		if index == 0 {
+			return fmt.Errorf("%s 0: job already exists", RegisterEnforceIndexErrPrefix)
+		} else if index != j.JobModifyIndex {
+			return fmt.Errorf("%s %d: job exists with conflicting job modify index: %d",
+				RegisterEnforceIndexErrPrefix, index, j.JobModifyIndex)
+		}
+	} else if index != 0 {
+		return fmt.Errorf("%s %d: job does not exist", RegisterEnforceIndexErrPrefix, index)
+	}
+	return nil
 }

--- a/nomad/structs/job_test.go
+++ b/nomad/structs/job_test.go
@@ -514,3 +514,24 @@ func TestJob_RequiredTproxy(t *testing.T) {
 	result := job.RequiredTransparentProxy()
 	must.SliceContainsAll(t, expect, result.Slice())
 }
+
+func TestJob_EnforceIndex(t *testing.T) {
+	job := &Job{
+		JobModifyIndex: 456,
+		TaskGroups: []*TaskGroup{
+			{Name: "no services"},
+		},
+	}
+	job.Canonicalize()
+
+	// The job will only be registered if the passed `JobModifyIndex` matches the current job's index.
+	must.Error(t, job.EnforceIndex(0))
+	must.Error(t, job.EnforceIndex(123))
+	must.NoError(t, job.EnforceIndex(456))
+	must.Error(t, job.EnforceIndex(789))
+
+	// If the index is zero, the register only occurs if the job is new.
+	var noJob *Job = nil
+	must.NoError(t, noJob.EnforceIndex(0))
+	must.Error(t, noJob.EnforceIndex(123))
+}


### PR DESCRIPTION
### Description

A few times over the past months, some jobs were inexplicably reverted to a previous version. When looking at autoscaler, Nomad, and deployment logs, nothing fit nor made sense. Since I don't know the codebase well nor have much company time to dig in, I decided to give Copilot a try. I explained the situation and instructed it to diagnose the issue, then write a failing test for it, and then a fix. This PR is the result of cleaning up its output.

The issue manifested as follows:

- Job version N is running.
- The autoscaler uses the `Job.Scale` endpoint to adjust the task group count.
- We shipped job version N+1 and the deployment completed successfully.
- Sometime afterwards the job was reverted by Nomad, without any external provocation, to version N.

### Testing & Reproduction steps

The added test should work as a regression test.

### Links

I found no relevant issues.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes, as far as I can tell.
