### PR TITLE
build: push go requirement to 1.26.2

### DIFF
--- a/client/allocdir/alloc_dir.go
+++ b/client/allocdir/alloc_dir.go
@@ -487,7 +487,7 @@ func (a *AllocDir) ReadAt(path string, offset int64) (io.ReadCloser, error) {
 		return nil, err
 	}
 	if _, err := f.Seek(offset, 0); err != nil {
-		return nil, fmt.Errorf("can't seek to offset %q: %w", offset, err)
+		return nil, fmt.Errorf("can't seek to offset %d: %w", offset, err)
 	}
 	return f, nil
 }

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -882,7 +882,7 @@ func TestAllocRunner_Lifecycle_Restart(t *testing.T) {
 					}
 					if got.Restarts != 0 {
 						errs = multierror.Append(errs, fmt.Errorf(
-							"expected no initial restarts of task %q, not %q",
+							"expected no initial restarts of task %q, not %d",
 							task, got.Restarts))
 					}
 					if expected == "dead" && got.Failed {

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -969,10 +969,10 @@ func TestAgent_HTTPCheck(t *testing.T) {
 			t.Errorf("expected normalized addr not %q", check.PortLabel)
 		}
 		if expected := 2; check.FailuresBeforeCritical != expected {
-			t.Errorf("expected failured before critical count not: %q", expected)
+			t.Errorf("expected failured before critical count not: %d", expected)
 		}
 		if expected := 1; check.FailuresBeforeWarning != expected {
-			t.Errorf("expected failured before warning count not: %q", expected)
+			t.Errorf("expected failured before warning count not: %d", expected)
 		}
 	})
 
@@ -1043,10 +1043,10 @@ func TestAgent_HTTPCheckPath(t *testing.T) {
 	}
 	// ensure server failures before critical and warning are set
 	if expected := 4; check.FailuresBeforeCritical != expected {
-		t.Errorf("expected failured before critical count not: %q", expected)
+		t.Errorf("expected failured before critical count not: %d", expected)
 	}
 	if expected := 3; check.FailuresBeforeWarning != expected {
-		t.Errorf("expected failured before warning count not: %q", expected)
+		t.Errorf("expected failured before warning count not: %d", expected)
 	}
 
 	// Assert client check uses /v1/agent/health?type=client

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad
 
-go 1.25.8
+go 1.26.2
 
 // Pinned dependencies are noted in github.com/hashicorp/nomad/issues/11826.
 replace (


### PR DESCRIPTION
We already build Nomad with 1.26.2 and [incoming CT release](https://github.com/hashicorp/consul-template/releases/tag/v0.42.0) pushes go version in its go.mod to 1.26.2. Since Nomad is not a dependency for any other project than nomad-pack, I see no reason why we wouldn't push our go.mod up to comply, especially since the new CT release contains vulnerability patches and fixes for Nomad.