### PR TITLE
UI: fix regression in rendering eval detail panel

### DIFF
--- a/.changelog/27987.txt
+++ b/.changelog/27987.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed a bug where the evaluation detail panel would render improperly
+```

--- a/ui/app/components/evaluation-sidebar/detail.hbs
+++ b/ui/app/components/evaluation-sidebar/detail.hbs
@@ -172,7 +172,7 @@
             Evaluation Response
           </div>
           <div class="boxed-section-body is-full-bleed">
-            <JsonViewer @json={{evaluation}} />
+            <JsonViewer @json={{this.evaluationJSON}} />
           </div>
         </div>
       {{/if}}

--- a/ui/app/components/evaluation-sidebar/detail.js
+++ b/ui/app/components/evaluation-sidebar/detail.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2015, 2025
+ * Copyright IBM Corp. 2015, 2026
  * SPDX-License-Identifier: BUSL-1.1
  */
 
@@ -38,6 +38,11 @@ export default class Detail extends Component {
 
   get currentEvalDetail() {
     return this.statechart.state.context.evaluation;
+  }
+
+  get evaluationJSON() {
+    const evaluation = this.currentEvalDetail;
+    return evaluation?.serialize?.() || evaluation?.toJSON?.() || {};
   }
 
   get hierarchy() {

--- a/ui/tests/unit/components/evaluation-sidebar-test.js
+++ b/ui/tests/unit/components/evaluation-sidebar-test.js
@@ -1,0 +1,145 @@
+/**
+ * Copyright IBM Corp. 2015, 2026
+ * SPDX-License-Identifier: BUSL-1.1
+ */
+
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import DetailComponent from 'nomad-ui/components/evaluation-sidebar/detail';
+
+module('Unit | Component | evaluation-sidebar/detail', function (hooks) {
+  setupTest(hooks);
+
+  test('evaluationJSON serializes the evaluation model and excludes Ember internals', function (assert) {
+    // Mock an Ember Data model with internal properties that should be excluded
+    const mockEvaluation = {
+      id: 'eval-123',
+      status: 'complete',
+      // Ember Data internal properties that should NOT appear in JSON
+      _internalModel: { /* internal state */ },
+      store: { /* store reference */ },
+      __data__: { /* internal data */ },
+      serialize() {
+        // serialize() should return only the clean data
+        return {
+          id: this.id,
+          status: this.status,
+        };
+      },
+    };
+
+    const component = new DetailComponent(this.owner, {
+      statechart: {
+        state: {
+          context: {
+            evaluation: mockEvaluation,
+          },
+        },
+      },
+    });
+
+    const result = component.evaluationJSON;
+
+    // Verify only clean data is returned, no Ember internals
+    assert.deepEqual(result, {
+      id: 'eval-123',
+      status: 'complete',
+    }, 'evaluationJSON returns only serialized data without Ember internals');
+
+    assert.notOk(result._internalModel, 'does not include _internalModel');
+    assert.notOk(result.store, 'does not include store');
+    assert.notOk(result.__data__, 'does not include __data__');
+  });
+
+  test('evaluationJSON falls back to toJSON and excludes Ember internals', function (assert) {
+    // Mock an Ember Data model without serialize() but with toJSON()
+    const mockEvaluation = {
+      id: 'eval-456',
+      status: 'pending',
+      // Ember Data internal properties that should NOT appear in JSON
+      _internalModel: { /* internal state */ },
+      store: { /* store reference */ },
+      toJSON() {
+        // toJSON() should return only the clean data
+        return {
+          id: this.id,
+          status: this.status,
+        };
+      },
+    };
+
+    const component = new DetailComponent(this.owner, {
+      statechart: {
+        state: {
+          context: {
+            evaluation: mockEvaluation,
+          },
+        },
+      },
+    });
+
+    const result = component.evaluationJSON;
+
+    // Verify only clean data is returned via toJSON fallback
+    assert.deepEqual(result, {
+      id: 'eval-456',
+      status: 'pending',
+    }, 'evaluationJSON falls back to toJSON and returns clean data');
+
+    assert.notOk(result._internalModel, 'does not include _internalModel');
+    assert.notOk(result.store, 'does not include store');
+  });
+
+  test('evaluationJSON returns empty object if no serialization method available (prevents exposing Ember internals)', function (assert) {
+    // Mock an Ember Data model without serialize() or toJSON()
+    // This simulates the bug scenario where model internals would be exposed
+    const mockEvaluation = {
+      id: 'eval-789',
+      status: 'failed',
+      // Ember Data internal properties that WOULD be exposed without serialization
+      _internalModel: { /* internal state */ },
+      store: { /* store reference */ },
+      __data__: { /* internal data */ },
+      // No serialize() or toJSON() methods
+    };
+
+    const component = new DetailComponent(this.owner, {
+      statechart: {
+        state: {
+          context: {
+            evaluation: mockEvaluation,
+          },
+        },
+      },
+    });
+
+    const result = component.evaluationJSON;
+
+    // Without serialization methods, return empty object as safe fallback
+    // This prevents exposing Ember internals to JsonViewer
+    assert.deepEqual(result, {}, 'evaluationJSON returns empty object as safe fallback');
+    assert.notOk(result._internalModel, 'does not expose _internalModel');
+    assert.notOk(result.store, 'does not expose store');
+    assert.notOk(result.__data__, 'does not expose __data__');
+  });
+
+  test('evaluationJSON returns empty object when evaluation is null (safe handling)', function (assert) {
+    const component = new DetailComponent(this.owner, {
+      statechart: {
+        state: {
+          context: {
+            evaluation: null,
+          },
+        },
+      },
+    });
+
+    const result = component.evaluationJSON;
+
+    // When evaluation is null/undefined, return empty object as safe fallback
+    // This prevents errors and ensures JsonViewer always receives valid JSON
+    assert.deepEqual(result, {}, 'evaluationJSON returns empty object when evaluation is null');
+    assert.strictEqual(typeof result, 'object', 'result is an object');
+    assert.ok(Object.keys(result).length === 0, 'result is empty');
+  });
+});


### PR DESCRIPTION
The detail panel on the evals page was rendering out the EmberJS model to the JSON-like format instead of the evaluation struct that comes from the API. Fix this with a serialization step and include a regression test.

Fixes: https://github.com/hashicorp/nomad/issues/27981
Ref: https://hashicorp.atlassian.net/browse/NMD-1472

### Testing & Reproduction steps

Run a job, such as this one that will always have a blocked eval:

<details><summary>jobspec</summary>

```hcl
job "example" {

  group "group" {

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
    }

    constraint {
      attribute = "${node.pool}"
      value     = "does-not-exist"
    }

    service {
      name     = "httpd-web"
      provider = "nomad"
      port     = "www"
    }

    task "task" {

      driver = "docker"
      user   = "www-data"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}
```

</details>

Then go to the evaluations page in the UI. Without this patch, we get the screenshot in https://github.com/hashicorp/nomad/issues/27981. With this patch, we get the following:

<img width="1322" height="1448" alt="Screenshot From 2026-05-15 14-54-49" src="https://github.com/user-attachments/assets/8eca5a47-ba03-44e3-99b5-2c8472c2bccd" />


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
