### PR TITLE
cli: display job deadline if present

### DIFF
--- a/.changelog/27913.txt
+++ b/.changelog/27913.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: display job deadline if present
+```

--- a/command/alloc_status.go
+++ b/command/alloc_status.go
@@ -198,7 +198,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 
 	// Format the allocation data
 	if short {
-		c.Ui.Output(formatAllocShortInfo(alloc, client))
+		c.Ui.Output(formatAllocShortInfo(alloc))
 	} else {
 		output, err := formatAllocBasicInfo(alloc, client, length, verbose)
 		if err != nil {
@@ -256,7 +256,7 @@ func (c *AllocStatusCommand) Run(args []string) int {
 	return 0
 }
 
-func formatAllocShortInfo(alloc *api.Allocation, client *api.Client) string {
+func formatAllocShortInfo(alloc *api.Allocation) string {
 	formattedCreateTime := prettyTimeDiff(time.Unix(0, alloc.CreateTime), time.Now())
 	formattedModifyTime := prettyTimeDiff(time.Unix(0, alloc.ModifyTime), time.Now())
 
@@ -265,6 +265,10 @@ func formatAllocShortInfo(alloc *api.Allocation, client *api.Client) string {
 		fmt.Sprintf("Name|%s", alloc.Name),
 		fmt.Sprintf("Created|%s", formattedCreateTime),
 		fmt.Sprintf("Modified|%s", formattedModifyTime),
+	}
+
+	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates); ok {
+		basic = append(basic, fmt.Sprintf("Max Run Deadline|%s", formatMaxRunDeadline(deadline, false)))
 	}
 
 	return formatKV(basic)
@@ -295,6 +299,10 @@ func formatAllocBasicInfo(alloc *api.Allocation, client *api.Client, uuidLength 
 		fmt.Sprintf("Desired Description|%s", alloc.DesiredDescription),
 		fmt.Sprintf("Created|%s", formattedCreateTime),
 		fmt.Sprintf("Modified|%s", formattedModifyTime),
+	}
+
+	if deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates); ok {
+		basic = append(basic, fmt.Sprintf("Max Run Deadline|%s", formatMaxRunDeadline(deadline, verbose)))
 	}
 
 	if alloc.DeploymentID != "" {

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/cli"
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -201,6 +202,65 @@ func TestAllocStatusCommand_Run(t *testing.T) {
 
 	// make sure nsd checks status output is elided if none exist
 	must.StrNotContains(t, out, `Nomad Service Checks:`)
+}
+
+func TestFormatAllocBasicInfo_MaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeBatch
+	version := uint64(1)
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := startedAt.Add(maxRunDuration)
+
+	alloc := &api.Allocation{
+		ID:                 "alloc-id",
+		EvalID:             "eval-id",
+		Name:               "alloc-name",
+		NodeID:             "node-id",
+		NodeName:           "node-name",
+		JobID:              "job-id",
+		Job:                &api.Job{Type: &jobType, Version: &version, TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}}},
+		TaskGroup:          groupName,
+		ClientStatus:       "running",
+		ClientDescription:  "running",
+		DesiredStatus:      "run",
+		DesiredDescription: "run",
+		TaskStates: map[string]*api.TaskState{
+			"task-a": {State: "running", StartedAt: startedAt.Add(-1 * time.Minute)},
+			"task-b": {State: "running", StartedAt: startedAt},
+		},
+		Metrics: &api.AllocationMetric{},
+	}
+
+	out, err := formatAllocBasicInfo(alloc, nil, fullId, true)
+	must.NoError(t, err)
+	must.StrContains(t, out, "Max Run Deadline")
+	must.StrContains(t, out, formatTime(deadline))
+}
+
+func TestFormatAllocShortInfo_MaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeBatch
+	version := uint64(1)
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+	startedAt := time.Now().Add(-5 * time.Minute)
+
+	alloc := &api.Allocation{
+		ID:        "alloc-id",
+		Name:      "alloc-name",
+		Job:       &api.Job{Type: &jobType, Version: &version, TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}}},
+		TaskGroup: groupName,
+		TaskStates: map[string]*api.TaskState{
+			"task-a": {State: "running", StartedAt: startedAt},
+		},
+	}
+
+	out := formatAllocShortInfo(alloc)
+	must.StrContains(t, out, "Max Run Deadline")
 }
 
 func TestAllocStatusCommand_RescheduleInfo(t *testing.T) {

--- a/command/alloc_status_test.go
+++ b/command/alloc_status_test.go
@@ -229,7 +229,7 @@ func TestFormatAllocBasicInfo_MaxRunDeadline(t *testing.T) {
 		DesiredDescription: "run",
 		TaskStates: map[string]*api.TaskState{
 			"task-a": {State: "running", StartedAt: startedAt.Add(-1 * time.Minute)},
-			"task-b": {State: "running", StartedAt: startedAt},
+			"task-b": {State: "dead", StartedAt: startedAt},
 		},
 		Metrics: &api.AllocationMetric{},
 	}

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -122,6 +122,68 @@ func formatTimeDifference(first, second time.Time, d time.Duration) string {
 	return second.Truncate(d).Sub(first.Truncate(d)).String()
 }
 
+func formatMaxRunDeadline(deadline time.Time, verbose bool) string {
+	if verbose {
+		return formatTime(deadline)
+	}
+
+	return prettyTimeDiff(deadline, time.Now())
+}
+
+func jobTaskGroupMaxRunDeadline(job *api.Job, taskGroupName string, taskStates map[string]*api.TaskState) (time.Time, bool) {
+	maxRunDuration, ok := jobTaskGroupMaxRunDuration(job, taskGroupName)
+	if !ok {
+		return time.Time{}, false
+	}
+
+	startedAt, ok := taskStatesFullyRunningSince(taskStates)
+	if !ok {
+		return time.Time{}, false
+	}
+
+	return startedAt.Add(maxRunDuration), true
+}
+
+func jobTaskGroupMaxRunDuration(job *api.Job, taskGroupName string) (time.Duration, bool) {
+	if job == nil || job.Type == nil {
+		return 0, false
+	}
+
+	tg := job.LookupTaskGroup(taskGroupName)
+	if tg == nil || tg.MaxRunDuration == nil || *tg.MaxRunDuration <= 0 {
+		return 0, false
+	}
+
+	switch *job.Type {
+	case api.JobTypeBatch, api.JobTypeSysbatch:
+		return *tg.MaxRunDuration, true
+	default:
+		return 0, false
+	}
+}
+
+func taskStatesFullyRunningSince(taskStates map[string]*api.TaskState) (time.Time, bool) {
+	if len(taskStates) == 0 {
+		return time.Time{}, false
+	}
+
+	var latest time.Time
+	for _, ts := range taskStates {
+		if ts == nil || ts.State != "running" || ts.StartedAt.IsZero() {
+			return time.Time{}, false
+		}
+		if ts.StartedAt.After(latest) {
+			latest = ts.StartedAt
+		}
+	}
+
+	if latest.IsZero() {
+		return time.Time{}, false
+	}
+
+	return latest, true
+}
+
 // fmtInt formats v into the tail of buf.
 // It returns the index where the output begins.
 func fmtInt(buf []byte, v uint64) int {

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -181,7 +181,7 @@ func taskStatesFullyStartedSince(taskStates map[string]*api.TaskState) (time.Tim
 		return time.Time{}, false
 	}
 
-	return latest, true
+	return latest.Local(), true
 }
 
 // fmtInt formats v into the tail of buf.

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -136,7 +136,7 @@ func jobTaskGroupMaxRunDeadline(job *api.Job, taskGroupName string, taskStates m
 		return time.Time{}, false
 	}
 
-	startedAt, ok := taskStatesFullyRunningSince(taskStates)
+	startedAt, ok := taskStatesFullyStartedSince(taskStates)
 	if !ok {
 		return time.Time{}, false
 	}
@@ -162,14 +162,14 @@ func jobTaskGroupMaxRunDuration(job *api.Job, taskGroupName string) (time.Durati
 	}
 }
 
-func taskStatesFullyRunningSince(taskStates map[string]*api.TaskState) (time.Time, bool) {
+func taskStatesFullyStartedSince(taskStates map[string]*api.TaskState) (time.Time, bool) {
 	if len(taskStates) == 0 {
 		return time.Time{}, false
 	}
 
 	var latest time.Time
 	for _, ts := range taskStates {
-		if ts == nil || ts.State != "running" || ts.StartedAt.IsZero() {
+		if ts == nil || ts.StartedAt.IsZero() {
 			return time.Time{}, false
 		}
 		if ts.StartedAt.After(latest) {

--- a/command/job_allocs.go
+++ b/command/job_allocs.go
@@ -107,8 +107,13 @@ func (c *JobAllocsCommand) Run(args []string) int {
 
 	q := &api.QueryOptions{Namespace: namespace}
 
+	// Fetch job info to enrich allocations output (e.g. Max Run Deadline
+	// column). This is best-effort: when the jobID was returned as a raw
+	// prefix by JobIDByPrefix (e.g. because the token lacks list-jobs), the
+	// Info call may fail. In that case we continue with a nil job so that
+	// formatJobAllocListStubs still works — it omits the deadline column.
 	job, _, err := client.Jobs().Info(jobID, q)
-	if err != nil {
+	if err != nil && strings.Contains(err.Error(), api.PermissionDeniedErrorContent) {
 		c.Ui.Error(fmt.Sprintf("Error querying job: %s", err))
 		return 1
 	}

--- a/command/job_allocs.go
+++ b/command/job_allocs.go
@@ -107,6 +107,12 @@ func (c *JobAllocsCommand) Run(args []string) int {
 
 	q := &api.QueryOptions{Namespace: namespace}
 
+	job, _, err := client.Jobs().Info(jobID, q)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Error querying job: %s", err))
+		return 1
+	}
+
 	allocs, _, err := client.Jobs().Allocations(jobID, all, q)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error retrieving allocations: %s", err))
@@ -130,6 +136,6 @@ func (c *JobAllocsCommand) Run(args []string) int {
 		length = fullId
 	}
 
-	c.Ui.Output(formatAllocListStubs(allocs, verbose, length))
+	c.Ui.Output(formatJobAllocListStubs(allocs, job, verbose, length))
 	return 0
 }

--- a/command/job_allocs_test.go
+++ b/command/job_allocs_test.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/nomad/api"
@@ -95,6 +96,45 @@ func TestJobAllocsCommand_Run(t *testing.T) {
 
 	ui.OutputWriter.Reset()
 	ui.ErrorWriter.Reset()
+}
+
+func TestJobAllocsCommand_MaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+	srv, _, url := testServer(t, true, nil)
+	defer srv.Shutdown()
+
+	ui := cli.NewMockUi()
+	cmd := &JobAllocsCommand{Meta: Meta{Ui: ui}}
+	state := srv.Agent.Server().State()
+
+	job := mock.BatchJob()
+	maxRunDuration := 10 * time.Minute
+	job.TaskGroups[0].MaxRunDuration = &maxRunDuration
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 100, nil, job))
+
+	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := startedAt.Add(maxRunDuration)
+
+	a := mock.Alloc()
+	a.Job = job
+	a.JobID = job.ID
+	a.TaskGroup = job.TaskGroups[0].Name
+	a.Metrics = &structs.AllocMetric{}
+	a.DesiredStatus = structs.AllocDesiredStatusRun
+	a.ClientStatus = structs.AllocClientStatusRunning
+	a.TaskStates = map[string]*structs.TaskState{
+		"web": {State: "running", StartedAt: startedAt},
+	}
+	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 200, []*structs.Allocation{a}))
+
+	code := cmd.Run([]string{"-address=" + url, "-verbose", job.ID})
+	out := ui.OutputWriter.String()
+	outerr := ui.ErrorWriter.String()
+
+	must.Zero(t, code)
+	must.Eq(t, "", outerr)
+	must.StrContains(t, out, "Max Run Deadline")
+	must.StrContains(t, out, formatTime(deadline))
 }
 
 func TestJobAllocsCommand_Template(t *testing.T) {

--- a/command/job_status.go
+++ b/command/job_status.go
@@ -519,7 +519,7 @@ func (c *JobStatusCommand) outputJobInfo(client *api.Client, job *api.Job) error
 
 	// Format the allocs
 	c.Ui.Output(c.Colorize().Color("\n[bold]Allocations[reset]"))
-	c.Ui.Output(formatAllocListStubs(jobAllocs, c.verbose, c.length))
+	c.Ui.Output(formatJobAllocListStubs(jobAllocs, job, c.verbose, c.length))
 	return nil
 }
 
@@ -574,16 +574,38 @@ func formatJobActions(actions []map[string]string) string {
 	return formatList(actionsOut)
 }
 
+func formatJobAllocListStubs(stubs []*api.AllocationListStub, job *api.Job, verbose bool, uuidLength int) string {
+	deadlines := make([]string, len(stubs))
+	for i, alloc := range stubs {
+		deadline, ok := jobTaskGroupMaxRunDeadline(job, alloc.TaskGroup, alloc.TaskStates)
+		if !ok {
+			continue
+		}
+
+		deadlines[i] = formatMaxRunDeadline(deadline, verbose)
+	}
+
+	return formatAllocListStubsWithDeadlines(stubs, verbose, uuidLength, deadlines)
+}
+
 func formatAllocListStubs(stubs []*api.AllocationListStub, verbose bool, uuidLength int) string {
+	return formatAllocListStubsWithDeadlines(stubs, verbose, uuidLength, nil)
+}
+
+func formatAllocListStubsWithDeadlines(stubs []*api.AllocationListStub, verbose bool, uuidLength int, deadlines []string) string {
 	if len(stubs) == 0 {
 		return "No allocations placed"
 	}
 
+	showDeadline := allocationDeadlineColumnVisible(deadlines)
 	allocs := make([]string, len(stubs)+1)
 	if verbose {
 		allocs[0] = "ID|Eval ID|Node ID|Node Name|Task Group|Version|Desired|Status|Created|Modified"
+		if showDeadline {
+			allocs[0] += "|Max Run Deadline"
+		}
 		for i, alloc := range stubs {
-			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%s|%d|%s|%s|%s|%s",
+			row := fmt.Sprintf("%s|%s|%s|%s|%s|%d|%s|%s|%s|%s",
 				limit(alloc.ID, uuidLength),
 				limit(alloc.EvalID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
@@ -594,14 +616,21 @@ func formatAllocListStubs(stubs []*api.AllocationListStub, verbose bool, uuidLen
 				alloc.ClientStatus,
 				formatUnixNanoTime(alloc.CreateTime),
 				formatUnixNanoTime(alloc.ModifyTime))
+			if showDeadline {
+				row += fmt.Sprintf("|%s", deadlines[i])
+			}
+			allocs[i+1] = row
 		}
 	} else {
 		allocs[0] = "ID|Node ID|Task Group|Version|Desired|Status|Created|Modified"
+		if showDeadline {
+			allocs[0] += "|Max Run Deadline"
+		}
+		now := time.Now()
 		for i, alloc := range stubs {
-			now := time.Now()
 			createTimePretty := prettyTimeDiff(time.Unix(0, alloc.CreateTime), now)
 			modTimePretty := prettyTimeDiff(time.Unix(0, alloc.ModifyTime), now)
-			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%d|%s|%s|%s|%s",
+			row := fmt.Sprintf("%s|%s|%s|%d|%s|%s|%s|%s",
 				limit(alloc.ID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
 				alloc.TaskGroup,
@@ -610,10 +639,24 @@ func formatAllocListStubs(stubs []*api.AllocationListStub, verbose bool, uuidLen
 				alloc.ClientStatus,
 				createTimePretty,
 				modTimePretty)
+			if showDeadline {
+				row += fmt.Sprintf("|%s", deadlines[i])
+			}
+			allocs[i+1] = row
 		}
 	}
 
 	return formatList(allocs)
+}
+
+func allocationDeadlineColumnVisible(deadlines []string) bool {
+	for _, deadline := range deadlines {
+		if deadline != "" {
+			return true
+		}
+	}
+
+	return false
 }
 
 func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int) string {
@@ -621,11 +664,25 @@ func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int
 		return "No allocations placed"
 	}
 
+	deadlines := make([]string, len(allocations))
+	for i, alloc := range allocations {
+		deadline, ok := jobTaskGroupMaxRunDeadline(alloc.Job, alloc.TaskGroup, alloc.TaskStates)
+		if !ok {
+			continue
+		}
+
+		deadlines[i] = formatMaxRunDeadline(deadline, verbose)
+	}
+	showDeadline := allocationDeadlineColumnVisible(deadlines)
+
 	allocs := make([]string, len(allocations)+1)
 	if verbose {
 		allocs[0] = "ID|Eval ID|Node ID|Task Group|Version|Desired|Status|Created|Modified"
+		if showDeadline {
+			allocs[0] += "|Max Run Deadline"
+		}
 		for i, alloc := range allocations {
-			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%s|%d|%s|%s|%s|%s",
+			row := fmt.Sprintf("%s|%s|%s|%s|%d|%s|%s|%s|%s",
 				limit(alloc.ID, uuidLength),
 				limit(alloc.EvalID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
@@ -635,14 +692,21 @@ func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int
 				alloc.ClientStatus,
 				formatUnixNanoTime(alloc.CreateTime),
 				formatUnixNanoTime(alloc.ModifyTime))
+			if showDeadline {
+				row += fmt.Sprintf("|%s", deadlines[i])
+			}
+			allocs[i+1] = row
 		}
 	} else {
 		allocs[0] = "ID|Node ID|Task Group|Version|Desired|Status|Created|Modified"
+		if showDeadline {
+			allocs[0] += "|Max Run Deadline"
+		}
+		now := time.Now()
 		for i, alloc := range allocations {
-			now := time.Now()
 			createTimePretty := prettyTimeDiff(time.Unix(0, alloc.CreateTime), now)
 			modTimePretty := prettyTimeDiff(time.Unix(0, alloc.ModifyTime), now)
-			allocs[i+1] = fmt.Sprintf("%s|%s|%s|%d|%s|%s|%s|%s",
+			row := fmt.Sprintf("%s|%s|%s|%d|%s|%s|%s|%s",
 				limit(alloc.ID, uuidLength),
 				limit(alloc.NodeID, uuidLength),
 				alloc.TaskGroup,
@@ -651,6 +715,10 @@ func formatAllocList(allocations []*api.Allocation, verbose bool, uuidLength int
 				alloc.ClientStatus,
 				createTimePretty,
 				modTimePretty)
+			if showDeadline {
+				row += fmt.Sprintf("|%s", deadlines[i])
+			}
+			allocs[i+1] = row
 		}
 	}
 

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -250,6 +250,102 @@ func TestJobStatusCommand_Fails(t *testing.T) {
 	}
 }
 
+func TestFormatJobAllocListStubs_MaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeBatch
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := startedAt.Add(maxRunDuration)
+
+	job := &api.Job{
+		Type: &jobType,
+		TaskGroups: []*api.TaskGroup{{
+			Name:           &groupName,
+			MaxRunDuration: &maxRunDuration,
+		}},
+	}
+
+	allocs := []*api.AllocationListStub{{
+		ID:            "alloc-id",
+		EvalID:        "eval-id",
+		NodeID:        "node-id",
+		NodeName:      "node-name",
+		TaskGroup:     groupName,
+		JobVersion:    1,
+		DesiredStatus: "run",
+		ClientStatus:  "running",
+		TaskStates: map[string]*api.TaskState{
+			"task-a": {State: "running", StartedAt: startedAt},
+		},
+	}}
+
+	out := formatJobAllocListStubs(allocs, job, true, fullId)
+	must.StrContains(t, out, "Max Run Deadline")
+	must.StrContains(t, out, formatTime(deadline))
+}
+
+func TestFormatJobAllocListStubs_NoMaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeService
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+	startedAt := time.Now().Add(-5 * time.Minute)
+
+	job := &api.Job{
+		Type: &jobType,
+		TaskGroups: []*api.TaskGroup{{
+			Name:           &groupName,
+			MaxRunDuration: &maxRunDuration,
+		}},
+	}
+
+	allocs := []*api.AllocationListStub{{
+		ID:            "alloc-id",
+		NodeID:        "node-id",
+		TaskGroup:     groupName,
+		JobVersion:    1,
+		DesiredStatus: "run",
+		ClientStatus:  "running",
+		TaskStates: map[string]*api.TaskState{
+			"task-a": {State: "running", StartedAt: startedAt},
+		},
+	}}
+
+	out := formatJobAllocListStubs(allocs, job, false, fullId)
+	must.StrNotContains(t, out, "Max Run Deadline")
+}
+
+func TestFormatAllocList_MaxRunDeadline(t *testing.T) {
+	ci.Parallel(t)
+
+	jobType := api.JobTypeBatch
+	version := uint64(1)
+	groupName := "group"
+	maxRunDuration := 10 * time.Minute
+	startedAt := time.Now().Add(-5 * time.Minute).Round(time.Second)
+	deadline := startedAt.Add(maxRunDuration)
+
+	allocs := []*api.Allocation{{
+		ID:            "alloc-id",
+		EvalID:        "eval-id",
+		NodeID:        "node-id",
+		TaskGroup:     groupName,
+		Job:           &api.Job{Type: &jobType, Version: &version, TaskGroups: []*api.TaskGroup{{Name: &groupName, MaxRunDuration: &maxRunDuration}}},
+		DesiredStatus: "run",
+		ClientStatus:  "running",
+		TaskStates: map[string]*api.TaskState{
+			"task-a": {State: "running", StartedAt: startedAt},
+		},
+	}}
+
+	out := formatAllocList(allocs, true, fullId)
+	must.StrContains(t, out, "Max Run Deadline")
+	must.StrContains(t, out, formatTime(deadline))
+}
+
 func TestJobStatusCommand_AutocompleteArgs(t *testing.T) {
 	ci.Parallel(t)
 

--- a/command/job_status_test.go
+++ b/command/job_status_test.go
@@ -277,7 +277,8 @@ func TestFormatJobAllocListStubs_MaxRunDeadline(t *testing.T) {
 		DesiredStatus: "run",
 		ClientStatus:  "running",
 		TaskStates: map[string]*api.TaskState{
-			"task-a": {State: "running", StartedAt: startedAt},
+			"task-a": {State: "running", StartedAt: startedAt.Add(-1 * time.Minute)},
+			"task-b": {State: "complete", StartedAt: startedAt},
 		},
 	}}
 
@@ -337,7 +338,8 @@ func TestFormatAllocList_MaxRunDeadline(t *testing.T) {
 		DesiredStatus: "run",
 		ClientStatus:  "running",
 		TaskStates: map[string]*api.TaskState{
-			"task-a": {State: "running", StartedAt: startedAt},
+			"task-a": {State: "running", StartedAt: startedAt.Add(-1 * time.Minute)},
+			"task-b": {State: "complete", StartedAt: startedAt},
 		},
 	}}
 


### PR DESCRIPTION
This changeset adds displaying the deadline (if present) to all CLI commands
that display information about jobs or allocations. 

See #27803 for context. 

```
$ nomad status maxrun
ID            = maxrun
Name          = maxrun
Submit Date   = 2026-05-07T17:33:08+02:00
Type          = batch
Priority      = 50
Datacenters   = *
Namespace     = default
Node Pool     = default
Status        = running
Periodic      = false
Parameterized = false

