### PR TITLE
post-2.0.1 release changelogs for ENT backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,37 @@ BUG FIXES:
 * oidc: Fixed a bug where the request cache could be corrupted by concurrent requests with the same nonce [[GH-27747](https://github.com/hashicorp/nomad/issues/27747)]
 * tls: fix parsing of combined key files when creating tls expiry metric [[GH-27667](https://github.com/hashicorp/nomad/issues/27667)]
 
+## 1.11.5 Enterprise (May 12, 2026)
+
+BREAKING CHANGES:
+
+* logging: The allocation logs directory is bind-mounted read-only for task drivers that support with filesystem isolation [[GH-27918](https://github.com/hashicorp/nomad/issues/27918)]
+
+SECURITY:
+
+* dynamic host volumes: Prevent unintended code execution outside the plugin directory (CVE-2026-7474) [[GH-27919](https://github.com/hashicorp/nomad/issues/27919)]
+* logging: Protect logging FIFO from symlink swap attacks (CVE-2026-6959) [[GH-27918](https://github.com/hashicorp/nomad/issues/27918)]
+* sentinel: require sentinel-override ACL capability for overriding soft-mandatory policies on volumes
+* ui: Upgraded Ember to 6.10 [[GH-27674](https://github.com/hashicorp/nomad/issues/27674)]
+
+IMPROVEMENTS:
+
+* build: Update Go toolchain to 1.26.3 [[GH-27924](https://github.com/hashicorp/nomad/issues/27924)]
+* drivers: include volume RequestName within mount config information if available [[GH-27710](https://github.com/hashicorp/nomad/issues/27710)]
+* server: RPC dial timeout is configurable [[GH-27862](https://github.com/hashicorp/nomad/issues/27862)]
+* services: warn on job submit when job has services but no shutdown_delay [[GH-27782](https://github.com/hashicorp/nomad/issues/27782)]
+
+BUG FIXES:
+
+* api: Fix a bug where the Create Job, Update Job, and Scale Job APIs could fail to respect EnforceIndex under concurrent requests [[GH-27832](https://github.com/hashicorp/nomad/issues/27832)]
+* core: avoid setting job to dead while waiting for allocations to reschedule [[GH-27852](https://github.com/hashicorp/nomad/issues/27852)]
+* csi: improve check of StagePublishBaseDir being subdirectory of MountDir [[GH-27717](https://github.com/hashicorp/nomad/issues/27717)]
+* deployments: reset ProgressDeadline after pausing and do not fail while paused [[GH-27804](https://github.com/hashicorp/nomad/issues/27804)]
+* drivers: kill plugin instance on dispense failure [[GH-27711](https://github.com/hashicorp/nomad/issues/27711)]
+* job: renabled use of multiple vault namespaces in a single job [[GH-4002](https://github.com/hashicorp/nomad/issues/4002)]
+* plugins: Fixed a bug where plugin clients would continuously leak file descriptors when the agent was restarted [[GH-27885](https://github.com/hashicorp/nomad/issues/27885)]
+* scheduler: Fixed a bug where preemption of allocations by tasks that require devices could incorrectly fail placement [[GH-27880](https://github.com/hashicorp/nomad/issues/27880)]
+
 ## 1.11.4 Enterprise (April 21, 2026)
 
 FEATURES:
@@ -290,6 +321,36 @@ BUG FIXES:
 * state: Fixed a bug where the server could panic when attempting to remove unneeded evals from the eval broker [[GH-26872](https://github.com/hashicorp/nomad/issues/26872)]
 * ui: Fixed a bug where action fly-outs would fail to open due to a missing module [[GH-26833](https://github.com/hashicorp/nomad/issues/26833)]
 * windows: Fixed a bug where agents would not gracefully shut down on Ctrl-C [[GH-26780](https://github.com/hashicorp/nomad/issues/26780)]
+
+## 1.10.11 Enterprise (May 12, 2026)
+
+BREAKING CHANGES:
+
+* logging: The allocation logs directory is bind-mounted read-only for task drivers that support with filesystem isolation [[GH-27918](https://github.com/hashicorp/nomad/issues/27918)]
+
+SECURITY:
+
+* dynamic host volumes: Prevent unintended code execution outside the plugin directory (CVE-2026-7474) [[GH-27919](https://github.com/hashicorp/nomad/issues/27919)]
+* logging: Protect logging FIFO from symlink swap attacks (CVE-2026-6959) [[GH-27918](https://github.com/hashicorp/nomad/issues/27918)]
+* sentinel: require sentinel-override ACL capability for overriding soft-mandatory policies on volumes
+* ui: Upgraded Ember to 6.10 [[GH-27674](https://github.com/hashicorp/nomad/issues/27674)]
+
+IMPROVEMENTS:
+
+* build: Update Go toolchain to 1.26.3 [[GH-27924](https://github.com/hashicorp/nomad/issues/27924)]
+* drivers: include volume RequestName within mount config information if available [[GH-27710](https://github.com/hashicorp/nomad/issues/27710)]
+* server: RPC dial timeout is configurable [[GH-27862](https://github.com/hashicorp/nomad/issues/27862)]
+* services: warn on job submit when job has services but no shutdown_delay [[GH-27782](https://github.com/hashicorp/nomad/issues/27782)]
+
+BUG FIXES:
+
+* api: Fix a bug where the Create Job, Update Job, and Scale Job APIs could fail to respect EnforceIndex under concurrent requests [[GH-27832](https://github.com/hashicorp/nomad/issues/27832)]
+* csi: improve check of StagePublishBaseDir being subdirectory of MountDir [[GH-27717](https://github.com/hashicorp/nomad/issues/27717)]
+* deployments: reset ProgressDeadline after pausing and do not fail while paused [[GH-27804](https://github.com/hashicorp/nomad/issues/27804)]
+* drivers: kill plugin instance on dispense failure [[GH-27711](https://github.com/hashicorp/nomad/issues/27711)]
+* job: renabled use of multiple vault namespaces in a single job [[GH-4002](https://github.com/hashicorp/nomad/issues/4002)]
+* plugins: Fixed a bug where plugin clients would continuously leak file descriptors when the agent was restarted [[GH-27885](https://github.com/hashicorp/nomad/issues/27885)]
+* scheduler: Fixed a bug where preemption of allocations by tasks that require devices could incorrectly fail placement [[GH-27880](https://github.com/hashicorp/nomad/issues/27880)]
 
 ## 1.10.10 Enterprise (April 21, 2026)
 


### PR DESCRIPTION


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
