### PR TITLE
e2e: added tests for `max_run_duration`

### DIFF
--- a/e2e/batch_timeout/batch_timeout_test.go
+++ b/e2e/batch_timeout/batch_timeout_test.go
@@ -1,0 +1,131 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package batch_timeout
+
+import (
+	"testing"
+	"time"
+
+	nomadapi "github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/e2e/v3/cluster3"
+	"github.com/hashicorp/nomad/e2e/v3/jobs3"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+// testTimeout is the upper bound we allow for each sub-test. It must be long
+// enough to cover: job registration → eval → alloc placement → the
+// max_run_duration timer firing (5 s) → terminal state propagation.
+const testTimeout = 60 * time.Second
+
+func TestBatchJobMaxRunDuration(t *testing.T) {
+	cluster3.Establish(t,
+		cluster3.Leader(),
+		cluster3.LinuxClients(1),
+	)
+
+	t.Run("testBatchTimesOut", testBatchJobTimesOut)
+	t.Run("testBatchCompletesBeforeTimeout", testBatchJobCompletesBeforeTimeout)
+	t.Run("testBatchTimeoutSkipsPoststop", testBatchJobTimeoutSkipsPoststop)
+	t.Run("testSysbatchTimesOut", testSysbatchJobTimesOut)
+}
+
+// testBatchJobTimesOut verifies that a batch job with max_run_duration is
+// killed after the configured deadline and that the resulting allocation:
+//   - has ClientStatus == "complete" (not "failed")
+//   - has ClientDescription == AllocTimeoutReasonMaxRunDuration
+func testBatchJobTimesOut(t *testing.T) {
+	job, cleanup := jobs3.Submit(t,
+		"./input/batch_timeout_basic.hcl",
+		jobs3.WaitComplete("group"),
+		jobs3.Timeout(testTimeout),
+	)
+	t.Cleanup(cleanup)
+
+	allocs := job.Allocs()
+	must.Len(t, 1, allocs,
+		must.Sprint("expected exactly one allocation for this batch job"))
+
+	alloc := allocs[0]
+	must.Eq(t, nomadapi.AllocClientStatusComplete, alloc.ClientStatus,
+		must.Sprint("allocation timed out by max_run_duration must be 'complete', not 'failed'"))
+	must.Eq(t, structs.AllocTimeoutReasonMaxRunDuration, alloc.ClientDescription,
+		must.Sprint("allocation description must indicate a max_run_duration timeout"))
+}
+
+// testBatchJobCompletesBeforeTimeout verifies that a batch job whose task
+// finishes before the deadline completes normally; the timeout description must
+// not appear on the allocation.
+func testBatchJobCompletesBeforeTimeout(t *testing.T) {
+	job, cleanup := jobs3.Submit(t,
+		"./input/batch_timeout_completes.hcl",
+		jobs3.WaitComplete("group"),
+		jobs3.Timeout(testTimeout),
+	)
+	t.Cleanup(cleanup)
+
+	allocs := job.Allocs()
+	must.Len(t, 1, allocs,
+		must.Sprint("expected exactly one allocation for this batch job"))
+
+	alloc := allocs[0]
+	must.Eq(t, nomadapi.AllocClientStatusComplete, alloc.ClientStatus,
+		must.Sprint("allocation must be 'complete' after finishing normally"))
+	must.NotEq(t, structs.AllocTimeoutReasonMaxRunDuration, alloc.ClientDescription,
+		must.Sprint("allocation description must NOT indicate a timeout when job finishes naturally"))
+}
+
+// testBatchJobTimeoutSkipsPoststop verifies that when a batch job is terminated
+// by max_run_duration, its poststop lifecycle task is not started.
+func testBatchJobTimeoutSkipsPoststop(t *testing.T) {
+	job, cleanup := jobs3.Submit(t,
+		"./input/batch_timeout_poststop.hcl",
+		jobs3.WaitComplete("group"),
+		jobs3.Timeout(testTimeout),
+	)
+	t.Cleanup(cleanup)
+
+	allocs := job.Allocs()
+	must.Len(t, 1, allocs,
+		must.Sprint("expected exactly one allocation for this batch job"))
+
+	alloc := allocs[0]
+
+	// Confirm the allocation was indeed terminated by the deadline.
+	must.Eq(t, nomadapi.AllocClientStatusComplete, alloc.ClientStatus,
+		must.Sprint("timed-out allocation must be 'complete'"))
+	must.Eq(t, structs.AllocTimeoutReasonMaxRunDuration, alloc.ClientDescription,
+		must.Sprint("timed-out allocation must carry the max_run_duration description"))
+
+	// The poststop task must NOT have been started.
+	poststopState, ok := alloc.TaskStates["poststop"]
+	must.True(t, ok,
+		must.Sprint("poststop task state must be present in the allocation"))
+	must.Eq(t, structs.TaskStatePending, poststopState.State,
+		must.Sprint("poststop task must remain 'pending' — it must not be started when max_run_duration is exceeded"))
+	must.True(t, poststopState.StartedAt.IsZero(),
+		must.Sprint("poststop task StartedAt must be zero — it was never started"))
+}
+
+// testSysbatchJobTimesOut verifies that max_run_duration also works for
+// sysbatch jobs.
+func testSysbatchJobTimesOut(t *testing.T) {
+	job, cleanup := jobs3.Submit(t,
+		"./input/sysbatch_timeout_basic.hcl",
+		jobs3.WaitComplete("group"),
+		jobs3.Timeout(testTimeout),
+	)
+	t.Cleanup(cleanup)
+
+	allocs := job.Allocs()
+	must.Positive(t, len(allocs),
+		must.Sprint("expected at least one allocation for the sysbatch job"))
+
+	for _, alloc := range allocs {
+		must.Eq(t, nomadapi.AllocClientStatusComplete, alloc.ClientStatus,
+			must.Sprintf("sysbatch alloc %s must be 'complete' after timeout", alloc.ID[:8]))
+		must.Eq(t, structs.AllocTimeoutReasonMaxRunDuration, alloc.ClientDescription,
+			must.Sprintf("sysbatch alloc %s must carry the max_run_duration description", alloc.ID[:8]))
+	}
+}

--- a/e2e/batch_timeout/doc.go
+++ b/e2e/batch_timeout/doc.go
@@ -1,0 +1,6 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+// Package batch_timeout contains e2e tests for the max_run_duration task group
+// field introduced in https://github.com/hashicorp/nomad/pull/27803.
+package batch_timeout

--- a/e2e/batch_timeout/input/batch_timeout_basic.hcl
+++ b/e2e/batch_timeout/input/batch_timeout_basic.hcl
@@ -1,0 +1,45 @@
+# Copyright IBM Corp. 2015, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# batch_timeout_basic: a batch job whose sole task sleeps for a very long time.
+# The max_run_duration of 5s ensures it is terminated before it finishes
+# naturally, so the allocation should end in "complete" with the timeout
+# description.
+
+job "batch-timeout-basic" {
+  type = "batch"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "group" {
+    # The allocation must be killed after 5 seconds.
+    max_run_duration = "5s"
+
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    task "sleep" {
+      driver = "raw_exec"
+
+      config {
+        command = "sleep"
+        args    = ["3600"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 10
+      }
+    }
+  }
+}

--- a/e2e/batch_timeout/input/batch_timeout_basic.hcl
+++ b/e2e/batch_timeout/input/batch_timeout_basic.hcl
@@ -23,8 +23,9 @@ job "batch-timeout-basic" {
       unlimited = false
     }
 
+    # Set restart on failure to check that it doesn't get triggered
     restart {
-      attempts = 0
+      attempts = 3
       mode     = "fail"
     }
 

--- a/e2e/batch_timeout/input/batch_timeout_completes.hcl
+++ b/e2e/batch_timeout/input/batch_timeout_completes.hcl
@@ -1,0 +1,43 @@
+# Copyright IBM Corp. 2015, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# batch_timeout_completes: a batch job whose task finishes almost immediately.
+# With a 30s max_run_duration the job should complete normally.
+
+job "batch-timeout-completes" {
+  type = "batch"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "group" {
+    # generous timeout
+    max_run_duration = "30s"
+
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    task "echo" {
+      driver = "raw_exec"
+
+      config {
+        command = "echo"
+        args    = ["hello from batch-timeout-completes"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 10
+      }
+    }
+  }
+}

--- a/e2e/batch_timeout/input/batch_timeout_poststop.hcl
+++ b/e2e/batch_timeout/input/batch_timeout_poststop.hcl
@@ -1,0 +1,66 @@
+# Copyright IBM Corp. 2015, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# batch_timeout_poststop: a batch job with a poststop lifecycle task.
+#
+# The main task sleeps indefinitely; the max_run_duration of 5s will kill it.
+# Per the feature spec, the poststop task must not be started when the
+# allocation is terminated due to timeout,
+
+job "batch-timeout-poststop" {
+  type = "batch"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "group" {
+    max_run_duration = "5s"
+
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    # Main task — runs until killed by the deadline.
+    task "sleep" {
+      driver = "raw_exec"
+
+      config {
+        command = "sleep"
+        args    = ["3600"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 10
+      }
+    }
+
+    # poststop task must not run
+    task "poststop" {
+      driver = "raw_exec"
+
+      lifecycle {
+        hook    = "poststop"
+        sidecar = false
+      }
+
+      config {
+        command = "echo"
+        args    = ["poststop executed"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 10
+      }
+    }
+  }
+}

--- a/e2e/batch_timeout/input/sysbatch_timeout_basic.hcl
+++ b/e2e/batch_timeout/input/sysbatch_timeout_basic.hcl
@@ -1,0 +1,38 @@
+# Copyright IBM Corp. 2015, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+# sysbatch_timeout_basic: a sysbatch job whose sole task sleeps for a very long
+# time. The max_run_duration of 5s ensures it is terminated on every node before
+# it finishes naturally.
+
+job "sysbatch-timeout-basic" {
+  type = "sysbatch"
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+
+  group "group" {
+    max_run_duration = "5s"
+
+    restart {
+      attempts = 0
+      mode     = "fail"
+    }
+
+    task "sleep" {
+      driver = "raw_exec"
+
+      config {
+        command = "sleep"
+        args    = ["3600"]
+      }
+
+      resources {
+        cpu    = 10
+        memory = 10
+      }
+    }
+  }
+}


### PR DESCRIPTION
This changeset adds end-to-end tests for batch job timeouts introduced in #27803 