### PR TITLE
UI: fix client detail page failing to render

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,9 @@ settings:
 
 overrides:
   '@babel/runtime@<7.26.10': '>=7.26.10'
+  '@ember/string': 4.0.1
   '@glimmer/component': ^2.1.1
+  ember-inflector: 6.0.0
   ansi-html@<0.0.8: '>=0.0.8'
   basic-ftp@<=5.3.0: '>=5.3.1'
   diff@>=6.0.0 <8.0.3: '>=8.0.3'
@@ -44,7 +46,7 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       '@ember/string':
-        specifier: ^4.0.1
+        specifier: 4.0.1
         version: 4.0.1
       '@ember/test-helpers':
         specifier: ^5.4.1
@@ -204,7 +206,7 @@ importers:
         version: 2.1.0
       ember-cli-mirage:
         specifier: ^3.0.4
-        version: 3.0.4(@ember-data/model@4.12.8)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-data@4.12.8(@babel/core@7.29.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2))(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2)
+        version: 3.0.4(@ember-data/model@4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-data@4.12.8(@babel/core@7.29.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2))(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2)
       ember-cli-moment-shim:
         specifier: ^3.8.0
         version: 3.8.0(@babel/core@7.29.0)(@glint/template@1.7.7)
@@ -245,7 +247,7 @@ importers:
         specifier: 10.1.0
         version: 10.1.0(@glint/template@1.7.7)(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(qunit@2.25.0)(webpack@5.106.2)
       ember-inflector:
-        specifier: ^6.0.0
+        specifier: 6.0.0
         version: 6.0.0(@babel/core@7.29.0)
       ember-load-initializers:
         specifier: ^3.0.1
@@ -1083,15 +1085,15 @@ packages:
     engines: {node: 16.* || >= 18.*}
     peerDependencies:
       '@ember-data/store': 4.12.8
-      '@ember/string': ^3.0.1
-      ember-inflector: ^4.0.2
+      '@ember/string': 4.0.1
+      ember-inflector: 6.0.0
 
   '@ember-data/debug@4.12.8':
     resolution: {integrity: sha512-dA2VXsO8OPddZ723oQxLbjQVoWMpVuqhskBgaf8kRNmJI9ru8AxhR6KWJaF2LMeJ3VhI5ujo1rNfOC2Y1t/chw==}
     engines: {node: 16.* || >= 18.*}
     peerDependencies:
       '@ember-data/store': 4.12.8
-      '@ember/string': ^3.0.1
+      '@ember/string': 4.0.1
 
   '@ember-data/graph@4.12.8':
     resolution: {integrity: sha512-Nm297TOVsOvIqnzRPclW3YL+ILgpz00Rc5Z5KNk1Je3RP8+02uA7Sh39p5WG9YQr6rz3+xY5jd1VbmIoLOQiaA==}
@@ -1112,7 +1114,7 @@ packages:
     peerDependencies:
       '@ember-data/graph': 4.12.8
       '@ember-data/json-api': 4.12.8
-      '@ember/string': ^3.0.1
+      '@ember/string': 4.0.1
     peerDependenciesMeta:
       '@ember-data/graph':
         optional: true
@@ -1129,8 +1131,8 @@ packages:
       '@ember-data/legacy-compat': 4.12.8
       '@ember-data/store': 4.12.8
       '@ember-data/tracking': 4.12.8
-      '@ember/string': ^3.0.1
-      ember-inflector: ^4.0.2
+      '@ember/string': 4.0.1
+      ember-inflector: 6.0.0
     peerDependenciesMeta:
       '@ember-data/debug':
         optional: true
@@ -1155,8 +1157,8 @@ packages:
     engines: {node: 16.* || >= 18.*}
     peerDependencies:
       '@ember-data/store': 4.12.8
-      '@ember/string': ^3.0.1
-      ember-inflector: ^4.0.2
+      '@ember/string': 4.0.1
+      ember-inflector: 6.0.0
 
   '@ember-data/store@4.12.8':
     resolution: {integrity: sha512-pI+c/ZtRO5T02JcQ+yvUQsRZIIw/+fVUUnxa6mHiiNkjOJZaK8/2resdskSgV3SFGI82icanV7Ve5LJj9EzscA==}
@@ -1167,7 +1169,7 @@ packages:
       '@ember-data/legacy-compat': 4.12.8
       '@ember-data/model': 4.12.8
       '@ember-data/tracking': 4.12.8
-      '@ember/string': ^3.0.1
+      '@ember/string': 4.0.1
       '@glimmer/tracking': ^1.1.2
     peerDependenciesMeta:
       '@ember-data/graph':
@@ -1235,10 +1237,6 @@ packages:
 
   '@ember/render-modifiers@4.0.0':
     resolution: {integrity: sha512-QWo6rBJ9EwCLWbAzdppco2/Lh86Op3ad5UAn34yE9QaRgoMSf08XkMoE+5ftPiYOo08SG/QsNBDcxbpe3OgqWA==}
-
-  '@ember/string@3.1.1':
-    resolution: {integrity: sha512-UbXJ+k3QOrYN4SRPHgXCqYIJ+yWWUg1+vr0H4DhdQPTy8LJfyqwZ2tc5uqpSSnEXE+/1KopHBE5J8GDagAg5cg==}
-    engines: {node: 12.* || 14.* || >= 16}
 
   '@ember/string@4.0.1':
     resolution: {integrity: sha512-VWeng8BSWrIsdPfffOQt/bKwNKJL7+37gPFh/6iZZ9bke+S83kKqkS30poo4bTGfRcMnvAE0ie7txom+iDu81Q==}
@@ -3378,8 +3376,8 @@ packages:
   ember-can@8.0.0:
     resolution: {integrity: sha512-JsS7tJ7sg52p8jPY2ND9uqHdEpAB+RpJLN8+lo7t5j65JgBX5gWXCCJ8seJ28AE278Im2ok0OoQBv5VXWqkvOw==}
     peerDependencies:
-      '@ember/string': '>= 3.0.1'
-      ember-inflector: '>= 5.0.1'
+      '@ember/string': 4.0.1
+      ember-inflector: 6.0.0
       ember-resolver: '>= 10.0.0'
       ember-source: '>= 4.12.0'
 
@@ -3520,7 +3518,7 @@ packages:
     resolution: {integrity: sha512-uS7lSb+PgGVQbJBHiZBHUsti6wcGQ2nJHWxxrWBUgTpTONcn8oQ2HZBFhVbt0y289rryi+QFMWhsW0lutXUf4A==}
     engines: {node: '>= 20', pnpm: '>= 10'}
     peerDependencies:
-      '@ember/string': '>= 3.1.1'
+      '@ember/string': 4.0.1
 
   ember-cli-string-utils@1.1.0:
     resolution: {integrity: sha512-PlJt4fUDyBrC/0X+4cOpaGCiMawaaB//qD85AXmDRikxhxVzfVdpuoec02HSiTGTTB85qCIzWBIh8lDOiMyyFg==}
@@ -3604,7 +3602,7 @@ packages:
     resolution: {integrity: sha512-fK9mp+chqXGWYx6lal/azBKP4AtW8E6u3xUUWet6henO2zPN4S5lRs6iBfaynPkmhW5DK5bvaxNmFvSzmPOghw==}
     engines: {node: 16.* || >= 18.*}
     peerDependencies:
-      '@ember/string': ^3.0.1
+      '@ember/string': 4.0.1
 
   ember-decorators@6.1.1:
     resolution: {integrity: sha512-63vZPntPn1aqMyeNRLoYjJD+8A8obd+c2iZkJflswpDRNVIsp2m7aQdSCtPt4G0U/TEq2251g+N10maHX3rnJQ==}
@@ -3647,12 +3645,6 @@ packages:
   ember-get-config@2.1.1:
     resolution: {integrity: sha512-uNmv1cPG/4qsac8oIf5txJ2FZ8p88LEpG4P3dNcjsJS98Y8hd0GPMFwVqpnzI78Lz7VYRGQWY4jnE4qm5R3j4g==}
     engines: {node: 12.* || 14.* || >= 16}
-
-  ember-inflector@4.0.3:
-    resolution: {integrity: sha512-E+NnmzybMRWn1JyEfDxY7arjOTJLIcGjcXnUxizgjD4TlvO1s3O65blZt+Xq2C2AFSPeqHLC6PXd6XHYM8BxdQ==}
-    engines: {node: 14.* || 16.* || >= 18}
-    peerDependencies:
-      ember-source: ^3.16.0 || ^4.0.0 || ^5.0.0
 
   ember-inflector@6.0.0:
     resolution: {integrity: sha512-g6trqBhQHRwlq9bBmoyxhAl0tD0/CaTKK0xWPUgi3BfxFOgGG1bbiwAx+tjyiAkLzDqU+ihyjtT+sd41y6K1hA==}
@@ -3784,7 +3776,7 @@ packages:
     resolution: {integrity: sha512-ReVGW9fZmDIsCWsuJGH4joiiHOv9aF9Yv4lUZUjXjQyR9SEAae7RWjZcjPgmEJwpN7yDSyy4PIwdJa0smT2A3g==}
     engines: {node: 18.* || >= 20, pnpm: '>= 10.*'}
     peerDependencies:
-      '@ember/string': ^3.1.1 || ^4.0.0
+      '@ember/string': 4.0.1
 
   ember-template-imports@4.4.0:
     resolution: {integrity: sha512-HNOHabTEMbRluci1uScvh3ljMDo9E46dHHNcJAIf5yjOhIQ/zN4Y0DVDWrRfcbihlHvt4v/iF69G+8tffC1YkA==}
@@ -7937,7 +7929,7 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.1
 
-  '@ember-data/adapter@4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))':
+  '@ember-data/adapter@4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
       '@ember-data/store': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
@@ -7945,7 +7937,7 @@ snapshots:
       '@embroider/macros': 1.20.2(@babel/core@7.29.0)(@glint/template@1.7.7)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
+      ember-inflector: 6.0.0(@babel/core@7.29.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -8005,7 +7997,7 @@ snapshots:
       - '@glint/template'
       - supports-color
 
-  '@ember-data/model@4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@glint/template@1.7.7))(@ember-data/json-api@4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7))(@ember-data/legacy-compat@4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7))(@ember-data/store@4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))':
+  '@ember-data/model@4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))':
     dependencies:
       '@ember-data/legacy-compat': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
@@ -8019,32 +8011,6 @@ snapshots:
       ember-cli-string-utils: 1.1.0
       ember-cli-test-info: 1.0.0
       ember-inflector: 6.0.0(@babel/core@7.29.0)
-      inflection: 2.0.1
-    optionalDependencies:
-      '@ember-data/debug': 4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)(webpack@5.106.2)
-      '@ember-data/graph': 4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
-      '@ember-data/json-api': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@glint/template'
-      - ember-source
-      - supports-color
-    optional: true
-
-  '@ember-data/model@4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))':
-    dependencies:
-      '@ember-data/legacy-compat': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)
-      '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
-      '@ember-data/store': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
-      '@ember-data/tracking': 4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7)
-      '@ember/edition-utils': 1.2.0
-      '@ember/string': 4.0.1
-      '@embroider/macros': 1.20.2(@babel/core@7.29.0)(@glint/template@1.7.7)
-      ember-cached-decorator-polyfill: 1.0.2(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
-      ember-cli-babel: 7.26.11
-      ember-cli-string-utils: 1.1.0
-      ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       inflection: 2.0.1
     optionalDependencies:
       '@ember-data/debug': 4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)(webpack@5.106.2)
