### PR TITLE
ci: declare permissions on build-on-push and jira-sync

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -17,6 +17,12 @@ on:
       # to build.yml directly during a release).
       - 'release/[0-9].[0-9]+.x*'
 
+# Caller scopes for the reusable build.yml (which declares the same set
+# at its job level).
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     uses: ./.github/workflows/build.yml

--- a/.github/workflows/jira-sync.yml
+++ b/.github/workflows/jira-sync.yml
@@ -15,6 +15,11 @@ env:
   JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}
   JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
 
+# Jira mirror only reads issue/comment metadata; writes go to Jira.
+permissions:
+  contents: read
+  issues: read
+
 jobs:
   sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two workflows in this repo still inherit the default `GITHUB_TOKEN` scope. Pinning each to the minimum it needs:

- **build-on-push.yml** — `contents: read` + `id-token: write`. Caller for the reusable `build.yml` (whose existing job-level block declares the same set for the CRT pre-prepare upload). Mirroring the caller-side scopes avoids implicitly clipping the reusable workflow's permissions.
- **jira-sync.yml** — `contents: read` + `issues: read`. The atlassian/gajira-* + tomhjp/gh-action-jira-* steps write to the Jira API via `JIRA_API_TOKEN`; the GitHub side only reads the issue/comment context.

YAML validated locally with `yaml.safe_load`.