### PR TITLE
node config: add default_ineligible configuration option

### DIFF
--- a/.changelog/27965.txt
+++ b/.changelog/27965.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: Adds default_ineligible configuration option
+```

--- a/client/client.go
+++ b/client/client.go
@@ -1750,6 +1750,12 @@ func (c *Client) setupNode() error {
 		return fmt.Errorf("error syncing dynamic node metadata: %w", err)
 	}
 
+	if c.config.DefaultIneligible {
+		node.SchedulingEligibility = structs.NodeSchedulingIneligible
+	} else {
+		node.SchedulingEligibility = structs.NodeSchedulingEligible
+	}
+
 	c.config = newConfig
 	return nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,6 +4,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"net"
@@ -2319,20 +2320,20 @@ func TestClient_DefaultIneligible(t *testing.T) {
 	var out structs.SingleNodeResponse
 
 	// Register should succeed
-	testutil.WaitForResult(func() (bool, error) {
-		err := s1.RPC("Node.GetNode", &req, &out)
-		if err != nil {
-			return false, err
-		}
-		if out.Node == nil {
-			return false, fmt.Errorf("missing reg")
-		}
-		must.Eq(t, structs.NodeSchedulingIneligible, out.Node.SchedulingEligibility)
-		return out.Node.ID == req.NodeID, nil
-	}, func(err error) {
-		must.NoError(t, err)
-	})
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(func() error {
+			err := s1.RPC("Node.GetNode", &req, &out)
+			if err != nil {
+				return err
+			}
+			if out.Node == nil {
+				return fmt.Errorf("missing reg")
+			}
+			return nil
+		}),
+	))
 
+	// Set node as eligible
 	req2 := structs.NodeUpdateEligibilityRequest{
 		NodeID:       c1.Node().ID,
 		Eligibility:  structs.NodeSchedulingEligible,
@@ -2340,19 +2341,9 @@ func TestClient_DefaultIneligible(t *testing.T) {
 	}
 	var out2 structs.NodeEligibilityUpdateResponse
 
-	// Set node as eligible and restart, should return as eligible
-
-	// Update eligibility should succeed
-	must.Wait(t, wait.InitialSuccess(
-		wait.ErrorFunc(func() error {
-			err := s1.RPC("Node.UpdateEligibility", &req2, &out2)
-			if err != nil {
-				return err
-			}
-			must.NotEq(t, out2.NodeModifyIndex, out.Index)
-			return nil
-		}),
-	))
+	err := s1.RPC("Node.UpdateEligibility", &req2, &out2)
+	must.NoError(t, err)
+	must.NotEq(t, out2.NodeModifyIndex, out.Index)
 
 	// Query node to confirm eligibility was toggled on
 	req3 := structs.NodeSpecificRequest{
@@ -2360,18 +2351,9 @@ func TestClient_DefaultIneligible(t *testing.T) {
 		QueryOptions: structs.QueryOptions{Region: "global"},
 	}
 	var out3 structs.SingleNodeResponse
-	must.Wait(t, wait.InitialSuccess(
-		wait.ErrorFunc(func() error {
-			err := s1.RPC("Node.GetNode", &req3, &out3)
-			if err != nil {
-				return err
-			}
-			must.Eq(t, structs.NodeSchedulingEligible, out3.Node.SchedulingEligibility)
-			return nil
-		}),
-		wait.Timeout(time.Second*1),
-		wait.Gap(time.Millisecond*30),
-	))
+	err = s1.RPC("Node.GetNode", &req3, &out3)
+	must.NoError(t, err)
+	must.Eq(t, structs.NodeSchedulingEligible, out3.Node.SchedulingEligibility)
 
 	// Save client config, shutdown and start new client
 	c1Config := c1.config.Copy()
@@ -2387,21 +2369,27 @@ func TestClient_DefaultIneligible(t *testing.T) {
 
 	// Query to confirm restarted node is still eligible
 	req4 := structs.NodeSpecificRequest{
-		NodeID:       c2.Node().ID,
-		QueryOptions: structs.QueryOptions{Region: "global"},
+		NodeID: c2.Node().ID,
+		QueryOptions: structs.QueryOptions{
+			Region: "global",
+		},
 	}
 	var out4 structs.SingleNodeResponse
 	must.Wait(t, wait.InitialSuccess(
 		wait.ErrorFunc(func() error {
 			err := s1.RPC("Node.GetNode", &req4, &out4)
-			if err != nil {
-				return err
+			must.NoError(t, err)
+			if out4.Node.LastMissedHeartbeatIndex != 0 {
+				return errors.New("wait until node is ready")
 			}
+
+			fmt.Print("\nindex : ", out4.Index, "last missed heartbeat index", out4.Node.LastMissedHeartbeatIndex, "\n")
 			must.Eq(t, structs.NodeSchedulingEligible, out4.Node.SchedulingEligibility)
+
 			return nil
 		}),
-		wait.Timeout(time.Second*1),
-		wait.Gap(time.Millisecond*30),
+		wait.Gap(time.Second*1),
+		wait.Attempts(10),
 	))
 
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2304,6 +2304,7 @@ func TestClient_DefaultIneligible(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC)
 
 	c1, cleanupC1 := TestClient(t, func(c *config.Config) {
+		c.DevMode = false
 		c.DefaultIneligible = true
 		c.RPCHandler = s1
 	})
@@ -2328,6 +2329,74 @@ func TestClient_DefaultIneligible(t *testing.T) {
 		}
 		must.Eq(t, structs.NodeSchedulingIneligible, out.Node.SchedulingEligibility)
 		return out.Node.ID == req.NodeID, nil
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+
+	req2 := structs.NodeUpdateEligibilityRequest{
+		NodeID:       c1.Node().ID,
+		Eligibility:  structs.NodeSchedulingEligible,
+		WriteRequest: structs.WriteRequest{Region: "global"},
+	}
+	var out2 structs.NodeEligibilityUpdateResponse
+
+	// Set node as eligible and restart, should return as eligible
+
+	// Update eligibility should succeed
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.RPC("Node.UpdateEligibility", &req2, &out2)
+		if err != nil {
+			return false, err
+		}
+		return out2.NodeModifyIndex != 0, nil
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+
+	// Query node to confirm eligibility was toggled on
+	var out3 structs.SingleNodeResponse
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.RPC("Node.GetNode", &req, &out3)
+		if err != nil {
+			return false, err
+		}
+		if out.Node == nil {
+			return false, fmt.Errorf("missing reg")
+		}
+		must.Eq(t, structs.NodeSchedulingEligible, out3.Node.SchedulingEligibility)
+		return out3.Node.ID == req.NodeID, nil
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+
+	// Restart Client
+	c1Config := c1.config.Copy()
+	must.NoError(t, c1.Shutdown())
+
+	// actually make and start the client
+	c2, err := NewClient(c1Config, c1.consulCatalog, nil, c1.consulServices, nil)
+	must.NoError(t, err)
+	t.Cleanup(func() {
+		test.NoError(t, c2.Shutdown())
+	})
+
+	req4 := structs.NodeSpecificRequest{
+		NodeID:       c2.Node().ID,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var out4 structs.SingleNodeResponse
+
+	// Should still be eligible
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.RPC("Node.GetNode", &req4, &out4)
+		if err != nil {
+			return false, err
+		}
+		if out.Node == nil {
+			return false, fmt.Errorf("missing reg")
+		}
+		must.Eq(t, structs.NodeSchedulingEligible, out4.Node.SchedulingEligibility)
+		return out4.Node.ID == req.NodeID, nil
 	}, func(err error) {
 		must.NoError(t, err)
 	})

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2296,6 +2296,43 @@ func TestClient_ReconnectAllocs(t *testing.T) {
 	require.Equal(t, unknownAlloc.AllocModifyIndex, finalAlloc.AllocModifyIndex)
 }
 
+func TestClient_DefaultIneligible(t *testing.T) {
+	ci.Parallel(t)
+
+	s1, _, cleanupS1 := testServer(t, nil)
+	defer cleanupS1()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	c1, cleanupC1 := TestClient(t, func(c *config.Config) {
+		c.DefaultIneligible = true
+		c.RPCHandler = s1
+	})
+	defer cleanupC1()
+
+	must.Eq(t, structs.NodeSchedulingIneligible, c1.Node().SchedulingEligibility)
+
+	req := structs.NodeSpecificRequest{
+		NodeID:       c1.Node().ID,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var out structs.SingleNodeResponse
+
+	// Register should succeed
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.RPC("Node.GetNode", &req, &out)
+		if err != nil {
+			return false, err
+		}
+		if out.Node == nil {
+			return false, fmt.Errorf("missing reg")
+		}
+		must.Eq(t, structs.NodeSchedulingIneligible, out.Node.SchedulingEligibility)
+		return out.Node.ID == req.NodeID, nil
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+}
+
 // TestClient_AllocPrerunErrorDuringRestore ensures that a running allocation,
 // which fails Prerun during Restore on client restart, should be killed.
 func TestClient_AllocPrerunErrorDuringRestore(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,7 +4,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"io/fs"
 	"net"
@@ -2371,26 +2370,14 @@ func TestClient_DefaultIneligible(t *testing.T) {
 	req4 := structs.NodeSpecificRequest{
 		NodeID: c2.Node().ID,
 		QueryOptions: structs.QueryOptions{
-			Region: "global",
+			Region:        "global",
+			MinQueryIndex: out3.Index + 1,
 		},
 	}
 	var out4 structs.SingleNodeResponse
-	must.Wait(t, wait.InitialSuccess(
-		wait.ErrorFunc(func() error {
-			err := s1.RPC("Node.GetNode", &req4, &out4)
-			must.NoError(t, err)
-			if out4.Node.LastMissedHeartbeatIndex != 0 {
-				return errors.New("wait until node is ready")
-			}
-
-			fmt.Print("\nindex : ", out4.Index, "last missed heartbeat index", out4.Node.LastMissedHeartbeatIndex, "\n")
-			must.Eq(t, structs.NodeSchedulingEligible, out4.Node.SchedulingEligibility)
-
-			return nil
-		}),
-		wait.Gap(time.Second*1),
-		wait.Attempts(10),
-	))
+	err = s1.RPC("Node.GetNode", &req4, &out4)
+	must.NoError(t, err)
+	must.Eq(t, structs.NodeSchedulingEligible, out4.Node.SchedulingEligibility)
 
 }
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2343,63 +2343,67 @@ func TestClient_DefaultIneligible(t *testing.T) {
 	// Set node as eligible and restart, should return as eligible
 
 	// Update eligibility should succeed
-	testutil.WaitForResult(func() (bool, error) {
-		err := s1.RPC("Node.UpdateEligibility", &req2, &out2)
-		if err != nil {
-			return false, err
-		}
-		return out2.NodeModifyIndex != 0, nil
-	}, func(err error) {
-		must.NoError(t, err)
-	})
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(func() error {
+			err := s1.RPC("Node.UpdateEligibility", &req2, &out2)
+			if err != nil {
+				return err
+			}
+			must.NotEq(t, out2.NodeModifyIndex, out.Index)
+			return nil
+		}),
+	))
 
 	// Query node to confirm eligibility was toggled on
+	req3 := structs.NodeSpecificRequest{
+		NodeID:       c1.Node().ID,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
 	var out3 structs.SingleNodeResponse
-	testutil.WaitForResult(func() (bool, error) {
-		err := s1.RPC("Node.GetNode", &req, &out3)
-		if err != nil {
-			return false, err
-		}
-		if out.Node == nil {
-			return false, fmt.Errorf("missing reg")
-		}
-		must.Eq(t, structs.NodeSchedulingEligible, out3.Node.SchedulingEligibility)
-		return out3.Node.ID == req.NodeID, nil
-	}, func(err error) {
-		must.NoError(t, err)
-	})
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(func() error {
+			err := s1.RPC("Node.GetNode", &req3, &out3)
+			if err != nil {
+				return err
+			}
+			must.Eq(t, structs.NodeSchedulingEligible, out3.Node.SchedulingEligibility)
+			return nil
+		}),
+		wait.Timeout(time.Second*1),
+		wait.Gap(time.Millisecond*30),
+	))
 
-	// Restart Client
+	// Save client config, shutdown and start new client
 	c1Config := c1.config.Copy()
 	must.NoError(t, c1.Shutdown())
-
-	// actually make and start the client
 	c2, err := NewClient(c1Config, c1.consulCatalog, nil, c1.consulServices, nil)
 	must.NoError(t, err)
 	t.Cleanup(func() {
 		test.NoError(t, c2.Shutdown())
 	})
 
+	// Assert new client and old client are same node
+	must.Eq(t, c1.NodeID(), c2.NodeID())
+
+	// Query to confirm restarted node is still eligible
 	req4 := structs.NodeSpecificRequest{
 		NodeID:       c2.Node().ID,
 		QueryOptions: structs.QueryOptions{Region: "global"},
 	}
 	var out4 structs.SingleNodeResponse
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(func() error {
+			err := s1.RPC("Node.GetNode", &req4, &out4)
+			if err != nil {
+				return err
+			}
+			must.Eq(t, structs.NodeSchedulingEligible, out4.Node.SchedulingEligibility)
+			return nil
+		}),
+		wait.Timeout(time.Second*1),
+		wait.Gap(time.Millisecond*30),
+	))
 
-	// Should still be eligible
-	testutil.WaitForResult(func() (bool, error) {
-		err := s1.RPC("Node.GetNode", &req4, &out4)
-		if err != nil {
-			return false, err
-		}
-		if out.Node == nil {
-			return false, fmt.Errorf("missing reg")
-		}
-		must.Eq(t, structs.NodeSchedulingEligible, out4.Node.SchedulingEligibility)
-		return out4.Node.ID == req.NodeID, nil
-	}, func(err error) {
-		must.NoError(t, err)
-	})
 }
 
 // TestClient_AllocPrerunErrorDuringRestore ensures that a running allocation,

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -374,6 +374,9 @@ type Config struct {
 	// used for template functions which require access to the Nomad API.
 	TemplateDialer *bufconndialer.BufConnWrapper
 
+	// DefaultIneligible disables scheduling eligibility for newly-created nodes.
+	DefaultIneligible bool
+
 	// APIListenerRegistrar allows the client to register listeners created at
 	// runtime (eg the Task API) with the agent's HTTP server. Since the agent
 	// creates the HTTP *after* the client starts, we have to use this shim to

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1161,6 +1161,8 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	}
 
 	conf.LogFile = agentConfig.LogFile
+	conf.DefaultIneligible = agentConfig.Client.DefaultIneligible
+
 	return conf, nil
 }
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -447,6 +447,9 @@ type ClientConfig struct {
 	// internal use.
 	Fingerprinters []*client.Fingerprint `hcl:"fingerprint"`
 
+	// DefaultIneligible disables scheduling eligibility for newly-created nodes.
+	DefaultIneligible bool `hcl:"default_ineligible"`
+
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
@@ -3014,6 +3017,10 @@ func (c *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	// supplied an override value.
 	if b.NomadServiceDiscovery != nil {
 		result.NomadServiceDiscovery = b.NomadServiceDiscovery
+	}
+
+	if b.DefaultIneligible {
+		result.DefaultIneligible = true
 	}
 
 	if b.CgroupParent != "" {


### PR DESCRIPTION
This PR picks up where @wjordan left off in #13082 as suggested in [NMD-1461](https://hashicorp.atlassian.net/browse/NMD-1461).

The original PR creates a `DefaultIneligible` config option on the client that allows a user to set nodes as ineligible at initialization. 

[Restart behavior](https://github.com/hashicorp/nomad/pull/13082#issuecomment-1133399451) came up in the original review and @wjordan correctly identified that `upsertNodeTxn` in [state_store.go](https://github.com/hashicorp/nomad/blob/main/nomad/state/state_store.go#L1013)  overwrites eligibility with the last known state of recognized nodes. 

I added some steps to their TestClient_DefaultIneligble test to capture that behavior. The test now marks the node as `Eligible` queries to confirm desired state, restarts the node, and queries once again to confirm desired state.

### Links
Refs:
[NMD-1461](https://hashicorp.atlassian.net/browse/NMD-1461)
Closes: GH #10329
Rebase & inclusion of @wjordan's [PR](https://github.com/hashicorp/nomad/pull/13082)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


[NMD-1461]: https://hashicorp.atlassian.net/browse/NMD-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NMD-1461]: https://hashicorp.atlassian.net/browse/NMD-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