### PR TITLE
 fix stale device allocator state after preemption

### DIFF
--- a/.changelog/27880.txt
+++ b/.changelog/27880.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fixed a bug where preemption of allocations by tasks that require devices could incorrectly fail placement
+```

--- a/scheduler/feasible/rank.go
+++ b/scheduler/feasible/rank.go
@@ -641,6 +641,7 @@ NEXTNODE:
 
 							offer = offerEvict
 							sumAffinities = sumAffinitiesEvict
+							devAllocator = devAllocatorEvict
 						}
 
 						// assign the offer for this device to our allocator

--- a/scheduler/feasible/rank_test.go
+++ b/scheduler/feasible/rank_test.go
@@ -2066,6 +2066,119 @@ func TestBinPackIterator_Device_Failure_With_Eviction(t *testing.T) {
 	must.Eq(t, 1, ctx.metrics.DimensionExhausted["devices: no devices match request"])
 }
 
+func TestBinPackIterator_Device_Preemption_MultipleDeviceRequests(t *testing.T) {
+	_, ctx := MockContext(t)
+
+	lowPriorityJob := mock.Job()
+	lowPriorityJob.Priority = 50
+
+	node := &RankedNode{
+		Node: &structs.Node{
+			ID: uuid.Generate(),
+			NodeResources: &structs.NodeResources{
+				Processors: processorResources4096,
+				Cpu:        legacyCpuResources4096,
+				Memory: structs.NodeMemoryResources{
+					MemoryMB: 4096,
+				},
+				Networks: []*structs.NetworkResource{},
+				Devices: []*structs.NodeDeviceResource{
+					{
+						Vendor: "nvidia",
+						Type:   "gpu",
+						Name:   "SOME-GPU",
+						Instances: []*structs.NodeDevice{
+							{
+								ID:                "1",
+								Healthy:           true,
+								HealthDescription: "healthy",
+								Locality:          &structs.NodeDeviceLocality{},
+							},
+							{
+								ID:                "2",
+								Healthy:           true,
+								HealthDescription: "healthy",
+								Locality:          &structs.NodeDeviceLocality{},
+							},
+						},
+					},
+				},
+			},
+			ReservedResources: &structs.NodeReservedResources{},
+		},
+	}
+
+	existingAlloc := &structs.Allocation{
+		ID:     uuid.Generate(),
+		JobID:  lowPriorityJob.ID,
+		Job:    lowPriorityJob,
+		NodeID: node.Node.ID,
+		AllocatedResources: &structs.AllocatedResources{
+			Tasks: map[string]*structs.AllocatedTaskResources{
+				"web": {
+					Devices: []*structs.AllocatedDeviceResource{
+						{
+							Vendor:    "nvidia",
+							Type:      "gpu",
+							Name:      "SOME-GPU",
+							DeviceIDs: []string{"1", "2"},
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx.Plan().NodeAllocation[node.Node.ID] = []*structs.Allocation{existingAlloc}
+
+	highPriorityJob := mock.Job()
+	highPriorityJob.Priority = 100
+
+	taskGroup := &structs.TaskGroup{
+		EphemeralDisk: &structs.EphemeralDisk{},
+		Tasks: []*structs.Task{
+			{
+				Name: "trainer",
+				Resources: &structs.Resources{
+					CPU:      1000,
+					MemoryMB: 512,
+					Networks: []*structs.NetworkResource{},
+					Devices: structs.ResourceDevices{
+						{
+							Name:  "nvidia/gpu",
+							Count: 1,
+						},
+						{
+							Name:  "nvidia/gpu",
+							Count: 1,
+						},
+					},
+					NUMA: &structs.NUMA{Affinity: structs.NoneNUMA},
+				},
+			},
+		},
+		Networks: []*structs.NetworkResource{},
+	}
+
+	static := NewStaticRankIterator(ctx, []*RankedNode{node})
+	binp := NewBinPackIterator(ctx, static, true, 0)
+	binp.SetJob(highPriorityJob)
+	binp.SetTaskGroup(taskGroup)
+	binp.SetSchedulerConfiguration(testSchedulerConfig)
+
+	scoreNorm := NewScoreNormalizationIterator(ctx, binp)
+	out := collectRanked(scoreNorm)
+
+	must.Len(t, 1, out)
+	must.Len(t, 1, out[0].PreemptedAllocs)
+	must.Eq(t, existingAlloc.ID, out[0].PreemptedAllocs[0].ID)
+
+	tr, ok := out[0].TaskResources["trainer"]
+	must.True(t, ok)
+	must.Len(t, 2, tr.Devices)
+	must.Eq(t, 1, len(tr.Devices[0].DeviceIDs))
+	must.Eq(t, 1, len(tr.Devices[1].DeviceIDs))
+}
+
 // Tests that bin packing iterator will not place workloads on nodes
 // that would go over a designated MaxAlloc value
 func TestBinPackIterator_MaxAlloc(t *testing.T) {


### PR DESCRIPTION
### Description
Fixes a scheduler bug where stale device allocator state caused false node exhaustion during preemption of multi-device tasks.

In `scheduler/feasible/rank.go`, the NUMA-aware device scheduling path (`SELECT_BY_NUMA_WITH_EVICT`) creates a fresh allocator (`devAllocatorEvict`) after successful preemption to reflect the post-eviction state. While the offer is correctly computed from this updated allocator, the reservation is mistakenly recorded on the original (stale) allocator.

As a result, subsequent device requests within the same task observe outdated allocation state and incorrectly treat already-evicted devices as still in use. This causes placement to fail and the node to be marked as exhausted, even though sufficient devices are available.

This PR fixes the issue by ensuring that reservations are recorded against the updated allocator state used after preemption.


### Testing & Reproduction

#### Reproduction
1. Use a node with 2+ devices (e.g., GPUs).
2. Run a low-priority job consuming those devices.
3. Submit a higher-priority job requesting multiple devices.
4. Without this fix, scheduling fails after preemption due to stale allocator state.

#### Automated Tests
Adds a regression test:
`TestBinPackIterator_Device_Preemption_MultipleDeviceRequests`

This test verifies that multi-device requests succeed after preemption and do not observe stale allocator state.

Run with:
```bash
GOTOOLCHAIN=auto go test -v ./scheduler/feasible -run TestBinPackIterator_Device_Preemption_MultipleDeviceRequests
```

Links

Fixes #27820

### Contributor Checklist
- [ ] Changelog Entry Recommended (scheduler behavior fix affecting placement correctness)
- [X] Testing Added regression test covering multi-device preemption scenario
- [X] Documentation Not required (internal scheduler fix)

### Reviewer Checklist
- [ ] Backport Labels
- [ ] Commit Type (squash and merge recommended)

### Changes to Security Controls
None