@@ -8100,7 +8066,7 @@ snapshots:
 
   '@ember-data/rfc395-data@0.0.4': {}
 
-  '@ember-data/serializer@4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))':
+  '@ember-data/serializer@4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))':
     dependencies:
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
       '@ember-data/store': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
@@ -8108,7 +8074,7 @@ snapshots:
       '@embroider/macros': 1.20.2(@babel/core@7.29.0)(@glint/template@1.7.7)
       ember-cli-babel: 7.26.11
       ember-cli-test-info: 1.0.0
-      ember-inflector: 4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
+      ember-inflector: 6.0.0(@babel/core@7.29.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -8127,7 +8093,7 @@ snapshots:
       '@ember-data/graph': 4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
       '@ember-data/json-api': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
       '@ember-data/legacy-compat': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)
-      '@ember-data/model': 4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@glint/template@1.7.7))(@ember-data/json-api@4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7))(@ember-data/legacy-compat@4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7))(@ember-data/store@4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
+      '@ember-data/model': 4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
@@ -8248,12 +8214,6 @@ snapshots:
   '@ember/render-modifiers@4.0.0':
     dependencies:
       '@embroider/addon-shim': 1.10.2
-    transitivePeerDependencies:
-      - supports-color
-
-  '@ember/string@3.1.1':
-    dependencies:
-      ember-cli-babel: 7.26.11
     transitivePeerDependencies:
       - supports-color
 
@@ -8522,7 +8482,7 @@ snapshots:
   '@hashicorp/design-system-components@4.13.0(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-basic-dropdown@8.11.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(ember-concurrency@4.0.6(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))':
     dependencies:
       '@ember/render-modifiers': 2.1.0(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
-      '@ember/string': 3.1.1
+      '@ember/string': 4.0.1
       '@ember/test-waiters': 3.1.0
       '@embroider/addon-shim': 1.10.2
       '@floating-ui/dom': 1.7.2
@@ -8539,7 +8499,7 @@ snapshots:
       ember-power-select: 8.12.1(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-basic-dropdown@8.11.0(@babel/core@7.29.0)(@ember/string@4.0.1)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glimmer/component@2.1.1)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(ember-concurrency@4.0.6(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       ember-source: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
       ember-stargate: 0.4.3(@babel/core@7.29.0)(@ember/test-waiters@3.1.0)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-concurrency@4.0.6(@babel/core@7.29.0)(@glint/template@1.7.7))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
-      ember-style-modifier: 4.5.1(@babel/core@7.29.0)(@ember/string@3.1.1)
+      ember-style-modifier: 4.5.1(@babel/core@7.29.0)(@ember/string@4.0.1)
       ember-truth-helpers: 4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       prismjs: 1.30.0
       sass: 1.99.0
@@ -11178,7 +11138,7 @@ snapshots:
 
   ember-cli-is-package-missing@1.0.0: {}
 
-  ember-cli-mirage@3.0.4(@ember-data/model@4.12.8)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-data@4.12.8(@babel/core@7.29.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2))(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2):
+  ember-cli-mirage@3.0.4(@ember-data/model@4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(ember-data@4.12.8(@babel/core@7.29.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2))(ember-qunit@9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(miragejs@0.1.48)(webpack@5.106.2):
     dependencies:
       '@babel/core': 7.29.0
       '@embroider/macros': 1.20.2(@babel/core@7.29.0)(@glint/template@1.7.7)
@@ -11188,11 +11148,11 @@ snapshots:
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
       ember-cli-babel: 8.3.1(@babel/core@7.29.0)
       ember-get-config: 2.1.1(@babel/core@7.29.0)(@glint/template@1.7.7)
-      ember-inflector: 4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
+      ember-inflector: 6.0.0(@babel/core@7.29.0)
       ember-source: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
       miragejs: 0.1.48
     optionalDependencies:
-      '@ember-data/model': 4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@glint/template@1.7.7))(@ember-data/json-api@4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7))(@ember-data/legacy-compat@4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7))(@ember-data/store@4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
+      '@ember-data/model': 4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       '@ember/test-helpers': 5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7)
       ember-data: 4.12.8(@babel/core@7.29.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2)
       ember-qunit: 9.0.4(@babel/core@7.29.0)(@ember/test-helpers@5.4.1(@babel/core@7.29.0)(@glint/template@1.7.7))(@glint/template@1.7.7)(qunit@2.25.0)
