### PR TITLE
fix accessibility: Associate label with input in drain-popover component

### DIFF
--- a/.changelog/28029.txt
+++ b/.changelog/28029.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed the drain popover deadline field so its label is properly associated with the input for improved accessibility
+```

--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,4 +1,4 @@
-# Copyright IBM Corp. 2015, 2025
+# Copyright IBM Corp. 2015, 2026
 # SPDX-License-Identifier: BUSL-1.1
 
 schema_version = 1

--- a/ui/app/components/drain-popover.hbs
+++ b/ui/app/components/drain-popover.hbs
@@ -62,8 +62,9 @@
       </div>
       {{#if this.durationIsCustom}}
         <div class="field is-sub-field">
-          <label class="label">Deadline</label>
+          <label class="label" for="drain-custom-deadline-input">Deadline</label>
           <input
+            id="drain-custom-deadline-input"
             data-test-drain-custom-deadline
             type="text"
             class="input {{if this.parseError 'is-danger'}}"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015, 2025
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package version


### PR DESCRIPTION

### Description
This PR fixes an accessibility issue in the drain-popover component where the "Deadline" label and its associated input field were not programmatically connected. This violates WCAG 2.1 Success Criteria 4.1.2 (Name, Role, Value - Level A) and 2.4.6 (Headings and Labels - Level AA).

**Changes:**
- Added `id="drain-custom-deadline-input"` to the custom deadline input element
- Added `for="drain-custom-deadline-input"` to the corresponding label element

This creates proper programmatic association between the form control and its label, ensuring:
- Screen readers properly announce the field purpose when focused
- Users can click the label to focus the input field
- Compliance with WCAG 2.1 Level AA accessibility standards

### Testing & Reproduction steps

**Manual Testing:**
1. Navigate to Clients → select any client
2. Click the "Drain" button to open the drain popover
3. Toggle "Deadline" ON
4. Select "Custom" from the deadline dropdown
5. **Verify the fix:**
   - Click on the "Deadline" label text → the input field should receive focus
   - Inspect element in DevTools → verify `for` attribute on label matches `id` attribute on input

**Automated Testing:**
- Existing tests continue to pass as they use `data-test-*` attributes which remain unchanged
- No new tests required as this is a markup-only accessibility fix

### Links
- Jira : https://hashicorp.atlassian.net/browse/NMD-1468

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught. *(No new tests needed - existing tests cover functionality, this is a markup-only accessibility fix)*
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR. *(No documentation changes needed - internal accessibility improvement)*

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

No changes to security controls. This PR only adds accessibility attributes (`id` and `for`) to improve form label-input association for assistive technologies. No changes to access controls, encryption, or logging.