### PR TITLE
Fix: Event type for node eligibility update

### DIFF
--- a/nomad/state/events.go
+++ b/nomad/state/events.go
@@ -21,7 +21,7 @@ var MsgTypeEvents = map[structs.MessageType]string{
 	structs.JobDeregisterRequestType:                     structs.TypeJobDeregistered,
 	structs.JobBatchDeregisterRequestType:                structs.TypeJobBatchDeregistered,
 	structs.AllocUpdateDesiredTransitionRequestType:      structs.TypeAllocationUpdateDesiredStatus,
-	structs.NodeUpdateEligibilityRequestType:             structs.TypeNodeDrain,
+	structs.NodeUpdateEligibilityRequestType:             structs.TypeNodeEligibilityUpdate,
 	structs.NodeUpdateDrainRequestType:                   structs.TypeNodeDrain,
 	structs.BatchNodeUpdateDrainRequestType:              structs.TypeNodeDrain,
 	structs.DeploymentStatusUpdateRequestType:            structs.TypeDeploymentUpdate,

--- a/nomad/state/events_test.go
+++ b/nomad/state/events_test.go
@@ -627,7 +627,7 @@ func TestEventsFromChanges_NodeUpdateEligibilityRequestType(t *testing.T) {
 
 	for _, e := range events {
 		must.Eq(t, 100, int(e.Index))
-		must.Eq(t, structs.TypeNodeDrain, e.Type)
+		must.Eq(t, structs.TypeNodeEligibilityUpdate, e.Type)
 		must.Eq(t, structs.TopicNode, e.Topic)
 		ne := e.Payload.(*structs.NodeStreamEvent)
 		must.Eq(t, event.Message, ne.Node.Events[len(ne.Node.Events)-1].Message)


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Fix event type for node eligibility update, which earlier defaulted to node drain
(I am not sure why we defaulted to node drain earlier, but happy to discuss if there was any reason for that, since right now I am unable to distinguish between the node drain even and node eligibility update event)

### Testing & Reproduction steps
* Subscribe to an event stream and toggle the eligibility of a node, the even you will get is of type `NodeDrain` while they should be of type `NodeEligibility`
* I have updated the test around it, which also currently checks for `NodeDrain`

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
