### PR TITLE
Avoid setting jobs as dead while being rescheduled

### DIFF
--- a/.changelog/27852.txt
+++ b/.changelog/27852.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: avoid setting job to dead while wauting to reschedule
+```

--- a/.changelog/27852.txt
+++ b/.changelog/27852.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-core: avoid setting job to dead while wauting to reschedule
+core: avoid setting job to dead while waiting for allocations to reschedule
 ```

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -620,9 +620,13 @@ func TestAllocEndpoint_List_Blocking(t *testing.T) {
 	alloc2 := mock.Alloc()
 	alloc2.ID = alloc.ID
 	alloc2.ClientStatus = structs.AllocClientStatusRunning
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc2},
+	}
+
 	time.AfterFunc(100*time.Millisecond, func() {
 		state.UpsertJobSummary(3, mock.JobSummary(alloc2.JobID))
-		if err := state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 5, []*structs.Allocation{alloc2}); err != nil {
+		if err := state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 5, updateReq); err != nil {
 			t.Fatalf("err: %v", err)
 		}
 	})

--- a/nomad/deployment_endpoint_test.go
+++ b/nomad/deployment_endpoint_test.go
@@ -1758,7 +1758,11 @@ func TestDeploymentEndpoint_Allocations_Blocking(t *testing.T) {
 	a2.ClientStatus = structs.AllocClientStatusRunning
 	time.AfterFunc(100*time.Millisecond, func() {
 		assert.Nil(state.UpsertJobSummary(5, mock.JobSummary(a2.JobID)), "UpsertJobSummary")
-		assert.Nil(state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 6, []*structs.Allocation{a2}), "updateAllocsFromClient")
+
+		req := structs.AllocUpdateRequest{
+			Alloc: []*structs.Allocation{a2},
+		}
+		assert.Nil(state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 6, req), "updateAllocsFromClient")
 	})
 
 	req.MinQueryIndex = 4

--- a/nomad/deploymentwatcher/deployments_watcher_test.go
+++ b/nomad/deploymentwatcher/deployments_watcher_test.go
@@ -911,7 +911,11 @@ func TestDeploymentWatcher_Watch_ProgressDeadline(t *testing.T) {
 		Healthy:   pointer.Of(false),
 		Timestamp: now,
 	}
-	must.NoError(t, m.state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 100, []*structs.Allocation{a2}))
+
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{a2},
+	}
+	must.NoError(t, m.state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 100, updateReq))
 
 	// Wait for the deployment to be failed
 	must.Wait(t, wait.InitialSuccess(wait.BoolFunc(func() bool {
@@ -1062,7 +1066,11 @@ func TestDeploymentWatcher_Watch_ProgressDeadline_Canaries(t *testing.T) {
 		Healthy:   pointer.Of(true),
 		Timestamp: now,
 	}
-	must.NoError(t, m.state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a2}))
+
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{a2},
+	}
+	must.NoError(t, m.state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, m.nextIndex(), updateReq))
 
 	// Wait for the deployment to cross the deadline
 	dout, err := m.state.DeploymentByID(nil, d.ID)
@@ -1233,8 +1241,11 @@ func TestDeploymentWatcher_ProgressDeadline_LatePromote(t *testing.T) {
 		Timestamp: now,
 	}
 
-	allocs = []*structs.Allocation{canary2}
-	err := m.state.UpdateAllocsFromClient(mtype, m.nextIndex(), allocs)
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{canary2},
+	}
+
+	err := m.state.UpdateAllocsFromClient(mtype, m.nextIndex(), updateReq)
 	must.NoError(t, err)
 
 	// wait for long enough to ensure we read deployment update channel
@@ -1252,8 +1263,11 @@ func TestDeploymentWatcher_ProgressDeadline_LatePromote(t *testing.T) {
 		Timestamp: now,
 	}
 
-	allocs = []*structs.Allocation{canary1}
-	err = m.state.UpdateAllocsFromClient(mtype, m.nextIndex(), allocs)
+	updateReq2 := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{canary1},
+	}
+
+	err = m.state.UpdateAllocsFromClient(mtype, m.nextIndex(), updateReq2)
 	must.NoError(t, err)
 
 	// ensure progress_deadline has definitely expired
@@ -1319,8 +1333,11 @@ func TestDeploymentWatcher_ProgressDeadline_LatePromote(t *testing.T) {
 		Timestamp: now,
 	}
 
-	allocs = []*structs.Allocation{alloc1a, alloc1b}
-	err = m.state.UpdateAllocsFromClient(mtype, m.nextIndex(), allocs)
+	updateReq3 := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc1a, alloc1b},
+	}
+
+	err = m.state.UpdateAllocsFromClient(mtype, m.nextIndex(), updateReq3)
 	must.NoError(t, err)
 
 	// ensure any progress deadline has expired
@@ -1383,7 +1400,12 @@ func TestDeploymentWatcher_Watch_StartWithoutProgressDeadline(t *testing.T) {
 		Healthy:   pointer.Of(false),
 		Timestamp: time.Now(),
 	}
-	must.NoError(t, m.state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a2}))
+
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{a2},
+	}
+
+	must.NoError(t, m.state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, m.nextIndex(), updateReq))
 
 	// Wait for the alloc's DesiredState to set reschedule
 	must.Wait(t, wait.InitialSuccess(wait.ErrorFunc(func() error {
@@ -1441,7 +1463,12 @@ func TestDeploymentWatcher_Watch_FailEarly(t *testing.T) {
 		Healthy:   pointer.Of(false),
 		Timestamp: now,
 	}
-	must.Nil(t, m.state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, m.nextIndex(), []*structs.Allocation{a2}))
+
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{a2},
+	}
+
+	must.Nil(t, m.state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, m.nextIndex(), updateReq))
 
 	// Wait for the deployment to be failed
 	must.Wait(t, wait.InitialSuccess(wait.ErrorFunc(func() error {

--- a/nomad/drainer/watch_jobs_test.go
+++ b/nomad/drainer/watch_jobs_test.go
@@ -210,7 +210,10 @@ func TestDrainingJobWatcher_DrainJobs(t *testing.T) {
 		a.ClientStatus = structs.AllocClientStatusComplete
 		completeAllocs[i] = a
 	}
-	must.NoError(t, store.UpdateAllocsFromClient(structs.MsgTypeTestSetup, index, completeAllocs))
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: completeAllocs,
+	}
+	must.NoError(t, store.UpdateAllocsFromClient(structs.MsgTypeTestSetup, index, updateReq))
 	index++
 
 	// The drained allocs stopping cause migrations but no new drains

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -665,6 +665,7 @@ func (n *nomadFSM) applyNodePoolDelete(msgType structs.MessageType, buf []byte, 
 
 func (n *nomadFSM) applyUpsertJob(msgType structs.MessageType, buf []byte, index uint64) interface{} {
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "register_job"}, time.Now())
+	n.logger.Error("calling applyUpsertJob", "index", index)
 	var req structs.JobRegisterRequest
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))
@@ -937,11 +938,12 @@ func (n *nomadFSM) handleJobDeregister(index uint64, jobID, namespace string, pu
 
 func (n *nomadFSM) applyUpdateEval(msgType structs.MessageType, buf []byte, index uint64) interface{} {
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "update_eval"}, time.Now())
+
 	var req structs.EvalUpdateRequest
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
-
+	n.logger.Error("applyUpdateEval", "index", index, "eval", req.Evals[0].ID, "eval_status", req.Evals[0].Status, "triggered_by", req.Evals[0].TriggeredBy)
 	return n.upsertEvals(msgType, index, req.Evals)
 }
 
@@ -970,6 +972,7 @@ func (n *nomadFSM) handleUpsertedEval(eval *structs.Evaluation) {
 	}
 
 	if eval.ShouldEnqueue() {
+		n.logger.Error("Enqueueing evaluation", "eval_id", eval.ID, "triggered_by", eval.TriggeredBy, "status", eval.Status)
 		n.evalBroker.Enqueue(eval)
 	} else if eval.ShouldBlock() {
 		n.blockedEvals.Block(eval)
@@ -1012,6 +1015,7 @@ func (n *nomadFSM) applyAllocUpdate(_ structs.MessageType, _ []byte, _ uint64) i
 
 func (n *nomadFSM) applyAllocClientUpdate(msgType structs.MessageType, buf []byte, index uint64) interface{} {
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "alloc_client_update"}, time.Now())
+	n.logger.Error("applyAllocClientUpdate", "index", index)
 	var req structs.AllocUpdateRequest
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))
@@ -1040,7 +1044,7 @@ func (n *nomadFSM) applyAllocClientUpdate(msgType structs.MessageType, buf []byt
 		}
 	}
 
