### PR TITLE
script: add helper script for generating changelog locally

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -eu
+
+which changelog-build > /dev/null || {
+    echo "installing changelog-build from repo"
+    go install github.com/hashicorp/go-changelog/cmd/changelog-build@latest
+}
+
+SRC_DIR=$(dirname "${BASH_SOURCE[0]}")
+CHANGELOG_DIR="${SRC_DIR}/../.changelog"
+PREVIOUS=${1:-undefined}
+NEXT=${2:-undefined}
+
+if [ $PREVIOUS == "--help" ]; then
+    echo "./scripts/changelog.sh <PREVIOUS> <NEXT>"
+    exit 0
+fi
+
+if [ $PREVIOUS == "undefined" ]; then
+    echo "first argument should be previous release tag/ref"
+    exit 1
+fi
+
+if [ $NEXT == "undefined" ]; then
+    echo "second argument should be target release tag/ref"
+    exit 1
+fi
+
+changelog-build \
+    -entries-dir "$CHANGELOG_DIR" \
+    -changelog-template "$CHANGELOG_DIR/changelog.tmpl" \
+    -note-template  "$CHANGELOG_DIR/note.tmpl" \
+    -local-fs \
+    -last-release v2.0.0 \
+    -this-release release/2.0.x


### PR DESCRIPTION
Sometimes we end up needing to generate a changelog locally to have internal discussions about what's planned in a release or for comparing it to documentation PRs. Add a helper script that runs the changelog build with all the right arguments.

### Contributor Checklist
- [ ] **Changelog Entry** n/a
- [ ] **Testing**: ran `../scripts/changelog.sh v2.0.0 release/2.0.x` and saw what you'd expect
- [ ] **Documentation** n/a

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
