### PR TITLE
ci: Handle cygwin in OS type install Vault action.

### DIFF
--- a/.github/actions/install-vault/action.yml
+++ b/.github/actions/install-vault/action.yml
@@ -19,6 +19,7 @@ runs:
         linux*)  os="linux" ;;
         darwin*) os="darwin" ;;
         msys*)   os="windows" ;;
+        cygwin*)  os="windows" ;;
         *)       echo "unknown os: ${OSTYPE}"; exit 1 ;;
       esac
 


### PR DESCRIPTION
I've not been able to pinpoint what changed, but our Windows CI has started failing with `unknown os: cygwin` when attempting to install Vault. This change adds handling cygwin to the install script which resolves CI errors.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

