### PR TITLE
upgrade websockets early to permit auditing of browser requests

### DIFF
--- a/.changelog/28025.txt
+++ b/.changelog/28025.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+audit (Enterprise): Fixed a bug where alloc exec and job actions requests from the webbrowser would be marked as anonymous in audit logs
+```

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package agent
@@ -614,51 +614,12 @@ func (s *HTTPServer) allocExec(allocID string, resp http.ResponseWriter, req *ht
 	}
 	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
 
-	conn, err := s.wsUpgrader.Upgrade(resp, req, nil)
+	conn, err := s.getWebsocketConnection(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to upgrade connection: %v", err)
-	}
-
-	if err := readWsHandshake(conn.ReadJSON, req, &args.QueryOptions); err != nil {
-		conn.WriteMessage(websocket.CloseMessage,
-			websocket.FormatCloseMessage(toWsCode(400), err.Error()))
 		return nil, err
 	}
 
 	return s.execStream(conn, &args)
-}
-
-// readWsHandshake reads the websocket handshake message and sets
-// query authentication token, if request requires a handshake
-func readWsHandshake(readFn func(interface{}) error, req *http.Request, q *structs.QueryOptions) error {
-
-	// Avoid handshake if request doesn't require one
-	if hv := req.URL.Query().Get("ws_handshake"); hv == "" {
-		return nil
-	} else if h, err := strconv.ParseBool(hv); err != nil {
-		return fmt.Errorf("ws_handshake value is not a boolean: %v", err)
-	} else if !h {
-		return nil
-	}
-
-	var h wsHandshakeMessage
-	err := readFn(&h)
-	if err != nil {
-		return err
-	}
-
-	supportedWSHandshakeVersion := 1
-	if h.Version != supportedWSHandshakeVersion {
-		return fmt.Errorf("unexpected handshake value: %v", h.Version)
-	}
-
-	q.AuthToken = h.AuthToken
-	return nil
-}
-
-type wsHandshakeMessage struct {
-	Version   int    `json:"version"`
-	AuthToken string `json:"auth_token"`
 }
 
 // execStream finds the appropriate RPC handler and then runs the bidirectional

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -1072,66 +1072,10 @@ func TestHTTP_AllocAllGC_ACL(t *testing.T) {
 	})
 }
 
-func TestHTTP_ReadWsHandshake(t *testing.T) {
-	ci.Parallel(t)
-
-	cases := []struct {
-		name      string
-		token     string
-		handshake bool
-	}{
-		{
-			name:      "plain compatible mode",
-			token:     "",
-			handshake: false,
-		},
-		{
-			name:      "handshake unauthenticated",
-			token:     "",
-			handshake: true,
-		},
-		{
-			name:      "handshake authenticated",
-			token:     "mysupersecret",
-			handshake: true,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-
-			called := false
-			readFn := func(h interface{}) error {
-				called = true
-				if !c.handshake {
-					return fmt.Errorf("should not be called")
-				}
-
-				hm := h.(*wsHandshakeMessage)
-				hm.Version = 1
-				hm.AuthToken = c.token
-				return nil
-			}
-
-			req := httptest.NewRequest(http.MethodPut, "/target", nil)
-			if c.handshake {
-				req.URL.RawQuery = "ws_handshake=true"
-			}
-
-			var q structs.QueryOptions
-
-			err := readWsHandshake(readFn, req, &q)
-			require.NoError(t, err)
-			require.Equal(t, c.token, q.AuthToken)
-			require.Equal(t, c.handshake, called)
-		})
-	}
-}
-
-// TestHTTP_AllocsExecStream_SafeClose verifies that we are safely closing the
+// TestHTTP_AllocExecStream_SafeClose verifies that we are safely closing the
 // AllocExec stream when we're done without making concurrent writes to the
 // websocket that can cause a panic
-func TestHTTP_AllocsExecStream_SafeClose(t *testing.T) {
+func TestHTTP_AllocExecStream_SafeClose(t *testing.T) {
 	httpTest(t,
 		func(c *Config) { c.Server.NumSchedulers = pointer.Of(0) },
 		func(s *TestAgent) {

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -735,8 +735,8 @@ func errCodeFromHandler(err error) (int, string) {
 }
 
 // wrap is used to wrap functions to make them more convenient
-func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Request) (interface{}, error)) func(resp http.ResponseWriter, req *http.Request) {
-	f := func(resp http.ResponseWriter, req *http.Request) {
+func (s *HTTPServer) wrap(handler handlerFn) func(resp http.ResponseWriter, req *http.Request) {
+	return func(resp http.ResponseWriter, req *http.Request) {
 		setHeaders(resp, s.agent.GetConfig().HTTPAPIResponseHeaders)
 		// Invoke the handler
 		reqURL := req.URL.String()
@@ -744,7 +744,17 @@ func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Reque
 		defer func() {
 			s.logger.Debug("request complete", "method", req.Method, "path", reqURL, "duration", time.Since(start))
 		}()
-		obj, err := s.auditHandler(handler)(resp, req)
+
+		var obj any
+		var err error
+		if isWebsocketUpgrade(req) {
+			// Because the browser WebSocket API doesn't allow for setting the
+			// auth headers, we have to perform the upgrade and extract the auth
+			// token from the first message before we can audit the request
+			obj, err = s.wrapWebsocketHandler(s.auditHandler(handler))(resp, req)
+		} else {
+			obj, err = s.auditHandler(handler)(resp, req)
+		}
 
 		// Check for an error
 	HAS_ERR:
@@ -811,7 +821,6 @@ func (s *HTTPServer) wrap(handler func(resp http.ResponseWriter, req *http.Reque
 			resp.Write(buf.Bytes())
 		}
 	}
-	return f
 }
 
 // wrapNonJSON is used to wrap functions returning non JSON
@@ -1016,8 +1025,9 @@ func parseInt(req *http.Request, field string) (*int, error) {
 	return nil, nil
 }
 
-// parseToken is used to parse the X-Nomad-Token param
+// parseToken is used to get an authentication token from the request
 func (s *HTTPServer) parseToken(req *http.Request, token *string) {
+
 	if other := req.Header.Get("X-Nomad-Token"); other != "" {
 		*token = strings.TrimSpace(other)
 		return
@@ -1040,7 +1050,18 @@ func (s *HTTPServer) parseToken(req *http.Request, token *string) {
 				// Since Bearer tokens shouldn't contain spaces (rfc6750#section-2.1)
 				// "value" is tokenized, only the first item is used
 				*token = strings.TrimSpace(strings.Split(value, " ")[0])
+				return
 			}
+		}
+	}
+
+	// Websocket requests may not have an auth header if they came from a
+	// browser, so extract the token from the request context added when we
+	// upgraded the connection instead
+	if ctxVal := req.Context().Value("ws_auth_token"); ctxVal != nil {
+		if ctxToken, ok := ctxVal.(string); ok && ctxToken != "" {
+			*token = ctxToken
+			return
 		}
 	}
 }

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -1058,7 +1058,7 @@ func (s *HTTPServer) parseToken(req *http.Request, token *string) {
 	// Websocket requests may not have an auth header if they came from a
 	// browser, so extract the token from the request context added when we
 	// upgraded the connection instead
-	if ctxVal := req.Context().Value("ws_auth_token"); ctxVal != nil {
+	if ctxVal := req.Context().Value(ctxKeyWebSocketAuthToken); ctxVal != nil {
 		if ctxToken, ok := ctxVal.(string); ok && ctxToken != "" {
 			*token = ctxToken
 			return

--- a/command/agent/job_endpoint.go
+++ b/command/agent/job_endpoint.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 
 	"github.com/golang/snappy"
-	"github.com/gorilla/websocket"
 	"github.com/hashicorp/nomad/acl"
 	api "github.com/hashicorp/nomad/api"
 	cstructs "github.com/hashicorp/nomad/client/structs"
@@ -400,14 +399,8 @@ func (s *HTTPServer) jobRunAction(resp http.ResponseWriter, req *http.Request, j
 	}
 	s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
 
-	conn, err := s.wsUpgrader.Upgrade(resp, req, nil)
+	conn, err := s.getWebsocketConnection(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to upgrade connection: %v", err)
-	}
-
-	if err := readWsHandshake(conn.ReadJSON, req, &args.QueryOptions); err != nil {
-		conn.WriteMessage(websocket.CloseMessage,
-			websocket.FormatCloseMessage(toWsCode(400), err.Error()))
 		return nil, err
 	}
 

--- a/command/agent/websockets.go
+++ b/command/agent/websockets.go
@@ -1,0 +1,123 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package agent
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	ctxKeyWebSocketConn      = "ws_connection"
+	ctxKeyWebSocketAuthToken = "ws_auth_token"
+)
+
+// isWebsocketUpgrade checks if the request is a websocket upgrade request
+func isWebsocketUpgrade(req *http.Request) bool {
+	return req.Header.Get("Upgrade") == "websocket" &&
+		strings.Contains(strings.ToLower(req.Header.Get("Connection")), "upgrade")
+}
+
+// wrapWebsocketHandler upgrades the HTTP connection to a websocket. Auditing
+// for websockets gets complicated because browsers won't send the X-Nomad-Token
+// header and only authenticate via the first message. This means we have to
+// upgrade the connection, write audit logs, and then hand off the
+// already-upgraded connection to the handler. We pass the connection and the
+// auth token via request context.
+func (s *HTTPServer) wrapWebsocketHandler(handler handlerFn) handlerFn {
+	return func(w http.ResponseWriter, req *http.Request) (any, error) {
+
+		// Upgrade the connection
+		conn, err := s.wsUpgrader.Upgrade(w, req, nil)
+		if err != nil {
+
+			return "", fmt.Errorf("failed to upgrade connection: %v", err)
+		}
+
+		token, err := s.readWsHandshake(conn.ReadJSON, req)
+		if err != nil {
+			conn.WriteMessage(websocket.CloseMessage,
+				websocket.FormatCloseMessage(toWsCode(400), err.Error()))
+			return "", err
+		}
+
+		// Store connection and token in context for handler to use
+		ctx := req.Context()
+		ctx = context.WithValue(ctx, ctxKeyWebSocketConn, conn)
+		ctx = context.WithValue(ctx, ctxKeyWebSocketAuthToken, token)
+		*req = *req.WithContext(ctx)
+
+		obj, err := handler(w, req)
+
+		if err != nil {
+			code, errMsg := errCodeFromHandler(err)
+			conn.WriteMessage(websocket.CloseMessage,
+				websocket.FormatCloseMessage(toWsCode(code), errMsg))
+			return "", err
+		}
+
+		return obj, nil
+	}
+}
+
+type wsHandshakeMessage struct {
+	Version   int    `json:"version"`
+	AuthToken string `json:"auth_token"`
+}
+
+// readWsHandshake reads the websocket handshake message and returns the auth token
+func (s *HTTPServer) readWsHandshake(readFn func(interface{}) error, req *http.Request) (string, error) {
+	// Avoid handshake if request doesn't require one
+	if hv := req.URL.Query().Get("ws_handshake"); hv == "" {
+		return "", nil
+	} else if h, err := strconv.ParseBool(hv); err != nil {
+		return "", fmt.Errorf("ws_handshake value is not a boolean: %v", err)
+	} else if !h {
+		return "", nil
+	}
+
+	// verify that any header token set by a non-browser client agrees with the
+	// auth header
+	reqToken := new(string)
+	s.parseToken(req, reqToken)
+
+	var h wsHandshakeMessage
+	err := readFn(&h)
+	if err != nil {
+		return "", err
+	}
+
+	if reqToken != nil && *reqToken != "" && *reqToken != h.AuthToken {
+		return "", fmt.Errorf("handshake auth token mismatched auth header token")
+	}
+
+	supportedWSHandshakeVersion := 1
+	if h.Version != supportedWSHandshakeVersion {
+		return "", fmt.Errorf("unexpected handshake value: %v", h.Version)
+	}
+
+	return h.AuthToken, nil
+}
+
+// getWebsocketConnection retrieves the websocket connection from context
+func (s *HTTPServer) getWebsocketConnection(req *http.Request) (*websocket.Conn, error) {
+	ctx := req.Context()
+
+	// Get websocket connection from context (set by audit wrapper)
+	connRaw := ctx.Value(ctxKeyWebSocketConn)
+	if connRaw == nil {
+		return nil, fmt.Errorf("websocket connection not found in context")
+	}
+	conn, ok := connRaw.(*websocket.Conn)
+	if !ok {
+		return nil, fmt.Errorf("invalid websocket connection in context")
+	}
+
+	return conn, nil
+}

--- a/command/agent/websockets.go
+++ b/command/agent/websockets.go
@@ -20,8 +20,8 @@ const (
 
 // isWebsocketUpgrade checks if the request is a websocket upgrade request
 func isWebsocketUpgrade(req *http.Request) bool {
-	return req.Header.Get("Upgrade") == "websocket" &&
-		strings.Contains(strings.ToLower(req.Header.Get("Connection")), "upgrade")
+	return strings.EqualFold(req.Header.Get("Upgrade"), "websocket") &&
+		strings.EqualFold(req.Header.Get("Connection"), "upgrade")
 }
 
 // wrapWebsocketHandler upgrades the HTTP connection to a websocket. Auditing

--- a/command/agent/websockets_test.go
+++ b/command/agent/websockets_test.go
@@ -1,0 +1,222 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package agent
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+	"github.com/hashicorp/nomad/ci"
+	cstructs "github.com/hashicorp/nomad/client/structs"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+// TestHTTP_WrapWebsocketHandler exercises the the wrapper for the websockets,
+// making sure that the inner handler gets the auth token
+func TestHTTP_WrapWebsocketHandler(t *testing.T) {
+	ci.Parallel(t)
+
+	httpACLTest(t, nil, func(ta *TestAgent) {
+		s := ta.Server
+
+		rpcHandler := mockStreamingRpcHandler(t, [][]byte{
+			[]byte("one"), []byte("two"), []byte("done!")})
+
+		wsHandler := func(resp http.ResponseWriter, req *http.Request) (any, error) {
+			args := cstructs.AllocExecRequest{
+				AllocID: uuid.Generate(),
+				Task:    "foo",
+				Cmd:     []string{"bar"},
+			}
+			s.parse(resp, req, &args.QueryOptions.Region, &args.QueryOptions)
+
+			conn, err := s.getWebsocketConnection(req)
+			if err != nil {
+				return nil, err
+			}
+			if args.QueryOptions.AuthToken != ta.RootToken.SecretID {
+				return nil, structs.ErrPermissionDenied
+			}
+
+			_, err = s.execStreamImpl(conn, &args, rpcHandler)
+			return nil, err
+		}
+
+		srv := httptest.NewServer(http.HandlerFunc(s.wrap(wsHandler)))
+		t.Cleanup(srv.Close)
+
+		cases := []struct {
+			name        string
+			msgToken    string
+			headerToken string
+			expectMsg   []string
+			expectErr   string
+		}{
+			{
+				name:      "token from browser",
+				msgToken:  ta.RootToken.SecretID,
+				expectMsg: []string{"one", "two", "done!"},
+			},
+			{
+				name:        "token from CLI",
+				headerToken: ta.RootToken.SecretID,
+				expectMsg:   []string{"one", "two", "done!"},
+			},
+			{
+				name:      "unauthenticated",
+				expectErr: "Permission denied",
+				expectMsg: []string{"websocket: close 1008 (policy violation): Permission denied"},
+			},
+			{
+				name:        "attempted mismatch token",
+				headerToken: ta.RootToken.SecretID,
+				msgToken:    uuid.Generate(),
+				expectMsg:   []string{"websocket: close 1008 (policy violation): handshake auth token mismatched auth header token"},
+			},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+
+				url := strings.Replace(srv.URL, "http://", "ws://", 1)
+				var conn *websocket.Conn
+				var err error
+
+				switch {
+				case tc.headerToken != "" && tc.msgToken != "":
+					url += "?ws_handshake=1"
+					h := http.Header{}
+					h.Set("X-Nomad-Token", tc.headerToken)
+					conn, _, err = websocket.DefaultDialer.Dial(url, h)
+					must.NoError(t, err, must.Sprint("failed to dial"))
+					handshake := wsHandshakeMessage{Version: 1, AuthToken: tc.msgToken}
+					must.NoError(t, conn.WriteJSON(handshake))
+
+				case tc.headerToken != "":
+					h := http.Header{}
+					h.Set("X-Nomad-Token", tc.headerToken)
+					conn, _, err = websocket.DefaultDialer.Dial(url, h)
+					must.NoError(t, err, must.Sprint("failed to dial"))
+
+				case tc.msgToken != "":
+					url += "?ws_handshake=1"
+					conn, _, err = websocket.DefaultDialer.Dial(url, nil)
+					must.NoError(t, err, must.Sprint("failed to dial"))
+					handshake := wsHandshakeMessage{Version: 1, AuthToken: tc.msgToken}
+					must.NoError(t, conn.WriteJSON(handshake))
+
+				default:
+					conn, _, err = websocket.DefaultDialer.Dial(url, nil)
+					must.NoError(t, err, must.Sprint("failed to dial"))
+				}
+
+				t.Cleanup(func() { _ = conn.Close() })
+
+				drainConn := func() []string {
+					resp := []string{}
+
+					for {
+						select {
+						case <-t.Context().Done():
+							return resp
+						default:
+							_, message, err := conn.ReadMessage()
+							if err != nil {
+								if !isClosedError(err) {
+									resp = append(resp, err.Error())
+									return resp
+								}
+								return resp
+							}
+							resp = append(resp, string(message))
+						}
+					}
+				}
+				resp := drainConn()
+				must.SliceContainsAll(t, tc.expectMsg, resp, must.Sprintf("%+v", resp))
+			})
+		}
+
+	})
+
+}
+
+// TestHTTP_ReadWsHandshake exercises the extracting the auth token from the
+// websocket handshake
+func TestHTTP_ReadWsHandshake(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name        string
+		token       string
+		handshake   bool
+		headerToken string
+		expectErr   string
+	}{
+		{
+			name:      "plain compatible mode",
+			token:     "",
+			handshake: false,
+		},
+		{
+			name:      "handshake unauthenticated",
+			token:     "",
+			handshake: true,
+		},
+		{
+			name:      "handshake authenticated",
+			token:     "mysupersecret",
+			handshake: true,
+		},
+		{
+			name:        "handshake mismatch",
+			token:       "mysupersecret",
+			handshake:   true,
+			headerToken: "evil",
+			expectErr:   "handshake auth token mismatched auth header token",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			called := false
+			readFn := func(h interface{}) error {
+				called = true
+				if !tc.handshake {
+					return fmt.Errorf("should not be called")
+				}
+
+				hm := h.(*wsHandshakeMessage)
+				hm.Version = 1
+				hm.AuthToken = tc.token
+				return nil
+			}
+
+			req := httptest.NewRequest(http.MethodPut, "/target", nil)
+			if tc.handshake {
+				req.URL.RawQuery = "ws_handshake=true"
+			}
+			if tc.headerToken != "" {
+				req.Header.Add("X-Nomad-Token", tc.headerToken)
+			}
+
+			s := &HTTPServer{}
+			authToken, err := s.readWsHandshake(readFn, req)
+			if tc.expectErr != "" {
+				must.EqError(t, err, tc.expectErr)
+				must.Eq(t, "", authToken)
+			} else {
+				must.NoError(t, err)
+				must.Eq(t, tc.token, authToken)
+			}
+			must.Eq(t, tc.handshake, called)
+		})
+	}
+}


### PR DESCRIPTION
The browser Websocket API does not allow adding headers outside of those used to control the connection upgrade. This means that the browser can't add the usual `X-Nomad-Token` header. So in order to authenticate websocket requests for `alloc exec`, we have the browser send an initial websocket handshake message that includes the auth token. But because the audit wrapper happens before we upgrade, this results in all websocket requests coming from the browser being marked as anonymous in Nomad Enterprise audit logs.

Add a new `wrapWebsockethandler` middleware that sits between the `wrap` middleware and the `auditHandler` middleware. When the request is a websocket upgrade, we'll perform the upgrade and then pull off the first message to find the auth token. The resulting connection and token will get stuffed into the request context. The token in context is made accessible via `parseToken`, and the connection can be accessed by the innermost handler via a helper function.

Fixes: https://hashicorp.atlassian.net/browse/NMD-662

### Testing & Reproduction steps

Testing this thoroughly requires a bunch of different configurations. But the test is to run any job and then `alloc exec` into its allocation from the command line and do the same from the browser. You should successfully exec into the container. Or if the token is invalid, you should get an expected error.

**Test cases**

- :heavy_check_mark: Nomad CE with ACLs disabled, from the CLI
- :heavy_check_mark: Nomad CE with ACLs disabled, from the browser
- :heavy_check_mark: Nomad CE with ACLs enabled, using a valid token, from the CLI
- :heavy_check_mark: Nomad CE with ACLs enabled, using a valid token, from the browser
- :heavy_check_mark: Nomad CE with ACLs enabled, missing a token, from the CLI (expect failure)
- :heavy_check_mark: Nomad CE with ACLs enabled, missing a token, from the browser (expect cannot see page)
- :heavy_check_mark: Nomad CE with ACLs enabled, unauthorized token, from the CLI (expect failure)
- :heavy_check_mark: Nomad CE with ACLs enabled, unauthorized token, from the browser (expect disabled)
- :heavy_check_mark: Nomad Enterprise with ACLs disabled (lol), from the CLI
- :heavy_check_mark: Nomad Enterprise with ACLs disabled, from the browser
- :heavy_check_mark: Nomad Enterprise with ACLs enabled, using a valid token, from the CLI, make sure audit logs are good
- :heavy_check_mark: Nomad Enterprise with ACLs enabled, using a valid token, from the browser, make sure audit logs are good
- :heavy_check_mark: Nomad Enterprise with ACLs enabled, missing a token, from the CLI (expect failure)
- :heavy_check_mark: Nomad Enterprise with ACLs enabled, missing a token, from the browser (expect failure)
- :heavy_check_mark: Nomad Enterprise with ACLs enabled, unauthorized token, from the CLI (expect failure)
- :heavy_check_mark: Nomad Enterprise with ACLs enabled, unauthorized token, from the browser (expect failure)

The Nomad Enterprise configuration, with audit logging enabled to send logs to `/tmp/nomad-audit.log`

<details><summary>config.hcl</summary>

```hcl
acl {
  enabled = true
}

