### PR TITLE
ui: Fix "cannot toggle global mode" error when updating ACL tokens

### DIFF
--- a/ui/app/components/token-editor.js
+++ b/ui/app/components/token-editor.js
@@ -148,10 +148,14 @@ export default class TokenEditorComponent extends Component {
         this.activeToken.roles = [];
       }
 
-      if (this.tokenRegion === 'global') {
-        this.activeToken.global = true;
-      } else {
-        this.activeToken.global = false;
+      // Only set global property for new tokens
+      // Existing tokens cannot toggle global mode
+      if (this.activeToken.isNew) {
+        if (this.tokenRegion === 'global') {
+          this.activeToken.global = true;
+        } else {
+          this.activeToken.global = false;
+        }
       }
 
       // Sets to "never" for auto-selecting the radio button;


### PR DESCRIPTION

### Description

This PR fixes a bug where editing an existing ACL token in the UI would fail with the error: `token 0 invalid: 1 error occurred: * cannot toggle global mode`.

**Root Cause:** The `token-editor` component was setting the `global` property on every save operation, even for existing tokens. The Nomad API doesn't allow changing the `global` property after token creation, which caused the error.

**Solution:** Modified `ui/app/components/token-editor.js` to only set the `global` property for new tokens. For existing tokens, the `global` property is preserved from the loaded model and not modified, preventing Ember Data from marking it as changed and including it in the update request.

**Impact:** Users can now successfully:
- Edit token names
- Add/remove policies from tokens
- Add/remove roles from tokens
- Change any token property except `global` (which is immutable after creation)

### Testing & Reproduction steps

**To Reproduce the Bug (Before Fix):**
1. Enable ACLs in Nomad
2. Bootstrap ACLs: `nomad acl bootstrap`
3. Create a client token with `Global = false`:
   ```bash
   nomad acl policy apply test-policy - <<EOF
   namespace "default" { policy = "read" }
   EOF
   nomad acl token create -name="test-token" -type="client" -global=false -policy="test-policy"
   ```
4. Open Nomad UI and sign in with management token
5. Navigate to Administration → Tokens
6. Click on `test-token`
7. Edit the token name (e.g., change to "test-token-updated")
8. Click "Save"
9. **Bug:** Error appears: "Error creating Token: token 0 invalid: 1 error occurred: * cannot toggle global mode"

https://github.com/user-attachments/assets/73a1d920-9459-4971-9a32-654a56433534


**After Fix:**
- Step 8 succeeds without error
- Token name is updated successfully

https://github.com/user-attachments/assets/3433cdaa-76c4-4b92-8777-7ee4981a52e6

**Automated Tests:**
Existing tests in `ui/tests/acceptance/token-test.js` already cover this functionality:
- Line 1310-1319: "Token name can be edited"
- Line 1321-1395: "Token policies and roles can be edited"

These tests will now pass with the fix applied.

### Links

Jira Item : https://hashicorp.atlassian.net/browse/NMD-1278
Fixes: https://github.com/hashicorp/nomad/issues/27456

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and ensure regressions will be caught.
  - *Note: Existing acceptance tests already cover this functionality and will pass with the fix.*
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI, and job configuration, please update the Nomad product documentation.
  - *Note: This is a bug fix that restores expected behavior; no documentation changes needed.*

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge" in the majority of situations.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry within the public repository.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

**No changes to security controls.** This PR only fixes a bug in the UI that prevented users from editing ACL tokens. The ACL token permissions, access controls, and API behavior remain unchanged. The fix ensures that the `global` property (which controls token replication across regions) is not inadvertently modified during token updates, maintaining the existing security model.