### PR TITLE
cli: Add `shutdown_delay` to full job init output to fix warning.

### DIFF
--- a/command/asset/connect-short.nomad.hcl
+++ b/command/asset/connect-short.nomad.hcl
@@ -15,7 +15,8 @@ job "countdash" {
     }
 
     task "web" {
-      driver = "docker"
+      driver         = "docker"
+      shutdown_delay = "10s"
 
       config {
         image          = "hashicorpdev/counter-api:v3"
@@ -51,7 +52,8 @@ job "countdash" {
     }
 
     task "dashboard" {
-      driver = "docker"
+      driver         = "docker"
+      shutdown_delay = "10s"
 
       env {
         COUNTING_SERVICE_URL = "http://${NOMAD_UPSTREAM_ADDR_count_api}"

--- a/command/asset/connect.nomad.hcl
+++ b/command/asset/connect.nomad.hcl
@@ -122,6 +122,17 @@ job "countdash" {
         auth_soft_fail = true
       }
 
+      # Specifies the duration to wait when killing a task between removing its
+      # service registrations from Consul or Nomad, and sending it a shutdown
+      # signal. Ideally services would fail health checks once they receive a
+      # shutdown signal.
+      #
+      # For more information on the "shutdown_delay" parameter, refer to:
+      #
+      #     https://developer.hashicorp.com/nomad/docs/job-specification/task#shutdown_delay
+      #
+      shutdown_delay = "10s"
+
       # The "resources" block describes the requirements a task needs to
       # execute. Resource requirements include attributes such as memory, cpu,
       # cores, and devices.
@@ -232,6 +243,17 @@ job "countdash" {
         image          = "hashicorpdev/counter-dashboard:v3"
         auth_soft_fail = true
       }
+
+      # Specifies the duration to wait when killing a task between removing its
+      # service registrations from Consul or Nomad, and sending it a shutdown
+      # signal. Ideally services would fail health checks once they receive a
+      # shutdown signal.
+      #
+      # For more information on the "shutdown_delay" parameter, refer to:
+      #
+      #     https://developer.hashicorp.com/nomad/docs/job-specification/task#shutdown_delay
+      #
+      shutdown_delay = "10s"
     }
   }
 }

--- a/command/asset/example.nomad.hcl
+++ b/command/asset/example.nomad.hcl
@@ -300,6 +300,17 @@ job "example" {
         auth_soft_fail = true
       }
 
+      # Specifies the duration to wait when killing a task between removing its
+      # service registrations from Consul or Nomad, and sending it a shutdown
+      # signal. Ideally services would fail health checks once they receive a
+      # shutdown signal.
+      #
+      # For more information on the "shutdown_delay" parameter, refer to:
+      #
+      #     https://developer.hashicorp.com/nomad/docs/job-specification/task#shutdown_delay
+      #
+      shutdown_delay = "10s"
+
       # The "artifact" block instructs Nomad to download an artifact from a
       # remote source prior to starting the task. This provides a convenient
       # mechanism for downloading configuration files or data needed to run the


### PR DESCRIPTION
Nomad recently added a warning to the CLI output when a job includes a service in a group/task that doesn't have a shutdown delay configured.

This change brings the Nomad example job spec created by the init command inline with our recommendations.

### Links
Related: https://github.com/hashicorp/nomad/pull/27782

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

