### PR TITLE
chore: typo sweep (seperate, publically, nonexistant, succesful)

### DIFF
--- a/client/allocrunner/taskrunner/getter/util_linux.go
+++ b/client/allocrunner/taskrunner/getter/util_linux.go
@@ -47,7 +47,7 @@ func findHomeDir() string {
 
 // findConfigDir returns the config directory as provided by os.UserConfigDir. In
 // case os.UserConfigDir returns an error, the path is built if possible. Otherwise
-// a nonexistant path is returned.
+// a nonexistent path is returned.
 func findConfigDir() string {
 	config, err := os.UserConfigDir()
 	if err == nil {

--- a/command/monitor_test.go
+++ b/command/monitor_test.go
@@ -323,7 +323,7 @@ func TestMonitor_MonitorBlockedEval(t *testing.T) {
 		t.Fatalf("eval monitor took too long")
 	}
 
-	// Verify status code is 0 since deployment was succesful.
+	// Verify status code is 0 since deployment was successful.
 	must.Zero(t, code)
 }
 

--- a/contributing/ai.md
+++ b/contributing/ai.md
@@ -19,7 +19,7 @@ in your Pull Request description.
 ### Accountability
 Understanding that AI usage can range along a spectrum from AI assistance to AI
 led approaches we strongly prefer an approach that leaves the contributor in the
-drivers seat. AI is a tool, not a seperate contributor. The responsibility for
+drivers seat. AI is a tool, not a separate contributor. The responsibility for
 changes submitted lies entirely with you, the human opening the PR.
 
 - Human ownership: All PRs must be submitted by a real, human-owned account. We

--- a/nomad/keyring_endpoint.go
+++ b/nomad/keyring_endpoint.go
@@ -435,7 +435,7 @@ func (k *Keyring) ListPublic(args *structs.GenericRequest, reply *structs.Keyrin
 // GetConfig for workload identities. This RPC is used to back an OIDC
 // Discovery endpoint.
 //
-// Unauthenticated because OIDC Discovery endpoints must be publically
+// Unauthenticated because OIDC Discovery endpoints must be publicly
 // available.
 func (k *Keyring) GetConfig(args *structs.GenericRequest, reply *structs.KeyringGetConfigResponse) error {
 

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -7558,7 +7558,7 @@ func TestServiceSched_CSIVolumesPerAlloc(t *testing.T) {
 	must.NoError(t, err)
 	must.Len(t, 5, out, must.Sprint("expected 5 placed allocations total"))
 
-	// Make sure they're still all on seperate clients
+	// Make sure they're still all on separate clients
 	seen = map[string]struct{}{}
 	for _, alloc := range out {
 		_, ok := seen[alloc.NodeID]


### PR DESCRIPTION
Five single-character typo fixes, all in comments/prose — no functional change:

- `contributing/ai.md:22` — AI is a tool, not a `seperate` -> `separate` contributor
- `scheduler/generic_sched_test.go:7561` — `seperate` -> `separate` clients (test comment)
- `nomad/keyring_endpoint.go:438` — OIDC Discovery `publically` -> `publicly` available (doc comment)
- `client/allocrunner/taskrunner/getter/util_linux.go:50` — `nonexistant` -> `nonexistent` path (doc comment)
- `command/monitor_test.go:326` — deployment was `succesful` -> `successful` (test comment)