### PR TITLE
vault: clone the client and set headers

### DIFF
--- a/client/vaultclient/vaultclient.go
+++ b/client/vaultclient/vaultclient.go
@@ -119,9 +119,24 @@ func NewVaultClient(config *config.VaultConfig, logger hclog.Logger) (*vaultClie
 	return c, nil
 }
 
+// Clone returns a cloned vaultapi.Client with the same headers that we have set on our main client. The vault API config exposes a setting for cloning the client with headers, but we always want these headers to be set and to not be configurable.
+func (c *vaultClient) Clone() (*vaultapi.Client, error) {
+	cc, err := c.client.Clone()
+	if err != nil {
+		return nil, err
+	}
+	useragent.SetHeaders(cc)
+
+	if c.config.Namespace != "" {
+		cc.SetNamespace(c.config.Namespace)
+	}
+
+	return cc, nil
+}
+
 // DeriveTokenWithJWT returns a Vault ACL token using the JWT login endpoint.
 func (c *vaultClient) DeriveTokenWithJWT(ctx context.Context, req JWTLoginRequest) (string, bool, int, error) {
-	cc, err := c.client.Clone()
+	cc, err := c.Clone()
 	if err != nil {
 		return "", false, 0, err
 	}
@@ -158,7 +173,7 @@ func (c *vaultClient) DeriveTokenWithJWT(ctx context.Context, req JWTLoginReques
 }
 
 func (c *vaultClient) Renew(ctx context.Context, token string, lease int) (duration time.Duration, err error) {
-	cc, err := c.client.Clone()
+	cc, err := c.Clone()
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
