### PR TITLE
cli: add -json and -t flags to operator autopilot get-config

### DIFF
--- a/.changelog/27991.txt
+++ b/.changelog/27991.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Added `-json` and `-t` options to the `operator autopilot get-config` command.
+```

--- a/command/operator_autopilot_get.go
+++ b/command/operator_autopilot_get.go
@@ -15,7 +15,11 @@ type OperatorAutopilotGetCommand struct {
 }
 
 func (c *OperatorAutopilotGetCommand) AutocompleteFlags() complete.Flags {
-	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient))
+	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
+		complete.Flags{
+			"-json": complete.PredictNothing,
+			"-t":    complete.PredictAnything,
+		})
 }
 
 func (c *OperatorAutopilotGetCommand) AutocompleteArgs() complete.Predictor {
@@ -24,8 +28,13 @@ func (c *OperatorAutopilotGetCommand) AutocompleteArgs() complete.Predictor {
 
 func (c *OperatorAutopilotGetCommand) Name() string { return "operator autopilot get-config" }
 func (c *OperatorAutopilotGetCommand) Run(args []string) int {
+	var json bool
+	var tmpl string
+
 	flags := c.Meta.FlagSet("autopilot", FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
+	flags.BoolVar(&json, "json", false, "")
+	flags.StringVar(&tmpl, "t", "", "")
 
 	if err := flags.Parse(args); err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to parse args: %v", err))
@@ -45,6 +54,17 @@ func (c *OperatorAutopilotGetCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Error querying Autopilot configuration: %s", err))
 		return 1
 	}
+
+	if json || len(tmpl) > 0 {
+		out, err := Format(json, tmpl, config)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 1
+		}
+		c.Ui.Output(out)
+		return 0
+	}
+
 	c.Ui.Output(fmt.Sprintf("CleanupDeadServers = %v", config.CleanupDeadServers))
 	c.Ui.Output(fmt.Sprintf("LastContactThreshold = %v", config.LastContactThreshold.String()))
 	c.Ui.Output(fmt.Sprintf("MaxTrailingLogs = %v", config.MaxTrailingLogs))
@@ -72,7 +92,16 @@ Usage: nomad operator autopilot get-config [options]
 
 General Options:
 
-  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace)
+  ` + generalOptionsUsage(usageOptsDefault|usageOptsNoNamespace) + `
+
+Get Config Options:
+
+  -json
+    Output the Autopilot configuration in JSON format.
+
+  -t
+    Format and display the Autopilot configuration using a Go template.
+`
 
 	return strings.TrimSpace(helpText)
 }

--- a/command/operator_autopilot_get_test.go
+++ b/command/operator_autopilot_get_test.go
@@ -4,11 +4,14 @@
 package command
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/hashicorp/cli"
+	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
 )
 
 func TestOperator_Autopilot_GetConfig_Implements(t *testing.T) {
@@ -33,4 +36,38 @@ func TestOperatorAutopilotGetConfigCommand(t *testing.T) {
 	if !strings.Contains(output, "CleanupDeadServers = true") {
 		t.Fatalf("bad: %s", output)
 	}
+}
+
+func TestOperatorAutopilotGetConfigCommand_JSON(t *testing.T) {
+	ci.Parallel(t)
+	s, _, addr := testServer(t, false, nil)
+	defer s.Shutdown()
+
+	ui := cli.NewMockUi()
+	c := &OperatorAutopilotGetCommand{Meta: Meta{Ui: ui}}
+	args := []string{"-address=" + addr, "-json"}
+
+	code := c.Run(args)
+	must.Eq(t, 0, code)
+
+	output := ui.OutputWriter.String()
+	var config api.AutopilotConfiguration
+	must.NoError(t, json.Unmarshal([]byte(output), &config))
+	must.True(t, config.CleanupDeadServers)
+}
+
+func TestOperatorAutopilotGetConfigCommand_Template(t *testing.T) {
+	ci.Parallel(t)
+	s, _, addr := testServer(t, false, nil)
+	defer s.Shutdown()
+
+	ui := cli.NewMockUi()
+	c := &OperatorAutopilotGetCommand{Meta: Meta{Ui: ui}}
+	args := []string{"-address=" + addr, "-t", "{{.CleanupDeadServers}}"}
+
+	code := c.Run(args)
+	must.Eq(t, 0, code)
+
+	output := strings.TrimSpace(ui.OutputWriter.String())
+	must.Eq(t, "true", output)
 }


### PR DESCRIPTION
I noticed that `nomad operator autopilot get-config` is missing the `-json` and `-t` flags that other inspection commands have. Scripting and automation tools benefit from machine-readable output instead of parsing the default key=value lines.

This PR adds both flags following the same pattern used by `nomad server members` and other commands:
- `-json` outputs the full AutopilotConfiguration struct as JSON
- `-t` accepts a Go template for custom formatting

Two tests are included to verify the JSON unmarshals correctly and that templates work as expected.

Addresses #15894 (partial)