-	if err := n.state.UpdateAllocsAndEvalsFromClient(msgType, index, req); err != nil {
+	if err := n.state.UpdateAllocsFromClient(msgType, index, req); err != nil {
 		n.logger.Error("UpdateAllocFromClient failed", "error", err)
 		return err
 	}
@@ -2130,6 +2134,7 @@ func (n *nomadFSM) reconcileQueuedAllocations(index uint64) error {
 			Status:         structs.EvalStatusPending,
 			AnnotatePlan:   true,
 		}
+		n.logger.Error("Reconciling queued allocations for job during snapshot restore", "job_id", job.ID, "eval_id", eval.ID)
 		// Ignore eval event creation during snapshot restore
 		snap.UpsertEvals(structs.IgnoreUnknownTypeFlag, 100, []*structs.Evaluation{eval})
 		// Create the scheduler and run it

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1049,7 +1049,7 @@ func (n *nomadFSM) applyAllocClientUpdate(msgType structs.MessageType, buf []byt
 		return err
 	}
 
-	// Handle any evals that were added by the RPC handler
+	// Enqueue any evals that were added by the RPC handler
 	n.handleUpsertedEvals(req.Evals)
 
 	// Unblock evals for the nodes computed node class if the client has

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -665,7 +665,7 @@ func (n *nomadFSM) applyNodePoolDelete(msgType structs.MessageType, buf []byte, 
 
 func (n *nomadFSM) applyUpsertJob(msgType structs.MessageType, buf []byte, index uint64) interface{} {
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "register_job"}, time.Now())
-	n.logger.Error("calling applyUpsertJob", "index", index)
+
 	var req structs.JobRegisterRequest
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))
@@ -972,7 +972,6 @@ func (n *nomadFSM) handleUpsertedEval(eval *structs.Evaluation) {
 	}
 
 	if eval.ShouldEnqueue() {
-		n.logger.Error("Enqueueing evaluation", "eval_id", eval.ID, "triggered_by", eval.TriggeredBy, "status", eval.Status)
 		n.evalBroker.Enqueue(eval)
 	} else if eval.ShouldBlock() {
 		n.blockedEvals.Block(eval)
@@ -1015,7 +1014,7 @@ func (n *nomadFSM) applyAllocUpdate(_ structs.MessageType, _ []byte, _ uint64) i
 
 func (n *nomadFSM) applyAllocClientUpdate(msgType structs.MessageType, buf []byte, index uint64) interface{} {
 	defer metrics.MeasureSince([]string{"nomad", "fsm", "alloc_client_update"}, time.Now())
-	n.logger.Error("applyAllocClientUpdate", "index", index)
+
 	var req structs.AllocUpdateRequest
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))
@@ -2134,7 +2133,7 @@ func (n *nomadFSM) reconcileQueuedAllocations(index uint64) error {
 			Status:         structs.EvalStatusPending,
 			AnnotatePlan:   true,
 		}
