### PR TITLE
github: Update issue template community link and debug email.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ Hi there,
 
 Thank you for opening an issue. Please note that we try to keep the Nomad issue
 tracker reserved for bug reports and feature requests. For general usage
-questions, please see: https://developer.hashicorp.com/nomad/community
+questions, please use: https://discuss.hashicorp.com/c/nomad/28
 
 -->
 
@@ -31,17 +31,16 @@ Output from `nomad version`
 <!--
 If possible please post relevant logs in the issue.
 `
-Logs and other artifacts may also be sent to: nomad-oss-debug@hashicorp.com
+Logs and other artifacts may also be sent to: Nomad_OSS_Debug@wwpdl.vnet.ibm.com
 
 Please link to your Github issue in the email and reference it in the subject
 line:
 
-> To: nomad-oss-debug@hashicorp.com
+> To: Nomad_OSS_Debug@wwpdl.vnet.ibm.com
 >
 > Subject: GH-1234: Errors garbage collecting allocs
 
-Emails sent to that address are readable by all HashiCorp employees but are
-*not* publicly visible.
+Emails sent to that address are readable by all Nomad engineering team members.
 -->
 
 ### Nomad Server logs (if appropriate)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,7 @@ Hi there,
 
 Thank you for opening an issue. Please note that we try to keep the Nomad issue
 tracker reserved for bug reports and feature requests. For general usage
-questions, please see: https://developer.hashicorp.com/nomad/community
+questions, please see: https://discuss.hashicorp.com/c/nomad/28
 
 -->
 
@@ -32,5 +32,3 @@ If you have already tried to solve the problem within Nomad’s existing feature
 and found a limitation that prevented you from succeeding, please describe it
 below.
 -->
-
-


### PR DESCRIPTION
The issue template link for general questions did not work, so it is now updated to point to the HashiCorp Discuss site.

The debug email address has also been updated as part of our migration to IBM and now uses an IBM domained distribution group.

Backport: it probably could just be merged into main, but to ensure people working across different branches have the right information, I'll backport it. This will also reduce the potential for conflicts in these files in the future.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