@@ -11568,15 +11528,15 @@ snapshots:
 
   ember-data@4.12.8(@babel/core@7.29.0)(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))(webpack@5.106.2):
     dependencies:
-      '@ember-data/adapter': 4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))
+      '@ember-data/adapter': 4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))
       '@ember-data/debug': 4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)(webpack@5.106.2)
       '@ember-data/graph': 4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
       '@ember-data/json-api': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/store@4.12.8)(@glint/template@1.7.7)
       '@ember-data/legacy-compat': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)
-      '@ember-data/model': 4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
+      '@ember-data/model': 4.12.8(@babel/core@7.29.0)(@ember-data/debug@4.12.8)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/store@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       '@ember-data/private-build-infra': 4.12.8(@glint/template@1.7.7)
       '@ember-data/request': 4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7)
-      '@ember-data/serializer': 4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)))
+      '@ember-data/serializer': 4.12.8(@babel/core@7.29.0)(@ember-data/store@4.12.8)(@ember/string@4.0.1)(@glint/template@1.7.7)(ember-inflector@6.0.0(@babel/core@7.29.0))
       '@ember-data/store': 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       '@ember-data/tracking': 4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7)
       '@ember/edition-utils': 1.2.0
@@ -11586,7 +11546,7 @@ snapshots:
       broccoli-merge-trees: 4.2.0
       ember-auto-import: 2.13.1(@glint/template@1.7.7)(webpack@5.106.2)
       ember-cli-babel: 7.26.11
