### PR TITLE
scheduler: reject sticky on a static host volume

### DIFF
--- a/.changelog/28097.txt
+++ b/.changelog/28097.txt
@@ -1,0 +1,7 @@
+```release-note:bug
+scheduler: Fixed a bug where setting `sticky` on a static host volume could fail the evaluation instead of being rejected during feasibility checking
+```
+
+```release-note:bug
+scheduler: Fixed a bug where a node could be marked feasible for a task group requesting multiple host volumes when a satisfied sticky volume request short-circuited the checks for the remaining requests
+```

--- a/scheduler/feasible/feasible.go
+++ b/scheduler/feasible/feasible.go
@@ -330,60 +330,81 @@ func (h *HostVolumeChecker) hasVolumes(n *structs.Node) bool {
 	}
 
 	for _, req := range h.volumeReqs {
-		volCfg, ok := n.HostVolumes[req.Source]
-		if !ok {
+		if !h.nodeIsFeasibleForRequest(n, req, proposed) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// nodeIsFeasibleForRequest determines if the node can satisfy a single host
+// volume request. hasVolumes calls it for every request and rejects the node if
+// any one is infeasible, so a request that is satisfied here must not
+// short-circuit the checks for the other requests.
+func (h *HostVolumeChecker) nodeIsFeasibleForRequest(n *structs.Node, req *structs.VolumeRequest, proposed []*structs.Allocation) bool {
+	volCfg, ok := n.HostVolumes[req.Source]
+	if !ok {
+		return false
+	}
+
+	if volCfg.ID != "" { // dynamic host volume
+		vol, err := h.ctx.State().HostVolumeByID(nil, h.namespace, volCfg.ID, false)
+		if err != nil || vol == nil {
+			// the dynamic host volume in the node fingerprint does not
+			// belong to the namespace we need. or the volume is no longer
+			// in the state store because the batched fingerprint update
+			// from a delete RPC is written before the delete RPC's raft
+			// entry completes
+			return false
+		}
+		if !h.hostVolumeIsAvailable(vol,
+			req.AccessMode,
+			req.AttachmentMode,
+			req.ReadOnly,
+			proposed,
+		) {
 			return false
 		}
 
-		if volCfg.ID != "" { // dynamic host volume
-			vol, err := h.ctx.State().HostVolumeByID(nil, h.namespace, volCfg.ID, false)
-			if err != nil || vol == nil {
-				// the dynamic host volume in the node fingerprint does not
-				// belong to the namespace we need. or the volume is no longer
-				// in the state store because the batched fingerprint update
-				// from a delete RPC is written before the delete RPC's raft
-				// entry completes
-				return false
-			}
-			if !h.hostVolumeIsAvailable(vol,
-				req.AccessMode,
-				req.AttachmentMode,
-				req.ReadOnly,
-				proposed,
-			) {
-				return false
+		if req.Sticky {
+			// the node is feasible for this request if there are no remaining
+			// claims to fulfill or if there's an exact match
+			if len(h.unmetClaims) == 0 {
+				return true
 			}
 
-			if req.Sticky {
-				// the node is feasible if there are no remaining claims to
-				// fulfill or if there's an exact match
-				if len(h.unmetClaims) == 0 {
+			for _, c := range h.unmetClaims {
+				if c.VolumeID == vol.ID {
+					// if we have a match for a volume claim, delete this
+					// claim from the claims list in the feasibility
+					// checker. This is needed for situations when jobs get
+					// scaled up and new allocations need to be placed on
+					// the same node.
+					h.unmetClaims = slices.DeleteFunc(h.unmetClaims,
+						func(claim *structs.TaskGroupHostVolumeClaim) bool {
+							return claim.VolumeID == vol.ID
+						})
 					return true
 				}
-
-				for _, c := range h.unmetClaims {
-					if c.VolumeID == vol.ID {
-						// if we have a match for a volume claim, delete this
-						// claim from the claims list in the feasibility
-						// checker. This is needed for situations when jobs get
-						// scaled up and new allocations need to be placed on
-						// the same node.
-						h.unmetClaims = slices.DeleteFunc(h.unmetClaims,
-							func(claim *structs.TaskGroupHostVolumeClaim) bool {
-								return claim.VolumeID == vol.ID
-							})
-						return true
-					}
-				}
-				return false
 			}
-		} else if !req.ReadOnly {
-			// this is a static host volume and can only be mounted ReadOnly,
-			// validate that no requests for it are ReadWrite.
-			if volCfg.ReadOnly {
-				return false
-			}
+			return false
 		}
+
+		return true
+	}
+
+	// this is a static host volume
+
+	// sticky is only supported on dynamic host volumes
+	if req.Sticky {
+		return false
+	}
+
+	// a static host volume that is configured read-only can only be mounted
+	// ReadOnly, so validate that no requests for it are ReadWrite
+	if !req.ReadOnly && volCfg.ReadOnly {
+		return false
 	}
 
 	return true

--- a/scheduler/feasible/feasible_test.go
+++ b/scheduler/feasible/feasible_test.go
@@ -240,6 +240,116 @@ func TestHostVolumeChecker_Static(t *testing.T) {
 	}
 }
 
+func TestHostVolumeChecker_StaticSticky(t *testing.T) {
+	ci.Parallel(t)
+
+	_, ctx := MockContext(t)
+
+	node := mock.Node()
+	node.HostVolumes = map[string]*structs.ClientHostVolumeConfig{
+		"foo": {}, // static host volume: ID is empty
+	}
+
+	// sticky is only supported on dynamic host volumes, so requesting it on a
+	// static host volume must fail feasibility regardless of ReadOnly.
+	cases := []struct {
+		name   string
+		req    *structs.VolumeRequest
+		result bool
+	}{
+		{
+			name:   "sticky read-write",
+			req:    &structs.VolumeRequest{Type: "host", Source: "foo", Sticky: true},
+			result: false,
+		},
+		{
+			name:   "sticky read-only",
+			req:    &structs.VolumeRequest{Type: "host", Source: "foo", Sticky: true, ReadOnly: true},
+			result: false,
+		},
+		{
+			name:   "not sticky",
+			req:    &structs.VolumeRequest{Type: "host", Source: "foo"},
+			result: true,
+		},
+	}
+
+	checker := NewHostVolumeChecker(ctx)
+	alloc := mock.Alloc()
+	alloc.NodeID = node.ID
+	job := mock.Job()
+	taskGroup := job.TaskGroups[0]
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			checker.SetVolumes(alloc.Name, structs.DefaultNamespace, job.ID, taskGroup.Name,
+				map[string]*structs.VolumeRequest{"foo": tc.req})
+			must.Eq(t, tc.result, checker.Feasible(node))
+		})
+	}
+}
+
+func TestHostVolumeChecker_StaticStickyMultiVolume(t *testing.T) {
+	ci.Parallel(t)
+
+	store, ctx := MockContext(t)
+
+	// the node has one dynamic host volume (ID set) and one static host volume
+	// (ID empty)
+	dhvID := uuid.Generate()
+	node := mock.Node()
+	node.HostVolumes = map[string]*structs.ClientHostVolumeConfig{
+		"dyn":  {ID: dhvID},
+		"stat": {},
+	}
+	must.NoError(t, store.UpsertNode(structs.MsgTypeTestSetup, 1000, node))
+
+	dhv := &structs.HostVolume{
+		Namespace: structs.DefaultNamespace,
+		ID:        dhvID,
+		Name:      "dyn",
+		NodeID:    node.ID,
+		RequestedCapabilities: []*structs.HostVolumeCapability{{
+			AttachmentMode: structs.HostVolumeAttachmentModeFilesystem,
+			AccessMode:     structs.HostVolumeAccessModeSingleNodeSingleWriter,
+		}},
+		State: structs.HostVolumeStateReady,
+	}
+	must.NoError(t, store.UpsertHostVolume(1000, dhv))
+
+	// both volumes are requested sticky. The dynamic one is available with no
+	// outstanding claims, so on its own it satisfies the per-request check; the
+	// static one is invalid for sticky. The node must be infeasible no matter
+	// which request is checked first.
+	dynReq := &structs.VolumeRequest{
+		Type:           "host",
+		Source:         "dyn",
+		Sticky:         true,
+		AccessMode:     structs.HostVolumeAccessModeSingleNodeSingleWriter,
+		AttachmentMode: structs.CSIVolumeAttachmentModeFilesystem,
+	}
+	statReq := &structs.VolumeRequest{Type: "host", Source: "stat", Sticky: true}
+
+	checker := NewHostVolumeChecker(ctx)
+	alloc := mock.Alloc()
+	alloc.NodeID = node.ID
+	job := mock.Job()
+	taskGroup := job.TaskGroups[0]
+	checker.SetVolumes(alloc.Name, structs.DefaultNamespace, job.ID, taskGroup.Name,
+		map[string]*structs.VolumeRequest{"dyn": dynReq, "stat": statReq})
+
+	// SetVolumes builds volumeReqs from a map, so set the order explicitly and
+	// check both: a satisfied dynamic request must not let the static one slip
+	// through whether it is checked first or second.
+	checker.volumeReqs = []*structs.VolumeRequest{dynReq, statReq}
+	must.False(t, checker.Feasible(node),
+		must.Sprint("infeasible with the dynamic request checked first"))
+
+	checker.volumeReqs = []*structs.VolumeRequest{statReq, dynReq}
+	must.False(t, checker.Feasible(node),
+		must.Sprint("infeasible with the static request checked first"))
+}
+
 func TestHostVolumeChecker_Dynamic(t *testing.T) {
 	ci.Parallel(t)
 

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/scheduler/feasible"
 	"github.com/hashicorp/nomad/scheduler/reconciler"
 	sstructs "github.com/hashicorp/nomad/scheduler/structs"
 	"github.com/hashicorp/nomad/scheduler/tests"
@@ -474,6 +475,57 @@ func TestServiceSched_JobRegister_StickyHostVolumes(t *testing.T) {
 		newPlanned = append(newPlanned, allocList...)
 	}
 	must.SliceLen(t, 10, newPlanned)
+}
+
+func TestServiceSched_JobRegister_StickyStaticHostVolume(t *testing.T) {
+	ci.Parallel(t)
+
+	h := tests.NewHarness(t)
+
+	// A node with a static host volume (its ID is empty).
+	node := mock.Node()
+	node.HostVolumes = map[string]*structs.ClientHostVolumeConfig{"foo": {Name: "foo"}}
+	must.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
+
+	// A job that requests the static volume with sticky, which is only valid for
+	// dynamic host volumes.
+	job := mock.Job()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Volumes = map[string]*structs.VolumeRequest{
+		"foo": {
+			Type:   "host",
+			Source: "foo",
+			Sticky: true,
+		},
+	}
+	must.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
+
+	eval := &structs.Evaluation{
+		Namespace:   structs.DefaultNamespace,
+		ID:          uuid.Generate(),
+		Priority:    job.Priority,
+		TriggeredBy: structs.EvalTriggerJobRegister,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+	must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
+
+	must.NoError(t, h.Process(NewServiceScheduler, eval))
+
+	// Nothing is placed, so the scheduler submits no plan.
+	must.SliceLen(t, 0, h.Plans)
+
+	// The unplaced allocation spawns a blocked eval, and the node is filtered
+	// out for the host volume constraint.
+	must.SliceLen(t, 1, h.CreateEvals)
+	must.Eq(t, structs.EvalStatusBlocked, h.CreateEvals[0].Status)
+
+	must.SliceLen(t, 1, h.Evals)
+	outEval := h.Evals[0]
+	must.MapLen(t, 1, outEval.FailedTGAllocs)
+	metrics := outEval.FailedTGAllocs[job.TaskGroups[0].Name]
+	must.NotNil(t, metrics)
+	must.MapContainsKey(t, metrics.ConstraintFiltered, feasible.FilterConstraintHostVolumes)
 }
 
 func TestServiceSched_JobRegister_DiskConstraints(t *testing.T) {


### PR DESCRIPTION
### Description

Setting `sticky = true` on a static host volume passed feasibility checking, so the scheduler placed the allocation and then failed to apply the plan with `Task group volume claim insert failed: object missing primary index`. Static host volumes have an empty ID, and the sticky claim is keyed by volume ID, so the claim insert hits an empty primary index. Static and dynamic host volumes share the same `type = "host"` jobspec, so the distinction is only known once a node is selected, which is why this can't be caught at job submission.

The fix rejects `sticky` on a static host volume during feasibility checking, before the allocation is placed. The check runs before the per-volume loop, so a feasible dynamic sticky volume in the same task group can't return early and skip it. A job that sets `sticky = true` on a static host volume will now fail feasibility with a clear constraint instead of failing the evaluation. Removing the `sticky` flag restores placement.

### Testing & Reproduction steps

Added two tests. `TestHostVolumeChecker_StaticSticky` covers the feasibility checker directly. Sticky read-write and read-only on a static volume are infeasible, and non-sticky stays feasible. `TestServiceSched_JobRegister_StickyStaticHostVolume` runs the service scheduler end to end. On `main` it fails with the `object missing primary index` claim error, and with the fix the evaluation completes with the allocation left unplaced and the host volume constraint recorded. `go test ./scheduler/feasible/ ./scheduler/` passes.

### Links

Fixes #27153

Per @tgross's note on the issue, this can't be caught at job submission because the static/dynamic distinction isn't known until feasibility checking.

### Contributor Checklist
- [x] **Changelog Entry** Added at `.changelog/27153.txt`.
- [x] **Testing** Added a feasibility-checker test and an end-to-end scheduler test.
- [ ] **Documentation** No product doc change. The behavior change may need an upgrade note in the web-unified-docs repo.

## Changes to Security Controls

No changes to security controls.

This contribution was developed with AI assistance (Claude Code), used to trace the feasibility path and draft the fix and tests.
