### PR TITLE
template: continue monitoring runner even with change_mode=noop

### DIFF
--- a/.changelog/28016.txt
+++ b/.changelog/28016.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+template: Fixed a bug where templates with `change_mode=noop` would stop monitoring templates that fatally fail after initial rendering
+```

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -277,11 +277,6 @@ func (tm *TaskTemplateManager) Run() {
 	// Unblock the task
 	close(tm.config.UnblockCh)
 
-	// If all our templates are change mode no-op, then we can exit here
-	if tm.allTemplatesNoop() {
-		return
-	}
-
 	// handle all subsequent render events.
 	tm.handleTemplateRerenders(time.Now())
 }

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -2830,3 +2830,50 @@ func TestTaskTemplateManager_deniedSprig(t *testing.T) {
 	}
 
 }
+
+// TestTaskTemplateManager_noopExitsOnFatal tests that templates with
+// change_mode=noop fail their task if the template runner throws a fatal error
+// because it's lost connection with the dependency
+func TestTaskTemplateManager_noopExitsOnFatal(t *testing.T) {
+	ci.Parallel(t)
+	clienttestutil.RequireConsul(t)
+
+	// Make a template that will render based on a key in Consul
+	consulKey := "foo"
+	consulContent := "barbaz"
+	consulEmbedded := fmt.Sprintf(`{{key "%s"}}`, consulKey)
+	consulFile := "consul.tmpl"
+	template := &structs.Template{
+		EmbeddedTmpl: consulEmbedded,
+		DestPath:     consulFile,
+		ChangeMode:   structs.TemplateChangeModeNoop,
+	}
+
+	harness := newTestHarness(t, []*structs.Template{template}, true, false)
+	harness.config.TemplateConfig.ConsulRetry = &config.RetryConfig{
+		Backoff:    pointer.Of(10 * time.Millisecond),
+		Attempts:   pointer.Of(2),
+		MaxBackoff: pointer.Of(20 * time.Millisecond),
+	}
+	harness.consul.SetKV(t, consulKey, []byte(consulContent))
+
+	must.NoError(t, harness.startWithErr(), must.Sprint("couldn't setup initial harness"))
+	t.Cleanup(harness.stop)
+
+	// Wait for the template to render once
+	select {
+	case <-harness.mockHooks.UnblockCh:
+	case <-time.After(time.Duration(5 * time.Second)):
+		t.Fatalf("Task unblock should have been called")
+	}
+
+	// Wait for template to throw a fatal error and expect the task to be killed
+	harness.consul.Stop()
+
+	select {
+	case <-harness.mockHooks.KillCh:
+		t.Log("task killed!")
+	case <-time.After(time.Duration(5 * time.Second)):
+		t.Fatalf("Task kill should have been called")
+	}
+}


### PR DESCRIPTION
If all the templates in a task have `change_mode = "noop"`, the task template manager returns after the initial rendering under the assumption that we no longer need to monitor the template runner. But if a template with a Consul or Vault dependency loses contact with the upstream service for long enough for the `client.template.consul_retry` or `client.template.vault_retry` to expire, the template runner exits. If a task is monitoring its own template contents and not relying on `change_mode`, the task ends up with stale content, and its up to applications to handle that stale content safely.

But this presents a problem when connectivity is restored, because now the template runner has exited and will never be restarted. So the application that may have been able to handle stale content for the configured `consul_retry` or `vault_retry` duration will no loner get template updates, rather than being killed and restarted. This turns a "loud" outage that's visible to Nomad into a "silent" outage that's only visible to the application, which is generally a bad situation.

Drop the optimization that stops the monitoring of the template runner.

Fixes: https://hashicorp.atlassian.net/browse/NMD-1487

### Testing & Reproduction steps

In addition to the unit test I've added here, which fails without the patch, you can reproduce this with a single Consul and Nomad node. (Note this same issue can appear with Vault too, but this is a little easier to setup.)

Start Consul and Nomad. Nomad can be in dev mode but Consul should be in normal mode so that you can restart it. Use the following in the Nomad client `template` configuration:

```hcl
client {
  template {
    consul_retry {
      backoff     = "50ms"
      attempts    = 2
      max_backoff = "5s"
    }
  }
}
```

Add data to Consul KV: `consul kv put "nomad/name" Tim`. After configuring Consul and Nomad ACLs so that Nomad tasks can read from the `nomad/` KV prefix, run the following job:

<details><summary>jobspec</summary>

```hcl
job "example" {

  group "web" {

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
    }

    task "http" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      consul {}

      template {
        data =       <<EOT
<html>
  <div>hello, {{key "nomad/name"}}</div>
</html>
        EOT


        destination = "${NOMAD_TASK_DIR}/index.html"
        change_mode = "noop"
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}
```

</details>

You can curl the allocation's port to see the KV data:

```
$ curl  192.168.1.194:23495
<html>
  <div>hello, Tim</div>
</html>
```

Then stop Consul and wait to see:

> 2026-05-20T10:13:00.390-0400 [WARN]  agent: (view) kv.block(nomad/name): Get "http://localhost:8500/v1/kv/nomad/name?index=72&stale=&wait=300000ms": dial tcp [::1]:8500: connect: connection refused (retry attempt 1 after "50ms")
> 2026-05-20T10:13:00.390-0400 [ERROR] agent: (runner) sending server error back to caller
> 2026-05-20T10:13:00.441-0400 [WARN]  agent: (view) kv.block(nomad/name): Get "http://localhost:8500/v1/kv/nomad/name?index=72&stale=&wait=300000ms": dial tcp [::1]:8500: connect: connection refused (retry attempt 2 after "100ms")

Then restart Consul and update the the KV: `consul kv put "nomad/name" Austin`. This will not be updated if you curl the allocation again.

With this patch, the task instead is killed.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** strictly speaking this doesn't need docs, but I think I'll open a PR explaining the difference between `template.change_mode = "noop"` vs `template.once = true` which comes into play here https://github.com/hashicorp/web-unified-docs/pull/2493

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
