### PR TITLE
ui: fix blocking-query watch index not advancing from X-Nomad-Index header

### DIFF
--- a/.changelog/28074.txt
+++ b/.changelog/28074.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+ui: Fixed the namespace list being continually fetched when on the job overview page
+```
+
+```release-note:bug
+ui: Fixed flickering on the log streaming pop out when viewing them from job overview page
+```

--- a/ui/app/adapters/watchable.js
+++ b/ui/app/adapters/watchable.js
@@ -268,9 +268,16 @@ export default class Watchable extends ApplicationAdapter {
       : null;
     const newIndex = headerIndex || fallbackIndex;
 
+    // When the response carries a real X-Nomad-Index header we always cache it.
+    // The blocking `index` query param travels in the request body options and
+    // is not reflected on `requestData` by the underlying fetch adapter, so we
+    // must not gate header-derived indexes behind `hasWatchIndex`. The
+    // hasWatchIndex guard only applies to the test-only pre-advance fallback.
+    const shouldStoreIndex = headerIndex ? true : hasWatchIndex(requestData);
+
     if (
       newIndex &&
-      hasWatchIndex(requestData) &&
+      shouldStoreIndex &&
       !this.isDestroying &&
       !this.isDestroyed
     ) {

--- a/ui/tests/unit/adapters/volume-test.js
+++ b/ui/tests/unit/adapters/volume-test.js
@@ -192,4 +192,39 @@ module('Unit | Adapter | Volume', function (hooks) {
     findAllRequest();
     assert.deepEqual(pretender.handledRequests[2].url, '/v1/volumes?index=1');
   });
+
+  test('the X-Nomad-Index response header advances the watch index', async function (assert) {
+    await this.initializeUI();
+
+    const adapter = this.subject();
+    const watchList = this.owner.lookup('service:watch-list');
+
+    // The blocking index travels in the request options rather than on
+    // requestData, so the watch index must be sourced from the response
+    // header. Without it, blocking queries always re-request index=1 and
+    // return immediately (see hashicorp/nomad#28051 and #28062). Exercise
+    // handleResponse directly because the test environment pre-advances the
+    // index synchronously when the request is built, which would otherwise
+    // mask the header-derived value.
+    assert.strictEqual(
+      watchList.getIndexFor('/v1/volumes'),
+      1,
+      'the watch index starts at 1',
+    );
+
+    adapter.handleResponse(
+      200,
+      { 'x-nomad-index': '42' },
+      [],
+      // requestData intentionally has no `index`, mirroring the native-fetch
+      // adapter which keeps the blocking index in the request options.
+      { url: '/v1/volumes', method: 'GET' },
+    );
+
+    assert.strictEqual(
+      watchList.getIndexFor('/v1/volumes'),
+      42,
+      'the watch index is sourced from the X-Nomad-Index response header',
+    );
+  });
 });


### PR DESCRIPTION
The Ember 6.10 LTS upgrade removed ember-fetch and switched to the Ember Data 4.12 native-fetch path, where requestData only carries { url, method }. The blocking 'index' query param now travels in the request options and is serialized into the fetch URL later, so it is no longer present on requestData.

handleResponse gated caching the new index behind hasWatchIndex(requestData), which never saw the index, so watchList.setIndexFor was never called. The watch index stayed pinned at 1 and every blocking query returned immediately, causing the UI to poll once per second.

Always cache a real X-Nomad-Index response header; restrict the hasWatchIndex guard to the test-only pre-advance fallback.

Fixes #28051 (namespaces poll loop) and #28062 (log-stream flicker, a downstream effect of the job page re-rendering every second).

### Links
https://hashicorp.atlassian.net/browse/NMD-1504
https://hashicorp.atlassian.net/browse/NMD-1514

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.
