### PR TITLE
Revert "vault: refactor the vault client and hook (#27946)"

### DIFF
--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -78,7 +78,6 @@ func (tr *TaskRunner) initHooks() {
 			logger:           hookLogger,
 			alloc:            tr.Alloc(),
 			task:             tr.Task(),
-			taskCtx:          tr.shutdownCtx,
 			widmgr:           tr.widmgr,
 		}))
 	}

--- a/client/allocrunner/taskrunner/task_runner_linux_test.go
+++ b/client/allocrunner/taskrunner/task_runner_linux_test.go
@@ -8,6 +8,7 @@ package taskrunner
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"testing"
 	"time"
 
@@ -51,12 +53,12 @@ import (
 	structsc "github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/plugins/device"
 	"github.com/hashicorp/nomad/plugins/drivers"
+	"github.com/hashicorp/nomad/plugins/drivers/fsisolation"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/kr/pretty"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 	"github.com/stretchr/testify/assert"
-	tmock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1427,6 +1429,348 @@ func useMockEnvoyBootstrapHook(tr *TaskRunner) {
 	}
 }
 
+// TestTaskRunner_BlockForVaultToken asserts tasks do not start until a vault token
+// is derived.
+func TestTaskRunner_BlockForVaultToken(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Config = map[string]interface{}{
+		"run_for": "0s",
+	}
+	task.Vault = &structs.Vault{
+		Cluster: structs.VaultDefaultCluster,
+	}
+
+	// Control when we get a Vault token
+	token := "1234"
+	waitCh := make(chan struct{})
+	handler := func(ctx context.Context, req vaultclient.JWTLoginRequest) (string, bool, int, error) {
+		<-waitCh
+		return token, true, 30, nil
+	}
+
+	vc, err := vaultclient.NewMockVaultClient(structs.VaultDefaultCluster)
+	must.NoError(t, err)
+	vaultClient := vc.(*vaultclient.MockVaultClient)
+	vaultClient.SetDeriveTokenWithJWTFn(handler)
+
+	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, vaultClient)
+	defer cleanup()
+
+	// The test triggers the task runner Vault hook which performs a call to
+	// the WI manager. We therefore need to seed the WI manager with data and
+	// use the mock implementation for this. The data itself doesn't matter, we
+	// just care about the lookup success.
+	mockIDManager := widmgr.NewMockIdentityManager()
+	mockIDManager.(*widmgr.MockIdentityManager).SetIdentity(
+		structs.WIHandle{
+			IdentityName:       task.Vault.IdentityName(),
+			WorkloadIdentifier: task.Name,
+			WorkloadType:       structs.WorkloadTypeTask,
+		}, &structs.SignedWorkloadIdentity{
+			WorkloadIdentityRequest: structs.WorkloadIdentityRequest{},
+			JWT:                     "",
+		},
+	)
+
+	conf.WIDMgr = mockIDManager
+
+	tr, err := NewTaskRunner(conf)
+	require.NoError(t, err)
+	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
+	go tr.Run()
+
+	// Assert TR blocks on vault token (does *not* exit)
+	select {
+	case <-tr.WaitCh():
+		require.Fail(t, "tr exited before vault unblocked")
+	case <-time.After(1 * time.Second):
+	}
+
+	// Assert task state is still Pending
+	require.Equal(t, structs.TaskStatePending, tr.TaskState().State)
+
+	// Unblock vault token
+	close(waitCh)
+
+	// TR should exit now that it's unblocked by vault as its a batch job
+	// with 0 sleeping.
+	testWaitForTaskToDie(t, tr)
+
+	// Assert task exited successfully
+	finalState := tr.TaskState()
+	require.Equal(t, structs.TaskStateDead, finalState.State)
+	require.False(t, finalState.Failed)
+
+	// Check that the token is on disk
+	tokenPath := filepath.Join(conf.TaskDir.PrivateDir, vaultTokenFile)
+	data, err := os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	require.Equal(t, token, string(data))
+
+	tokenPath = filepath.Join(conf.TaskDir.SecretsDir, vaultTokenFile)
+	data, err = os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	require.Equal(t, token, string(data))
+
+	// Kill task runner to trigger stop hooks
+	tr.Kill(context.Background(), structs.NewTaskEvent("kill"))
+	select {
+	case <-tr.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		require.Fail(t, "timed out waiting for task runner to exit")
+	}
+
+	// Check the token was revoked
+	testutil.WaitForResult(func() (bool, error) {
+		if len(vaultClient.StoppedTokens()) != 1 {
+			return false, fmt.Errorf("Expected a stopped token %q but found: %v", token, vaultClient.StoppedTokens())
+		}
+
+		if a := vaultClient.StoppedTokens()[0]; a != token {
+			return false, fmt.Errorf("got stopped token %q; want %q", a, token)
+		}
+		return true, nil
+	}, func(err error) {
+		require.Fail(t, err.Error())
+	})
+}
+
+func TestTaskRunner_DisableFileForVaultToken(t *testing.T) {
+	ci.Parallel(t)
+
+	// Create test allocation with a Vault block disabling the token file in
+	// the secrets dir.
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Config = map[string]any{
+		"run_for": "0s",
+	}
+	task.Vault = &structs.Vault{
+		Cluster:     structs.VaultDefaultCluster,
+		DisableFile: true,
+	}
+
+	// Setup a test Vault client
+	token := "1234"
+	handler := func(ctx context.Context, req vaultclient.JWTLoginRequest) (string, bool, int, error) {
+		return token, true, 30, nil
+	}
+	vc, err := vaultclient.NewMockVaultClient(structs.VaultDefaultCluster)
+	must.NoError(t, err)
+	vaultClient := vc.(*vaultclient.MockVaultClient)
+	vaultClient.SetDeriveTokenWithJWTFn(handler)
+
+	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, vaultClient)
+	defer cleanup()
+
+	// The test triggers the task runner Vault hook which performs a call to
+	// the WI manager. We therefore need to seed the WI manager with data and
+	// use the mock implementation for this. The data itself doesn't matter, we
+	// just care about the lookup success.
+	mockIDManager := widmgr.NewMockIdentityManager()
+	mockIDManager.(*widmgr.MockIdentityManager).SetIdentity(
+		structs.WIHandle{
+			IdentityName:       task.Vault.IdentityName(),
+			WorkloadIdentifier: task.Name,
+			WorkloadType:       structs.WorkloadTypeTask,
+		}, &structs.SignedWorkloadIdentity{
+			WorkloadIdentityRequest: structs.WorkloadIdentityRequest{},
+			JWT:                     "",
+		},
+	)
+
+	conf.WIDMgr = mockIDManager
+
+	// Start task runner and wait for it to complete.
+	tr, err := NewTaskRunner(conf)
+	must.NoError(t, err)
+	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
+	go tr.Run()
+
+	testWaitForTaskToDie(t, tr)
+
+	// Verify task exited successfully.
+	finalState := tr.TaskState()
+	must.Eq(t, structs.TaskStateDead, finalState.State)
+	must.False(t, finalState.Failed)
+
+	// Verify token is in the private dir.
+	tokenPath := filepath.Join(conf.TaskDir.PrivateDir, vaultTokenFile)
+	data, err := os.ReadFile(tokenPath)
+	must.NoError(t, err)
+	must.Eq(t, token, string(data))
+
+	// Verify token is not in secrets dir.
+	tokenPath = filepath.Join(conf.TaskDir.SecretsDir, vaultTokenFile)
+	_, err = os.Stat(tokenPath)
+	must.ErrorIs(t, err, os.ErrNotExist)
+}
+
+// TestTaskRunner_DeriveToken_Retry asserts that if a recoverable error is
+// returned when deriving a vault token a task will continue to block while
+// it's retried.
+func TestTaskRunner_DeriveToken_Retry(t *testing.T) {
+	ci.Parallel(t)
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Vault = &structs.Vault{
+		Cluster: structs.VaultDefaultCluster,
+	}
+
+	// Fail on the first attempt to derive a vault token
+	token := "1234"
+	count := 0
+	handler := func(ctx context.Context, req vaultclient.JWTLoginRequest) (string, bool, int, error) {
+		if count > 0 {
+			return token, true, 30, nil
+		}
+
+		count++
+		return "", false, 0, structs.NewRecoverableError(fmt.Errorf("want a retry"), true)
+	}
+	vc, err := vaultclient.NewMockVaultClient(structs.VaultDefaultCluster)
+	must.NoError(t, err)
+	vaultClient := vc.(*vaultclient.MockVaultClient)
+	vaultClient.SetDeriveTokenWithJWTFn(handler)
+
+	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, vaultClient)
+	defer cleanup()
+
+	// The test triggers the task runner Vault hook which performs a call to
+	// the WI manager. We therefore need to seed the WI manager with data and
+	// use the mock implementation for this. The data itself doesn't matter, we
+	// just care about the lookup success.
+	mockIDManager := widmgr.NewMockIdentityManager()
+	mockIDManager.(*widmgr.MockIdentityManager).SetIdentity(
+		structs.WIHandle{
+			IdentityName:       task.Vault.IdentityName(),
+			WorkloadIdentifier: task.Name,
+			WorkloadType:       structs.WorkloadTypeTask,
+		}, &structs.SignedWorkloadIdentity{
+			WorkloadIdentityRequest: structs.WorkloadIdentityRequest{},
+			JWT:                     "",
+		},
+	)
+
+	conf.WIDMgr = mockIDManager
+
+	tr, err := NewTaskRunner(conf)
+	require.NoError(t, err)
+	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
+	go tr.Run()
+
+	// Wait for TR to die and check its state
+	testWaitForTaskToDie(t, tr)
+
+	state := tr.TaskState()
+	require.Equal(t, structs.TaskStateDead, state.State)
+	require.False(t, state.Failed)
+
+	// Kill task runner to trigger stop hooks
+	tr.Kill(context.Background(), structs.NewTaskEvent("kill"))
+	select {
+	case <-tr.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*15) * time.Second):
+		require.Fail(t, "timed out waiting for task runner to exit")
+	}
+
+	require.Equal(t, 1, count)
+
+	// Check that the token is on disk
+	tokenPath := filepath.Join(conf.TaskDir.PrivateDir, vaultTokenFile)
+	data, err := os.ReadFile(tokenPath)
+	require.NoError(t, err)
+	require.Equal(t, token, string(data))
+
+	// Check the token was revoked
+	testutil.WaitForResult(func() (bool, error) {
+		if len(vaultClient.StoppedTokens()) != 1 {
+			return false, fmt.Errorf("Expected a stopped token: %v", vaultClient.StoppedTokens())
+		}
+
+		if a := vaultClient.StoppedTokens()[0]; a != token {
+			return false, fmt.Errorf("got stopped token %q; want %q", a, token)
+		}
+		return true, nil
+	}, func(err error) {
+		require.Fail(t, err.Error())
+	})
+}
+
+// TestTaskRunner_DeriveToken_Unrecoverable asserts that an unrecoverable error
+// from deriving a vault token will fail a task.
+func TestTaskRunner_DeriveToken_Unrecoverable(t *testing.T) {
+	ci.Parallel(t)
+
+	// Use a batch job with no restarts
+	alloc := mock.BatchAlloc()
+	tg := alloc.Job.TaskGroups[0]
+	tg.RestartPolicy.Attempts = 0
+	tg.RestartPolicy.Interval = 0
+	tg.RestartPolicy.Delay = 0
+	tg.RestartPolicy.Mode = structs.RestartPolicyModeFail
+	task := tg.Tasks[0]
+	task.Config = map[string]interface{}{
+		"run_for": "0s",
+	}
+	task.Vault = &structs.Vault{
+		Cluster: structs.VaultDefaultCluster,
+	}
+
+	// Error the token derivation
+	vc, err := vaultclient.NewMockVaultClient(structs.VaultDefaultCluster)
+	must.NoError(t, err)
+
+	vc.(*vaultclient.MockVaultClient).SetDeriveTokenWithJWTFn(
+		func(ctx context.Context, req vaultclient.JWTLoginRequest) (string, bool, int, error) {
+			return "", false, 0, errors.New("unrecoverable")
+		},
+	)
+
+	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, vc)
+	defer cleanup()
+
+	// The test triggers the task runner Vault hook which performs a call to
+	// the WI manager. We therefore need to seed the WI manager with data and
+	// use the mock implementation for this. The data itself doesn't matter, we
+	// just care about the lookup success.
+	mockIDManager := widmgr.NewMockIdentityManager()
+	mockIDManager.(*widmgr.MockIdentityManager).SetIdentity(
+		structs.WIHandle{
+			IdentityName:       task.Vault.IdentityName(),
+			WorkloadIdentifier: task.Name,
+			WorkloadType:       structs.WorkloadTypeTask,
+		}, &structs.SignedWorkloadIdentity{
+			WorkloadIdentityRequest: structs.WorkloadIdentityRequest{},
+			JWT:                     "",
+		},
+	)
+
+	conf.WIDMgr = mockIDManager
+
+	tr, err := NewTaskRunner(conf)
+	require.NoError(t, err)
+	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
+	go tr.Run()
+
+	// Wait for the task to die
+	select {
+	case <-tr.WaitCh():
+	case <-time.After(time.Duration(testutil.TestMultiplier()*30) * time.Second):
+		require.Fail(t, "timed out waiting for task runner to fail")
+	}
+
+	// Task should be dead and last event should have failed task
+	state := tr.TaskState()
+	require.Equal(t, structs.TaskStateDead, state.State)
+	require.True(t, state.Failed)
+	require.Len(t, state.Events, 3)
+	require.True(t, state.Events[2].FailsTask)
+}
+
 // TestTaskRunner_Download_RawExec asserts that downloaded artifacts may be
 // executed in a driver without filesystem isolation.
 func TestTaskRunner_Download_RawExec(t *testing.T) {
@@ -1714,13 +2058,18 @@ func TestTaskRunner_RestartSignalTask_NotRunning(t *testing.T) {
 	}
 
 	// Control when we get a Vault token
-	waitCh := make(chan time.Time)
+	waitCh := make(chan struct{}, 1)
 	defer close(waitCh)
+	handler := func(ctx context.Context, req vaultclient.JWTLoginRequest) (string, bool, int, error) {
+		<-waitCh
+		return "1234", true, 30, nil
+	}
+	vc, err := vaultclient.NewMockVaultClient(structs.VaultDefaultCluster)
+	must.NoError(t, err)
+	vaultClient := vc.(*vaultclient.MockVaultClient)
+	vaultClient.SetDeriveTokenWithJWTFn(handler)
 
-	vc := vaultclient.NewMockVaultClient()
-	vc.On("DeriveTokenWithJWT", tmock.Anything, tmock.Anything).Return("", false, 0, nil).WaitUntil(waitCh)
-
-	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, vc)
+	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, vaultClient)
 	defer cleanup()
 
 	// The test triggers the task runner Vault hook which performs a call to