-		n.logger.Error("Reconciling queued allocations for job during snapshot restore", "job_id", job.ID, "eval_id", eval.ID)
+
 		// Ignore eval event creation during snapshot restore
 		snap.UpsertEvals(structs.IgnoreUnknownTypeFlag, 100, []*structs.Evaluation{eval})
 		// Create the scheduler and run it

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -943,7 +943,7 @@ func (n *nomadFSM) applyUpdateEval(msgType structs.MessageType, buf []byte, inde
 	if err := structs.Decode(buf, &req); err != nil {
 		panic(fmt.Errorf("failed to decode request: %v", err))
 	}
-	n.logger.Error("applyUpdateEval", "index", index, "eval", req.Evals[0].ID, "eval_status", req.Evals[0].Status, "triggered_by", req.Evals[0].TriggeredBy)
+
 	return n.upsertEvals(msgType, index, req.Evals)
 }
 

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -1024,7 +1024,6 @@ func (n *nomadFSM) applyAllocClientUpdate(msgType structs.MessageType, buf []byt
 	ws := memdb.NewWatchSet()
 
 	followupEvalsToCancel := []string{}
-
 	// Updating the allocs with the job id and task group name
 	for _, alloc := range req.Alloc {
 		if existing, _ := n.state.AllocByID(ws, alloc.ID); existing != nil {
@@ -1041,19 +1040,13 @@ func (n *nomadFSM) applyAllocClientUpdate(msgType structs.MessageType, buf []byt
 		}
 	}
 
-	// Update all the client allocations
-	if err := n.state.UpdateAllocsFromClient(msgType, index, req.Alloc); err != nil {
+	if err := n.state.UpdateAllocsAndEvalsFromClient(msgType, index, req); err != nil {
 		n.logger.Error("UpdateAllocFromClient failed", "error", err)
 		return err
 	}
 
-	// Update any evals that were added by the RPC handler
-	if len(req.Evals) > 0 {
-		if err := n.upsertEvals(msgType, index, req.Evals); err != nil {
-			n.logger.Error("applyAllocClientUpdate failed to update evaluations", "error", err)
-			return err
-		}
-	}
+	// Handle any evals that were added by the RPC handler
+	n.handleUpsertedEvals(req.Evals)
 
 	// Unblock evals for the nodes computed node class if the client has
 	// finished running an allocation.

--- a/nomad/job_endpoint_test.go
+++ b/nomad/job_endpoint_test.go
@@ -7252,7 +7252,11 @@ func TestJobEndpoint_Dispatch_JobChildrenSummary(t *testing.T) {
 		require.NoError(t, err)
 		nalloc = nalloc.Copy()
 		nalloc.ClientStatus = status
-		err = s1.State().UpdateAllocsFromClient(structs.MsgTypeTestSetup, nextIdx, []*structs.Allocation{nalloc})
+
+		updateReq := structs.AllocUpdateRequest{
+			Alloc: []*structs.Allocation{nalloc},
+		}
+		err = s1.State().UpdateAllocsFromClient(structs.MsgTypeTestSetup, nextIdx, updateReq)
 		require.NoError(t, err)
 	}
 

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1519,6 +1519,7 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 	if len(args.Alloc) == 0 {
 		return fmt.Errorf("must update at least one allocation")
 	}
+
 	// Ensure the node is allowed to update allocs.
 	// The node needs to successfully heartbeat before updating its allocs.
 	nodeID := args.Alloc[0].NodeID
@@ -1546,7 +1547,6 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 	// Update modified timestamp for client initiated allocation updates
 	now := time.Now()
 	var evals []*structs.Evaluation
-	n.logger.Error("Updating an alloc", "alloc_ID", args.Alloc[0].ID, "status", args.Alloc[0].ClientStatus)
 
 	for _, allocToUpdate := range args.Alloc {
 		evalTriggerBy := ""

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1519,7 +1519,6 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 	if len(args.Alloc) == 0 {
 		return fmt.Errorf("must update at least one allocation")
 	}
-
 	// Ensure the node is allowed to update allocs.
 	// The node needs to successfully heartbeat before updating its allocs.
 	nodeID := args.Alloc[0].NodeID
@@ -1547,6 +1546,7 @@ func (n *Node) UpdateAlloc(args *structs.AllocUpdateRequest, reply *structs.Gene
 	// Update modified timestamp for client initiated allocation updates
 	now := time.Now()
 	var evals []*structs.Evaluation
+	n.logger.Error("Updating an alloc", "alloc_ID", args.Alloc[0].ID, "status", args.Alloc[0].ClientStatus)
 
 	for _, allocToUpdate := range args.Alloc {
 		evalTriggerBy := ""

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -3415,7 +3415,11 @@ func TestClientEndpoint_GetAllocs_Blocking(t *testing.T) {
 		allocUpdate.ID = alloc.ID
 		allocUpdate.ClientStatus = structs.AllocClientStatusRunning
 		state.UpsertJobSummary(199, mock.JobSummary(allocUpdate.JobID))
-		err := state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 200, []*structs.Allocation{allocUpdate})
+
+		req := structs.AllocUpdateRequest{
+			Alloc: []*structs.Allocation{allocUpdate},
+		}
+		err := state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 200, req)
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4068,9 +4068,7 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 }
 
 // nestedUpdateAllocFromClient is used to nest an update of an allocation with
-//
 //	client status.
-//
 // It returns an allocation fully populated with the values from the state store.
 func (s *StateStore) nestedUpdateAllocFromClient(txn *txn, index uint64,
 	alloc *structs.Allocation) (*structs.Allocation, error) {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4014,7 +4014,6 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 	// Capture all nodes being affected. Alloc updates from clients are batched
 	// so this request may include allocs from several nodes.
 	nodeIDs := set.New[string](1)
-	s.logger.Error("                     starting")
 	populatedAllocs := []*structs.Allocation{}
 	// Handle each of the updated allocations
 	for _, a := range allocs {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4067,9 +4067,7 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 }
 
 // nestedUpdateAllocFromClient is used to nest an update of an allocation with
-//
 //	client status.
-//
 // It returns an allocation fully populated with the values from the state store.
 func (s *StateStore) nestedUpdateAllocFromClient(txn *txn, index uint64,
 	alloc *structs.Allocation) (*structs.Allocation, error) {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4067,8 +4067,10 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 	return txn.Commit()
 }
 
-// nestedUpdateAllocFromClient is used to nest an update of an allocation with
+// NestedUpdateAllocFromClient is used to nest an update of an allocation with
+//
 //	client status.
+//
 // It returns an allocation fully populated with the values from the state store.
 func (s *StateStore) nestedUpdateAllocFromClient(txn *txn, index uint64,
 	alloc *structs.Allocation) (*structs.Allocation, error) {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4014,16 +4014,16 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 	// Capture all nodes being affected. Alloc updates from clients are batched
 	// so this request may include allocs from several nodes.
 	nodeIDs := set.New[string](1)
-
+	s.logger.Error("                     starting")
 	populatedAllocs := []*structs.Allocation{}
 	// Handle each of the updated allocations
-	for _, alloc := range allocs {
-		if alloc == nil {
+	for _, a := range allocs {
+		nodeIDs.Insert(a.NodeID)
+		ca, err := s.nestedUpdateAllocFromClient(txn, index, a)
+		if ca == nil {
 			continue
 		}
 
-		nodeIDs.Insert(alloc.NodeID)
-		ca, err := s.nestedUpdateAllocFromClient(txn, index, alloc)
 		if err != nil {
 			return fmt.Errorf("updating alloc failed: %v", err)
 		}
@@ -4038,6 +4038,7 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 	}
 
 	jobs := map[structs.NamespacedID]string{}
+
 	for _, alloc := range populatedAllocs {
 		tuple := structs.NamespacedID{
 			ID:        alloc.JobID,

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4067,9 +4067,7 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 }
 
 // NestedUpdateAllocFromClient is used to nest an update of an allocation with
-//
-//	client status.
-//
+// client status.
 // It returns an allocation fully populated with the values from the state store.
 func (s *StateStore) nestedUpdateAllocFromClient(txn *txn, index uint64,
 	alloc *structs.Allocation) (*structs.Allocation, error) {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -596,7 +596,7 @@ func (s *StateStore) upsertDeploymentImpl(index uint64, deployment *structs.Depl
 		deployment.CreateIndex = index
 		deployment.ModifyIndex = index
 	}
-
+	s.logger.Debug("upserting deployment", "deployment_id", deployment.ID, "status", deployment.Status)
 	// Insert the deployment
 	if err := txn.Insert("deployment", deployment); err != nil {
 		return err
@@ -3424,6 +3424,7 @@ func (s *StateStore) UpsertEvals(msgType structs.MessageType, index uint64, eval
 // in a transaction.  Useful for when making multiple modifications atomically.
 func (s *StateStore) UpsertEvalsTxn(index uint64, evals []*structs.Evaluation, txn Txn) error {
 	// Do a nested upsert
+
 	jobs := make(map[structs.NamespacedID]string, len(evals))
 	for _, eval := range evals {
 		if err := s.nestedUpsertEval(txn, index, eval); err != nil {
@@ -4004,11 +4005,11 @@ func (s *StateStore) EvalsByNamespaceOrdered(ws memdb.WatchSet, namespace string
 // most things, some updates are authoritative from the client. Specifically,
 // the desired state comes from the schedulers, while the actual state comes
 // from clients.
-func (s *StateStore) UpdateAllocsAndEvalsFromClient(msgType structs.MessageType, index uint64,
+func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index uint64,
 	req structs.AllocUpdateRequest) error {
 	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
-	s.logger.Error("UpdateAllocsAndEvalsFromClient", "allocs", len(req.Alloc), "evals", len(req.Evals), "namespace", req.Alloc[0].Namespace)
+
 	allocs := req.Alloc
 	evals := req.Evals
 
@@ -4019,6 +4020,7 @@ func (s *StateStore) UpdateAllocsAndEvalsFromClient(msgType structs.MessageType,
 	completeAllocs := []structs.Allocation{}
 	// Handle each of the updated allocations
 	for _, alloc := range allocs {
+
 		nodeIDs.Insert(alloc.NodeID)
 
 		ca, err := s.nestedUpdateAllocFromClient(txn, index, alloc)
@@ -4044,7 +4046,6 @@ func (s *StateStore) UpdateAllocsAndEvalsFromClient(msgType structs.MessageType,
 		jobs[tuple] = ""
 	}
 
-	s.logger.Error("updating job", "jobs", len(jobs))
 	if err := s.setJobStatuses(index, txn, jobs, false); err != nil {
 		return fmt.Errorf("setting job status failed: %v", err)
 	}
@@ -5405,7 +5406,6 @@ func (s *StateStore) setJobStatuses(index uint64, txn *txn,
 		}
 
 		if existing == nil {
-			s.logger.Error("esta monda no existe????", "job_id", tuple.ID)
 			continue
 		}
 
@@ -5538,7 +5538,6 @@ func (s *StateStore) setJobSummary(txn *txn, updated *structs.Job, index uint64,
 func (s *StateStore) getJobStatus(txn *txn, job *structs.Job, evalDelete bool) (string, error) {
 	// System, Periodic and Parameterized jobs are running until explicitly
 	// stopped.
-	s.logger.Error("get job status", "job_status", job.Status)
 	if job.Type == structs.JobTypeSystem ||
 		job.IsParameterized() ||
 		job.IsPeriodic() {
@@ -5548,23 +5547,26 @@ func (s *StateStore) getJobStatus(txn *txn, job *structs.Job, evalDelete bool) (
 		return structs.JobStatusRunning, nil
 	}
 
+	deployments, err := txn.Get("deployment", "job", job.Namespace, job.ID)
+	if err != nil {
+		return "", err
+	}
+
+	// If there is a non-terminal deployment, the job is running.
+	for deployment := deployments.Next(); deployment != nil; deployment = deployments.Next() {
+		if !deployment.(*structs.Deployment).IsTerminal() {
+			return structs.JobStatusRunning, nil
+		}
+	}
+
 	allocs, err := txn.Get("allocs", "job", job.Namespace, job.ID)
 	if err != nil {
 		return "", err
 	}
 
-	jAlloc := []structs.Allocation{}
 	// If there is a non-terminal allocation, the job is running.
 	for alloc := allocs.Next(); alloc != nil; alloc = allocs.Next() {
-		jAlloc = append(jAlloc, *alloc.(*structs.Allocation))
 		if !alloc.(*structs.Allocation).TerminalStatus() {
-			/* s.logger.Error("**** job running", "allocs", func() []string {
-				ids := make([]string, len(jAlloc))
-				for i, a := range jAlloc {
-					ids[i] = a.ID + ":" + a.ClientStatus
-				}
-				return ids
-			}()) */
 			return structs.JobStatusRunning, nil
 		}
 	}
@@ -5574,30 +5576,13 @@ func (s *StateStore) getJobStatus(txn *txn, job *structs.Job, evalDelete bool) (
 		return "", err
 	}
 
-	jEvals := []structs.Evaluation{}
 	hasEval := false
 	for raw := evals.Next(); raw != nil; raw = evals.Next() {
 		eval := raw.(*structs.Evaluation)
-		jEvals = append(jEvals, *eval)
 		if eval.JobID != job.ID {
 			continue
 		}
 		if !eval.TerminalStatus() {
-			/* s.logger.Error("**** job pending")
-			s.logger.Error("a", "allocs", func() []string {
-				ids := make([]string, len(jAlloc))
-				for i, a := range jAlloc {
-					ids[i] = a.ID + ":" + a.ClientStatus
-				}
-				return ids
-			}())
-			s.logger.Error("e", "evals", func() []string {
-				ids := make([]string, len(jEvals))
-				for i, e := range jEvals {
-					ids[i] = e.ID + ":" + e.Status
-				}
-				return ids
-			}()) */
 			return structs.JobStatusPending, nil
 		}
 		hasEval = true
@@ -5607,29 +5592,13 @@ func (s *StateStore) getJobStatus(txn *txn, job *structs.Job, evalDelete bool) (
 	// and all evals are terminal. In the event a jobs allocs and evals
 	// are all GC'd, we don't want the job to be marked pending.
 	if evalDelete || hasEval || job.Stop {
-		s.logger.Error("**** job dead")
+		s.logger.Info("marking job as dead")
 		return structs.JobStatusDead, nil
 	}
 
 	// There are no allocs/evals yet, which can happen for new job submissions,
 	// running new versions of a job, or reverting. This will happen if
 	// the evaluation is persisted after the job is persisted.
-
-	/* 	s.logger.Error("**** job pending by default")
-	   	s.logger.Error("a", "allocs", func() []string {
-	   		ids := make([]string, len(jAlloc))
-	   		for i, a := range jAlloc {
-	   			ids[i] = a.ID + ":" + a.ClientStatus
-	   		}
-	   		return ids
-	   	}())
-	   	s.logger.Error("e", "evals", func() []string {
-	   		ids := make([]string, len(jEvals))
-	   		for i, e := range jEvals {
-	   			ids[i] = e.ID + ":" + e.Status
-	   		}
-	   		return ids
-	   	}()) */
 	return structs.JobStatusPending, nil
 }
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -5590,7 +5590,6 @@ func (s *StateStore) getJobStatus(txn *txn, job *structs.Job, evalDelete bool) (
 	// and all evals are terminal. In the event a jobs allocs and evals
 	// are all GC'd, we don't want the job to be marked pending.
 	if evalDelete || hasEval || job.Stop {
-		s.logger.Info("marking job as dead")
 		return structs.JobStatusDead, nil
 	}
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4015,17 +4015,19 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 	// so this request may include allocs from several nodes.
 	nodeIDs := set.New[string](1)
 
-	completeAllocs := []*structs.Allocation{}
+	populatedAllocs := []*structs.Allocation{}
 	// Handle each of the updated allocations
 	for _, alloc := range allocs {
+		if alloc == nil {
+			continue
+		}
 
 		nodeIDs.Insert(alloc.NodeID)
-
 		ca, err := s.nestedUpdateAllocFromClient(txn, index, alloc)
 		if err != nil {
 			return fmt.Errorf("updating alloc failed: %v", err)
 		}
-		completeAllocs = append(completeAllocs, ca)
+		populatedAllocs = append(populatedAllocs, ca)
 	}
 
 	if len(req.Evals) > 0 {
@@ -4036,15 +4038,13 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 	}
 
 	jobs := map[structs.NamespacedID]string{}
-	for _, alloc := range completeAllocs {
-		if alloc != nil {
-			tuple := structs.NamespacedID{
-				ID:        alloc.JobID,
-				Namespace: alloc.Namespace,
-			}
-
-			jobs[tuple] = ""
+	for _, alloc := range populatedAllocs {
+		tuple := structs.NamespacedID{
+			ID:        alloc.JobID,
+			Namespace: alloc.Namespace,
 		}
+
+		jobs[tuple] = ""
 	}
 
 	if err := s.setJobStatuses(index, txn, jobs, false); err != nil {
@@ -4067,7 +4067,9 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 }
 
 // nestedUpdateAllocFromClient is used to nest an update of an allocation with
+//
 //	client status.
+//
 // It returns an allocation fully populated with the values from the state store.
 func (s *StateStore) nestedUpdateAllocFromClient(txn *txn, index uint64,
 	alloc *structs.Allocation) (*structs.Allocation, error) {

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -596,7 +596,6 @@ func (s *StateStore) upsertDeploymentImpl(index uint64, deployment *structs.Depl
 		deployment.CreateIndex = index
 		deployment.ModifyIndex = index
 	}
-	s.logger.Debug("upserting deployment", "deployment_id", deployment.ID, "status", deployment.Status)
 	// Insert the deployment
 	if err := txn.Insert("deployment", deployment); err != nil {
 		return err
@@ -3424,7 +3423,6 @@ func (s *StateStore) UpsertEvals(msgType structs.MessageType, index uint64, eval
 // in a transaction.  Useful for when making multiple modifications atomically.
 func (s *StateStore) UpsertEvalsTxn(index uint64, evals []*structs.Evaluation, txn Txn) error {
 	// Do a nested upsert
-
 	jobs := make(map[structs.NamespacedID]string, len(evals))
 	for _, eval := range evals {
 		if err := s.nestedUpsertEval(txn, index, eval); err != nil {
@@ -4017,7 +4015,7 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 	// so this request may include allocs from several nodes.
 	nodeIDs := set.New[string](1)
 
-	completeAllocs := []structs.Allocation{}
+	completeAllocs := []*structs.Allocation{}
 	// Handle each of the updated allocations
 	for _, alloc := range allocs {
 
@@ -4071,16 +4069,16 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 //
 // It returns an allocation fully populated with the values from the state store.
 func (s *StateStore) nestedUpdateAllocFromClient(txn *txn, index uint64,
-	alloc *structs.Allocation) (structs.Allocation, error) {
+	alloc *structs.Allocation) (*structs.Allocation, error) {
 	// Look for existing alloc
 	existing, err := txn.First("allocs", "id", alloc.ID)
 	if err != nil {
-		return structs.Allocation{}, fmt.Errorf("alloc lookup failed: %v", err)
+		return nil, fmt.Errorf("alloc lookup failed: %v", err)
 	}
 
 	// Nothing to do if this does not exist
 	if existing == nil {
-		return structs.Allocation{}, nil
+		return nil, nil
 	}
 	exist := existing.(*structs.Allocation)
 
@@ -4120,35 +4118,35 @@ func (s *StateStore) nestedUpdateAllocFromClient(txn *txn, index uint64,
 	copyAlloc.ModifyTime = alloc.ModifyTime
 
 	if err := s.updateDeploymentWithAlloc(index, copyAlloc, exist, txn); err != nil {
-		return structs.Allocation{}, fmt.Errorf("error updating deployment: %v", err)
+		return nil, fmt.Errorf("error updating deployment: %v", err)
 	}
 
 	if err := s.updateSummaryWithAlloc(index, copyAlloc, exist, txn); err != nil {
-		return structs.Allocation{}, fmt.Errorf("error updating job summary: %v", err)
+		return nil, fmt.Errorf("error updating job summary: %v", err)
 	}
 
 	if err := s.updateEntWithAlloc(index, copyAlloc, exist, txn); err != nil {
-		return structs.Allocation{}, fmt.Errorf("error updating enterprise features: %v", err)
+		return nil, fmt.Errorf("error updating enterprise features: %v", err)
 	}
 
 	if err := s.updatePluginForTerminalAlloc(index, copyAlloc, txn); err != nil {
-		return structs.Allocation{}, fmt.Errorf("error updating plugin for terminal alloc: %v", err)
+		return nil, fmt.Errorf("error updating plugin for terminal alloc: %v", err)
 	}
 
 	if err := s.cancelFollowupEvalsForReconnect(txn, index, copyAlloc, alloc); err != nil {
-		return structs.Allocation{}, err
+		return nil, err
 	}
 
 	// Update the allocation
 	if err := txn.Insert("allocs", copyAlloc); err != nil {
-		return structs.Allocation{}, fmt.Errorf("alloc insert failed: %v", err)
+		return nil, fmt.Errorf("alloc insert failed: %v", err)
 	}
 
 	if err := s.deregisterServicesForTerminalAllocs(txn, index, copyAlloc); err != nil {
-		return structs.Allocation{}, fmt.Errorf("error deregistering services for terminal allocs: %v", err)
+		return nil, fmt.Errorf("error deregistering services for terminal allocs: %v", err)
 	}
 
-	return *copyAlloc, nil
+	return copyAlloc, nil
 }
 
 // cancelFollowupEvalsForReconnect cancels any follow-up evals for an allocation

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4004,20 +4004,49 @@ func (s *StateStore) EvalsByNamespaceOrdered(ws memdb.WatchSet, namespace string
 // most things, some updates are authoritative from the client. Specifically,
 // the desired state comes from the schedulers, while the actual state comes
 // from clients.
-func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index uint64, allocs []*structs.Allocation) error {
+func (s *StateStore) UpdateAllocsAndEvalsFromClient(msgType structs.MessageType, index uint64,
+	req structs.AllocUpdateRequest) error {
 	txn := s.db.WriteTxnMsgT(msgType, index)
 	defer txn.Abort()
+	s.logger.Error("UpdateAllocsAndEvalsFromClient", "allocs", len(req.Alloc), "evals", len(req.Evals), "namespace", req.Alloc[0].Namespace)
+	allocs := req.Alloc
+	evals := req.Evals
 
 	// Capture all nodes being affected. Alloc updates from clients are batched
 	// so this request may include allocs from several nodes.
 	nodeIDs := set.New[string](1)
 
+	completeAllocs := []structs.Allocation{}
 	// Handle each of the updated allocations
 	for _, alloc := range allocs {
 		nodeIDs.Insert(alloc.NodeID)
-		if err := s.nestedUpdateAllocFromClient(txn, index, alloc); err != nil {
-			return err
+
+		ca, err := s.nestedUpdateAllocFromClient(txn, index, alloc)
+		if err != nil {
+			return fmt.Errorf("updating alloc failed: %v", err)
 		}
+		completeAllocs = append(completeAllocs, ca)
+	}
+
+	if len(req.Evals) > 0 {
+		err := s.UpsertEvalsTxn(index, evals, txn)
+		if err != nil {
+			return fmt.Errorf("upserting evals failed: %v", err)
+		}
+	}
+
+	jobs := map[structs.NamespacedID]string{}
+	for _, alloc := range completeAllocs {
+		tuple := structs.NamespacedID{
+			ID:        alloc.JobID,
+			Namespace: alloc.Namespace,
+		}
+		jobs[tuple] = ""
+	}
+
+	s.logger.Error("updating job", "jobs", len(jobs))
+	if err := s.setJobStatuses(index, txn, jobs, false); err != nil {
+		return fmt.Errorf("setting job status failed: %v", err)
 	}
 
 	// Update the indexes
@@ -4035,17 +4064,22 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 	return txn.Commit()
 }
 
-// nestedUpdateAllocFromClient is used to nest an update of an allocation with client status
-func (s *StateStore) nestedUpdateAllocFromClient(txn *txn, index uint64, alloc *structs.Allocation) error {
+// nestedUpdateAllocFromClient is used to nest an update of an allocation with
+//
+//	client status.
+//
+// It returns an allocation fully populated with the values from the state store.
+func (s *StateStore) nestedUpdateAllocFromClient(txn *txn, index uint64,
+	alloc *structs.Allocation) (structs.Allocation, error) {
 	// Look for existing alloc
 	existing, err := txn.First("allocs", "id", alloc.ID)
 	if err != nil {
-		return fmt.Errorf("alloc lookup failed: %v", err)
+		return structs.Allocation{}, fmt.Errorf("alloc lookup failed: %v", err)
 	}
 
 	// Nothing to do if this does not exist
 	if existing == nil {
-		return nil
+		return structs.Allocation{}, nil
 	}
 	exist := existing.(*structs.Allocation)
 
@@ -4085,51 +4119,35 @@ func (s *StateStore) nestedUpdateAllocFromClient(txn *txn, index uint64, alloc *
 	copyAlloc.ModifyTime = alloc.ModifyTime
 
 	if err := s.updateDeploymentWithAlloc(index, copyAlloc, exist, txn); err != nil {
-		return fmt.Errorf("error updating deployment: %v", err)
+		return structs.Allocation{}, fmt.Errorf("error updating deployment: %v", err)
 	}
 
 	if err := s.updateSummaryWithAlloc(index, copyAlloc, exist, txn); err != nil {
-		return fmt.Errorf("error updating job summary: %v", err)
+		return structs.Allocation{}, fmt.Errorf("error updating job summary: %v", err)
 	}
 
 	if err := s.updateEntWithAlloc(index, copyAlloc, exist, txn); err != nil {
-		return err
+		return structs.Allocation{}, fmt.Errorf("error updating enterprise features: %v", err)
 	}
 
 	if err := s.updatePluginForTerminalAlloc(index, copyAlloc, txn); err != nil {
-		return err
+		return structs.Allocation{}, fmt.Errorf("error updating plugin for terminal alloc: %v", err)
 	}
 
 	if err := s.cancelFollowupEvalsForReconnect(txn, index, copyAlloc, alloc); err != nil {
-		return err
+		return structs.Allocation{}, err
 	}
 
 	// Update the allocation
 	if err := txn.Insert("allocs", copyAlloc); err != nil {
-		return fmt.Errorf("alloc insert failed: %v", err)
-	}
-
-	// Set the job's status
-	forceStatus := ""
-	if !copyAlloc.TerminalStatus() {
-		forceStatus = structs.JobStatusRunning
-	}
-
-	tuple := structs.NamespacedID{
-		ID:        exist.JobID,
-		Namespace: exist.Namespace,
-	}
-	jobs := map[structs.NamespacedID]string{tuple: forceStatus}
-
-	if err := s.setJobStatuses(index, txn, jobs, false); err != nil {
-		return fmt.Errorf("setting job status failed: %v", err)
+		return structs.Allocation{}, fmt.Errorf("alloc insert failed: %v", err)
 	}
 
 	if err := s.deregisterServicesForTerminalAllocs(txn, index, copyAlloc); err != nil {
-		return err
+		return structs.Allocation{}, fmt.Errorf("error deregistering services for terminal allocs: %v", err)
 	}
 
-	return nil
+	return *copyAlloc, nil
 }
 
 // cancelFollowupEvalsForReconnect cancels any follow-up evals for an allocation
@@ -5381,13 +5399,13 @@ func (s *StateStore) ReconcileJobSummaries(index uint64) error {
 func (s *StateStore) setJobStatuses(index uint64, txn *txn,
 	jobs map[structs.NamespacedID]string, evalDelete bool) error {
 	for tuple, forceStatus := range jobs {
-
 		existing, err := txn.First("jobs", "id", tuple.Namespace, tuple.ID)
 		if err != nil {
 			return fmt.Errorf("job lookup failed: %v", err)
 		}
 
 		if existing == nil {
+			s.logger.Error("esta monda no existe????", "job_id", tuple.ID)
 			continue
 		}
 
@@ -5520,6 +5538,7 @@ func (s *StateStore) setJobSummary(txn *txn, updated *structs.Job, index uint64,
 func (s *StateStore) getJobStatus(txn *txn, job *structs.Job, evalDelete bool) (string, error) {
 	// System, Periodic and Parameterized jobs are running until explicitly
 	// stopped.
+	s.logger.Error("get job status", "job_status", job.Status)
 	if job.Type == structs.JobTypeSystem ||
 		job.IsParameterized() ||
 		job.IsPeriodic() {
@@ -5534,9 +5553,18 @@ func (s *StateStore) getJobStatus(txn *txn, job *structs.Job, evalDelete bool) (
 		return "", err
 	}
 
+	jAlloc := []structs.Allocation{}
 	// If there is a non-terminal allocation, the job is running.
 	for alloc := allocs.Next(); alloc != nil; alloc = allocs.Next() {
+		jAlloc = append(jAlloc, *alloc.(*structs.Allocation))
 		if !alloc.(*structs.Allocation).TerminalStatus() {
+			/* s.logger.Error("**** job running", "allocs", func() []string {
+				ids := make([]string, len(jAlloc))
+				for i, a := range jAlloc {
+					ids[i] = a.ID + ":" + a.ClientStatus
+				}
+				return ids
+			}()) */
 			return structs.JobStatusRunning, nil
 		}
 	}
@@ -5546,13 +5574,30 @@ func (s *StateStore) getJobStatus(txn *txn, job *structs.Job, evalDelete bool) (
 		return "", err
 	}
 
+	jEvals := []structs.Evaluation{}
 	hasEval := false
 	for raw := evals.Next(); raw != nil; raw = evals.Next() {
 		eval := raw.(*structs.Evaluation)
+		jEvals = append(jEvals, *eval)
 		if eval.JobID != job.ID {
 			continue
 		}
 		if !eval.TerminalStatus() {
+			/* s.logger.Error("**** job pending")
+			s.logger.Error("a", "allocs", func() []string {
+				ids := make([]string, len(jAlloc))
+				for i, a := range jAlloc {
+					ids[i] = a.ID + ":" + a.ClientStatus
+				}
+				return ids
+			}())
+			s.logger.Error("e", "evals", func() []string {
+				ids := make([]string, len(jEvals))
+				for i, e := range jEvals {
+					ids[i] = e.ID + ":" + e.Status
+				}
+				return ids
+			}()) */
 			return structs.JobStatusPending, nil
 		}
 		hasEval = true
@@ -5562,12 +5607,29 @@ func (s *StateStore) getJobStatus(txn *txn, job *structs.Job, evalDelete bool) (
 	// and all evals are terminal. In the event a jobs allocs and evals
 	// are all GC'd, we don't want the job to be marked pending.
 	if evalDelete || hasEval || job.Stop {
+		s.logger.Error("**** job dead")
 		return structs.JobStatusDead, nil
 	}
 
 	// There are no allocs/evals yet, which can happen for new job submissions,
 	// running new versions of a job, or reverting. This will happen if
 	// the evaluation is persisted after the job is persisted.
+
+	/* 	s.logger.Error("**** job pending by default")
+	   	s.logger.Error("a", "allocs", func() []string {
+	   		ids := make([]string, len(jAlloc))
+	   		for i, a := range jAlloc {
+	   			ids[i] = a.ID + ":" + a.ClientStatus
+	   		}
+	   		return ids
+	   	}())
+	   	s.logger.Error("e", "evals", func() []string {
+	   		ids := make([]string, len(jEvals))
+	   		for i, e := range jEvals {
+	   			ids[i] = e.ID + ":" + e.Status
+	   		}
+	   		return ids
+	   	}()) */
 	return structs.JobStatusPending, nil
 }
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -4037,11 +4037,14 @@ func (s *StateStore) UpdateAllocsFromClient(msgType structs.MessageType, index u
 
 	jobs := map[structs.NamespacedID]string{}
 	for _, alloc := range completeAllocs {
-		tuple := structs.NamespacedID{
-			ID:        alloc.JobID,
-			Namespace: alloc.Namespace,
+		if alloc != nil {
+			tuple := structs.NamespacedID{
+				ID:        alloc.JobID,
+				Namespace: alloc.Namespace,
+			}
+
+			jobs[tuple] = ""
 		}
-		jobs[tuple] = ""
 	}
 
 	if err := s.setJobStatuses(index, txn, jobs, false); err != nil {

--- a/nomad/state/state_store_host_volumes_test.go
+++ b/nomad/state/state_store_host_volumes_test.go
@@ -159,8 +159,13 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 	alloc = alloc.Copy()
 	alloc.DesiredStatus = structs.AllocDesiredStatusStop
 	index++
+
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc},
+	}
+
 	must.NoError(t, store.UpdateAllocsFromClient(structs.MsgTypeTestSetup,
-		index, []*structs.Allocation{alloc}))
+		index, updateReq))
 
 	index++
 	err = store.DeleteHostVolume(index, vol2.Namespace, vols[2].ID)
@@ -198,9 +203,13 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 	alloc = alloc.Copy()
 	alloc.ClientStatus = structs.AllocClientStatusComplete
 	index++
-	must.NoError(t, store.UpdateAllocsFromClient(structs.MsgTypeTestSetup,
-		index, []*structs.Allocation{alloc}))
 
+	updateReq2 := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc},
+	}
+
+	must.NoError(t, store.UpdateAllocsFromClient(structs.MsgTypeTestSetup,
+		index, updateReq2))
 	index++
 	must.NoError(t, store.DeleteNode(structs.MsgTypeTestSetup, index, []string{vol2.NodeID}))
 	iter, err = store.HostVolumesByNodeID(nil, vol2.NodeID, SortDefault)

--- a/nomad/state/state_store_service_registration_test.go
+++ b/nomad/state/state_store_service_registration_test.go
@@ -684,8 +684,13 @@ func TestAlloc_ServiceRegistrationLifecycle(t *testing.T) {
 	alloc0 = alloc0.Copy()
 	alloc0.ClientStatus = structs.AllocClientStatusComplete
 	index++
+
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc0},
+	}
+
 	must.NoError(t, store.UpdateAllocsFromClient(structs.MsgTypeTestSetup, index,
-		[]*structs.Allocation{alloc0}))
+		updateReq))
 
 	iter, err := store.GetServiceRegistrationsByAllocID(nil, alloc0.ID)
 	must.NoError(t, err)

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -3900,13 +3900,18 @@ func TestStateStore_CSIPlugin_Lifecycle(t *testing.T) {
 		}
 		switch kind {
 		case SERVER:
+
 			err = store.UpsertAllocs(structs.MsgTypeTestSetup, nextIndex(store), allocs)
 		case CLIENT:
 			// this is somewhat artificial b/c we get alloc updates
 			// from multiple nodes concurrently but not in a single
 			// RPC call. But this guarantees we'll trigger any nested
 			// transaction setup bugs
-			err = store.UpdateAllocsFromClient(structs.MsgTypeTestSetup, nextIndex(store), allocs)
+
+			updateReq := structs.AllocUpdateRequest{
+				Alloc: allocs,
+			}
+			err = store.UpdateAllocsFromClient(structs.MsgTypeTestSetup, nextIndex(store), updateReq)
 		}
 		must.NoError(t, err)
 		return allocs
@@ -5337,15 +5342,20 @@ func TestStateStore_UpdateAllocsFromClient(t *testing.T) {
 
 	// Create the delta updates
 	ts := map[string]*structs.TaskState{"web": {State: structs.TaskStateRunning}}
-	update := &structs.Allocation{
-		ID:           alloc.ID,
-		NodeID:       alloc.NodeID,
-		ClientStatus: structs.AllocClientStatusComplete,
-		TaskStates:   ts,
-		JobID:        alloc.JobID,
-		TaskGroup:    alloc.TaskGroup,
+
+	update := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{
+			{
+				ID:           alloc.ID,
+				NodeID:       alloc.NodeID,
+				ClientStatus: structs.AllocClientStatusComplete,
+				TaskStates:   ts,
+				JobID:        alloc.JobID,
+				TaskGroup:    alloc.TaskGroup,
+			},
+		},
 	}
-	err = state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{update})
+	err = state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1002, update)
 	must.NoError(t, err)
 
 	must.True(t, watchFired(ws))
@@ -5408,24 +5418,29 @@ func TestStateStore_UpdateAllocsFromClient_ChildJob(t *testing.T) {
 
 	// Create the delta updates
 	ts := map[string]*structs.TaskState{"web": {State: structs.TaskStatePending}}
-	update := &structs.Allocation{
-		ID:           alloc1.ID,
-		NodeID:       alloc1.NodeID,
-		ClientStatus: structs.AllocClientStatusFailed,
-		TaskStates:   ts,
-		JobID:        alloc1.JobID,
-		TaskGroup:    alloc1.TaskGroup,
-	}
-	update2 := &structs.Allocation{
-		ID:           alloc2.ID,
-		NodeID:       alloc2.NodeID,
-		ClientStatus: structs.AllocClientStatusRunning,
-		TaskStates:   ts,
-		JobID:        alloc2.JobID,
-		TaskGroup:    alloc2.TaskGroup,
+
+	update := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{
+			{
+				ID:           alloc1.ID,
+				NodeID:       alloc1.NodeID,
+				ClientStatus: structs.AllocClientStatusFailed,
+				TaskStates:   ts,
+				JobID:        alloc1.JobID,
+				TaskGroup:    alloc1.TaskGroup,
+			},
+			{
+				ID:           alloc2.ID,
+				NodeID:       alloc2.NodeID,
+				ClientStatus: structs.AllocClientStatusRunning,
+				TaskStates:   ts,
+				JobID:        alloc2.JobID,
+				TaskGroup:    alloc2.TaskGroup,
+			},
+		},
 	}
 
-	err = state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{update, update2})
+	err = state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1001, update)
 	must.NoError(t, err)
 
 	for _, ws := range watches {
@@ -5487,24 +5502,29 @@ func TestStateStore_UpdateMultipleAllocsFromClient(t *testing.T) {
 
 	// Create the delta updates
 	ts := map[string]*structs.TaskState{"web": {State: structs.TaskStatePending}}
-	update := &structs.Allocation{
-		ID:           alloc.ID,
-		NodeID:       alloc.NodeID,
-		ClientStatus: structs.AllocClientStatusRunning,
-		TaskStates:   ts,
-		JobID:        alloc.JobID,
-		TaskGroup:    alloc.TaskGroup,
-	}
-	update2 := &structs.Allocation{
-		ID:           alloc.ID,
-		NodeID:       alloc.NodeID,
-		ClientStatus: structs.AllocClientStatusPending,
-		TaskStates:   ts,
-		JobID:        alloc.JobID,
-		TaskGroup:    alloc.TaskGroup,
+
+	update := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{
+			{
+				ID:           alloc.ID,
+				NodeID:       alloc.NodeID,
+				ClientStatus: structs.AllocClientStatusRunning,
+				TaskStates:   ts,
+				JobID:        alloc.JobID,
+				TaskGroup:    alloc.TaskGroup,
+			},
+			{
+				ID:           alloc.ID,
+				NodeID:       alloc.NodeID,
+				ClientStatus: structs.AllocClientStatusPending,
+				TaskStates:   ts,
+				JobID:        alloc.JobID,
+				TaskGroup:    alloc.TaskGroup,
+			},
+		},
 	}
 
-	err := state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{update, update2})
+	err := state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1001, update)
 	must.NoError(t, err)
 
 	ws := memdb.NewWatchSet()
@@ -5557,18 +5577,23 @@ func TestStateStore_UpdateAllocsFromClient_Deployment(t *testing.T) {
 	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{alloc}))
 
 	healthy := now.Add(time.Second)
-	update := &structs.Allocation{
-		ID:           alloc.ID,
-		NodeID:       alloc.NodeID,
-		ClientStatus: structs.AllocClientStatusRunning,
-		JobID:        alloc.JobID,
-		TaskGroup:    alloc.TaskGroup,
-		DeploymentStatus: &structs.AllocDeploymentStatus{
-			Healthy:   pointer.Of(true),
-			Timestamp: healthy,
+	update := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{
+			{
+				ID:           alloc.ID,
+				NodeID:       alloc.NodeID,
+				ClientStatus: structs.AllocClientStatusRunning,
+				JobID:        alloc.JobID,
+				TaskGroup:    alloc.TaskGroup,
+				DeploymentStatus: &structs.AllocDeploymentStatus{
+					Healthy:   pointer.Of(true),
+					Timestamp: healthy,
+				},
+			},
 		},
 	}
-	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{update}))
+
+	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1001, update))
 
 	// Check that the deployment state was updated because the healthy
 	// deployment
@@ -5612,7 +5637,8 @@ func TestStateStore_UpdateAllocsFromClient_DeploymentStateMerges(t *testing.T) {
 
 	// note this is the equivalent of the "stripped" alloc update that the
 	// client sends
-	update := &structs.Allocation{
+	updateAlloc := &structs.Allocation{
+
 		ID:           alloc.ID,
 		NodeID:       alloc.NodeID,
 		ClientStatus: structs.AllocClientStatusRunning,
@@ -5622,7 +5648,11 @@ func TestStateStore_UpdateAllocsFromClient_DeploymentStateMerges(t *testing.T) {
 			Canary: false, // should not update
 		},
 	}
-	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{update}))
+
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{updateAlloc},
+	}
+	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1001, updateReq))
 
 	// Check that the merging of the deployment status was correct
 	out, err := state.AllocByID(nil, alloc.ID)
@@ -5639,13 +5669,18 @@ func TestStateStore_UpdateAllocsFromClient_DeploymentStateMerges(t *testing.T) {
 	must.NoError(t, state.UpsertPlanResults(structs.MsgTypeTestSetup, 1005,
 		&structs.ApplyPlanResultsRequest{Deployment: deployment}))
 
-	update = update.Copy()
-	update.DeploymentStatus = &structs.AllocDeploymentStatus{
+	updateAlloc = updateAlloc.Copy()
+	updateAlloc.DeploymentStatus = &structs.AllocDeploymentStatus{
 		Healthy: pointer.Of(true), // should update
 		Canary:  false,            // should not update
 	}
+
+	updateReq2 := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{updateAlloc},
+	}
+
 	must.NoError(t, state.UpdateAllocsFromClient(
-		structs.MsgTypeTestSetup, 1010, []*structs.Allocation{update}))
+		structs.MsgTypeTestSetup, 1010, updateReq2))
 
 	out, err = state.AllocByID(nil, alloc.ID)
 	must.NoError(t, err)
@@ -5722,9 +5757,11 @@ func TestStateStore_UpdateAllocsFromClient_UpdateNodes(t *testing.T) {
 		TaskGroup:    "group",
 	}
 
-	err = state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1005, []*structs.Allocation{
-		updateAlloc1, updateAlloc2, updateAllocNonExisting,
-	})
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{updateAlloc1, updateAlloc2, updateAllocNonExisting},
+	}
+
+	err = state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1005, updateReq)
 	must.NoError(t, err)
 
 	// Check that node update watches fired.
@@ -6249,7 +6286,11 @@ func TestStateStore_UpdateAlloc_JobPurge(t *testing.T) {
 	// state as it has already been removed by the purge.
 	allocCopy1 := alloc.Copy()
 	allocCopy1.ClientStatus = structs.AllocClientStatusComplete
-	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1001, []*structs.Allocation{allocCopy1}))
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{allocCopy1},
+	}
+
+	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1001, updateReq))
 
 	// Ensure the client allocation update was a noop due to the job being
 	// purged.
@@ -6355,12 +6396,20 @@ func TestStateStore_JobSummary(t *testing.T) {
 	alloc1 := alloc.Copy()
 	alloc1.ClientStatus = structs.AllocClientStatusPending
 	alloc1.DesiredStatus = ""
-	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 920, []*structs.Allocation{alloc})
+
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc},
+	}
+	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 920, updateReq)
 
 	alloc3 := alloc.Copy()
 	alloc3.ClientStatus = structs.AllocClientStatusRunning
 	alloc3.DesiredStatus = ""
-	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 930, []*structs.Allocation{alloc3})
+
+	updateReq2 := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc3},
+	}
+	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 930, updateReq2)
 
 	// Upsert the alloc
 	alloc4 := alloc.Copy()
@@ -6399,7 +6448,11 @@ func TestStateStore_JobSummary(t *testing.T) {
 	alloc6 := alloc.Copy()
 	alloc6.ClientStatus = structs.AllocClientStatusRunning
 	alloc6.DesiredStatus = ""
-	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 990, []*structs.Allocation{alloc6})
+
+	updateReq3 := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc6},
+	}
+	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 990, updateReq3)
 
 	// We shouldn't have any summary at this point
 	summary, _ = state.JobSummaryByID(ws, job.Namespace, job.ID)
@@ -6426,7 +6479,10 @@ func TestStateStore_JobSummary(t *testing.T) {
 	alloc7.Job = outJob
 	alloc7.ClientStatus = structs.AllocClientStatusComplete
 	alloc7.DesiredStatus = structs.AllocDesiredStatusRun
-	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1020, []*structs.Allocation{alloc7})
+	updateReq4 := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc7},
+	}
+	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1020, updateReq4)
 
 	expectedSummary = structs.JobSummary{
 		JobID:     job.ID,
@@ -6469,7 +6525,11 @@ func TestStateStore_ReconcileJobSummary(t *testing.T) {
 	// Change the state of the first alloc to running
 	alloc3 := alloc.Copy()
 	alloc3.ClientStatus = structs.AllocClientStatusRunning
-	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 120, []*structs.Allocation{alloc3})
+
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc3},
+	}
+	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 120, updateReq)
 
 	//Add some more allocs to the second tg
 	alloc4 := mock.Alloc()
@@ -6508,7 +6568,11 @@ func TestStateStore_ReconcileJobSummary(t *testing.T) {
 
 	state.UpsertAllocs(structs.MsgTypeTestSetup, 130, []*structs.Allocation{alloc4, alloc6, alloc8, alloc10, alloc12})
 
-	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 150, []*structs.Allocation{alloc5, alloc7, alloc9, alloc11})
+	updateReq2 := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc5, alloc7, alloc9, alloc11},
+	}
+
+	state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 150, updateReq2)
 
 	// DeleteJobSummary is a helper method and doesn't modify the indexes table
 	state.DeleteJobSummary(130, alloc.Namespace, alloc.Job.ID)
@@ -6645,7 +6709,11 @@ func TestStateStore_UpdateAlloc_JobNotPresent(t *testing.T) {
 	alloc1.ClientStatus = structs.AllocClientStatusRunning
 
 	// Updating allocation should not throw any error
-	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 400, []*structs.Allocation{alloc1}))
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc1},
+	}
+
+	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 400, updateReq))
 
 	// Re-Register the job
 	state.UpsertJob(structs.MsgTypeTestSetup, 500, nil, alloc.Job)
