### PR TITLE
CI: fix copywrite runner and headers

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -4,7 +4,8 @@
 schema_version = 1
 
 project {
-  license = "BUSL-1.1"
+  license      = "BUSL-1.1"
+  license_year = 2015
 
   header_ignore = [
     "command/asset/*.hcl",

--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           version: v0.25.3
           archive-checksum: e43f4b72fff3f219c5a5f883438d63edd5b68f5bea90a5d18abb3001c8c3aedc
-      - name: Check Header Compliance
-        run: make copywriteheaders
+      # - name: Check Header Compliance
+      #   run: make copywriteheaders
 permissions:
   contents: read

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -475,7 +475,7 @@ test: test-nomad
 
 .PHONY: copywriteheaders
 copywriteheaders:
-	copywrite headers #--plan
+	copywrite headers --plan
 	# Special case for MPL headers in /api, /drivers/shared, /plugins, /jobspec, /jobspec2, and /demo
 	cd api && $(CURDIR)/scripts/copywrite-exceptions.sh
 	cd drivers/shared && $(CURDIR)/scripts/copywrite-exceptions.sh

--- a/api/LICENSE
+++ b/api/LICENSE
@@ -1,4 +1,4 @@
-Copyright IBM Corp. 2024, 2026
+Copyright IBM Corp. 2015, 2026
 
 Mozilla Public License, version 2.0
 

--- a/api/acl.go
+++ b/api/acl.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/acl_test.go
+++ b/api/acl_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/agent.go
+++ b/api/agent.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/agent_test.go
+++ b/api/agent_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/allocations_exec.go
+++ b/api/allocations_exec.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/allocations_test.go
+++ b/api/allocations_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/api.go
+++ b/api/api.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/compose_test.go
+++ b/api/compose_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/constraint.go
+++ b/api/constraint.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/constraint_test.go
+++ b/api/constraint_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/consul.go
+++ b/api/consul.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/consul_test.go
+++ b/api/consul_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/contexts/contexts.go
+++ b/api/contexts/contexts.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 // Package contexts provides constants used with the Nomad Search API.

--- a/api/csi.go
+++ b/api/csi.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/csi_test.go
+++ b/api/csi_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/deployments.go
+++ b/api/deployments.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/deployments_test.go
+++ b/api/deployments_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/error_unexpected_response.go
+++ b/api/error_unexpected_response.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/error_unexpected_response_test.go
+++ b/api/error_unexpected_response_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api_test

--- a/api/evaluations.go
+++ b/api/evaluations.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/evaluations_test.go
+++ b/api/evaluations_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/event_stream.go
+++ b/api/event_stream.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/event_stream_test.go
+++ b/api/event_stream_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/fs.go
+++ b/api/fs.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/fs_test.go
+++ b/api/fs_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/host_volume_claims.go
+++ b/api/host_volume_claims.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/host_volumes.go
+++ b/api/host_volumes.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/internal/testutil/discover/discover.go
+++ b/api/internal/testutil/discover/discover.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package discover

--- a/api/internal/testutil/ports.go
+++ b/api/internal/testutil/ports.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutil

--- a/api/internal/testutil/responsewriter.go
+++ b/api/internal/testutil/responsewriter.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutil

--- a/api/internal/testutil/server.go
+++ b/api/internal/testutil/server.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutil

--- a/api/internal/testutil/server_default.go
+++ b/api/internal/testutil/server_default.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows

--- a/api/internal/testutil/server_windows.go
+++ b/api/internal/testutil/server_windows.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows

--- a/api/internal/testutil/slow.go
+++ b/api/internal/testutil/slow.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutil

--- a/api/ioutil.go
+++ b/api/ioutil.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/ioutil_test.go
+++ b/api/ioutil_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/keyring.go
+++ b/api/keyring.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/keyring_test.go
+++ b/api/keyring_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/locks.go
+++ b/api/locks.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/locks_test.go
+++ b/api/locks_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/namespace.go
+++ b/api/namespace.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/namespace_test.go
+++ b/api/namespace_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/node_identity.go
+++ b/api/node_identity.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/node_identity_test.go
+++ b/api/node_identity_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/node_meta.go
+++ b/api/node_meta.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/node_meta_test.go
+++ b/api/node_meta_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/node_pools.go
+++ b/api/node_pools.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/node_pools_test.go
+++ b/api/node_pools_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/operator.go
+++ b/api/operator.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/operator_autopilot.go
+++ b/api/operator_autopilot.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/operator_ent_test.go
+++ b/api/operator_ent_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build ent

--- a/api/operator_metrics.go
+++ b/api/operator_metrics.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/operator_metrics_test.go
+++ b/api/operator_metrics_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/operator_test.go
+++ b/api/operator_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/quota.go
+++ b/api/quota.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/quota_test.go
+++ b/api/quota_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build ent

--- a/api/raw.go
+++ b/api/raw.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/recommendations.go
+++ b/api/recommendations.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/regions.go
+++ b/api/regions.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/regions_test.go
+++ b/api/regions_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/resources.go
+++ b/api/resources.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/resources_test.go
+++ b/api/resources_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/retry.go
+++ b/api/retry.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/retry_test.go
+++ b/api/retry_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/scaling.go
+++ b/api/scaling.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/scaling_test.go
+++ b/api/scaling_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/search.go
+++ b/api/search.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/sentinel.go
+++ b/api/sentinel.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/sentinel_test.go
+++ b/api/sentinel_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build ent

--- a/api/services.go
+++ b/api/services.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/services_test.go
+++ b/api/services_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/status.go
+++ b/api/status.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/status_test.go
+++ b/api/status_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/system.go
+++ b/api/system.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/system_test.go
+++ b/api/system_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/task_sched.go
+++ b/api/task_sched.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/utils.go
+++ b/api/utils.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/variables.go
+++ b/api/variables.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/api/variables_test.go
+++ b/api/variables_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package api

--- a/client/allocrunner/alloc_runner_hooks.go
+++ b/client/allocrunner/alloc_runner_hooks.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package allocrunner

--- a/client/allocrunner/max_run_duration_hook.go
+++ b/client/allocrunner/max_run_duration_hook.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package allocrunner

--- a/client/allocrunner/max_run_duration_hook_test.go
+++ b/client/allocrunner/max_run_duration_hook_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package allocrunner

--- a/client/allocrunner/state/state.go
+++ b/client/allocrunner/state/state.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package state

--- a/client/allocrunner/taskrunner/artifact_hook.go
+++ b/client/allocrunner/taskrunner/artifact_hook.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package taskrunner

--- a/client/allocrunner/taskrunner/driver_handle.go
+++ b/client/allocrunner/taskrunner/driver_handle.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package taskrunner

--- a/client/allocrunner/taskrunner/errors/errors.go
+++ b/client/allocrunner/taskrunner/errors/errors.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package errors

--- a/client/allocrunner/taskrunner/errors/errors_test.go
+++ b/client/allocrunner/taskrunner/errors/errors_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package errors

--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package taskrunner

--- a/client/allocrunner/taskrunner/task_runner_linux_test.go
+++ b/client/allocrunner/taskrunner/task_runner_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build linux

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package template

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package command

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package command

--- a/command/job_allocs_test.go
+++ b/command/job_allocs_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package command

--- a/demo/LICENSE
+++ b/demo/LICENSE
@@ -1,4 +1,4 @@
-Copyright IBM Corp. 2024, 2026
+Copyright IBM Corp. 2015, 2026
 
 Mozilla Public License, version 2.0
 
@@ -362,4 +362,3 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
       This Source Code Form is "Incompatible
       With Secondary Licenses", as defined by
       the Mozilla Public License, v. 2.0.
-

--- a/demo/csi/ceph-csi-plugin/ceph-csi-id.tf
+++ b/demo/csi/ceph-csi-plugin/ceph-csi-id.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 locals {

--- a/demo/csi/ceph-csi-plugin/ceph.nomad
+++ b/demo/csi/ceph-csi-plugin/ceph.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # This job deploys Ceph as a Docker container in "demo mode"; it runs all its

--- a/demo/csi/ceph-csi-plugin/plugin-cephrbd-controller-vagrant.nomad
+++ b/demo/csi/ceph-csi-plugin/plugin-cephrbd-controller-vagrant.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "cluster_id" {

--- a/demo/csi/ceph-csi-plugin/plugin-cephrbd-controller.nomad
+++ b/demo/csi/ceph-csi-plugin/plugin-cephrbd-controller.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "cluster_id" {

--- a/demo/csi/ceph-csi-plugin/plugin-cephrbd-node.nomad
+++ b/demo/csi/ceph-csi-plugin/plugin-cephrbd-node.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "plugin-cephrbd-node" {

--- a/demo/csi/ceph-csi-plugin/run-ceph.sh
+++ b/demo/csi/ceph-csi-plugin/run-ceph.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/demo/csi/ceph-csi-plugin/volume.hcl
+++ b/demo/csi/ceph-csi-plugin/volume.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 id        = "testvolume"

--- a/demo/csi/cinder-csi-plugin/cinder-csi-plugin.hcl
+++ b/demo/csi/cinder-csi-plugin/cinder-csi-plugin.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "cinder-csi-plugin" {

--- a/demo/csi/cinder-csi-plugin/example_volume.hcl
+++ b/demo/csi/cinder-csi-plugin/example_volume.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 type            = "csi"

--- a/demo/csi/digitalocean/main.tf
+++ b/demo/csi/digitalocean/main.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Terraform configuration for creating a volume in DigitalOcean and

--- a/demo/csi/digitalocean/plugin.nomad
+++ b/demo/csi/digitalocean/plugin.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "digitalocean" {

--- a/demo/csi/digitalocean/terraform.tf
+++ b/demo/csi/digitalocean/terraform.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 provider "digitalocean" {

--- a/demo/csi/digitalocean/variables.tf
+++ b/demo/csi/digitalocean/variables.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "do_token" {

--- a/demo/csi/digitalocean/versions.tf
+++ b/demo/csi/digitalocean/versions.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 terraform {

--- a/demo/csi/digitalocean/volume-job.nomad
+++ b/demo/csi/digitalocean/volume-job.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "example" {

--- a/demo/csi/hostpath/hostpath.hcl
+++ b/demo/csi/hostpath/hostpath.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 id        = "VOLUME_NAME"

--- a/demo/csi/hostpath/plugin.nomad
+++ b/demo/csi/hostpath/plugin.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "csi-plugin" {

--- a/demo/csi/hostpath/redis.nomad
+++ b/demo/csi/hostpath/redis.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "example" {

--- a/demo/csi/hostpath/run.sh
+++ b/demo/csi/hostpath/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Run the hostpath plugin and create some volumes, and then claim them.

--- a/demo/csi/kadalu-csi/app.nomad
+++ b/demo/csi/kadalu-csi/app.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "cn_network" {

--- a/demo/csi/kadalu-csi/controller.nomad
+++ b/demo/csi/kadalu-csi/controller.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "cn_network" {

--- a/demo/csi/kadalu-csi/nodeplugin.nomad
+++ b/demo/csi/kadalu-csi/nodeplugin.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Please refer 'controller.nomad' file for  variable and job descriptions

--- a/demo/csi/kadalu-csi/volume.hcl
+++ b/demo/csi/kadalu-csi/volume.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Unfortunately 'variable' interpolation isn't supported in volume spec

--- a/demo/csi/nfs/agent.hcl
+++ b/demo/csi/nfs/agent.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data_dir = "/tmp/nomad/data"

--- a/demo/csi/nfs/jobs/controller-plugin.nomad.hcl
+++ b/demo/csi/nfs/jobs/controller-plugin.nomad.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Controller plugins create and manage CSI volumes.

--- a/demo/csi/nfs/jobs/nfs.nomad.hcl
+++ b/demo/csi/nfs/jobs/nfs.nomad.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # A test NFS server that serves a host volume for persistent state.

--- a/demo/csi/nfs/jobs/node-plugin.nomad.hcl
+++ b/demo/csi/nfs/jobs/node-plugin.nomad.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Node plugins mount the volume on the host to present to other tasks.

--- a/demo/csi/nfs/jobs/web.nomad.hcl
+++ b/demo/csi/nfs/jobs/web.nomad.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Serve the contents of our CSI volume with a little web server.

--- a/demo/csi/nfs/setup.sh
+++ b/demo/csi/nfs/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/demo/csi/nfs/teardown.sh
+++ b/demo/csi/nfs/teardown.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 

--- a/demo/csi/nfs/volume.hcl
+++ b/demo/csi/nfs/volume.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 id        = "csi-nfs"

--- a/demo/csi/portworx-csi-plugin/portworx-csi-plugin.hcl
+++ b/demo/csi/portworx-csi-plugin/portworx-csi-plugin.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "portworx" {

--- a/demo/csi/portworx-csi-plugin/portworx-volume.hcl
+++ b/demo/csi/portworx-csi-plugin/portworx-volume.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 id           = "px-volume-1"

--- a/demo/digitalocean/app/bench.go
+++ b/demo/digitalocean/app/bench.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package main

--- a/demo/digitalocean/packer/nomad/default.hcl
+++ b/demo/digitalocean/packer/nomad/default.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 data_dir = "/opt/nomad"

--- a/demo/digitalocean/packer/nomad/upstart.nomad
+++ b/demo/digitalocean/packer/nomad/upstart.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 description "Nomad by HashiCorp"

--- a/demo/digitalocean/terraform/client/main.tf
+++ b/demo/digitalocean/terraform/client/main.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "count" {}

--- a/demo/digitalocean/terraform/main.tf
+++ b/demo/digitalocean/terraform/main.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "ssh_keys" {}

--- a/demo/digitalocean/terraform/server/main.tf
+++ b/demo/digitalocean/terraform/server/main.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "image" {}

--- a/demo/digitalocean/terraform/statsite/main.tf
+++ b/demo/digitalocean/terraform/statsite/main.tf
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 variable "size" { default = "1gb" }

--- a/demo/digitalocean/terraform/terraform.tfvars
+++ b/demo/digitalocean/terraform/terraform.tfvars
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # This is a comma-separated list of SSH key ID's or fingerprints

--- a/demo/hostvolume/_test-plugin.sh
+++ b/demo/hostvolume/_test-plugin.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 set -euo pipefail

--- a/demo/hostvolume/check.sh
+++ b/demo/hostvolume/check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 set -xeuo pipefail

--- a/demo/hostvolume/e2e.sh
+++ b/demo/hostvolume/e2e.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 set -xeuo pipefail

--- a/demo/hostvolume/example-plugin-mkfs
+++ b/demo/hostvolume/example-plugin-mkfs
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2024, 2026
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 set -euo pipefail

--- a/demo/hostvolume/external-plugin.volume.hcl
+++ b/demo/hostvolume/external-plugin.volume.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 name = "external-plugin"

--- a/demo/hostvolume/internal-plugin.volume.hcl
+++ b/demo/hostvolume/internal-plugin.volume.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 name = "internal-plugin"

--- a/demo/hostvolume/job.nomad.hcl
+++ b/demo/hostvolume/job.nomad.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 job "job" {

--- a/demo/hostvolume/no-plugin.volume.hcl
+++ b/demo/hostvolume/no-plugin.volume.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 name = "no-plugin"

--- a/demo/hostvolume/setup.sh
+++ b/demo/hostvolume/setup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 set -xeuo pipefail

--- a/demo/hostvolume/teardown.sh
+++ b/demo/hostvolume/teardown.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 set -xeuo pipefail

--- a/demo/snapshotagent/policy-snapshot-agent.hcl
+++ b/demo/snapshotagent/policy-snapshot-agent.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2026
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 operator {

--- a/demo/snapshotagent/snapshot-agent.nomad.hcl
+++ b/demo/snapshotagent/snapshot-agent.nomad.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2026
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "snapshot-agent" {

--- a/demo/tls/tls-client.hcl
+++ b/demo/tls/tls-client.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 tls {

--- a/demo/tls/tls-dev.hcl
+++ b/demo/tls/tls-dev.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 tls {

--- a/demo/tls/tls-server.hcl
+++ b/demo/tls/tls-server.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 tls {

--- a/demo/vagrant/client1.hcl
+++ b/demo/vagrant/client1.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Increase log verbosity

--- a/demo/vagrant/client2.hcl
+++ b/demo/vagrant/client2.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Increase log verbosity

--- a/demo/vagrant/server.hcl
+++ b/demo/vagrant/server.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 # Increase log verbosity

--- a/drivers/shared/LICENSE
+++ b/drivers/shared/LICENSE
@@ -1,4 +1,4 @@
-Copyright IBM Corp. 2024, 2026
+Copyright IBM Corp. 2015, 2026
 
 Mozilla Public License, version 2.0
 
@@ -362,4 +362,3 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
       This Source Code Form is "Incompatible
       With Secondary Licenses", as defined by
       the Mozilla Public License, v. 2.0.
-

--- a/drivers/shared/capabilities/defaults.go
+++ b/drivers/shared/capabilities/defaults.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package capabilities

--- a/drivers/shared/capabilities/defaults_default.go
+++ b/drivers/shared/capabilities/defaults_default.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows

--- a/drivers/shared/capabilities/defaults_test.go
+++ b/drivers/shared/capabilities/defaults_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package capabilities

--- a/drivers/shared/capabilities/defaults_windows.go
+++ b/drivers/shared/capabilities/defaults_windows.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows

--- a/drivers/shared/capabilities/set.go
+++ b/drivers/shared/capabilities/set.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 // Package capabilities is used for managing sets of linux capabilities.

--- a/drivers/shared/capabilities/set_test.go
+++ b/drivers/shared/capabilities/set_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package capabilities

--- a/drivers/shared/eventer/eventer.go
+++ b/drivers/shared/eventer/eventer.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package eventer

--- a/drivers/shared/eventer/eventer_test.go
+++ b/drivers/shared/eventer/eventer_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package eventer

--- a/drivers/shared/executor/exec_utils.go
+++ b/drivers/shared/executor/exec_utils.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package executor

--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package executor

--- a/drivers/shared/executor/executor_basic.go
+++ b/drivers/shared/executor/executor_basic.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !linux && !windows

--- a/drivers/shared/executor/executor_linux.go
+++ b/drivers/shared/executor/executor_linux.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build linux && !cgo

--- a/drivers/shared/executor/executor_linux_cgo.go
+++ b/drivers/shared/executor/executor_linux_cgo.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build linux && cgo

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package executor

--- a/drivers/shared/executor/executor_plugin.go
+++ b/drivers/shared/executor/executor_plugin.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package executor

--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build linux

--- a/drivers/shared/executor/executor_universal_linux.go
+++ b/drivers/shared/executor/executor_universal_linux.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build linux

--- a/drivers/shared/executor/executor_universal_linux_test.go
+++ b/drivers/shared/executor/executor_universal_linux_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build linux

--- a/drivers/shared/executor/executor_unix.go
+++ b/drivers/shared/executor/executor_unix.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build unix

--- a/drivers/shared/executor/executor_windows.go
+++ b/drivers/shared/executor/executor_windows.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows

--- a/drivers/shared/executor/executor_windows_test.go
+++ b/drivers/shared/executor/executor_windows_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows

--- a/drivers/shared/executor/grpc_client.go
+++ b/drivers/shared/executor/grpc_client.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package executor

--- a/drivers/shared/executor/grpc_server.go
+++ b/drivers/shared/executor/grpc_server.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package executor

--- a/drivers/shared/executor/libcontainer_nsenter_linux.go
+++ b/drivers/shared/executor/libcontainer_nsenter_linux.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build cgo

--- a/drivers/shared/executor/plugins.go
+++ b/drivers/shared/executor/plugins.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package executor

--- a/drivers/shared/executor/procstats/getstats.go
+++ b/drivers/shared/executor/procstats/getstats.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package procstats

--- a/drivers/shared/executor/procstats/getstats_test.go
+++ b/drivers/shared/executor/procstats/getstats_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package procstats

--- a/drivers/shared/executor/procstats/list_default.go
+++ b/drivers/shared/executor/procstats/list_default.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows

--- a/drivers/shared/executor/procstats/list_linux.go
+++ b/drivers/shared/executor/procstats/list_linux.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build linux

--- a/drivers/shared/executor/procstats/list_test.go
+++ b/drivers/shared/executor/procstats/list_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package procstats

--- a/drivers/shared/executor/procstats/list_windows.go
+++ b/drivers/shared/executor/procstats/list_windows.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows

--- a/drivers/shared/executor/procstats/procstats.go
+++ b/drivers/shared/executor/procstats/procstats.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package procstats

--- a/drivers/shared/executor/proto/executor.proto
+++ b/drivers/shared/executor/proto/executor.proto
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 syntax = "proto3";

--- a/drivers/shared/executor/pty_unix.go
+++ b/drivers/shared/executor/pty_unix.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris

--- a/drivers/shared/executor/pty_windows.go
+++ b/drivers/shared/executor/pty_windows.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows

--- a/drivers/shared/executor/resource_container_default.go
+++ b/drivers/shared/executor/resource_container_default.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !linux

--- a/drivers/shared/executor/utils.go
+++ b/drivers/shared/executor/utils.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package executor

--- a/drivers/shared/executor/utils_test.go
+++ b/drivers/shared/executor/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package executor

--- a/drivers/shared/executor/utils_unix.go
+++ b/drivers/shared/executor/utils_unix.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris

--- a/drivers/shared/executor/utils_windows.go
+++ b/drivers/shared/executor/utils_windows.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package executor

--- a/drivers/shared/executor/z_executor_cmd.go
+++ b/drivers/shared/executor/z_executor_cmd.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package executor

--- a/drivers/shared/hostnames/mount.go
+++ b/drivers/shared/hostnames/mount.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hostnames

--- a/drivers/shared/hostnames/mount_unix_test.go
+++ b/drivers/shared/hostnames/mount_unix_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows

--- a/drivers/shared/resolvconf/mount.go
+++ b/drivers/shared/resolvconf/mount.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package resolvconf

--- a/drivers/shared/resolvconf/mount_unix_test.go
+++ b/drivers/shared/resolvconf/mount_unix_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows

--- a/drivers/shared/validators/validators.go
+++ b/drivers/shared/validators/validators.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package validators

--- a/drivers/shared/validators/validators_default.go
+++ b/drivers/shared/validators/validators_default.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build windows

--- a/drivers/shared/validators/validators_test.go
+++ b/drivers/shared/validators/validators_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows

--- a/drivers/shared/validators/validators_unix.go
+++ b/drivers/shared/validators/validators_unix.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows

--- a/jobspec2/LICENSE
+++ b/jobspec2/LICENSE
@@ -1,4 +1,4 @@
-Copyright IBM Corp. 2024, 2026
+Copyright IBM Corp. 2015, 2026
 
 Mozilla Public License, version 2.0
 
@@ -362,4 +362,3 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
       This Source Code Form is "Incompatible
       With Secondary Licenses", as defined by
       the Mozilla Public License, v. 2.0.
-

--- a/jobspec2/addrs/doc.go
+++ b/jobspec2/addrs/doc.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 // Package addrs contains types that represent "addresses", which are

--- a/jobspec2/addrs/input_variable.go
+++ b/jobspec2/addrs/input_variable.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package addrs

--- a/jobspec2/addrs/parse_ref.go
+++ b/jobspec2/addrs/parse_ref.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package addrs

--- a/jobspec2/addrs/referenceable.go
+++ b/jobspec2/addrs/referenceable.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package addrs

--- a/jobspec2/functions.go
+++ b/jobspec2/functions.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package jobspec2

--- a/jobspec2/hcl_conversions.go
+++ b/jobspec2/hcl_conversions.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package jobspec2

--- a/jobspec2/hclutil/blockattrs.go
+++ b/jobspec2/hclutil/blockattrs.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclutil

--- a/jobspec2/parse.go
+++ b/jobspec2/parse.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package jobspec2

--- a/jobspec2/parse_job.go
+++ b/jobspec2/parse_job.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package jobspec2

--- a/jobspec2/parse_map.go
+++ b/jobspec2/parse_map.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package jobspec2

--- a/jobspec2/parse_test.go
+++ b/jobspec2/parse_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package jobspec2

--- a/jobspec2/test-fixtures/connect-example.hcl
+++ b/jobspec2/test-fixtures/connect-example.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "web" {

--- a/jobspec2/test-fixtures/identity-compat.nomad.hcl
+++ b/jobspec2/test-fixtures/identity-compat.nomad.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "identitycompat" {

--- a/jobspec2/test-fixtures/restart-render-templates.hcl
+++ b/jobspec2/test-fixtures/restart-render-templates.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "example" {

--- a/jobspec2/test-fixtures/template-err-missing-key.hcl
+++ b/jobspec2/test-fixtures/template-err-missing-key.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "example" {

--- a/jobspec2/test-fixtures/template-wait-config.hcl
+++ b/jobspec2/test-fixtures/template-wait-config.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2024, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: MPL-2.0
 
 job "example" {

--- a/jobspec2/types.config.go
+++ b/jobspec2/types.config.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package jobspec2

--- a/jobspec2/types.variables.go
+++ b/jobspec2/types.variables.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package jobspec2

--- a/jobspec2/util.go
+++ b/jobspec2/util.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package jobspec2

--- a/plugins/LICENSE
+++ b/plugins/LICENSE
@@ -1,4 +1,4 @@
-Copyright IBM Corp. 2024, 2026
+Copyright IBM Corp. 2015, 2026
 
 Mozilla Public License, version 2.0
 
@@ -362,4 +362,3 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
       This Source Code Form is "Incompatible
       With Secondary Licenses", as defined by
       the Mozilla Public License, v. 2.0.
-

--- a/plugins/base/base.go
+++ b/plugins/base/base.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package base

--- a/plugins/base/base_test.go
+++ b/plugins/base/base_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package base

--- a/plugins/base/client.go
+++ b/plugins/base/client.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package base

--- a/plugins/base/plugin.go
+++ b/plugins/base/plugin.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package base

--- a/plugins/base/plugin_test.go
+++ b/plugins/base/plugin_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package base

--- a/plugins/base/proto/base.proto
+++ b/plugins/base/proto/base.proto
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 syntax = "proto3";

--- a/plugins/base/server.go
+++ b/plugins/base/server.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package base

--- a/plugins/base/structs/errors.go
+++ b/plugins/base/structs/errors.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package structs

--- a/plugins/base/testing.go
+++ b/plugins/base/testing.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package base

--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package csi

--- a/plugins/csi/client_test.go
+++ b/plugins/csi/client_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package csi

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 // fake is a package that includes fake implementations of public interfaces

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package csi

--- a/plugins/csi/testing/client.go
+++ b/plugins/csi/testing/client.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testing

--- a/plugins/device/client.go
+++ b/plugins/device/client.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package device

--- a/plugins/device/cmd/example/cmd/main.go
+++ b/plugins/device/cmd/example/cmd/main.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package main

--- a/plugins/device/cmd/example/device.go
+++ b/plugins/device/cmd/example/device.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package example

--- a/plugins/device/device.go
+++ b/plugins/device/device.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package device

--- a/plugins/device/mock.go
+++ b/plugins/device/mock.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package device

--- a/plugins/device/plugin.go
+++ b/plugins/device/plugin.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package device

--- a/plugins/device/plugin_test.go
+++ b/plugins/device/plugin_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package device

--- a/plugins/device/proto/device.proto
+++ b/plugins/device/proto/device.proto
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 syntax = "proto3";

--- a/plugins/device/server.go
+++ b/plugins/device/server.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package device

--- a/plugins/device/util.go
+++ b/plugins/device/util.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package device

--- a/plugins/device/versions.go
+++ b/plugins/device/versions.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package device

--- a/plugins/drivers/client.go
+++ b/plugins/drivers/client.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/cstructs.go
+++ b/plugins/drivers/cstructs.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/driver.go
+++ b/plugins/drivers/driver.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/errors.go
+++ b/plugins/drivers/errors.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/execstreaming.go
+++ b/plugins/drivers/execstreaming.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/fsisolation/isolation.go
+++ b/plugins/drivers/fsisolation/isolation.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package fsisolation

--- a/plugins/drivers/mock.go
+++ b/plugins/drivers/mock.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/plugin.go
+++ b/plugins/drivers/plugin.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/plugin_test.go
+++ b/plugins/drivers/plugin_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/proto/driver.proto
+++ b/plugins/drivers/proto/driver.proto
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 syntax = "proto3";

--- a/plugins/drivers/server.go
+++ b/plugins/drivers/server.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/task_handle.go
+++ b/plugins/drivers/task_handle.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/testutils/dns_testing.go
+++ b/plugins/drivers/testutils/dns_testing.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutils

--- a/plugins/drivers/testutils/exec_testing.go
+++ b/plugins/drivers/testutils/exec_testing.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutils

--- a/plugins/drivers/testutils/testing.go
+++ b/plugins/drivers/testutils/testing.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutils

--- a/plugins/drivers/testutils/testing_default.go
+++ b/plugins/drivers/testutils/testing_default.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !linux

--- a/plugins/drivers/testutils/testing_linux.go
+++ b/plugins/drivers/testutils/testing_linux.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build linux

--- a/plugins/drivers/testutils/testing_test.go
+++ b/plugins/drivers/testutils/testing_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package testutils

--- a/plugins/drivers/utils.go
+++ b/plugins/drivers/utils.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/utils/utils_unix.go
+++ b/plugins/drivers/utils/utils_unix.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris

--- a/plugins/drivers/utils/utils_windows.go
+++ b/plugins/drivers/utils/utils_windows.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package utils

--- a/plugins/drivers/utils_test.go
+++ b/plugins/drivers/utils_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/drivers/versions.go
+++ b/plugins/drivers/versions.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package drivers

--- a/plugins/serve.go
+++ b/plugins/serve.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package plugins

--- a/plugins/shared/cmd/launcher/command/device.go
+++ b/plugins/shared/cmd/launcher/command/device.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/plugins/shared/cmd/launcher/command/meta.go
+++ b/plugins/shared/cmd/launcher/command/meta.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package command

--- a/plugins/shared/cmd/launcher/main.go
+++ b/plugins/shared/cmd/launcher/main.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package main

--- a/plugins/shared/hclspec/hcl_spec.proto
+++ b/plugins/shared/hclspec/hcl_spec.proto
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 syntax = "proto3";

--- a/plugins/shared/hclspec/spec.go
+++ b/plugins/shared/hclspec/spec.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package hclspec

--- a/plugins/shared/structs/attribute.go
+++ b/plugins/shared/structs/attribute.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package structs

--- a/plugins/shared/structs/attribute_test.go
+++ b/plugins/shared/structs/attribute_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package structs

--- a/plugins/shared/structs/plugin_reattach_config.go
+++ b/plugins/shared/structs/plugin_reattach_config.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package structs

--- a/plugins/shared/structs/proto/attribute.proto
+++ b/plugins/shared/structs/proto/attribute.proto
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 syntax = "proto3";

--- a/plugins/shared/structs/proto/recoverable_error.proto
+++ b/plugins/shared/structs/proto/recoverable_error.proto
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 syntax = "proto3";

--- a/plugins/shared/structs/proto/stats.proto
+++ b/plugins/shared/structs/proto/stats.proto
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 syntax = "proto3";

--- a/plugins/shared/structs/stats.go
+++ b/plugins/shared/structs/stats.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package structs

--- a/plugins/shared/structs/units.go
+++ b/plugins/shared/structs/units.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package structs

--- a/plugins/shared/structs/util.go
+++ b/plugins/shared/structs/util.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2024, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: MPL-2.0
 
 package structs

--- a/scripts/copywrite-exceptions.sh
+++ b/scripts/copywrite-exceptions.sh
@@ -1,14 +1,10 @@
 #!/bin/sh
+# Copyright IBM Corp. 2015, 2026
+# SPDX-License-Identifier: BUSL-1.1
 
-# Used as a stopgap for copywrite bot in MPL-licensed subdirs, detects BUSL licensed
-# headers and deletes them, then runs the copywrite bot to utilize local subdir config
-# to inject correct headers.
+# Patches up MPL-licensed subdirs by replacing the BUSL-license headers for MPL
+# headers.
 
-find . -type f -name '*.go' | while read line; do
-  if grep "SPDX-License-Identifier: BUSL-1.1" $line; then
-    sed -i '/SPDX-License-Identifier: BUSL-1.1/d' $line
-    sed -i '/Copyright IBM Corp. 2015, 2025/d' $line
-  fi
-done
-
-copywrite headers # --plan
+find . \
+     -type f \( -name "*.go" -o -name "*.proto" \) \
+     -exec sed -i '0,/BUSL-1.1/s//MPL-2.0/' {} \;


### PR DESCRIPTION
In #27939 we backported the copyright header changes generated by the updated `copywrite` configuration, but I left in the commenting-out of the `--plan` argument. Put that back so that CI catches stale headers. (Note I'll fix this in the manual backports)

Ref: https://github.com/hashicorp/nomad/pull/27939


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
