### PR TITLE
client: fix a bug in alloc runner where we could accidentally overwrite task states

### DIFF
--- a/.changelog/27944.txt
+++ b/.changelog/27944.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: fix a bug where we could accidentally overwrite task states
+```

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -983,7 +983,7 @@ func (ar *allocRunner) AllocState() *state.State {
 	// If TaskStateUpdated has not been called yet, ar.state.TaskStates
 	// won't be set as it is not the canonical source of TaskStates.
 	if len(state.TaskStates) == 0 {
-		ar.state.TaskStates = make(map[string]*structs.TaskState, len(ar.tasks))
+		state.TaskStates = make(map[string]*structs.TaskState, len(ar.tasks))
 		for k, tr := range ar.tasks {
 			state.TaskStates[k] = tr.TaskState()
 		}


### PR DESCRIPTION
found during #27803 work which would only get backported to 2.0.x branch. 