@@ -1728,7 +2077,7 @@ func TestTaskRunner_RestartSignalTask_NotRunning(t *testing.T) {
 	// use the mock implementation for this. The data itself doesn't matter, we
 	// just care about the lookup success.
 	mockIDManager := widmgr.NewMockIdentityManager()
-	mockIDManager.SetIdentity(
+	mockIDManager.(*widmgr.MockIdentityManager).SetIdentity(
 		structs.WIHandle{
 			IdentityName:       task.Vault.IdentityName(),
 			WorkloadIdentifier: task.Name,
@@ -1763,7 +2112,7 @@ func TestTaskRunner_RestartSignalTask_NotRunning(t *testing.T) {
 	require.EqualError(t, err, te.ErrTaskNotRunning.Error())
 
 	// Unblock and let it finish
-	waitCh <- time.Now()
+	waitCh <- struct{}{}
 	testWaitForTaskToDie(t, tr)
 
 	// Assert the task ran and never restarted
@@ -2079,6 +2428,288 @@ func TestTaskRunner_TemplateWorkloadIdentity(t *testing.T) {
 	renderedTmpl := string(data)
 	must.StrContains(t, renderedTmpl, expectedConsulValue)
 	must.StrContains(t, renderedTmpl, expectedVaultSecret)
+}
+
+// TestTaskRunner_Template_NewVaultToken asserts that a new vault token is
+// created when rendering template and that it is revoked on alloc completion
+func TestTaskRunner_Template_NewVaultToken(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Templates = []*structs.Template{
+		{
+			EmbeddedTmpl: `{{key "foo"}}`,
+			DestPath:     "local/test",
+			ChangeMode:   structs.TemplateChangeModeNoop,
+		},
+	}
+	task.Vault = &structs.Vault{
+		Cluster: structs.VaultDefaultCluster,
+	}
+
+	vc, err := vaultclient.NewMockVaultClient(structs.VaultDefaultCluster)
+	must.NoError(t, err)
+	vaultClient := vc.(*vaultclient.MockVaultClient)
+
+	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, vaultClient)
+	defer cleanup()
+
+	// The test triggers the task runner Vault hook which performs a call to
+	// the WI manager. We therefore need to seed the WI manager with data and
+	// use the mock implementation for this. The data itself doesn't matter, we
+	// just care about the lookup success.
+	mockIDManager := widmgr.NewMockIdentityManager()
+	mockIDManager.(*widmgr.MockIdentityManager).SetIdentity(
+		structs.WIHandle{
+			IdentityName:       task.Vault.IdentityName(),
+			WorkloadIdentifier: task.Name,
+			WorkloadType:       structs.WorkloadTypeTask,
+		}, &structs.SignedWorkloadIdentity{
+			WorkloadIdentityRequest: structs.WorkloadIdentityRequest{},
+			JWT:                     "",
+		},
+	)
+
+	conf.WIDMgr = mockIDManager
+
+	tr, err := NewTaskRunner(conf)
+	require.NoError(t, err)
+	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
+	go tr.Run()
+
+	// Wait for a Vault token
+	var token string
+	testutil.WaitForResult(func() (bool, error) {
+		token = tr.getVaultToken()
+
+		if token == "" {
+			return false, fmt.Errorf("No Vault token")
+		}
+
+		return true, nil
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+
+	renewalCh, ok := vaultClient.RenewTokens()[token]
+	require.True(t, ok, "no renewal channel for token")
+
+	renewalCh <- fmt.Errorf("Test killing")
+	close(renewalCh)
+
+	var token2 string
+	testutil.WaitForResult(func() (bool, error) {
+		token2 = tr.getVaultToken()
+
+		if token2 == "" {
+			return false, fmt.Errorf("No Vault token")
+		}
+
+		if token2 == token {
+			return false, fmt.Errorf("token wasn't recreated")
+		}
+
+		return true, nil
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+
+	// Check the token was revoked
+	testutil.WaitForResult(func() (bool, error) {
+		if len(vaultClient.StoppedTokens()) != 1 {
+			return false, fmt.Errorf("Expected a stopped token: %v", vaultClient.StoppedTokens())
+		}
+
+		if a := vaultClient.StoppedTokens()[0]; a != token {
+			return false, fmt.Errorf("got stopped token %q; want %q", a, token)
+		}
+
+		return true, nil
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+
+}
+
+// TestTaskRunner_VaultManager_Restart asserts that the alloc is restarted when
+// the alloc derived vault token expires, when task is configured with Restart
+// change mode.
+func TestTaskRunner_VaultManager_Restart(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Config = map[string]interface{}{
+		"run_for": "10s",
+	}
+	task.Vault = &structs.Vault{
+		Cluster:    structs.VaultDefaultCluster,
+		ChangeMode: structs.VaultChangeModeRestart,
+	}
+
+	vc, err := vaultclient.NewMockVaultClient(structs.VaultDefaultCluster)
+	vaultClient := vc.(*vaultclient.MockVaultClient)
+	must.NoError(t, err)
+
+	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, vaultClient)
+	defer cleanup()
+
+	// The test triggers the task runner Vault hook which performs a call to
+	// the WI manager. We therefore need to seed the WI manager with data and
+	// use the mock implementation for this. The data itself doesn't matter, we
+	// just care about the lookup success.
+	mockIDManager := widmgr.NewMockIdentityManager()
+	mockIDManager.(*widmgr.MockIdentityManager).SetIdentity(
+		structs.WIHandle{
+			IdentityName:       task.Vault.IdentityName(),
+			WorkloadIdentifier: task.Name,
+			WorkloadType:       structs.WorkloadTypeTask,
+		}, &structs.SignedWorkloadIdentity{
+			WorkloadIdentityRequest: structs.WorkloadIdentityRequest{},
+			JWT:                     "",
+		},
+	)
+
+	conf.WIDMgr = mockIDManager
+
+	tr, err := NewTaskRunner(conf)
+	require.NoError(t, err)
+	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
+	go tr.Run()
+
+	testWaitForTaskToStart(t, tr)
+
+	tr.vaultTokenLock.Lock()
+	token := tr.vaultToken
+	tr.vaultTokenLock.Unlock()
+
+	require.NotEmpty(t, token)
+
+	renewalCh, ok := vaultClient.RenewTokens()[token]
+	require.True(t, ok, "no renewal channel for token")
+
+	renewalCh <- fmt.Errorf("Test killing")
+	close(renewalCh)
+
+	testutil.WaitForResult(func() (bool, error) {
+		state := tr.TaskState()
+
+		if len(state.Events) == 0 {
+			return false, fmt.Errorf("no events yet")
+		}
+
+		foundRestartSignal, foundRestarting := false, false
+		for _, e := range state.Events {
+			switch e.Type {
+			case structs.TaskRestartSignal:
+				foundRestartSignal = true
+			case structs.TaskRestarting:
+				foundRestarting = true
+			}
+		}
+
+		if !foundRestartSignal {
+			return false, fmt.Errorf("no restart signal event yet: %#v", state.Events)
+		}
+
+		if !foundRestarting {
+			return false, fmt.Errorf("no restarting event yet: %#v", state.Events)
+		}
+
+		lastEvent := state.Events[len(state.Events)-1]
+		if lastEvent.Type != structs.TaskStarted {
+			return false, fmt.Errorf("expected last event to be task starting but was %#v", lastEvent)
+		}
+		return true, nil
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+}
+
+// TestTaskRunner_VaultManager_Signal asserts that the alloc is signalled when
+// the alloc derived vault token expires, when task is configured with signal
+// change mode.
+func TestTaskRunner_VaultManager_Signal(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Config = map[string]interface{}{
+		"run_for": "10s",
+	}
+	task.Vault = &structs.Vault{
+		Cluster:      structs.VaultDefaultCluster,
+		ChangeMode:   structs.VaultChangeModeSignal,
+		ChangeSignal: "SIGUSR1",
+	}
+	vc, err := vaultclient.NewMockVaultClient(structs.VaultDefaultCluster)
+	must.NoError(t, err)
+	vaultClient := vc.(*vaultclient.MockVaultClient)
+
+	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, vaultClient)
+	defer cleanup()
+
+	// The test triggers the task runner Vault hook which performs a call to
+	// the WI manager. We therefore need to seed the WI manager with data and
+	// use the mock implementation for this. The data itself doesn't matter, we
+	// just care about the lookup success.
+	mockIDManager := widmgr.NewMockIdentityManager()
+	mockIDManager.(*widmgr.MockIdentityManager).SetIdentity(
+		structs.WIHandle{
+			IdentityName:       task.Vault.IdentityName(),
+			WorkloadIdentifier: task.Name,
+			WorkloadType:       structs.WorkloadTypeTask,
+		}, &structs.SignedWorkloadIdentity{
+			WorkloadIdentityRequest: structs.WorkloadIdentityRequest{},
+			JWT:                     "",
+		},
+	)
+
+	conf.WIDMgr = mockIDManager
+
+	tr, err := NewTaskRunner(conf)
+	require.NoError(t, err)
+	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
+	go tr.Run()
+
+	testWaitForTaskToStart(t, tr)
+
+	tr.vaultTokenLock.Lock()
+	token := tr.vaultToken
+	tr.vaultTokenLock.Unlock()
+
+	require.NotEmpty(t, token)
+
+	renewalCh, ok := vaultClient.RenewTokens()[token]
+	require.True(t, ok, "no renewal channel for token")
+
+	renewalCh <- fmt.Errorf("Test killing")
+	close(renewalCh)
+
+	testutil.WaitForResult(func() (bool, error) {
+		state := tr.TaskState()
+
+		if len(state.Events) == 0 {
+			return false, fmt.Errorf("no events yet")
+		}
+
+		foundSignaling := false
+		for _, e := range state.Events {
+			if e.Type == structs.TaskSignaling {
+				foundSignaling = true
+			}
+		}
+
+		if !foundSignaling {
+			return false, fmt.Errorf("no signaling event yet: %#v", state.Events)
+		}
+
+		return true, nil
+	}, func(err error) {
+		require.NoError(t, err)
+	})
+
 }
 
 // TestTaskRunner_UnregisterConsul_Retries asserts a task is unregistered from
@@ -2444,4 +3075,72 @@ func TestTaskRunner_setHookStatsHandler(t *testing.T) {
 	noopHandler, ok := baseTaskRunner.hookStatsHandler.(*hookstats.NoOpHandler)
 	must.True(t, ok)
 	must.NotNil(t, noopHandler)
+}
+
+func TestTaskRunner_DisableFileForVaultToken_UpgradePath(t *testing.T) {
+	ci.Parallel(t)
+	ci.SkipTestWithoutRootAccess(t)
+
+	// Create test allocation with a Vault block.
+	alloc := mock.BatchAlloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Config = map[string]any{
+		"run_for": "0s",
+	}
+	task.Vault = &structs.Vault{
+		Cluster: structs.VaultDefaultCluster,
+	}
+
+	// Setup a test Vault client.
+	token := "1234"
+	handler := func(ctx context.Context, req vaultclient.JWTLoginRequest) (string, bool, int, error) {
+		return token, true, 30, nil
+	}
+	vc, err := vaultclient.NewMockVaultClient(structs.VaultDefaultCluster)
+	must.NoError(t, err)
+	vaultClient := vc.(*vaultclient.MockVaultClient)
+	vaultClient.SetDeriveTokenWithJWTFn(handler)
+
+	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, vaultClient)
+	defer cleanup()
+
+	// Remove private dir and write the Vault token to the secrets dir to
+	// simulate an old task.
+	err = conf.TaskDir.Build(fsisolation.None, nil, task.User)
+	must.NoError(t, err)
+
+	err = syscall.Unmount(conf.TaskDir.PrivateDir, 0)
+	must.NoError(t, err)
+	err = os.Remove(conf.TaskDir.PrivateDir)
+	must.NoError(t, err)
+
+	tokenPath := filepath.Join(conf.TaskDir.SecretsDir, vaultTokenFile)
+	err = os.WriteFile(tokenPath, []byte(token), 0666)
+	must.NoError(t, err)
+
+	// Start task runner and wait for task to finish.
+	tr, err := NewTaskRunner(conf)
+	must.NoError(t, err)
+	defer tr.Kill(context.Background(), structs.NewTaskEvent("cleanup"))
+	go tr.Run()
+	time.Sleep(500 * time.Millisecond)
+
+	testWaitForTaskToDie(t, tr)
+
+	// Verify task exited successfully.
+	finalState := tr.TaskState()
+	must.Eq(t, structs.TaskStateDead, finalState.State)
+	must.False(t, finalState.Failed)
+
+	// Verify token is in secrets dir.
+	tokenPath = filepath.Join(conf.TaskDir.SecretsDir, vaultTokenFile)
+	data, err := os.ReadFile(tokenPath)
+	must.NoError(t, err)
+	must.Eq(t, token, string(data))
+
+	// Varify token is not in private dir since the allocation doesn't have
+	// this path.
+	tokenPath = filepath.Join(conf.TaskDir.PrivateDir, vaultTokenFile)
+	_, err = os.Stat(tokenPath)
+	must.ErrorIs(t, err, os.ErrNotExist)
 }

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -10,12 +10,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/consul-template/signals"
 	"github.com/hashicorp/go-hclog"
 	log "github.com/hashicorp/go-hclog"
-	metrics "github.com/hashicorp/go-metrics/compat"
 
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	ti "github.com/hashicorp/nomad/client/allocrunner/taskrunner/interfaces"
@@ -62,7 +62,6 @@ type vaultHookConfig struct {
 	logger           log.Logger
 	alloc            *structs.Allocation
 	task             *structs.Task
-	taskCtx          context.Context
 	widmgr           widmgr.IdentityManager
 }
 
@@ -91,9 +90,9 @@ type vaultHook struct {
 	// logger is used to log
 	logger log.Logger
 
-	// The taskRunner's context. This is stored on the vaulHook because it
-	// cuurently is not injected via Prestart.
-	taskCtx context.Context
+	// ctx and cancel are used to kill the long running token manager
+	ctx    context.Context
+	cancel context.CancelFunc
 
 	// privateDirTokenPath is the path inside the task's private directory where
 	// the Vault token is read and written.
@@ -102,6 +101,9 @@ type vaultHook struct {
 	// secretsDirTokenPath is the path inside the task's secret directory where the
 	// Vault token is written unless disabled by the task.
 	secretsDirTokenPath string
+
+	// alloc is the allocation
+	alloc *structs.Allocation
 
 	// task is the task to run.
 	task *structs.Task
@@ -117,9 +119,13 @@ type vaultHook struct {
 
 	// allowTokenExpiration determines if a renew loop should be run
 	allowTokenExpiration bool
+
+	// future is used to wait on retrieving a Vault token
+	future *tokenFuture
 }
 
 func newVaultHook(config *vaultHookConfig) *vaultHook {
+	ctx, cancel := context.WithCancel(context.Background())
 	h := &vaultHook{
 		vaultBlock:           config.vaultBlock,
 		vaultConfigsFunc:     config.vaultConfigsFunc,
@@ -127,9 +133,12 @@ func newVaultHook(config *vaultHookConfig) *vaultHook {
 		eventEmitter:         config.events,
 		lifecycle:            config.lifecycle,
 		updater:              config.updater,
+		alloc:                config.alloc,
 		task:                 config.task,
-		taskCtx:              config.taskCtx,
 		firstRun:             true,
+		ctx:                  ctx,
+		cancel:               cancel,
+		future:               newTokenFuture(),
 		widmgr:               config.widmgr,
 		widName:              config.task.Vault.IdentityName(),
 		allowTokenExpiration: config.vaultBlock.AllowTokenExpiration,
@@ -166,7 +175,7 @@ func (h *vaultHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRe
 
 	// Try to recover a token if it was previously written in the secrets
 	// directory
-	token := ""
+	recoveredToken := ""
 	h.privateDirTokenPath = filepath.Join(req.TaskDir.PrivateDir, vaultTokenFile)
 	h.secretsDirTokenPath = filepath.Join(req.TaskDir.SecretsDir, vaultTokenFile)
 
@@ -182,138 +191,178 @@ func (h *vaultHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRe
 			// Token file doesn't exist in this path.
 		} else {
 			// Store the recovered token
-			token = string(data)
+			recoveredToken = string(data)
 			break
 		}
 	}
 
-	duration := 30
-	if token == "" {
-		var err error
-		token, duration, err = h.deriveVaultToken(ctx)
-		if err != nil {
-			return err
-		}
+	// Launch the token manager
+	go h.run(recoveredToken)
 
-		// Write the token to disk
-		if err := h.writeToken(token); err != nil {
-			errorString := "failed to write Vault token to disk"
-			h.logger.Error(errorString, "error", err)
-			h.lifecycle.Kill(ctx,
-				structs.NewTaskEvent(structs.TaskKilling).
-					SetFailsTask().
-					SetDisplayMessage(fmt.Sprintf("Vault %v", errorString)))
-			return err
-		}
+	// Block until we get a token
+	select {
+	case <-h.future.Wait():
+	case <-ctx.Done():
+		return nil
 	}
 
-	if !h.allowTokenExpiration {
-		go h.run(h.taskCtx, token, time.Duration(duration*int(time.Second)))
-	}
-
-	h.updater.updatedVaultToken(token)
+	h.updater.updatedVaultToken(h.future.Get())
 	return nil
 }
 
 func (h *vaultHook) Stop(ctx context.Context, req *interfaces.TaskStopRequest, resp *interfaces.TaskStopResponse) error {
+	// Shutdown any created manager
+	h.cancel()
 	return nil
 }
 
-func (h *vaultHook) Shutdown() {}
+func (h *vaultHook) Shutdown() {
+	h.cancel()
+}
 
-func (h *vaultHook) run(ctx context.Context, token string, lease time.Duration) {
-	var err error
-
-	for {
-		select {
-		case <-ctx.Done():
+// run should be called in a go-routine and manages the derivation, renewal and
+// handling of errors with the Vault token. The optional parameter allows
+// setting the initial Vault token. This is useful when the Vault token is
+// recovered off disk.
+func (h *vaultHook) run(token string) {
+	// Helper for stopping token renewal
+	stopRenewal := func() {
+		if h.allowTokenExpiration {
 			return
-		case <-time.After(withJitter(lease)):
-			lease, err = h.renewWithBackoff(ctx, token)
-			if err != nil {
-				// failing to renew results in a triggering the change_mode
-				h.handleRenewal(ctx, "")
+		}
+		if err := h.client.StopRenewToken(h.future.Get()); err != nil {
+			h.logger.Warn("failed to stop token renewal", "error", err)
+		}
+	}
+
+	// updatedToken lets us store state between loops. If true, a new token
+	// has been retrieved and we need to apply the Vault change mode
+	var updatedToken bool
+	leaseDuration := 30
+
+OUTER:
+	for {
+		// Check if we should exit
+		if h.ctx.Err() != nil {
+			stopRenewal()
+			return
+		}
+
+		// Clear the token
+		h.future.Clear()
+
+		// Check if there already is a token which can be the case for
+		// restoring the TaskRunner
+		if token == "" {
+			// Get a token
+			var exit bool
+			token, leaseDuration, exit = h.deriveVaultToken()
+			if exit {
+				// Exit the manager
 				return
 			}
 
-			h.handleRenewal(ctx, token)
+			// Write the token to disk
+			if err := h.writeToken(token); err != nil {
+				errorString := "failed to write Vault token to disk"
+				h.logger.Error(errorString, "error", err)
+				h.lifecycle.Kill(h.ctx,
+					structs.NewTaskEvent(structs.TaskKilling).
+						SetFailsTask().
+						SetDisplayMessage(fmt.Sprintf("Vault %v", errorString)))
+				return
+			}
 		}
-	}
-}
 
-func (h *vaultHook) handleRenewal(ctx context.Context, token string) {
-	var event *structs.TaskEvent
-	switch h.vaultBlock.ChangeMode {
-	case structs.VaultChangeModeSignal:
-		s, err := signals.Parse(h.vaultBlock.ChangeSignal)
+		if h.allowTokenExpiration {
+			h.future.Set(token)
+			h.logger.Debug("Vault token will not renew")
+			return
+		}
+
+		// Start the renewal process.
+		//
+		// This is the initial renew of the token which we derived from the
+		// server. The client does not know how long it took for the token to
+		// be generated and derived and also wants to gain control of the
+		// process quickly, but not too quickly. We therefore use a hardcoded
+		// increment value of 30; this value without a suffix is in seconds.
+		//
+		// If Vault is having availability issues or is overloaded, a large
+		// number of initial token renews can exacerbate the problem.
+		if leaseDuration == 0 {
+			leaseDuration = 30
+		}
+		renewCh, err := h.client.RenewToken(token, leaseDuration)
+
+		// An error returned means the token is not being renewed
 		if err != nil {
-			h.logger.Error("failed to parse signal", "error", err)
-			event = structs.NewTaskEvent(structs.TaskKilling).
-				SetFailsTask().
-				SetDisplayMessage(fmt.Sprintf("Vault: failed to parse signal: %v", err))
-			h.lifecycle.Kill(ctx, event)
-			return
+			h.logger.Error("failed to start renewal of Vault token", "error", err)
+			token = ""
+			goto OUTER
 		}
 
-		event := structs.NewTaskEvent(structs.TaskSignaling).SetTaskSignal(s).SetDisplayMessage("Vault: new Vault token acquired")
-		if err := h.lifecycle.Signal(event, h.vaultBlock.ChangeSignal); err != nil {
-			h.logger.Error("failed to send signal", "error", err)
-			event = structs.NewTaskEvent(structs.TaskKilling).
-				SetFailsTask().
-				SetDisplayMessage(fmt.Sprintf("Vault: failed to send signal: %v", err))
+		// The Vault token is valid now, so set it
+		h.future.Set(token)
 
-			h.lifecycle.Kill(ctx, event)
-			return
-		}
-	case structs.VaultChangeModeRestart:
-		event = structs.NewTaskEvent(structs.TaskRestartSignal).SetDisplayMessage("Vault: new Vault token acquired")
-		h.lifecycle.Restart(ctx, event, false)
-	case structs.VaultChangeModeNoop:
-		// True to its name, this is a noop!
-	default:
-		h.logger.Error("invalid Vault change mode", "mode", h.vaultBlock.ChangeMode)
-	}
+		if updatedToken {
+			switch h.vaultBlock.ChangeMode {
+			case structs.VaultChangeModeSignal:
+				s, err := signals.Parse(h.vaultBlock.ChangeSignal)
+				if err != nil {
+					h.logger.Error("failed to parse signal", "error", err)
+					h.lifecycle.Kill(h.ctx,
+						structs.NewTaskEvent(structs.TaskKilling).
+							SetFailsTask().
+							SetDisplayMessage(fmt.Sprintf("Vault: failed to parse signal: %v", err)))
+					return
+				}
 
-	// Call the handler
-	h.updater.updatedVaultToken(token)
-}
+				event := structs.NewTaskEvent(structs.TaskSignaling).SetTaskSignal(s).SetDisplayMessage("Vault: new Vault token acquired")
+				if err := h.lifecycle.Signal(event, h.vaultBlock.ChangeSignal); err != nil {
+					h.logger.Error("failed to send signal", "error", err)
+					h.lifecycle.Kill(h.ctx,
+						structs.NewTaskEvent(structs.TaskKilling).
+							SetFailsTask().
+							SetDisplayMessage(fmt.Sprintf("Vault: failed to send signal: %v", err)))
+					return
+				}
+			case structs.VaultChangeModeRestart:
+				const noFailure = false
+				h.lifecycle.Restart(h.ctx,
+					structs.NewTaskEvent(structs.TaskRestartSignal).
+						SetDisplayMessage("Vault: new Vault token acquired"), noFailure)
+			case structs.VaultChangeModeNoop:
+				// True to its name, this is a noop!
+			default:
+				h.logger.Error("invalid Vault change mode", "mode", h.vaultBlock.ChangeMode)
+			}
 
-func (h *vaultHook) renewWithBackoff(ctx context.Context, token string) (time.Duration, error) {
-	var attempts uint64
+			// We have handled it
+			updatedToken = false
 
-	for {
-		// Renewing with a duration of 0 renews with the default TTL configured
-		duration, err := h.client.Renew(ctx, token, 0)
-		if err == nil {
-			return duration, nil
-		}
-
-		metrics.IncrCounter([]string{"client", "vault", "renew_token_error"}, 1)
-
-		if !structs.IsRecoverable(err) {
-			metrics.IncrCounter([]string{"client", "vault", "renew_token_failure"}, 1)
-			h.logger.Error("failed to renew Vault token", "error", err, "recoverable", false)
-			h.lifecycle.Kill(ctx,
-				structs.NewTaskEvent(structs.TaskKilling).
-					SetFailsTask().
-					SetDisplayMessage(fmt.Sprintf("Vault: failed to renew vault token: %v", err)))
-			return 0, err
+			// Call the handler
+			h.updater.updatedVaultToken(token)
 		}
 
-		backoff := helper.Backoff(vaultBackoffBaseline, vaultBackoffLimit, attempts)
-		attempts++
-
+		// Start watching for renewal errors
 		select {
-		case <-ctx.Done():
-			return 0, ctx.Err()
-		case <-time.After(backoff):
+		case err := <-renewCh:
+			// Clear the token
+			token = ""
+			h.logger.Error("failed to renew Vault token", "error", err)
+			stopRenewal()
+			updatedToken = true
+		case <-h.ctx.Done():
+			stopRenewal()
+			return
 		}
 	}
 }
 
 // deriveVaultToken derives the Vault token using exponential backoffs. It
 // returns the Vault token and whether the manager should exit.
-func (h *vaultHook) deriveVaultToken(ctx context.Context) (string, int, error) {
+func (h *vaultHook) deriveVaultToken() (string, int, bool) {
 	var attempts uint64
 	var backoff time.Duration
 
@@ -321,19 +370,19 @@ func (h *vaultHook) deriveVaultToken(ctx context.Context) (string, int, error) {
 	defer stopTimer()
 
 	for {
-		token, lease, err := h.deriveVaultTokenJWT(ctx)
+		token, lease, err := h.deriveVaultTokenJWT()
 		if err == nil {
-			return token, lease, nil
+			return token, lease, false
 		}
 
 		// Check if we can't recover from the error
 		if !structs.IsRecoverable(err) {
 			h.logger.Error("failed to derive Vault token", "error", err, "recoverable", false)
-			h.lifecycle.Kill(ctx,
+			h.lifecycle.Kill(h.ctx,
 				structs.NewTaskEvent(structs.TaskKilling).
 					SetFailsTask().
 					SetDisplayMessage(fmt.Sprintf("Vault: failed to derive vault token: %v", err)))
-			return "", 0, err
+			return "", 0, true
 		}
 
 		// Handle the retry case
@@ -345,15 +394,15 @@ func (h *vaultHook) deriveVaultToken(ctx context.Context) (string, int, error) {
 
 		// Wait till retrying
 		select {
-		case <-ctx.Done():
-			return "", 0, ctx.Err()
+		case <-h.ctx.Done():
+			return "", 0, true
 		case <-timer.C:
 		}
 	}
 }
 
 // deriveVaultTokenJWT returns a Vault ACL token using JWT auth login.
-func (h *vaultHook) deriveVaultTokenJWT(ctx context.Context) (string, int, error) {
+func (h *vaultHook) deriveVaultTokenJWT() (string, int, error) {
 	// Retrieve signed identity.
 	signed, err := h.widmgr.Get(structs.WIHandle{
 		IdentityName:       h.widName,
@@ -379,7 +428,7 @@ func (h *vaultHook) deriveVaultTokenJWT(ctx context.Context) (string, int, error
 	}
 
 	// Derive Vault token with signed identity.
-	token, renewable, leaseDuration, err := h.client.DeriveTokenWithJWT(ctx, vaultclient.JWTLoginRequest{
+	token, renewable, leaseDuration, err := h.client.DeriveTokenWithJWT(h.ctx, vaultclient.JWTLoginRequest{
 		JWT:       signed.JWT,
 		Role:      role,
 		Namespace: h.vaultBlock.Namespace,
@@ -425,21 +474,63 @@ func (h *vaultHook) writeToken(token string) error {
 	return nil
 }
 
-// withJitter returns when a token should be renewed given its leaseDuration
-// and a randomizer to provide jitter.
-//
-// Leases < 1m will not use jitter.
-func withJitter(leaseDuration time.Duration) time.Duration {
-	// Start trying to renew at half the lease duration to allow ample time
-	// for latency and retries.
-	renew := leaseDuration / 2
+// tokenFuture stores the Vault token and allows consumers to block till a valid
+// token exists
+type tokenFuture struct {
+	waiting []chan struct{}
+	token   string
+	set     bool
+	m       sync.Mutex
+}
 
-	// Don't bother about introducing randomness if the
-	// leaseDuration is too small.
-	const cutoff = 30 * time.Second
-	if renew < cutoff {
-		return renew
+// newTokenFuture returns a new token future without any token set
+func newTokenFuture() *tokenFuture {
+	return &tokenFuture{}
+}
+
+// Wait returns a channel that can be waited on. When this channel unblocks, a
+// valid token will be available via the Get method
+func (f *tokenFuture) Wait() <-chan struct{} {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	c := make(chan struct{})
+	if f.set {
+		close(c)
+		return c
 	}
 
-	return renew + helper.RandomStagger(20*time.Second) - (10 - time.Second)
+	f.waiting = append(f.waiting, c)
+	return c
+}
+
+// Set sets the token value and unblocks any caller of Wait
+func (f *tokenFuture) Set(token string) *tokenFuture {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	f.set = true
+	f.token = token
+	for _, w := range f.waiting {
+		close(w)
+	}
+	f.waiting = nil
+	return f
+}
+
+// Clear clears the set vault token.
+func (f *tokenFuture) Clear() *tokenFuture {
+	f.m.Lock()
+	defer f.m.Unlock()
+
+	f.token = ""
+	f.set = false
+	return f
+}
+
+// Get returns the set Vault token
+func (f *tokenFuture) Get() string {
+	f.m.Lock()
+	defer f.m.Unlock()
+	return f.token
 }

--- a/client/allocrunner/taskrunner/vault_hook_test.go
+++ b/client/allocrunner/taskrunner/vault_hook_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 	"testing"
 	"time"
 
@@ -18,16 +17,16 @@ import (
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/allocrunner/interfaces"
 	trtesting "github.com/hashicorp/nomad/client/allocrunner/taskrunner/testing"
+	cstate "github.com/hashicorp/nomad/client/state"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/client/vaultclient"
 	"github.com/hashicorp/nomad/client/widmgr"
 	"github.com/hashicorp/nomad/helper/testlog"
-	nmock "github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	sconfig "github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
-	"github.com/stretchr/testify/mock"
 )
 
 // Statically assert the stats hook implements the expected interfaces
@@ -35,324 +34,417 @@ var _ interfaces.TaskPrestartHook = (*vaultHook)(nil)
 var _ interfaces.TaskStopHook = (*vaultHook)(nil)
 var _ interfaces.ShutdownHook = (*vaultHook)(nil)
 
-func TestVaultHook_Prestart(t *testing.T) {
+// vaultTokenUpdaterMock is a mock of the vaultTokenUpdateHandler interface.
+type vaultTokenUpdaterMock struct {
+	currentToken string
+}
 
-	t.Run("derives a token and renews it", func(t *testing.T) {
-		widMgr := widmgr.NewMockIdentityManager()
-		widMgr.SetIdentity(
-			structs.WIHandle{IdentityName: "vault_default", WorkloadType: 0, WorkloadIdentifier: "t"},
-			&structs.SignedWorkloadIdentity{},
-		)
+func (v *vaultTokenUpdaterMock) updatedVaultToken(token string) {
+	v.currentToken = token
+}
 
-		client := vaultclient.NewMockVaultClient()
-		// return a lease time of 0, so it is quickly renewed
-		client.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{}).Return(
-			"testToken", true, 0, nil,
-		)
-		client.On("Renew", mock.Anything, "testToken", 0).Return(time.Minute, nil)
+func setupTestVaultHook(t *testing.T, config *vaultHookConfig) *vaultHook {
+	t.Helper()
 
-		hook := setupTestVaultHook(t, &vaultHookConfig{widmgr: widMgr}, client)
+	if config == nil {
+		config = &vaultHookConfig{}
+	}
 
-		var resp interfaces.TaskPrestartResponse
-		req := &interfaces.TaskPrestartRequest{
-			TaskEnv: taskenv.NewEmptyTaskEnv(),
-			TaskDir: &allocdir.TaskDir{
-				SecretsDir: t.TempDir(),
-				PrivateDir: t.TempDir(),
-			},
-			Task: hook.task,
+	job := mock.MinJob()
+	if config.alloc == nil {
+		config.alloc = mock.MinAlloc()
+		config.alloc.Job = job
+	}
+	if config.task == nil {
+		config.task = job.TaskGroups[0].Tasks[0]
+		config.task.Identities = []*structs.WorkloadIdentity{
+			{Name: "vault_default"},
+		}
+		config.task.Vault = &structs.Vault{
+			Cluster: structs.VaultDefaultCluster,
 		}
 
-		err := hook.Prestart(t.Context(), req, &resp)
-		must.NoError(t, err)
-
-		must.Wait(t, wait.InitialSuccess(wait.ErrorFunc(func() error {
-			if slices.ContainsFunc(client.Calls, func(m mock.Call) bool {
-				return m.Method == "Renew"
-			}) {
-				return nil
+		if config.vaultBlock != nil {
+			config.task.Identities[0].Name = config.vaultBlock.IdentityName()
+			config.task.Vault = config.vaultBlock
+		}
+	}
+	if config.vaultBlock == nil {
+		config.vaultBlock = config.task.Vault
+	}
+	if config.vaultConfigsFunc == nil {
+		config.vaultConfigsFunc = func(hclog.Logger) map[string]*sconfig.VaultConfig {
+			return map[string]*sconfig.VaultConfig{
+				"default": sconfig.DefaultVaultConfig(),
 			}
-			return errors.New("Has not called both derive and renew yet")
-		})))
-	})
-
-	t.Run("does not renew non-renewable token", func(t *testing.T) {
-		widMgr := widmgr.NewMockIdentityManager()
-		widMgr.SetIdentity(
-			structs.WIHandle{IdentityName: "vault_default", WorkloadType: 0, WorkloadIdentifier: "t"},
-			&structs.SignedWorkloadIdentity{},
-		)
-
-		client := vaultclient.NewMockVaultClient()
-		client.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{}).Return(
-			"testToken", false, 0, nil,
-		)
-
-		hook := setupTestVaultHook(t, &vaultHookConfig{widmgr: widMgr}, client)
-		hook.allowTokenExpiration = false // explicitly set this to false
-
-		var resp interfaces.TaskPrestartResponse
-		req := &interfaces.TaskPrestartRequest{
-			TaskEnv: taskenv.NewEmptyTaskEnv(),
-			TaskDir: &allocdir.TaskDir{
-				SecretsDir: t.TempDir(),
-				PrivateDir: t.TempDir(),
-			},
-			Task: hook.task,
 		}
-
-		err := hook.Prestart(t.Context(), req, &resp)
+	}
+	if config.clientFunc == nil {
+		config.clientFunc = func(cluster string) (vaultclient.VaultClient, error) {
+			return vaultclient.NewMockVaultClient(cluster)
+		}
+	}
+	if config.logger == nil {
+		config.logger = testlog.HCLogger(t)
+	}
+	if config.events == nil {
+		config.events = &trtesting.MockEmitter{}
+	}
+	if config.lifecycle == nil {
+		config.lifecycle = trtesting.NewMockTaskHooks()
+	}
+	if config.updater == nil {
+		config.updater = &vaultTokenUpdaterMock{}
+	}
+	if config.widmgr == nil {
+		db := cstate.NewMemDB(config.logger)
+		signer := widmgr.NewMockWIDSigner(config.task.Identities)
+		allocEnv := taskenv.NewBuilder(mock.Node(), config.alloc, nil, "global").Build()
+		config.widmgr = widmgr.NewWIDMgr(signer, config.alloc, db, config.logger, allocEnv)
+		err := config.widmgr.Run()
 		must.NoError(t, err)
-		must.True(t, hook.allowTokenExpiration)
-		must.Wait(t, wait.ContinualSuccess(wait.Attempts(10), wait.BoolFunc(func() bool {
-			return len(client.Calls) == 1
-		})))
-	})
+	}
 
-	t.Run("overrides role with task vault block role", func(t *testing.T) {
-		widMgr := widmgr.NewMockIdentityManager()
-		widMgr.SetIdentity(
-			structs.WIHandle{IdentityName: "vault_default", WorkloadType: 0, WorkloadIdentifier: "t"},
-			&structs.SignedWorkloadIdentity{},
-		)
+	return newVaultHook(config)
+}
 
-		client := vaultclient.NewMockVaultClient()
-		// This mock will only accept `Role: "test-role"`. Any other role will fail
-		client.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{Role: "test-role"}).Return(
-			"testToken", false, 0, nil,
-		)
+func TestTaskRunner_VaultHook(t *testing.T) {
+	ci.Parallel(t)
 
-		hook := setupTestVaultHook(t, &vaultHookConfig{widmgr: widMgr}, client)
-		hook.task.Vault.Role = "test-role" // use "test-role"
-
-		var resp interfaces.TaskPrestartResponse
-		req := &interfaces.TaskPrestartRequest{
-			TaskEnv: taskenv.NewEmptyTaskEnv(),
-			TaskDir: &allocdir.TaskDir{
-				SecretsDir: t.TempDir(),
-				PrivateDir: t.TempDir(),
+	testCases := []struct {
+		name               string
+		task               *structs.Task
+		configs            map[string]*sconfig.VaultConfig
+		configNonrenewable bool
+		expectRole         string
+		expectNoRenew      bool
+	}{
+		{
+			name: "jwt flow",
+			task: &structs.Task{
+				Vault: &structs.Vault{
+					Cluster: structs.VaultDefaultCluster,
+				},
+				Identities: []*structs.WorkloadIdentity{
+					{Name: "vault_default"},
+				},
 			},
-			Task: hook.task,
-		}
-
-		err := hook.Prestart(t.Context(), req, &resp)
-		must.NoError(t, err) // Will error if a different role is passed
-	})
-
-	t.Run("reads existing token from private dir", func(t *testing.T) {
-		widMgr := widmgr.NewMockIdentityManager()
-		widMgr.SetIdentity(
-			structs.WIHandle{IdentityName: "vault_default", WorkloadType: 0, WorkloadIdentifier: "t"},
-			&structs.SignedWorkloadIdentity{},
-		)
-
-		client := vaultclient.NewMockVaultClient()
-		updater := &vaultTokenUpdaterMock{}
-		hook := setupTestVaultHook(t, &vaultHookConfig{widmgr: widMgr, updater: updater}, client)
-
-		var resp interfaces.TaskPrestartResponse
-		req := &interfaces.TaskPrestartRequest{
-			TaskEnv: taskenv.NewEmptyTaskEnv(),
-			TaskDir: &allocdir.TaskDir{
-				SecretsDir: t.TempDir(),
-				PrivateDir: t.TempDir(),
+		},
+		{
+			name: "jwt flow with role",
+			task: &structs.Task{
+				Vault: &structs.Vault{
+					Cluster: structs.VaultDefaultCluster,
+					Role:    "task-role",
+				},
+				Identities: []*structs.WorkloadIdentity{
+					{Name: "vault_default"},
+				},
 			},
-			Task: hook.task,
-		}
-
-		os.WriteFile(filepath.Join(req.TaskDir.PrivateDir, vaultTokenFile), []byte("testToken"), 0600)
-
-		err := hook.Prestart(t.Context(), req, &resp)
-		must.NoError(t, err)
-		must.Len(t, 0, client.Calls)
-		must.Eq(t, updater.currentToken, "testToken")
-	})
-
-	t.Run("reads existing token from secret dir", func(t *testing.T) {
-		widMgr := widmgr.NewMockIdentityManager()
-		widMgr.SetIdentity(
-			structs.WIHandle{IdentityName: "vault_default", WorkloadType: 0, WorkloadIdentifier: "t"},
-			&structs.SignedWorkloadIdentity{},
-		)
-
-		client := vaultclient.NewMockVaultClient()
-		updater := &vaultTokenUpdaterMock{}
-		hook := setupTestVaultHook(t, &vaultHookConfig{widmgr: widMgr, updater: updater}, client)
-
-		var resp interfaces.TaskPrestartResponse
-		req := &interfaces.TaskPrestartRequest{
-			TaskEnv: taskenv.NewEmptyTaskEnv(),
-			TaskDir: &allocdir.TaskDir{
-				SecretsDir: t.TempDir(),
-				PrivateDir: t.TempDir(),
+			configs: map[string]*sconfig.VaultConfig{
+				"default": {
+					Role: "client-role",
+				},
 			},
-			Task: hook.task,
-		}
-
-		os.WriteFile(filepath.Join(req.TaskDir.SecretsDir, vaultTokenFile), []byte("testToken"), 0600)
-
-		err := hook.Prestart(t.Context(), req, &resp)
-		must.NoError(t, err)
-		must.Len(t, 0, client.Calls)
-		must.Eq(t, updater.currentToken, "testToken")
-	})
-
-	t.Run("does not write to file when disabled", func(t *testing.T) {
-		widMgr := widmgr.NewMockIdentityManager()
-		widMgr.SetIdentity(
-			structs.WIHandle{IdentityName: "vault_default", WorkloadType: 0, WorkloadIdentifier: "t"},
-			&structs.SignedWorkloadIdentity{},
-		)
-
-		client := vaultclient.NewMockVaultClient()
-		client.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{}).Return(
-			"testToken", false, 0, nil,
-		)
-
-		hook := setupTestVaultHook(t, &vaultHookConfig{widmgr: widMgr}, client)
-		hook.task.Vault.DisableFile = true
-
-		var resp interfaces.TaskPrestartResponse
-		req := &interfaces.TaskPrestartRequest{
-			TaskEnv: taskenv.NewEmptyTaskEnv(),
-			TaskDir: &allocdir.TaskDir{
-				SecretsDir: t.TempDir(),
-				PrivateDir: t.TempDir(),
+			expectRole: "task-role",
+		},
+		{
+			name: "jwt flow with role from client",
+			task: &structs.Task{
+				Vault: &structs.Vault{
+					Cluster: structs.VaultDefaultCluster,
+				},
+				Identities: []*structs.WorkloadIdentity{
+					{Name: "vault_default"},
+				},
 			},
-			Task: hook.task,
-		}
-
-		err := hook.Prestart(t.Context(), req, &resp)
-		must.NoError(t, err)
-
-		_, err = os.Stat(filepath.Join(req.TaskDir.SecretsDir, vaultTokenFile))
-		must.ErrorIs(t, err, os.ErrNotExist)
-	})
-
-	t.Run("retries if DeriveToken returns recoverable error", func(t *testing.T) {
-		widMgr := widmgr.NewMockIdentityManager()
-		widMgr.SetIdentity(
-			structs.WIHandle{IdentityName: "vault_default", WorkloadType: 0, WorkloadIdentifier: "t"},
-			&structs.SignedWorkloadIdentity{},
-		)
-
-		client := vaultclient.NewMockVaultClient()
-		client.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{}).Return(
-			"", false, 0, structs.NewRecoverableError(errors.New("try again!"), true),
-		).Times(1)
-
-		client.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{}).Return(
-			"testToken", false, 0, nil,
-		)
-
-		hook := setupTestVaultHook(t, &vaultHookConfig{widmgr: widMgr}, client)
-
-		var resp interfaces.TaskPrestartResponse
-		req := &interfaces.TaskPrestartRequest{
-			TaskEnv: taskenv.NewEmptyTaskEnv(),
-			TaskDir: &allocdir.TaskDir{
-				SecretsDir: t.TempDir(),
-				PrivateDir: t.TempDir(),
+			configs: map[string]*sconfig.VaultConfig{
+				"default": {
+					Role: "client-role",
+				},
 			},
-			Task: hook.task,
-		}
-
-		err := hook.Prestart(t.Context(), req, &resp)
-		must.NoError(t, err)
-	})
-
-	t.Run("exits with error if DeriveToken returns unrecoverable error", func(t *testing.T) {
-		widMgr := widmgr.NewMockIdentityManager()
-		widMgr.SetIdentity(
-			structs.WIHandle{IdentityName: "vault_default", WorkloadType: 0, WorkloadIdentifier: "t"},
-			&structs.SignedWorkloadIdentity{},
-		)
-
-		client := vaultclient.NewMockVaultClient()
-		client.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{}).Return(
-			"", false, 0, structs.NewRecoverableError(errors.New("go away"), false),
-		).Times(1)
-
-		hook := setupTestVaultHook(t, &vaultHookConfig{widmgr: widMgr}, client)
-
-		var resp interfaces.TaskPrestartResponse
-		req := &interfaces.TaskPrestartRequest{
-			TaskEnv: taskenv.NewEmptyTaskEnv(),
-			TaskDir: &allocdir.TaskDir{
-				SecretsDir: t.TempDir(),
-				PrivateDir: t.TempDir(),
+			expectRole: "client-role",
+		},
+		{
+			name: "jwt flow with role from client and non-default cluster",
+			task: &structs.Task{
+				Vault: &structs.Vault{
+					Cluster: "prod",
+				},
+				Identities: []*structs.WorkloadIdentity{
+					{Name: "vault_prod"},
+				},
 			},
-			Task: hook.task,
-		}
-
-		err := hook.Prestart(t.Context(), req, &resp)
-		must.Error(t, err)
-	})
-
-	t.Run("retries if Renew returns recoverable error", func(t *testing.T) {
-		widMgr := widmgr.NewMockIdentityManager()
-		widMgr.SetIdentity(
-			structs.WIHandle{IdentityName: "vault_default", WorkloadType: 0, WorkloadIdentifier: "t"},
-			&structs.SignedWorkloadIdentity{},
-		)
-
-		client := vaultclient.NewMockVaultClient()
-		client.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{}).Return(
-			"testToken", true, 0, nil,
-		)
-
-		client.On("Renew", mock.Anything, "testToken", 0).Return(
-			time.Minute,
-			structs.NewRecoverableError(errors.New("try again!"), true),
-		).Times(1)
-
-		client.On("Renew", mock.Anything, "testToken", 0).Return(time.Minute, nil).Times(1)
-
-		hook := setupTestVaultHook(t, &vaultHookConfig{widmgr: widMgr}, client)
-
-		var resp interfaces.TaskPrestartResponse
-		req := &interfaces.TaskPrestartRequest{
-			TaskEnv: taskenv.NewEmptyTaskEnv(),
-			TaskDir: &allocdir.TaskDir{
-				SecretsDir: t.TempDir(),
-				PrivateDir: t.TempDir(),
+			configs: map[string]*sconfig.VaultConfig{
+				"default": {
+					Role: "client-role",
+				},
+				"prod": {
+					Role: "client-prod-role",
+				},
 			},
-			Task: hook.task,
-		}
+			expectRole: "client-prod-role",
+		},
+		{
+			name: "disable file",
+			task: &structs.Task{
+				Vault: &structs.Vault{
+					Cluster:     structs.VaultDefaultCluster,
+					DisableFile: true,
+				},
+				Identities: []*structs.WorkloadIdentity{
+					{Name: "vault_default"},
+				},
+			},
+		},
+		{
+			name: "job requests no renewal",
+			task: &structs.Task{
+				Vault: &structs.Vault{
+					Cluster:              structs.VaultDefaultCluster,
+					AllowTokenExpiration: true,
+				},
+				Identities: []*structs.WorkloadIdentity{
+					{Name: "vault_default"},
+				},
+			},
+			expectNoRenew: true,
+		},
+		{
+			name: "tokens are not renewable",
+			task: &structs.Task{
+				Vault: &structs.Vault{
+					Cluster: structs.VaultDefaultCluster,
+				},
+				Identities: []*structs.WorkloadIdentity{
+					{Name: "vault_default"},
+				},
+			},
+			configNonrenewable: true,
+			expectNoRenew:      true,
+		},
+	}
 
-		err := hook.Prestart(t.Context(), req, &resp)
-		must.NoError(t, err)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			alloc := mock.MinAlloc()
+			alloc.Job.TaskGroups[0].Tasks[0] = tc.task
 
-		must.Wait(t, wait.InitialSuccess(wait.Timeout(6*time.Second), wait.ErrorFunc(func() error {
-			if len(client.Calls) == 3 {
-				return nil
+			hookConfig := &vaultHookConfig{
+				task:  tc.task,
+				alloc: alloc,
+				vaultConfigsFunc: func(hclog.Logger) map[string]*sconfig.VaultConfig {
+					if tc.configs != nil {
+						return tc.configs
+					}
+					return map[string]*sconfig.VaultConfig{
+						"default": sconfig.DefaultVaultConfig(),
+					}
+				},
 			}
-			return errors.New("has not called renew twice")
-		})))
-	})
 
-	t.Run("trigger lifecycle if Renew returns unrecoverable error", func(t *testing.T) {
-		widMgr := widmgr.NewMockIdentityManager()
-		widMgr.SetIdentity(
-			structs.WIHandle{IdentityName: "vault_default", WorkloadType: 0, WorkloadIdentifier: "t"},
-			&structs.SignedWorkloadIdentity{},
-		)
+			if tc.configNonrenewable {
+				hookConfig.clientFunc = func(cluster string) (vaultclient.VaultClient, error) {
+					client := &vaultclient.MockVaultClient{}
+					client.SetRenewable(false)
+					return client, nil
+				}
+			}
 
-		client := vaultclient.NewMockVaultClient()
-		client.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{}).Return(
-			"testToken", true, 0, nil,
-		)
-		client.On("Renew", mock.Anything, "testToken", 0).Return(
-			time.Minute,
-			errors.New("permission denied"),
-		)
+			hook := setupTestVaultHook(t, hookConfig)
 
-		mockLifecycle := trtesting.NewMockTaskHooks()
-		hook := setupTestVaultHook(t, &vaultHookConfig{widmgr: widMgr}, client)
-		hook.lifecycle = mockLifecycle
-		hook.task.Vault.ChangeMode = structs.VaultChangeModeRestart
+			// Ensure Prestart() returns within a reasonable time.
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			t.Cleanup(cancel)
 
-		var resp interfaces.TaskPrestartResponse
+			req := &interfaces.TaskPrestartRequest{
+				TaskEnv: taskenv.NewEmptyTaskEnv(),
+				TaskDir: &allocdir.TaskDir{
+					SecretsDir: t.TempDir(),
+					PrivateDir: t.TempDir(),
+				},
+				Task: tc.task,
+			}
+			var resp interfaces.TaskPrestartResponse
+
+			err := hook.Prestart(ctx, req, &resp)
+			must.NoError(t, err)
+			must.NoError(t, ctx.Err())
+
+			// Token must have been derived.
+			var token string
+			client := hook.client.(*vaultclient.MockVaultClient)
+
+			tokens := client.JWTTokens()
+			must.MapLen(t, 1, tokens)
+
+			swid, err := hook.widmgr.Get(structs.WIHandle{
+				IdentityName:       tc.task.Vault.IdentityName(),
+				WorkloadIdentifier: tc.task.Name,
+				WorkloadType:       structs.WorkloadTypeTask,
+			})
+			must.NoError(t, err)
+			token = tokens[swid.JWT]
+
+			must.NotEq(t, "", token)
+
+			// Token must be derived with correct role.
+			//
+			// MockVaultClient generates random UUIDv4 tokens, but append the
+			// role when requested.
+			if tc.expectRole != "" {
+				must.StrHasSuffix(t, tc.expectRole, token)
+			} else {
+				must.UUIDv4(t, token)
+			}
+
+			// Token must be set in token updater.
+			updater := (hook.updater).(*vaultTokenUpdaterMock)
+			must.Eq(t, token, updater.currentToken)
+
+			// Token must be written to disk.
+			tokenFile, err := os.ReadFile(hook.privateDirTokenPath)
+			must.NoError(t, err)
+			must.Eq(t, updater.currentToken, string(tokenFile))
+
+			if !tc.task.Vault.DisableFile {
+				tokenFile, err := os.ReadFile(hook.secretsDirTokenPath)
+				must.NoError(t, err)
+				must.Eq(t, updater.currentToken, string(tokenFile))
+			} else {
+				_, err = os.ReadFile(hook.secretsDirTokenPath)
+				must.ErrorIs(t, err, os.ErrNotExist)
+			}
+
+			// Token must be set for renewal.
+			if tc.expectNoRenew {
+				must.MapEmpty(t, client.RenewTokens())
+			} else {
+				must.MapLen(t, 1, client.RenewTokens())
+				must.NotNil(t, client.RenewTokens()[updater.currentToken])
+			}
+
+			// PrestartDone must be false so we can recover tokens.
+			// firstRun is used to prevent multiple executions.
+			must.False(t, resp.Done)
+			must.False(t, hook.firstRun)
+
+			// Stop renewal when hook stops.
+			err = hook.Stop(ctx, nil, nil)
+			must.NoError(t, err)
+			must.Wait(t, wait.InitialSuccess(
+				wait.ErrorFunc(func() error {
+					tokens := client.StoppedTokens()
+
+					if tc.expectNoRenew {
+						if len(tokens) != 0 {
+							return fmt.Errorf("expected no stopped tokens when renewal is disabled, got %d", len(tokens))
+						}
+						return nil
+					}
+
+					if len(tokens) != 1 {
+						return fmt.Errorf("expected stopped tokens to be %d, got %d", 1, len(tokens))
+					}
+					got := tokens[0]
+					expect := updater.currentToken
+					if got != expect {
+						return fmt.Errorf("expected stopped token to be %s, got %s", expect, got)
+					}
+					return nil
+				}),
+				wait.Timeout(5*time.Second),
+				wait.Gap(100*time.Millisecond),
+			))
+		})
+	}
+}
+
+func TestTaskRunner_VaultHook_recover(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name     string
+		setupReq func() (*interfaces.TaskPrestartRequest, error)
+	}{
+		{
+			name: "recover from secrets dir",
+			setupReq: func() (*interfaces.TaskPrestartRequest, error) {
+				// Write token to secrets dir.
+				secretsDirPath := t.TempDir()
+				err := os.WriteFile(filepath.Join(secretsDirPath, vaultTokenFile), []byte("much secret"), 0666)
+				if err != nil {
+					return nil, err
+				}
+
+				req := &interfaces.TaskPrestartRequest{
+					TaskEnv: taskenv.NewEmptyTaskEnv(),
+					TaskDir: &allocdir.TaskDir{
+						SecretsDir: secretsDirPath,
+						PrivateDir: t.TempDir(),
+					},
+				}
+				return req, nil
+			},
+		},
+		{
+			name: "recover from private dir",
+			setupReq: func() (*interfaces.TaskPrestartRequest, error) {
+				// Write token to private dir.
+				privateDirPath := t.TempDir()
+				err := os.WriteFile(filepath.Join(privateDirPath, vaultTokenFile), []byte("much secret"), 0666)
+				if err != nil {
+					return nil, err
+				}
+
+				req := &interfaces.TaskPrestartRequest{
+					TaskEnv: taskenv.NewEmptyTaskEnv(),
+					TaskDir: &allocdir.TaskDir{
+						SecretsDir: t.TempDir(),
+						PrivateDir: privateDirPath,
+					},
+				}
+				return req, nil
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			hook := setupTestVaultHook(t, nil)
+
+			req, err := tc.setupReq()
+			must.NoError(t, err)
+			req.Task = hook.task
+
+			// Ensure Prestart() returns in a reasonable time.
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			t.Cleanup(cancel)
+
+			var resp interfaces.TaskPrestartResponse
+			err = hook.Prestart(ctx, req, &resp)
+			must.NoError(t, err)
+			must.NoError(t, ctx.Err())
+
+			// Verify token was recovered and not derived.
+			client := hook.client.(*vaultclient.MockVaultClient)
+			must.MapLen(t, 0, client.JWTTokens())
+		})
+	}
+}
+
+func TestTaskRunner_VaultHook_deriveError(t *testing.T) {
+	ci.Parallel(t)
+
+	t.Run("unrecoverable error", func(t *testing.T) {
+		vaultClient, _ := vaultclient.NewMockVaultClient("")
+		mockVaultClient := vaultClient.(*vaultclient.MockVaultClient)
+
+		hook := setupTestVaultHook(t, &vaultHookConfig{
+			clientFunc: func(string) (vaultclient.VaultClient, error) {
+				return mockVaultClient, nil
+			},
+		})
 		req := &interfaces.TaskPrestartRequest{
 			TaskEnv: taskenv.NewEmptyTaskEnv(),
 			TaskDir: &allocdir.TaskDir{
@@ -361,19 +453,130 @@ func TestVaultHook_Prestart(t *testing.T) {
 			},
 			Task: hook.task,
 		}
+		var resp interfaces.TaskPrestartResponse
 
-		err := hook.Prestart(t.Context(), req, &resp)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		// Set unrecoverable error.
+		mockVaultClient.SetDeriveTokenWithJWTFn(
+			func(_ context.Context, _ vaultclient.JWTLoginRequest) (string, bool, int, error) {
+				// Cancel the context to simulate the task being killed.
+				cancel()
+				return "", false, 0, structs.NewRecoverableError(errors.New("unrecoverable test error"), false)
+			})
+
+		err := hook.Prestart(ctx, req, &resp)
 		must.NoError(t, err)
-		must.Wait(t, wait.InitialSuccess(wait.Timeout(1*time.Second), wait.ErrorFunc(func() error {
-			if mockLifecycle.KillEvent() != nil {
+
+		// Verify task is killed because of unrecoverable error.
+		must.Wait(t, wait.InitialSuccess(
+			wait.ErrorFunc(func() error {
+				killEv := (hook.lifecycle.(*trtesting.MockTaskHooks)).KillEvent()
+				if killEv == nil {
+					return errors.New("missing kill event")
+				}
 				return nil
-			}
-			return errors.New("test")
-		})))
+			}),
+			wait.Timeout(5*time.Second),
+			wait.Gap(100*time.Millisecond),
+		))
+		killEv := (hook.lifecycle.(*trtesting.MockTaskHooks)).KillEvent()
+		must.StrContains(t, killEv.DisplayMessage, "unrecoverable test error")
+	})
+
+	t.Run("recoverable error", func(t *testing.T) {
+		vaultClient, _ := vaultclient.NewMockVaultClient("")
+		mockVaultClient := vaultClient.(*vaultclient.MockVaultClient)
+
+		hook := setupTestVaultHook(t, &vaultHookConfig{
+			clientFunc: func(string) (vaultclient.VaultClient, error) {
+				return mockVaultClient, nil
+			},
+		})
+		req := &interfaces.TaskPrestartRequest{
+			TaskEnv: taskenv.NewEmptyTaskEnv(),
+			TaskDir: &allocdir.TaskDir{
+				SecretsDir: t.TempDir(),
+				PrivateDir: t.TempDir(),
+			},
+			Task: hook.task,
+		}
+		var resp interfaces.TaskPrestartResponse
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(cancel)
+
+		// Set recoverable error.
+		mockVaultClient.SetDeriveTokenWithJWTFn(
+			func(_ context.Context, _ vaultclient.JWTLoginRequest) (string, bool, int, error) {
+				return "", false, 0, structs.NewRecoverableError(errors.New("recoverable test error"), true)
+			})
+
+		go func() {
+			// Wait a bit for the first error then fix token renewal.
+			time.Sleep(time.Second)
+			mockVaultClient.SetDeriveTokenWithJWTFn(
+				func(_ context.Context, _ vaultclient.JWTLoginRequest) (string, bool, int, error) {
+					return "secret", true, 30, nil
+				})
+
+		}()
+		err := hook.Prestart(ctx, req, &resp)
+		must.NoError(t, err)
+		must.NoError(t, ctx.Err())
+
+		// Verify retry happened and token was derived.
+		updater := (hook.updater).(*vaultTokenUpdaterMock)
+		must.Eq(t, "secret", updater.currentToken)
+	})
+
+	t.Run("renew request failed", func(t *testing.T) {
+		vaultClient, _ := vaultclient.NewMockVaultClient("")
+		mockVaultClient := vaultClient.(*vaultclient.MockVaultClient)
+
+		hook := setupTestVaultHook(t, &vaultHookConfig{
+			clientFunc: func(string) (vaultclient.VaultClient, error) {
+				return mockVaultClient, nil
+			},
+		})
+		req := &interfaces.TaskPrestartRequest{
+			TaskEnv: taskenv.NewEmptyTaskEnv(),
+			TaskDir: &allocdir.TaskDir{
+				SecretsDir: t.TempDir(),
+				PrivateDir: t.TempDir(),
+			},
+			Task: hook.task,
+		}
+		var resp interfaces.TaskPrestartResponse
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		t.Cleanup(cancel)
+
+		// Derive predictable token and fail renew request.
+		mockVaultClient.SetDeriveTokenWithJWTFn(
+			func(_ context.Context, _ vaultclient.JWTLoginRequest) (string, bool, int, error) {
+				return "secret", true, 30, nil
+			})
+		mockVaultClient.SetRenewTokenError("secret", errors.New("test error"))
+
+		go func() {
+			// Wait a bit for the renew error then fix token renewal.
+			time.Sleep(10 * time.Millisecond)
+			mockVaultClient.SetRenewTokenError("secret", nil)
+
+		}()
+		err := hook.Prestart(ctx, req, &resp)
+		must.NoError(t, err)
+		must.NoError(t, ctx.Err())
+
+		// Verify retry happened and token was derived.
+		updater := (hook.updater).(*vaultTokenUpdaterMock)
+		must.Eq(t, "secret", updater.currentToken)
 	})
 }
 
-func TestVaultHook_handleRenewal(t *testing.T) {
+func TestTaskRunner_VaultHook_tokenRenewalFail(t *testing.T) {
 	ci.Parallel(t)
 
 	testCases := []struct {
@@ -437,94 +640,53 @@ func TestVaultHook_handleRenewal(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			vaultClient := vaultclient.NewMockVaultClient()
+			vaultClient, _ := vaultclient.NewMockVaultClient("")
+			mockVaultClient := vaultClient.(*vaultclient.MockVaultClient)
 
-			hook := setupTestVaultHook(t, &vaultHookConfig{vaultBlock: tc.vaultBlock}, vaultClient)
+			hook := setupTestVaultHook(t, &vaultHookConfig{
+				vaultBlock: tc.vaultBlock,
+				clientFunc: func(string) (vaultclient.VaultClient, error) {
+					return mockVaultClient, nil
+				},
+			})
 
+			req := &interfaces.TaskPrestartRequest{
+				TaskEnv: taskenv.NewEmptyTaskEnv(),
+				TaskDir: &allocdir.TaskDir{
+					SecretsDir: t.TempDir(),
+					PrivateDir: t.TempDir(),
+				},
+				Task: hook.task,
+			}
+			var resp interfaces.TaskPrestartResponse
+
+			// Ensure Prestart() returns within a reasonable time.
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 			t.Cleanup(cancel)
 
-			hook.handleRenewal(ctx, "secret")
+			err := hook.Prestart(ctx, req, &resp)
+			must.NoError(t, err)
 
 			// Fetch derived token.
 			updater := (hook.updater).(*vaultTokenUpdaterMock)
 			token := updater.currentToken
 			must.NotEq(t, "", token)
 
-			err := tc.verifyTaskLifecycle((hook.lifecycle).(*trtesting.MockTaskHooks))
-			must.NoError(t, err)
+			// Fetch renewal token error channel.
+			renewErrCh := mockVaultClient.RenewTokenErrCh(token)
+			must.NotNil(t, renewErrCh)
+
+			// Emit renewal error.
+			renewErrCh <- errors.New("renew error")
+
+			// Verify expected lifecycle events happen.
+			must.Wait(t, wait.InitialSuccess(
+				wait.ErrorFunc(func() error {
+					return tc.verifyTaskLifecycle((hook.lifecycle).(*trtesting.MockTaskHooks))
+				}),
+				wait.Timeout(3*time.Second),
+				wait.Gap(100*time.Millisecond),
+			))
 		})
 	}
-}
-
-// vaultTokenUpdaterMock is a mock of the vaultTokenUpdateHandler interface.
-type vaultTokenUpdaterMock struct {
-	currentToken string
-}
-
-func (v *vaultTokenUpdaterMock) updatedVaultToken(token string) {
-	v.currentToken = token
-}
-
-func setupTestVaultHook(t *testing.T, config *vaultHookConfig, client *vaultclient.MockVaultClient) *vaultHook {
-	t.Helper()
-
-	config.taskCtx = t.Context()
-
-	if config == nil {
-		config = &vaultHookConfig{}
-	}
-
-	job := nmock.MinJob()
-	if config.alloc == nil {
-		config.alloc = nmock.MinAlloc()
-		config.alloc.Job = job
-	}
-	if config.task == nil {
-		config.task = job.TaskGroups[0].Tasks[0]
-		config.task.Identities = []*structs.WorkloadIdentity{
-			{Name: "vault_default"},
-		}
-		config.task.Vault = &structs.Vault{
-			Cluster:    structs.VaultDefaultCluster,
-			ChangeMode: structs.VaultChangeModeNoop,
-		}
-
-		if config.vaultBlock != nil {
-			config.task.Identities[0].Name = config.vaultBlock.IdentityName()
-			config.task.Vault = config.vaultBlock
-		}
-	}
-	if config.vaultBlock == nil {
-		config.vaultBlock = config.task.Vault
-	}
-	if config.vaultConfigsFunc == nil {
-		config.vaultConfigsFunc = func(hclog.Logger) map[string]*sconfig.VaultConfig {
-			return map[string]*sconfig.VaultConfig{
-				"default": sconfig.DefaultVaultConfig(),
-			}
-		}
-	}
-	if config.clientFunc == nil {
-		config.clientFunc = func(cluster string) (vaultclient.VaultClient, error) {
-			return client, nil
-		}
-	}
-	if config.logger == nil {
-		config.logger = testlog.HCLogger(t)
-	}
-	if config.events == nil {
-		config.events = &trtesting.MockEmitter{}
-	}
-	if config.lifecycle == nil {
-		config.lifecycle = trtesting.NewMockTaskHooks()
-	}
-	if config.updater == nil {
-		config.updater = &vaultTokenUpdaterMock{}
-	}
-	if config.widmgr == nil {
-		config.widmgr = widmgr.NewMockIdentityManager()
-	}
-
-	return newVaultHook(config)
 }

--- a/client/allocrunner/testing.go
+++ b/client/allocrunner/testing.go
@@ -84,7 +84,7 @@ func testAllocRunnerConfig(t *testing.T, alloc *structs.Allocation) (*config.All
 		ClientConfig:       clientConf,
 		StateDB:            stateDB,
 		ConsulServices:     consulRegMock,
-		VaultFunc:          func(string) (vaultclient.VaultClient, error) { return vaultclient.NewMockVaultClient(), nil },
+		VaultFunc:          vaultclient.NewMockVaultClient,
 		StateUpdater:       &MockStateUpdater{},
 		PrevAllocWatcher:   allocwatcher.NoopPrevAlloc{},
 		PrevAllocMigrator:  allocwatcher.NoopPrevAlloc{},

--- a/client/client.go
+++ b/client/client.go
@@ -998,6 +998,11 @@ func (c *Client) Shutdown() error {
 	}
 	c.logger.Info("shutting down")
 
+	// Stop renewing tokens and secrets
+	for _, vaultClient := range c.vaultClients {
+		vaultClient.Stop()
+	}
+
 	// Stop Garbage collector
 	c.garbageCollector.Stop()
 
@@ -3009,7 +3014,8 @@ func (c *Client) newAllocRunnerConfig(
 	}
 }
 
-// setupVaultClients created vault clients for each configured cluster
+// setupVaultClients creates the objects that periodically renew tokens and
+// secrets with vault.
 func (c *Client) setupVaultClients() error {
 
 	c.vaultClients = map[string]vaultclient.VaultClient{}
@@ -3024,6 +3030,12 @@ func (c *Client) setupVaultClients() error {
 			return fmt.Errorf("failed to create vault client for cluster %q", vaultConfig.Name)
 		}
 		c.vaultClients[vaultConfig.Name] = vaultClient
+	}
+
+	// Start renewing tokens and secrets only once we've ensured we have created
+	// all the clients
+	for _, vaultClient := range c.vaultClients {
+		vaultClient.Start()
 	}
 
 	return nil

--- a/client/state/upgrade_int_test.go
+++ b/client/state/upgrade_int_test.go
@@ -209,7 +209,7 @@ func checkUpgradedAlloc(t *testing.T, path string, db StateDB, alloc *structs.Al
 		ClientConfig:      clientConf,
 		StateDB:           db,
 		ConsulServices:    regMock.NewServiceRegistrationHandler(clientConf.Logger),
-		VaultFunc:         func(string) (vaultclient.VaultClient, error) { return vaultclient.NewMockVaultClient(), nil },
+		VaultFunc:         vaultclient.NewMockVaultClient,
 		StateUpdater:      &allocrunner.MockStateUpdater{},
 		PrevAllocWatcher:  allocwatcher.NoopPrevAlloc{},
 		PrevAllocMigrator: allocwatcher.NoopPrevAlloc{},

--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -4,15 +4,18 @@
 package vaultclient
 
 import (
+	"container/heap"
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"strings"
+	"sync"
 	"time"
 
 	hclog "github.com/hashicorp/go-hclog"
+	metrics "github.com/hashicorp/go-metrics/compat"
 	"github.com/hashicorp/nomad/helper/useragent"
-	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/nomad/structs/config"
 	vaultapi "github.com/hashicorp/vault/api"
 )
@@ -40,13 +43,24 @@ type JWTLoginRequest struct {
 // VaultClient is the interface which nomad client uses to interact with vault and
 // periodically renews the tokens and secrets.
 type VaultClient interface {
+	// Start initiates the renewal loop of tokens and secrets
+	Start()
+
+	// Stop terminates the renewal loop for tokens and secrets
+	Stop()
+
 	// DeriveTokenWithJWT returns a Vault ACL token using the JWT login
 	// endpoint, along with whether or not the token is renewable and its lease
 	// duration.
 	DeriveTokenWithJWT(context.Context, JWTLoginRequest) (string, bool, int, error)
 
-	// Renew returns a tokens renewed lease duration and expiration
-	Renew(context.Context, string, int) (time.Duration, error)
+	// RenewToken renews a token with the given increment and adds it to
+	// the min-heap for periodic renewal.
+	RenewToken(string, int) (<-chan error, error)
+
+	// StopRenewToken removes the token from the min-heap, stopping its
+	// renewal.
+	StopRenewToken(string) error
 }
 
 // Implementation of VaultClient interface to interact with vault and perform
@@ -66,11 +80,51 @@ type vaultClient struct {
 	// stopCh is the channel to trigger termination of renewal loop
 	stopCh chan struct{}
 
+	// heap is the min-heap to keep track of both tokens and leases
+	heap *vaultClientHeap
+
 	// config is the configuration to connect to vault
 	config *config.VaultConfig
 
+	lock   sync.RWMutex
 	logger hclog.Logger
 }
+
+// vaultClientRenewalRequest is a request object for renewal of both tokens and
+// secret's leases.
+type vaultClientRenewalRequest struct {
+	// errCh is the channel into which any renewal error will be sent to
+	errCh chan error
+
+	// id is an identifier which represents either a token or a lease
+	id string
+
+	// increment is the duration for which the token or lease should be
+	// renewed for
+	increment int
+
+	// isToken indicates whether the 'id' field is a token or not
+	isToken bool
+}
+
+// Element representing an entry in the renewal heap
+type vaultClientHeapEntry struct {
+	req   *vaultClientRenewalRequest
+	next  time.Time
+	index int
+}
+
+// Wrapper around the actual heap to provide additional semantics on top of
+// functions provided by the heap interface. In order to achieve that, an
+// additional map is placed beside the actual heap. This map can be used to
+// check if an entry is already present in the heap.
+type vaultClientHeap struct {
+	heapMap map[string]*vaultClientHeapEntry
+	heap    vaultDataHeapImp
+}
+
+// Data type of the heap
+type vaultDataHeapImp []*vaultClientHeapEntry
 
 // NewVaultClient returns a new vault client from the given config.
 func NewVaultClient(config *config.VaultConfig, logger hclog.Logger) (*vaultClient, error) {
@@ -84,6 +138,7 @@ func NewVaultClient(config *config.VaultConfig, logger hclog.Logger) (*vaultClie
 		config:   config,
 		stopCh:   make(chan struct{}),
 		updateCh: make(chan struct{}, 1), // Update channel should be buffered.
+		heap:     newVaultClientHeap(),
 		logger:   logger,
 	}
 
@@ -119,22 +174,90 @@ func NewVaultClient(config *config.VaultConfig, logger hclog.Logger) (*vaultClie
 	return c, nil
 }
 
+// newVaultClientHeap returns a new vault client heap with both the heap and a
+// map which is a secondary index for heap elements, both initialized.
+func newVaultClientHeap() *vaultClientHeap {
+	return &vaultClientHeap{
+		heapMap: make(map[string]*vaultClientHeapEntry),
+		heap:    make(vaultDataHeapImp, 0),
+	}
+}
+
+// isTracked returns if a given identifier is already present in the heap and
+// hence is being renewed. Lock should be held before calling this method.
+func (c *vaultClient) isTracked(id string) bool {
+	if id == "" {
+		return false
+	}
+
+	_, ok := c.heap.heapMap[id]
+	return ok
+}
+
+// isRunning returns true if the client is running.
+func (c *vaultClient) isRunning() bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.running
+}
+
+// Start starts the renewal loop of vault client
+func (c *vaultClient) Start() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.config.IsEnabled() || c.running {
+		return
+	}
+
+	c.running = true
+
+	go c.run()
+}
+
+// Stop stops the renewal loop of vault client
+func (c *vaultClient) Stop() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.config.IsEnabled() || !c.running {
+		return
+	}
+
+	c.running = false
+	close(c.stopCh)
+}
+
+// unlockAndUnset is used to unset the vault token on the client, restore the
+// client's default configured namespace, and release the lock. Helper method
+// for deferring a call that does both.
+func (c *vaultClient) unlockAndUnset() {
+	c.client.SetToken("")
+	c.client.SetNamespace(c.config.Namespace)
+	c.lock.Unlock()
+}
+
 // DeriveTokenWithJWT returns a Vault ACL token using the JWT login endpoint.
 func (c *vaultClient) DeriveTokenWithJWT(ctx context.Context, req JWTLoginRequest) (string, bool, int, error) {
-	cc, err := c.client.Clone()
-	if err != nil {
-		return "", false, 0, err
+	if !c.config.IsEnabled() {
+		return "", false, 0, fmt.Errorf("vault client not enabled")
 	}
+	if !c.isRunning() {
+		return "", false, 0, fmt.Errorf("vault client is not running")
+	}
+
+	c.lock.Lock()
+	defer c.unlockAndUnset()
 
 	// Make sure the login request is not passing any token and that we're using
 	// the expected namespace to login
-	cc.SetToken("")
+	c.client.SetToken("")
 	if req.Namespace != "" {
-		cc.SetNamespace(req.Namespace)
+		c.client.SetNamespace(req.Namespace)
 	}
 
 	jwtLoginPath := fmt.Sprintf("auth/%s/login", c.config.JWTAuthBackendPath)
-	s, err := cc.Logical().WriteWithContext(ctx, jwtLoginPath,
+	s, err := c.client.Logical().WriteWithContext(ctx, jwtLoginPath,
 		map[string]any{
 			"role": req.Role,
 			"jwt":  req.JWT,
@@ -157,34 +280,447 @@ func (c *vaultClient) DeriveTokenWithJWT(ctx context.Context, req JWTLoginReques
 	return s.Auth.ClientToken, s.Auth.Renewable, s.Auth.LeaseDuration, nil
 }
 
-func (c *vaultClient) Renew(ctx context.Context, token string, lease int) (duration time.Duration, err error) {
-	cc, err := c.client.Clone()
-	if err != nil {
-		return 0, err
+// RenewToken renews the supplied token for a given duration (in seconds) and
+// adds it to the min-heap so that it is renewed periodically by the renewal
+// loop. Any error returned during renewal will be written to a buffered
+// channel and the channel is returned instead of an actual error. This helps
+// the caller be notified of a renewal failure asynchronously for appropriate
+// actions to be taken. The caller of this function need not have to close the
+// error channel.
+func (c *vaultClient) RenewToken(token string, increment int) (<-chan error, error) {
+	if token == "" {
+		err := fmt.Errorf("missing token")
+		return nil, err
 	}
-	cc.SetToken(token)
-
-	res, err := cc.Auth().Token().RenewSelfWithContext(ctx, lease)
-	if err != nil {
-		return 0, wrapRenewErr(err)
+	if increment < 1 {
+		err := fmt.Errorf("increment cannot be less than 1")
+		return nil, err
 	}
 
-	duration = time.Duration(res.Auth.LeaseDuration * int(time.Second))
+	// Create a buffered error channel
+	errCh := make(chan error, 1)
 
-	return duration, nil
+	// Create a renewal request and indicate that the identifier in the
+	// request is a token and not a lease
+	renewalReq := &vaultClientRenewalRequest{
+		errCh:     errCh,
+		id:        token,
+		isToken:   true,
+		increment: increment,
+	}
+
+	// Perform the renewal of the token and send any error to the dedicated
+	// error channel.
+	if err := c.renew(renewalReq); err != nil {
+		c.logger.Error("error during renewal of token", "error", err)
+		metrics.IncrCounter([]string{"client", "vault", "renew_token_failure"}, 1)
+		return nil, err
+	}
+
+	return errCh, nil
 }
 
-func wrapRenewErr(err error) error {
-	errMsg := err.Error()
-	if strings.Contains(errMsg, "no namespace") ||
-		strings.Contains(errMsg, "cannot renew a token across namespaces") ||
-		strings.Contains(errMsg, "invalid lease ID") ||
-		strings.Contains(errMsg, "lease expired") ||
-		strings.Contains(errMsg, "lease is not renewable") ||
-		strings.Contains(errMsg, "lease not found") ||
-		strings.Contains(errMsg, "permission denied") ||
-		strings.Contains(errMsg, "token not found") {
-		return err
+// renew is a common method to handle renewal of both tokens and secret leases.
+// It invokes a token renewal or a secret's lease renewal. If renewal is
+// successful, min-heap is updated based on the duration after which it needs
+// renewal again. The next renewal time is randomly selected to avoid spikes in
+// the number of APIs periodically.
+func (c *vaultClient) renew(req *vaultClientRenewalRequest) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if req == nil {
+		return fmt.Errorf("nil renewal request")
 	}
-	return structs.NewRecoverableError(err, true)
+	if req.errCh == nil {
+		return fmt.Errorf("renewal request error channel nil")
+	}
+
+	if !c.config.IsEnabled() {
+		close(req.errCh)
+		return fmt.Errorf("vault client not enabled")
+	}
+	if !c.running {
+		close(req.errCh)
+		return fmt.Errorf("vault client is not running")
+	}
+	if req.id == "" {
+		close(req.errCh)
+		return fmt.Errorf("missing id in renewal request")
+	}
+	if req.increment < 1 {
+		close(req.errCh)
+		return fmt.Errorf("increment cannot be less than 1")
+	}
+
+	var renewalErr error
+	leaseDuration := req.increment
+
+	if req.isToken {
+		// Set the token in the API client to the one that needs renewal
+		c.client.SetToken(req.id)
+
+		// Renew the token
+		renewResp, err := c.client.Auth().Token().RenewSelf(req.increment)
+		if err != nil {
+			renewalErr = fmt.Errorf("failed to renew the vault token: %v", err)
+		} else if renewResp == nil || renewResp.Auth == nil {
+			renewalErr = fmt.Errorf("failed to renew the vault token")
+		} else {
+			// Don't set this if renewal fails
+			leaseDuration = renewResp.Auth.LeaseDuration
+			req.increment = leaseDuration
+		}
+
+		// Reset the token in the API client before returning
+		c.client.SetToken("")
+	} else {
+		// Renew the secret
+		renewResp, err := c.client.Sys().Renew(req.id, req.increment)
+		if err != nil {
+			renewalErr = fmt.Errorf("failed to renew vault secret: %v", err)
+		} else if renewResp == nil {
+			renewalErr = fmt.Errorf("failed to renew vault secret")
+		} else {
+			// Don't set this if renewal fails
+			leaseDuration = renewResp.LeaseDuration
+		}
+	}
+
+	// Determine the next renewal time
+	renewalDuration := renewalTime(rand.Intn, leaseDuration)
+	next := time.Now().Add(renewalDuration)
+
+	fatal := false
+	if renewalErr != nil {
+		// These errors aren't wrapped by the Vault SDK, so we have to read the
+		// error messages. Unfortunately we can't easily enumerate non-fatal
+		// errors so we have a large set here. These can be found at in
+		// vault/expiration.go.
+		// Current as of vault commit 52ba156d47da170bf40471fe57d72522030bdc7e
+		errMsg := renewalErr.Error()
+		if strings.Contains(errMsg, "no namespace") ||
+			strings.Contains(errMsg, "cannot renew a token across namespaces") ||
+			strings.Contains(errMsg, "invalid lease ID") ||
+			strings.Contains(errMsg, "lease expired") ||
+			strings.Contains(errMsg, "lease is not renewable") ||
+			strings.Contains(errMsg, "lease not found") ||
+			strings.Contains(errMsg, "permission denied") ||
+			strings.Contains(errMsg, "token not found") {
+			fatal = true
+		} else {
+			// In the event of a non fatal error, retry in a maximum of 1 minute
+			// TODO: mismithhisler - This is a temporary fix until a followup
+			// refactor of the vault client is merged that contains proper
+			// exponential backoffs.
+			retry := time.Now().Add(time.Minute)
+			if retry.Before(next) {
+				next = retry
+			}
+
+			c.logger.Debug("renewal error details", "req.increment", req.increment, "lease_duration", leaseDuration, "renewal_duration", renewalDuration)
+			c.logger.Error("error during renewal of lease or token failed due to a non-fatal error; retrying",
+				"error", renewalErr, "period", next)
+		}
+	}
+
+	if c.isTracked(req.id) {
+		if fatal {
+			// If encountered with an error where in a lease or a
+			// token is not valid at all with vault, and if that
+			// item is tracked by the renewal loop, stop renewing
+			// it by removing the corresponding heap entry.
+			if err := c.heap.Remove(req.id); err != nil {
+				return fmt.Errorf("failed to remove heap entry: %v", err)
+			}
+
+			// Report the fatal error to the client
+			req.errCh <- renewalErr
+			close(req.errCh)
+
+			return renewalErr
+		}
+
+		// If the identifier is already tracked, this indicates a
+		// subsequest renewal. In this case, update the existing
+		// element in the heap with the new renewal time.
+		if err := c.heap.Update(req, next); err != nil {
+			return fmt.Errorf("failed to update heap entry. err: %v", err)
+		}
+
+		// There is no need to signal an update to the renewal loop
+		// here because this case is hit from the renewal loop itself.
+	} else {
+		if fatal {
+			// If encountered with an error where in a lease or a
+			// token is not valid at all with vault, and if that
+			// item is not tracked by renewal loop, don't add it.
+
+			// Report the fatal error to the client
+			req.errCh <- renewalErr
+			close(req.errCh)
+
+			return renewalErr
+		}
+
+		// If the identifier is not already tracked, this is a first
+		// renewal request. In this case, add an entry into the heap
+		// with the next renewal time.
+		if err := c.heap.Push(req, next); err != nil {
+			return fmt.Errorf("failed to push an entry to heap.  err: %v", err)
+		}
+
+		// Signal an update for the renewal loop to trigger a fresh
+		// computation for the next best candidate for renewal.
+		if c.running {
+			select {
+			case c.updateCh <- struct{}{}:
+			default:
+			}
+		}
+	}
+
+	return nil
+}
+
+// run is the renewal loop which performs the periodic renewals of both the
+// tokens and the secret leases.
+func (c *vaultClient) run() {
+	if !c.config.IsEnabled() {
+		return
+	}
+
+	var renewalCh <-chan time.Time
+	for c.config.IsEnabled() && c.isRunning() {
+		// Fetches the candidate for next renewal
+		renewalReq, renewalTime := c.nextRenewal()
+		if renewalTime.IsZero() {
+			// If the heap is empty, don't do anything
+			renewalCh = nil
+		} else {
+			now := time.Now()
+			if renewalTime.After(now) {
+				// Compute the duration after which the item
+				// needs renewal and set the renewalCh to fire
+				// at that time.
+				renewalDuration := time.Until(renewalTime)
+				renewalCh = time.After(renewalDuration)
+			} else {
+				// If the renewals of multiple items are too
+				// close to each other and by the time the
+				// entry is fetched from heap it might be past
+				// the current time (by a small margin). In
+				// which case, fire immediately.
+				renewalCh = time.After(0)
+			}
+		}
+
+		select {
+		case <-renewalCh:
+			if err := c.renew(renewalReq); err != nil {
+				c.logger.Error("error renewing token", "error", err)
+				metrics.IncrCounter([]string{"client", "vault", "renew_token_error"}, 1)
+			}
+		case <-c.updateCh:
+			continue
+		case <-c.stopCh:
+			c.logger.Debug("stopped")
+			return
+		}
+	}
+}
+
+// StopRenewToken removes the item from the heap which represents the given
+// token.
+func (c *vaultClient) StopRenewToken(token string) error {
+	return c.stopRenew(token)
+}
+
+// stopRenew removes the given identifier from the heap and signals the renewal
+// loop to compute the next best candidate for renewal.
+func (c *vaultClient) stopRenew(id string) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if !c.isTracked(id) {
+		return nil
+	}
+
+	if err := c.heap.Remove(id); err != nil {
+		return fmt.Errorf("failed to remove heap entry: %v", err)
+	}
+
+	// Signal an update to the renewal loop.
+	if c.running {
+		select {
+		case c.updateCh <- struct{}{}:
+		default:
+		}
+	}
+
+	return nil
+}
+
+// nextRenewal returns the root element of the min-heap, which represents the
+// next element to be renewed and the time at which the renewal needs to be
+// triggered.
+func (c *vaultClient) nextRenewal() (*vaultClientRenewalRequest, time.Time) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	if c.heap.Length() == 0 {
+		return nil, time.Time{}
+	}
+
+	// Fetches the root element in the min-heap
+	nextEntry := c.heap.Peek()
+	if nextEntry == nil {
+		return nil, time.Time{}
+	}
+
+	return nextEntry.req, nextEntry.next
+}
+
+// Additional helper functions on top of interface methods
+
+// Length returns the number of elements in the heap
+func (h *vaultClientHeap) Length() int {
+	return len(h.heap)
+}
+
+// Returns the root node of the min-heap
+func (h *vaultClientHeap) Peek() *vaultClientHeapEntry {
+	if len(h.heap) == 0 {
+		return nil
+	}
+
+	return h.heap[0]
+}
+
+// Push adds the secondary index and inserts an item into the heap
+func (h *vaultClientHeap) Push(req *vaultClientRenewalRequest, next time.Time) error {
+	if req == nil {
+		return fmt.Errorf("nil request")
+	}
+
+	if _, ok := h.heapMap[req.id]; ok {
+		return fmt.Errorf("entry %v already exists", req.id)
+	}
+
+	heapEntry := &vaultClientHeapEntry{
+		req:  req,
+		next: next,
+	}
+	h.heapMap[req.id] = heapEntry
+	heap.Push(&h.heap, heapEntry)
+	return nil
+}
+
+// Update will modify the existing item in the heap with the new data and the
+// time, and fixes the heap.
+func (h *vaultClientHeap) Update(req *vaultClientRenewalRequest, next time.Time) error {
+	if entry, ok := h.heapMap[req.id]; ok {
+		entry.req = req
+		entry.next = next
+		heap.Fix(&h.heap, entry.index)
+		return nil
+	}
+
+	return fmt.Errorf("heap doesn't contain %v", req.id)
+}
+
+// Remove will remove an identifier from the secondary index and deletes the
+// corresponding node from the heap.
+func (h *vaultClientHeap) Remove(id string) error {
+	if entry, ok := h.heapMap[id]; ok {
+		heap.Remove(&h.heap, entry.index)
+		delete(h.heapMap, id)
+		return nil
+	}
+
+	return fmt.Errorf("heap doesn't contain entry for %v", id)
+}
+
+// The heap interface requires the following methods to be implemented.
+// * Push(x interface{}) // add x as element Len()
+// * Pop() interface{}   // remove and return element Len() - 1.
+// * sort.Interface
+//
+// sort.Interface comprises of the following methods:
+// * Len() int
+// * Less(i, j int) bool
+// * Swap(i, j int)
+
+// Part of sort.Interface
+func (h vaultDataHeapImp) Len() int { return len(h) }
+
+// Part of sort.Interface
+func (h vaultDataHeapImp) Less(i, j int) bool {
+	// Two zero times should return false.
+	// Otherwise, zero is "greater" than any other time.
+	// (To sort it at the end of the list.)
+	// Sort such that zero times are at the end of the list.
+	iZero, jZero := h[i].next.IsZero(), h[j].next.IsZero()
+	if iZero && jZero {
+		return false
+	} else if iZero {
+		return false
+	} else if jZero {
+		return true
+	}
+
+	return h[i].next.Before(h[j].next)
+}
+
+// Part of sort.Interface
+func (h vaultDataHeapImp) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
+}
+
+// Part of heap.Interface
+func (h *vaultDataHeapImp) Push(x interface{}) {
+	n := len(*h)
+	entry := x.(*vaultClientHeapEntry)
+	entry.index = n
+	*h = append(*h, entry)
+}
+
+// Part of heap.Interface
+func (h *vaultDataHeapImp) Pop() interface{} {
+	old := *h
+	n := len(old)
+	entry := old[n-1]
+	entry.index = -1 // for safety
+	*h = old[0 : n-1]
+	return entry
+}
+
+// randIntn is the function in math/rand needed by renewalTime. A type is used
+// to ease deterministic testing.
+type randIntn func(int) int
+
+// renewalTime returns when a token should be renewed given its leaseDuration
+// and a randomizer to provide jitter.
+//
+// Leases < 1m will be not jitter.
+func renewalTime(dice randIntn, leaseDuration int) time.Duration {
+	// Start trying to renew at half the lease duration to allow ample time
+	// for latency and retries.
+	renew := leaseDuration / 2
+
+	// Don't bother about introducing randomness if the
+	// leaseDuration is too small.
+	const cutoff = 30
+	if renew < cutoff {
+		return time.Duration(renew) * time.Second
+	}
+
+	// jitter is the amount +/- to vary the renewal time
+	const jitter = 10
+	min := renew - jitter
+	renew = min + dice(jitter*2)
+
+	return time.Duration(renew) * time.Second
 }

--- a/client/vaultclient/vaultclient_test.go
+++ b/client/vaultclient/vaultclient_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,13 +19,16 @@ import (
 	josejwt "github.com/go-jose/go-jose/v3/jwt"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/widmgr"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/useragent"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	structsc "github.com/hashicorp/nomad/nomad/structs/config"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/hashicorp/vault/api"
+	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/shoenig/test/must"
 )
 
@@ -159,7 +163,7 @@ func setupVaultForWorkloadIdentity(v *testutil.TestVault, jwksURL string) error 
 	return nil
 }
 
-func TestVaultClient_DerivesAndRenewsToken(t *testing.T) {
+func TestVaultClient_DeriveTokenWithJWT(t *testing.T) {
 	ci.Parallel(t)
 
 	// Create signer and signed identities.
@@ -214,6 +218,9 @@ func TestVaultClient_DerivesAndRenewsToken(t *testing.T) {
 	c, err := NewVaultClient(v.Config, logger)
 	must.NoError(t, err)
 
+	c.Start()
+	defer c.Stop()
+
 	// Derive Vault token using signed JWT.
 	jwtStr := signedWIDs[0].JWT
 	token, renewable, leaseDuration, err := c.DeriveTokenWithJWT(context.Background(), JWTLoginRequest{
@@ -229,11 +236,6 @@ func TestVaultClient_DerivesAndRenewsToken(t *testing.T) {
 	v.Client.SetToken(token)
 	s, err := v.Client.Logical().Read("auth/token/lookup-self")
 	must.NoError(t, err)
-
-	// Verify it can renew the token
-	renewedLease, err := c.Renew(t.Context(), token, 0)
-	must.Nil(t, err)
-	must.Eq(t, 72*60*60*time.Second, renewedLease)
 
 	jwt, err := josejwt.ParseSigned(jwtStr)
 	must.NoError(t, err)
@@ -290,6 +292,152 @@ func TestVaultClient_NamespaceSupport(t *testing.T) {
 	must.Eq(t, testNs, c.client.Headers().Get(VaultNamespaceHeaderName))
 }
 
+func TestVaultClient_Heap(t *testing.T) {
+	ci.Parallel(t)
+
+	tr := true
+	conf := structsc.DefaultVaultConfig()
+	conf.Enabled = &tr
+
+	logger := testlog.HCLogger(t)
+	c, err := NewVaultClient(conf, logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c == nil {
+		t.Fatal("failed to create vault Vault")
+	}
+
+	now := time.Now()
+
+	renewalReq1 := &vaultClientRenewalRequest{
+		errCh:     make(chan error, 1),
+		id:        "id1",
+		increment: 10,
+	}
+	if err := c.heap.Push(renewalReq1, now.Add(50*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if !c.isTracked("id1") {
+		t.Fatalf("id1 should have been tracked")
+	}
+
+	renewalReq2 := &vaultClientRenewalRequest{
+		errCh:     make(chan error, 1),
+		id:        "id2",
+		increment: 10,
+	}
+	if err := c.heap.Push(renewalReq2, now.Add(40*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if !c.isTracked("id2") {
+		t.Fatalf("id2 should have been tracked")
+	}
+
+	renewalReq3 := &vaultClientRenewalRequest{
+		errCh:     make(chan error, 1),
+		id:        "id3",
+		increment: 10,
+	}
+	if err := c.heap.Push(renewalReq3, now.Add(60*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if !c.isTracked("id3") {
+		t.Fatalf("id3 should have been tracked")
+	}
+
+	// Reading elements should yield id2, id1 and id3 in order
+	req, _ := c.nextRenewal()
+	if req != renewalReq2 {
+		t.Fatalf("bad: expected: %#v, actual: %#v", renewalReq2, req)
+	}
+	if err := c.heap.Update(req, now.Add(70*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+
+	req, _ = c.nextRenewal()
+	if req != renewalReq1 {
+		t.Fatalf("bad: expected: %#v, actual: %#v", renewalReq1, req)
+	}
+	if err := c.heap.Update(req, now.Add(80*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+
+	req, _ = c.nextRenewal()
+	if req != renewalReq3 {
+		t.Fatalf("bad: expected: %#v, actual: %#v", renewalReq3, req)
+	}
+	if err := c.heap.Update(req, now.Add(90*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.StopRenewToken("id1"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.StopRenewToken("id2"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.StopRenewToken("id3"); err != nil {
+		t.Fatal(err)
+	}
+
+	if c.isTracked("id1") {
+		t.Fatalf("id1 should not have been tracked")
+	}
+
+	if c.isTracked("id1") {
+		t.Fatalf("id1 should not have been tracked")
+	}
+
+	if c.isTracked("id1") {
+		t.Fatalf("id1 should not have been tracked")
+	}
+
+}
+
+// TestVaultClient_RenewalTime_Long asserts that for leases over 1m the renewal
+// time is jittered.
+func TestVaultClient_RenewalTime_Long(t *testing.T) {
+	ci.Parallel(t)
+
+	// highRoller is a randIntn func that always returns the max value
+	highRoller := func(n int) int {
+		return n - 1
+	}
+
+	// lowRoller is a randIntn func that always returns the min value (0)
+	lowRoller := func(int) int {
+		return 0
+	}
+
+	must.Eq(t, 39*time.Second, renewalTime(highRoller, 60))
+	must.Eq(t, 20*time.Second, renewalTime(lowRoller, 60))
+
+	must.Eq(t, 309*time.Second, renewalTime(highRoller, 600))
+	must.Eq(t, 290*time.Second, renewalTime(lowRoller, 600))
+
+	const days3 = 60 * 60 * 24 * 3
+	must.Eq(t, (days3/2+9)*time.Second, renewalTime(highRoller, days3))
+	must.Eq(t, (days3/2-10)*time.Second, renewalTime(lowRoller, days3))
+}
+
+// TestVaultClient_RenewalTime_Short asserts that for leases under 1m the renewal
+// time is lease/2.
+func TestVaultClient_RenewalTime_Short(t *testing.T) {
+	ci.Parallel(t)
+
+	dice := func(int) int {
+		t.Error("dice should not have been called")
+		panic("unreachable")
+	}
+
+	must.Eq(t, 29*time.Second, renewalTime(dice, 58))
+	must.Eq(t, 15*time.Second, renewalTime(dice, 30))
+	must.Eq(t, 1*time.Second, renewalTime(dice, 2))
+}
+
 func TestVaultClient_SetUserAgent(t *testing.T) {
 	ci.Parallel(t)
 
@@ -301,4 +449,115 @@ func TestVaultClient_SetUserAgent(t *testing.T) {
 
 	ua := c.client.Headers().Get("User-Agent")
 	must.Eq(t, useragent.String(), ua)
+}
+
+func TestVaultClient_RenewalConcurrent(t *testing.T) {
+	ci.Parallel(t)
+
+	// collects renewal requests that the mock Vault API gets
+	requestCh := make(chan string, 10)
+
+	// Create test server to mock the Vault API.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		requestCh <- string(b)
+
+		resp := vaultapi.Secret{
+			RequestID: uuid.Generate(),
+			LeaseID:   uuid.Generate(),
+			Renewable: true,
+			Data:      map[string]any{},
+			Auth: &vaultapi.SecretAuth{
+				ClientToken:   uuid.Generate(),
+				Accessor:      uuid.Generate(),
+				LeaseDuration: 1, // force a fast renewal
+			},
+		}
+
+		out, err := json.Marshal(resp)
+		if err != nil {
+			t.Errorf("failed to generate JWKS json response: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprintln(w, string(out))
+	}))
+	defer ts.Close()
+
+	// Start Vault client.
+	conf := structsc.DefaultVaultConfig()
+	conf.Addr = ts.URL
+	conf.Enabled = new(true)
+
+	vc, err := NewVaultClient(conf, testlog.HCLogger(t))
+	must.NoError(t, err)
+	vc.Start()
+
+	// Renew token multiple times in parallel.
+	expectedRenewals := 100
+	resultCh := make(chan any)
+	for range expectedRenewals {
+		go func() {
+			_, err := vc.RenewToken("token", 30)
+			resultCh <- err
+		}()
+	}
+
+	// Collect results with timeout.
+	timer, stop := helper.NewSafeTimer(3 * time.Second)
+	defer stop()
+
+	sawInitial := 0
+	sawRenew := 0
+	for {
+		select {
+		case got := <-requestCh:
+			switch got {
+			case `{"increment":1}`:
+				sawRenew++
+			case `{"increment":30}`:
+				sawInitial++
+			default:
+				t.Fatalf("unexpected request body: %q", got)
+			}
+			if sawInitial == expectedRenewals && sawRenew >= expectedRenewals {
+				return
+			}
+		case got := <-resultCh:
+			must.Nil(t, got, must.Sprintf("token renewal error: %v", got))
+		case <-timer.C:
+			t.Fatalf("timeout waiting for expected token renewals (initial: %d renewed: %d)",
+				sawInitial, sawRenew)
+		}
+	}
+}
+
+func TestVaultClient_NamespaceReset(t *testing.T) {
+
+	// Mock Vault API that always returns an error
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintln(w, "error")
+	}))
+	defer ts.Close()
+
+	conf := structsc.DefaultVaultConfig()
+	conf.Addr = ts.URL
+	conf.Enabled = new(true)
+
+	for _, ns := range []string{"", "foo"} {
+		conf.Namespace = ns
+
+		vc, err := NewVaultClient(conf, testlog.HCLogger(t))
+		must.NoError(t, err)
+		vc.Start()
+
+		_, _, _, err = vc.DeriveTokenWithJWT(context.Background(), JWTLoginRequest{
+			JWT:       "bogus",
+			Namespace: "bar",
+		})
+		must.Error(t, err)
+		must.Eq(t, ns, vc.client.Namespace(),
+			must.Sprintf("expected %q, not %q", ns, vc.client.Namespace()))
+	}
 }

--- a/client/vaultclient/vaultclient_testing.go
+++ b/client/vaultclient/vaultclient_testing.go
@@ -5,25 +5,166 @@ package vaultclient
 
 import (
 	"context"
-	"time"
+	"fmt"
+	"sync"
 
-	"github.com/stretchr/testify/mock"
+	"github.com/hashicorp/nomad/helper/uuid"
 )
 
+// MockVaultClient is used for testing the vaultclient integration and is safe
+// for concurrent access.
 type MockVaultClient struct {
-	mock.Mock
+
+	// jwtTokens stores the tokens derived using the JWT flow.
+	jwtTokens map[string]string
+
+	// stoppedTokens tracks the tokens that have stopped renewing
+	stoppedTokens []string
+
+	// renewTokens are the tokens that have been renewed and their error
+	// channels
+	renewTokens map[string]chan error
+
+	// renewTokenErrors is used to return an error when the RenewToken is called
+	// with the given token
+	renewTokenErrors map[string]error
+
+	// deriveTokenErrors maps an allocation ID and tasks to an error when the
+	// token is derived
+	deriveTokenErrors map[string]map[string]error
+
+	// deriveTokenWithJWTFn allows the caller to control the DeriveTokenWithJWT
+	// function.
+	deriveTokenWithJWTFn func(context.Context, JWTLoginRequest) (string, bool, int, error)
+
+	// renewable determines if the tokens returned should be marked as renewable
+	renewable bool
+
+	duration int
+
+	mu sync.Mutex
 }
 
-func NewMockVaultClient() *MockVaultClient {
-	return &MockVaultClient{}
+// NewMockVaultClient returns a MockVaultClient for testing
+func NewMockVaultClient(_ string) (VaultClient, error) {
+	return &MockVaultClient{renewable: true, duration: 30}, nil
 }
 
-func (m *MockVaultClient) DeriveTokenWithJWT(ctx context.Context, req JWTLoginRequest) (string, bool, int, error) {
-	args := m.Called(ctx, req)
-	return args.String(0), args.Bool(1), args.Int(2), args.Error(3)
+func (vc *MockVaultClient) DeriveTokenWithJWT(ctx context.Context, req JWTLoginRequest) (string, bool, int, error) {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+
+	if vc.deriveTokenWithJWTFn != nil {
+		return vc.deriveTokenWithJWTFn(ctx, req)
+	}
+
+	if vc.jwtTokens == nil {
+		vc.jwtTokens = make(map[string]string)
+	}
+
+	token := uuid.Generate()
+	if req.Role != "" {
+		token = fmt.Sprintf("%s-%s", token, req.Role)
+	}
+	vc.jwtTokens[req.JWT] = token
+	return token, vc.renewable, vc.duration, nil
 }
 
-func (m *MockVaultClient) Renew(ctx context.Context, token string, lease int) (time.Duration, error) {
-	args := m.Called(ctx, token, lease)
-	return args.Get(0).(time.Duration), args.Error(1)
+func (vc *MockVaultClient) SetDeriveTokenError(allocID string, tasks []string, err error) {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+
+	if vc.deriveTokenErrors == nil {
+		vc.deriveTokenErrors = make(map[string]map[string]error, 10)
+	}
+
+	if _, ok := vc.deriveTokenErrors[allocID]; !ok {
+		vc.deriveTokenErrors[allocID] = make(map[string]error, 10)
+	}
+
+	for _, task := range tasks {
+		vc.deriveTokenErrors[allocID][task] = err
+	}
+}
+
+func (vc *MockVaultClient) RenewToken(token string, interval int) (<-chan error, error) {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+
+	if err, ok := vc.renewTokenErrors[token]; ok {
+		return nil, err
+	}
+
+	renewCh := make(chan error)
+	if vc.renewTokens == nil {
+		vc.renewTokens = make(map[string]chan error, 10)
+	}
+	vc.renewTokens[token] = renewCh
+	return renewCh, nil
+}
+
+func (vc *MockVaultClient) SetRenewTokenError(token string, err error) {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+
+	if vc.renewTokenErrors == nil {
+		vc.renewTokenErrors = make(map[string]error, 10)
+	}
+
+	vc.renewTokenErrors[token] = err
+}
+
+func (vc *MockVaultClient) StopRenewToken(token string) error {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+
+	vc.stoppedTokens = append(vc.stoppedTokens, token)
+	return nil
+}
+
+func (vc *MockVaultClient) Start() {}
+
+func (vc *MockVaultClient) Stop() {}
+
+func (vc *MockVaultClient) SetRenewable(renewable bool) {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	vc.renewable = renewable
+}
+
+// JWTTokens returns the tokens generated suing the JWT flow.
+func (vc *MockVaultClient) JWTTokens() map[string]string {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	return vc.jwtTokens
+}
+
+// StoppedTokens tracks the tokens that have stopped renewing
+func (vc *MockVaultClient) StoppedTokens() []string {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	return vc.stoppedTokens
+}
+
+// RenewTokens are the tokens that have been renewed and their error
+// channels
+func (vc *MockVaultClient) RenewTokens() map[string]chan error {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	return vc.renewTokens
+}
+
+// RenewTokenErrCh returns the error channel for the given token renewal
+// process.
+func (vc *MockVaultClient) RenewTokenErrCh(token string) chan error {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	return vc.renewTokens[token]
+}
+
+// SetDeriveTokenWithJWTFn sets the function used to derive tokens using JWT.
+func (vc *MockVaultClient) SetDeriveTokenWithJWTFn(f func(context.Context, JWTLoginRequest) (string, bool, int, error)) {
+	vc.mu.Lock()
+	defer vc.mu.Unlock()
+	vc.deriveTokenWithJWTFn = f
 }

--- a/client/widmgr/mock.go
+++ b/client/widmgr/mock.go
@@ -124,7 +124,7 @@ type MockIdentityManager struct {
 
 // NewMockIdentityManager returns an implementation of the IdentityManager
 // interface which supports data manipulation for testing.
-func NewMockIdentityManager() *MockIdentityManager {
+func NewMockIdentityManager() IdentityManager {
 	return &MockIdentityManager{
 		lastToken: make(map[structs.WIHandle]*structs.SignedWorkloadIdentity),
 	}

--- a/command/agent/consul/int_test.go
+++ b/command/agent/consul/int_test.go
@@ -139,6 +139,7 @@ func TestConsul_Integration(t *testing.T) {
 		r.NoError(allocDir.Destroy())
 	})
 	taskDir := allocDir.NewTaskDir(task)
+	vclient, err := vaultclient.NewMockVaultClient("default")
 	must.NoError(t, err)
 	consulClient, err := consulapi.NewClient(consulConfig)
 	r.Nil(err)
@@ -165,7 +166,7 @@ func TestConsul_Integration(t *testing.T) {
 		Task:                task,
 		TaskDir:             taskDir,
 		Logger:              logger,
-		VaultFunc:           func(string) (vaultclient.VaultClient, error) { return vaultclient.NewMockVaultClient(), nil },
+		VaultFunc:           func(string) (vaultclient.VaultClient, error) { return vclient, nil },
 		StateDB:             state.NoopDB{},
 		StateUpdater:        logUpdate,
 		DeviceManager:       devicemanager.NoopMockManager(),


### PR DESCRIPTION
I love the ambition of this change, but revert #27946 for now.

It seems to cause errors in e2e tests:
- e2e/secret TestVaultSecret
- e2e/vaultsecrets TestVaultSecrets

I say "seems", because I couldn't repro on my laptop, but pointing e2e CI at a branch with this reverted, tests were able to pass again. :shrug: 

Example failure:

```
=== FAIL: e2e/secret TestVaultSecret (21.74s)
    secret_test.go:39: submitting job: "./input/vault_secret.hcl"
    jobs3.go:453:
        jobs3.go:453: expected not to execute this code path
        ↪ PostScript | annotation ↷
        	timeout reached waiting for deployment
    jobs3.go:683: tg 'group' alloc status 'failed': Failed tasks
    jobs3.go:689: tg 'group' task 'task' event: Task received by client
    jobs3.go:689: tg 'group' task 'task' event: Building Task Directory
    jobs3.go:689: tg 'group' task 'task' event: Vault: failed to derive vault token: failed to derive Vault token for identity vault_default: failed to login with JWT: Error making API request.

        URL: PUT https://nomad-e2e-shared-hcp-vault.[...].hashicorp.cloud:8200/v1/auth/jwt-nomad-nomad-e2e-balanced-spaniel/login
        Code: 403. Errors:

        * permission denied
```