### PR TITLE
server: Configurable RPC dial timeout

### DIFF
--- a/.changelog/27862.txt
+++ b/.changelog/27862.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+server: RPC dial timeout is configurable
+```

--- a/client/client.go
+++ b/client/client.go
@@ -386,7 +386,7 @@ func NewClient(cfg *config.Config, consulCatalog consul.CatalogAPI, consulProxie
 		consulProxiesFunc:    consulProxiesFunc,
 		consulServices:       consulServices,
 		start:                time.Now(),
-		connPool:             pool.NewPool(logger, clientRPCCache, clientMaxStreams, tlsWrap, cfg.RPCSessionConfig),
+		connPool:             pool.NewPool(logger, clientRPCCache, clientMaxStreams, tlsWrap, cfg.RPCSessionConfig, cfg.RPCDialTimeout),
 		tlsWrap:              tlsWrap,
 		streamingRpcs:        structs.NewStreamingRpcRegistry(),
 		logger:               logger,

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -285,6 +285,10 @@ type Config struct {
 	// RPCSessionConfig configures yamux multiplex
 	RPCSessionConfig *yamux.Config
 
+	// RPCDialTimeout is the timeout used when establishing new outbound RPC
+	// connections to servers. Defaults to 10s.
+	RPCDialTimeout time.Duration
+
 	// PluginLoader is used to load plugins.
 	PluginLoader loader.PluginCatalog
 
@@ -925,6 +929,7 @@ func DefaultConfig() *Config {
 		TemplateConfig:          DefaultTemplateConfig(),
 		RPCHoldTimeout:          5 * time.Second,
 		RPCSessionConfig:        yamux.DefaultConfig(),
+		RPCDialTimeout:          10 * time.Second,
 		CNIPath:                 DefaultCNIPath,
 		CNIConfigDir:            "/opt/cni/config",
 		CNIInterfacePrefix:      "eth",

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -221,7 +221,7 @@ func bridgedStreamingRpcHandler(sideA io.ReadWriteCloser) structs.StreamingRpcHa
 // streaming RPC.
 func (c *Client) streamingRpcConn(server *servers.Server, method string) (net.Conn, error) {
 	// Dial the server
-	conn, err := net.DialTimeout("tcp", server.Addr.String(), 10*time.Second)
+	conn, err := net.DialTimeout("tcp", server.Addr.String(), c.config.RPCDialTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/client/testing.go
+++ b/client/testing.go
@@ -120,7 +120,7 @@ func TestRPCOnlyClient(t testing.TB, cb func(c *config.Config), srvAddr net.Addr
 	}
 	client.heartbeatStop = newHeartbeatStop(
 		client.getAllocRunner, time.Second, client.logger, client.shutdownCh)
-	client.connPool = pool.NewPool(testlog.HCLogger(t), 10*time.Second, 10, nil, yamux.DefaultConfig())
+	client.connPool = pool.NewPool(testlog.HCLogger(t), 10*time.Second, 10, nil, yamux.DefaultConfig(), 10*time.Second)
 	client.init()
 
 	cancelFunc := func() {

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -573,6 +573,9 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 		if agentConfig.RPC.StreamOpenTimeout > 0 {
 			conf.RPCSessionConfig.StreamOpenTimeout = agentConfig.RPC.StreamOpenTimeout
 		}
+		if agentConfig.RPC.DialTimeout > 0 {
+			conf.RPCDialTimeout = agentConfig.RPC.DialTimeout
+		}
 	}
 
 	// Set the TLS config
@@ -945,6 +948,9 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 		}
 		if agentConfig.RPC.StreamOpenTimeout > 0 {
 			conf.RPCSessionConfig.StreamOpenTimeout = agentConfig.RPC.StreamOpenTimeout
+		}
+		if agentConfig.RPC.DialTimeout > 0 {
+			conf.RPCDialTimeout = agentConfig.RPC.DialTimeout
 		}
 	}
 

--- a/command/agent/agent_test.go
+++ b/command/agent/agent_test.go
@@ -817,6 +817,21 @@ func TestConvertClientConfig(t *testing.T) {
 				must.True(t, cc.DisableAllocationHookMetrics)
 			},
 		},
+		{
+			name: "rpc dial timeout default",
+			assert: func(t *testing.T, cc *clientconfig.Config) {
+				must.Eq(t, 10*time.Second, cc.RPCDialTimeout)
+			},
+		},
+		{
+			name: "rpc dial timeout override",
+			modConfig: func(c *Config) {
+				c.RPC.DialTimeout = 25 * time.Second
+			},
+			assert: func(t *testing.T, cc *clientconfig.Config) {
+				must.Eq(t, 25*time.Second, cc.RPCDialTimeout)
+			},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -838,6 +853,46 @@ func TestConvertClientConfig(t *testing.T) {
 			if tc.assert != nil {
 				tc.assert(t, cc)
 			}
+		})
+	}
+}
+
+// TestAgent_ServerConfig_RPCDialTimeout verifies that rpc.dial_timeout is
+// plumbed through to the nomad server config, falling back to the default
+// when unset.
+func TestAgent_ServerConfig_RPCDialTimeout(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name       string
+		modConfig  func(*Config)
+		expectedTO time.Duration
+	}{
+		{
+			name:       "default",
+			expectedTO: 10 * time.Second,
+		},
+		{
+			name: "override",
+			modConfig: func(c *Config) {
+				c.RPC.DialTimeout = 25 * time.Second
+			},
+			expectedTO: 25 * time.Second,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conf := DevConfig(nil)
+			require.NoError(t, conf.normalizeAddrs())
+			if tc.modConfig != nil {
+				tc.modConfig(conf)
+			}
+
+			nc, err := convertServerConfig(conf)
+			must.NoError(t, err)
+			must.NotNil(t, nc)
+			must.Eq(t, tc.expectedTO, nc.RPCDialTimeout)
 		})
 	}
 }

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -872,6 +872,11 @@ type RPCConfig struct {
 	// and send a RST to the remote side.
 	StreamCloseTimeout    time.Duration
 	StreamCloseTimeoutHCL string `hcl:"stream_close_timeout,optional"`
+
+	// DialTimeout is the timeout used when establishing new outbound RPC
+	// connections to peers. A zero value uses the default.
+	DialTimeout    time.Duration
+	DialTimeoutHCL string `hcl:"dial_timeout,optional"`
 }
 
 func (r *RPCConfig) Copy() *RPCConfig {
@@ -921,6 +926,12 @@ func (r *RPCConfig) Merge(rpc *RPCConfig) *RPCConfig {
 	if rpc.StreamCloseTimeout > 0 {
 		result.StreamCloseTimeout = rpc.StreamCloseTimeout
 	}
+	if rpc.DialTimeoutHCL != "" {
+		result.DialTimeoutHCL = rpc.DialTimeoutHCL
+	}
+	if rpc.DialTimeout > 0 {
+		result.DialTimeout = rpc.DialTimeout
+	}
 	return &result
 }
 
@@ -940,6 +951,9 @@ func (r *RPCConfig) Validate() error {
 		}
 		if r.StreamOpenTimeout < 0 {
 			return errors.New("rcp.stream_open_timeout must be greater than zero")
+		}
+		if r.DialTimeout < 0 {
+			return errors.New("rpc.dial_timeout must be greater than or equal to zero")
 		}
 	}
 
@@ -1819,6 +1833,8 @@ func DefaultConfig() *Config {
 			StreamOpenTimeoutHCL:      "75s",
 			StreamCloseTimeout:        5 * time.Minute,
 			StreamCloseTimeoutHCL:     "5m",
+			DialTimeout:               10 * time.Second,
+			DialTimeoutHCL:            "10s",
 		},
 		Client: &ClientConfig{
 			Enabled:               false,

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -191,6 +191,7 @@ func ParseConfigFile(path string) (*Config, error) {
 		{"rpc.connection_write_timeout", &c.RPC.ConnectionWriteTimeout, &c.RPC.ConnectionWriteTimeoutHCL, nil},
 		{"rpc.stream_open_timeout", &c.RPC.StreamOpenTimeout, &c.RPC.StreamOpenTimeoutHCL, nil},
 		{"rpc.stream_close_timeout", &c.RPC.StreamCloseTimeout, &c.RPC.StreamCloseTimeoutHCL, nil},
+		{"rpc.dial_timeout", &c.RPC.DialTimeout, &c.RPC.DialTimeoutHCL, nil},
 		{
 			"server.client_introduction.default_identity_ttl",
 			&c.Server.ClientIntroduction.DefaultIdentityTTL,

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -868,6 +868,8 @@ var sample1 = &Config{
 		StreamOpenTimeoutHCL:      "75s",
 		StreamCloseTimeout:        5 * time.Minute,
 		StreamCloseTimeoutHCL:     "5m",
+		DialTimeout:               15 * time.Second,
+		DialTimeoutHCL:            "15s",
 	},
 	Audit: &config.AuditConfig{
 		Enabled: pointer.Of(true),

--- a/command/agent/testdata/sample1/sample0.json
+++ b/command/agent/testdata/sample1/sample0.json
@@ -25,7 +25,8 @@
     "connection_write_timeout": "10s",
     "max_stream_window_size": 262144,
     "stream_open_timeout": "75s",
-    "stream_close_timeout": "5m"
+    "stream_close_timeout": "5m",
+    "dial_timeout": "15s"
   },
   "leave_on_interrupt": true,
   "leave_on_terminate": true,

--- a/command/agent/testdata/sample1/sample1.json
+++ b/command/agent/testdata/sample1/sample1.json
@@ -24,7 +24,8 @@
     "connection_write_timeout": "10s",
     "max_stream_window_size": 262144,
     "stream_open_timeout": "75s",
-    "stream_close_timeout": "5m"
+    "stream_close_timeout": "5m",
+    "dial_timeout": "15s"
   },
   "server": {
     "bootstrap_expect": 3,

--- a/command/agent/testdata/sample1/sample2.hcl
+++ b/command/agent/testdata/sample1/sample2.hcl
@@ -24,6 +24,7 @@ rpc {
   max_stream_window_size   = 262144
   stream_open_timeout      = "75s"
   stream_close_timeout     = "5m"
+  dial_timeout             = "15s"
 }
 
 vault = {

--- a/helper/pool/pool.go
+++ b/helper/pool/pool.go
@@ -22,6 +22,10 @@ import (
 	"github.com/hashicorp/yamux"
 )
 
+// defaultDialTimeout is the fallback timeout used when a ConnPool is
+// constructed without an explicit dial timeout.
+const defaultDialTimeout = 10 * time.Second
+
 // NewClientCodec returns a new rpc.ClientCodec to be used to make RPC calls.
 func NewClientCodec(conn io.ReadWriteCloser) rpc.ClientCodec {
 	return msgpackrpc.NewCodecFromHandle(true, true, conn, structs.MsgpackHandle)
@@ -185,6 +189,10 @@ type ConnPool struct {
 	// The maximum number of open streams to keep
 	maxStreams int
 
+	// dialTimeout is the timeout used when establishing new outbound
+	// connections. A zero value falls back to defaultDialTimeout.
+	dialTimeout time.Duration
+
 	// Pool maps an address to a open connection
 	pool map[string]*Conn
 
@@ -213,18 +221,25 @@ type ConnPool struct {
 // Maintain at most one connection per host, for up to maxTime.
 // Set maxTime to 0 to disable reaping. maxStreams is used to control
 // the number of idle streams allowed.
+// dialTimeout is the timeout used when establishing new outbound
+// connections. A zero value falls back to defaultDialTimeout.
 // If TLS settings are provided outgoing connections use TLS.
 func NewPool(
-	logger hclog.Logger, maxTime time.Duration, maxStreams int, tlsWrap tlsutil.RegionWrapper, yamuxCfg *yamux.Config,
+	logger hclog.Logger, maxTime time.Duration, maxStreams int, tlsWrap tlsutil.RegionWrapper,
+	yamuxCfg *yamux.Config, dialTimeout time.Duration,
 ) *ConnPool {
+	if dialTimeout <= 0 {
+		dialTimeout = defaultDialTimeout
+	}
 	pool := &ConnPool{
-		logger:     logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true}),
-		maxTime:    maxTime,
-		maxStreams: maxStreams,
-		pool:       make(map[string]*Conn),
-		limiter:    make(map[string]chan struct{}),
-		tlsWrap:    tlsWrap,
-		shutdownCh: make(chan struct{}),
+		logger:      logger.StandardLogger(&hclog.StandardLoggerOptions{InferLevels: true}),
+		maxTime:     maxTime,
+		maxStreams:  maxStreams,
+		dialTimeout: dialTimeout,
+		pool:        make(map[string]*Conn),
+		limiter:     make(map[string]chan struct{}),
+		tlsWrap:     tlsWrap,
+		shutdownCh:  make(chan struct{}),
 	}
 
 	// The passed yamux config is the shared server object, so we do not want to
@@ -372,7 +387,7 @@ func (p *ConnPool) acquire(region string, addr net.Addr) (*Conn, error) {
 // getNewConn is used to return a new connection
 func (p *ConnPool) getNewConn(region string, addr net.Addr) (*Conn, error) {
 	// Try to dial the conn
-	conn, err := net.DialTimeout("tcp", addr.String(), 10*time.Second)
+	conn, err := net.DialTimeout("tcp", addr.String(), p.dialTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/helper/pool/pool_test.go
+++ b/helper/pool/pool_test.go
@@ -19,7 +19,7 @@ import (
 
 func newTestPool(t *testing.T) *ConnPool {
 	l := testlog.HCLogger(t)
-	p := NewPool(l, 1*time.Minute, 10, nil, yamux.DefaultConfig())
+	p := NewPool(l, 1*time.Minute, 10, nil, yamux.DefaultConfig(), 10*time.Second)
 	return p
 }
 
@@ -30,10 +30,19 @@ func Test_NewPool(t *testing.T) {
 	yamuxConfig := yamux.DefaultConfig()
 	yamuxConfig.AcceptBacklog = math.MaxInt
 
-	testPool := NewPool(hclog.NewNullLogger(), 10*time.Second, 10, nil, yamuxConfig)
+	testPool := NewPool(hclog.NewNullLogger(), 10*time.Second, 10, nil, yamuxConfig, 15*time.Second)
 	must.NotNil(t, testPool)
 	must.NotNil(t, testPool.yamuxCfg)
 	must.Eq(t, yamuxConfig.AcceptBacklog, testPool.yamuxCfg.AcceptBacklog)
+	must.Eq(t, 15*time.Second, testPool.dialTimeout)
+}
+
+func Test_NewPool_DefaultDialTimeout(t *testing.T) {
+	// A zero (or negative) dial timeout should fall back to the default
+	// rather than dialing with no timeout at all.
+	testPool := NewPool(hclog.NewNullLogger(), 10*time.Second, 10, nil, yamux.DefaultConfig(), 0)
+	must.NotNil(t, testPool)
+	must.Eq(t, defaultDialTimeout, testPool.dialTimeout)
 }
 
 func TestConnPool_ConnListener(t *testing.T) {

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -407,6 +407,10 @@ type Config struct {
 	// RPCSessionConfig configures the yamux session configuration for RPC
 	RPCSessionConfig *yamux.Config
 
+	// RPCDialTimeout is the timeout used when establishing new outbound RPC
+	// connections to peer servers. Defaults to 10s.
+	RPCDialTimeout time.Duration
+
 	// LicenseConfig stores information about the Enterprise license loaded for the server.
 	LicenseConfig *LicenseConfig
 
@@ -678,6 +682,7 @@ func DefaultConfig() *Config {
 			structs.VaultDefaultCluster: config.DefaultVaultConfig()},
 		RPCHoldTimeout:           5 * time.Second,
 		RPCSessionConfig:         yamux.DefaultConfig(),
+		RPCDialTimeout:           10 * time.Second,
 		StatsCollectionInterval:  1 * time.Minute,
 		TLSConfig:                &config.TLSConfig{},
 		ReplicationBackoff:       30 * time.Second,

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -361,7 +361,7 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigFunc
 	s := &Server{
 		config:                  config,
 		consulCatalog:           consulCatalog,
-		connPool:                pool.NewPool(logger, serverRPCCache, serverMaxStreams, tlsWrap, config.RPCSessionConfig),
+		connPool:                pool.NewPool(logger, serverRPCCache, serverMaxStreams, tlsWrap, config.RPCSessionConfig, config.RPCDialTimeout),
 		logger:                  logger,
 		tlsWrap:                 tlsWrap,
 		rpcServer:               rpc.NewServer(),


### PR DESCRIPTION
### Description

An open issue is #27834 Server shutdown can cause long delays for non-blocking RPCs.

A mitigation for this problem is to allow a configurable dial timeout for contacting servers. Prior to this change the dial timeout is a hardcoded 10s, which is a very long time on networks where nomad is likely to be running.

### Testing & Reproduction steps

To reproduce shutdown delays, shut down a server and then quickly make a request like 'read-allocation-statistics' against different servers. A 10s RPC hang should be observable.

You can then set this setting, repeat, and observe a delay matching the new setting.

### Contributor Checklist
- [X] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [X] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
