### PR TITLE
Security backports main CE

### DIFF
--- a/.changelog/27918.txt
+++ b/.changelog/27918.txt
@@ -1,0 +1,7 @@
+```release-note:security
+logging: Protect logging FIFO from symlink swap attacks (CVE-2026-6959)
+```
+
+```release-note:breaking-change
+logging: The allocation logs directory is bind-mounted read-only for task drivers that support with filesystem isolation
+```

--- a/.changelog/27919.txt
+++ b/.changelog/27919.txt
@@ -1,0 +1,3 @@
+```release-note:security
+dynamic host volumes: Prevent unintended code execution outside the plugin directory (CVE-2026-7474)
+```

--- a/.changelog/_4008.txt
+++ b/.changelog/_4008.txt
@@ -1,0 +1,3 @@
+```release-note:security
+sentinel: require sentinel-override ACL capability for overriding soft-mandatory policies on volumes
+```

--- a/client/allocdir/fs_darwin.go
+++ b/client/allocdir/fs_darwin.go
@@ -9,7 +9,7 @@ import (
 )
 
 // linkDir hardlinks src to dst. The src and dst must be on the same filesystem.
-func linkDir(src, dst string) error {
+func linkDir(src, dst string, _ bool) error {
 	return syscall.Link(src, dst)
 }
 

--- a/client/allocdir/fs_freebsd.go
+++ b/client/allocdir/fs_freebsd.go
@@ -9,7 +9,7 @@ import (
 )
 
 // linkDir hardlinks src to dst. The src and dst must be on the same filesystem.
-func linkDir(src, dst string) error {
+func linkDir(src, dst string, _ bool) error {
 	return syscall.Link(src, dst)
 }
 

--- a/client/allocdir/fs_linux.go
+++ b/client/allocdir/fs_linux.go
@@ -22,11 +22,14 @@ const (
 
 // linkDir bind mounts src to dst as Linux doesn't support hardlinking
 // directories.
-func linkDir(src, dst string) error {
+func linkDir(src, dst string, ro bool) error {
 	if err := os.MkdirAll(dst, fileMode777); err != nil {
 		return err
 	}
 
+	if ro {
+		return syscall.Mount(src, dst, "", syscall.MS_BIND|syscall.MS_RDONLY, "")
+	}
 	return syscall.Mount(src, dst, "", syscall.MS_BIND, "")
 }
 

--- a/client/allocdir/fs_netbsd.go
+++ b/client/allocdir/fs_netbsd.go
@@ -9,7 +9,7 @@ import (
 )
 
 // linkDir hardlinks src to dst. The src and dst must be on the same filesystem.
-func linkDir(src, dst string) error {
+func linkDir(src, dst string, _ bool) error {
 	return syscall.Link(src, dst)
 }
 

--- a/client/allocdir/fs_solaris.go
+++ b/client/allocdir/fs_solaris.go
@@ -9,7 +9,7 @@ import (
 )
 
 // linkDir hardlinks src to dst. The src and dst must be on the same filesystem.
-func linkDir(src, dst string) error {
+func linkDir(src, dst string, _ bool) error {
 	return syscall.Link(src, dst)
 }
 

--- a/client/allocdir/fs_windows.go
+++ b/client/allocdir/fs_windows.go
@@ -28,7 +28,7 @@ func linkOrCopy(src, dst string, uid, gid int, perm os.FileMode) error {
 }
 
 // The windows version does nothing currently.
-func linkDir(src, dst string) error {
+func linkDir(src, dst string, _ bool) error {
 	return nil
 }
 

--- a/client/allocdir/task_dir.go
+++ b/client/allocdir/task_dir.go
@@ -153,9 +153,13 @@ func (t *TaskDir) Build(fsi fsisolation.Mode, chroot map[string]string, username
 		// If the path doesn't exist OR it exists and is empty, link it
 		empty, _ := pathEmpty(t.SharedTaskDir)
 		if !pathExists(t.SharedTaskDir) || empty {
-			if err := linkDir(t.SharedAllocDir, t.SharedTaskDir); err != nil {
+			if err := linkDir(t.SharedAllocDir, t.SharedTaskDir, false); err != nil {
 				return fmt.Errorf("Failed to mount shared directory for task: %w", err)
 			}
+			if err := linkDir(t.LogDir, filepath.Join(t.SharedTaskDir, "logs"), true); err != nil {
+				return fmt.Errorf("Failed to mount shared directory for task: %w", err)
+			}
+
 		}
 	}
 
@@ -326,6 +330,12 @@ func (t *TaskDir) Unmount() error {
 
 	// Check if the directory has the shared alloc mounted.
 	if pathExists(t.SharedTaskDir) {
+		if err := unlinkDir(filepath.Join(t.SharedTaskDir, "logs")); err != nil {
+			mErr = multierror.Append(mErr,
+				fmt.Errorf("failed to unmount logs dir %q: %w",
+					filepath.Join(t.SharedTaskDir, "logs"), err))
+		}
+
 		if err := unlinkDir(t.SharedTaskDir); err != nil {
 			mErr = multierror.Append(mErr,
 				fmt.Errorf("failed to unmount shared alloc dir %q: %w", t.SharedTaskDir, err))

--- a/client/hostvolumemanager/host_volume_plugin.go
+++ b/client/hostvolumemanager/host_volume_plugin.go
@@ -223,20 +223,27 @@ var _ HostVolumePlugin = &HostVolumePluginExternal{}
 // if the specified executable exists on disk.
 func NewHostVolumePluginExternal(log hclog.Logger,
 	pluginDir, filename, volumesDir, nodePool string) (*HostVolumePluginExternal, error) {
-	// this should only be called with already-detected executables,
-	// but we'll double-check it anyway, so we can provide a tidy error message
-	// if it has changed between fingerprinting and execution.
-	executable := filepath.Join(pluginDir, filename)
-	f, err := os.Stat(executable)
+	// this should only be called with already-detected executables, but we'll
+	// double-check it anyway, so we can provide a tidy error message if it has
+	// changed between fingerprinting and execution and to ensure that the
+	// plugin ID can't traverse outside the plugin directory.
+	root, err := os.OpenRoot(pluginDir)
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, fmt.Errorf("%w: %q", ErrPluginNotExists, filename)
-		}
-		return nil, err
+		return nil, fmt.Errorf("%w: %q", ErrPluginNotExists, filename)
+	}
+
+	f, err := root.Stat(filename)
+	if err != nil {
+		// note we intentionally obscure the root-escape error here and return a
+		// ErrPluginNotExists, because there's no legitimate reason to ever get
+		// this error
+		return nil, fmt.Errorf("%w: %q", ErrPluginNotExists, filename)
 	}
 	if !helper.IsExecutable(f) {
 		return nil, fmt.Errorf("%w: %q", ErrPluginNotExecutable, filename)
 	}
+	executable := filepath.Join(pluginDir, filename)
+
 	return &HostVolumePluginExternal{
 		ID:         filename,
 		Executable: executable,

--- a/client/hostvolumemanager/host_volume_plugin_test.go
+++ b/client/hostvolumemanager/host_volume_plugin_test.go
@@ -218,6 +218,14 @@ func TestNewHostVolumePluginExternal(t *testing.T) {
 	_, err = NewHostVolumePluginExternal(log, ".", "non-existent", "target", "")
 	must.ErrorIs(t, err, ErrPluginNotExists)
 
+	// OpenRoot fails
+	_, err = NewHostVolumePluginExternal(log, "/xxxxxxxxxxxxxxxxx", "non-existent", "target", "")
+	must.ErrorIs(t, err, ErrPluginNotExists)
+
+	// tries to escape root
+	_, err = NewHostVolumePluginExternal(log, ".", "../non-existent", "target", "")
+	must.ErrorIs(t, err, ErrPluginNotExists)
+
 	_, err = NewHostVolumePluginExternal(log, ".", "host_volume_plugin_test.go", "target", "")
 	must.ErrorIs(t, err, ErrPluginNotExecutable)
 

--- a/client/hostvolumemanager/host_volumes_test.go
+++ b/client/hostvolumemanager/host_volumes_test.go
@@ -363,7 +363,7 @@ func TestHostVolumeManager_restoreFromState(t *testing.T) {
 		}
 		must.NoError(t, state.PutDynamicHostVolume(vol))
 
-		hvm := NewHostVolumeManager(log, Config{StateMgr: state})
+		hvm := NewHostVolumeManager(log, Config{StateMgr: state, PluginDir: t.TempDir()})
 		vols, err := hvm.restoreFromState(timeout(t))
 		must.ErrorIs(t, err, ErrPluginNotExists)
 		must.MapEmpty(t, vols)

--- a/client/lib/fifo/doc.go
+++ b/client/lib/fifo/doc.go
@@ -3,9 +3,13 @@
 
 /*
 Package fifo implements functions to create and open a fifo for inter-process
-communication in an OS agnostic way. A few assumptions should be made when
-using this package. First, New() must always be called before Open(). Second
-Open() returns an io.ReadWriteCloser that is only connected with the
-io.ReadWriteCloser returned from New().
+communication in an OS agnostic way. A few assumptions should be made when using
+this package. First, New() must always be called before Open(). Second Open()
+returns an io.ReadWriteCloser that is only connected with the io.ReadWriteCloser
+returned from New().
+
+On Unix, all exported functions use os.Root under the hood to avoid chasing
+symlinks out of their parent directory. On Windows, this is unnecessary because
+named pipes exist in their own namespace and not the filesystem.
 */
 package fifo

--- a/client/lib/fifo/fifo_test.go
+++ b/client/lib/fifo/fifo_test.go
@@ -22,10 +22,12 @@ func TestFIFO(t *testing.T) {
 	require := require.New(t)
 	var path string
 
+	rootDir := t.TempDir()
+
 	if runtime.GOOS == "windows" {
 		path = "//./pipe/fifo"
 	} else {
-		path = filepath.Join(t.TempDir(), "fifo")
+		path = filepath.Join(rootDir, "fifo")
 	}
 
 	readerOpenFn, err := CreateAndRead(path)
@@ -82,10 +84,12 @@ func TestWriteClose(t *testing.T) {
 	require := require.New(t)
 	var path string
 
+	rootDir := t.TempDir()
+
 	if runtime.GOOS == "windows" {
 		path = "//./pipe/" + uuid.Generate()[:4]
 	} else {
-		path = filepath.Join(t.TempDir(), "fifo")
+		path = filepath.Join(rootDir, "fifo")
 	}
 
 	readerOpenFn, err := CreateAndRead(path)

--- a/client/lib/fifo/fifo_unix.go
+++ b/client/lib/fifo/fifo_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !windows
-// +build !windows
 
 package fifo
 
@@ -10,19 +9,19 @@ import (
 	"fmt"
 	"io"
 	"os"
-
-	"golang.org/x/sys/unix"
+	"path/filepath"
 )
 
-// CreateAndRead creates a fifo at the given path, and returns an open function for reading.
-// For compatibility with windows, the fifo must not exist already.
+// CreateAndRead creates a fifo at the given path, and returns an open function
+// for reading. For compatibility with windows, the fifo must not exist
+// already.
 //
 // It returns a reader open function that may block until a writer opens
 // so it's advised to run it in a goroutine different from reader goroutine
 func CreateAndRead(path string) (func() (io.ReadCloser, error), error) {
 	// create first
 	if err := mkfifo(path, 0600); err != nil {
-		return nil, fmt.Errorf("error creating fifo %v: %v", path, err)
+		return nil, fmt.Errorf("error creating fifo %v: %w", path, err)
 	}
 
 	return func() (io.ReadCloser, error) {
@@ -31,17 +30,54 @@ func CreateAndRead(path string) (func() (io.ReadCloser, error), error) {
 }
 
 func OpenReader(path string) (io.ReadCloser, error) {
-	return os.OpenFile(path, unix.O_RDONLY, os.ModeNamedPipe)
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, fmt.Errorf("error opening fifo parent directory %q: %w", dir, err)
+	}
+	defer root.Close()
+
+	// also uses O_NOFOLLOW under the hood
+	f, err := root.OpenFile(base, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("error opening reader at %s: %w", path, err)
+	}
+	return f, nil
 }
 
 // OpenWriter opens a fifo file for writer, assuming it already exists, returns io.WriteCloser
 func OpenWriter(path string) (io.WriteCloser, error) {
-	return os.OpenFile(path, unix.O_WRONLY, os.ModeNamedPipe)
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return nil, fmt.Errorf("error opening fifo parent directory %q: %w", dir, err)
+	}
+	defer root.Close()
+
+	// also uses O_NOFOLLOW under the hood
+	f, err := root.OpenFile(base, os.O_WRONLY, 0)
+	if err != nil {
+		return nil, fmt.Errorf("error opening writer at %s: %w", path, err)
+	}
+	return f, nil
 }
 
 // Remove a fifo that already exists at a given path
 func Remove(path string) error {
-	return os.Remove(path)
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return fmt.Errorf("error opening root dir %q: %w", dir, err)
+	}
+	defer root.Close()
+
+	return root.Remove(base)
 }
 
 func IsClosedErr(err error) bool {
@@ -50,8 +86,4 @@ func IsClosedErr(err error) bool {
 		return err2.Err == os.ErrClosed
 	}
 	return false
-}
-
-func mkfifo(path string, mode uint32) (err error) {
-	return unix.Mkfifo(path, mode)
 }

--- a/client/lib/fifo/mkfifo_unix.go
+++ b/client/lib/fifo/mkfifo_unix.go
@@ -1,0 +1,21 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !linux && !freebsd && !netbsd && !openbsd && !windows
+
+package fifo
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+func mkfifo(path string, mode uint32) (err error) {
+	// macOS doesn't support mkfifoat
+	err = unix.Mkfifo(path, mode)
+	if err != nil {
+		return fmt.Errorf("error creating fifo: %w", err)
+	}
+	return nil
+}

--- a/client/lib/fifo/mkfifoat.go
+++ b/client/lib/fifo/mkfifoat.go
@@ -1,0 +1,39 @@
+// Copyright IBM Corp. 2015, 2025
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build linux || freebsd || netbsd || openbsd
+
+package fifo
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/sys/unix"
+)
+
+func mkfifo(path string, mode uint32) (err error) {
+	dir := filepath.Dir(path)
+	base := filepath.Base(path)
+
+	root, err := os.OpenRoot(dir)
+	if err != nil {
+		return fmt.Errorf("error opening fifo parent directory %q: %v", dir, err)
+	}
+	defer root.Close()
+
+	parent, err := root.Open(".")
+	if err != nil {
+		return fmt.Errorf("error getting file handle to fifo parent directory %q: %v", dir, err)
+	}
+	defer parent.Close()
+
+	// os.Root doesn't support creating a FIFO, so we need to drop to the
+	// syscall and grab the parent's FD
+	err = unix.Mkfifoat(int(parent.Fd()), base, mode)
+	if err != nil {
+		return fmt.Errorf("error creating fifo: %w", err)
+	}
+	return nil
+}

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -769,15 +769,20 @@ func (d *Driver) containerBinds(task *drivers.TaskConfig, driverConfig *TaskConf
 	allocDirBind := fmt.Sprintf("%s:%s", task.TaskDir().SharedAllocDir, task.Env[taskenv.AllocDir])
 	taskLocalBind := fmt.Sprintf("%s:%s", task.TaskDir().LocalDir, task.Env[taskenv.TaskLocalDir])
 	secretDirBind := fmt.Sprintf("%s:%s", task.TaskDir().SecretsDir, task.Env[taskenv.SecretsDir])
+	selinuxLabel := d.config.Volumes.SelinuxLabel
+
 	binds := []string{allocDirBind, taskLocalBind, secretDirBind}
 
-	selinuxLabel := d.config.Volumes.SelinuxLabel
+	logsROFlag := "ro"
 	if selinuxLabel != "" {
 		// Apply SELinux Label to each built-in bind
 		for i := range binds {
 			binds[i] = fmt.Sprintf("%s:%s", binds[i], selinuxLabel)
 		}
+		logsROFlag = "ro," + selinuxLabel
 	}
+	allocLogsDirBind := fmt.Sprintf("%s/logs:%s/logs:%s", task.TaskDir().SharedAllocDir, task.Env[taskenv.AllocDir], logsROFlag)
+	binds = append(binds, allocLogsDirBind)
 
 	for _, userbind := range driverConfig.Volumes {
 		// This assumes host OS = docker container OS.

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -1392,6 +1392,7 @@ func TestDockerDriver_CreateContainerConfig_Mounts(t *testing.T) {
 		"alloc:/alloc:z",
 		"redis-demo/local:/local:z",
 		"redis-demo/secrets:/secrets:z",
+		"alloc/logs:/alloc/logs:ro,z",
 		"/etc/ssl/certs:/etc/ssl/certs:ro,z",
 		"/var/www:/srv/www:z",
 	}, cc.Host.Binds)
@@ -1469,6 +1470,7 @@ func TestDockerDriver_CreateContainerConfig_Mounts_Windows(t *testing.T) {
 		`alloc:c:/alloc`,
 		`redis-demo\local:c:/local`,
 		`redis-demo\secrets:c:/secrets`,
+		`alloc/logs:c:/alloc/logs:ro`,
 		`c:\etc\ssl\certs:c:/etc/ssl/certs`,
 		`c:\var\www:c:/srv/www`,
 	}, cc.Host.Binds)

--- a/nomad/csi_endpoint.go
+++ b/nomad/csi_endpoint.go
@@ -310,6 +310,13 @@ func (v *CSIVolume) Register(args *structs.CSIVolumeRegisterRequest, reply *stru
 		if !allowVolume(aclObj, vol.Namespace) {
 			return structs.ErrPermissionDenied
 		}
+		// Check if override is set and we do not have permissions
+		if args.PolicyOverride {
+			if !aclObj.AllowNsOp(vol.Namespace, acl.NamespaceCapabilitySentinelOverride) {
+				return structs.ErrPermissionDenied
+			}
+		}
+
 		if err = vol.Validate(); err != nil {
 			return err
 		}
@@ -1153,6 +1160,13 @@ func (v *CSIVolume) Create(args *structs.CSIVolumeCreateRequest, reply *structs.
 		if !allowVolume(aclObj, vol.Namespace) {
 			return structs.ErrPermissionDenied
 		}
+		// Check if override is set and we do not have permissions
+		if args.PolicyOverride {
+			if !aclObj.AllowNsOp(vol.Namespace, acl.NamespaceCapabilitySentinelOverride) {
+				return structs.ErrPermissionDenied
+			}
+		}
+
 		if err = vol.Validate(); err != nil {
 			return err
 		}

--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -220,6 +220,12 @@ func (v *HostVolume) Create(args *structs.HostVolumeCreateRequest, reply *struct
 	if !allowVolume(aclObj, vol.Namespace) {
 		return structs.ErrPermissionDenied
 	}
+	// Check if override is set and we do not have permissions
+	if args.PolicyOverride {
+		if !aclObj.AllowNsOp(vol.Namespace, acl.NamespaceCapabilitySentinelOverride) {
+			return structs.ErrPermissionDenied
+		}
+	}
 
 	// ensure we only try to create a valid volume or make valid updates to a
 	// volume
@@ -328,6 +334,12 @@ func (v *HostVolume) Register(args *structs.HostVolumeRegisterRequest, reply *st
 	}
 	if !allowVolume(aclObj, vol.Namespace) {
 		return structs.ErrPermissionDenied
+	}
+	// Check if override is set and we do not have permissions
+	if args.PolicyOverride {
+		if !aclObj.AllowNsOp(vol.Namespace, acl.NamespaceCapabilitySentinelOverride) {
+			return structs.ErrPermissionDenied
+		}
 	}
 
 	snap, err := v.srv.State().Snapshot()

--- a/nomad/host_volume_endpoint.go
+++ b/nomad/host_volume_endpoint.go
@@ -521,6 +521,18 @@ func (v *HostVolume) registerVolume(vol *structs.HostVolume) error {
 // by that name. It returns the node (for testing) and an error indicating
 // placement failed.
 func (v *HostVolume) placeHostVolume(snap *state.StateSnapshot, vol *structs.HostVolume) (*structs.Node, error) {
+	ctx := &placementContext{
+		regexpCache:  make(map[string]*regexp.Regexp),
+		versionCache: make(map[string]feasible.VerConstraints),
+		semverCache:  make(map[string]feasible.VerConstraints),
+	}
+	constraints := []*structs.Constraint{{
+		LTarget: fmt.Sprintf("${attr.plugins.host_volume.%s.version}", vol.PluginID),
+		Operand: "is_set",
+	}}
+	constraints = append(constraints, vol.Constraints...)
+	checker := feasible.NewConstraintChecker(ctx, constraints)
+
 	if vol.NodeID != "" {
 		node, err := snap.NodeByID(nil, vol.NodeID)
 		if err != nil {
@@ -529,6 +541,10 @@ func (v *HostVolume) placeHostVolume(snap *state.StateSnapshot, vol *structs.Hos
 		if node == nil {
 			return nil, fmt.Errorf("no such node %s", vol.NodeID)
 		}
+		if ok := checker.Feasible(node); !ok {
+			return nil, fmt.Errorf("node %s is not feasible for volume", vol.NodeID)
+		}
+
 		vol.NodePool = node.NodePool
 		return node, nil
 	}
@@ -551,19 +567,6 @@ func (v *HostVolume) placeHostVolume(snap *state.StateSnapshot, vol *structs.Hos
 	if err != nil {
 		return nil, err
 	}
-
-	var checker *feasible.ConstraintChecker
-	ctx := &placementContext{
-		regexpCache:  make(map[string]*regexp.Regexp),
-		versionCache: make(map[string]feasible.VerConstraints),
-		semverCache:  make(map[string]feasible.VerConstraints),
-	}
-	constraints := []*structs.Constraint{{
-		LTarget: fmt.Sprintf("${attr.plugins.host_volume.%s.version}", vol.PluginID),
-		Operand: "is_set",
-	}}
-	constraints = append(constraints, vol.Constraints...)
-	checker = feasible.NewConstraintChecker(ctx, constraints)
 
 	var (
 		filteredByExisting    int


### PR DESCRIPTION
Security updates for today's release of Nomad 2.0.1 that are being cherry-picked over to the CE repo.

Includes:
* https://github.com/hashicorp/nomad-enterprise/pull/3957 
* https://github.com/hashicorp/nomad-enterprise/pull/3958 
* https://github.com/hashicorp/nomad-enterprise/pull/4008 

I'll make an equivalent PR to `release/2.0.x` as well.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
