### PR TITLE
cli: Redact CLI flags and env vars when writing debug bundle.

### DIFF
--- a/.changelog/28063.txt
+++ b/.changelog/28063.txt
@@ -1,0 +1,3 @@
+```release-note:security
+cli: Redact token and certificate key CLI flags and environment variables when writing debug bundle
+```

--- a/command/operator_debug.go
+++ b/command/operator_debug.go
@@ -1612,14 +1612,63 @@ func (c *OperatorDebugCommand) writeBody(dir, file string, resp *http.Response, 
 	}
 }
 
+// sensitiveFlagNames is the set of flag names whose values are redacted before
+// being written into the debug bundle. This covers Nomad, Consul, and Vault
+// credentials as well as TLS private-key paths.
+var sensitiveFlagNames = map[string]struct{}{
+	"token":             {},
+	"consul-auth":       {},
+	"consul-token":      {},
+	"consul-client-key": {},
+	"vault-token":       {},
+	"vault-client-key":  {},
+	"client-key":        {},
+}
+
+// redactedFlagValue is the placeholder substituted for any sensitive flag value.
+// Square brackets are used deliberately: Go's encoding/json HTML-escapes angle
+// brackets (< >) to Unicode escape sequences, which would make the placeholder
+// unreadable in the resulting JSON file.
+const redactedFlagValue = "[redacted]"
+
+// safeFlag is a sanitized snapshot of a flag.Flag that is safe to write into
+// the debug bundle. Values for flags listed in sensitiveFlagNames are replaced
+// with redactedFlagValue.
+type safeFlag struct {
+	Name     string
+	Value    string
+	DefValue string
+	Usage    string
+}
+
+// toSafeFlag converts a flag.Flag into a safeFlag, redacting any value
+// belonging to a sensitive flag name.
+func toSafeFlag(f *flag.Flag) *safeFlag {
+	val := f.Value.String()
+	defVal := f.DefValue
+	if _, sensitive := sensitiveFlagNames[f.Name]; sensitive {
+		if val != "" {
+			val = redactedFlagValue
+		}
+		if defVal != "" {
+			defVal = redactedFlagValue
+		}
+	}
+	return &safeFlag{
+		Name:     f.Name,
+		Value:    val,
+		DefValue: defVal,
+		Usage:    f.Usage,
+	}
+}
+
 type flagExport struct {
 	Name      string
 	Parsed    bool
-	Actual    map[string]*flag.Flag
-	Formal    map[string]*flag.Flag
-	Effective map[string]*flag.Flag // All flags with non-empty value
-	Args      []string              // arguments after flags
-	OsArgs    []string
+	Actual    map[string]*safeFlag
+	Formal    map[string]*safeFlag
+	Effective map[string]*safeFlag // All flags with non-empty value
+	Args      []string             // arguments after flags
 }
 
 // writeFlags exports the CLI flags to JSON file