@@ -6653,7 +6721,10 @@ func TestStateStore_UpdateAlloc_JobNotPresent(t *testing.T) {
 	// Update the alloc again
 	alloc2 := alloc.Copy()
 	alloc2.ClientStatus = structs.AllocClientStatusComplete
-	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 400, []*structs.Allocation{alloc1}))
+	updateReq2 := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc1},
+	}
+	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 400, updateReq2))
 
 	// Job Summary of the newly registered job shouldn't account for the
 	// allocation update for the older job
@@ -7525,7 +7596,11 @@ func TestStateJobSummary_UpdateJobCount(t *testing.T) {
 	alloc5.JobID = alloc3.JobID
 	alloc5.ClientStatus = structs.AllocClientStatusComplete
 
-	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1004, []*structs.Allocation{alloc4, alloc5}))
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc4, alloc5},
+	}
+
+	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1004, updateReq))
 
 	must.True(t, watchFired(ws2))
 
@@ -7592,7 +7667,11 @@ func TestJobSummary_UpdateClientStatus(t *testing.T) {
 	alloc6.JobID = alloc.JobID
 	alloc6.ClientStatus = structs.AllocClientStatusRunning
 
-	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1002, []*structs.Allocation{alloc4, alloc5, alloc6}))
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc4, alloc5, alloc6},
+	}
+
+	must.NoError(t, state.UpdateAllocsFromClient(structs.MsgTypeTestSetup, 1002, updateReq))
 
 	must.True(t, watchFired(ws), must.Sprint("expected watch to fire"))
 
