### PR TITLE
f-ui: Improve ACL permission error message to prompt sign-in check

### DIFF
--- a/ui/app/utils/message-from-adapter-error.js
+++ b/ui/app/utils/message-from-adapter-error.js
@@ -8,7 +8,7 @@ import { ForbiddenError } from '@ember-data/adapter/error';
 // Returns a single string based on the response the adapter received
 export default function messageFromAdapterError(error, actionMessage) {
   if (error instanceof ForbiddenError) {
-    return `Your ACL token does not grant permission to ${actionMessage}.`;
+    return `Your ACL token does not grant permission to ${actionMessage}. Please ensure you are signed in.`;
   }
 
   if (error.errors?.length) {

--- a/ui/app/utils/message-from-adapter-error.js
+++ b/ui/app/utils/message-from-adapter-error.js
@@ -5,10 +5,22 @@
 
 import { ForbiddenError } from '@ember-data/adapter/error';
 
+function hasNomadToken() {
+  try {
+    return Boolean(globalThis?.localStorage?.nomadTokenSecret);
+  } catch {
+    return false;
+  }
+}
+
 // Returns a single string based on the response the adapter received
 export default function messageFromAdapterError(error, actionMessage) {
   if (error instanceof ForbiddenError) {
-    return `Your ACL token does not grant permission to ${actionMessage}. Please ensure you are signed in.`;
+    const hasToken = hasNomadToken();
+    if (!hasToken) {
+      return 'You are not signed in. Please sign in to perform this action.';
+    }
+    return `Your ACL token does not grant permission to ${actionMessage}.`;
   }
 
   if (error.errors?.length) {

--- a/ui/tests/acceptance/allocation-detail-test.js
+++ b/ui/tests/acceptance/allocation-detail-test.js
@@ -449,8 +449,10 @@ module('Acceptance | allocation detail', function (hooks) {
       'Title is descriptive',
     );
     assert.ok(
-      /ACL token.+?allocation lifecycle/.test(Allocation.inlineError.message),
-      'Message mentions ACLs and the appropriate permission',
+      /ACL token.+?allocation lifecycle|not signed in.+sign in to perform this action/i.test(
+        Allocation.inlineError.message,
+      ),
+      'Message mentions ACL permissions or sign-in guidance',
     );
 
     await Allocation.inlineError.dismiss();

--- a/ui/tests/acceptance/task-detail-test.js
+++ b/ui/tests/acceptance/task-detail-test.js
@@ -327,8 +327,10 @@ module('Acceptance | task detail', function (hooks) {
       'Title is descriptive',
     );
     assert.ok(
-      /ACL token.+?allocation lifecycle/.test(Task.inlineError.message),
-      'Message mentions ACLs and the appropriate permission',
+      /ACL token.+?allocation lifecycle|not signed in.+sign in to perform this action/i.test(
+        Task.inlineError.message,
+      ),
+      'Message mentions ACL permissions or sign-in guidance',
     );
 
     await Task.inlineError.dismiss();

--- a/ui/tests/unit/utils/message-from-adapter-error-test.js
+++ b/ui/tests/unit/utils/message-from-adapter-error-test.js
@@ -9,11 +9,6 @@ import messageFromAdapterError from 'nomad-ui/utils/message-from-adapter-error';
 
 const testCases = [
   {
-    name: 'Forbidden Error',
-    in: [new ForbiddenError([], "Can't do that"), 'run tests'],
-    out: 'Your ACL token does not grant permission to run tests. Please ensure you are signed in.',
-  },
-  {
     name: 'Generic Error',
     in: [
       new ServerError([{ detail: 'DB Max Connections' }], 'Server Error'),
@@ -39,7 +34,41 @@ const testCases = [
   },
 ];
 
-module('Unit | Util | messageFromAdapterError', function () {
+module('Unit | Util | messageFromAdapterError', function (hooks) {
+  let originalToken;
+
+  hooks.beforeEach(function () {
+    originalToken = window.localStorage.nomadTokenSecret;
+  });
+
+  hooks.afterEach(function () {
+    if (originalToken == null) {
+      window.localStorage.removeItem('nomadTokenSecret');
+    } else {
+      window.localStorage.nomadTokenSecret = originalToken;
+    }
+  });
+
+  test('Forbidden Error - not signed in', function (assert) {
+    window.localStorage.removeItem('nomadTokenSecret');
+
+    assert.deepEqual(
+      messageFromAdapterError(new ForbiddenError([], "Can't do that"), 'run tests'),
+      'You are not signed in. Please sign in to perform this action.',
+      'Returns sign-in guidance when no token is present'
+    );
+  });
+
+  test('Forbidden Error - signed in, insufficient permissions', function (assert) {
+    window.localStorage.nomadTokenSecret = 'some-token';
+
+    assert.deepEqual(
+      messageFromAdapterError(new ForbiddenError([], "Can't do that"), 'run tests'),
+      'Your ACL token does not grant permission to run tests.',
+      'Returns permission message when token is present'
+    );
+  });
+
   testCases.forEach((testCase) => {
     test(testCase.name, function (assert) {
       assert.deepEqual(

--- a/ui/tests/unit/utils/message-from-adapter-error-test.js
+++ b/ui/tests/unit/utils/message-from-adapter-error-test.js
@@ -11,7 +11,7 @@ const testCases = [
   {
     name: 'Forbidden Error',
     in: [new ForbiddenError([], "Can't do that"), 'run tests'],
-    out: 'Your ACL token does not grant permission to run tests.',
+    out: 'Your ACL token does not grant permission to run tests. Please ensure you are signed in.',
   },
   {
     name: 'Generic Error',


### PR DESCRIPTION
### Description

This PR updates the error message for ACL permission failures to be more actionable by suggesting that users verify they are signed in. Previously, when users encountered a 403 Forbidden error, the message only stated that their ACL token didn't grant permission, which could be confusing for users who weren't logged in at all.

The updated error message now reads: `Your ACL token does not grant permission to ${actionMessage}. Please ensure you are signed in.`

This change improves the user experience by providing a clear next step when encountering permission errors.

### Testing & Reproduction steps

**Manual Testing:**
1. Open the Nomad UI without being logged in
2. Attempt to perform an action that requires ACL permissions (e.g., accessing jobs, allocations, or other protected resources)
3. Verify that the error message now includes "Please ensure you are signed in."
4. Log in with valid credentials and verify the action works as expected

**To reproduce this error message:**

1. Use read-only token  or anonymous token in the UI
2. Navigate to Jobs and select any job
3. Click "Definition" tab
4. Click "Edit" button
5. Make a change
6. Click "Plan" button
🐛 YOU SHOULD SEE THE ERROR


### Links
- Jira Issue: https://hashicorp.atlassian.net/browse/NMD-1050


**User Not Signed In**
<img width="1728" height="999" alt="image" src="https://github.com/user-attachments/assets/411c82eb-20b6-4d9c-bd67-72778ff7da96" />

**User Signed In with Insufficient Permissions**
<img width="1728" height="992" alt="image" src="https://github.com/user-attachments/assets/d2758851-76dc-4ff3-bba2-aa38be969ca9" />




### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.
- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

No changes to security controls. This PR only modifies the error message text to be more user-friendly by suggesting users verify they are signed in when encountering ACL permission errors. The underlying authentication and authorization mechanisms remain unchanged.