@@ -1628,24 +1677,27 @@ func (c *OperatorDebugCommand) writeFlags(flags *flag.FlagSet) {
 	var f flagExport
 	f.Name = flags.Name()
 	f.Parsed = flags.Parsed()
-	f.Formal = make(map[string]*flag.Flag)
-	f.Actual = make(map[string]*flag.Flag)
-	f.Effective = make(map[string]*flag.Flag)
+	f.Formal = make(map[string]*safeFlag)
+	f.Actual = make(map[string]*safeFlag)
+	f.Effective = make(map[string]*safeFlag)
 	f.Args = flags.Args()
-	f.OsArgs = os.Args
 
 	// Formal flags (all flags)
 	flags.VisitAll(func(flagA *flag.Flag) {
-		f.Formal[flagA.Name] = flagA
+		safe := toSafeFlag(flagA)
+		f.Formal[flagA.Name] = safe
 
-		// Determine which of thees are "effective" flags by comparing to empty string
+		// Determine which of these are "effective" flags by comparing to empty string.
+		// Use the original value (pre-redaction) so that a sensitive flag whose
+		// value was set is still reflected in the Effective map (with a redacted
+		// placeholder), while an unset sensitive flag is not.
 		if flagA.Value.String() != "" {
-			f.Effective[flagA.Name] = flagA
+			f.Effective[flagA.Name] = safe
 		}
 	})
 	// Actual flags (everything passed on cmdline)
-	flags.Visit(func(flag *flag.Flag) {
-		f.Actual[flag.Name] = flag
+	flags.Visit(func(flagA *flag.Flag) {
+		f.Actual[flagA.Name] = toSafeFlag(flagA)
 	})
 
 	c.reportErr(writeResponseToFile(f, c.newFile(clusterDir, "cli-flags.json")))

--- a/command/operator_debug_test.go
+++ b/command/operator_debug_test.go
@@ -4,6 +4,8 @@
 package command
 
 import (
+	"encoding/json"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
@@ -1191,4 +1193,127 @@ func TestDebug_MonitorExportFiles(t *testing.T) {
 
 		})
 	}
+}
+
+func TestOperatorDebugCommand_toSafeFlag(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name       string
+		flagName   string
+		value      string
+		inputVault string
+		wantRedact bool
+	}{
+		{name: "nomad token", flagName: "token", value: "secret-nomad-token", wantRedact: true},
+		{name: "consul-auth", flagName: "consul-auth", value: "user:password", wantRedact: true},
+		{name: "consul-token", flagName: "consul-token", value: "secret-consul-token", wantRedact: true},
+		{name: "consul-client-key", flagName: "consul-client-key", value: "/path/to/key.pem", wantRedact: true},
+		{name: "vault-token", flagName: "vault-token", value: "secret-vault-token", wantRedact: true},
+		{name: "vault-client-key", flagName: "vault-client-key", value: "/path/to/vault-key.pem", wantRedact: true},
+		{name: "client-key", flagName: "client-key", value: "/path/to/client.key", wantRedact: true},
+		{name: "vault-token with default", flagName: "vault-token", value: "live-token", inputVault: "default-token", wantRedact: true},
+		{name: "unset sensitive flag", flagName: "token", wantRedact: false},
+		{name: "address", flagName: "address", value: "http://127.0.0.1:4646", wantRedact: false},
+		{name: "log-level", flagName: "log-level", value: "DEBUG", inputVault: "INFO", wantRedact: false},
+		{name: "duration", flagName: "duration", value: "2m", inputVault: "30s", wantRedact: false},
+		{name: "consul-http-addr", flagName: "consul-http-addr", value: "http://127.0.0.1:8500", wantRedact: false},
+		{name: "vault-address", flagName: "vault-address", value: "https://vault.example.com", wantRedact: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			fs := flag.NewFlagSet("test", flag.ContinueOnError)
+			var val string
+			fs.StringVar(&val, tc.flagName, tc.inputVault, "")
+			must.NoError(t, fs.Parse([]string{"-" + tc.flagName, tc.value}))
+
+			f := fs.Lookup(tc.flagName)
+			must.NotNil(t, f)
+
+			safe := toSafeFlag(f)
+			must.Eq(t, tc.flagName, safe.Name)
+
+			if tc.wantRedact {
+				must.Eq(t, redactedFlagValue, safe.Value)
+			} else {
+				must.Eq(t, tc.value, safe.Value)
+			}
+		})
+	}
+}
+
+func TestOperatorDebugCommand_writeFlags(t *testing.T) {
+	ci.Parallel(t)
+
+	// Build a flag set that mirrors the sensitive flags registered by
+	// OperatorDebugCommand so we can exercise the full writeFlags path.
+	fs := flag.NewFlagSet("operator debug", flag.ContinueOnError)
+	var (
+		tokenVal        string
+		consulAuth      string
+		consulToken     string
+		consulClientKey string
+		vaultToken      string
+		logLevel        string
+		duration        string
+	)
+	fs.StringVar(&tokenVal, "token", "", "")
+	fs.StringVar(&consulAuth, "consul-auth", "", "")
+	fs.StringVar(&consulToken, "consul-token", "", "")
+	fs.StringVar(&consulClientKey, "consul-client-key", "", "")
+	fs.StringVar(&vaultToken, "vault-token", "", "")
+	fs.StringVar(&logLevel, "log-level", "TRACE", "")
+	fs.StringVar(&duration, "duration", "2m", "")
+
+	must.NoError(t, fs.Parse([]string{
+		"-token", "super-secret-nomad-token",
+		"-consul-auth", "user:p4ssw0rd",
+		"-consul-token", "super-secret-consul-token",
+		"-consul-client-key", "/private/consul.key",
+		"-vault-token", "super-secret-vault-token",
+		"-log-level", "DEBUG",
+		"-duration", "5m",
+	}))
+
+	testDir := t.TempDir()
+
+	ui := cli.NewMockUi()
+	cmd := &OperatorDebugCommand{
+		Meta:       Meta{Ui: ui},
+		collectDir: testDir,
+	}
+
+	cmd.writeFlags(fs)
+
+	// Decode the produced JSON file into flagExport so we can assert on
+	// individual flag values rather than doing raw string matching.
+	rawJSON, err := os.ReadFile(filepath.Join(testDir, clusterDir, "cli-flags.json"))
+	must.NoError(t, err)
+
+	var got flagExport
+	must.NoError(t, json.Unmarshal(rawJSON, &got))
+
+	// Every sensitive flag that was explicitly set must appear in Actual with
+	// its value replaced by the redaction placeholder.
+	for _, flagName := range []string{
+		"token", "consul-auth", "consul-token", "consul-client-key", "vault-token",
+	} {
+		actualFlag, ok := got.Actual[flagName]
+		must.True(t, ok)
+		must.Eq(t, redactedFlagValue, actualFlag.Value)
+
+		effectiveFlag, ok := got.Effective[flagName]
+		must.True(t, ok)
+		must.Eq(t, redactedFlagValue, effectiveFlag.Value)
+
+		formalFlag, ok := got.Formal[flagName]
+		must.True(t, ok)
+		must.Eq(t, redactedFlagValue, formalFlag.Value)
+	}
+
+	// Ensure that non-sensitive flags persist their flags.
+	must.Eq(t, "DEBUG", got.Actual["log-level"].Value)
+	must.Eq(t, "5m", got.Actual["duration"].Value)
 }


### PR DESCRIPTION
The operator debug bundle writes out details of the CLI flags used to run the command, in order to provide additional context for support purposes. This process, however, did not perform any redaction of the values, so could include the raw data of ACL tokens used.

This change performs redaction of CLI values before writing out the file in the debug bundle and includes ACL tokens as paths to TLS certificate keys for completeness.

### Links
https://hashicorp.atlassian.net/browse/SECVULN-43985

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

