### PR TITLE
timer: removes NewSafeTimer in favor of time.After

### DIFF
--- a/client/allochealth/tracker.go
+++ b/client/allochealth/tracker.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/nomad/client/serviceregistration/checks/checkstore"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/taskenv"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -626,10 +625,6 @@ func evaluateConsulChecks(services []*structs.Service, registrations *servicereg
 //
 // Does not watch Consul service checks; see watchConsulEvents for those.
 func (t *Tracker) watchNomadEvents() {
-	// checkTicker is the ticker that triggers us to look at the checks in Nomad
-	checkTicker, cancel := helper.NewSafeTimer(t.checkLookupInterval)
-	defer cancel()
-
 	// waiter is used to fire when the checks have been healthy for the MinHealthyTime
 	waiter := newHealthyFuture()
 
@@ -650,9 +645,8 @@ func (t *Tracker) watchNomadEvents() {
 			return
 
 		// it is time to check the checks
-		case <-checkTicker.C:
+		case <-time.After(t.checkLookupInterval):
 			results = t.checkStore.List(allocID)
-			checkTicker.Reset(t.checkLookupInterval)
 
 		// enough time has passed with healthy checks
 		case <-waiter.C():

--- a/client/allocrunner/checks_hook.go
+++ b/client/allocrunner/checks_hook.go
@@ -41,7 +41,7 @@ type observer struct {
 // start checking our check on its interval
 func (o *observer) start() {
 	// compromise between immediate (too early) and waiting full interval (slow)
-	firstWait := o.check.Interval / 2
+	wait := o.check.Interval / 2
 
 	for {
 		select {
@@ -51,12 +51,14 @@ func (o *observer) start() {
 			return
 
 		// time to execute the check
-		case <-time.After(firstWait):
+		case <-time.After(wait):
 			query := checks.GetCheckQuery(o.check)
 			result := o.checker.Do(o.ctx, o.qc, query)
 
 			// and put the results into the store (already logged)
 			_ = o.checkStore.Set(o.allocID, result)
+
+			wait = o.check.Interval
 		}
 	}
 }

--- a/client/allocrunner/checks_hook.go
+++ b/client/allocrunner/checks_hook.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hashicorp/nomad/client/serviceregistration/checks"
 	"github.com/hashicorp/nomad/client/serviceregistration/checks/checkstore"
 	"github.com/hashicorp/nomad/client/taskenv"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -44,9 +43,6 @@ func (o *observer) start() {
 	// compromise between immediate (too early) and waiting full interval (slow)
 	firstWait := o.check.Interval / 2
 
-	timer, cancel := helper.NewSafeTimer(firstWait)
-	defer cancel()
-
 	for {
 		select {
 
@@ -55,15 +51,12 @@ func (o *observer) start() {
 			return
 
 		// time to execute the check
-		case <-timer.C:
+		case <-time.After(firstWait):
 			query := checks.GetCheckQuery(o.check)
 			result := o.checker.Do(o.ctx, o.qc, query)
 
 			// and put the results into the store (already logged)
 			_ = o.checkStore.Set(o.allocID, result)
-
-			// setup timer for next interval
-			timer.Reset(o.check.Interval)
 		}
 	}
 }

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -394,13 +394,11 @@ func (c *csiHook) claimWithRetry(req *structs.CSIVolumeClaimRequest) (*structs.C
 	var resp structs.CSIVolumeClaimResponse
 	var err error
 	backoff := c.minBackoffInterval
-	t, stop := helper.NewSafeTimer(0)
-	defer stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return nil, err
-		case <-t.C:
+		case <-time.After(backoff):
 		}
 
 		err = c.rpcClient.RPC("CSIVolume.Claim", req, &resp)
@@ -420,7 +418,6 @@ func (c *csiHook) claimWithRetry(req *structs.CSIVolumeClaimRequest) (*structs.C
 		}
 		c.logger.Debug(
 			"volume could not be claimed because it is in use", "retry_in", backoff)
-		t.Reset(backoff)
 	}
 	return &resp, err
 }
@@ -499,13 +496,11 @@ func (c *csiHook) unmountWithRetry(result *volumePublishResult) error {
 	defer cancel()
 	var err error
 	backoff := c.minBackoffInterval
-	t, stop := helper.NewSafeTimer(0)
-	defer stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return err
-		case <-t.C:
+		case <-time.After(backoff):
 		}
 
 		err = c.unmountImpl(result)
@@ -520,7 +515,6 @@ func (c *csiHook) unmountWithRetry(result *volumePublishResult) error {
 			}
 		}
 		c.logger.Debug("volume could not be unmounted", "retry_in", backoff)
-		t.Reset(backoff)
 	}
 	return nil
 }

--- a/client/allocrunner/csi_hook.go
+++ b/client/allocrunner/csi_hook.go
@@ -395,26 +395,22 @@ func (c *csiHook) claimWithRetry(req *structs.CSIVolumeClaimRequest) (*structs.C
 	var err error
 	backoff := c.minBackoffInterval
 	for {
+		err = c.rpcClient.RPC("CSIVolume.Claim", req, &resp)
+		if err == nil {
+			break
+		}
+		if !isRetryableClaimRPCError(err) {
+			break
+		}
+
 		select {
 		case <-ctx.Done():
 			return nil, err
 		case <-time.After(backoff):
 		}
 
-		err = c.rpcClient.RPC("CSIVolume.Claim", req, &resp)
-		if err == nil {
-			break
-		}
-
-		if !isRetryableClaimRPCError(err) {
-			break
-		}
-
 		if backoff < c.maxBackoffInterval {
-			backoff = backoff * 2
-			if backoff > c.maxBackoffInterval {
-				backoff = c.maxBackoffInterval
-			}
+			backoff = min(backoff*2, c.maxBackoffInterval)
 		}
 		c.logger.Debug(
 			"volume could not be claimed because it is in use", "retry_in", backoff)
@@ -497,22 +493,19 @@ func (c *csiHook) unmountWithRetry(result *volumePublishResult) error {
 	var err error
 	backoff := c.minBackoffInterval
 	for {
+		err = c.unmountImpl(result)
+		if err == nil {
+			break
+		}
+
 		select {
 		case <-ctx.Done():
 			return err
 		case <-time.After(backoff):
 		}
 
-		err = c.unmountImpl(result)
-		if err == nil {
-			break
-		}
-
 		if backoff < c.maxBackoffInterval {
-			backoff = backoff * 2
-			if backoff > c.maxBackoffInterval {
-				backoff = c.maxBackoffInterval
-			}
+			backoff = min(backoff*2, c.maxBackoffInterval)
 		}
 		c.logger.Debug("volume could not be unmounted", "retry_in", backoff)
 	}

--- a/client/allocrunner/group_service_hook.go
+++ b/client/allocrunner/group_service_hook.go
@@ -248,13 +248,10 @@ func (h *groupServiceHook) preKillLocked() {
 
 	h.logger.Debug("delay before killing tasks", "group", h.group, "shutdown_delay", h.delay)
 
-	timer, cancel := helper.NewSafeTimer(h.delay)
-	defer cancel()
-
 	select {
 	// Wait for specified shutdown_delay unless ignored
 	// This will block an agent from shutting down.
-	case <-timer.C:
+	case <-time.After(h.delay):
 	case <-h.shutdownDelayCtx.Done():
 	}
 }

--- a/client/allocrunner/tasklifecycle/gate_test.go
+++ b/client/allocrunner/tasklifecycle/gate_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/ci"
-	"github.com/hashicorp/nomad/helper"
 )
 
 func TestGate(t *testing.T) {
@@ -101,18 +100,15 @@ func TestGate_shutdown(t *testing.T) {
 		close(closeCh)
 	}()
 
-	timer, stop := helper.NewSafeTimer(time.Second)
-	defer stop()
-
 	select {
 	case <-openCh:
-	case <-timer.C:
+	case <-time.After(1 * time.Second):
 		t.Fatalf("timeout waiting for gate operations")
 	}
 
 	select {
 	case <-closeCh:
-	case <-timer.C:
+	case <-time.After(1 * time.Second):
 		t.Fatalf("timeout waiting for gate operations")
 	}
 

--- a/client/allocrunner/taskrunner/task_runner.go
+++ b/client/allocrunner/taskrunner/task_runner.go
@@ -36,7 +36,6 @@ import (
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/client/widmgr"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclspecutils"
 	"github.com/hashicorp/nomad/helper/pluginutils/hclutils"
 	"github.com/hashicorp/nomad/helper/users/dynamic"
@@ -622,10 +621,6 @@ func (tr *TaskRunner) Run() {
 	// Set the initial task state.
 	tr.stateUpdater.TaskStateUpdated()
 
-	// start with a stopped timer; actual restart delay computed later
-	timer, stop := helper.NewStoppedTimer()
-	defer stop()
-
 MAIN:
 	for !tr.shouldShutdown() {
 		if dead {
@@ -730,11 +725,9 @@ MAIN:
 			break MAIN
 		}
 
-		timer.Reset(restartDelay)
-
 		// Actually restart by sleeping and also watching for destroy events
 		select {
-		case <-timer.C:
+		case <-time.After(restartDelay):
 		case <-tr.killCtx.Done():
 			tr.logger.Trace("task killed between restarts", "delay", restartDelay)
 			break MAIN

--- a/client/allocrunner/taskrunner/task_runner_linux_test.go
+++ b/client/allocrunner/taskrunner/task_runner_linux_test.go
@@ -39,7 +39,6 @@ import (
 	cstate "github.com/hashicorp/nomad/client/state"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/client/taskenv"
-	"github.com/hashicorp/nomad/helper"
 	structsc "github.com/hashicorp/nomad/nomad/structs/config"
 
 	ctestutil "github.com/hashicorp/nomad/client/testutil"
@@ -2340,11 +2339,8 @@ func TestTaskRunner_TemplateWorkloadIdentity(t *testing.T) {
 				doneCh := make(chan struct{})
 				t.Cleanup(func() { close(doneCh) })
 
-				timer, stop := helper.NewSafeTimer(wait)
-				t.Cleanup(stop)
-
 				select {
-				case <-timer.C:
+				case <-time.After(wait):
 				case <-doneCh:
 					return
 				}

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -366,9 +366,6 @@ func (h *vaultHook) deriveVaultToken() (string, int, bool) {
 	var attempts uint64
 	var backoff time.Duration
 
-	timer, stopTimer := helper.NewSafeTimer(0)
-	defer stopTimer()
-
 	for {
 		token, lease, err := h.deriveVaultTokenJWT()
 		if err == nil {
@@ -387,7 +384,6 @@ func (h *vaultHook) deriveVaultToken() (string, int, bool) {
 
 		// Handle the retry case
 		backoff = helper.Backoff(vaultBackoffBaseline, vaultBackoffLimit, attempts)
-		timer.Reset(backoff)
 		attempts++
 
 		h.logger.Error("failed to derive Vault token", "error", err, "recoverable", true, "backoff", backoff)
@@ -396,7 +392,7 @@ func (h *vaultHook) deriveVaultToken() (string, int, bool) {
 		select {
 		case <-h.ctx.Done():
 			return "", 0, true
-		case <-timer.C:
+		case <-time.After(backoff):
 		}
 	}
 }

--- a/client/allocwatcher/alloc_watcher.go
+++ b/client/allocwatcher/alloc_watcher.go
@@ -376,13 +376,11 @@ func (p *remotePrevAlloc) Wait(ctx context.Context) error {
 		err := p.rpc.RPC("Alloc.GetAlloc", &req, &resp)
 		if err != nil {
 			retry := getRemoteRetryIntv + helper.RandomStagger(getRemoteRetryIntv)
-			timer, stop := helper.NewSafeTimer(retry)
 			p.logger.Error("error querying previous alloc", "error", err, "wait", retry)
 			select {
-			case <-timer.C:
+			case <-time.After(retry):
 				continue
 			case <-ctx.Done():
-				stop()
 				return ctx.Err()
 			}
 		}
@@ -390,17 +388,15 @@ func (p *remotePrevAlloc) Wait(ctx context.Context) error {
 		// Ensure that we didn't receive a stale response
 		if req.AllowStale && resp.Index < req.MinQueryIndex {
 			retry := getRemoteRetryIntv + helper.RandomStagger(getRemoteRetryIntv)
-			timer, stop := helper.NewSafeTimer(retry)
 			p.logger.Warn("received stale alloc; retrying",
 				"req_index", req.MinQueryIndex,
 				"resp_index", resp.Index,
 				"wait", retry,
 			)
 			select {
-			case <-timer.C:
+			case <-time.After(retry):
 				continue
 			case <-ctx.Done():
-				stop()
 				return ctx.Err()
 			}
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -2648,7 +2648,6 @@ OUTER:
 			// Node.GetClientAllocs which returns older results.
 			if allocsResp.Index <= allocsReq.MinQueryIndex {
 				retry := c.retryIntv(getAllocRetryIntv)
-				timer, stop := helper.NewSafeTimer(retry)
 				c.logger.Warn("failed to retrieve updated allocs; retrying",
 					"req_index", allocsReq.MinQueryIndex,
 					"resp_index", allocsResp.Index,
@@ -2656,10 +2655,9 @@ OUTER:
 					"wait", retry,
 				)
 				select {
-				case <-timer.C:
+				case <-time.After(retry):
 					continue
 				case <-c.shutdownCh:
-					stop()
 					return
 				}
 			}

--- a/client/consul/consul.go
+++ b/client/consul/consul.go
@@ -168,9 +168,6 @@ func (c *consulClient) RevokeTokens(tokens []*consulapi.ACLToken) error {
 // TokenPreflightCheck verifies that a token has been replicated before we
 // try to use it for registering services or bootstrapping Envoy
 func (c *consulClient) TokenPreflightCheck(pctx context.Context, t *consulapi.ACLToken) error {
-	timer, timerStop := helper.NewStoppedTimer()
-	defer timerStop()
-
 	var retry uint64
 	var err error
 	ctx, cancel := context.WithTimeout(pctx, c.preflightCheckTimeout)
@@ -191,11 +188,10 @@ func (c *consulClient) TokenPreflightCheck(pctx context.Context, t *consulapi.AC
 		backoff := helper.Backoff(
 			c.preflightCheckBaseInterval, c.preflightCheckBaseInterval*2, retry)
 		c.logger.Trace("Consul token not ready", "error", err, "backoff", backoff)
-		timer.Reset(backoff)
 		select {
 		case <-ctx.Done():
 			return err
-		case <-timer.C:
+		case <-time.After(backoff):
 			continue
 		}
 	}

--- a/client/drain.go
+++ b/client/drain.go
@@ -99,17 +99,18 @@ func (c *Client) pollServerForDrainStatus(ctx context.Context, interval time.Dur
 	var statusResp structs.SingleNodeResponse
 
 	for {
+		err := c.RPC("Node.GetNode", statusReq, &statusResp)
+		if err != nil {
+			return err
+		}
+		if statusResp.Node.DrainStrategy == nil {
+			return nil
+		}
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(1 * time.Second):
-			err := c.RPC("Node.GetNode", statusReq, &statusResp)
-			if err != nil {
-				return err
-			}
-			if &statusResp != nil && statusResp.Node.DrainStrategy == nil {
-				return nil
-			}
+		case <-time.After(interval):
 		}
 	}
 }
@@ -148,14 +149,14 @@ func (c *Client) pollLocalStatusForDrainStatus(ctx context.Context,
 	}
 
 	for {
+		if drainIsDone() {
+			return nil
+		}
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(1 * time.Second):
-			if drainIsDone() {
-				return nil
-			}
+		case <-time.After(interval):
 		}
-
 	}
 }

--- a/client/drain.go
+++ b/client/drain.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/client/config"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -89,9 +88,6 @@ func (c *Client) DrainSelf() error {
 // drain status, returning an error if the context expires or get any error from
 // the RPC call. If this function returns nil, the drain was successful.
 func (c *Client) pollServerForDrainStatus(ctx context.Context, interval time.Duration) error {
-	timer, stop := helper.NewSafeTimer(0)
-	defer stop()
-
 	statusReq := &structs.NodeSpecificRequest{
 		NodeID:   c.NodeID(),
 		SecretID: c.secretNodeID(),
@@ -106,7 +102,7 @@ func (c *Client) pollServerForDrainStatus(ctx context.Context, interval time.Dur
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-timer.C:
+		case <-time.After(1 * time.Second):
 			err := c.RPC("Node.GetNode", statusReq, &statusResp)
 			if err != nil {
 				return err
@@ -114,7 +110,6 @@ func (c *Client) pollServerForDrainStatus(ctx context.Context, interval time.Dur
 			if &statusResp != nil && statusResp.Node.DrainStrategy == nil {
 				return nil
 			}
-			timer.Reset(interval)
 		}
 	}
 }
@@ -152,18 +147,14 @@ func (c *Client) pollLocalStatusForDrainStatus(ctx context.Context,
 		return true
 	}
 
-	timer, stop := helper.NewSafeTimer(0)
-	defer stop()
-
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-timer.C:
+		case <-time.After(1 * time.Second):
 			if drainIsDone() {
 				return nil
 			}
-			timer.Reset(interval)
 		}
 
 	}

--- a/client/dynamicplugins/registry.go
+++ b/client/dynamicplugins/registry.go
@@ -13,8 +13,6 @@ import (
 	"fmt"
 	"sync"
 	"time"
-
-	"github.com/hashicorp/nomad/helper"
 )
 
 const (
@@ -339,14 +337,12 @@ func (d *dynamicRegistry) WaitForPlugin(ctx context.Context, ptype, name string)
 	ctx, cancel := context.WithTimeout(ctx, 24*time.Hour)
 	defer cancel()
 
-	timer, stop := helper.NewSafeTimer(time.Duration(delay) * time.Millisecond)
-	defer stop()
 	for {
 		select {
 		case <-ctx.Done():
 			// an externally-defined timeout wins the day
 			return nil, ctx.Err()
-		case <-timer.C:
+		case <-time.After(time.Duration(delay) * time.Millisecond):
 			// continue after our internal delay
 		}
 
@@ -360,7 +356,6 @@ func (d *dynamicRegistry) WaitForPlugin(ctx context.Context, ptype, name string)
 		if delay > maxDelay {
 			delay = maxDelay
 		}
-		timer.Reset(time.Duration(delay) * time.Millisecond)
 	}
 }
 

--- a/client/heartbeatstop.go
+++ b/client/heartbeatstop.go
@@ -76,7 +76,8 @@ func (h *heartbeatStop) watch() {
 	h.setLastOk(time.Now())
 	allocIntervals := map[string]time.Duration{}
 
-	var timer *time.Timer
+	timer := time.NewTimer(100)
+	timer.Stop()
 
 	for {
 		// we want to fire the ticker only once the shortest
@@ -89,11 +90,7 @@ func (h *heartbeatStop) watch() {
 			}
 		}
 		if interval != 0 {
-			if timer == nil {
-				timer = time.NewTimer(interval)
-			} else {
-				timer.Reset(interval)
-			}
+			timer.Reset(interval)
 		}
 
 		select {

--- a/client/heartbeatstop.go
+++ b/client/heartbeatstop.go
@@ -76,8 +76,7 @@ func (h *heartbeatStop) watch() {
 	h.setLastOk(time.Now())
 	allocIntervals := map[string]time.Duration{}
 
-	timer := time.NewTimer(1 * time.Second)
-	timer.Stop()
+	var timer *time.Timer
 
 	for {
 		// we want to fire the ticker only once the shortest
@@ -90,7 +89,11 @@ func (h *heartbeatStop) watch() {
 			}
 		}
 		if interval != 0 {
-			timer.Reset(interval)
+			if timer == nil {
+				timer = time.NewTimer(interval)
+			} else {
+				timer.Reset(interval)
+			}
 		}
 
 		select {

--- a/client/heartbeatstop.go
+++ b/client/heartbeatstop.go
@@ -10,7 +10,6 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -77,8 +76,8 @@ func (h *heartbeatStop) watch() {
 	h.setLastOk(time.Now())
 	allocIntervals := map[string]time.Duration{}
 
-	timer, stopTimer := helper.NewStoppedTimer()
-	defer stopTimer()
+	timer := time.NewTimer(1 * time.Second)
+	timer.Stop()
 
 	for {
 		// we want to fire the ticker only once the shortest
@@ -92,8 +91,6 @@ func (h *heartbeatStop) watch() {
 		}
 		if interval != 0 {
 			timer.Reset(interval)
-		} else {
-			timer.Stop()
 		}
 
 		select {

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -144,12 +144,9 @@ TRY:
 		return rpcErr
 	}
 
-	// Wait to avoid thundering herd
-	timer, cancel := helper.NewSafeTimer(helper.RandomStagger(conf.RPCHoldTimeout / structs.JitterFraction))
-	defer cancel()
-
 	select {
-	case <-timer.C:
+	// Wait to avoid thundering herd
+	case <-time.After(helper.RandomStagger(conf.RPCHoldTimeout / structs.JitterFraction)):
 		// If we are going to retry a blocking query we need to update the time
 		// to block so it finishes by our deadline.
 

--- a/client/serviceregistration/watcher.go
+++ b/client/serviceregistration/watcher.go
@@ -244,7 +244,7 @@ func (w *UniversalCheckWatcher) Run(ctx context.Context) {
 			w.logger.Trace("now watching check", "alloc_i", allocID, "task", taskName, "check", checkName)
 
 		// poll time; refresh check statuses
-		case now := <-time.After(1 * time.Second):
+		case now := <-time.After(w.pollFrequency):
 			if len(watched) == 0 {
 				continue
 			}

--- a/client/serviceregistration/watcher.go
+++ b/client/serviceregistration/watcher.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-set/v3"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -225,26 +224,7 @@ func (w *UniversalCheckWatcher) Run(ctx context.Context) {
 	// map of checkID to their restarter handle (contains only checks we are watching)
 	watched := make(map[string]*restarter)
 
-	checkTimer, cleanupCheckTimer := helper.NewSafeTimer(0)
-	defer cleanupCheckTimer()
-
-	stopCheckTimer := func() { // todo: refactor using that other pattern
-		checkTimer.Stop()
-		select {
-		case <-checkTimer.C:
-		default:
-		}
-	}
-
-	// initialize with checkTimer disabled
-	stopCheckTimer()
-
 	for {
-		// disable polling if there are no checks
-		if len(watched) == 0 {
-			stopCheckTimer()
-		}
-
 		select {
 		// caller cancelled us; goodbye
 		case <-ctx.Done():
@@ -263,16 +243,12 @@ func (w *UniversalCheckWatcher) Run(ctx context.Context) {
 			checkName := update.restart.checkName
 			w.logger.Trace("now watching check", "alloc_i", allocID, "task", taskName, "check", checkName)
 
-			// turn on the timer if we are now active
-			if len(watched) == 1 {
-				stopCheckTimer()
-				checkTimer.Reset(w.pollFrequency)
-			}
-
 		// poll time; refresh check statuses
-		case now := <-checkTimer.C:
+		case now := <-time.After(1 * time.Second):
+			if len(watched) == 0 {
+				continue
+			}
 			w.interval(ctx, now, watched)
-			checkTimer.Reset(w.pollFrequency)
 		}
 	}
 }

--- a/client/vaultclient/vaultclient_test.go
+++ b/client/vaultclient/vaultclient_test.go
@@ -19,7 +19,6 @@ import (
 	josejwt "github.com/go-jose/go-jose/v3/jwt"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/widmgr"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/useragent"
@@ -505,9 +504,6 @@ func TestVaultClient_RenewalConcurrent(t *testing.T) {
 	}
 
 	// Collect results with timeout.
-	timer, stop := helper.NewSafeTimer(3 * time.Second)
-	defer stop()
-
 	sawInitial := 0
 	sawRenew := 0
 	for {
@@ -526,7 +522,7 @@ func TestVaultClient_RenewalConcurrent(t *testing.T) {
 			}
 		case got := <-resultCh:
 			must.Nil(t, got, must.Sprintf("token renewal error: %v", got))
-		case <-timer.C:
+		case <-time.After(3 * time.Second):
 			t.Fatalf("timeout waiting for expected token renewals (initial: %d renewed: %d)",
 				sawInitial, sawRenew)
 		}

--- a/client/widmgr/widmgr.go
+++ b/client/widmgr/widmgr.go
@@ -364,9 +364,6 @@ func (m *WIDMgr) renew() {
 		wait = helper.ExpiryToRenewTime(minExp, time.Now, m.minWait)
 	}
 
-	timer, timerStop := helper.NewStoppedTimer()
-	defer timerStop()
-
 	var retry uint64
 
 	for {
@@ -378,9 +375,8 @@ func (m *WIDMgr) renew() {
 		}
 
 		m.logger.Debug("waiting to renew identities", "num", len(reqs), "wait", wait)
-		timer.Reset(wait)
 		select {
-		case <-timer.C:
+		case <-time.After(wait):
 			m.logger.Trace("getting new signed identities", "num", len(reqs))
 		case <-m.stopCtx.Done():
 			// close watchers and shutdown

--- a/command/agent/consul/version_checker.go
+++ b/command/agent/consul/version_checker.go
@@ -23,9 +23,6 @@ func checkConsulTLSSkipVerify(ctx context.Context, logger log.Logger, client Age
 
 	defer close(done)
 
-	timer, stop := helper.NewSafeTimer(limit)
-	defer stop()
-
 	var attempts uint64
 	var backoff time.Duration
 
@@ -43,12 +40,11 @@ func checkConsulTLSSkipVerify(ctx context.Context, logger log.Logger, client Age
 
 		backoff = helper.Backoff(baseline, limit, attempts)
 		attempts++
-		timer.Reset(backoff)
 
 		select {
 		case <-ctx.Done():
 			return
-		case <-timer.C:
+		case <-time.After(backoff):
 		}
 	}
 }

--- a/command/agent/monitor/monitor.go
+++ b/command/agent/monitor/monitor.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	log "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/nomad/helper"
 )
 
 // Monitor provides a mechanism to stream logs using go-hclog
@@ -111,17 +110,12 @@ func (d *monitor) Start() <-chan []byte {
 	// dropped messages and makes room on the logCh
 	// to add a dropped message count warning
 	go func() {
-		timer, stop := helper.NewSafeTimer(d.droppedDuration)
-		defer stop()
-
 		// loop and check for dropped messages
 		for {
-			timer.Reset(d.droppedDuration)
-
 			select {
 			case <-d.doneCh:
 				return
-			case <-timer.C:
+			case <-time.After(d.droppedDuration):
 				d.Lock()
 
 				// Check if there have been any dropped messages.

--- a/command/agent/retry_join_test.go
+++ b/command/agent/retry_join_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-netaddrs"
 	"github.com/hashicorp/nomad/ci"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/shoenig/test/must"
@@ -272,11 +271,6 @@ func TestRetryJoin_RetryMaxAttempts(t *testing.T) {
 	// to test this apart from inspecting log entries.
 	errCh := make(chan struct{})
 
-	// Create a timeout to protect against problems within the test blocking
-	// for arbitrary long times.
-	timeout, timeoutStop := helper.NewSafeTimer(2 * time.Second)
-	defer timeoutStop()
-
 	var output []string
 
 	joiner := retryJoiner{
@@ -307,7 +301,7 @@ func TestRetryJoin_RetryMaxAttempts(t *testing.T) {
 		must.Len(t, 0, output)
 	case <-doneCh:
 		t.Fatal("retry join completed without closing error channel")
-	case <-timeout.C:
+	case <-time.After(2 * time.Second):
 		t.Fatal("timeout reached without error channel close")
 	}
 }
@@ -320,11 +314,6 @@ func TestRetryJoin_joinFuncFailure(t *testing.T) {
 
 	// Create an output for logging that can be inspected
 	logOutput := bytes.NewBufferString("")
-
-	// Create a timeout to protect against problems within the test blocking
-	// for arbitrary long times.
-	timeout, timeoutStop := helper.NewSafeTimer(2 * time.Second)
-	defer timeoutStop()
 
 	var output []string
 
@@ -362,7 +351,7 @@ func TestRetryJoin_joinFuncFailure(t *testing.T) {
 		must.Len(t, 0, output)
 	case <-doneCh:
 		t.Fatal("retry join completed without closing error channel")
-	case <-timeout.C:
+	case <-time.After(2 * time.Second):
 		t.Fatal("timeout reached without error channel close")
 	}
 

--- a/command/agent/testagent.go
+++ b/command/agent/testagent.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/nomad/ci"
 	client "github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/fingerprint"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -299,16 +298,12 @@ func (a *TestAgent) Shutdown() {
 		ch <- a.Agent.Shutdown()
 	}()
 
-	// one minute grace period on shutdown
-	timer, cancel := helper.NewSafeTimer(1 * time.Minute)
-	defer cancel()
-
 	select {
 	case err := <-ch:
 		if err != nil {
 			a.T.Fatalf("agent shutdown error: %v", err)
 		}
-	case <-timer.C:
+	case <-time.After(1 * time.Minute):
 		a.T.Fatal("agent shutdown timeout")
 	}
 }

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1080,18 +1080,15 @@ func (c *OperatorDebugCommand) collectPeriodicPprofs(client *api.Client) {
 	go func() {
 		ctx, cancel := context.WithTimeout(c.ctx, c.duration)
 		defer cancel()
-		timer, stop := helper.NewSafeTimer(c.pprofInterval)
-		defer stop()
 
 		pprofIntervalCount := 1
 		for {
 			select {
 			case <-ctx.Done():
 				return
-			case <-timer.C:
+			case <-time.After(c.pprofInterval):
 				c.Ui.Output(fmt.Sprintf("    Capture pprofInterval %04d", pprofIntervalCount))
 				c.collectPprofs(client, pprofServerIDs, pprofNodeIDs, pprofIntervalCount)
-				timer.Reset(c.pprofInterval)
 				pprofIntervalCount++
 			}
 		}

--- a/drivers/docker/cpuset.go
+++ b/drivers/docker/cpuset.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
-	"github.com/hashicorp/nomad/helper"
 )
 
 const (
@@ -36,16 +35,12 @@ func (c *cpuset) watch() {
 		c.sync = c.copyCpuset
 	}
 
-	ticks, cancel := helper.NewSafeTimer(cpusetSyncPeriod)
-	defer cancel()
-
 	for {
 		select {
 		case <-c.doneCh:
 			return
-		case <-ticks.C:
+		case <-time.After(cpusetSyncPeriod):
 			c.sync(c.source, c.destination)
-			ticks.Reset(cpusetSyncPeriod)
 		}
 	}
 }

--- a/drivers/shared/eventer/eventer.go
+++ b/drivers/shared/eventer/eventer.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/plugins/drivers"
 )
 
@@ -66,19 +65,14 @@ func NewEventer(ctx context.Context, logger hclog.Logger) *Eventer {
 // eventLoop is the main logic which pulls events from the channel and broadcasts
 // them to all consumers
 func (e *Eventer) eventLoop() {
-	timer, stop := helper.NewSafeTimer(ConsumerGCInterval)
-	defer stop()
-
 	for {
-		timer.Reset(ConsumerGCInterval)
-
 		select {
 		case <-e.ctx.Done():
 			e.logger.Trace("task event loop shutdown")
 			return
 		case event := <-e.events:
 			e.iterateConsumers(event)
-		case <-timer.C:
+		case <-time.After(ConsumerGCInterval):
 			e.gcConsumers()
 		}
 	}

--- a/helper/backoff.go
+++ b/helper/backoff.go
@@ -38,13 +38,11 @@ func Backoff(backoffBase time.Duration, backoffLimit time.Duration, attempt uint
 func WithBackoffFunc(ctx context.Context, minBackoff, maxBackoff time.Duration, fn func() error) error {
 	var err error
 	backoff := minBackoff
-	t, stop := NewSafeTimer(0)
-	defer stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("operation cancelled: %w", err)
-		case <-t.C:
+		case <-time.After(backoff):
 		}
 
 		err = fn()
@@ -58,7 +56,5 @@ func WithBackoffFunc(ctx context.Context, minBackoff, maxBackoff time.Duration, 
 				backoff = maxBackoff
 			}
 		}
-
-		t.Reset(backoff)
 	}
 }

--- a/helper/backoff.go
+++ b/helper/backoff.go
@@ -24,10 +24,7 @@ func Backoff(backoffBase time.Duration, backoffLimit time.Duration, attempt uint
 	}
 
 	// Compute deadline and clamp it to backoffLimit
-	deadline := 1 << attempt * backoffBase
-	if deadline > backoffLimit {
-		deadline = backoffLimit
-	}
+	deadline := min(1<<attempt*backoffBase, backoffLimit)
 
 	return deadline
 }
@@ -36,25 +33,24 @@ func Backoff(backoffBase time.Duration, backoffLimit time.Duration, attempt uint
 // small jitter to a maximum backoff. It returns once the context closes, with
 // the error wrapping over the error from the function.
 func WithBackoffFunc(ctx context.Context, minBackoff, maxBackoff time.Duration, fn func() error) error {
-	var err error
-	backoff := minBackoff
+	var (
+		backoff time.Duration = minBackoff
+		err     error
+	)
+
 	for {
+		if err = fn(); err == nil {
+			return nil
+		}
+
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("operation cancelled: %w", err)
 		case <-time.After(backoff):
 		}
 
-		err = fn()
-		if err == nil {
-			return nil
-		}
-
 		if backoff < maxBackoff {
-			backoff = backoff*2 + RandomStagger(minBackoff/10)
-			if backoff > maxBackoff {
-				backoff = maxBackoff
-			}
+			backoff = min(backoff*2+RandomStagger(minBackoff/10), maxBackoff)
 		}
 	}
 }

--- a/helper/broker/notify.go
+++ b/helper/broker/notify.go
@@ -6,8 +6,6 @@ package broker
 import (
 	"context"
 	"time"
-
-	"github.com/hashicorp/nomad/helper"
 )
 
 // GenericNotifier allows a process to send updates to many subscribers in an
@@ -93,10 +91,6 @@ func (g *GenericNotifier) WaitForChange(timeout time.Duration) interface{} {
 	case g.subscribeCh <- updateCh:
 	}
 
-	// Create a timeout timer and use the helper to ensure this routine doesn't
-	// panic and making the stop call clear.
-	timeoutTimer, timeoutStop := helper.NewSafeTimer(timeout)
-
 	// Defer a function which performs all the required cleanup of the
 	// subscriber once it has been notified of a change, or reached its wait
 	// timeout.
@@ -106,7 +100,6 @@ func (g *GenericNotifier) WaitForChange(timeout time.Duration) interface{} {
 		case g.unsubscribeCh <- updateCh:
 		}
 		close(updateCh)
-		timeoutStop()
 	}()
 
 	// Enter the main loop which listens for an update or timeout and returns
@@ -114,7 +107,7 @@ func (g *GenericNotifier) WaitForChange(timeout time.Duration) interface{} {
 	select {
 	case <-g.ctx.Done():
 		return "shutting down"
-	case <-timeoutTimer.C:
+	case <-time.After(timeout):
 		return "wait timed out after " + timeout.String()
 	case update := <-updateCh:
 		return update

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha512"
 	"fmt"
 	"maps"
-	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -358,35 +357,8 @@ func CheckNamespaceScope(provided string, requested []string) []string {
 	return nil
 }
 
-// StopFunc is used to stop a time.Timer created with NewSafeTimer
+// StopFunc is used to stop a time.Timer created with NewSafeTicker
 type StopFunc func()
-
-// NewSafeTimer creates a time.Timer but does not panic if duration is <= 0.
-//
-// Using a time.Timer is recommended instead of time.After when it is necessary
-// to avoid leaking goroutines (e.g. in a select inside a loop).
-//
-// Returns the time.Timer and also a StopFunc, forcing the caller to deal
-// with stopping the time.Timer to avoid leaking a goroutine.
-//
-// Note: If creating a Timer that should do nothing until Reset is called, use
-// NewStoppedTimer instead for safely creating the timer in a stopped state.
-func NewSafeTimer(duration time.Duration) (*time.Timer, StopFunc) {
-	if duration <= 0 {
-		// Avoid panic by using the smallest positive value. This is close enough
-		// to the behavior of time.After(0), which this helper is intended to
-		// replace.
-		// https://go.dev/play/p/EIkm9MsPbHY
-		duration = 1
-	}
-
-	t := time.NewTimer(duration)
-	cancel := func() {
-		t.Stop()
-	}
-
-	return t, cancel
-}
 
 // NewSafeTicker creates a time.Ticker but does not panic if duration is <= 0.
 //
@@ -407,14 +379,6 @@ func NewSafeTicker(duration time.Duration) (*time.Ticker, StopFunc) {
 	}
 
 	return t, cancel
-}
-
-// NewStoppedTimer creates a time.Timer in a stopped state. This is useful when
-// the actual wait time will computed and set later via Reset.
-func NewStoppedTimer() (*time.Timer, StopFunc) {
-	t, f := NewSafeTimer(math.MaxInt64)
-	t.Stop()
-	return t, f
 }
 
 // ConvertSlice takes the input slice and generates a new one using the

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -335,31 +335,6 @@ func TestCheckNamespaceScope(t *testing.T) {
 	}
 }
 
-func TestTimer_NewSafeTimer(t *testing.T) {
-	t.Run("zero", func(t *testing.T) {
-		timer, stop := NewSafeTimer(0)
-		defer stop()
-		<-timer.C
-	})
-
-	t.Run("positive", func(t *testing.T) {
-		timer, stop := NewSafeTimer(1)
-		defer stop()
-		<-timer.C
-	})
-}
-
-func TestTimer_NewStoppedTimer(t *testing.T) {
-	timer, stop := NewStoppedTimer()
-	defer stop()
-
-	select {
-	case <-timer.C:
-		must.Unreachable(t)
-	default:
-	}
-}
-
 func Test_ConvertSlice(t *testing.T) {
 	t.Run("string wrapper", func(t *testing.T) {
 

--- a/helper/winsvc/events_windows.go
+++ b/helper/winsvc/events_windows.go
@@ -7,19 +7,15 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/nomad/helper"
 )
 
 var chanEvents = make(chan Event)
 
 // SendEvent sends an event to the Windows eventlog
 func SendEvent(e Event) {
-	timer, stop := helper.NewSafeTimer(100 * time.Millisecond)
-	defer stop()
-
 	select {
 	case chanEvents <- e:
-	case <-timer.C:
+	case <-time.After(100 * time.Millisecond):
 		hclog.L().Error("failed to send event to windows eventlog, timed out",
 			"event", e)
 	}

--- a/helper/winsvc/windows_service_windows.go
+++ b/helper/winsvc/windows_service_windows.go
@@ -14,7 +14,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/hashicorp/nomad/helper"
 	"golang.org/x/sys/windows/registry"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -231,13 +230,7 @@ func waitFor(ctx context.Context, condition func() (bool, error)) error {
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
 	defer stop()
 
-	pauseDur := time.Millisecond * 250
-	t, timerStop := helper.NewSafeTimer(pauseDur)
-	defer timerStop()
-
 	for {
-		t.Reset(pauseDur)
-
 		complete, err := condition()
 		if err != nil {
 			return err
@@ -250,7 +243,7 @@ func waitFor(ctx context.Context, condition func() (bool, error)) error {
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("timeout exceeded waiting for process")
-		case <-t.C:
+		case <-time.After(250 * time.Millisecond):
 		}
 	}
 }

--- a/nomad/blocked_evals.go
+++ b/nomad/blocked_evals.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hashicorp/go-hclog"
 	metrics "github.com/hashicorp/go-metrics/compat"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -800,15 +799,9 @@ func (b *BlockedEvals) Flush() {
 
 // EmitStats is used to export metrics about the blocked eval tracker while enabled
 func (b *BlockedEvals) EmitStats(period time.Duration, stopCh <-chan struct{}) {
-	timer, stop := helper.NewSafeTimer(period)
-	defer stop()
-
 	for {
-		timer.Reset(period)
-
 		select {
-
-		case <-timer.C:
+		case <-time.After(period):
 			stats := b.stats.Copy()
 			metrics.SetGauge([]string{"nomad", "blocked_evals", "total_quota_limit"}, float32(stats.TotalQuotaLimit))
 			metrics.SetGauge([]string{"nomad", "blocked_evals", "total_blocked"}, float32(stats.TotalBlocked))

--- a/nomad/drainer/watch_jobs.go
+++ b/nomad/drainer/watch_jobs.go
@@ -7,11 +7,11 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
 
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"golang.org/x/time/rate"
@@ -142,14 +142,9 @@ func (w *drainingJobWatcher) deregisterJob(jobID, namespace string) {
 
 // watch is the long lived watching routine that detects job drain changes.
 func (w *drainingJobWatcher) watch() {
-	timer, stop := helper.NewSafeTimer(stateReadErrorDelay)
-	defer stop()
-
 	waitIndex := uint64(1)
 
 	for {
-		timer.Reset(stateReadErrorDelay)
-
 		w.logger.Trace("getting job allocs at index", "index", waitIndex)
 		jobAllocs, index, err := w.getJobAllocs(w.getQueryCtx(), waitIndex)
 
@@ -173,7 +168,7 @@ func (w *drainingJobWatcher) watch() {
 			case <-w.ctx.Done():
 				w.logger.Trace("shutting down")
 				return
-			case <-timer.C:
+			case <-time.After(stateReadErrorDelay):
 				continue
 			}
 		}

--- a/nomad/drainer/watch_nodes.go
+++ b/nomad/drainer/watch_nodes.go
@@ -5,10 +5,10 @@ package drainer
 
 import (
 	"context"
+	"time"
 
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/nomad/helper"
 
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -146,13 +146,9 @@ func NewNodeDrainWatcher(ctx context.Context, limiter *rate.Limiter, state *stat
 
 // watch is the long lived watching routine that detects node changes.
 func (w *nodeDrainWatcher) watch() {
-	timer, stop := helper.NewSafeTimer(stateReadErrorDelay)
-	defer stop()
-
 	nindex := uint64(1)
 
 	for {
-		timer.Reset(stateReadErrorDelay)
 		nodes, index, err := w.getNodes(nindex)
 		if err != nil {
 			if err == context.Canceled {
@@ -163,7 +159,7 @@ func (w *nodeDrainWatcher) watch() {
 			select {
 			case <-w.ctx.Done():
 				return
-			case <-timer.C:
+			case <-time.After(stateReadErrorDelay):
 				continue
 			}
 		}

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -25,7 +25,6 @@ import (
 	wrapping "github.com/hashicorp/go-kms-wrapping/v2"
 	msgpackrpc "github.com/hashicorp/net-rpc-msgpackrpc/v2"
 	"github.com/hashicorp/nomad/ci"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/pointer"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -1046,29 +1045,25 @@ func TestEncrypter_IsReady_eventuallyReady(t *testing.T) {
 		respCh <- encrypter.IsReady(timeoutCtx)
 	}()
 
+	select {
 	// Create a timer at 1/3 the value of the timeout. When this triggers, we
 	// add a new decryption task to the encrypter. This simulates Nomad
 	// upserting a new key into state which was not part of the original
 	// snapshot or trailing logs and therefore should not block the readiness
 	// check.
-	taskAddTimer, stop := helper.NewSafeTimer(timeout / 3)
-	t.Cleanup(stop)
+	case <-time.After(timeout / 3):
+		encrypter.decryptTasksLock.Lock()
+		encrypter.decryptTasks["id2"] = struct{}{}
+		encrypter.decryptTasksLock.Unlock()
 
 	// Create a timer at half the value of the timeout. When this triggers, we
 	// will remove the task from the encrypter simulating it finishing and the
 	// encrypter becoming ready.
-	taskDeleteTimer, stop := helper.NewSafeTimer(timeout / 2)
-	t.Cleanup(stop)
-
-	select {
-	case <-taskAddTimer.C:
-		encrypter.decryptTasksLock.Lock()
-		encrypter.decryptTasks["id2"] = struct{}{}
-		encrypter.decryptTasksLock.Unlock()
-	case <-taskDeleteTimer.C:
+	case <-time.After(timeout / 2):
 		encrypter.decryptTasksLock.Lock()
 		delete(encrypter.decryptTasks, "id1")
 		encrypter.decryptTasksLock.Unlock()
+
 	case err := <-respCh:
 		must.NoError(t, err)
 		encrypter.decryptTasksLock.RLock()
@@ -1352,17 +1347,11 @@ func TestEncrypter_decryptWrappedKeyTask_contextCancel(t *testing.T) {
 	//
 	// Canceling the context should cause the routine to exit and send an error
 	// which we can check to ensure we correctly unblock.
-	timer, timerStop := helper.NewSafeTimer(500 * time.Millisecond)
-	defer timerStop()
-
-	<-timer.C
+	<-time.After(500 * time.Millisecond)
 	cancel()
 
-	timer, timerStop = helper.NewSafeTimer(200 * time.Millisecond)
-	defer timerStop()
-
 	select {
-	case <-timer.C:
+	case <-time.After(200 * time.Millisecond):
 		t.Fatal("timed out waiting for decryptWrappedKeyTask to send its error")
 	case err := <-errorCh:
 		must.ErrorContains(t, err, "context canceled")

--- a/nomad/encrypter_test.go
+++ b/nomad/encrypter_test.go
@@ -1312,23 +1312,13 @@ func TestEncrypter_decryptWrappedKeyTask_contextCancel(t *testing.T) {
 
 	respCh := make(chan *cipherSet, 1)
 
-	// Generate a context and immediately cancel it.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	// Ensure we receive an error indicating we hit the context done case and
-	// check no cipher response was sent.
-	err = encrypter.decryptWrappedKeyTask(ctx, kmsWrapper, key.Meta, wrappedKey, respCh)
-	must.ErrorContains(t, err, "operation cancelled")
-	must.Eq(t, 0, len(respCh))
-
 	// Recreate the response channel so that it is no longer buffered. The
 	// decrypt task should now block on attempting to send to it.
 	respCh = make(chan *cipherSet)
 
 	// Generate a new context and an error channel so we can gather the response
 	// of decryptWrappedKeyTask running inside a goroutine.
-	ctx, cancel = context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
 
 	errorCh := make(chan error, 1)
 

--- a/nomad/eval_broker.go
+++ b/nomad/eval_broker.go
@@ -15,7 +15,6 @@ import (
 
 	metrics "github.com/hashicorp/go-metrics/compat"
 
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/broker"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/lib/delayheap"
@@ -982,14 +981,9 @@ func (b *EvalBroker) Cancelable(batchSize int) []*structs.Evaluation {
 
 // EmitStats is used to export metrics about the broker while enabled
 func (b *EvalBroker) EmitStats(period time.Duration, stopCh <-chan struct{}) {
-	timer, stop := helper.NewSafeTimer(period)
-	defer stop()
-
 	for {
-		timer.Reset(period)
-
 		select {
-		case <-timer.C:
+		case <-time.After(period):
 			stats := b.Stats()
 			metrics.SetGauge([]string{"nomad", "broker", "total_ready"}, float32(stats.TotalReady))
 			metrics.SetGauge([]string{"nomad", "broker", "total_unacked"}, float32(stats.TotalUnacked))

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/go-memdb"
 	metrics "github.com/hashicorp/go-metrics/compat"
 	"github.com/hashicorp/go-version"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/peers"
 	"github.com/hashicorp/nomad/nomad/state"
@@ -957,10 +956,6 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 	variablesRekey := time.NewTicker(s.config.VariablesRekeyInterval)
 	defer variablesRekey.Stop()
 
-	// Set up the expired ACL local token garbage collection timer.
-	localTokenExpiredGC, localTokenExpiredGCStop := helper.NewSafeTimer(s.config.ACLTokenExpirationGCInterval)
-	defer localTokenExpiredGCStop()
-
 	for {
 
 		select {
@@ -1000,11 +995,10 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 			if index, ok := s.getLatestIndex(); ok {
 				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobOneTimeTokenGC, index))
 			}
-		case <-localTokenExpiredGC.C:
+		case <-time.After(s.config.ACLTokenExpirationGCInterval):
 			if index, ok := s.getLatestIndex(); ok {
 				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobLocalTokenExpiredGC, index))
 			}
-			localTokenExpiredGC.Reset(s.config.ACLTokenExpirationGCInterval)
 		case <-rootKeyGC.C:
 			if index, ok := s.getLatestIndex(); ok {
 				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobRootKeyRotateOrGC, index))
@@ -1024,18 +1018,12 @@ func (s *Server) schedulePeriodic(stopCh chan struct{}) {
 // onto the _core scheduler for ACL based activities such as removing expired
 // global ACL tokens.
 func (s *Server) schedulePeriodicAuthoritative(stopCh chan struct{}) {
-
-	// Set up the expired ACL global token garbage collection timer.
-	globalTokenExpiredGC, globalTokenExpiredGCStop := helper.NewSafeTimer(s.config.ACLTokenExpirationGCInterval)
-	defer globalTokenExpiredGCStop()
-
 	for {
 		select {
-		case <-globalTokenExpiredGC.C:
+		case <-time.After(s.config.ACLTokenExpirationGCInterval):
 			if index, ok := s.getLatestIndex(); ok {
 				s.evalBroker.Enqueue(s.coreJobEval(structs.CoreJobGlobalTokenExpiredGC, index))
 			}
-			globalTokenExpiredGC.Reset(s.config.ACLTokenExpirationGCInterval)
 		case <-stopCh:
 			return
 		}
@@ -1192,18 +1180,14 @@ func (s *Server) reapCancelableEvaluations(stopCh chan struct{}) chan struct{} {
 
 	wakeCh := make(chan struct{}, 1)
 	go func() {
-
-		timer, cancel := helper.NewSafeTimer(s.config.EvalReapCancelableInterval)
-		defer cancel()
 		for {
 			select {
 			case <-stopCh:
 				return
 			case <-wakeCh:
 				cancelCancelableEvals(s)
-			case <-timer.C:
+			case <-time.After(s.config.EvalReapCancelableInterval):
 				cancelCancelableEvals(s)
-				timer.Reset(s.config.EvalReapCancelableInterval)
 			}
 		}
 	}()
@@ -2583,12 +2567,8 @@ func diffACLBindingRules(
 //	    return
 //	  }
 func (s *Server) replicationBackoffContinue(stopCh chan struct{}) bool {
-
-	timer, timerStopFn := helper.NewSafeTimer(s.config.ReplicationBackoff)
-	defer timerStopFn()
-
 	select {
-	case <-timer.C:
+	case <-time.After(s.config.ReplicationBackoff):
 		return true
 	case <-stopCh:
 		return false

--- a/nomad/lock/delay.go
+++ b/nomad/lock/delay.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	metrics "github.com/hashicorp/go-metrics/compat"
-	"github.com/hashicorp/nomad/helper"
 )
 
 // DelayTimer is used to mark certain locks as unacquirable. When a locks TTL
@@ -68,13 +67,9 @@ func (d *DelayTimer) RemoveAll() {
 // EmitMetrics is a long-running routine used to emit periodic metrics about
 // the Delay.
 func (d *DelayTimer) EmitMetrics(period time.Duration, shutdownCh chan struct{}) {
-	timer, stop := helper.NewSafeTimer(period)
-	defer stop()
-
 	for {
-		timer.Reset(period)
 		select {
-		case <-timer.C:
+		case <-time.After(period):
 			metrics.SetGauge([]string{"variables", "locks", "delay_timer", "num"}, float32(d.timerNum()))
 		case <-shutdownCh:
 			return

--- a/nomad/lock/ttl.go
+++ b/nomad/lock/ttl.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	metrics "github.com/hashicorp/go-metrics/compat"
-	"github.com/hashicorp/nomad/helper"
 )
 
 // TTLTimer provides a map of named timers which is safe for concurrent use.
@@ -84,13 +83,9 @@ func (t *TTLTimer) StopAndRemoveAll() {
 // EmitMetrics is a long-running routine used to emit periodic metrics about
 // the Timer.
 func (t *TTLTimer) EmitMetrics(period time.Duration, shutdownCh chan struct{}) {
-	timer, stop := helper.NewSafeTimer(period)
-	defer stop()
-
 	for {
-		timer.Reset(period)
 		select {
-		case <-timer.C:
+		case <-time.After(period):
 			metrics.SetGauge([]string{"variables", "locks", "ttl_timer", "num"}, float32(t.TimerNum()))
 		case <-shutdownCh:
 			return

--- a/nomad/plan_apply_node_tracker.go
+++ b/nomad/plan_apply_node_tracker.go
@@ -10,7 +10,6 @@ import (
 	"github.com/hashicorp/go-hclog"
 	metrics "github.com/hashicorp/go-metrics/compat"
 	lru "github.com/hashicorp/golang-lru/v2"
-	"github.com/hashicorp/nomad/helper"
 	"golang.org/x/time/rate"
 )
 
@@ -111,14 +110,9 @@ func (c *CachedBadNodeTracker) Add(nodeID string) bool {
 // EmitStats generates metrics for the bad nodes being currently tracked. Must
 // be called in a goroutine.
 func (c *CachedBadNodeTracker) EmitStats(period time.Duration, stopCh <-chan struct{}) {
-	timer, stop := helper.NewSafeTimer(period)
-	defer stop()
-
 	for {
-		timer.Reset(period)
-
 		select {
-		case <-timer.C:
+		case <-time.After(period):
 			c.emitStats()
 		case <-stopCh:
 			return

--- a/nomad/plan_queue.go
+++ b/nomad/plan_queue.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	metrics "github.com/hashicorp/go-metrics/compat"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -200,14 +199,9 @@ func (q *PlanQueue) Stats() *QueueStats {
 
 // EmitStats is used to export metrics about the broker while enabled
 func (q *PlanQueue) EmitStats(period time.Duration, stopCh <-chan struct{}) {
-	timer, stop := helper.NewSafeTimer(period)
-	defer stop()
-
 	for {
-		timer.Reset(period)
-
 		select {
-		case <-timer.C:
+		case <-time.After(period):
 			stats := q.Stats()
 			metrics.SetGauge([]string{"nomad", "plan", "queue_depth"}, float32(stats.Depth))
 		case <-stopCh:

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -2200,14 +2200,9 @@ func (s *Server) Stats() map[string]map[string]string {
 
 // EmitRaftStats is used to export metrics about raft indexes and state store snapshot index
 func (s *Server) EmitRaftStats(period time.Duration, stopCh <-chan struct{}) {
-	timer, stop := helper.NewSafeTimer(period)
-	defer stop()
-
 	for {
-		timer.Reset(period)
-
 		select {
-		case <-timer.C:
+		case <-time.After(period):
 			lastIndex := s.raft.LastIndex()
 			metrics.SetGauge([]string{"raft", "lastIndex"}, float32(lastIndex))
 			appliedIndex := s.raft.AppliedIndex()

--- a/nomad/volumewatcher/volume_watcher.go
+++ b/nomad/volumewatcher/volume_watcher.go
@@ -11,7 +11,6 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"golang.org/x/time/rate"
@@ -118,9 +117,6 @@ func (vw *volumeWatcher) watch() {
 	defer vw.deleteFn()
 	defer vw.Stop()
 
-	timer, stop := helper.NewSafeTimer(vw.quiescentTimeout)
-	defer stop()
-
 	for {
 		select {
 		// TODO(tgross): currently server->client RPC have no cancellation
@@ -137,8 +133,7 @@ func (vw *volumeWatcher) watch() {
 				return
 			}
 			vw.volumeReap(vol)
-			timer.Reset(vw.quiescentTimeout)
-		case <-timer.C:
+		case <-time.After(vw.quiescentTimeout):
 			// Wait until the volume has "settled" before stopping this
 			// goroutine so that we can handle the burst of updates around
 			// freeing claims without having to spin it back up

--- a/nomad/worker_test.go
+++ b/nomad/worker_test.go
@@ -15,7 +15,6 @@ import (
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/ci"
-	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -365,12 +364,10 @@ func TestWorker_runBackoff(t *testing.T) {
 	// We expect to be paused for 10ms + 1ms but otherwise can't be all that
 	// precise here because of concurrency. But checking coverage for this test
 	// shows we've covered the logic
-	t1, cancelT1 := helper.NewSafeTimer(100 * time.Millisecond)
-	defer cancelT1()
 	select {
 	case <-doneCh:
 		t.Fatal("returned early")
-	case <-t1.C:
+	case <-time.After(100 * time.Millisecond):
 	}
 
 	workerCancel()


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
This is a followup to https://github.com/hashicorp/nomad/pull/27784 where we removed the semgrep rule that prevented use of time.After because prior to Go 1.23, it was not garbage collected.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