-      ember-inflector: 4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
+      ember-inflector: 6.0.0(@babel/core@7.29.0)
     transitivePeerDependencies:
       - '@babel/core'
       - '@glimmer/tracking'
@@ -11673,13 +11633,6 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - '@glint/template'
-      - supports-color
-
-  ember-inflector@4.0.3(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)):
-    dependencies:
-      ember-cli-babel: 7.26.11
-      ember-source: 6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5)
-    transitivePeerDependencies:
       - supports-color
 
   ember-inflector@6.0.0(@babel/core@7.29.0):
@@ -11913,17 +11866,6 @@ snapshots:
       ember-cli-htmlbars: 5.7.2
       ember-cli-typescript: 3.1.4(@babel/core@7.29.0)
       xstate: 4.38.3
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  ember-style-modifier@4.5.1(@babel/core@7.29.0)(@ember/string@3.1.1):
-    dependencies:
-      '@ember/string': 3.1.1
-      '@embroider/addon-shim': 1.10.2
-      csstype: 3.1.3
-      decorator-transforms: 2.3.1(@babel/core@7.29.0)
-      ember-modifier: 4.3.0(@babel/core@7.29.0)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@babel/plugin-proposal-decorators':
         specifier: ^7.29.0
         version: 7.29.0(@babel/core@7.29.0)
