### PR TITLE
scheduler: keep draining batch alloc counted when node is re-enabled

### DIFF
--- a/.changelog/28018.txt
+++ b/.changelog/28018.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: keep draining batch alloc counted when node is re-enabled
+```

--- a/scheduler/reconciler/filters.go
+++ b/scheduler/reconciler/filters.go
@@ -137,6 +137,21 @@ var classificationRules = []classificationRule{
 		},
 		category: categoryReconnecting,
 	},
+	// A drained batch alloc (MigrateDisablePlacement is only set by the
+	// batch drainer) must keep counting toward the desired total — the
+	// drain explicitly said "don't place a replacement", so the slot must
+	// stay occupied from the reconciler's perspective. Otherwise a
+	// follow-up eval — e.g. node-update when the node is made eligible
+	// again before the drain completes — sees zero existing allocs and
+	// places a replacement.
+	{
+		condition: func(ctx allocContext) bool {
+			return ctx.alloc.ServerTerminalStatus() &&
+				!ctx.shouldReconnect &&
+				ctx.alloc.DesiredTransition.ShouldDisableMigrationPlacement()
+		},
+		category: categoryUntainted,
+	},
 	// Server-terminal allocs should be ignored when they are not reconnecting.
 	{
 		condition: func(ctx allocContext) bool {
@@ -438,6 +453,17 @@ func shouldFilter(alloc *structs.Allocation, isBatch bool) (untainted, ignore bo
 	// status is failed so that they will be replaced. If they are
 	// complete but not failed, they shouldn't be replaced.
 	if isBatch {
+		// A batch alloc that was drained (MigrateDisablePlacement) must
+		// remain untainted so it counts toward the desired total and no
+		// replacement is placed. Without this, classifyAllocs routes the
+		// alloc to untainted but filterByRescheduleable then drops it here
+		// via the DesiredStatus=stop / !RanSuccessfully branch below, and
+		// the missing count causes computePlacements to schedule a
+		// replacement.
+		if alloc.DesiredTransition.ShouldDisableMigrationPlacement() {
+			return true, false
+		}
+
 		// if the batch job allocation is flagged for being rescheduled,
 		// which happens when stopped with the `alloc stop` command, the
 		// allocation should not be untainted nor ignored.

--- a/scheduler/reconciler/reconcile_cluster_test.go
+++ b/scheduler/reconciler/reconcile_cluster_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package reconciler

--- a/scheduler/reconciler/reconcile_cluster_test.go
+++ b/scheduler/reconciler/reconcile_cluster_test.go
@@ -1414,8 +1414,8 @@ func TestReconciler_MigrateDisablePlacementBatchAllocs_StillRunningAfterStop(t *
 	for i := 0; i < 2; i++ {
 		allocs[i].DesiredStatus = structs.AllocDesiredStatusStop
 		allocs[i].ClientStatus = structs.AllocClientStatusRunning
-		allocs[i].DesiredTransition.Migrate = pointer.Of(true)
-		allocs[i].DesiredTransition.MigrateDisablePlacement = pointer.Of(true)
+		allocs[i].DesiredTransition.Migrate = new(true)
+		allocs[i].DesiredTransition.MigrateDisablePlacement = new(true)
 	}
 
 	reconciler := NewAllocReconciler(

--- a/scheduler/reconciler/reconcile_cluster_test.go
+++ b/scheduler/reconciler/reconcile_cluster_test.go
@@ -1382,6 +1382,72 @@ func TestReconciler_MigrateDisablePlacementBatchAllocs(t *testing.T) {
 	assertPlacementsAreRescheduled(t, 0, r.Place)
 }
 
+// Tests that the reconciler does not place a replacement when a follow-up
+// evaluation runs for a batch allocation that is still draining. The first
+// drain eval flips DesiredStatus to stop and sets the migrate transition
+// flags; while the client is still finishing the allocation, a subsequent
+// eval (for example the node-update eval triggered when an operator makes
+// the draining node eligible again before the drain completes) must keep
+// counting the still-running allocation toward the desired total instead of
+// scheduling a replacement.
+func TestReconciler_MigrateDisablePlacementBatchAllocs_StillRunningAfterStop(t *testing.T) {
+	ci.Parallel(t)
+
+	job := mock.BatchJob()
+
+	// Create 10 existing allocations.
+	var allocs []*structs.Allocation
+	for i := 0; i < 10; i++ {
+		alloc := mock.BatchAlloc()
+		alloc.Job = job
+		alloc.JobID = job.ID
+		alloc.NodeID = uuid.Generate()
+		alloc.Name = structs.AllocName(job.ID, job.TaskGroups[0].Name, uint(i))
+		alloc.ClientStatus = structs.AllocClientStatusRunning
+		allocs = append(allocs, alloc)
+	}
+
+	// Simulate the state of two allocations after the first drain eval has
+	// been applied: the server has marked them stopped and set the migrate +
+	// disable-placement transition flags, but the client has not yet finished
+	// shutting them down.
+	for i := 0; i < 2; i++ {
+		allocs[i].DesiredStatus = structs.AllocDesiredStatusStop
+		allocs[i].ClientStatus = structs.AllocClientStatusRunning
+		allocs[i].DesiredTransition.Migrate = pointer.Of(true)
+		allocs[i].DesiredTransition.MigrateDisablePlacement = pointer.Of(true)
+	}
+
+	reconciler := NewAllocReconciler(
+		testlog.HCLogger(t), allocUpdateFnIgnore, ReconcilerState{
+			JobIsBatch:        true,
+			JobID:             job.ID,
+			Job:               job,
+			DeploymentCurrent: nil,
+			ExistingAllocs:    allocs,
+			EvalPriority:      50,
+		}, ClusterState{
+			Now: time.Now().UTC(),
+		})
+	r := reconciler.Compute()
+
+	// No replacement should be placed; no allocation should be re-stopped.
+	// All allocations (the 8 still running normally plus the 2 draining) must
+	// remain counted toward the desired total, so they end up in Ignore.
+	assertResults(t, r, &resultExpectation{
+		createDeployment:  nil,
+		deploymentUpdates: nil,
+		place:             0,
+		inplace:           0,
+		stop:              0,
+		desiredTGUpdates: map[string]*structs.DesiredUpdates{
+			job.TaskGroups[0].Name: {
+				Ignore: 10,
+			},
+		},
+	})
+}
+
 // Tests that the reconciler properly handles batch job allocations that
 // are flagged as should migrate and should reschedule. This behavior is
 // used when stopping a batch allocation using the `alloc stop` command.

--- a/ui/tests/unit/serializers/port-test.js
+++ b/ui/tests/unit/serializers/port-test.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2015, 2025
+ * Copyright IBM Corp. 2015, 2026
  * SPDX-License-Identifier: BUSL-1.1
  */
 


### PR DESCRIPTION
### Description
When a node that is currently draining a batch job allocation is re-enabled
(set back to eligible) before the allocation has finished stopping, Nomad
creates a new replacement allocation for the batch job. This contradicts the
documented batch-drain behavior, which says a batch allocation should be
allowed to complete on the draining node and should not be replaced.

This appears to be a regression / follow-up edge case to the fix shipped in
https://github.com/hashicorp/nomad/pull/26961, which corrected the case where a new allocation was created
immediately on batch-job drain. That fix works correctly when the drain runs
to completion. The bug shows up only in the narrow window where the
allocation is still running (i.e. it takes some time to shut down) and the
operator toggles the node back to eligible during that window.

The evaluation that creates the extra allocation is shown in the UI as
triggered by node-update, which lines up with the node going from
ineligible back to eligible.

### Testing & Reproduction steps
1. Submit a batch job with a task whose graceful-shutdown takes a noticeable
    amount of time (e.g. ~1 minute — a `kill_timeout` long enough that the
    alloc remains in `running` for a while after being asked to stop).
2. Wait for the allocation to be `running` on some node.
3. Drain the node. The drain begins; the
    allocation is marked for stop but is still `running` on the node (this is
    the documented behavior — the batch alloc is allowed to finish).
4. Before the allocation actually transitions to a terminal client status,
    re-enable the node.
5. Observe the job's allocations and evaluations.

### Links
Fixes https://github.com/hashicorp/nomad/issues/28008

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
