### PR TITLE
Allow stopping failed allocations

### DIFF
--- a/.changelog/27971.txt
+++ b/.changelog/27971.txt
@@ -1,3 +1,3 @@
 ```release-note:improvement
-core: Allow stopping failed allocations
+scheduler: Stop failed allocations first when downscaling a task group
 ```

--- a/.changelog/27971.txt
+++ b/.changelog/27971.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+core: Allow stopping failed allocations
+```

--- a/scheduler/reconciler/filters.go
+++ b/scheduler/reconciler/filters.go
@@ -61,6 +61,17 @@ func (set allocSet) filterByTerminal() (nonTerminal allocSet) {
 	return
 }
 
+// filterByServerTerminal returns a new allocSet without any server-terminal allocations.
+func (set allocSet) filterByServerTerminal() (nonTerminal allocSet) {
+	nonTerminal = make(allocSet)
+	for id, alloc := range set {
+		if !alloc.ServerTerminalStatus() {
+			nonTerminal[id] = alloc
+		}
+	}
+	return
+}
+
 // filterByDeployment returns two new allocSets: those allocations that match the
 // given deployment ID and those that don't.
 func (set allocSet) filterByDeployment(id string) (match, nonmatch allocSet) {

--- a/scheduler/reconciler/reconcile_cluster.go
+++ b/scheduler/reconciler/reconcile_cluster.go
@@ -1140,9 +1140,9 @@ func (a *AllocReconciler) computeStop(group *structs.TaskGroup, nameIndex *Alloc
 		return
 	}
 
-	// Filter out any terminal allocations from the untainted set
+	// Filter out any server-terminal allocations from the untainted set
 	// This is so that we don't try to mark them as stopped redundantly
-	working = working.filterByTerminal()
+	working = working.filterByServerTerminal()
 
 	// Prefer stopping any alloc that has the same name as the canaries if we
 	// are promoted

--- a/scheduler/reconciler/reconcile_cluster_test.go
+++ b/scheduler/reconciler/reconcile_cluster_test.go
@@ -7379,3 +7379,186 @@ func TestReconciler_ComputeDeploymentPaused(t *testing.T) {
 		})
 	}
 }
+
+// Tests the reconciler properly counts batch client-terminal (but not
+// server-terminal) allocs against the total count when scaling down
+func TestReconciler_ScaleDown_ClientTerminal_Batch(t *testing.T) {
+	ci.Parallel(t)
+
+	job := mock.BatchJob()
+	job.TaskGroups[0].Count = 5
+
+	var allocs []*structs.Allocation
+	for i := range 7 {
+		alloc := mock.Alloc()
+		alloc.Job = job
+		alloc.JobID = job.ID
+		alloc.NodeID = uuid.Generate()
+		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		allocs = append(allocs, alloc)
+	}
+
+	allocs[5].DesiredStatus = structs.AllocDesiredStatusRun
+	allocs[5].ClientStatus = structs.AllocClientStatusComplete
+	allocs[5].TaskStates = map[string]*structs.TaskState{"web": {
+		State: "dead",
+	}}
+	allocs[6].DesiredStatus = structs.AllocDesiredStatusStop
+	allocs[6].ClientStatus = structs.AllocClientStatusComplete
+	allocs[6].TaskStates = map[string]*structs.TaskState{"web": {
+		State: "dead",
+	}}
+
+	reconciler := NewAllocReconciler(
+		testlog.HCLogger(t), allocUpdateFnIgnore, ReconcilerState{
+			JobIsBatch:        true,
+			JobID:             job.ID,
+			Job:               job,
+			DeploymentCurrent: nil,
+			ExistingAllocs:    allocs,
+			EvalPriority:      50,
+		}, ClusterState{
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
+		})
+	r := reconciler.Compute()
+
+	// Assert the correct results
+	assertResults(t, r, &resultExpectation{
+		createDeployment:  nil,
+		deploymentUpdates: nil,
+		place:             0,
+		stop:              1,
+		desiredTGUpdates: map[string]*structs.DesiredUpdates{
+			job.TaskGroups[0].Name: {
+				Ignore: 6,
+				Stop:   1,
+			},
+		},
+	})
+
+	assertNamesHaveIndexes(t, []int{5}, stopResultsToNames(r.Stop))
+}
+
+// Tests the reconciler properly counts service client-terminal (but not
+// server-terminal) allocs against the total count when scaling down
+func TestReconciler_ScaleDown_ClientTerminal_Service(t *testing.T) {
+	ci.Parallel(t)
+
+	job := mock.Job()
+	job.TaskGroups[0].Count = 5
+
+	var allocs []*structs.Allocation
+	for i := range 6 {
+		alloc := mock.Alloc()
+		alloc.Job = job
+		alloc.JobID = job.ID
+		alloc.NodeID = uuid.Generate()
+		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		allocs = append(allocs, alloc)
+	}
+
+	allocs[3].DesiredStatus = structs.AllocDesiredStatusRun
+	allocs[3].ClientStatus = structs.AllocClientStatusFailed
+	allocs[3].TaskStates = map[string]*structs.TaskState{"web": {
+		State:  "dead",
+		Failed: true,
+	}}
+
+	reconciler := NewAllocReconciler(
+		testlog.HCLogger(t), allocUpdateFnIgnore, ReconcilerState{
+			JobIsBatch:        false,
+			JobID:             job.ID,
+			Job:               job,
+			DeploymentCurrent: nil,
+			ExistingAllocs:    allocs,
+			EvalPriority:      50,
+		}, ClusterState{
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
+		})
+	r := reconciler.Compute()
+
+	assertNamesHaveIndexes(t, []int{3}, stopResultsToNames(r.Stop))
+	assertResults(t, r, &resultExpectation{
+		createDeployment:  nil,
+		deploymentUpdates: nil,
+		place:             1,
+		stop:              1,
+		desiredTGUpdates: map[string]*structs.DesiredUpdates{
+			job.TaskGroups[0].Name: {
+				Ignore: 5,
+				Place:  1, // this is because we're eligible for reschedule
+				Stop:   1,
+			},
+		},
+	})
+}
+
+// Tests the reconciler does not stop a healthy service alloc when scaling down
+// with an active deployment and a failed terminal alloc that is not marked
+// reschedulable.
+func TestReconciler_ScaleDown_ClientTerminal_Service_ActiveDeployment(t *testing.T) {
+	ci.Parallel(t)
+
+	job := mock.Job()
+	job.TaskGroups[0].Count = 2
+
+	d := structs.NewDeployment(job, 50, time.Now().UnixNano())
+	d.Status = structs.DeploymentStatusRunning
+	d.TaskGroups[job.TaskGroups[0].Name] = &structs.DeploymentState{
+		DesiredTotal:  3,
+		PlacedAllocs:  3,
+		HealthyAllocs: 0,
+	}
+
+	var allocs []*structs.Allocation
+	for i := range 3 {
+		alloc := mock.Alloc()
+		alloc.Job = job
+		alloc.JobID = job.ID
+		alloc.NodeID = uuid.Generate()
+		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		alloc.DeploymentID = d.ID
+		allocs = append(allocs, alloc)
+	}
+
+	allocs[2].DesiredStatus = structs.AllocDesiredStatusRun
+	allocs[2].ClientStatus = structs.AllocClientStatusFailed
+	allocs[2].TaskStates = map[string]*structs.TaskState{"web": {
+		State:  "dead",
+		Failed: true,
+	}}
+
+	reconciler := NewAllocReconciler(
+		testlog.HCLogger(t), allocUpdateFnIgnore, ReconcilerState{
+			JobIsBatch:        false,
+			JobID:             job.ID,
+			Job:               job,
+			DeploymentCurrent: d,
+			ExistingAllocs:    allocs,
+			EvalPriority:      50,
+		}, ClusterState{
+			TaintedNodes: nil,
+			Now:          time.Now().UTC(),
+		})
+	r := reconciler.Compute()
+
+	assertResults(t, r, &resultExpectation{
+		createDeployment:  nil,
+		deploymentUpdates: nil,
+		place:             0,
+		stop:              1,
+		desiredTGUpdates: map[string]*structs.DesiredUpdates{
+			job.TaskGroups[0].Name: {
+				Ignore: 2,
+				Stop:   1,
+			},
+		},
+	})
+
+	must.Eq(t, len(r.Stop), 1)
+	for _, stop := range r.Stop {
+		must.Eq(t, stop.Alloc.ID, allocs[2].ID)
+	}
+}


### PR DESCRIPTION
### Description
Currently when downscaling a group. If there are allocations failed, they are not being taken into account, and nomad removes a running (and healthy) allocation instead of a failing one.

Maybe it's even redundant the call to _filterByServerTerminal_ as all working allocs should be in that state. Also maybe it's worth to not only stop by index but do it by health also and stop a failed allocation that's not the highest index.

I don't know if this change has any other implications and could make some other behaviour fail unexpectedly but I checked for this case and it worked fine.

Fixes #27906 


### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.
