### PR TITLE
WI: allow clients to request implicit identities for existing allocs

### DIFF
--- a/.changelog/28066.txt
+++ b/.changelog/28066.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+workload identity: client now requests identities for pre-WI tasks with `consul` or `vault` blocks
+```
+
+```release-note:improvement
+workload identity: added configuration for forcing the client to request identity for Consul for tasks with `template` blocks but no `consul` block
+```

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -239,6 +239,8 @@ func NewAllocRunner(config *config.AllocRunnerConfig) (interfaces.AllocRunner, e
 		return nil, fmt.Errorf("failed to lookup task group %q", alloc.TaskGroup)
 	}
 
+	alloc, tg = migrateTaskGroup(alloc, tg, config.ClientConfig)
+
 	ar := &allocRunner{
 		id:                       alloc.ID,
 		alloc:                    alloc,
@@ -1649,4 +1651,112 @@ func (ar *allocRunner) setHookStatsHandler(ns string) {
 		labels = append(labels, metrics.Label{Name: "namespace", Value: ns})
 		ar.hookStatsHandler = hookstats.NewHandler(labels, "alloc_hook")
 	}
+}
+
+// migrateTaskGroup allows the allocrunner to add missing features such as
+// implicit workload identities on the task group before we try to restore
+// it. It returns either the unmodified alloc and task group, or copies of both.
+func migrateTaskGroup(alloc *structs.Allocation, tg *structs.TaskGroup, cfg *config.Config) (*structs.Allocation, *structs.TaskGroup) {
+
+	// copying the task group is expensive, so track any required changes and
+	// then apply them to a copy only if we need to
+	groupSvcWI := map[string]*structs.WorkloadIdentity{}
+	taskSvcWI := map[string]map[string]*structs.WorkloadIdentity{}
+	taskWI := map[string][]*structs.WorkloadIdentity{}
+
+	for _, service := range tg.Services {
+		if service.Identity == nil && service.Provider != structs.ServiceProviderNomad {
+			fallbackWI := &structs.WorkloadIdentity{
+				Name:        service.MakeUniqueIdentityName(),
+				ServiceName: service.Name,
+			}
+			groupSvcWI[service.Name] = fallbackWI
+		}
+	}
+
+	for _, task := range tg.Tasks {
+
+		for _, service := range task.Services {
+			if service.Identity == nil && service.Provider != structs.ServiceProviderNomad {
+				fallbackWI := &structs.WorkloadIdentity{
+					Name:        service.MakeUniqueIdentityName(),
+					ServiceName: service.Name,
+				}
+				if taskSvcWI[task.Name] == nil {
+					taskSvcWI[task.Name] = map[string]*structs.WorkloadIdentity{
+						service.Name: fallbackWI}
+				} else {
+					taskSvcWI[task.Name][service.Name] = fallbackWI
+				}
+			}
+		}
+
+		if len(task.Identities) > 0 {
+			// note the default identity is in task.Identity and not this slice;
+			// if we have any non-default identities we can safely assume this
+			// job was submitted either to a server with WI configured for
+			// Consul/Vault, or that the user has configured specific identities
+			// and we shouldn't try to change those
+			continue
+		}
+		taskWI[task.Name] = []*structs.WorkloadIdentity{}
+		if task.Vault != nil {
+			fallbackWI := &structs.WorkloadIdentity{
+				Name: task.Vault.IdentityName(),
+			}
+			taskWI[task.Name] = append(taskWI[task.Name], fallbackWI)
+		}
+
+		if task.Consul != nil {
+			fallbackWI := &structs.WorkloadIdentity{
+				Name: task.Consul.IdentityName(),
+			}
+			taskWI[task.Name] = append(taskWI[task.Name], fallbackWI)
+		} else if tg.Consul != nil && len(task.Templates) > 0 {
+			fallbackWI := &structs.WorkloadIdentity{
+				Name: tg.Consul.IdentityName(),
+			}
+			taskWI[task.Name] = append(taskWI[task.Name], fallbackWI)
+		} else if cfg.TemplateConfig.DeriveConsulToken && len(task.Templates) > 0 {
+			fallbackWI := &structs.WorkloadIdentity{
+				Name: task.Consul.IdentityName(), // will be safe with nil
+			}
+			taskWI[task.Name] = append(taskWI[task.Name], fallbackWI)
+		}
+	}
+
+	if len(groupSvcWI) > 0 || len(taskSvcWI) > 0 || len(taskWI) > 0 {
+		// this copy is expensive, so only do it if we need it
+		alloc = alloc.Copy()
+		tg = alloc.Job.LookupTaskGroup(tg.Name)
+
+		for i, svc := range tg.Services {
+			if wid, ok := groupSvcWI[svc.Name]; ok {
+				svc.Identity = wid
+				tg.Services[i] = svc
+			}
+		}
+		for i, task := range tg.Tasks {
+			if wids, ok := taskSvcWI[task.Name]; ok {
+				for j, svc := range task.Services {
+					if wid, ok := wids[svc.Name]; ok {
+						svc.Identity = wid
+						task.Services[j] = svc
+					}
+				}
+				tg.Tasks[i] = task
+			}
+			if wids, ok := taskWI[task.Name]; ok {
+				task.Identities = append(task.Identities, wids...)
+				tg.Tasks[i] = task
+			}
+		}
+		for i, otg := range alloc.Job.TaskGroups {
+			if otg.Name == tg.Name {
+				alloc.Job.TaskGroups[i] = tg
+			}
+		}
+	}
+
+	return alloc, tg
 }

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -2966,3 +2966,111 @@ func (h *allocPostrunHook) Postrun() error {
 	h.ran = true
 	return h.err
 }
+
+// TestAllocRunner_Migration tests the restore path on existing pre-WI
+// allocations that don't have any injected implicit identities for Consul/Vault
+func TestAllocRunner_Migration(t *testing.T) {
+
+	testCases := []struct {
+		name      string
+		setup     func(*structs.TaskGroup)
+		cfgDerive bool
+		assert    func(*testing.T, *structs.TaskGroup)
+	}{
+		{
+			name: "vault block",
+			setup: func(tg *structs.TaskGroup) {
+				tg.Tasks[0].Vault = &structs.Vault{}
+			},
+			assert: func(t *testing.T, tg *structs.TaskGroup) {
+				t.Helper()
+				must.Len(t, 1, tg.Tasks[0].Identities)
+				must.Eq(t, "vault_default", tg.Tasks[0].Identities[0].Name)
+			},
+		},
+		{
+			name: "consul task service",
+			setup: func(tg *structs.TaskGroup) {
+				tg.Tasks[0].Services[1].Provider = "nomad"
+			},
+			assert: func(t *testing.T, tg *structs.TaskGroup) {
+				t.Helper()
+				must.NotNil(t, tg.Tasks[0].Services[0].Identity)
+				must.Eq(t, "consul-service_web-web-frontend-http", tg.Tasks[0].Services[0].Identity.Name)
+				must.Nil(t, tg.Tasks[0].Services[1].Identity)
+			},
+		},
+		{
+			name: "consul group service",
+			setup: func(tg *structs.TaskGroup) {
+				tg.Consul = &structs.Consul{} // will always exist for consul group service
+				tg.Services = []*structs.Service{{
+					Name:      "httpd",
+					PortLabel: "www",
+					Provider:  "consul",
+				}}
+			},
+			assert: func(t *testing.T, tg *structs.TaskGroup) {
+				t.Helper()
+				must.NotNil(t, tg.Services[0].Identity)
+				must.Eq(t, "consul-service_httpd-www", tg.Services[0].Identity.Name)
+				must.Len(t, 0, tg.Tasks[0].Identities, must.Sprint(
+					"group consul block should not create task-level identity without template"))
+			},
+		},
+		{
+			name: "consul block in task",
+			setup: func(tg *structs.TaskGroup) {
+				tg.Tasks[0].Consul = &structs.Consul{}
+			},
+			assert: func(t *testing.T, tg *structs.TaskGroup) {
+				t.Helper()
+				must.Len(t, 1, tg.Tasks[0].Identities)
+				must.Eq(t, "consul_default", tg.Tasks[0].Identities[0].Name)
+			},
+		},
+		{
+			name: "templates but no consul block without derive token config",
+			setup: func(tg *structs.TaskGroup) {
+				tg.Tasks[0].Templates = []*structs.Template{{
+					EmbeddedTmpl: "template-contents-foo",
+				}}
+			},
+			assert: func(t *testing.T, tg *structs.TaskGroup) {
+				t.Helper()
+				must.Len(t, 0, tg.Tasks[0].Identities)
+			},
+		},
+		{
+			name: "templates but no consul block with derive token config",
+			setup: func(tg *structs.TaskGroup) {
+				tg.Tasks[0].Templates = []*structs.Template{{
+					EmbeddedTmpl: "template-contents-foo",
+				}}
+			},
+			cfgDerive: true,
+			assert: func(t *testing.T, tg *structs.TaskGroup) {
+				t.Helper()
+				must.Len(t, 1, tg.Tasks[0].Identities)
+				must.Eq(t, "consul_default", tg.Tasks[0].Identities[0].Name)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		alloc := mock.Alloc()
+		tg := alloc.Job.TaskGroups[0]
+		tc.setup(tg)
+
+		conf, cleanup := testAllocRunnerConfig(t, alloc)
+		t.Cleanup(cleanup)
+		conf.ClientConfig.TemplateConfig.DeriveConsulToken = tc.cfgDerive
+
+		ar, err := NewAllocRunner(conf)
+		must.NoError(t, err)
+
+		migratedAlloc := ar.Alloc()
+		migratedTG := migratedAlloc.Job.TaskGroups[0]
+		tc.assert(t, migratedTG)
+	}
+}

--- a/client/allocrunner/testing.go
+++ b/client/allocrunner/testing.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/nomad/client/serviceregistration/wrapper"
 	"github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/vaultclient"
+	"github.com/hashicorp/nomad/client/widmgr"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/stretchr/testify/require"
@@ -96,6 +97,7 @@ func testAllocRunnerConfig(t *testing.T, alloc *structs.Allocation) (*config.All
 		Getter:             getter.TestSandbox(t),
 		Wranglers:          proclib.MockWranglers(t),
 		Partitions:         cgroupslib.NoopPartition(),
+		WIDSigner:          widmgr.NewMockWIDSigner(nil),
 	}
 
 	return conf, cleanup

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -488,6 +488,11 @@ type ClientTemplateConfig struct {
 	// to wait for the cluster to become available, as is customary in distributed
 	// systems.
 	NomadRetry *RetryConfig `hcl:"nomad_retry,optional"`
+
+	// DeriveConsulToken is a compatibility configuration that forces the client
+	// to derive a Consul token for existing allocations with template blocks if
+	// they don't have an implicit identity for Consul
+	DeriveConsulToken bool `hcl:"derive_consul_token"`
 }
 
 func DefaultTemplateConfig() *ClientTemplateConfig {
@@ -515,6 +520,7 @@ func DefaultTemplateConfig() *ClientTemplateConfig {
 			Backoff:    new(time.Millisecond * 250),
 			MaxBackoff: new(time.Minute),
 		},
+		DeriveConsulToken: false,
 	}
 }
 
@@ -618,6 +624,9 @@ func (c *ClientTemplateConfig) Merge(o *ClientTemplateConfig) *ClientTemplateCon
 	}
 	if o.NomadRetry != nil {
 		result.NomadRetry = c.NomadRetry.Merge(o.NomadRetry)
+	}
+	if o.DeriveConsulToken {
+		result.DeriveConsulToken = true
 	}
 
 	return &result

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -633,8 +633,45 @@ func (a *Alloc) signTasks(
 
 		claims := builder.Build(now)
 		err = a.signClaims(claims, idReq, reply)
-		break
+		return
 	}
+
+	// fallback for existing allocations
+	if len(task.Identities) == 0 {
+		wid := &structs.WorkloadIdentity{
+			Name: idReq.IdentityName,
+		}
+
+		if task.Vault != nil && wid.IsVault() {
+			widFound = true
+			builder := structs.NewIdentityClaimsBuilder(alloc.Job, alloc, &idReq.WIHandle, wid).
+				WithTask(task)
+
+			vaultCfg := a.srv.GetConfig().GetVaultForIdentity(wid)
+			if vaultCfg != nil && vaultCfg.DefaultIdentity != nil {
+				builder.WithVault(vaultCfg.DefaultIdentity.ExtraClaims)
+			}
+			claims := builder.Build(now)
+			err = a.signClaims(claims, idReq, reply)
+			if err != nil {
+				return
+			}
+		}
+
+		if wid.IsConsul() && (task.Consul != nil || len(task.Templates) > 0) {
+			widFound = true
+			builder := structs.NewIdentityClaimsBuilder(alloc.Job, alloc, &idReq.WIHandle, wid).
+				WithTask(task).
+				WithConsul()
+			claims := builder.Build(now)
+			err = a.signClaims(claims, idReq, reply)
+			if err != nil {
+				return
+			}
+		}
+
+	}
+
 	return
 }
 
@@ -650,20 +687,39 @@ func (a *Alloc) signServices(
 	// services can be on the level of task groups or tasks
 	for _, tg := range job.TaskGroups {
 		for _, service := range tg.Services {
-			if service.IdentityHandle(nil).Equal(wid) {
+			serviceHandle := service.IdentityHandle(nil)
+			serviceIdentity := service.Identity
+			if serviceHandle == nil {
+				// fallback for legacy allocations on clusters that have been
+				// upgraded to use WI but haven't been redeployed as new job
+				// versions yet
+				serviceHandle, serviceIdentity = a.fallbackServiceIdentityHandle(
+					tg, service)
+			}
+			if serviceHandle.Equal(wid) {
 				claims := structs.NewIdentityClaimsBuilder(
-					alloc.Job, alloc, &idReq.WIHandle, service.Identity).
+					alloc.Job, alloc, &idReq.WIHandle, serviceIdentity).
 					WithConsul().
 					WithService(service).
 					Build(now)
 				return true, a.signClaims(claims, idReq, reply)
 			}
 		}
+
 		for _, task := range tg.Tasks {
 			for _, service := range task.Services {
-				if service.IdentityHandle(nil).Equal(wid) {
+				serviceHandle := service.IdentityHandle(nil)
+				serviceIdentity := service.Identity
+				if serviceHandle == nil {
+					// fallback for legacy allocations on clusters that have been
+					// upgraded to use WI but haven't been redeployed as new job
+					// versions yet
+					serviceHandle, serviceIdentity = a.fallbackServiceIdentityHandle(
+						tg, service)
+				}
+				if serviceHandle.Equal(wid) {
 					claims := structs.NewIdentityClaimsBuilder(
-						alloc.Job, alloc, &idReq.WIHandle, service.Identity).
+						alloc.Job, alloc, &idReq.WIHandle, serviceIdentity).
 						WithTask(task).
 						WithConsul().
 						WithService(service).
@@ -692,4 +748,24 @@ func (a *Alloc) signClaims(
 	})
 
 	return nil
+}
+
+func (a *Alloc) fallbackServiceIdentityHandle(tg *structs.TaskGroup, service *structs.Service) (*structs.WIHandle, *structs.WorkloadIdentity) {
+	if service.Provider == structs.ServiceProviderNomad {
+		return nil, nil // note: the client shouldn't send WID requests for this
+	}
+
+	serviceWID := a.srv.GetConfig().ConsulServiceIdentity(
+		service.GetConsulClusterName(tg))
+	if serviceWID == nil {
+		return nil, nil
+	}
+
+	serviceWID.Name = service.MakeUniqueIdentityName()
+	serviceWID.ServiceName = service.Name
+	service = service.Copy()
+	service.Identity = serviceWID
+
+	handle := service.IdentityHandle(nil)
+	return handle, serviceWID
 }

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
@@ -1985,4 +1986,149 @@ func TestAlloc_SignIdentities_Blocking(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatalf("result not returned when expected")
 	}
+}
+
+// TestAlloc_SignIdentitiesLegacy tests cases where the client is requesting
+// signed identities for a pre-WI allocation to migrate its use of Consul/Vault.
+func TestAlloc_SignIdentitiesLegacy(t *testing.T) {
+	ci.Parallel(t)
+
+	// Use non-ACL server because auth should always be enforced on this endpoint
+	srv, cleanup := TestServer(t, func(c *Config) {
+		c.ConsulConfigs = map[string]*config.ConsulConfig{
+			structs.ConsulDefaultCluster: {
+				ServiceIdentity: &config.WorkloadIdentityConfig{
+					Audience: []string{"consul.io"},
+				},
+			},
+		}
+	})
+	t.Cleanup(cleanup)
+	codec := rpcClient(t, srv)
+	testutil.WaitForKeyring(t, srv.RPC, srv.Region())
+	store := srv.fsm.State()
+	index, _ := store.LatestIndex()
+
+	node := mock.Node()
+	index++
+	must.NoError(t, store.UpsertNode(structs.MsgTypeTestSetup, index, node))
+
+	// Insert an alloc that's missing implicit identities but wants WIs. Because
+	// this job has no services, Consul/Vault blocks, or templates, the server
+	// should reject any requests for implicit identities. This ensures the
+	// server can't be tricked by a malicious client into handing out WIs it
+	// shouldn't.
+	alloc0 := mock.MinAlloc()
+	alloc0.NodeID = node.ID
+	alloc0.Job.TaskGroups[0].Tasks[0].Identities = nil // definitely empty
+
+	summary := mock.JobSummary(alloc0.JobID)
+	index++
+	must.NoError(t, store.UpsertJobSummary(index, summary))
+	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, index, nil, alloc0.Job))
+	must.NoError(t, store.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc0}))
+
+	evilSvc0 := &structs.Service{Name: "${TASK}-frontend", PortLabel: "www"}
+	evilSvcIDName := evilSvc0.MakeUniqueIdentityName()
+
+	qo := structs.QueryOptions{
+		Region:     "global",
+		Namespace:  structs.DefaultNamespace,
+		AllowStale: true,
+		AuthToken:  node.SecretID,
+	}
+
+	req := &structs.AllocIdentitiesRequest{
+		Identities: []*structs.WorkloadIdentityRequest{
+			{
+				AllocID: alloc0.ID,
+				WIHandle: structs.WIHandle{
+					IdentityName:                   "vault_default",
+					WorkloadIdentifier:             "t",
+					WorkloadType:                   structs.WorkloadTypeTask,
+					InterpolatedWorkloadIdentifier: "t",
+				},
+			},
+			{
+				AllocID: alloc0.ID,
+				WIHandle: structs.WIHandle{
+					IdentityName:                   "consul_default",
+					WorkloadIdentifier:             "t",
+					WorkloadType:                   structs.WorkloadTypeTask,
+					InterpolatedWorkloadIdentifier: "t",
+				},
+			},
+			{
+				AllocID: alloc0.ID,
+				WIHandle: structs.WIHandle{
+					IdentityName:                   evilSvcIDName,
+					WorkloadIdentifier:             evilSvc0.Name,
+					WorkloadType:                   structs.WorkloadTypeService,
+					InterpolatedWorkloadIdentifier: "t-frontend",
+				},
+			},
+		},
+		QueryOptions: qo,
+	}
+	var resp structs.AllocIdentitiesResponse
+	err := msgpackrpc.CallWithCodec(codec, "Alloc.SignIdentities", &req, &resp)
+	must.NoError(t, err)
+	must.Len(t, 3, resp.Rejections)
+
+	// Insert an alloc that's missing implicit identities and wants WIs, but
+	// should be allowed to get them for its services, Consul/Vault blocks, or
+	// templates.
+	alloc1 := mock.AllocForNode(node)
+	alloc1.Job.TaskGroups[0].Tasks[0].Identities = nil // definitely empty
+
+	tg0 := alloc1.Job.TaskGroups[0]
+	task0 := tg0.Tasks[0]
+	task0.Vault = &structs.Vault{}
+
+	service0 := alloc1.Job.TaskGroups[0].Tasks[0].Services[0]
+	alloc1.Job.TaskGroups[0].Tasks[0].Services[1].Provider = "nomad"
+	task0.Templates = []*structs.Template{{
+		EmbeddedTmpl: "template-contents-foo",
+	}}
+
+	summary = mock.JobSummary(alloc1.JobID)
+	index++
+	must.NoError(t, store.UpsertJobSummary(index, summary))
+	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, index, nil, alloc1.Job))
+	must.NoError(t, store.UpsertAllocs(structs.MsgTypeTestSetup, index, []*structs.Allocation{alloc1}))
+	req = &structs.AllocIdentitiesRequest{
+		Identities: []*structs.WorkloadIdentityRequest{
+			{
+				AllocID: alloc1.ID,
+				WIHandle: structs.WIHandle{
+					IdentityName:                   "vault_default",
+					WorkloadIdentifier:             task0.Name,
+					WorkloadType:                   structs.WorkloadTypeTask,
+					InterpolatedWorkloadIdentifier: task0.Name,
+				},
+			},
+			{
+				AllocID: alloc1.ID,
+				WIHandle: structs.WIHandle{
+					IdentityName:                   "consul_default",
+					WorkloadIdentifier:             task0.Name,
+					WorkloadType:                   structs.WorkloadTypeTask,
+					InterpolatedWorkloadIdentifier: task0.Name,
+				},
+			},
+			{
+				AllocID: alloc1.ID,
+				WIHandle: structs.WIHandle{
+					IdentityName:                   service0.MakeUniqueIdentityName(),
+					WorkloadIdentifier:             service0.Name,
+					WorkloadType:                   structs.WorkloadTypeService,
+					InterpolatedWorkloadIdentifier: service0.Name,
+				},
+			},
+		},
+		QueryOptions: qo,
+	}
+	err = msgpackrpc.CallWithCodec(codec, "Alloc.SignIdentities", &req, &resp)
+	must.NoError(t, err)
+	must.Len(t, 0, resp.Rejections, must.Sprintf("%+v", resp.Rejections))
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -10441,7 +10441,14 @@ type Vault struct {
 // IdentityName returns the name of the workload identity to be used to access
 // this Vault cluster.
 func (v *Vault) IdentityName() string {
-	return fmt.Sprintf("%s%s", WorkloadIdentityVaultPrefix, v.Cluster)
+	var clusterName string
+	if v != nil && v.Cluster != "" {
+		clusterName = v.Cluster
+	} else {
+		clusterName = VaultDefaultCluster
+	}
+
+	return fmt.Sprintf("%s%s", WorkloadIdentityVaultPrefix, clusterName)
 }
 
 func (v *Vault) Equal(o *Vault) bool {


### PR DESCRIPTION
_WIP: the client side of this is getting re-worked to see if we can do a "migration" step in `NewAllocRunner` instead of having to do all this work in the WID manager and then again in the `consul_hook`; alternately, whether we can allow the `service` (but not `connect`) blocks to work without WI at all; this is explored in https://github.com/hashicorp/nomad/pull/28106_

---

All newly-submitted jobs get server-injected implicit `identity` blocks to fetch a Consul/Vault token if they have a `consul` or `vault` block, or if they have a Consul `service` block (including `service.connect`). Using Workload Identity (WI) is required if you want a Consul/Vault token from 1.10.0 on.

Originally for 1.7 we wanted to support both legacy and WI workflows for signing workload identities for Consul/Vault so that users could migrate gradually. That meant we couldn't implicitly cut-over workloads to use WI without cutting all of them on the same node over at once. The intended workflow is that as jobs were cycled through the cluster between 1.7 and 1.9, replacement allocations would have the appropriate signed identities, and that once you're on 1.10 or later allocations whose jobs were not upgraded would fail.

Unfortunately this did not correctly account for existing pre-WI allocations that did not have their jobs submitted during the upgrade window. When the client restarts with the new version, these allocations will continue to use the ambient authority of the Nomad client to access Consul or Vault. This generally means they'll fail as cluster administrators start removing required permissions from the Nomad clients.

We can ease upgrades by allowing the client to identify allocations that are missing the expected implicit identities injected by the server:
* Tasks with a `vault` block will get a WI to login into the appropriate Vault cluster, and the resulting token will be exposed to the `template` block.
* Tasks with a `consul` block will get a WI to login to the appropriate Consul cluster, and the resulting token will be exposed to the `template` block.
* Tasks with a `service` block with the Consul provider will get a WI to login to the appropriate Consul cluster, and the resulting SI token will be expose to the service client and `connect`.

But because the `consul` block is not otherwise required (especially for CE users), this leaves allocations that need Consul tokens for `template` blocks. For these, we'll add a new `client.template.derive_consul_token` configuration that forces the client to fetch a Consul token for all jobs with template blocks.

Fixes: https://hashicorp.atlassian.net/browse/NMD-1338

### Testing & Reproduction steps

_WIP_

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