Summary
Task Group         Queued  Starting  Running  Failed  Complete  Lost  Unknown
huge_docker_image  0       0         0        0       1         0     0
maxrun             0       0         1        0       0         0     0

Allocations
ID        Node ID   Task Group         Version  Desired  Status    Created  Modified  Max Run Deadline
4c414d3b  9f4d1232  huge_docker_image  0        run      complete  19s ago  4s ago    2s ago
d7c16834  9f4d1232  maxrun             0        run      running   19s ago  14s ago   2m13s from now

==> View job details and metrics in the Web UI: http://127.0.0.1:4646/ui/jobs/maxrun@default

$ nomad alloc status d7c
ID                  = d7c16834-3f9a-9880-654c-4e24d0f98b7f
Eval ID             = 753fa1f9
Name                = maxrun.maxrun[0]
Node ID             = 9f4d1232
Node Name           = piotrkazmierczak-WWQLTFG2KP
Job ID              = maxrun
Job Version         = 0
Client Status       = running
Client Description  = Tasks are running
Desired Status      = run
Desired Description = <none>
Created             = 57s ago
Modified            = 52s ago
Max Run Deadline    = 1m35s from now

Task "maxrun3" (prestart) is "dead"
Task Resources:
CPU        Memory           Disk     Addresses
0/100 MHz  1.1 MiB/300 MiB  300 MiB

