### PR TITLE
E2E: adjust batch timeout poststop test assertion to match bugfix

### DIFF
--- a/e2e/batch_timeout/batch_timeout_test.go
+++ b/e2e/batch_timeout/batch_timeout_test.go
@@ -4,6 +4,7 @@
 package batch_timeout
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/e2e/v3/jobs3"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/shoenig/test/must"
+	"github.com/shoenig/test/wait"
 )
 
 // testTimeout is the upper bound we allow for each sub-test. It must be long
@@ -99,13 +101,26 @@ func testBatchJobTimeoutSkipsPoststop(t *testing.T) {
 		must.Sprint("timed-out allocation must carry the max_run_duration description"))
 
 	// The poststop task must NOT have been started.
-	poststopState, ok := alloc.TaskStates["poststop"]
-	must.True(t, ok,
-		must.Sprint("poststop task state must be present in the allocation"))
-	must.Eq(t, structs.TaskStatePending, poststopState.State,
-		must.Sprint("poststop task must remain 'pending' — it must not be started when max_run_duration is exceeded"))
-	must.True(t, poststopState.StartedAt.IsZero(),
-		must.Sprint("poststop task StartedAt must be zero — it was never started"))
+	must.Wait(t, wait.InitialSuccess(wait.ErrorFunc(func() error {
+		poststopState, ok := alloc.TaskStates["poststop"]
+		if !ok {
+			return fmt.Errorf("poststop task state must be present in the allocation")
+		}
+		if poststopState.State != structs.TaskStateDead {
+			return fmt.Errorf("poststop task must be marked 'dead': %+v",
+				poststopState)
+		}
+		if !poststopState.StartedAt.IsZero() {
+			return fmt.Errorf(
+				"poststop task StartedAt must be zero — it was never started: %+v",
+				poststopState)
+		}
+		return nil
+	}),
+		wait.Timeout(2*time.Second),
+		wait.Gap(10*time.Millisecond),
+	))
+
 }
 
 // testSysbatchJobTimesOut verifies that max_run_duration also works for

--- a/e2e/batch_timeout/input/batch_timeout_poststop.hcl
+++ b/e2e/batch_timeout/input/batch_timeout_poststop.hcl
@@ -53,8 +53,8 @@ job "batch-timeout-poststop" {
       }
 
       config {
-        command = "echo"
-        args    = ["poststop executed"]
+        command = "sleep"
+        args    = ["10"]
       }
 
       resources {


### PR DESCRIPTION
In #28073 we fixed a bug where poststop tasks for allocations stopped by `max_run_duration` were incorrectly being expected to be pending and not killed. But we neglected to fix the assertions in the E2E test to match.

Ref: https://github.com/hashicorp/nomad/pull/28073

### Testing & Reproduction steps

```
$ go test -count=1 -v ./e2e/batch_timeout -run  TestBatchJobMaxRunDuration/testBatchTimeoutSkipsPoststop
=== RUN   TestBatchJobMaxRunDuration
=== RUN   TestBatchJobMaxRunDuration/testBatchTimeoutSkipsPoststop
    batch_timeout_test.go:84: submitting job: "./input/batch_timeout_poststop.hcl"
--- PASS: TestBatchJobMaxRunDuration (6.02s)
    --- PASS: TestBatchJobMaxRunDuration/testBatchTimeoutSkipsPoststop (6.02s)
PASS
ok      github.com/hashicorp/nomad/e2e/batch_timeout    6.037s
```

### Contributor Checklist
- [x] **Changelog Entry** no changelog; original bug hasn't shipped in a release yet
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
