### PR TITLE
command: propagate -hcl2-strict=false into job plan output

### DIFF
--- a/.changelog/23656.txt
+++ b/.changelog/23656.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: `job plan` now propagates `-hcl2-strict=false` into the suggested `nomad job run -check-index` invocation when the user passed it on the plan command line
+```

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -231,6 +231,13 @@ func (c *JobPlanCommand) Run(args []string) int {
 		runArgs.WriteString(fmt.Sprintf("-namespace=%q ", c.namespace))
 	}
 
+	// -hcl2-strict defaults to true. If the user opted out for plan, the
+	// follow-up `nomad job run -check-index ...` invocation needs the same
+	// flag or the parser will reject the file again.
+	if !c.JobGetter.Strict {
+		runArgs.WriteString("-hcl2-strict=false ")
+	}
+
 	exitCode := c.outputPlannedJob(job, resp, diff, verbose)
 	c.Ui.Output(c.Colorize().Color(formatJobModifyIndex(resp.JobModifyIndex, runArgs.String(), path)))
 	return exitCode


### PR DESCRIPTION
### Description

When the user passes `-hcl2-strict=false` to `nomad job plan` (because their job file references vars not defined in the root variables — see #16136), the follow-up command suggestion that `plan` prints today only echoes `-var`, `-var-file`, and `-namespace`:

```
To submit the job with version verification run:

nomad job run -check-index 463904 -var-file="staging.vars" myjobfile.hcl
```

So copy-pasting that command fails the same way the original `plan` would have failed without `-hcl2-strict=false`, and the user has to re-add the flag on every iteration.

This PR appends `-hcl2-strict=false` to the suggested args whenever the user opted out for plan, and leaves the default (true) case alone so the suggestion stays clean in the common path.

### Testing & Reproduction steps

```
nomad job plan -hcl2-strict=false -var-file=staging.vars myjob.hcl
# Now the printed run command also includes -hcl2-strict=false
```

### Links

Fixes #23656

### Contributor Checklist
- [x] **Changelog Entry** `make cl` style entry added at `.changelog/23656.txt`.
- [ ] **Testing** No new test added; the change is purely string-builder formatting and the existing `TestPlanCommand_*` tests still pass.
- [ ] **Documentation** No doc change; `-hcl2-strict` is already documented in the plan/run command help.