### PR TITLE
feat(cli): nomad job run monitoring retry on error

### DIFF
--- a/.changelog/27887.txt
+++ b/.changelog/27887.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added retry for nomad job run monitoring
+```

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gosuri/uilive"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/contexts"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/mitchellh/go-glint"
 	"github.com/mitchellh/go-glint/components"
 	"github.com/moby/term"
@@ -277,18 +278,38 @@ func (c *DeploymentStatusCommand) ttyMonitor(client *api.Client, deployID string
 	var statusComponent *glint.LayoutComponent
 	var endSpinner *glint.LayoutComponent
 
+	// Retry on error monitoring config
+	const (
+		retryBackoffBase = time.Second
+		retryBackoffMax  = 8 * time.Second
+		retry            = 4
+	)
+
 UPDATE:
 	for {
 		var deploy *api.Deployment
 		var meta *api.QueryMeta
-		deploy, meta, err = client.Deployments().Info(deployID, &q)
-		if err != nil {
+
+		for attempt := 0; ; attempt++ {
+			deploy, meta, err = client.Deployments().Info(deployID, &q)
+			if err == nil {
+				break
+			}
+
+			if attempt >= retry {
+				return
+			}
+
+			backoff := helper.Backoff(retryBackoffBase, retryBackoffMax, uint64(attempt))
+
 			d.Append(glint.Layout(glint.Style(
-				glint.Text(fmt.Sprintf("%s: Error fetching deployment: %v", formatTime(time.Now()), err)),
+				glint.Text(fmt.Sprintf("%s: Error fetching deployment: %v, retrying in %s (attempt %d/%d)",
+					formatTime(time.Now()), err, backoff, retry+1, attempt+1)),
 				glint.Color("red"),
 			)).MarginLeft(4), glint.Text(""))
 			d.RenderFrame()
-			return
+
+			time.Sleep(backoff)
 		}
 
 		status = deploy.Status

--- a/command/deployment_status.go
+++ b/command/deployment_status.go
@@ -281,8 +281,8 @@ func (c *DeploymentStatusCommand) ttyMonitor(client *api.Client, deployID string
 	// Retry on error monitoring config
 	const (
 		retryBackoffBase = time.Second
-		retryBackoffMax  = 8 * time.Second
-		retry            = 4
+		retryBackoffMax  = 12 * time.Second
+		maxRetries       = 10
 	)
 
 UPDATE:
@@ -296,17 +296,25 @@ UPDATE:
 				break
 			}
 
-			if attempt >= retry {
+			if attempt >= maxRetries {
+				// Final attempt failed, print error and exit monitoring
+				d.Set()
+				d.Append(
+					glint.Layout(glint.Style(
+						glint.Text(fmt.Sprintf("%s: Error fetching deployment: %v", formatTime(time.Now()), err)),
+						glint.Color("red"),
+					)).MarginLeft(4), glint.Text(""))
+				d.RenderFrame()
 				return
 			}
 
 			backoff := helper.Backoff(retryBackoffBase, retryBackoffMax, uint64(attempt))
 
-			d.Append(glint.Layout(glint.Style(
-				glint.Text(fmt.Sprintf("%s: Error fetching deployment: %v, retrying in %s (attempt %d/%d)",
-					formatTime(time.Now()), err, backoff, retry+1, attempt+1)),
-				glint.Color("red"),
-			)).MarginLeft(4), glint.Text(""))
+			retryComponent := glint.Layout(
+				glint.Text(fmt.Sprintf("Failed fetching deployment: %v, retrying in %s (attempt %d/%d)",
+					err, backoff, attempt+1, maxRetries)),
+			).Row().MarginLeft(4)
+			d.Set(spinner, retryComponent)
 			d.RenderFrame()
 
 			time.Sleep(backoff)


### PR DESCRIPTION
### Description

Adds a retry for errors when monitoring job status after a job run. Closes #12062 

### Testing & Reproduction steps

Unit tests added:
N/A

### Links

N/A

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls.