### PR TITLE
vault: add a retry for non fatal token renewals

### DIFF
--- a/.changelog/27947.txt
+++ b/.changelog/27947.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+vault: adds token renewal retries
+```

--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -409,6 +409,12 @@ func (c *vaultClient) renew(req *vaultClientRenewalRequest) error {
 			strings.Contains(errMsg, "token not found") {
 			fatal = true
 		} else {
+			// In the event of a non fatal error, retry in a minute.
+			// TODO: mismithhisler - This is a temporary fix until a subsequant
+			// refactor of the vault client is merged that contains proper
+			// exponential backoffs.
+			next = time.Now().Add(time.Minute)
+
 			c.logger.Debug("renewal error details", "req.increment", req.increment, "lease_duration", leaseDuration, "renewal_duration", renewalDuration)
 			c.logger.Error("error during renewal of lease or token failed due to a non-fatal error; retrying",
 				"error", renewalErr, "period", next)

--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -410,7 +410,7 @@ func (c *vaultClient) renew(req *vaultClientRenewalRequest) error {
 			fatal = true
 		} else {
 			// In the event of a non fatal error, retry in a minute.
-			// TODO: mismithhisler - This is a temporary fix until a subsequant
+			// TODO: mismithhisler - This is a temporary fix until a followup
 			// refactor of the vault client is merged that contains proper
 			// exponential backoffs.
 			next = time.Now().Add(time.Minute)

--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package vaultclient

--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -413,7 +413,7 @@ func (c *vaultClient) renew(req *vaultClientRenewalRequest) error {
 			// TODO: mismithhisler - This is a temporary fix until a followup
 			// refactor of the vault client is merged that contains proper
 			// exponential backoffs.
-			next = time.Now().Add(time.Minute)
+			next = min(time.Now().Add(time.Minute), next)
 
 			c.logger.Debug("renewal error details", "req.increment", req.increment, "lease_duration", leaseDuration, "renewal_duration", renewalDuration)
 			c.logger.Error("error during renewal of lease or token failed due to a non-fatal error; retrying",

--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -409,11 +409,14 @@ func (c *vaultClient) renew(req *vaultClientRenewalRequest) error {
 			strings.Contains(errMsg, "token not found") {
 			fatal = true
 		} else {
-			// In the event of a non fatal error, retry in a minute.
+			// In the event of a non fatal error, retry in a maximum of 1 minute
 			// TODO: mismithhisler - This is a temporary fix until a followup
 			// refactor of the vault client is merged that contains proper
 			// exponential backoffs.
-			next = min(time.Now().Add(time.Minute), next)
+			retry := time.Now().Add(time.Minute)
+			if retry.Before(next) {
+				next = retry
+			}
 
 			c.logger.Debug("renewal error details", "req.increment", req.increment, "lease_duration", leaseDuration, "renewal_duration", renewalDuration)
 			c.logger.Error("error during renewal of lease or token failed due to a non-fatal error; retrying",


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
The current vault token renewal logic tries to renew at 1/2 token TTL. If a non fatal error occurs (like network connectivity problems), the next retry is at another 1/2 TTL, which is the entire TTL. So it's likely that the token is expired by that time. These changes update that retry to be once per minute. This is a temporary fix until a subsequent PR refactors the vault client renewal process and includes proper exponential back-off retries.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes: https://github.com/hashicorp/nomad/issues/27920

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