@@ -10147,8 +10226,13 @@ func TestStateStore_CancelFollowupEvalsOnReconnect(t *testing.T) {
 			index++
 			alloc0 = alloc0.Copy()
 			alloc0.ClientStatus = tc.alloc0NewStatus
+
+			updateReq := structs.AllocUpdateRequest{
+				Alloc: []*structs.Allocation{alloc0},
+			}
+
 			must.NoError(t, store.UpdateAllocsFromClient(structs.MsgTypeTestSetup, index,
-				[]*structs.Allocation{alloc0}))
+				updateReq))
 
 			eval, err := store.EvalByID(nil, evalID)
 			must.NoError(t, err)

--- a/nomad/structs/deployment.go
+++ b/nomad/structs/deployment.go
@@ -246,6 +246,12 @@ func (d *Deployment) GetNamespace() string {
 	return d.Namespace
 }
 
+func (d *Deployment) IsTerminal() bool {
+	return d.Status == DeploymentStatusCancelled ||
+		d.Status == DeploymentStatusFailed ||
+		d.Status == DeploymentStatusSuccessful
+}
+
 // DeploymentState tracks the state of a deployment for a given task group.
 type DeploymentState struct {
 	// AutoRevert marks whether the task group has indicated the job should be

--- a/nomad/volumewatcher/volume_watcher_test.go
+++ b/nomad/volumewatcher/volume_watcher_test.go
@@ -65,8 +65,13 @@ func TestVolumeWatch_Reap(t *testing.T) {
 	alloc.ClientStatus = structs.AllocClientStatusComplete
 
 	index++
+
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc},
+	}
+
 	must.NoError(t, store.UpdateAllocsFromClient(
-		structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc}))
+		structs.MsgTypeTestSetup, index, updateReq))
 
 	vol, _ = store.CSIVolumeDenormalize(nil, vol.Copy())
 	must.MapLen(t, 1, vol.ReadClaims)

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -274,6 +274,7 @@ func (s *GenericScheduler) process() (bool, error) {
 	if len(s.followUpEvals) > 0 && s.eval.WaitUntil.IsZero() {
 		for _, eval := range s.followUpEvals {
 			eval.PreviousEval = s.eval.ID
+			s.eval.NextEval = eval.ID
 			// TODO(preetha) this should be batching evals before inserting them
 			if err := s.planner.CreateEval(eval); err != nil {
 				s.logger.Error("failed to make next eval for rescheduling", "error", err)

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -4095,7 +4095,12 @@ func TestServiceSched_NodeUpdate(t *testing.T) {
 	for i := 0; i < 4; i++ {
 		out, _ := h.State.AllocByID(ws, allocs[i].ID)
 		out.ClientStatus = structs.AllocClientStatusRunning
-		must.NoError(t, h.State.UpdateAllocsFromClient(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{out}))
+
+		updateReq := structs.AllocUpdateRequest{
+			Alloc: []*structs.Allocation{out},
+		}
+
+		must.NoError(t, h.State.UpdateAllocsFromClient(structs.MsgTypeTestSetup, h.NextIndex(), updateReq))
 	}
 
 	// Create a mock evaluation which won't trigger any new placements
@@ -4247,7 +4252,10 @@ func TestServiceSched_NodeDrain_Down(t *testing.T) {
 		newAlloc.ClientStatus = structs.AllocClientStatusRunning
 		running = append(running, newAlloc)
 	}
-	must.NoError(t, h.State.UpdateAllocsFromClient(structs.MsgTypeTestSetup, h.NextIndex(), running))
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: running,
+	}
+	must.NoError(t, h.State.UpdateAllocsFromClient(structs.MsgTypeTestSetup, h.NextIndex(), updateReq))
 
 	// Mark some of the allocations as complete
 	var complete []*structs.Allocation
@@ -4266,7 +4274,11 @@ func TestServiceSched_NodeDrain_Down(t *testing.T) {
 		newAlloc.ClientStatus = structs.AllocClientStatusComplete
 		complete = append(complete, newAlloc)
 	}
-	must.NoError(t, h.State.UpdateAllocsFromClient(structs.MsgTypeTestSetup, h.NextIndex(), complete))
+
+	updateReq2 := structs.AllocUpdateRequest{
+		Alloc: complete,
+	}
+	must.NoError(t, h.State.UpdateAllocsFromClient(structs.MsgTypeTestSetup, h.NextIndex(), updateReq2))
 
 	// Create a mock evaluation to deal with the node update
 	eval := &structs.Evaluation{

--- a/scheduler/scheduler_system_test.go
+++ b/scheduler/scheduler_system_test.go
@@ -142,7 +142,12 @@ func TestSystemSched_JobRegister_StickyAllocs(t *testing.T) {
 	// Get an allocation and mark it as failed
 	alloc := planned[4].Copy()
 	alloc.ClientStatus = structs.AllocClientStatusFailed
-	must.NoError(t, h.State.UpdateAllocsFromClient(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Allocation{alloc}))
+
+	updateReq := structs.AllocUpdateRequest{
+		Alloc: []*structs.Allocation{alloc},
+	}
+
+	must.NoError(t, h.State.UpdateAllocsFromClient(structs.MsgTypeTestSetup, h.NextIndex(), updateReq))
 
 	// Create a mock evaluation to handle the update
 	eval = &structs.Evaluation{


### PR DESCRIPTION
### Description
While trying to add a wait flag to batch jobs I noticed they are declared as `dead` at some point of the deployment process, after some investigation I noticed it happened too on service jobs. It came down to two issues:

- When updating a failed alloc and its corresponding evaluations, it was done in 2 different transactions. In the transaction when the alloc was updated, the evals where not updated yet, leading to a job that only had failed allocs and was rightfully considered dead.

- For service jobs, an alloc failed update from the client will generate an update that will only see failed allocs and complete evals because the replacement eval is created by the deployment watcher that is only triggered by the alloc update in the state store. 

To fix the problems this PR introduces:

- A unique transaction for updating both allocs and evals.
- When establishing the status of a job, take active deployments into account.

### Testing & Reproduction steps

To reproduce it run the following job and start a blocking query on the job:
```
job "example" {
  group "g" {
    task "t" {
      driver = "raw_exec"
      config {
        command = "bash"
        args    = ["-xc", "sleep 5; exit 1"]
      }
    }
    restart {
      attempts = 1
      interval = "30m"
      delay    = "1s"
    }
    reschedule {
      unlimited = false
      delay     = "5s"
      attempts  = 1
      interval  = "1h"
    }
  }
}
```


### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
