### PR TITLE
Update plugin's config in the agent after canonicalise

### DIFF
--- a/.changelog/28083.txt
+++ b/.changelog/28083.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+plugins: store verified and canonicalised plugin configuration in the agent
+```

--- a/command/agent/plugins.go
+++ b/command/agent/plugins.go
@@ -27,6 +27,11 @@ func (a *Agent) setupPlugins() error {
 		InternalPlugins:   internal,
 		SupportedVersions: loader.AgentSupportedApiVersions,
 	}
+
+	// IMPORTANT: This function will mutate the passed in config to update the
+	// plugin configs with any default values from the plugin's config schema.
+	//  They need to be propagated so we need to pass a pointer to the
+	// agent's config here.
 	l, err := loader.NewPluginLoader(config)
 	if err != nil {
 		return fmt.Errorf("failed to create plugin loader: %v", err)

--- a/command/agent/plugins.go
+++ b/command/agent/plugins.go
@@ -32,6 +32,9 @@ func (a *Agent) setupPlugins() error {
 	// plugin configs with any default values from the plugin's config schema.
 	//  They need to be propagated so we need to pass a pointer to the
 	// agent's config here.
+	a.configLock.Lock()
+	defer a.configLock.Unlock()
+
 	l, err := loader.NewPluginLoader(config)
 	if err != nil {
 		return fmt.Errorf("failed to create plugin loader: %v", err)

--- a/helper/pluginutils/hclutils/util.go
+++ b/helper/pluginutils/hclutils/util.go
@@ -68,7 +68,7 @@ func ParseHclInterface(val interface{}, spec hcldec.Spec, vars map[string]cty.Va
 // ParseHclInterface returns a cty.Value and callers sometimes need a generic
 // map payload (for example for plugin config maps). This helper converts that
 // value recursively into native Go values.
-func CtyValueToMapInterface(val cty.Value) (map[string]interface{}, error) {
+func CtyValueToMapInterface(val cty.Value) (map[string]any, error) {
 	if !val.IsKnown() {
 		return nil, fmt.Errorf("value is not known")
 	}
@@ -87,7 +87,7 @@ func CtyValueToMapInterface(val cty.Value) (map[string]interface{}, error) {
 		return nil, err
 	}
 
-	m, ok := v.(map[string]interface{})
+	m, ok := v.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("expected map/object cty value, got %T", v)
 	}

--- a/helper/pluginutils/hclutils/util.go
+++ b/helper/pluginutils/hclutils/util.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"math"
+	"math/big"
 
 	"github.com/hashicorp/go-msgpack/v2/codec"
 	hcl "github.com/hashicorp/hcl/v2"
@@ -58,6 +60,133 @@ func ParseHclInterface(val interface{}, spec hcldec.Spec, vars map[string]cty.Va
 	}
 
 	return value, diag, nil
+}
+
+// CtyValueToMapInterface converts a decoded cty value into a Go
+// map[string]interface{}.
+//
+// ParseHclInterface returns a cty.Value and callers sometimes need a generic
+// map payload (for example for plugin config maps). This helper converts that
+// value recursively into native Go values.
+func CtyValueToMapInterface(val cty.Value) (map[string]interface{}, error) {
+	if !val.IsKnown() {
+		return nil, fmt.Errorf("value is not known")
+	}
+
+	if val.IsNull() {
+		return nil, nil
+	}
+
+	t := val.Type()
+	if !t.IsMapType() && !t.IsObjectType() {
+		return nil, fmt.Errorf("expected map/object cty value, got %s", t.FriendlyName())
+	}
+
+	v, err := ctyValueToInterface(val)
+	if err != nil {
+		return nil, err
+	}
+
+	m, ok := v.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected map/object cty value, got %T", v)
+	}
+
+	return m, nil
+}
+
+func ctyValueToInterface(val cty.Value) (interface{}, error) {
+	t := val.Type()
+
+	if val.IsNull() {
+		return nil, nil
+	}
+
+	if !val.IsKnown() {
+		return nil, fmt.Errorf("value is not known")
+	}
+
+	switch {
+	case t.IsPrimitiveType():
+		switch t {
+		case cty.String:
+			return val.AsString(), nil
+		case cty.Number:
+			if val.RawEquals(cty.PositiveInfinity) {
+				return math.Inf(1), nil
+			}
+			if val.RawEquals(cty.NegativeInfinity) {
+				return math.Inf(-1), nil
+			}
+			return smallestNumber(val.AsBigFloat()), nil
+		case cty.Bool:
+			return val.True(), nil
+		default:
+			panic("unsupported primitive type")
+		}
+
+	case t.IsListType(), t.IsSetType(), t.IsTupleType():
+		result := []interface{}{}
+
+		it := val.ElementIterator()
+		for it.Next() {
+			_, ev := it.Element()
+			evi, err := ctyValueToInterface(ev)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, evi)
+		}
+		return result, nil
+
+	case t.IsMapType():
+		result := map[string]interface{}{}
+
+		it := val.ElementIterator()
+		for it.Next() {
+			ek, ev := it.Element()
+
+			evv, err := ctyValueToInterface(ev)
+			if err != nil {
+				return nil, err
+			}
+
+			result[ek.AsString()] = evv
+		}
+		return result, nil
+
+	case t.IsObjectType():
+		result := map[string]interface{}{}
+
+		for k := range t.AttributeTypes() {
+			av := val.GetAttr(k)
+			avv, err := ctyValueToInterface(av)
+			if err != nil {
+				return nil, err
+			}
+
+			result[k] = avv
+		}
+		return result, nil
+
+	case t.IsCapsuleType():
+		return val.EncapsulatedValue(), nil
+
+	default:
+		return nil, fmt.Errorf("cannot serialize %s", t.FriendlyName())
+	}
+}
+
+func smallestNumber(b *big.Float) interface{} {
+	if v, acc := b.Int64(); acc == big.Exact {
+		if int64(int(v)) == v {
+			return int(v)
+		}
+		return v
+	}
+
+	v, _ := b.Float64()
+	return v
 }
 
 // GetStdlibFuncs returns the set of stdlib functions.

--- a/helper/pluginutils/hclutils/util_test.go
+++ b/helper/pluginutils/hclutils/util_test.go
@@ -572,3 +572,79 @@ func TestParseInvalid(t *testing.T) {
 		})
 	}
 }
+
+func TestCtyValueToMapInterface(t *testing.T) {
+	spec := hclspec.NewObject(map[string]*hclspec.Spec{
+		"a": hclspec.NewAttr("a", "string", false),
+		"b": hclspec.NewAttr("b", "number", false),
+		"c": hclspec.NewAttr("c", "list(string)", false),
+		"d": hclspec.NewBlock("d", false, hclspec.NewObject(map[string]*hclspec.Spec{
+			"x": hclspec.NewAttr("x", "bool", false),
+		})),
+	})
+
+	decSpec, diags := hclspecutils.Convert(spec)
+	require.False(t, diags.HasErrors())
+
+	config := hclutils.HclConfigToInterface(t, `
+	config {
+		a = "hello"
+		b = 42
+		c = ["one", "two"]
+		d {
+			x = true
+		}
+	}`)
+
+	v, diag, errs := hclutils.ParseHclInterface(config, decSpec, nil)
+	require.False(t, diag.HasErrors(), errs)
+
+	m, err := hclutils.CtyValueToMapInterface(v)
+	require.NoError(t, err)
+	require.Equal(t, map[string]interface{}{
+		"a": "hello",
+		"b": 42,
+		"c": []interface{}{"one", "two"},
+		"d": map[string]interface{}{"x": true},
+	}, m)
+}
+
+func TestCtyValueToMapInterface_MapInput(t *testing.T) {
+	v := cty.MapVal(map[string]cty.Value{
+		"str": cty.StringVal("value"),
+		"num": cty.NumberIntVal(7),
+		"obj": cty.ObjectVal(map[string]cty.Value{
+			"flag": cty.True,
+		}),
+		"list": cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+	})
+
+	m, err := hclutils.CtyValueToMapInterface(v)
+	require.NoError(t, err)
+	require.Equal(t, map[string]interface{}{
+		"str":  "value",
+		"num":  7,
+		"obj":  map[string]interface{}{"flag": true},
+		"list": []interface{}{"a", "b"},
+	}, m)
+}
+
+func TestCtyValueToMapInterface_Null(t *testing.T) {
+	m, err := hclutils.CtyValueToMapInterface(cty.NullVal(cty.DynamicPseudoType))
+	require.NoError(t, err)
+	require.Nil(t, m)
+}
+
+func TestCtyValueToMapInterface_InvalidType(t *testing.T) {
+	_, err := hclutils.CtyValueToMapInterface(cty.StringVal("nope"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected map/object cty value")
+}
+
+func TestCtyValueToMapInterface_Unknown(t *testing.T) {
+	_, err := hclutils.CtyValueToMapInterface(cty.UnknownVal(cty.Object(map[string]cty.Type{
+		"a": cty.String,
+	})))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "value is not known")
+}

--- a/helper/pluginutils/hclutils/util_test.go
+++ b/helper/pluginutils/hclutils/util_test.go
@@ -611,21 +611,15 @@ func TestCtyValueToMapInterface(t *testing.T) {
 
 func TestCtyValueToMapInterface_MapInput(t *testing.T) {
 	v := cty.MapVal(map[string]cty.Value{
-		"str": cty.StringVal("value"),
-		"num": cty.NumberIntVal(7),
-		"obj": cty.ObjectVal(map[string]cty.Value{
-			"flag": cty.True,
-		}),
-		"list": cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+		"first":  cty.StringVal("value"),
+		"second": cty.StringVal("another"),
 	})
 
 	m, err := hclutils.CtyValueToMapInterface(v)
 	require.NoError(t, err)
 	require.Equal(t, map[string]interface{}{
-		"str":  "value",
-		"num":  7,
-		"obj":  map[string]interface{}{"flag": true},
-		"list": []interface{}{"a", "b"},
+		"first":  "value",
+		"second": "another",
 	}, m)
 }
 

--- a/helper/pluginutils/hclutils/util_test.go
+++ b/helper/pluginutils/hclutils/util_test.go
@@ -13,16 +13,16 @@ import (
 	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/hashicorp/nomad/plugins/shared/hclspec"
 	"github.com/kr/pretty"
-	"github.com/stretchr/testify/require"
+	"github.com/shoenig/test/must"
 	"github.com/zclconf/go-cty/cty"
 )
 
 func TestParseHclInterface_Hcl(t *testing.T) {
 	dockerDriver := new(docker.Driver)
 	dockerSpec, err := dockerDriver.TaskConfigSchema()
-	require.NoError(t, err)
+	must.NoError(t, err)
 	dockerDecSpec, diags := hclspecutils.Convert(dockerSpec)
-	require.False(t, diags.HasErrors())
+	must.False(t, diags.HasErrors())
 
 	vars := map[string]cty.Value{
 		"NOMAD_ALLOC_INDEX": cty.NumberIntVal(2),
@@ -401,12 +401,12 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 
 			// Test encoding
 			taskConfig := &drivers.TaskConfig{}
-			require.NoError(t, taskConfig.EncodeDriverConfig(ctyValue))
+			must.NoError(t, taskConfig.EncodeDriverConfig(ctyValue))
 
 			// Test decoding
-			require.NoError(t, taskConfig.DecodeDriverConfig(c.expectedType))
+			must.NoError(t, taskConfig.DecodeDriverConfig(c.expectedType))
 
-			require.EqualValues(t, c.expected, c.expectedType)
+			must.Eq(t, c.expected, c.expectedType)
 
 		})
 	}
@@ -487,7 +487,7 @@ func TestParseNullFields(t *testing.T) {
 			var tc TaskConfig
 			parser.ParseJson(t, c.json, &tc)
 
-			require.EqualValues(t, c.expected, tc)
+			must.Eq(t, c.expected, tc)
 		})
 	}
 }
@@ -500,7 +500,7 @@ func TestParseUnknown(t *testing.T) {
 		"map_list_field": hclspec.NewAttr("map_list_field", "list(map(string))", false),
 	})
 	cSpec, diags := hclspecutils.Convert(spec)
-	require.False(t, diags.HasErrors())
+	must.False(t, diags.HasErrors())
 
 	cases := []struct {
 		name string
@@ -533,9 +533,9 @@ func TestParseUnknown(t *testing.T) {
 			ctyValue, diag, errs := hclutils.ParseHclInterface(inter, cSpec, vars)
 			t.Logf("parsed: %# v", pretty.Formatter(ctyValue))
 
-			require.NotNil(t, errs)
-			require.True(t, diag.HasErrors())
-			require.Contains(t, errs[0].Error(), "no variable named")
+			must.NotNil(t, errs)
+			must.True(t, diag.HasErrors())
+			must.StrContains(t, errs[0].Error(), "no variable named")
 		})
 	}
 }
@@ -543,9 +543,9 @@ func TestParseUnknown(t *testing.T) {
 func TestParseInvalid(t *testing.T) {
 	dockerDriver := new(docker.Driver)
 	dockerSpec, err := dockerDriver.TaskConfigSchema()
-	require.NoError(t, err)
+	must.NoError(t, err)
 	spec, diags := hclspecutils.Convert(dockerSpec)
-	require.False(t, diags.HasErrors())
+	must.False(t, diags.HasErrors())
 
 	cases := []struct {
 		name string
@@ -566,9 +566,9 @@ func TestParseInvalid(t *testing.T) {
 			ctyValue, diag, errs := hclutils.ParseHclInterface(inter, spec, vars)
 			t.Logf("parsed: %# v", pretty.Formatter(ctyValue))
 
-			require.NotNil(t, errs)
-			require.True(t, diag.HasErrors())
-			require.Contains(t, errs[0].Error(), "Invalid label")
+			must.NotNil(t, errs)
+			must.True(t, diag.HasErrors())
+			must.StrContains(t, errs[0].Error(), "Invalid label")
 		})
 	}
 }
@@ -584,7 +584,7 @@ func TestCtyValueToMapInterface(t *testing.T) {
 	})
 
 	decSpec, diags := hclspecutils.Convert(spec)
-	require.False(t, diags.HasErrors())
+	must.False(t, diags.HasErrors())
 
 	config := hclutils.HclConfigToInterface(t, `
 	config {
@@ -597,11 +597,12 @@ func TestCtyValueToMapInterface(t *testing.T) {
 	}`)
 
 	v, diag, errs := hclutils.ParseHclInterface(config, decSpec, nil)
-	require.False(t, diag.HasErrors(), errs)
+	must.False(t, diag.HasErrors())
+	must.Nil(t, errs)
 
 	m, err := hclutils.CtyValueToMapInterface(v)
-	require.NoError(t, err)
-	require.Equal(t, map[string]interface{}{
+	must.NoError(t, err)
+	must.Eq(t, map[string]interface{}{
 		"a": "hello",
 		"b": 42,
 		"c": []interface{}{"one", "two"},
@@ -616,8 +617,8 @@ func TestCtyValueToMapInterface_MapInput(t *testing.T) {
 	})
 
 	m, err := hclutils.CtyValueToMapInterface(v)
-	require.NoError(t, err)
-	require.Equal(t, map[string]interface{}{
+	must.NoError(t, err)
+	must.Eq(t, map[string]interface{}{
 		"first":  "value",
 		"second": "another",
 	}, m)
@@ -625,20 +626,20 @@ func TestCtyValueToMapInterface_MapInput(t *testing.T) {
 
 func TestCtyValueToMapInterface_Null(t *testing.T) {
 	m, err := hclutils.CtyValueToMapInterface(cty.NullVal(cty.DynamicPseudoType))
-	require.NoError(t, err)
-	require.Nil(t, m)
+	must.NoError(t, err)
+	must.Nil(t, m)
 }
 
 func TestCtyValueToMapInterface_InvalidType(t *testing.T) {
 	_, err := hclutils.CtyValueToMapInterface(cty.StringVal("nope"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "expected map/object cty value")
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "expected map/object cty value")
 }
 
 func TestCtyValueToMapInterface_Unknown(t *testing.T) {
 	_, err := hclutils.CtyValueToMapInterface(cty.UnknownVal(cty.Object(map[string]cty.Type{
 		"a": cty.String,
 	})))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "value is not known")
+	must.Error(t, err)
+	must.StrContains(t, err.Error(), "value is not known")
 }

--- a/helper/pluginutils/loader/init.go
+++ b/helper/pluginutils/loader/init.go
@@ -54,37 +54,44 @@ func validateConfig(config *PluginLoaderConfig) error {
 
 // init initializes the plugin loader by compiling both internal and external
 // plugins and selecting the highest versioned version of any given plugin.
-func (l *PluginLoader) init(config *PluginLoaderConfig) error {
+func (l *PluginLoader) init(cfg *PluginLoaderConfig) (map[string]*config.PluginConfig, error) {
 	// Create a mapping of name to config
-	configMap := configMap(config.Configs)
+	configMap := configMap(cfg.Configs)
 
 	// Initialize the internal plugins
-	internal, err := l.initInternal(config.InternalPlugins, configMap)
+	internal, err := l.initInternal(cfg.InternalPlugins, configMap)
 	if err != nil {
-		return fmt.Errorf("failed to fingerprint internal plugins: %v", err)
+		return nil, fmt.Errorf("failed to fingerprint internal plugins: %v", err)
 	}
 
 	// Scan for eligibile binaries
 	plugins, err := l.scan()
 	if err != nil {
-		return fmt.Errorf("failed to scan plugin directory %q: %v", l.pluginDir, err)
+		return nil, fmt.Errorf("failed to scan plugin directory %q: %v", l.pluginDir, err)
 	}
 
 	// Fingerprint the passed plugins
 	external, err := l.fingerprintPlugins(plugins, configMap)
 	if err != nil {
-		return fmt.Errorf("failed to fingerprint plugins: %v", err)
+		return nil, fmt.Errorf("failed to fingerprint plugins: %v", err)
 	}
 
 	// Merge external and internal plugins
 	l.plugins = l.mergePlugins(internal, external)
 
 	// Validate that the configs are valid for the plugins
-	if err := l.validatePluginConfigs(); err != nil {
-		return fmt.Errorf("parsing plugin configurations failed: %v", err)
+	canonicalizedConfigs, err := l.validatePluginConfigs()
+	if err != nil {
+		return nil, fmt.Errorf("parsing plugin configurations failed: %v", err)
 	}
 
-	return nil
+	for i, _ := range configMap {
+		if updated, ok := canonicalizedConfigs[i]; ok {
+			configMap[i].Config = updated.Config
+		}
+	}
+
+	return configMap, nil
 }
 
 // initInternal initializes internal plugins.
@@ -430,40 +437,48 @@ func (l *PluginLoader) mergePlugins(internal, external map[PluginID]*pluginInfo)
 
 // validatePluginConfigs is used to validate each plugins' configuration. If the
 // plugin has a config, it is parsed with the plugins config schema and
-// SetConfig is called to ensure the config is valid.
-func (l *PluginLoader) validatePluginConfigs() error {
+// SetConfig is called to ensure the config is valid, it returns all the
+// errors encountered during validation and the canonicalized configurations
+// from the plugins.
+func (l *PluginLoader) validatePluginConfigs() (map[string]*InternalPluginConfig, error) {
 	var mErr multierror.Error
-	for id, info := range l.plugins {
-		if err := l.validatePluginConfig(id, info); err != nil {
+	config := map[string]*InternalPluginConfig{}
+	for id, _ := range l.plugins {
+		pc, err := l.validatePluginConfig(id, l.plugins[id])
+		if err != nil {
 			wrapped := multierror.Prefix(err, fmt.Sprintf("plugin %s:", id))
 			_ = multierror.Append(&mErr, wrapped)
 		}
+
+		config[id.Name] = &InternalPluginConfig{
+			Config: pc,
+		}
 	}
 
-	return mErr.ErrorOrNil()
+	return config, mErr.ErrorOrNil()
 }
 
 // validatePluginConfig is used to validate the plugin's configuration. If the
 // plugin has a config, it is parsed with the plugins config schema and
 // SetConfig is called to ensure the config is valid.
-func (l *PluginLoader) validatePluginConfig(id PluginID, info *pluginInfo) error {
+func (l *PluginLoader) validatePluginConfig(id PluginID, info *pluginInfo) (map[string]interface{}, error) {
 	var mErr multierror.Error
 
 	// Check if a config is allowed
 	if info.configSchema == nil {
 		if info.config != nil {
-			return fmt.Errorf("configuration not allowed but config passed")
+			return nil, fmt.Errorf("configuration not allowed but config passed")
 		}
 
 		// Nothing to do
-		return nil
+		return nil, nil
 	}
 
 	// Convert the schema to hcl
 	spec, diag := hclspecutils.Convert(info.configSchema)
 	if diag.HasErrors() {
 		_ = multierror.Append(&mErr, diag.Errs()...)
-		return multierror.Prefix(&mErr, "failed converting config schema:")
+		return nil, multierror.Prefix(&mErr, "failed converting config schema:")
 	}
 
 	// If there is no config, initialize it to an empty map so we can still
@@ -476,14 +491,14 @@ func (l *PluginLoader) validatePluginConfig(id PluginID, info *pluginInfo) error
 	val, diag, diagErrs := hclutils.ParseHclInterface(info.config, spec, nil)
 	if diag.HasErrors() {
 		_ = multierror.Append(&mErr, diagErrs...)
-		return multierror.Prefix(&mErr, "failed to parse config: ")
+		return nil, multierror.Prefix(&mErr, "failed to parse config: ")
 
 	}
 
 	// Marshal the value
 	cdata, err := msgpack.Marshal(val, val.Type())
 	if err != nil {
-		return fmt.Errorf("failed to msgpack encode config: %v", err)
+		return nil, fmt.Errorf("failed to msgpack encode config: %v", err)
 	}
 
 	// Store the marshalled config
@@ -492,13 +507,13 @@ func (l *PluginLoader) validatePluginConfig(id PluginID, info *pluginInfo) error
 	// Dispense the plugin and set its config and ensure it is error free
 	instance, err := l.Dispense(id.Name, id.PluginType, nil, l.logger)
 	if err != nil {
-		return fmt.Errorf("failed to dispense plugin: %v", err)
+		return nil, fmt.Errorf("failed to dispense plugin: %v", err)
 	}
 	defer instance.Kill()
 
 	b, ok := instance.Plugin().(base.BasePlugin)
 	if !ok {
-		return fmt.Errorf("dispensed plugin %s doesn't meet base plugin interface", id)
+		return nil, fmt.Errorf("dispensed plugin %s doesn't meet base plugin interface", id)
 	}
 
 	c := &base.Config{
@@ -508,7 +523,13 @@ func (l *PluginLoader) validatePluginConfig(id PluginID, info *pluginInfo) error
 	}
 
 	if err := b.SetConfig(c); err != nil {
-		return fmt.Errorf("setting config on plugin failed: %v", err)
+		return nil, fmt.Errorf("setting config on plugin failed: %v", err)
 	}
-	return nil
+
+	parsedConfig, err := hclutils.CtyValueToMapInterface(val)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert parsed config to map: %v", err)
+	}
+
+	return parsedConfig, nil
 }

--- a/helper/pluginutils/loader/init.go
+++ b/helper/pluginutils/loader/init.go
@@ -85,7 +85,7 @@ func (l *PluginLoader) init(cfg *PluginLoaderConfig) (map[string]*config.PluginC
 		return nil, fmt.Errorf("parsing plugin configurations failed: %v", err)
 	}
 
-	for i, _ := range configMap {
+	for i := range configMap {
 		if updated, ok := canonicalizedConfigs[i]; ok {
 			configMap[i].Config = updated.Config
 		}
@@ -443,7 +443,7 @@ func (l *PluginLoader) mergePlugins(internal, external map[PluginID]*pluginInfo)
 func (l *PluginLoader) validatePluginConfigs() (map[string]*InternalPluginConfig, error) {
 	var mErr multierror.Error
 	config := map[string]*InternalPluginConfig{}
-	for id, _ := range l.plugins {
+	for id := range l.plugins {
 		pc, err := l.validatePluginConfig(id, l.plugins[id])
 		if err != nil {
 			wrapped := multierror.Prefix(err, fmt.Sprintf("plugin %s:", id))

--- a/helper/pluginutils/loader/loader.go
+++ b/helper/pluginutils/loader/loader.go
@@ -112,6 +112,11 @@ type pluginInfo struct {
 
 // NewPluginLoader returns an instance of a plugin loader or an error if the
 // plugins could not be loaded
+//
+// IMPORTANT: This function will mutate the passed in config to update the plugin
+// configs with any default values from the plugin's config schema.
+// The config should be a pointer to the config in the agent to properly
+// update the plugin configs in the agent.
 func NewPluginLoader(config *PluginLoaderConfig) (*PluginLoader, error) {
 	if err := validateConfig(config); err != nil {
 		return nil, fmt.Errorf("invalid plugin loader configuration passed: %v", err)
@@ -135,8 +140,19 @@ func NewPluginLoader(config *PluginLoaderConfig) (*PluginLoader, error) {
 		plugins:           make(map[PluginID]*pluginInfo),
 	}
 
-	if err := l.init(config); err != nil {
+	updatedConfig, err := l.init(config)
+	if err != nil {
 		return nil, fmt.Errorf("failed to initialize plugin loader: %v", err)
+	}
+
+	// DANGER! Secondary effect of init is that it updates the plugin configs
+	// in the loader's plugins map with any default values from the plugin schemas.
+	//  We need to propagate those updated configs back to the agent config
+	// since the agent will use those to report the plugings configs in the API.
+	for i, c := range config.Configs {
+		if updated, ok := updatedConfig[c.Name]; ok {
+			config.Configs[i] = updated
+		}
 	}
 
 	return l, nil


### PR DESCRIPTION
### Description
Currently the plugin's config in the agent are stored as the user submits them, to pass them to the plugins they are canonicalised, codified and stored, but the canonicalised value is not return to the agent, resulting in a correct configuration but incomplete information when querying the agent. This PR adds that missing step so the agents information is coherent with the plugin's real configuration.

The function `CtyValueToMapInterface` was created using AI under the prompt: ```can you give me a function that takes the cty.Value that comes out of the #sym:ParseHclInterface function and makes it into a map[string]interface{} that can be stored as config in the InternalPluginConfig```

### Testing & Reproduction steps
Start a nomad client with the docker plugin enabled. A call to `nomad agent-info -json | jq '.config.Plugins[].Config.gc' ` should include all the default values:

```
{
  "image": true,
  "image_delay": "3m",
  "container": true,
  "dangling_containers": {
    "period": "1m",
    "creation_grace": "1m",
    "dry_run": false,
    "enabled": true
  }
```

### Links
This PR solves [NMD-828](https://hashicorp.atlassian.net/browse/NMD-828)

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


[NMD-828]: https://hashicorp.atlassian.net/browse/NMD-828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