+      '@ember-data/store':
+        specifier: ~4.12.8
+        version: 4.12.8(@babel/core@7.29.0)(@ember-data/graph@4.12.8)(@ember-data/json-api@4.12.8)(@ember-data/legacy-compat@4.12.8)(@ember-data/model@4.12.8)(@ember-data/tracking@4.12.8(@babel/core@7.29.0)(@glint/template@1.7.7))(@ember/string@4.0.1)(@glimmer/tracking@1.1.2)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))
       '@ember/legacy-built-in-components':
         specifier: ^0.5.0
         version: 0.5.0(@babel/core@7.29.0)(@glint/template@1.7.7)(ember-source@6.12.0(@glimmer/component@2.1.1)(rsvp@4.8.5))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,9 @@ autoInstallPeers: false
 
 overrides:
   '@babel/runtime@<7.26.10': '>=7.26.10'
+  '@ember/string': 4.0.1
   '@glimmer/component': ^2.1.1
+  ember-inflector: 6.0.0
   ansi-html@<0.0.8: '>=0.0.8'
   basic-ftp@<=5.3.0: '>=5.3.1'
   diff@>=6.0.0 <8.0.3: '>=8.0.3'
@@ -17,6 +19,21 @@ overrides:
   socket.io-parser@>=4.0.0 <4.2.6: '>=4.2.6'
   tmp@<=0.2.3: '>=0.2.4'
   uuid@<14.0.0: '>=14.0.0'
