### PR TITLE
add default_ineligible configuration option

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1750,6 +1750,12 @@ func (c *Client) setupNode() error {
 		return fmt.Errorf("error syncing dynamic node metadata: %w", err)
 	}
 
+	if c.config.DefaultIneligible {
+		node.SchedulingEligibility = structs.NodeSchedulingIneligible
+	} else {
+		node.SchedulingEligibility = structs.NodeSchedulingEligible
+	}
+
 	c.config = newConfig
 	return nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2296,6 +2296,43 @@ func TestClient_ReconnectAllocs(t *testing.T) {
 	require.Equal(t, unknownAlloc.AllocModifyIndex, finalAlloc.AllocModifyIndex)
 }
 
+func TestClient_DefaultIneligible(t *testing.T) {
+	ci.Parallel(t)
+
+	s1, _, cleanupS1 := testServer(t, nil)
+	defer cleanupS1()
+	testutil.WaitForLeader(t, s1.RPC)
+
+	c1, cleanupC1 := TestClient(t, func(c *config.Config) {
+		c.DefaultIneligible = true
+		c.RPCHandler = s1
+	})
+	defer cleanupC1()
+
+	must.Eq(t, structs.NodeSchedulingIneligible, c1.Node().SchedulingEligibility)
+
+	req := structs.NodeSpecificRequest{
+		NodeID:       c1.Node().ID,
+		QueryOptions: structs.QueryOptions{Region: "global"},
+	}
+	var out structs.SingleNodeResponse
+
+	// Register should succeed
+	testutil.WaitForResult(func() (bool, error) {
+		err := s1.RPC("Node.GetNode", &req, &out)
+		if err != nil {
+			return false, err
+		}
+		if out.Node == nil {
+			return false, fmt.Errorf("missing reg")
+		}
+		must.Eq(t, structs.NodeSchedulingIneligible, out.Node.SchedulingEligibility)
+		return out.Node.ID == req.NodeID, nil
+	}, func(err error) {
+		must.NoError(t, err)
+	})
+}
+
 // TestClient_AllocPrerunErrorDuringRestore ensures that a running allocation,
 // which fails Prerun during Restore on client restart, should be killed.
 func TestClient_AllocPrerunErrorDuringRestore(t *testing.T) {

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -374,6 +374,9 @@ type Config struct {
 	// used for template functions which require access to the Nomad API.
 	TemplateDialer *bufconndialer.BufConnWrapper
 
+	// DefaultIneligible disables scheduling eligibility for newly-created nodes.
+	DefaultIneligible bool
+
 	// APIListenerRegistrar allows the client to register listeners created at
 	// runtime (eg the Task API) with the agent's HTTP server. Since the agent
 	// creates the HTTP *after* the client starts, we have to use this shim to

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -1161,6 +1161,8 @@ func convertClientConfig(agentConfig *Config) (*clientconfig.Config, error) {
 	}
 
 	conf.LogFile = agentConfig.LogFile
+	conf.DefaultIneligible = agentConfig.Client.DefaultIneligible
+
 	return conf, nil
 }
 

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -447,6 +447,9 @@ type ClientConfig struct {
 	// internal use.
 	Fingerprinters []*client.Fingerprint `hcl:"fingerprint"`
 
+	// DefaultIneligible disables scheduling eligibility for newly-created nodes.
+	DefaultIneligible bool `hcl:"default_ineligible"`
+
 	// ExtraKeysHCL is used by hcl to surface unexpected keys
 	ExtraKeysHCL []string `hcl:",unusedKeys" json:"-"`
 }
@@ -3014,6 +3017,10 @@ func (c *ClientConfig) Merge(b *ClientConfig) *ClientConfig {
 	// supplied an override value.
 	if b.NomadServiceDiscovery != nil {
 		result.NomadServiceDiscovery = b.NomadServiceDiscovery
+	}
+
+	if b.DefaultIneligible {
+		result.DefaultIneligible = true
 	}
 
 	if b.CgroupParent != "" {


### PR DESCRIPTION
Specifies if scheduling eligibility should be
disabled by default for new client nodes.

### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
