### PR TITLE
e2e: bump windows client provisioners' timeouts to 20m

### DIFF
--- a/e2e/terraform/provision-infra/provision-nomad/install-windows.tf
+++ b/e2e/terraform/provision-infra/provision-nomad/install-windows.tf
@@ -11,7 +11,7 @@ resource "null_resource" "install_nomad_binary_windows" {
     port            = var.connection.port
     private_key     = file(var.connection.private_key)
     target_platform = "windows"
-    timeout         = "10m"
+    timeout         = "20m"
   }
 
   provisioner "file" {
@@ -39,7 +39,7 @@ resource "null_resource" "install_consul_configs_windows" {
     port            = var.connection.port
     private_key     = file(var.connection.private_key)
     target_platform = "windows"
-    timeout         = "10m"
+    timeout         = "20m"
   }
 
   provisioner "remote-exec" {
@@ -69,7 +69,7 @@ resource "null_resource" "install_nomad_configs_windows" {
     port            = var.connection.port
     private_key     = file(var.connection.private_key)
     target_platform = "windows"
-    timeout         = "10m"
+    timeout         = "20m"
   }
 
   provisioner "remote-exec" {
@@ -113,7 +113,7 @@ resource "null_resource" "restart_windows_services" {
     port            = var.connection.port
     private_key     = file(var.connection.private_key)
     target_platform = "windows"
-    timeout         = "10m"
+    timeout         = "20m"
   }
 
   provisioner "remote-exec" {


### PR DESCRIPTION
I'm not sure what the root cause is exactly, but our windows boxes started
taking ever so slightly more time than 10 minutes to provision Nomad clients.
I'm not sure if it's windows being slower after some updates or if it's Nomad,
or if t3 instances are running out of burst credits, but short of bumping
instance sizes this is the easiest fix to make tf provision the e2e infra
cleanly on CI. 