+
+peerDependencyRules:
+  allowedVersions:
+    # ember-data 4.12.x still declares @ember/string ^3, but our app uses v4
+    'ember-data>@ember/string': '^4.0.0'
+    '@ember-data/store>@ember/string': '^4.0.0'
+    '@ember-data/model>@ember/string': '^4.0.0'
+    '@ember-data/adapter>@ember/string': '^4.0.0'
+    '@ember-data/serializer>@ember/string': '^4.0.0'
+    '@ember-data/debug>@ember/string': '^4.0.0'
+    '@ember-data/legacy-compat>@ember/string': '^4.0.0'
+    # Older addons declare narrow peers; we run ember-source 6.x / ember-concurrency 4.x
+    ember-source: '^6.0.0'
+    ember-concurrency: '^4.0.0'
+    ember-inflector: '>=4.0.0'
 
 publicHoistPattern:
   - ember-source

--- a/ui/app/serializers/network.js
+++ b/ui/app/serializers/network.js
@@ -18,7 +18,7 @@ export default class NetworkSerializer extends ApplicationSerializer {
   normalize(typeHash, hash) {
     const ip = hash.IP;
 
-    if (isIPv6(ip)) {
+    if (ip && isIPv6(ip)) {
       hash.IP = `[${ip}]`;
     }
 

--- a/ui/app/serializers/port.js
+++ b/ui/app/serializers/port.js
@@ -16,7 +16,7 @@ export default class PortSerializer extends ApplicationSerializer {
   normalize(typeHash, hash) {
     const ip = hash.HostIP;
 
-    if (isIPv6(ip)) {
+    if (ip && isIPv6(ip)) {
       hash.HostIP = `[${ip}]`;
     }
 

--- a/ui/ember-cli-build.mjs
+++ b/ui/ember-cli-build.mjs
@@ -17,6 +17,7 @@ const isTest = environment === 'test';
 export default function (defaults) {
   const app = new EmberApp(defaults, {
     emberData: {
+      polyfillUUID: true,
       deprecations: {
         // New projects can safely leave this deprecation disabled.
         // If upgrading, to opt-into the deprecated behavior, set this to true and then follow:

--- a/ui/ember-cli-build.mjs
+++ b/ui/ember-cli-build.mjs
@@ -16,8 +16,14 @@ const isTest = environment === 'test';
 
 export default function (defaults) {
   const app = new EmberApp(defaults, {
+    '@embroider/macros': {
+      setConfig: {
+        '@ember-data/store': {
+          polyfillUUID: true,
+        },
+      },
+    },
     emberData: {
-      polyfillUUID: true,
       deprecations: {
         // New projects can safely leave this deprecation disabled.
         // If upgrading, to opt-into the deprecated behavior, set this to true and then follow:

--- a/ui/package.json
+++ b/ui/package.json
@@ -117,6 +117,7 @@
     "ember-concurrency": "^4.0.6",
     "ember-copy": "^2.0.1",
     "ember-data": "~4.12.8",
+    "@ember-data/store": "~4.12.8",
     "ember-data-model-fragments": "7.0.3",
     "ember-decorators": "^6.1.1",
     "ember-exam": "10.1.0",

--- a/ui/tests/unit/serializers/network-test.js
+++ b/ui/tests/unit/serializers/network-test.js
@@ -33,4 +33,15 @@ module('Unit | Serializer | Network', function (hooks) {
     const { data } = this.subject().normalize(NetworkModel, original);
     assert.deepEqual(data.attributes.ip, `[${ip}]`);
   });
+
+  test('missing IP does not throw', async function (assert) {
+    const original = {
+      ReservedPorts: [{ Label: 'http', Value: 80 }],
+    };
+
+    assert.deepEqual(
+      this.subject().normalize(NetworkModel, original).data.attributes.ip,
+      undefined,
+    );
+  });
 });

--- a/ui/tests/unit/serializers/port-test.js
+++ b/ui/tests/unit/serializers/port-test.js
@@ -1,0 +1,41 @@
+/**
+ * Copyright IBM Corp. 2015, 2025
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import PortModel from 'nomad-ui/models/port';
+
+module('Unit | Serializer | Port', function (hooks) {
+  setupTest(hooks);
+  hooks.beforeEach(function () {
+    this.store = this.owner.lookup('service:store');
+    this.subject = () => this.store.serializerFor('port');
+  });
+
+  test('v4 HostIPs are passed through', async function (assert) {
+    const ip = '10.0.13.12';
+    const original = { HostIP: ip };
+
+    const { data } = this.subject().normalize(PortModel, original);
+    assert.deepEqual(data.attributes.hostIp, ip);
+  });
+
+  test('v6 HostIPs are wrapped in square brackets', async function (assert) {
+    const ip = '2001:0dac:aba3:0000:0000:8a2e:0370:7334';
+    const original = { HostIP: ip };
+
+    const { data } = this.subject().normalize(PortModel, original);
+    assert.deepEqual(data.attributes.hostIp, `[${ip}]`);
+  });
+
+  test('missing HostIP does not throw', async function (assert) {
+    const original = { Label: 'http', Value: 80 };
+
+    assert.deepEqual(
+      this.subject().normalize(PortModel, original).data.attributes.hostIp,
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

Two distinct UI errors on the client detail page after the Ember 6.10 upgrade, plus dependency cleanup.

## 1. `crypto.randomUUID is not a function`

Ember Data 4.12 calls `crypto.randomUUID()` to mint record identifiers. The browser only exposes it in **secure contexts** (HTTPS or `localhost`/`127.0.0.1`), so users hitting Nomad over plain HTTP via a LAN IP/hostname crashed.


- `ui/package.json` — added `"@ember-data/store": "~4.12.8"` as a direct dep so embroider can resolve the macro target.
- `ui/ember-cli-build.mjs` — added:
  ```js
  '@embroider/macros': {
    setConfig: {
      '@ember-data/store': { polyfillUUID: true },
    },
  },
  ```

## 2. `Cannot read properties of undefined (reading 'length')`

`is-ip@5` (pulled in by the Ember 6 upgrade) tightened input validation: `isIPv6(undefined)` now throws on `string.length`. Triggered during fragment-array deserialization of `Resources.Networks` when an entry has no `IP` (e.g. reserved-port-only networks).

**Fix** — guard the call sites:

- `ui/app/serializers/network.js` — `if (ip && isIPv6(ip))`
- `ui/app/serializers/port.js` — `if (ip && isIPv6(ip))`
- `ui/app/utils/format-host.js` — already safe (early-returns if `!address`).

**Regression tests:**

- `ui/tests/unit/serializers/network-test.js` — added "missing IP does not throw"
- `ui/tests/unit/serializers/port-test.js` — new file with v4 / v6 / missing-HostIP cases

## 3. Duplicate package resolutions

The Ember 6.10 upgrade pulled in two majors of `@ember/string` and `ember-inflector`.

**Fix:**

- `pnpm-workspace.yaml` — pinned `@ember/string@4.0.1` and `ember-inflector@6.0.0` via `overrides`; added `peerDependencyRules.allowedVersions` for the noisy peer-dep warnings.

Lockfile verified: only single versions resolved.

---

**Net effect:** Linux/HTTP/LAN users no longer crash on `crypto.randomUUID`; nodes with IP-less network entries no longer crash on `isIPv6(undefined)`; build output is leaner due to deduplication.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

Fixes: https://github.com/hashicorp/nomad/issues/27955
Ref: https://hashicorp.atlassian.net/browse/NMD-1454

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
