### PR TITLE
template: don't fail tasks that aren't running while trying to send a signal

### DIFF
--- a/.changelog/27960.txt
+++ b/.changelog/27960.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where tasks could accidentally get killed mid-restart on template re-render
+```

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocrunner/state"
 	"github.com/hashicorp/nomad/client/allocrunner/tasklifecycle"
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner"
+	te "github.com/hashicorp/nomad/client/allocrunner/taskrunner/errors"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/consul"
 	"github.com/hashicorp/nomad/client/devicemanager"
@@ -750,7 +751,7 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 		taskEvent := taskEventFn(tr)
 
 		err := tr.Kill(context.TODO(), taskEvent)
-		if err != nil && err != taskrunner.ErrTaskNotRunning {
+		if err != nil && err != te.ErrTaskNotRunning {
 			ar.logger.Warn("error stopping leader task", "error", err, "task_name", name)
 		}
 
@@ -773,7 +774,7 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 			taskEvent := taskEventFn(tr)
 
 			err := tr.Kill(context.TODO(), taskEvent)
-			if err != nil && err != taskrunner.ErrTaskNotRunning {
+			if err != nil && err != te.ErrTaskNotRunning {
 				ar.logger.Warn("error stopping task", "error", err, "task_name", name)
 			}
 
@@ -797,7 +798,7 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 			taskEvent := taskEventFn(tr)
 
 			err := tr.Kill(context.TODO(), taskEvent)
-			if err != nil && err != taskrunner.ErrTaskNotRunning {
+			if err != nil && err != te.ErrTaskNotRunning {
 				ar.logger.Warn("error stopping sidecar task", "error", err, "task_name", name)
 			}
 
@@ -1401,7 +1402,7 @@ func (ar *allocRunner) restartTasks(ctx context.Context, event *structs.TaskEven
 
 				// Ignore ErrTaskNotRunning errors since tasks that are not
 				// running are expected to not be restarted.
-				if e != nil && e != taskrunner.ErrTaskNotRunning {
+				if e != nil && e != te.ErrTaskNotRunning {
 					errMutex.Lock()
 					defer errMutex.Unlock()
 					err = multierror.Append(err, fmt.Errorf("failed to restart task %s: %v", taskName, e))

--- a/client/allocrunner/taskrunner/artifact_hook.go
+++ b/client/allocrunner/taskrunner/artifact_hook.go
@@ -10,6 +10,7 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	te "github.com/hashicorp/nomad/client/allocrunner/taskrunner/errors"
 	ti "github.com/hashicorp/nomad/client/allocrunner/taskrunner/interfaces"
 	ci "github.com/hashicorp/nomad/client/interfaces"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -57,7 +58,7 @@ func (h *artifactHook) doWork(
 				fmt.Errorf("failed to download artifact %q: %v", artifact.GetterSource, err),
 				true,
 			)
-			herr := NewHookError(wrapped, structs.NewTaskEvent(structs.TaskArtifactDownloadFailed).SetDownloadError(wrapped))
+			herr := te.NewHookError(wrapped, structs.NewTaskEvent(structs.TaskArtifactDownloadFailed).SetDownloadError(wrapped))
 
 			errorChannel <- herr
 			continue

--- a/client/allocrunner/taskrunner/driver_handle.go
+++ b/client/allocrunner/taskrunner/driver_handle.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	te "github.com/hashicorp/nomad/client/allocrunner/taskrunner/errors"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
@@ -67,7 +68,7 @@ func (h *DriverHandle) Signal(s string) error {
 // Exec is the handled used by client endpoint handler to invoke the appropriate task driver exec.
 func (h *DriverHandle) Exec(timeout time.Duration, cmd string, args []string) ([]byte, int, error) {
 	if h == nil {
-		return nil, 0, ErrTaskNotRunning
+		return nil, 0, te.ErrTaskNotRunning
 	}
 	command := append([]string{cmd}, args...)
 	res, err := h.driver.ExecTask(h.taskID, command, timeout)
@@ -84,7 +85,7 @@ func (h *DriverHandle) ExecStreaming(ctx context.Context,
 	tty bool,
 	stream drivers.ExecTaskStream) error {
 	if h == nil {
-		return ErrTaskNotRunning
+		return te.ErrTaskNotRunning
 	}
 
 	if impl, ok := h.driver.(drivers.ExecTaskStreamingRawDriver); ok {

--- a/client/allocrunner/taskrunner/errors/errors.go
+++ b/client/allocrunner/taskrunner/errors/errors.go
@@ -1,7 +1,7 @@
 // Copyright IBM Corp. 2015, 2025
 // SPDX-License-Identifier: BUSL-1.1
 
-package taskrunner
+package errors
 
 import (
 	"errors"
@@ -9,13 +9,9 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
-const (
-	errTaskNotRunning = "Task not running"
-)
-
-var (
-	ErrTaskNotRunning = errors.New(errTaskNotRunning)
-)
+// ErrTaskNotRunning is returned when the underlying task is not currently
+// running. It's defined here in the template package to avoid import cycles.
+var ErrTaskNotRunning = errors.New("Task not running")
 
 // NewHookError contains an underlying err and a pre-formatted task event.
 func NewHookError(err error, taskEvent *structs.TaskEvent) error {

--- a/client/allocrunner/taskrunner/errors/errors.go
+++ b/client/allocrunner/taskrunner/errors/errors.go
@@ -30,7 +30,7 @@ func (h *HookError) Error() string {
 	return h.Err.Error()
 }
 
-// Recoverable is true if the underlying error is recoverable.
+// IsRecoverable is true if the underlying error is recoverable.
 func (h *HookError) IsRecoverable() bool {
 	return structs.IsRecoverable(h.Err)
 }

--- a/client/allocrunner/taskrunner/errors/errors.go
+++ b/client/allocrunner/taskrunner/errors/errors.go
@@ -10,7 +10,7 @@ import (
 )
 
 // ErrTaskNotRunning is returned when the underlying task is not currently
-// running. It's defined here in the template package to avoid import cycles.
+// running. It's defined here to avoid import cycles.
 var ErrTaskNotRunning = errors.New("Task not running")
 
 // NewHookError contains an underlying err and a pre-formatted task event.

--- a/client/allocrunner/taskrunner/errors/errors.go
+++ b/client/allocrunner/taskrunner/errors/errors.go
@@ -15,22 +15,22 @@ var ErrTaskNotRunning = errors.New("Task not running")
 
 // NewHookError contains an underlying err and a pre-formatted task event.
 func NewHookError(err error, taskEvent *structs.TaskEvent) error {
-	return &hookError{
-		err:       err,
-		taskEvent: taskEvent,
+	return &HookError{
+		Err:       err,
+		TaskEvent: taskEvent,
 	}
 }
 
-type hookError struct {
-	taskEvent *structs.TaskEvent
-	err       error
+type HookError struct {
+	TaskEvent *structs.TaskEvent
+	Err       error
 }
 
-func (h *hookError) Error() string {
-	return h.err.Error()
+func (h *HookError) Error() string {
+	return h.Err.Error()
 }
 
 // Recoverable is true if the underlying error is recoverable.
-func (h *hookError) IsRecoverable() bool {
-	return structs.IsRecoverable(h.err)
+func (h *HookError) IsRecoverable() bool {
+	return structs.IsRecoverable(h.Err)
 }

--- a/client/allocrunner/taskrunner/errors/errors_test.go
+++ b/client/allocrunner/taskrunner/errors/errors_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // Statically assert error implements the expected interfaces
-var _ structs.Recoverable = (*hookError)(nil)
+var _ structs.Recoverable = (*HookError)(nil)
 
 // TestHookError_Recoverable asserts that a NewHookError is recoverable if
 // passed a recoverable error.
@@ -31,7 +31,7 @@ func TestHookError_Recoverable(t *testing.T) {
 
 	herr := NewHookError(recov, ev)
 
-	must.Eq(t, ev, herr.(*hookError).taskEvent)
+	must.Eq(t, ev, herr.(*HookError).TaskEvent)
 	must.True(t, structs.IsRecoverable(herr))
 	must.Eq(t, root.Error(), herr.Error())
 	must.Eq(t, recov.Error(), herr.Error())
@@ -50,7 +50,7 @@ func TestHookError_Unrecoverable(t *testing.T) {
 
 	herr := NewHookError(err, ev)
 
-	must.Eq(t, ev, herr.(*hookError).taskEvent)
+	must.Eq(t, ev, herr.(*HookError).TaskEvent)
 	must.False(t, structs.IsRecoverable(herr))
 	must.Eq(t, err.Error(), herr.Error())
 }

--- a/client/allocrunner/taskrunner/errors/errors_test.go
+++ b/client/allocrunner/taskrunner/errors/errors_test.go
@@ -1,7 +1,7 @@
 // Copyright IBM Corp. 2015, 2025
 // SPDX-License-Identifier: BUSL-1.1
 
-package taskrunner
+package errors
 
 import (
 	"errors"
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/nomad/structs"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 )
 
 // Statically assert error implements the expected interfaces
@@ -31,10 +31,10 @@ func TestHookError_Recoverable(t *testing.T) {
 
 	herr := NewHookError(recov, ev)
 
-	require.Equal(t, ev, herr.(*hookError).taskEvent)
-	require.True(t, structs.IsRecoverable(herr))
-	require.Equal(t, root.Error(), herr.Error())
-	require.Equal(t, recov.Error(), herr.Error())
+	must.Eq(t, ev, herr.(*hookError).taskEvent)
+	must.True(t, structs.IsRecoverable(herr))
+	must.Eq(t, root.Error(), herr.Error())
+	must.Eq(t, recov.Error(), herr.Error())
 }
 
 // TestHookError_Unrecoverable asserts that a NewHookError is not recoverable
@@ -50,7 +50,7 @@ func TestHookError_Unrecoverable(t *testing.T) {
 
 	herr := NewHookError(err, ev)
 
-	require.Equal(t, ev, herr.(*hookError).taskEvent)
-	require.False(t, structs.IsRecoverable(herr))
-	require.Equal(t, err.Error(), herr.Error())
+	must.Eq(t, ev, herr.(*hookError).taskEvent)
+	must.False(t, structs.IsRecoverable(herr))
+	must.Eq(t, err.Error(), herr.Error())
 }

--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"time"
 
+	te "github.com/hashicorp/nomad/client/allocrunner/taskrunner/errors"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -18,12 +19,12 @@ func (tr *TaskRunner) Restart(ctx context.Context, event *structs.TaskEvent, fai
 
 	taskState := tr.TaskState()
 	if taskState == nil {
-		return ErrTaskNotRunning
+		return te.ErrTaskNotRunning
 	}
 
 	switch taskState.State {
 	case structs.TaskStatePending, structs.TaskStateDead:
-		return ErrTaskNotRunning
+		return te.ErrTaskNotRunning
 	}
 
 	return tr.restartImpl(ctx, event, failure)
@@ -40,7 +41,7 @@ func (tr *TaskRunner) ForceRestart(ctx context.Context, event *structs.TaskEvent
 
 	taskState := tr.TaskState()
 	if taskState == nil {
-		return ErrTaskNotRunning
+		return te.ErrTaskNotRunning
 	}
 
 	tr.stateLock.Lock()
@@ -48,18 +49,18 @@ func (tr *TaskRunner) ForceRestart(ctx context.Context, event *structs.TaskEvent
 	tr.stateLock.Unlock()
 
 	if localState == nil {
-		return ErrTaskNotRunning
+		return te.ErrTaskNotRunning
 	}
 
 	switch taskState.State {
 	case structs.TaskStatePending:
-		return ErrTaskNotRunning
+		return te.ErrTaskNotRunning
 
 	case structs.TaskStateDead:
 		// Tasks that are in the "dead" state are only allowed to restart if
 		// their Run() method is still active.
 		if localState.RunComplete {
-			return ErrTaskNotRunning
+			return te.ErrTaskNotRunning
 		}
 	}
 
@@ -76,7 +77,7 @@ func (tr *TaskRunner) restartImpl(ctx context.Context, event *structs.TaskEvent,
 	// restart event that was triggered.
 	taskState := tr.TaskState()
 	if taskState == nil {
-		return ErrTaskNotRunning
+		return te.ErrTaskNotRunning
 	}
 
 	// Emit the event since it may take a long time to kill
@@ -132,7 +133,7 @@ func (tr *TaskRunner) Exec(timeout time.Duration, cmd string, args []string) ([]
 
 	handle := tr.getDriverHandle()
 	if handle == nil {
-		return nil, 0, ErrTaskNotRunning
+		return nil, 0, te.ErrTaskNotRunning
 	}
 
 	out, code, err := handle.Exec(timeout, cmd, args)
@@ -147,7 +148,7 @@ func (tr *TaskRunner) Signal(event *structs.TaskEvent, s string) error {
 
 	// Check it is running
 	if handle == nil {
-		return ErrTaskNotRunning
+		return te.ErrTaskNotRunning
 	}
 
 	// Emit the event

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/LK4D4/joincontext"
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	te "github.com/hashicorp/nomad/client/allocrunner/taskrunner/errors"
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/plugins/drivers"
@@ -204,8 +205,8 @@ func (tr *TaskRunner) initHooks() {
 
 func (tr *TaskRunner) emitHookError(err error, hookName string) {
 	var taskEvent *structs.TaskEvent
-	if herr, ok := err.(*hookError); ok {
-		taskEvent = herr.taskEvent
+	if herr, ok := err.(*te.HookError); ok {
+		taskEvent = herr.TaskEvent
 	} else {
 		message := fmt.Sprintf("%s: %v", hookName, err)
 		taskEvent = structs.NewTaskEvent(structs.TaskHookFailed).SetMessage(message)

--- a/client/allocrunner/taskrunner/task_runner_linux_test.go
+++ b/client/allocrunner/taskrunner/task_runner_linux_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/allocrunner/hookstats"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
+	te "github.com/hashicorp/nomad/client/allocrunner/taskrunner/errors"
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/getter"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/devicemanager"
@@ -447,7 +448,7 @@ func TestTaskRunner_Restore_Dead(t *testing.T) {
 
 	ev := &structs.TaskEvent{Type: structs.TaskRestartSignal}
 	err = newTR2.ForceRestart(context.Background(), ev, false)
-	require.Equal(t, err, ErrTaskNotRunning)
+	require.Equal(t, err, te.ErrTaskNotRunning)
 }
 
 // setupRestoreFailureTest starts a service, shuts down the task runner, and
@@ -2106,11 +2107,11 @@ func TestTaskRunner_RestartSignalTask_NotRunning(t *testing.T) {
 
 	// Send a signal and restart
 	err = tr.Signal(structs.NewTaskEvent("don't panic"), "QUIT")
-	require.EqualError(t, err, ErrTaskNotRunning.Error())
+	require.EqualError(t, err, te.ErrTaskNotRunning.Error())
 
 	// Send a restart
 	err = tr.Restart(context.Background(), structs.NewTaskEvent("don't panic"), false)
-	require.EqualError(t, err, ErrTaskNotRunning.Error())
+	require.EqualError(t, err, te.ErrTaskNotRunning.Error())
 
 	// Unblock and let it finish
 	waitCh <- struct{}{}

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -23,6 +23,7 @@ import (
 	envparse "github.com/hashicorp/go-envparse"
 	"github.com/hashicorp/go-hclog"
 	multierror "github.com/hashicorp/go-multierror"
+	te "github.com/hashicorp/nomad/client/allocrunner/taskrunner/errors"
 	"github.com/hashicorp/nomad/client/allocrunner/taskrunner/interfaces"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/taskenv"
@@ -559,6 +560,17 @@ func (tm *TaskTemplateManager) handleChangeModeSignal(signals map[string]struct{
 		s := tm.signals[signal]
 		event := structs.NewTaskEvent(structs.TaskSignaling).SetTaskSignal(s).SetDisplayMessage("Template re-rendered")
 		if err := tm.config.Lifecycle.Signal(event, signal); err != nil {
+			// If the task is not running (e.g. it is mid-restart) do not
+			// permanently fail the allocation. When the task comes back up it
+			// will already have the latest rendered template data.
+			if errors.Is(err, te.ErrTaskNotRunning) {
+				tm.config.Events.EmitEvent(
+					structs.NewTaskEvent(structs.TaskHookMessage).
+						SetDisplayMessage(fmt.Sprintf(
+							"Template skipped signal %v: task is not running", s)),
+				)
+				continue
+			}
 			_ = multierror.Append(&mErr, err)
 		}
 	}

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -24,6 +24,7 @@ import (
 	ctestutil "github.com/hashicorp/consul/sdk/testutil"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocdir"
+	te "github.com/hashicorp/nomad/client/allocrunner/taskrunner/errors"
 	trtesting "github.com/hashicorp/nomad/client/allocrunner/taskrunner/testing"
 	"github.com/hashicorp/nomad/client/config"
 	"github.com/hashicorp/nomad/client/taskenv"
@@ -1261,6 +1262,62 @@ func TestTaskTemplateManager_Signal_Error(t *testing.T) {
 
 	must.NotNil(t, harness.mockHooks.KillEvent)
 	must.StrContains(t, harness.mockHooks.KillEvent().DisplayMessage, "failed to send signals")
+}
+
+// TestTaskTemplateManager_Rerender_Signal_TaskNotRunning checks that when
+// template re-render fires a signal and the task is not currently running
+// (e.g. it is mid-restart), the template manager does not permanently fail
+// the allocation.
+func TestTaskTemplateManager_Rerender_Signal_TaskNotRunning(t *testing.T) {
+	ci.Parallel(t)
+	clienttestutil.RequireConsul(t)
+
+	key := "foo"
+	content1 := "bar"
+	content2 := "baz"
+	embedded := fmt.Sprintf(`{{key "%s"}}`, key)
+	file := "my.tmpl"
+	tmpl := &structs.Template{
+		EmbeddedTmpl: embedded,
+		DestPath:     file,
+		ChangeMode:   structs.TemplateChangeModeSignal,
+		ChangeSignal: "SIGHUP",
+	}
+
+	harness := newTestHarness(t, []*structs.Template{tmpl}, true, false)
+	harness.start(t)
+	defer harness.stop()
+
+	// Write the initial value so the template renders and the task is unblocked.
+	harness.consul.SetKV(t, key, []byte(content1))
+	select {
+	case <-harness.mockHooks.UnblockCh:
+	case <-time.After(time.Duration(5*testutil.TestMultiplier()) * time.Second):
+		t.Fatalf("task should have been unblocked after initial render")
+	}
+
+	// Simulate the task being mid-restart: signal delivery returns
+	// ErrTaskNotRunning because the driver handle is temporarily nil.
+	harness.mockHooks.SignalError = te.ErrTaskNotRunning
+
+	// Update the Consul key to trigger a template re-render and signal attempt.
+	harness.consul.SetKV(t, key, []byte(content2))
+
+	// Wait for the signal to be attempted.
+	select {
+	case <-harness.mockHooks.SignalCh:
+	case <-time.After(time.Duration(5*testutil.TestMultiplier()) * time.Second):
+		t.Fatalf("expected signal to be attempted after re-render")
+	}
+
+	// We don't expect the alloc to be killed, this should be treated as a transient
+	// error.
+	select {
+	case event := <-harness.mockHooks.KillCh:
+		t.Fatalf("allocation must not be killed when signal fails with ErrTaskNotRunning; got kill event: %v", event)
+	case <-time.After(time.Duration(1*testutil.TestMultiplier()) * time.Second):
+		// no kill was triggered.
+	}
 }
 
 func TestTaskTemplateManager_ScriptExecution(t *testing.T) {


### PR DESCRIPTION
When we try to re-render a template and fire a signal, the taskrunner could
unnecessarily fail the allocation if the underlying task is not running (say,
mid-restart). This should not happen, and task-not-running should be treated as
an intermittent error in the template manager. If the task is restarted, a
signal will be sent upon restart. If the task is truly dead, the task runner
will handle it.

Resolves #5459
Internal ref: https://hashicorp.atlassian.net/browse/NMD-634