### PR TITLE
cli: automatically expand `exec -it` to `-i -t`

### DIFF
--- a/.changelog/27906.txt
+++ b/.changelog/27906.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Automatically expand `nomad exec -it` to `-i -t`
+```

--- a/command/alloc_exec.go
+++ b/command/alloc_exec.go
@@ -118,6 +118,7 @@ func (l *AllocExecCommand) Run(args []string) int {
 	flags.StringVar(&task, "task", "", "")
 	flags.StringVar(&group, "group", "", "")
 
+	args = expandITFlags(args)
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -338,6 +339,22 @@ func setRawTerminalOutput(stream interface{}) (cleanup func(), err error) {
 	}
 
 	return func() { term.RestoreTerminal(fd, state) }, nil
+}
+
+// expandITFlags preprocesses args to expand the combined short boolean flags
+// -it and -ti into their individual forms -i -t, mirroring the convention
+// established by tools like docker and ssh.
+func expandITFlags(args []string) []string {
+	expanded := make([]string, 0, len(args))
+	for _, arg := range args {
+		switch arg {
+		case "-it", "-ti":
+			expanded = append(expanded, "-i", "-t")
+		default:
+			expanded = append(expanded, arg)
+		}
+	}
+	return expanded
 }
 
 // watchTerminalSize watches terminal size changes to propagate to remote tty.

--- a/command/alloc_exec_test.go
+++ b/command/alloc_exec_test.go
@@ -77,6 +77,11 @@ func TestAllocExecCommand_Fails(t *testing.T) {
 			[]string{"-address=" + url, "-e", "es", "26470238-5CF2-438F-8772-DC67CFB0705C", "/bin/bash"},
 			`-e requires 'none' or a single character`,
 		},
+		{
+			"-it with stdin disabled is rejected",
+			[]string{"-it", "-i=false", "26470238-5CF2-438F-8772-DC67CFB0705C", "/bin/bash"},
+			`-i must be enabled if running with tty`,
+		},
 	}
 
 	for _, c := range cases {
@@ -163,6 +168,49 @@ func TestAllocExecCommand_AutocompleteArgs(t *testing.T) {
 	res := predictor.Predict(args)
 	must.Len(t, 1, res)
 	must.Eq(t, a.ID, res[0])
+}
+
+func TestExpandITFlags(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "no combined flags",
+			input:    []string{"-i", "-t", "alloc", "/bin/sh"},
+			expected: []string{"-i", "-t", "alloc", "/bin/sh"},
+		},
+		{
+			name:     "-it expanded",
+			input:    []string{"-it", "alloc", "/bin/sh"},
+			expected: []string{"-i", "-t", "alloc", "/bin/sh"},
+		},
+		{
+			name:     "-ti expanded",
+			input:    []string{"-ti", "alloc", "/bin/sh"},
+			expected: []string{"-i", "-t", "alloc", "/bin/sh"},
+		},
+		{
+			name:     "-it with other flags",
+			input:    []string{"-address=http://localhost", "-it", "alloc", "/bin/sh"},
+			expected: []string{"-address=http://localhost", "-i", "-t", "alloc", "/bin/sh"},
+		},
+		{
+			name:     "empty args",
+			input:    []string{},
+			expected: []string{},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result := expandITFlags(c.input)
+			must.Eq(t, c.expected, result)
+		})
+	}
 }
 
 func TestAllocExecCommand_Run(t *testing.T) {


### PR DESCRIPTION
so `nomad exec -it` works the same as `docker exec -it`

```
$ nomad job init -short
Example job file written to example.nomad.hcl

$ nomad run -detach example.nomad.hcl
Job registration successful
Evaluation ID: c402fb1f-4ab6-9b10-c881-b8655ca1473d

$ nomad exec -it -job example ls /usr/local/bin
docker-entrypoint.sh  redis-benchmark  redis-check-rdb  redis-sentinel
gosu                  redis-check-aof  redis-cli        redis-server
```


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
