### PR TITLE
CI: re-enable copywrite bot

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -4,8 +4,8 @@
 schema_version = 1
 
 project {
-  license      = "BUSL-1.1"
-  license_year = 2015
+  license        = "BUSL-1.1"
+  copyright_year = 2015
 
   header_ignore = [
     "command/asset/*.hcl",

--- a/.github/workflows/copywrite.yml
+++ b/.github/workflows/copywrite.yml
@@ -12,12 +12,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
       - uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
         name: Setup Copywrite
         with:
           version: v0.25.3
           archive-checksum: e43f4b72fff3f219c5a5f883438d63edd5b68f5bea90a5d18abb3001c8c3aedc
-      # - name: Check Header Compliance
-      #   run: make copywriteheaders
+      - name: Check Header Compliance
+        run: make copywriteheaders
 permissions:
   contents: read


### PR DESCRIPTION
Re-enable the `copywrite` check. The configuration in the GHA workflow that runs the makefile results in the following:
* Configure the start year to be 2015
* Configure the clone in CI to have the full history of the repo, so that it can find the latest year in which a file was touched and use that as the end year, as per policy.
* Overwrite the BUSL headers for MPL headers in the packages that are still MPL-licensed.

Results:

```
$ rg --no-filename -e "Copyright " | sort | uniq -c
      3 // Copyright 2013-2026 Moby authors
      1 // Copyright 2015-2017 CNI authors
      1 // Copyright 2018 CNI authors
     20   Copyright IBM Corp. 2015, 2025
    323  * Copyright IBM Corp. 2015, 2025
      4  Copyright IBM Corp. 2015, 2025
    410 # Copyright IBM Corp. 2015, 2025
      1 # Copyright IBM Corp. 2015, 2025
   1518 // Copyright IBM Corp. 2015, 2025
      8 Copyright IBM Corp. 2015, 2025
    257   Copyright IBM Corp. 2015, 2026
    743  * Copyright IBM Corp. 2015, 2026
     89 # Copyright IBM Corp. 2015, 2026
    614 // Copyright IBM Corp. 2015, 2026
      5 Copyright IBM Corp. 2015, 2026

$ rg --no-filename -e "SPDX" | sort | uniq -c
    277   SPDX-License-Identifier: BUSL-1.1
   1063  * SPDX-License-Identifier: BUSL-1.1
      4  SPDX-License-Identifier: BUSL-1.1
    449 # SPDX-License-Identifier: BUSL-1.1
      1 # SPDX-License-Identifier: BUSL-1.1
   1903 // SPDX-License-Identifier: BUSL-1.1
      1 SPDX-License-Identifier: BUSL-1.1
      3  * SPDX-License-Identifier: MPL-2.0
     50 # SPDX-License-Identifier: MPL-2.0
    228 // SPDX-License-Identifier: MPL-2.0
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
