### PR TITLE
batch job queue: add api for querying status of a batch job queue

### DIFF
--- a/api/jobs_batch_queue.go
+++ b/api/jobs_batch_queue.go
@@ -15,9 +15,9 @@ type DynamicPriorityWorkload struct {
 
 type QueueStatusResponse struct {
 	Type BatchQueueType
-	// Workloads are the actual queue workloads
-	// where their actual type is based on the
-	// "Type" parameter above.
+	// Workloads contains data about a specific queue
+	// that is important to a consumer of this API.
+	// The struct type is based on the "Type" parameter.
 	Workloads any
 }
 

--- a/api/jobs_batch_queue.go
+++ b/api/jobs_batch_queue.go
@@ -8,7 +8,7 @@ type DynamicPriorityWorkload struct {
 	Tenant           string
 	AdjustedPriority int
 	BasePriority     int
-	UsageAjustment   int
+	UsageAdjustment  int
 	AgeAdjustment    int
 	SizeAdjustment   int
 }

--- a/api/jobs_batch_queue.go
+++ b/api/jobs_batch_queue.go
@@ -3,8 +3,6 @@
 
 package api
 
-type DynamicPriorityStatus []DynamicPriorityWorkload
-
 type DynamicPriorityWorkload struct {
 	JobID            string
 	Tenant           string
@@ -15,11 +13,12 @@ type DynamicPriorityWorkload struct {
 	SizeAdjustment   int
 }
 
-type BatchQueueStatus any
-
 type QueueStatusResponse struct {
-	Type   BatchQueueType
-	Status BatchQueueStatus
+	Type BatchQueueType
+	// Workloads are the actual queue workloads
+	// where their actual type is based on the
+	// "Type" parameter above.
+	Workloads any
 }
 
 type BatchQueueStatusOptions struct{}

--- a/api/jobs_batch_queue.go
+++ b/api/jobs_batch_queue.go
@@ -3,21 +3,30 @@
 
 package api
 
-type Workload struct {
-	JobID    string
-	Tenant   string
-	Priority int
+type DynamicPriorityStatus []DynamicPriorityWorkload
+
+type DynamicPriorityWorkload struct {
+	JobID            string
+	Tenant           string
+	AdjustedPriority int
+	BasePriority     int
+	UsageAjustment   int
+	AgeAdjustment    int
+	SizeAdjustment   int
 }
 
-type BatchQueueStatusResponse struct {
-	Workloads []Workload
+type BatchQueueStatus any
+
+type QueueStatusResponse struct {
+	Type   BatchQueueType
+	Status BatchQueueStatus
 }
 
 type BatchQueueStatusOptions struct{}
 
 // BatchQueueStatus is used to query the current batch job queue.
-func (j *Jobs) BatchQueueStatus(opts *BatchQueueStatusOptions, q *QueryOptions) (*BatchQueueStatusResponse, *QueryMeta, error) {
-	var resp BatchQueueStatusResponse
+func (j *Jobs) BatchQueueStatus(opts *BatchQueueStatusOptions, q *QueryOptions) (*QueueStatusResponse, *QueryMeta, error) {
+	var resp QueueStatusResponse
 	qm, err := j.client.query("/v1/jobs/queue/status", &resp, q)
 	if err != nil {
 		return nil, nil, err

--- a/api/jobs_batch_queue.go
+++ b/api/jobs_batch_queue.go
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2015, 2026
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MPL-2.0
 
 package api
 

--- a/api/jobs_batch_queue_test.go
+++ b/api/jobs_batch_queue_test.go
@@ -17,7 +17,7 @@ func TestJobs_BatchQueue_Status(t *testing.T) {
 	defer s.Stop()
 	jobs := c.Jobs()
 
-	// Listing jobs before registering returns nothing
+	// The passthrough queue just returns the unset type
 	resp, _, err := jobs.BatchQueueStatus(nil, nil)
 	must.NoError(t, err)
 	must.Eq(t, resp.Type, "unset")

--- a/api/jobs_batch_queue_test.go
+++ b/api/jobs_batch_queue_test.go
@@ -1,5 +1,5 @@
 // Copyright IBM Corp. 2015, 2026
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MPL-2.0
 
 package api
 

--- a/api/jobs_batch_queue_test.go
+++ b/api/jobs_batch_queue_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package api
 
 import (

--- a/api/jobs_batch_queue_test.go
+++ b/api/jobs_batch_queue_test.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/api/internal/testutil"
+	"github.com/shoenig/test/must"
+)
+
+func TestJobs_BatchQueue_Status(t *testing.T) {
+	testutil.Parallel(t)
+
+	c, s := makeClient(t, nil, nil)
+	defer s.Stop()
+	jobs := c.Jobs()
+
+	// Listing jobs before registering returns nothing
+	resp, _, err := jobs.BatchQueueStatus(nil, nil)
+	must.NoError(t, err)
+	must.Eq(t, resp.Type, "unset")
+}

--- a/api/operator.go
+++ b/api/operator.go
@@ -235,7 +235,7 @@ const (
 	SchedulerAlgorithmBinpack SchedulerAlgorithm = "binpack"
 	SchedulerAlgorithmSpread  SchedulerAlgorithm = "spread"
 
-	BatchQueueTypeDynamic BatchQueueType = "dynamicPriority"
+	BatchQueueTypeDynamic BatchQueueType = "dynamic_priority"
 
 	TenantTypeMetadata  BatchQueueTenant = "metadata"
 	TenantTypeNamespace BatchQueueTenant = "namespace"

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -404,6 +404,7 @@ func (s *HTTPServer) registerHandlers(enableDebug bool) {
 	s.mux.HandleFunc("/v1/jobs", s.wrap(s.JobsRequest))
 	s.mux.HandleFunc("/v1/jobs/parse", s.wrap(s.JobsParseRequest))
 	s.mux.HandleFunc("/v1/jobs/statuses", s.wrap(s.JobStatusesRequest))
+	s.mux.HandleFunc("/v1/jobs/queue/status", s.wrap(s.JobQueueStatus))
 	s.mux.HandleFunc("/v1/job/", s.wrap(s.JobSpecificRequest))
 
 	s.mux.HandleFunc("/v1/nodes", s.wrap(s.NodesRequest))

--- a/command/agent/job_queue_status.go
+++ b/command/agent/job_queue_status.go
@@ -29,5 +29,5 @@ func (s *HTTPServer) JobQueueStatus(resp http.ResponseWriter, req *http.Request)
 	}
 
 	setMeta(resp, &out.QueryMeta)
-	return out.Status, nil
+	return out, nil
 }

--- a/command/agent/job_queue_status.go
+++ b/command/agent/job_queue_status.go
@@ -1,5 +1,11 @@
 package agent
 
+import (
+	"net/http"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
 func (s *HTTPServer) JobQueueStatus(resp http.ResponseWriter, req *http.Request) (any, error) {
 	switch req.Method {
 	case http.MethodGet:

--- a/command/agent/job_queue_status.go
+++ b/command/agent/job_queue_status.go
@@ -1,0 +1,24 @@
+package agent
+
+func (s *HTTPServer) JobQueueStatus(resp http.ResponseWriter, req *http.Request) (any, error) {
+	switch req.Method {
+	case http.MethodGet:
+		break
+	default:
+		return nil, CodedError(http.StatusMethodNotAllowed, ErrInvalidMethod)
+	}
+
+	var args structs.QueueStatusRequest
+	var out structs.QueueStatusResponse
+
+	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
+		return nil, nil
+	}
+
+	if err := s.agent.RPC("Job.QueueStatus", &args, &out); err != nil {
+		return nil, err
+	}
+
+	setMeta(resp, &out.QueryMeta)
+	return out.Status, nil
+}

--- a/command/agent/job_queue_status.go
+++ b/command/agent/job_queue_status.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package agent
 
 import (

--- a/command/agent/job_queue_status_test.go
+++ b/command/agent/job_queue_status_test.go
@@ -1,0 +1,36 @@
+package agent
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/shoenig/test/must"
+)
+
+func TestHTTP_JobsBatchQueue(t *testing.T) {
+	ci.Parallel(t)
+	httpTest(t, nil, func(s *TestAgent) {
+		// Make the HTTP request
+		req, err := http.NewRequest(http.MethodGet, "/v1/jobs/queue/status", nil)
+		must.NoError(t, err)
+		respW := httptest.NewRecorder()
+
+		// Make the request
+		_, err = s.Server.JobQueueStatus(respW, req)
+		must.NoError(t, err)
+
+		req.Method = http.MethodPost
+		_, err = s.Server.JobQueueStatus(respW, req)
+		must.Error(t, err)
+
+		req.Method = http.MethodPut
+		_, err = s.Server.JobQueueStatus(respW, req)
+		must.Error(t, err)
+
+		req.Method = http.MethodDelete
+		_, err = s.Server.JobQueueStatus(respW, req)
+		must.Error(t, err)
+	})
+}

--- a/command/agent/job_queue_status_test.go
+++ b/command/agent/job_queue_status_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package agent
 
 import (

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -318,6 +318,12 @@ func (s *HTTPServer) schedulerUpdateConfig(resp http.ResponseWriter, req *http.R
 			BatchSchedulerEnabled:    conf.PreemptionConfig.BatchSchedulerEnabled,
 			ServiceSchedulerEnabled:  conf.PreemptionConfig.ServiceSchedulerEnabled,
 		},
+		BatchQueue: structs.BatchQueue{
+			Type:        structs.BatchQueueType(conf.BatchQueue.Type),
+			TenantType:  structs.BatchQueueTenant(conf.BatchQueue.TenantType),
+			MetadataKey: conf.BatchQueue.MetadataKey,
+			Config:      conf.BatchQueue.Config,
+		},
 	}
 
 	if err := args.Config.Validate(); err != nil {

--- a/command/agent/operator_endpoint.go
+++ b/command/agent/operator_endpoint.go
@@ -318,12 +318,6 @@ func (s *HTTPServer) schedulerUpdateConfig(resp http.ResponseWriter, req *http.R
 			BatchSchedulerEnabled:    conf.PreemptionConfig.BatchSchedulerEnabled,
 			ServiceSchedulerEnabled:  conf.PreemptionConfig.ServiceSchedulerEnabled,
 		},
-		BatchQueue: structs.BatchQueue{
-			Type:        structs.BatchQueueType(conf.BatchQueue.Type),
-			TenantType:  structs.BatchQueueTenant(conf.BatchQueue.TenantType),
-			MetadataKey: conf.BatchQueue.MetadataKey,
-			Config:      conf.BatchQueue.Config,
-		},
 	}
 
 	if err := args.Config.Validate(); err != nil {

--- a/command/job_queue.go
+++ b/command/job_queue.go
@@ -164,7 +164,7 @@ func (c *JobQueueCommand) printDynamicQueueFormatted(resp []api.DynamicPriorityW
 			v.Tenant,
 			v.AdjustedPriority,
 			v.BasePriority,
-			v.UsageAjustment,
+			v.UsageAdjustment,
 			v.AgeAdjustment,
 			v.SizeAdjustment,
 		)

--- a/command/job_queue.go
+++ b/command/job_queue.go
@@ -91,7 +91,6 @@ func (c *JobQueueCommand) Run(args []string) int {
 	if limit > 0 {
 		qo.PerPage = int32(limit)
 	}
-	qo.Region = "global"
 
 	// Submit the request
 	resp, _, err := client.Jobs().BatchQueueStatus(nil, qo)
@@ -105,18 +104,18 @@ func (c *JobQueueCommand) Run(args []string) int {
 
 	switch resp.Type {
 	case api.BatchQueueTypeDynamic:
-		status := api.DynamicPriorityStatus{}
-		bytes, err := json.Marshal(resp.Status)
+		workloads := []api.DynamicPriorityWorkload{}
+		bytes, err := json.Marshal(resp.Workloads)
 		if err != nil {
 			c.Ui.Error("Error marshaling response status")
 			return 255
 		}
-		if err := json.Unmarshal(bytes, &status); err != nil {
+		if err := json.Unmarshal(bytes, &workloads); err != nil {
 			c.Ui.Error("Invalid Status response from server")
 			return 255
 		}
 
-		slices.SortFunc(status, func(a api.DynamicPriorityWorkload, b api.DynamicPriorityWorkload) int {
+		slices.SortFunc(workloads, func(a api.DynamicPriorityWorkload, b api.DynamicPriorityWorkload) int {
 			if a.AdjustedPriority < b.AdjustedPriority {
 				return 1
 			} else if b.AdjustedPriority < a.AdjustedPriority {
@@ -126,12 +125,12 @@ func (c *JobQueueCommand) Run(args []string) int {
 		})
 
 		if jsonOut {
-			if err := c.printDynamicQueueJSON(status); err != nil {
+			if err := c.printDynamicQueueJSON(workloads); err != nil {
 				c.Ui.Error("Error unmarshaling json response")
 				return 255
 			}
 		} else {
-			c.printDynamicQueueFormatted(status)
+			c.printDynamicQueueFormatted(workloads)
 		}
 	default:
 		c.Ui.Error("Unknown queue type")
@@ -141,7 +140,7 @@ func (c *JobQueueCommand) Run(args []string) int {
 	return 0
 }
 
-func (c *JobQueueCommand) printDynamicQueueJSON(resp api.DynamicPriorityStatus) error {
+func (c *JobQueueCommand) printDynamicQueueJSON(resp []api.DynamicPriorityWorkload) error {
 	out, err := json.Marshal(resp)
 	if err != nil {
 		return err
@@ -151,7 +150,7 @@ func (c *JobQueueCommand) printDynamicQueueJSON(resp api.DynamicPriorityStatus) 
 	return nil
 }
 
-func (c *JobQueueCommand) printDynamicQueueFormatted(resp api.DynamicPriorityStatus) {
+func (c *JobQueueCommand) printDynamicQueueFormatted(resp []api.DynamicPriorityWorkload) {
 	if resp == nil {
 		return
 	}

--- a/command/job_queue.go
+++ b/command/job_queue.go
@@ -132,8 +132,10 @@ func (c *JobQueueCommand) Run(args []string) int {
 		} else {
 			c.printDynamicQueueFormatted(workloads)
 		}
+	case "unset":
+		c.Ui.Output("No batch job queue configured")
 	default:
-		c.Ui.Error("Unknown queue type")
+		c.Ui.Error(fmt.Sprintf("Unknown queue type: %s", resp.Type))
 		return 255
 	}
 

--- a/command/job_queue.go
+++ b/command/job_queue.go
@@ -6,6 +6,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
@@ -65,12 +66,12 @@ func (c *JobQueueCommand) AutocompleteArgs() complete.Predictor {
 func (c *JobQueueCommand) Name() string { return "job queue" }
 
 func (c *JobQueueCommand) Run(args []string) int {
-	var verbose, json bool
+	var verbose, jsonOut bool
 	var limit int
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.BoolVar(&verbose, "verbose", false, "")
-	flags.BoolVar(&json, "json", false, "")
+	flags.BoolVar(&jsonOut, "json", false, "")
 	flags.IntVar(&limit, "limit", 0, "")
 
 	if err := flags.Parse(args); err != nil {
@@ -90,6 +91,7 @@ func (c *JobQueueCommand) Run(args []string) int {
 	if limit > 0 {
 		qo.PerPage = int32(limit)
 	}
+	qo.Region = "global"
 
 	// Submit the request
 	resp, _, err := client.Jobs().BatchQueueStatus(nil, qo)
@@ -101,19 +103,46 @@ func (c *JobQueueCommand) Run(args []string) int {
 		c.Ui.Error("Empty batch queue response")
 	}
 
-	if json {
-		if err := c.printJSON(resp); err != nil {
-			c.Ui.Error("Error unmarshaling json response")
+	switch resp.Type {
+	case api.BatchQueueTypeDynamic:
+		status := api.DynamicPriorityStatus{}
+		bytes, err := json.Marshal(resp.Status)
+		if err != nil {
+			c.Ui.Error("Error marshaling response status")
 			return 255
 		}
-	} else {
-		c.printFormatted(resp)
+		if err := json.Unmarshal(bytes, &status); err != nil {
+			c.Ui.Error("Invalid Status response from server")
+			return 255
+		}
+
+		slices.SortFunc(status, func(a api.DynamicPriorityWorkload, b api.DynamicPriorityWorkload) int {
+			if a.AdjustedPriority < b.AdjustedPriority {
+				return 1
+			} else if b.AdjustedPriority < a.AdjustedPriority {
+				return -1
+			}
+			return 0
+		})
+
+		if jsonOut {
+			if err := c.printDynamicQueueJSON(status); err != nil {
+				c.Ui.Error("Error unmarshaling json response")
+				return 255
+			}
+		} else {
+			c.printDynamicQueueFormatted(status)
+		}
+	default:
+		c.Ui.Error("Unknown queue type")
+		return 255
 	}
+
 	return 0
 }
 
-func (c *JobQueueCommand) printJSON(resp *api.BatchQueueStatusResponse) error {
-	out, err := json.Marshal(resp.Workloads)
+func (c *JobQueueCommand) printDynamicQueueJSON(resp api.DynamicPriorityStatus) error {
+	out, err := json.Marshal(resp)
 	if err != nil {
 		return err
 	}
@@ -122,13 +151,24 @@ func (c *JobQueueCommand) printJSON(resp *api.BatchQueueStatusResponse) error {
 	return nil
 }
 
-func (c *JobQueueCommand) printFormatted(resp *api.BatchQueueStatusResponse) {
+func (c *JobQueueCommand) printDynamicQueueFormatted(resp api.DynamicPriorityStatus) {
+	if resp == nil {
+		return
+	}
 
-	out := make([]string, len(resp.Workloads)+1)
-	out[0] = "JobID|Tenant|Priority"
+	out := make([]string, len(resp)+1)
+	out[0] = "JobID|Tenant|Adjusted Priority|Base Priority|Usage|Age|Size"
 
-	for i, v := range resp.Workloads {
-		out[i+1] = fmt.Sprintf("%s|%s|%d", v.JobID, v.Tenant, v.Priority)
+	for i, v := range resp {
+		out[i+1] = fmt.Sprintf("%s|%s|%d|%d|%d|%d|%d",
+			v.JobID,
+			v.Tenant,
+			v.AdjustedPriority,
+			v.BasePriority,
+			v.UsageAjustment,
+			v.AgeAdjustment,
+			v.SizeAdjustment,
+		)
 	}
 
 	c.Ui.Output(c.Colorize().Color("[bold]Batch Queue Workloads[reset]"))

--- a/command/job_queue_test.go
+++ b/command/job_queue_test.go
@@ -4,7 +4,6 @@
 package command
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/cli"
@@ -18,47 +17,44 @@ func TestJobQueue_Implements(t *testing.T) {
 	var _ cli.Command = &JobQueueCommand{}
 }
 
-func TestJobQueue_printFormatted(t *testing.T) {
+func TestJobQueue_printDynamicQueueFormatted(t *testing.T) {
 	ci.Parallel(t)
 	ui := cli.NewMockUi()
 	cmd := &JobQueueCommand{Meta: Meta{Ui: ui}}
 
-	testResp := &api.BatchQueueStatusResponse{
-		Workloads: []api.Workload{
-			{
-				JobID:    "123",
-				Tenant:   "testTenant1",
-				Priority: 5,
-			},
+	testResp := []api.DynamicPriorityWorkload{
+		{
+			JobID:            "123",
+			Tenant:           "testTenant1",
+			AdjustedPriority: 10,
+			BasePriority:     10,
 		},
 	}
-	cmd.printFormatted(testResp)
+	cmd.printDynamicQueueFormatted(testResp)
 
 	expect := "Batch Queue Workloads\n" +
-		"JobID  Tenant       Priority\n" +
-		"123    testTenant1  5\n"
+		"JobID  Tenant       Adjusted Priority  Base Priority  Usage  Age  Size\n" +
+		"123    testTenant1  10                 10             0      0    0\n"
 
-	fmt.Println(ui.OutputWriter.String())
 	must.Eq(t, expect, ui.OutputWriter.String())
 }
 
-func TestJobQueue_printJSON(t *testing.T) {
+func TestJobQueue_printDynamicQueueJSON(t *testing.T) {
 	ci.Parallel(t)
 	ui := cli.NewMockUi()
 	cmd := &JobQueueCommand{Meta: Meta{Ui: ui}}
 
-	testResp := &api.BatchQueueStatusResponse{
-		Workloads: []api.Workload{
-			{
-				JobID:    "123",
-				Tenant:   "testTenant1",
-				Priority: 5,
-			},
+	testResp := []api.DynamicPriorityWorkload{
+		{
+			JobID:            "123",
+			Tenant:           "testTenant1",
+			AdjustedPriority: 10,
+			BasePriority:     10,
 		},
 	}
-	cmd.printJSON(testResp)
+	cmd.printDynamicQueueJSON(testResp)
 
-	expect := "[{\"JobID\":\"123\",\"Tenant\":\"testTenant1\",\"Priority\":5}]\n"
+	expect := "[{\"JobID\":\"123\",\"Tenant\":\"testTenant1\",\"AdjustedPriority\":10,\"BasePriority\":10,\"UsageAdjustment\":0,\"AgeAdjustment\":0,\"SizeAdjustment\":0}]\n"
 
 	must.Eq(t, expect, ui.OutputWriter.String())
 }

--- a/command/job_queue_test.go
+++ b/command/job_queue_test.go
@@ -54,7 +54,7 @@ func TestJobQueue_printDynamicQueueJSON(t *testing.T) {
 	}
 	cmd.printDynamicQueueJSON(testResp)
 
-	expect := "[{\"JobID\":\"123\",\"Tenant\":\"testTenant1\",\"AdjustedPriority\":10,\"BasePriority\":10,\"UsageAdjustment\":0,\"AgeAdjustment\":0,\"SizeAdjustment\":0}]\n"
+	expect := `[{"JobID":"123","Tenant":"testTenant1","AdjustedPriority":10,"BasePriority":10,"UsageAdjustment":0,"AgeAdjustment":0,"SizeAdjustment":0}]` + "\n"
 
 	must.Eq(t, expect, ui.OutputWriter.String())
 }

--- a/nomad/job_endpoint_queue.go
+++ b/nomad/job_endpoint_queue.go
@@ -1,0 +1,19 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package nomad
+
+import "github.com/hashicorp/nomad/nomad/structs"
+
+func (j *Job) QueueStatus(args *structs.QueueStatusRequest, reply *structs.QueueStatusResponse) error {
+	authErr := j.srv.Authenticate(j.ctx, args)
+	if done, err := j.srv.forward("Job.QueueStatus", args, args, reply); done {
+		return err
+	}
+	if authErr != nil {
+		return structs.ErrPermissionDenied
+	}
+
+	reply.Status = j.srv.batchJobQueue.Status()
+	return nil
+}

--- a/nomad/job_endpoint_queue.go
+++ b/nomad/job_endpoint_queue.go
@@ -3,7 +3,9 @@
 
 package nomad
 
-import "github.com/hashicorp/nomad/nomad/structs"
+import (
+	"github.com/hashicorp/nomad/nomad/structs"
+)
 
 func (j *Job) QueueStatus(args *structs.QueueStatusRequest, reply *structs.QueueStatusResponse) error {
 	authErr := j.srv.Authenticate(j.ctx, args)
@@ -14,6 +16,9 @@ func (j *Job) QueueStatus(args *structs.QueueStatusRequest, reply *structs.Queue
 		return structs.ErrPermissionDenied
 	}
 
-	reply.Status = j.srv.batchJobQueue.Status()
+	status := j.srv.batchJobQueue.Status()
+
+	reply.Type = status.Type
+	reply.Workloads = status.Workloads
 	return nil
 }

--- a/nomad/job_endpoint_queue.go
+++ b/nomad/job_endpoint_queue.go
@@ -12,6 +12,7 @@ func (j *Job) QueueStatus(args *structs.QueueStatusRequest, reply *structs.Queue
 	if done, err := j.srv.forward("Job.QueueStatus", args, args, reply); done {
 		return err
 	}
+	j.srv.MeasureRPCRate("job", structs.RateMetricList, args)
 	if authErr != nil {
 		return structs.ErrPermissionDenied
 	}

--- a/nomad/job_endpoint_queue_test.go
+++ b/nomad/job_endpoint_queue_test.go
@@ -1,0 +1,55 @@
+package nomad
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
+	"github.com/stretchr/testify/mock"
+)
+
+type MockBatchQueue struct {
+	mock.Mock
+}
+
+func (m *MockBatchQueue) Enqueue(e *structs.Evaluation) {}
+
+func (m *MockBatchQueue) Start(context.Context) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *MockBatchQueue) Status() structs.QueueStatusResponse {
+	args := m.Called()
+	return args.Get(0).(structs.QueueStatusResponse)
+}
+
+func (m *MockBatchQueue) SetEnabled(bool, *state.StateStore) {}
+
+// Not much to test here at the moment
+func TestJob_BatchQueue(t *testing.T) {
+	s, cleanup := TestServer(t, nil)
+	t.Cleanup(cleanup)
+	testutil.WaitForLeader(t, s.RPC)
+
+	mockQueue := &MockBatchQueue{}
+	mockQueue.On("Status", mock.Anything).Return(structs.QueueStatusResponse{
+		Type:      "some_type",
+		Workloads: "some_workloads",
+	})
+	// swap the server's queue for a mock
+	s.batchJobQueue = mockQueue
+
+	req := structs.QueueStatusRequest{QueryOptions: structs.QueryOptions{
+		Region: "global",
+	}}
+	reply := structs.QueueStatusResponse{}
+
+	err := s.RPC("Job.QueueStatus", &req, &reply)
+	must.NoError(t, err)
+	must.Eq(t, reply.Type, "some_type")
+	must.Eq(t, reply.Workloads, "some_workloads")
+}

--- a/nomad/job_endpoint_queue_test.go
+++ b/nomad/job_endpoint_queue_test.go
@@ -29,5 +29,5 @@ func TestJob_BatchQueue(t *testing.T) {
 	err := s.RPC("Job.QueueStatus", &req, &reply)
 	must.NoError(t, err)
 	must.Eq(t, reply.Type, "unset")
-	must.Eq(t, reply.Workloads, nil)
+	must.Nil(t, reply.Workloads)
 }

--- a/nomad/job_endpoint_queue_test.go
+++ b/nomad/job_endpoint_queue_test.go
@@ -4,33 +4,13 @@
 package nomad
 
 import (
-	"context"
 	"testing"
 
-	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/queues"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/shoenig/test/must"
-	"github.com/stretchr/testify/mock"
 )
-
-type MockBatchQueue struct {
-	mock.Mock
-}
-
-func (m *MockBatchQueue) Enqueue(e *structs.Evaluation) {}
-
-func (m *MockBatchQueue) Start(context.Context) error {
-	args := m.Called()
-	return args.Error(0)
-}
-
-func (m *MockBatchQueue) Status() structs.QueueStatusResponse {
-	args := m.Called()
-	return args.Get(0).(structs.QueueStatusResponse)
-}
-
-func (m *MockBatchQueue) SetEnabled(bool, *state.StateStore) {}
 
 // Not much to test here at the moment
 func TestJob_BatchQueue(t *testing.T) {
@@ -38,13 +18,8 @@ func TestJob_BatchQueue(t *testing.T) {
 	t.Cleanup(cleanup)
 	testutil.WaitForLeader(t, s.RPC)
 
-	mockQueue := &MockBatchQueue{}
-	mockQueue.On("Status", mock.Anything).Return(structs.QueueStatusResponse{
-		Type:      "some_type",
-		Workloads: "some_workloads",
-	})
 	// swap the server's queue for a mock
-	s.batchJobQueue = mockQueue
+	s.batchJobQueue = &queues.PassthroughQueue{}
 
 	req := structs.QueueStatusRequest{QueryOptions: structs.QueryOptions{
 		Region: "global",
@@ -53,6 +28,6 @@ func TestJob_BatchQueue(t *testing.T) {
 
 	err := s.RPC("Job.QueueStatus", &req, &reply)
 	must.NoError(t, err)
-	must.Eq(t, reply.Type, "some_type")
-	must.Eq(t, reply.Workloads, "some_workloads")
+	must.Eq(t, reply.Type, "unset")
+	must.Eq(t, reply.Workloads, nil)
 }

--- a/nomad/job_endpoint_queue_test.go
+++ b/nomad/job_endpoint_queue_test.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package nomad
 
 import (

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -315,16 +315,16 @@ func (d *DynamicPriorityQueue) waitForPlacement(ctx context.Context, eval *struc
 	return nil
 }
 
-func (d *DynamicPriorityQueue) Status() structs.BatchQueueStatus {
+func (d *DynamicPriorityQueue) Status() structs.QueueStatusResponse {
 	d.qMux.Lock()
 	defer d.qMux.Unlock()
 
 	var resp structs.QueueStatusResponse
 	resp.Type = structs.BatchQueueTypeDynamic
 
-	status := structs.DynamicPriorityStatus{}
+	workloads := []structs.DynamicPriorityWorkload{}
 	for _, w := range d.queue {
-		status = append(status, structs.DynamicPriorityWorkload{
+		workloads = append(workloads, structs.DynamicPriorityWorkload{
 			JobID:            w.eval.JobID,
 			Tenant:           string(w.tid),
 			AdjustedPriority: w.priority,
@@ -334,7 +334,7 @@ func (d *DynamicPriorityQueue) Status() structs.BatchQueueStatus {
 			SizeAdjustment:   w.sizeAdjustment,
 		})
 	}
-	resp.Status = status
+	resp.Workloads = workloads
 
 	return resp
 }

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -84,6 +84,10 @@ type Workload struct {
 	eval     *structs.Evaluation
 	size     int
 	index    int
+
+	sizeAdjustment  int
+	ageAdjustment   int
+	usageAdjustment int
 }
 
 func (w *Workload) calculatePriority(_ int64) {
@@ -309,4 +313,28 @@ func (d *DynamicPriorityQueue) waitForPlacement(ctx context.Context, eval *struc
 	}
 
 	return nil
+}
+
+func (d *DynamicPriorityQueue) Status() structs.BatchQueueStatus {
+	d.qMux.Lock()
+	defer d.qMux.Unlock()
+
+	var resp structs.QueueStatusResponse
+	resp.Type = structs.BatchQueueTypeDynamic
+
+	status := structs.DynamicPriorityStatus{}
+	for _, w := range d.queue {
+		status = append(status, structs.DynamicPriorityWorkload{
+			JobID:            w.eval.JobID,
+			Tenant:           string(w.tid),
+			AdjustedPriority: w.priority,
+			BasePriority:     w.eval.Priority,
+			UsageAjustment:   w.usageAdjustment,
+			AgeAdjustment:    w.ageAdjustment,
+			SizeAdjustment:   w.sizeAdjustment,
+		})
+	}
+	resp.Status = status
+
+	return resp
 }

--- a/nomad/queues/interface.go
+++ b/nomad/queues/interface.go
@@ -13,7 +13,7 @@ import (
 type Queue interface {
 	Enqueue(*structs.Evaluation)
 	Start(context.Context) error
-	Status() structs.BatchQueueStatus
+	Status() structs.QueueStatusResponse
 	SetEnabled(bool, *state.StateStore)
 }
 

--- a/nomad/queues/interface.go
+++ b/nomad/queues/interface.go
@@ -13,6 +13,7 @@ import (
 type Queue interface {
 	Enqueue(*structs.Evaluation)
 	Start(context.Context) error
+	Status() structs.BatchQueueStatus
 	SetEnabled(bool, *state.StateStore)
 }
 

--- a/nomad/queues/passthrough_queue.go
+++ b/nomad/queues/passthrough_queue.go
@@ -26,3 +26,5 @@ func (p *PassthroughQueue) Start(context.Context) error { return nil }
 func (p *PassthroughQueue) Enqueue(e *structs.Evaluation) { p.broker.Enqueue(e) }
 
 func (p *PassthroughQueue) SetEnabled(bool, *state.StateStore) {}
+
+func (p *PassthroughQueue) Status() structs.BatchQueueStatus { return nil }

--- a/nomad/queues/passthrough_queue.go
+++ b/nomad/queues/passthrough_queue.go
@@ -27,4 +27,6 @@ func (p *PassthroughQueue) Enqueue(e *structs.Evaluation) { p.broker.Enqueue(e) 
 
 func (p *PassthroughQueue) SetEnabled(bool, *state.StateStore) {}
 
-func (p *PassthroughQueue) Status() structs.QueueStatusResponse { return structs.QueueStatusResponse{} }
+func (p *PassthroughQueue) Status() structs.QueueStatusResponse {
+	return structs.QueueStatusResponse{Type: "unset"}
+}

--- a/nomad/queues/passthrough_queue.go
+++ b/nomad/queues/passthrough_queue.go
@@ -27,4 +27,4 @@ func (p *PassthroughQueue) Enqueue(e *structs.Evaluation) { p.broker.Enqueue(e) 
 
 func (p *PassthroughQueue) SetEnabled(bool, *state.StateStore) {}
 
-func (p *PassthroughQueue) Status() structs.BatchQueueStatus { return nil }
+func (p *PassthroughQueue) Status() structs.QueueStatusResponse { return structs.QueueStatusResponse{} }

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -395,7 +395,6 @@ func DecodeBatchQueueConf[T any](in map[string]any, out *T) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Result:     out,
 		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
-		ErrorUnset: true,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to create config decoder, %w", err)

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -395,6 +395,7 @@ func DecodeBatchQueueConf[T any](in map[string]any, out *T) error {
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		Result:     out,
 		DecodeHook: mapstructure.StringToTimeDurationHookFunc(),
+		ErrorUnset: true,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to create config decoder, %w", err)

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -366,7 +366,7 @@ type (
 )
 
 const (
-	BatchQueueTypeDynamic BatchQueueType = "dynamicPriority"
+	BatchQueueTypeDynamic BatchQueueType = "dynamic_priority"
 
 	TenantTypeMetadata  BatchQueueTenant = "metadata"
 	TenantTypeNamespace BatchQueueTenant = "namespace"

--- a/nomad/structs/operator_test.go
+++ b/nomad/structs/operator_test.go
@@ -221,7 +221,7 @@ func TestBatchQueue_Validate(t *testing.T) {
 			err: "metadata key must be specified",
 		},
 		{
-			name: "dynamicPriority - invalid interval",
+			name: "dynamic_priority - invalid interval",
 			batchConfig: BatchQueue{
 				Type:       BatchQueueTypeDynamic,
 				TenantType: TenantTypeNamespace,
@@ -232,7 +232,7 @@ func TestBatchQueue_Validate(t *testing.T) {
 			err: "unable to decode conf",
 		},
 		{
-			name: "dynamicPriority - valid string interval",
+			name: "dynamic_priority - valid string interval",
 			batchConfig: BatchQueue{
 				Type:       BatchQueueTypeDynamic,
 				TenantType: TenantTypeNamespace,
@@ -243,7 +243,7 @@ func TestBatchQueue_Validate(t *testing.T) {
 			err: "",
 		},
 		{
-			name: "dynamicPriority - valid int interval",
+			name: "dynamic_priority - valid int interval",
 			batchConfig: BatchQueue{
 				Type:       BatchQueueTypeDynamic,
 				TenantType: TenantTypeNamespace,

--- a/nomad/structs/queue.go
+++ b/nomad/structs/queue.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package structs
 
 type QueueStatusRequest struct {

--- a/nomad/structs/queue.go
+++ b/nomad/structs/queue.go
@@ -1,0 +1,25 @@
+package structs
+
+type QueueStatusRequest struct {
+	QueryOptions
+}
+
+type DynamicPriorityStatus []DynamicPriorityWorkload
+
+type DynamicPriorityWorkload struct {
+	JobID            string
+	Tenant           string
+	AdjustedPriority int
+	BasePriority     int
+	UsageAjustment   int
+	AgeAdjustment    int
+	SizeAdjustment   int
+}
+
+type BatchQueueStatus any
+
+type QueueStatusResponse struct {
+	Type   BatchQueueType
+	Status BatchQueueStatus
+	QueryMeta
+}

--- a/nomad/structs/queue.go
+++ b/nomad/structs/queue.go
@@ -20,9 +20,9 @@ type DynamicPriorityWorkload struct {
 type QueueStatusResponse struct {
 	Type BatchQueueType
 
-	// Workloads are the actual queue workloads
-	// where their actual type is based on the
-	// "Type" parameter above.
+	// Workloads contains data about a specific queue
+	// that is important to a consumer of this API.
+	// The actual type is based on the "Type" parameter.
 	Workloads any
 	QueryMeta
 }

--- a/nomad/structs/queue.go
+++ b/nomad/structs/queue.go
@@ -7,8 +7,6 @@ type QueueStatusRequest struct {
 	QueryOptions
 }
 
-type DynamicPriorityStatus []DynamicPriorityWorkload
-
 type DynamicPriorityWorkload struct {
 	JobID            string
 	Tenant           string
@@ -19,10 +17,12 @@ type DynamicPriorityWorkload struct {
 	SizeAdjustment   int
 }
 
-type BatchQueueStatus any
-
 type QueueStatusResponse struct {
-	Type   BatchQueueType
-	Status BatchQueueStatus
+	Type BatchQueueType
+
+	// Workloads are the actual queue workloads
+	// where their actual type is based on the
+	// "Type" parameter above.
+	Workloads any
 	QueryMeta
 }


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes add the ability to query the status of a batch job queue via a new http route/handler, and a server RPC endpoint. 

A lot of the included changes are to the `nomad job queue` command in order to output more information specific to the Dynamic Priority Queue implementation.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
