### PR TITLE
batch: fix expected post stop behavior for max_run_duration

### DIFF
--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -757,10 +757,9 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 		// prevent any not-yet-running post stop tasks from starting when we
 		// kill the main task
 		for _, tr := range ar.tasks {
-			if !tr.IsPoststopTask() {
-				continue
+			if tr.IsPoststopTask() {
+				tr.Kill(context.TODO(), taskEventFn(tr))
 			}
-			tr.Kill(context.TODO(), taskEventFn(tr))
 		}
 	}
 

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -404,7 +404,6 @@ func (ar *allocRunner) Run() {
 
 	// Run the runners (blocks until they exit)
 	ar.runTasks()
-
 	if ar.isShuttingDown() {
 		return
 	}
@@ -748,11 +747,21 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 		event := structs.NewTaskEvent(structs.TaskKilling).
 			SetKillTimeout(tr.Task().KillTimeout, ar.clientConfig.MaxKillTimeout)
 
-		if ar.state.MaxRunDurationExceeded {
+		if ar.maxRunDurationExceeded() {
 			event.SetDisplayMessage(structs.AllocTimeoutReasonMaxRunDuration)
 		}
-
 		return event
+	}
+
+	if ar.maxRunDurationExceeded() {
+		// prevent any not-yet-running post stop tasks from starting when we
+		// kill the main task
+		for _, tr := range ar.tasks {
+			if !tr.IsPoststopTask() {
+				continue
+			}
+			tr.Kill(context.TODO(), taskEventFn(tr))
+		}
 	}
 
 	// Kill leader first, synchronously
@@ -822,23 +831,6 @@ func (ar *allocRunner) killTasks() map[string]*structs.TaskState {
 		}(name, tr)
 	}
 	wg.Wait()
-
-	// Skip poststop tasks entirely when max_run_duration has been exceeded so
-	// they are not started after the allocation has timed out.
-	if ar.state.MaxRunDurationExceeded {
-		for name, tr := range ar.tasks {
-			if !tr.IsPoststopTask() {
-				continue
-			}
-
-			state := tr.TaskState()
-			if state != nil {
-				states[name] = state
-			}
-		}
-
-		return states
-	}
 
 	// Perform no action on post stop tasks, but retain their states if they exist. This
 	// commonly happens at the time of alloc GC from the client node.
