### PR TITLE
consul: re-write consul si token to task dir on reattach

### DIFF
--- a/.changelog/27936.txt
+++ b/.changelog/27936.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+consul: re-write consul service identity token when reattaching to task
+```

--- a/client/allocrunner/taskrunner/sids_hook.go
+++ b/client/allocrunner/taskrunner/sids_hook.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
@@ -21,11 +20,6 @@ import (
 const (
 	// the name of this hook, used in logs
 	sidsHookName = "consul_si_token"
-
-	// sidsDerivationTimeout limits the amount of time we may spend trying to
-	// derive a SI token. If the hook does not get a token within this amount of
-	// time, the result is a failure.
-	sidsDerivationTimeout = 5 * time.Minute
 
 	// sidsTokenFile is the name of the file holding the Consul SI token inside
 	// the task's secret directory
@@ -92,12 +86,6 @@ func (h *sidsHook) Prestart(
 	h.lock.Lock()
 	defer h.lock.Unlock()
 
-	// do nothing if we have already done things
-	if h.earlyExit() {
-		resp.Done = true
-		return nil
-	}
-
 	// if we're using Workload Identities then this Connect task should already
 	// have a token stored under the cluster + service ID.
 	tokens := h.allocHookResources.GetConsulTokens()
@@ -119,25 +107,11 @@ func (h *sidsHook) Prestart(
 			if err := h.writeToken(req.TaskDir.SecretsDir, token.SecretID); err != nil {
 				return err
 			}
-			resp.Done = true
 			return nil
 		}
 	}
 
-	resp.Done = true
 	return nil
-}
-
-// earlyExit returns true if the Prestart hook has already been executed during
-// the instantiation of this task runner.
-//
-// assumes h is locked
-func (h *sidsHook) earlyExit() bool {
-	if h.firstRun {
-		h.firstRun = false
-		return false
-	}
-	return true
 }
 
 // writeToken writes token into the secrets directory for the task.
@@ -147,32 +121,4 @@ func (h *sidsHook) writeToken(dir string, token string) error {
 		return fmt.Errorf("failed to write SI token: %w", err)
 	}
 	return nil
-}
-
-// recoverToken returns the token saved to disk in the secrets directory for the
-// task if it exists, or the empty string if the file does not exist. an error
-// is returned only for some other (e.g. disk IO) error.
-func (h *sidsHook) recoverToken(dir string) (string, error) {
-	tokenPath := filepath.Join(dir, sidsTokenFile)
-	token, err := os.ReadFile(tokenPath)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			h.logger.Error("failed to recover SI token", "error", err)
-			return "", fmt.Errorf("failed to recover SI token: %w", err)
-		}
-		h.logger.Trace("no pre-existing SI token to recover", "task", h.task.Name)
-		return "", nil // token file does not exist yet
-	}
-	h.logger.Trace("recovered pre-existing SI token", "task", h.task.Name)
-	return string(token), nil
-}
-
-func (h *sidsHook) kill(ctx context.Context, reason error) {
-	if err := h.lifecycle.Kill(ctx,
-		structs.NewTaskEvent(structs.TaskKilling).
-			SetFailsTask().
-			SetDisplayMessage(reason.Error()),
-	); err != nil {
-		h.logger.Error("failed to kill task", "kill_reason", reason, "error", err)
-	}
 }

--- a/client/allocrunner/taskrunner/sids_hook.go
+++ b/client/allocrunner/taskrunner/sids_hook.go
@@ -5,9 +5,7 @@ package taskrunner
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"github.com/hashicorp/go-hclog"

--- a/client/allocrunner/taskrunner/sids_hook.go
+++ b/client/allocrunner/taskrunner/sids_hook.go
@@ -116,9 +116,16 @@ func (h *sidsHook) Prestart(
 
 // writeToken writes token into the secrets directory for the task.
 func (h *sidsHook) writeToken(dir string, token string) error {
-	tokenPath := filepath.Join(dir, sidsTokenFile)
-	if err := os.WriteFile(tokenPath, []byte(token), sidsTokenFilePerms); err != nil {
-		return fmt.Errorf("failed to write SI token: %w", err)
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return err
+	}
+	file, err := root.OpenFile(sidsTokenFile, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0440)
+	if err != nil {
+		return err
+	}
+	if _, err = file.WriteString(token); err != nil {
+		return err
 	}
 	return nil
 }

--- a/client/allocrunner/taskrunner/sids_hook_test.go
+++ b/client/allocrunner/taskrunner/sids_hook_test.go
@@ -16,93 +16,12 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
-	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
-	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
 )
 
 var _ interfaces.TaskPrestartHook = (*sidsHook)(nil)
-
-func sidecar(task string) (string, structs.TaskKind) {
-	name := structs.ConnectProxyPrefix + "-" + task
-	kind := structs.TaskKind(structs.ConnectProxyPrefix + ":" + task)
-	return name, kind
-}
-
-func TestSIDSHook_recoverToken(t *testing.T) {
-	ci.Parallel(t)
-	r := require.New(t)
-
-	secrets := t.TempDir()
-
-	taskName, taskKind := sidecar("foo")
-	h := newSIDSHook(sidsHookConfig{
-		task: &structs.Task{
-			Name: taskName,
-			Kind: taskKind,
-		},
-		logger: testlog.HCLogger(t),
-	})
-
-	expected := uuid.Generate()
-	err := h.writeToken(secrets, expected)
-	r.NoError(err)
-
-	token, err := h.recoverToken(secrets)
-	r.NoError(err)
-	r.Equal(expected, token)
-}
-
-func TestSIDSHook_recoverToken_empty(t *testing.T) {
-	ci.Parallel(t)
-	r := require.New(t)
-
-	secrets := t.TempDir()
-
-	taskName, taskKind := sidecar("foo")
-	h := newSIDSHook(sidsHookConfig{
-		task: &structs.Task{
-			Name: taskName,
-			Kind: taskKind,
-		},
-		logger: testlog.HCLogger(t),
-	})
-
-	token, err := h.recoverToken(secrets)
-	r.NoError(err)
-	r.Empty(token)
-}
-
-func TestSIDSHook_recoverToken_unReadable(t *testing.T) {
-	ci.Parallel(t)
-	// This test fails when running as root because the test case for checking
-	// the error condition when the file is unreadable fails (root can read the
-	// file even though the permissions are set to 0200).
-	if unix.Geteuid() == 0 {
-		t.Skip("test only works as non-root")
-	}
-
-	r := require.New(t)
-
-	secrets := t.TempDir()
-
-	err := os.Chmod(secrets, 0000)
-	r.NoError(err)
-
-	taskName, taskKind := sidecar("foo")
-	h := newSIDSHook(sidsHookConfig{
-		task: &structs.Task{
-			Name: taskName,
-			Kind: taskKind,
-		},
-		logger: testlog.HCLogger(t),
-	})
-
-	_, err = h.recoverToken(secrets)
-	r.Error(err)
-}
 
 func TestSIDSHook_writeToken(t *testing.T) {
 	ci.Parallel(t)


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
For plugins like docker and podman which can reattach to stopped/exited containers, we should rerun the sids hook in order to rewrite the token to the in memory secrets dir

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
<details>
  <summary>job.hcl</summary>
  
```
job "nginx" {
  type = "service"

  group "test-group" {

    disconnect {
      lost_after = "6h"
      replace = true
      reconcile = "keep_original"
    }

    network {
      mode = "bridge"
      port "foo" {
        to = 80
      }
    }

    service {
      name = "nginx-service"
      port = "foo"
      connect {
        sidecar_service {}
      }
    }
    task "nginx-task" {
      driver = "docker"
      config {
        image = "nginx:latest"
        ports = ["foo"]
      }
    }
  }
}

```
  
</details>
Run this job in a VM running the Nomad client. Reboot container, see that the envoy container that is started no longer gets a token.
Run with the above changes, see that the sids hook runs, and the envoy container now get's it's original token. 

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes https://github.com/hashicorp/nomad/issues/27824

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
