### PR TITLE
Do not attempt to restore an allocation whose directory is missing

### DIFF
--- a/.changelog/27933.txt
+++ b/.changelog/27933.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+alloc: don't restore when allocDir is inaccessible
+```

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"os"
 	"sync"
 	"time"
 
@@ -472,6 +473,13 @@ func (ar *allocRunner) GetAllocDir() allocdir.Interface {
 // Restore state from database. Must be called after NewAllocRunner but before
 // Run.
 func (ar *allocRunner) Restore() error {
+	// We should not carry on to restoring an allocation whose directory is
+	// inaccessible. This can happen if allocation storage is ephemeral, e.g.
+	// a tmpfs or cloud local SSDs.
+	if _, err := os.Stat(ar.allocDir.AllocDirPath()); err != nil {
+		return fmt.Errorf("allocation directory is inaccessible: %w", err)
+	}
+
 	// Retrieve deployment status to avoid reseting it across agent
 	// restarts. Once a deployment status is set Nomad no longer monitors
 	// alloc health, so we must persist deployment state across restarts.

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -1422,6 +1422,33 @@ func TestAllocRunner_Restore_LifecycleHooks(t *testing.T) {
 	tasklifecycle.RequireTaskAllowed(t, ar2.taskCoordinator, ar2.tasks["poststart"].Task())
 }
 
+// TestAllocRunner_Restore_MissingAllocDir asserts that Restore() fails when the
+// allocation directory is missing, which can happen if allocation storage is
+// ephemeral (e.g., tmpfs or cloud local SSDs).
+func TestAllocRunner_Restore_MissingAllocDir(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.Alloc()
+	conf, cleanup := testAllocRunnerConfig(t, alloc)
+	defer cleanup()
+
+	arIface, err := NewAllocRunner(conf)
+	must.NoError(t, err)
+	ar := arIface.(*allocRunner)
+
+	// Get the allocation directory path before deleting it
+	allocDirPath := ar.allocDir.AllocDirPath()
+
+	// Remove the allocation directory to simulate ephemeral storage being deleted
+	err = os.RemoveAll(allocDirPath)
+	must.NoError(t, err)
+
+	// Call Restore() and verify it fails with appropriate error
+	err = ar.Restore()
+	must.Error(t, err)
+	must.ErrorIs(t, err, os.ErrNotExist)
+}
+
 func TestAllocRunner_Update_Semantics(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -1327,6 +1327,7 @@ func TestAllocRunner_TaskLeader_StopRestoredTG(t *testing.T) {
 	must.NoError(t, err)
 	defer destroy(ar2)
 
+	must.NoError(t, ar2.(*allocRunner).allocDir.Build())
 	if err := ar2.Restore(); err != nil {
 		t.Fatalf("error restoring state: %v", err)
 	}
@@ -1403,6 +1404,7 @@ func TestAllocRunner_Restore_LifecycleHooks(t *testing.T) {
 	arIface2, err := NewAllocRunner(conf)
 	must.NoError(t, err)
 	ar2 := arIface2.(*allocRunner)
+	must.NoError(t, ar2.allocDir.Build())
 	must.NoError(t, ar2.Restore())
 
 	go ar2.Run()

--- a/client/allocrunner/alloc_runner_unix_test.go
+++ b/client/allocrunner/alloc_runner_unix_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !windows
@@ -113,8 +113,8 @@ func TestAllocRunner_Restore_RunningTerminal(t *testing.T) {
 	ar2Iface, err := NewAllocRunner(conf2)
 	must.NoError(t, err)
 	ar2 := ar2Iface.(*allocRunner)
-
-	require.NoError(t, ar2.Restore())
+	must.NoError(t, ar2.allocDir.Build())
+	must.NoError(t, ar2.Restore())
 
 	go ar2.Run()
 	defer destroy(ar2)
@@ -208,6 +208,7 @@ func TestAllocRunner_Restore_CompletedBatch(t *testing.T) {
 	ar2Iface, err := NewAllocRunner(conf2)
 	must.NoError(t, err)
 	ar2 := ar2Iface.(*allocRunner)
+	must.NoError(t, ar2.allocDir.Build())
 	must.NoError(t, ar2.Restore())
 
 	go ar2.Run()

--- a/client/state/upgrade_int_test.go
+++ b/client/state/upgrade_int_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package state_test
@@ -222,5 +222,6 @@ func checkUpgradedAlloc(t *testing.T, path string, db StateDB, alloc *structs.Al
 	require.NoError(t, err)
 
 	// AllocRunner.Restore should not error
+	require.NoError(t, ar.GetAllocDir().Build())
 	require.NoError(t, ar.Restore())
 }


### PR DESCRIPTION
### Description

We've recently noticed that tasks would sometimes encounter strange errors after reboot. The reproducer seems to be:

- We have a system job comprising:
  - One one-shot `root` `raw_exec` task.
  - One sidecar `nobody` `docker` task.
  - One main `nobody` `docker` task.
- Our node pool is mostly Google Cloud preemptible instances.
- For performance reasons, we place `client.alloc_dir` on local SSDs. These SSDs are wiped on power-off and when the instance is preempted.
- The client's `data_dir` is on persistent storage.
- After the machine is preempted, comes back up, and attempts to restart the allocation, the `nobody` tasks have no permission to write to their `$NOMAD_TASK_DIR` because `$NOMAD_TASK_DIR` is `root`-owned.

I think the issue is that the allocation directory is gone entirely but Nomad apparently doesn't recreate it the same it it creates it. This PR makes Nomad makes Nomad re-run the task hooks if the task directory is missing.

I'm not sure what the correct approach should be here. There are other hooks, both at the task level and the allocation level, but I'm not sure what the consequences are, so this is a minimal fix.

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.