audit {
  enabled = true

  # these are super noisy
  filter "alloc-stats" {
    type       = "HTTPEvent"
    endpoints  = ["/v1/client/allocation/*/stats"]
    stages     = ["*"]
    operations = ["GET"]
  }

  sink "audit" {
    type               = "file"
    delivery_guarantee = "enforced"
    format             = "json"
    path               = "/tmp/nomad-audit.log"
    mode               = "0666"
    rotate_duration    = "24h"
    rotate_max_files   = 1
  }
}
```

</details>

<details><summary>Examples of resulting audit logs</summary>

Audit log events from CLI:

```
{"created_at":"2026-05-21T15:54:30.200230874-04:00","event_type":"audit","payload":{"id":"4deb7cb2-4e3a-7eb4-9848-68ee6b674243","stage":"OperationReceived","type":"audit","timestamp":"2026-05-21T15:54:30.199841551-04:00","version":1,"auth":{"accessor_id":"fe971f8a-d53f-c3a0-439f-419be2b61c21","name":"operator","policies":["operator"],"create_time":"2026-05-21T19:53:15.74594023Z"},"request":{"id":"d3eb9591-315b-90fc-5534-794d8715c951","operation":"GET","endpoint":"/v1/client/allocation/1a73fb75-cc80-3bb4-1234-e4e9eeee59c6/exec?command=%5B%22%2Fbin%2Fsh%22%5D\u0026region=global\u0026task=task\u0026tty=true","namespace":{"id":"default"},"request_meta":{"remote_address":"192.168.1.194:38878","user_agent":"Go-http-client/1.1"},"node_meta":{"ip":"192.168.1.194:4646"}}}}
{"created_at":"2026-05-21T15:54:32.537903799-04:00","event_type":"audit","payload":{"id":"4deb7cb2-4e3a-7eb4-9848-68ee6b674243","stage":"OperationComplete","type":"audit","timestamp":"2026-05-21T15:54:30.199841551-04:00","version":1,"auth":{"accessor_id":"fe971f8a-d53f-c3a0-439f-419be2b61c21","name":"operator","policies":["operator"],"create_time":"2026-05-21T19:53:15.74594023Z"},"request":{"id":"d3eb9591-315b-90fc-5534-794d8715c951","operation":"GET","endpoint":"/v1/client/allocation/1a73fb75-cc80-3bb4-1234-e4e9eeee59c6/exec?command=%5B%22%2Fbin%2Fsh%22%5D\u0026region=global\u0026task=task\u0026tty=true","namespace":{"id":"default"},"request_meta":{"remote_address":"192.168.1.194:38878","user_agent":"Go-http-client/1.1"},"node_meta":{"ip":"192.168.1.194:4646"}},"response":{"status_code":200}}}
```

Audit log events from UI:

```
{"created_at":"2026-05-21T15:55:10.378517099-04:00","event_type":"audit","payload":{"id":"ea9736fb-30a5-3d3f-7e6a-5c993f65803a","stage":"OperationReceived","type":"audit","timestamp":"2026-05-21T15:55:10.377929172-04:00","version":1,"auth":{"accessor_id":"fe971f8a-d53f-c3a0-439f-419be2b61c21","name":"operator","policies":["operator"],"create_time":"2026-05-21T19:53:15.74594023Z"},"request":{"id":"65116771-8cb1-6df0-7aed-d5b2c8d44965","operation":"GET","endpoint":"/v1/client/allocation/1a73fb75-cc80-3bb4-1234-e4e9eeee59c6/exec?task=task\u0026tty=true\u0026ws_handshake=true\u0026region=global\u0026command=%5B%22%2Fbin%2Fsh%22%5D","namespace":{"id":"default"},"request_meta":{"remote_address":"[::1]:33358","user_agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"},"node_meta":{"ip":"192.168.1.194:4646"}}}}
{"created_at":"2026-05-21T15:55:13.626849425-04:00","event_type":"audit","payload":{"id":"ea9736fb-30a5-3d3f-7e6a-5c993f65803a","stage":"OperationComplete","type":"audit","timestamp":"2026-05-21T15:55:10.377929172-04:00","version":1,"auth":{"accessor_id":"fe971f8a-d53f-c3a0-439f-419be2b61c21","name":"operator","policies":["operator"],"create_time":"2026-05-21T19:53:15.74594023Z"},"request":{"id":"65116771-8cb1-6df0-7aed-d5b2c8d44965","operation":"GET","endpoint":"/v1/client/allocation/1a73fb75-cc80-3bb4-1234-e4e9eeee59c6/exec?task=task\u0026tty=true\u0026ws_handshake=true\u0026region=global\u0026command=%5B%22%2Fbin%2Fsh%22%5D","namespace":{"id":"default"},"request_meta":{"remote_address":"[::1]:33358","user_agent":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"},"node_meta":{"ip":"192.168.1.194:4646"}},"response":{"status_code":200}}}
```

Permission denied audit log events from CLI: 

```
{"created_at":"2026-05-21T15:55:50.924919023-04:00","event_type":"audit","payload":{"id":"93afe3a0-fb83-4c72-cc04-3c60a496e4f8","stage":"OperationReceived","type":"audit","timestamp":"2026-05-21T15:55:50.924552346-04:00","version":1,"auth":{"accessor_id":"40815e0e-3976-dfe4-5b97-cff3da5eca93","name":"developer","policies":["developer"],"create_time":"2026-05-21T19:53:15.687427626Z"},"request":{"id":"d60aa3c7-2a48-03d2-fb7a-9ee7b3d266db","operation":"GET","endpoint":"/v1/client/allocation/1a73fb75-cc80-3bb4-1234-e4e9eeee59c6/exec?command=%5B%22%2Fbin%2Fsh%22%5D\u0026region=global\u0026task=task\u0026tty=true","namespace":{"id":"default"},"request_meta":{"remote_address":"192.168.1.194:49520","user_agent":"Go-http-client/1.1"},"node_meta":{"ip":"192.168.1.194:4646"}}}}
{"created_at":"2026-05-21T15:55:50.926397766-04:00","event_type":"audit","payload":{"id":"93afe3a0-fb83-4c72-cc04-3c60a496e4f8","stage":"OperationComplete","type":"audit","timestamp":"2026-05-21T15:55:50.924552346-04:00","version":1,"auth":{"accessor_id":"40815e0e-3976-dfe4-5b97-cff3da5eca93","name":"developer","policies":["developer"],"create_time":"2026-05-21T19:53:15.687427626Z"},"request":{"id":"d60aa3c7-2a48-03d2-fb7a-9ee7b3d266db","operation":"GET","endpoint":"/v1/client/allocation/1a73fb75-cc80-3bb4-1234-e4e9eeee59c6/exec?command=%5B%22%2Fbin%2Fsh%22%5D\u0026region=global\u0026task=task\u0026tty=true","namespace":{"id":"default"},"request_meta":{"remote_address":"192.168.1.194:49520","user_agent":"Go-http-client/1.1"},"node_meta":{"ip":"192.168.1.194:4646"}},"response":{"status_code":500,"error":"Permission denied"}}}
```


</details>


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
