### PR TITLE
ui: fix versions page showing 'No Changes' on initial SPA navigation

### DIFF
--- a/ui/app/templates/jobs/job/versions.hbs
+++ b/ui/app/templates/jobs/job/versions.hbs
@@ -4,6 +4,7 @@
 ~}}
 
 {{page-title "Job " this.job.name " versions"}}
+{{did-insert this.versionsDidUpdate}}
 {{did-update this.versionsDidUpdate this.job.versions}}
 <JobSubnav @job={{this.job}} />
 <section class="section">


### PR DESCRIPTION
### Description

The Nomad UI was bugged: It would not show job diffs on first load when doing navigation to `Versions` inside the SPA.

See commit message for more details.

I tested this change against Nomad `v1.11.3` only.

One needs to run `make dev-ui` to regenerate `command/agent/bindata_assetfs.go` to test this change.

### Testing & Reproduction steps

Note I let an LLM generate these for me (as I ran the entire multi-hour original investigation with it) and then used them as my repro (so they work):

<details>

**Prerequisites:** A running Nomad cluster (even `nomad agent -dev` suffices).

**Setup — create a job with 2 versions:**

```sh
# Submit Version #0 (count=3)
cat <<'EOF' | curl -s -X PUT "http://localhost:4646/v1/jobs" -d @-
{
  "Job": {
    "ID": "test-versions-diff",
    "Name": "test-versions-diff",
    "Type": "batch",
    "Datacenters": ["dc1"],
    "TaskGroups": [{
      "Name": "main",
      "Count": 3,
      "Tasks": [{
        "Name": "sleep",
        "Driver": "raw_exec",
        "Config": { "command": "/bin/sleep", "args": ["300"] },
        "Resources": { "CPU": 100, "MemoryMB": 64 }
      }]
    }]
  }
}
EOF

# Submit Version #1 (count=1) — creates a diff (Count: 3 -> 1)
cat <<'EOF' | curl -s -X PUT "http://localhost:4646/v1/jobs" -d @-
{
  "Job": {
    "ID": "test-versions-diff",
    "Name": "test-versions-diff",
    "Type": "batch",
    "Datacenters": ["dc1"],
    "TaskGroups": [{
      "Name": "main",
      "Count": 1,
      "Tasks": [{
        "Name": "sleep",
        "Driver": "raw_exec",
        "Config": { "command": "/bin/sleep", "args": ["300"] },
        "Resources": { "CPU": 100, "MemoryMB": 64 }
      }]
    }]
  }
}
EOF
```

**Verify the API returns a diff:**

```sh
curl -s "http://localhost:4646/v1/job/test-versions-diff/versions?diffs=true" | jq '.Diffs | length'
# Should output: 1
```

**Reproduce the bug (before fix):**

1. **Close all Nomad UI browser tabs** (this resets the in-memory `watchList` service).
2. Open the job's **Overview** page: `http://localhost:4646/ui/jobs/test-versions-diff`
3. Wait for the page to fully load.
4. **Click the "Versions" tab** (SPA navigation — do NOT open it in a new tab or hard-refresh).
5. **Observe:** Version #1 shows **"No Changes"** despite the API having a valid diff.

**Verify the fix (after fix):**

Repeat steps 1-4 above. Version #1 should now show **"See 1 Change"** with the correct diff (Count: 3 -> 1).

**Root cause:** `{{did-update this.versionsDidUpdate this.job.versions}}` only fires when `this.job.versions` changes *after* the template's initial render. On SPA navigation from Overview to Versions, the versions are already loaded and cached at the current blocking-query index, so `did-update` never fires, `versionsDidUpdate()` is never called, and diffs are never fetched. Adding `{{did-insert this.versionsDidUpdate}}` ensures diffs are fetched on initial render of the Versions page.

</details>

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