Task Events:
Started At     = 2026-05-07T15:33:08Z
Finished At    = 2026-05-07T15:33:10Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2026-05-07T17:33:10+02:00  Terminated  Exit Code: 0
2026-05-07T17:33:08+02:00  Started     Task started by client
2026-05-07T17:33:08+02:00  Task Setup  Building Task Directory
2026-05-07T17:33:08+02:00  Received    Task received by client

Task "maxrun" is "running"
Task Resources:
CPU        Memory           Disk     Addresses
0/100 MHz  1.1 MiB/300 MiB  300 MiB

Task Events:
Started At     = 2026-05-07T15:33:10Z
Finished At    = N/A
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2026-05-07T17:33:10+02:00  Started     Task started by client
2026-05-07T17:33:10+02:00  Task Setup  Building Task Directory
2026-05-07T17:33:08+02:00  Received    Task received by client

Task "maxrun2" is "dead"
Task Resources:
CPU        Memory           Disk     Addresses
0/100 MHz  1.1 MiB/300 MiB  300 MiB

Task Events:
Started At     = 2026-05-07T15:33:10Z
Finished At    = 2026-05-07T15:33:12Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2026-05-07T17:33:12+02:00  Terminated  Exit Code: 0
2026-05-07T17:33:10+02:00  Started     Task started by client
2026-05-07T17:33:10+02:00  Task Setup  Building Task Directory
2026-05-07T17:33:08+02:00  Received    Task received by client

==> View allocation details in the Web UI: http://127.0.0.1:4646/ui/allocations/d7c16834-3f9a-9880-654c-4e24d0f98b7f
```
