### PR TITLE
acl: fixes a bug where client RPC's fail for node pool "all"

### DIFF
--- a/acl/acl.go
+++ b/acl/acl.go
@@ -1017,7 +1017,8 @@ func (a *ACL) AllowClientOp(pool string) bool {
 	if a.client == PolicyDeny {
 		return false
 	}
-	return pool == a.pool
+	// hardcode "all" until we can use node.IsInPool
+	return pool == a.pool || pool == "all"
 }
 
 // IsManagement checks if this represents a management token

--- a/acl/acl.go
+++ b/acl/acl.go
@@ -1017,7 +1017,6 @@ func (a *ACL) AllowClientOp(pool string) bool {
 	if a.client == PolicyDeny {
 		return false
 	}
-	// hardcode "all" until we can use node.IsInPool
 	return pool == a.pool || pool == "all"
 }
 

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -103,6 +103,14 @@ func TestACLManagement(t *testing.T) {
 	must.False(t, acl.AllowClientOp("my-pool"))
 }
 
+func TestClientACL(t *testing.T) {
+	acl := NewClientACL("test-pool")
+
+	must.True(t, acl.AllowClientOp("test-pool"))
+	must.True(t, acl.AllowClientOp("all")) // tests node_pool = "all"
+	must.False(t, acl.AllowClientOp("test-not-my-pool"))
+}
+
 func TestACLMerge(t *testing.T) {
 	ci.Parallel(t)
 

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -103,14 +103,6 @@ func TestACLManagement(t *testing.T) {
 	must.False(t, acl.AllowClientOp("my-pool"))
 }
 
-func TestClientACL(t *testing.T) {
-	acl := NewClientACL("test-pool")
-
-	must.True(t, acl.AllowClientOp("test-pool"))
-	must.True(t, acl.AllowClientOp("all")) // tests node_pool = "all"
-	must.False(t, acl.AllowClientOp("test-not-my-pool"))
-}
-
 func TestACLMerge(t *testing.T) {
 	ci.Parallel(t)
 
@@ -229,6 +221,14 @@ func TestACLMerge(t *testing.T) {
 
 func TestACLAllowClientOp_NodePoolScoped(t *testing.T) {
 	ci.Parallel(t)
+
+	t.Run("client acl works with node pool 'all'", func(t *testing.T) {
+		acl := NewClientACL("test-pool")
+
+		must.True(t, acl.AllowClientOp("test-pool"))
+		must.True(t, acl.AllowClientOp("all")) // tests node_pool = "all"
+		must.False(t, acl.AllowClientOp("test-not-my-pool"))
+	})
 
 	t.Run("management", func(t *testing.T) {
 		acl, err := NewACL(true, nil)

--- a/e2e/scheduler_system/input/system_job_all_pools.nomad
+++ b/e2e/scheduler_system/input/system_job_all_pools.nomad
@@ -1,0 +1,40 @@
+# Copyright IBM Corp. 2015, 2025
+# SPDX-License-Identifier: BUSL-1.1
+
+job "system_job" {
+  datacenters = ["dc1", "dc2"]
+
+  type = "system"
+
+  # Many system jobs are run in every node pool
+  # lets test this job runs as expected
+  node_pool = "all"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "system_job_group" {
+    count = 1
+
+    restart {
+      attempts = 10
+      interval = "1m"
+
+      delay = "2s"
+      mode  = "delay"
+    }
+
+    task "system_task" {
+      driver = "docker"
+
+      config {
+        image = "busybox:1"
+
+        command = "/bin/sh"
+        args    = ["-c", "sleep 15000"]
+      }
+    }
+  }
+}

--- a/e2e/scheduler_system/input/system_job_all_pools.nomad
+++ b/e2e/scheduler_system/input/system_job_all_pools.nomad
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2015, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 job "system_job" {

--- a/e2e/scheduler_system/systemsched_test.go
+++ b/e2e/scheduler_system/systemsched_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package scheduler_system

--- a/e2e/scheduler_system/systemsched_test.go
+++ b/e2e/scheduler_system/systemsched_test.go
@@ -21,9 +21,39 @@ func TestSystemScheduler(t *testing.T) {
 		cluster3.LinuxClients(3),
 	)
 
+	t.Run("testSystemJobAllNodePools", testSystemJobAllNodePools)
 	t.Run("testJobUpdateOnIneligibleNode", testJobUpdateOnIneligbleNode)
 	t.Run("testCanaryUpdate", testCanaryUpdate)
 	t.Run("testCanaryDeploymentToAllEligibleNodes", testCanaryDeploymentToAllEligibleNodes)
+}
+
+func testSystemJobAllNodePools(t *testing.T) {
+	job, cleanup := jobs3.Submit(t,
+		"./input/system_job_all_pools.nomad",
+		jobs3.DisableRandomJobID(),
+		jobs3.Timeout(60*time.Second),
+	)
+	t.Cleanup(cleanup)
+
+	deploymentsApi := job.DeploymentsApi()
+	deploymentsList, _, err := deploymentsApi.List(nil)
+	must.NoError(t, err)
+
+	var deployment *api.Deployment
+	for _, d := range deploymentsList {
+		if d.JobID == job.JobID() && d.Status == api.DeploymentStatusRunning {
+			deployment = d
+		}
+	}
+	must.NotNil(t, deployment)
+
+	// wait for the deployment to become healthy
+	timeout, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	job.WaitForDeploymentFunc(timeout, deployment.ID, func(d *api.Deployment) bool {
+		return d.Status == api.DeploymentStatusSuccessful
+	})
 }
 
 func testJobUpdateOnIneligbleNode(t *testing.T) {

--- a/e2e/scheduler_system/systemsched_test.go
+++ b/e2e/scheduler_system/systemsched_test.go
@@ -48,7 +48,7 @@ func testSystemJobAllNodePools(t *testing.T) {
 	must.NotNil(t, deployment)
 
 	// wait for the deployment to become healthy
-	timeout, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	timeout, cancel := context.WithTimeout(t.Context(), 60*time.Second)
 	defer cancel()
 
 	job.WaitForDeploymentFunc(timeout, deployment.ID, func(d *api.Deployment) bool {


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes add ACL code to handle client RPC's where the requested entitity is in `node_pool = "all"`. Without this, multiple client RPC endpoints will fail whenever a job is created in "all" nodepools. 

In a followup PR, we should be using the already defined [node.IsInPool](https://github.com/hashicorp/nomad/blob/v2.0.1/nomad/structs/structs.go#L2280-L2282), but it's going to take a small/medium refactor to get working nicely.  The included E2E test should catch any future regressions. 

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes: https://github.com/hashicorp/nomad/issues/27961

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
