### PR TITLE
deps: update hc-install to 0.9.4

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -139,7 +139,7 @@ deps:  ## Install build and development dependencies
 	go install github.com/bufbuild/buf/cmd/buf@v0.36.0
 	go install github.com/hashicorp/go-changelog/cmd/changelog-build@latest
 	go install golang.org/x/tools/cmd/stringer@v0.30.0
-	go install github.com/hashicorp/hc-install/cmd/hc-install@v0.9.0
+	go install github.com/hashicorp/hc-install/cmd/hc-install@v0.9.4
 	go install github.com/shoenig/go-modtool@v0.2.0
 
 .PHONY: lint-deps

--- a/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
@@ -33,7 +33,7 @@ sudo apt-get install -y \
      apt-transport-https ca-certificates gnupg2 stress
 
 # Install hc-install
-curl -o /tmp/hc-install.zip https://releases.hashicorp.com/hc-install/0.9.0/hc-install_0.9.0_linux_amd64.zip
+curl -o /tmp/hc-install.zip https://releases.hashicorp.com/hc-install/0.9.4/hc-install_0.9.4_linux_amd64.zip
 sudo unzip -d /usr/local/bin /tmp/hc-install.zip
 
 


### PR DESCRIPTION
addresses installer key expiry, vide https://github.com/hashicorp/hc-install/releases/tag/v0.9.4