@@ -1134,6 +1126,12 @@ func (ar *allocRunner) EnforceMaxRunDurationTimeout(deadline time.Time) {
 
 	ar.logger.Debug("allocation exceeded max_run_duration, killing tasks", "deadline", deadline)
 	ar.killTasks()
+}
+
+func (ar *allocRunner) maxRunDurationExceeded() bool {
+	ar.stateLock.Lock()
+	defer ar.stateLock.Unlock()
+	return ar.state.MaxRunDurationExceeded
 }
 
 func (ar *allocRunner) destroyImpl() {

--- a/client/allocrunner/alloc_runner_test.go
+++ b/client/allocrunner/alloc_runner_test.go
@@ -505,7 +505,7 @@ func TestAllocRunner_MaxRunDuration_SkipsPoststopTasks(t *testing.T) {
 	tr := alloc.AllocatedResources.Tasks[alloc.Job.TaskGroups[0].Tasks[0].Name]
 
 	alloc.Job.Type = structs.JobTypeBatch
-	maxRunDuration := 50 * time.Millisecond
+	maxRunDuration := 1 * time.Second
 	alloc.Job.TaskGroups[0].MaxRunDuration = &maxRunDuration
 
 	mainTask := alloc.Job.TaskGroups[0].Tasks[0]
@@ -535,56 +535,59 @@ func TestAllocRunner_MaxRunDuration_SkipsPoststopTasks(t *testing.T) {
 
 	upd := conf.StateUpdater.(*MockStateUpdater)
 
-	testutil.WaitForResult(func() (bool, error) {
-		last := upd.Last()
-		if last == nil {
-			return false, fmt.Errorf("no updates")
-		}
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(func() error {
+			last := upd.Last()
+			if last == nil {
+				return fmt.Errorf("no updates")
+			}
+			if last.ClientStatus != structs.AllocClientStatusRunning {
+				return fmt.Errorf("expected alloc to be running not %s", last.ClientStatus)
+			}
+			if s := last.TaskStates[mainTask.Name].State; s != structs.TaskStateRunning {
+				return fmt.Errorf("expected main task to be running not %s", s)
+			}
+			if s := last.TaskStates[poststopTask.Name].State; s != structs.TaskStatePending {
+				return fmt.Errorf("expected poststop task to be pending not %s", s)
+			}
+			return nil
+		}),
+		wait.Timeout(200*time.Millisecond), // max_run_duration is 1s
+		wait.Gap(5*time.Millisecond),
+	))
 
-		if last.ClientStatus != structs.AllocClientStatusRunning {
-			return false, fmt.Errorf("expected alloc to be running not %s", last.ClientStatus)
-		}
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(func() error {
+			last := upd.Last()
+			if last.ClientStatus != structs.AllocClientStatusComplete {
+				return fmt.Errorf("expected alloc to be complete not %s", last.ClientStatus)
+			}
+			if last.ClientDescription != structs.AllocTimeoutReasonMaxRunDuration {
+				return fmt.Errorf("expected alloc description %q not %q", structs.AllocTimeoutReasonMaxRunDuration, last.ClientDescription)
+			}
+			if s := last.TaskStates[mainTask.Name].State; s != structs.TaskStateDead {
+				return fmt.Errorf("expected main task to be dead not %s", s)
+			}
 
-		if s := last.TaskStates[mainTask.Name].State; s != structs.TaskStateRunning {
-			return false, fmt.Errorf("expected main task to be running not %s", s)
-		}
-
-		if s := last.TaskStates[poststopTask.Name].State; s != structs.TaskStatePending {
-			return false, fmt.Errorf("expected poststop task to be pending not %s", s)
-		}
-
-		return true, nil
-	}, func(err error) {
-		t.Fatalf("error waiting for initial state:\n%v", err)
-	})
-
-	testutil.WaitForResult(func() (bool, error) {
-		last := upd.Last()
-		if last == nil {
-			return false, fmt.Errorf("no updates")
-		}
-
-		if last.ClientStatus != structs.AllocClientStatusComplete {
-			return false, fmt.Errorf("expected alloc to be complete not %s", last.ClientStatus)
-		}
-
-		if last.ClientDescription != structs.AllocTimeoutReasonMaxRunDuration {
-			return false, fmt.Errorf("expected alloc description %q not %q", structs.AllocTimeoutReasonMaxRunDuration, last.ClientDescription)
-		}
-
-		if s := last.TaskStates[mainTask.Name].State; s != structs.TaskStateDead {
-			return false, fmt.Errorf("expected main task to be dead not %s", s)
-		}
-
-		if s := last.TaskStates[poststopTask.Name].State; s != structs.TaskStatePending {
-			return false, fmt.Errorf("expected poststop task to remain pending not %s", s)
-		}
-
-		return true, nil
-	}, func(err error) {
-		last := upd.Last()
-		t.Fatalf("error waiting for max_run_duration state:\n%v\nlast=%#v", err, last)
-	})
+			// poststop task would run for 10s if not for max_run_duration of
+			// 1s; all tasks should be dead by now and poststop tasks should
+			// never have run
+			poststopState := last.TaskStates[poststopTask.Name]
+			if poststopState.State != structs.TaskStateDead {
+				return fmt.Errorf("expected poststop task to be dead not %s", poststopState.State)
+			}
+			events := poststopState.Events
+			if len(events) != 2 {
+				return fmt.Errorf("expected poststop task to have event for max_run_duration: %+v", events)
+			}
+			if events[1].DisplayMessage != "allocation exceeded max_run_duration" {
+				return fmt.Errorf("expected poststop task to be dead because of max_run_duration")
+			}
+			return nil
+		}),
+		wait.Timeout(2000*time.Millisecond),
+		wait.Gap(5*time.Millisecond),
+	))
 }
 
 func TestAllocRunner_Lifecycle_Restart(t *testing.T) {


### PR DESCRIPTION
In https://github.com/hashicorp/nomad/pull/27803 we added support for halting an batch allocation when it exceeds a maximum run duration. While working on test fixes for #28066 I ran into what looked like a flaky test that turned out to be hiding a bug in the implementation around `poststop` tasks. The intent recorded in the documentation PR is that `poststop` tasks are never started if we exceed the deadline.

The test exercising this had a race where it checked if the poststop task was stuck in a pending state after the main task was killed. But the window between the two checks is tight enough that we don't detect that the poststop task starts immediately thereafter. Instead, we should be ensuring that the poststop task is dead, that it's never been started, and that it has an event indicating that the `max_run_duration` is the reason why.

Ref: https://github.com/hashicorp/nomad/pull/27803
Ref: https://github.com/hashicorp/web-unified-docs/pull/2407
Ref: https://hashicorp.atlassian.net/browse/NMD-1338
Ref: https://github.com/hashicorp/nomad/pull/28066

### Testing & Reproduction steps

Run the following batch jobspec:

<details><summary>jobspec</summary>

```hcl
job "example" {
  type = "batch"

  group "group" {

    max_run_duration = "5s"

    task "main" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "/bin/sh"
        args    = ["-c", "sleep 60"]
      }

      resources {
        cpu    = 128
        memory = 128
      }

    }

    task "poststop" {

      driver = "docker"

      lifecycle {
        hook    = "poststop"
        sidecar = false
      }

      config {
        image   = "busybox:1"
        command = "/bin/sh"
        args    = ["-c", "sleep 10"]
      }

      resources {
        cpu    = 64
        memory = 64
      }

    }
  }
}
```

</details>


**Before**: the main taskrunner gets the Killing event at 21:34:42, and the task exits 5s later at 21:34:47. At this point, the poststart task runs and is shown as terminated at 21:34:58 (~10s later).

<details><summary>alloc status (before)</summary>

```
$ nomad alloc status e5b
...
Client Status       = complete
Client Description  = allocation exceeded max_run_duration
Desired Status      = run
Desired Description = <none>
Created             = 23s ago
Modified            = 1s ago
Max Run Deadline    = 18s ago

Task "poststop" (poststop) is "dead"
Task Resources:
CPU       Memory      Disk     Addresses
0/64 MHz  0 B/64 MiB  300 MiB

Task Events:
Started At     = 2026-06-02T01:34:47Z
Finished At    = 2026-06-02T01:34:58Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2026-06-01T21:34:58-04:00  Terminated  Exit Code: 0
2026-06-01T21:34:47-04:00  Started     Task started by client
2026-06-01T21:34:47-04:00  Task Setup  Building Task Directory
2026-06-01T21:34:37-04:00  Received    Task received by client

Task "main" is "dead"
Task Resources:
CPU        Memory           Disk     Addresses
0/128 MHz  132 KiB/128 MiB  300 MiB

Task Events:
Started At     = 2026-06-02T01:34:37Z
Finished At    = 2026-06-02T01:34:47Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2026-06-01T21:34:47-04:00  Killed      Task successfully killed
2026-06-01T21:34:47-04:00  Terminated  Exit Code: 137, Exit Message: "Docker container exited with non-zero exit code: 137"
2026-06-01T21:34:42-04:00  Killing     allocation exceeded max_run_duration
2026-06-01T21:34:37-04:00  Started     Task started by client
2026-06-01T21:34:37-04:00  Task Setup  Building Task Directory
2026-06-01T21:34:37-04:00  Received    Task received by client
```

</details>

**After**: the main taskrunner gets the Killing event at 21:32:54, and the task exits 5s later at 21:32:59. But the poststop task also gets the Killing event at 21:32:54, ensuring that it never starts.

<details><summary>alloc status (before)</summary>

```
$ nomad alloc status d86
...
Client Status       = complete
Client Description  = allocation exceeded max_run_duration
...

Task "poststop" (poststop) is "dead"
Task Resources:
CPU     Memory  Disk     Addresses
64 MHz  64 MiB  300 MiB

Task Events:
Started At     = N/A
Finished At    = 2026-06-02T01:32:54Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type      Description
2026-06-01T21:32:54-04:00  Killing   allocation exceeded max_run_duration
2026-06-01T21:32:49-04:00  Received  Task received by client

Task "main" is "dead"
Task Resources:
CPU        Memory           Disk     Addresses
0/128 MHz  128 KiB/128 MiB  300 MiB

Task Events:
Started At     = 2026-06-02T01:32:49Z
Finished At    = 2026-06-02T01:32:59Z
Total Restarts = 0
Last Restart   = N/A

Recent Events:
Time                       Type        Description
2026-06-01T21:32:59-04:00  Killed      Task successfully killed
2026-06-01T21:32:59-04:00  Terminated  Exit Code: 137, Exit Message: "Docker container exited with non-zero exit code: 137"
2026-06-01T21:32:54-04:00  Killing     allocation exceeded max_run_duration
2026-06-01T21:32:49-04:00  Started     Task started by client
2026-06-01T21:32:49-04:00  Task Setup  Building Task Directory
2026-06-01T21:32:49-04:00  Received    Task received by client
```

</details>


### Contributor Checklist
- [x] **Changelog Entry** no changelog because this featured hasn't yet shipped in 2.0.3
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
