### PR TITLE
Consul: allow fallback to Nomad agent token

### DIFF
--- a/.changelog/28106.txt
+++ b/.changelog/28106.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+consul: Allow service, template, and connect blocks to fallback to the Nomad client agent's Consul token if workload identity is unavailable
+```

--- a/client/allocrunner/group_service_hook.go
+++ b/client/allocrunner/group_service_hook.go
@@ -289,6 +289,10 @@ func (h *groupServiceHook) getWorkloadServicesLocked() *serviceregistration.Work
 
 	tokens := map[string]string{}
 	for _, service := range h.services {
+		// these tokens will come from the consul_hook using Workload Identity
+		// to login to Consul, but if they're absent because WI is not
+		// configured, the service client will fallback to using the Nomad
+		// client's own token for registering services to Consul
 		cluster := service.GetConsulClusterName(h.tg)
 		if token, ok := allocTokens[cluster][service.MakeUniqueIdentityName()]; ok {
 			tokens[service.Name] = token.SecretID

--- a/client/allocrunner/taskrunner/envoy_bootstrap_hook.go
+++ b/client/allocrunner/taskrunner/envoy_bootstrap_hook.go
@@ -82,12 +82,13 @@ type allocServicesClient interface {
 }
 
 type envoyBootstrapHookConfig struct {
-	alloc           *structs.Allocation
-	consul          consulTransportConfig
-	consulNamespace string
-	consulServices  allocServicesClient
-	node            *structs.Node
-	logger          hclog.Logger
+	alloc               *structs.Allocation
+	consul              consulTransportConfig
+	consulNamespace     string
+	consulServices      allocServicesClient
+	consulFallbackToken string
+	node                *structs.Node
+	logger              hclog.Logger
 }
 
 func decodeTriState(b *bool) string {
@@ -103,12 +104,13 @@ func decodeTriState(b *bool) string {
 
 func newEnvoyBootstrapHookConfig(alloc *structs.Allocation, consul *config.ConsulConfig, consulNamespace string, consulServices allocServicesClient, node *structs.Node, logger hclog.Logger) *envoyBootstrapHookConfig {
 	return &envoyBootstrapHookConfig{
-		alloc:           alloc,
-		consul:          newConsulTransportConfig(consul),
-		consulNamespace: consulNamespace,
-		consulServices:  consulServices,
-		node:            node,
-		logger:          logger,
+		alloc:               alloc,
+		consul:              newConsulTransportConfig(consul),
+		consulNamespace:     consulNamespace,
+		consulServices:      consulServices,
+		consulFallbackToken: consul.Token,
+		node:                node,
+		logger:              logger,
 	}
 }
 
@@ -138,6 +140,11 @@ type envoyBootstrapHook struct {
 
 	// consulNamespace is the Consul namespace as set by in the job
 	consulNamespace string
+
+	// consulFallbackToken is the Nomad client agent's own Consul token, which
+	// we'll use as a fallback when Workload Identity has not been configured
+	// for the task
+	consulFallbackToken string
 
 	// envoyBootstrapWaitTime is the total amount of time hook will wait for Consul
 	envoyBootstrapWaitTime time.Duration
@@ -169,6 +176,7 @@ func newEnvoyBootstrapHook(c *envoyBootstrapHookConfig) *envoyBootstrapHook {
 		alloc:                    c.alloc,
 		consulConfig:             c.consul,
 		consulNamespace:          c.consulNamespace,
+		consulFallbackToken:      c.consulFallbackToken,
 		envoyBootstrapWaitTime:   waitTime,
 		envoyBootstrapInitialGap: initialGap,
 		envoyBootstrapMaxJitter:  envoyBootstrapMaxJitter,
@@ -626,8 +634,8 @@ func (h *envoyBootstrapHook) maybeLoadSIToken(task, dir string) (string, error) 
 			h.logger.Error("failed to load SI token", "task", task, "error", err)
 			return "", fmt.Errorf("failed to load SI token for %s: %w", task, err)
 		}
-		h.logger.Trace("no SI token to load", "task", task)
-		return "", nil // token file does not exist
+		h.logger.Trace("no SI token to load, falling back to agent token", "task", task)
+		return h.consulFallbackToken, nil // token file does not exist
 	}
 	h.logger.Trace("recovered pre-existing SI token", "task", task)
 	return string(token), nil

--- a/client/allocrunner/taskrunner/template_hook.go
+++ b/client/allocrunner/taskrunner/template_hook.go
@@ -136,7 +136,6 @@ func (h *templateHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 	consulWIDName := consulBlock.IdentityName()
 
 	// Check if task has an identity for Consul and assume WI flow if it does.
-	// COMPAT simplify this logic and assume WI flow in 1.9+
 	hasConsulIdentity := false
 	for _, wid := range req.Task.Identities {
 		if wid.Name == consulWIDName {
@@ -144,6 +143,12 @@ func (h *templateHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 			break
 		}
 	}
+
+	// If we leave the Consul token as an empty string, then consul-template
+	// will try to pick it up from the environment; we want to enforce that we
+	// don't have a Consul token unless intentionally configured
+	h.consulToken = "invalid-token"
+
 	if hasConsulIdentity {
 		consulCluster := req.Task.GetConsulClusterName(tg)
 		consulTokens := h.config.hookResources.GetConsulTokens()
@@ -165,6 +170,14 @@ func (h *templateHook) Prestart(ctx context.Context, req *interfaces.TaskPrestar
 		}
 
 		h.consulToken = consulToken.SecretID
+	} else if h.config.clientConfig.TemplateConfig != nil &&
+		h.config.clientConfig.TemplateConfig.UseClientConsulToken {
+		consulCluster := req.Task.GetConsulClusterName(tg)
+		if config, ok := h.config.clientConfig.ConsulConfigs[consulCluster]; ok {
+			h.consulToken = config.Token
+		} else {
+			h.consulToken = ""
+		}
 	}
 
 	// Set vault namespace if specified

--- a/client/allocrunner/taskrunner/template_hook_test.go
+++ b/client/allocrunner/taskrunner/template_hook_test.go
@@ -35,14 +35,21 @@ func TestTemplateHook_Prestart_ConsulWI(t *testing.T) {
 	ci.Parallel(t)
 	logger := testlog.HCLogger(t)
 
+	agentToken := uuid.Generate()
+	clientConfig := &config.Config{
+		Region:         "global",
+		TemplateConfig: &config.ClientTemplateConfig{UseClientConsulToken: true},
+		ConsulConfigs:  map[string]*structsc.ConsulConfig{"default": {Token: agentToken}},
+	}
+
 	// Create some alloc hook resources, one with tokens and an empty one.
-	defaultToken := uuid.Generate()
+	derivedToken := uuid.Generate()
 	hrTokens := cstructs.NewAllocHookResources()
 	hrTokens.SetConsulTokens(
 		map[string]map[string]*consulapi.ACLToken{
 			structs.ConsulDefaultCluster: {
 				fmt.Sprintf("consul_%s/web", structs.ConsulDefaultCluster): &consulapi.ACLToken{
-					SecretID: defaultToken,
+					SecretID: derivedToken,
 				},
 			},
 		},
@@ -59,21 +66,21 @@ func TestTemplateHook_Prestart_ConsulWI(t *testing.T) {
 		legacyFlow      bool
 	}{
 		{
-			// COMPAT remove in 1.9+
 			name:            "legacy flow",
 			hr:              hrEmpty,
 			legacyFlow:      true,
-			wantConsulToken: "",
+			wantConsulToken: agentToken,
 		},
 		{
-			name:       "task missing Consul token",
-			hr:         hrEmpty,
-			wantErrMsg: "not found",
+			name:            "task missing Consul token",
+			hr:              hrEmpty,
+			wantErrMsg:      "not found",
+			wantConsulToken: "invalid-token",
 		},
 		{
 			name:            "task without consul blocks uses default cluster",
 			hr:              hrTokens,
-			wantConsulToken: defaultToken,
+			wantConsulToken: derivedToken,
 		},
 		{
 			name: "task with consul block at task level",
@@ -81,7 +88,7 @@ func TestTemplateHook_Prestart_ConsulWI(t *testing.T) {
 			taskConsul: &structs.Consul{
 				Cluster: structs.ConsulDefaultCluster,
 			},
-			wantConsulToken: defaultToken,
+			wantConsulToken: derivedToken,
 		},
 		{
 			name: "task with consul block at group level",
@@ -89,7 +96,7 @@ func TestTemplateHook_Prestart_ConsulWI(t *testing.T) {
 			groupConsul: &structs.Consul{
 				Cluster: structs.ConsulDefaultCluster,
 			},
-			wantConsulToken: defaultToken,
+			wantConsulToken: derivedToken,
 		},
 	}
 	for _, tt := range tests {
@@ -106,7 +113,6 @@ func TestTemplateHook_Prestart_ConsulWI(t *testing.T) {
 				}
 			}
 
-			clientConfig := &config.Config{Region: "global"}
 			envBuilder := taskenv.NewBuilder(mock.Node(), a, task, clientConfig.Region)
 			taskHooks := trtesting.NewMockTaskHooks()
 

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -488,6 +488,10 @@ type ClientTemplateConfig struct {
 	// to wait for the cluster to become available, as is customary in distributed
 	// systems.
 	NomadRetry *RetryConfig `hcl:"nomad_retry,optional"`
+
+	// UseClientConsulToken is a compatibility configuration that allows the
+	// template runner to use the Nomad client's own Consul token
+	UseClientConsulToken bool `hcl:"use_client_consul_token"`
 }
 
 func DefaultTemplateConfig() *ClientTemplateConfig {
@@ -515,6 +519,7 @@ func DefaultTemplateConfig() *ClientTemplateConfig {
 			Backoff:    new(time.Millisecond * 250),
 			MaxBackoff: new(time.Minute),
 		},
+		UseClientConsulToken: false,
 	}
 }
 
@@ -576,7 +581,8 @@ func (c *ClientTemplateConfig) IsEmpty() bool {
 		c.Wait.IsEmpty() &&
 		c.ConsulRetry.IsEmpty() &&
 		c.VaultRetry.IsEmpty() &&
-		c.NomadRetry.IsEmpty()
+		c.NomadRetry.IsEmpty() &&
+		!c.UseClientConsulToken
 }
 
 func (c *ClientTemplateConfig) Merge(o *ClientTemplateConfig) *ClientTemplateConfig {
@@ -618,6 +624,9 @@ func (c *ClientTemplateConfig) Merge(o *ClientTemplateConfig) *ClientTemplateCon
 	}
 	if o.NomadRetry != nil {
 		result.NomadRetry = c.NomadRetry.Merge(o.NomadRetry)
+	}
+	if o.UseClientConsulToken {
+		result.UseClientConsulToken = true
 	}
 
 	return &result

--- a/e2e/consulcompat/input/connect.nomad.hcl
+++ b/e2e/consulcompat/input/connect.nomad.hcl
@@ -64,6 +64,7 @@ job "countdash" {
         auth_soft_fail = true
       }
 
+      consul {}
 
       # this template can't be used for the COUNTING_SERVICE_URL because it
       # needs the Nomad-assigned upstream address here and not the Consul


### PR DESCRIPTION
_An alternative approach to addressing the issues discussed in https://github.com/hashicorp/nomad/pull/28066_

In Nomad 1.10.0 we intended to require Workload Identity (WI) if you want to use the Consul integration with workloads for `service` blocks, `template` blocks, or `connect` blocks. This was originally done to mirror the Vault integration, where WI carries an enormous value in that Nomad agents no longer have their own Vault tokens. But for Consul, the Nomad agent still needs a fairly powerful Consul ACL token so that it can reliably delete services. This greatly reduces the value of WI for Nomad users of Consul. At the same time, configuring Nomad to use Workload Identity with Consul is meaningfully more complex than just giving the Nomad agent a Consul token, which creates migration pain.

Additionally, we've discovered that there are some bugs that allow workloads not migrated to Workload Identity to use the ambient authority of the Nomad client with Consul. This turns out to be convenient for helping with migration, but wasn't intended.

In order to ease migration to WI for Consul or allow cluster administrators to opt-out of using it for Consul entirely (with caveats), allow running workloads with `service` and `template` blocks without WI:

* For `service` blocks this already works as-is because the Consul service client is shared with the agent, and we're just removing comments in the code base suggesting these code paths need to be cleaned up.
* For `template` blocks the consul-template runner creates a new Consul API client for each task. We'll give the cluster admin the ability to opt-in a given client to sharing its Consul config with the template runner.
* For `connect` blocks, we'll give the Envoy bootstrap hook the client agent's token. While at first glance this appears to undermine the security properties of the Consul Service Mesh, the certificates Consul mints for Envoy still have all the expected controls around Service Intentions. Only what token is used to instruct the "control plane" (here the Nomad client's token) changes.

Fixes: https://hashicorp.atlassian.net/browse/NMD-1338

### Testing & Reproduction steps

To test this, I had to cover a large matrix of features to configurations. For features I covered `group.service` and `task.service`, `template` blocks that fetch Consul services and Consul KV, and `connect` blocks. These features are all covered with the following two jobspecs:

<details><summary>service job with templates</summary>

```hcl
job "example" {

  group "web" {

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
      port "admin" {
        to = 8888 # no actual listener
      }
    }

    service {
      port = "www"
    }

    task "http" {

      driver = "docker"
      user   = "www-data"

      consul {}

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      service {
        name = "admin"
        port = "admin"
      }

      template {
        data = <<EOF
server_name = "{{ key "nomad/name" }}"

{{ range services }}
upstream {{ .Name | toLower }} {
  {{- range service .Name }}
  server {{ .Address}}:{{ .Port }};{{- end }}
}
{{ end -}}
EOF

        destination = "local/out.txt"
        change_mode = "noop"
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}
```

</details>

<details><summary>Consul Service Mesh job</summary>

```hcl
job "countdash" {

  group "api" {
    network {
      mode = "bridge"
    }

    service {
      name = "count-api"
      port = "9001"

      connect {
        sidecar_service {}

        # if testing with SELinux and you don't want to do a bunch of setup.
        # see: https://github.com/hashicorp/nomad/issues/26852
        sidecar_task {
          config {
            security_opt = ["label=disable"]
          }
        }
      }
    }

    task "web" {
      driver = "docker"

      config {
        image          = "hashicorpdev/counter-api:v3"
        auth_soft_fail = true
      }
    }
  }

  group "dashboard" {
    network {
      mode = "bridge"

      port "http" {
        static = 9002
        to     = 9002
      }
    }

    service {
      name = "count-dashboard"
      port = "9002"

      connect {

        sidecar_service {
          proxy {
            upstreams {
              destination_name = "count-api"
              local_bind_port  = 8080
            }
          }
        }

        # if testing with SELinux and you don't want to do a bunch of setup.
        # see: https://github.com/hashicorp/nomad/issues/26852
        sidecar_task {
          config {
            security_opt = ["label=disable"]
          }
        }

      }
    }

    task "dashboard" {
      driver = "docker"

      consul {}

      template {
        data =<<EOT
{{- range service "count-api" }}
API_ADDR=http://{{ .Address }}:{{ .Port }}{{- end }}
EOT

        destination = "local/count-api.txt"
      }

      env {
        COUNTING_SERVICE_URL = "http://${NOMAD_UPSTREAM_ADDR_count_api}"
      }

      config {
        image          = "hashicorpdev/counter-dashboard:v3"
        auth_soft_fail = true
      }
    }
  }
}
```

</details>

**Nomad agent config**

For configurations I covered Workload Identity configured for service/task identities as the control.

```hcl
consul {
  token = "$REDACTED"

  service_identity {
    aud = ["consul.io"]
    ttl = "1h"
  }

  task_identity {
    aud = ["consul.io"]
    ttl = "1h"
  }
}
```

Then without WI:

```hcl
consul {
  token = "$REDACTED"
}

client {
  template {
    use_client_consul_token = true
  }
}
```


**Consul config**

We need a KV item written to Consul: `consul kv put nomad/name Tim`. I used two different Consul policies for the Nomad client's policy. The "open policy" is a Consul policy for the Nomad cluster with the following, which gives it rights to read KV (which with WI you wouldn't normally need):

```hcl
agent_prefix "" {
  policy = "read"
}

key_prefix "" {
  policy = "read"
}

node_prefix "" {
  policy = "read"
}

service_prefix "" {
  policy = "write"
}
```

The "no KV policy" removes the `key_prefix` block so that we can't read Consul KV.

And lastly, we have Service Intentions for the `connect` workload which we can apply with `consul config write intention.hcl`

```hcl
Kind = "service-intentions"
Name = "count-api"
Sources = [
  {
    Name   = "count-dashboard"
    Action = "allow"
  }
]
```

**Results**

All the tested features work where expected, and fail where expected because of lacking permissions. Service registration works with all fallback options. Reading from Consul with `template` blocks works only when the appropriate `client.template.use_client_consul_token` and ACL policy are allowed. The `connect` block works with the fallback token, but Service Intentions still control access over the Envoy proxy.


| Setup                                                | `group.service`    | `task.service`     | `template` services | `template` KV      | `connect`          |
|------------------------------------------------------|--------------------|--------------------|---------------------|--------------------|--------------------|
| Workload Identity                                    | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: |
| No WI, share token,<br/>good policy, good intentions | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:  | :heavy_check_mark: | :heavy_check_mark: |
| No WI, share token,<br/>good policy, no intentions   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:  | :heavy_check_mark: | :x: (expected)     |
| No WI, share token, no KV policy                     | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark:  | :x: (expected)     | :heavy_check_mark: |
| No WI, no share token                                | :heavy_check_mark: | :heavy_check_mark: | :x: (expected)      | :x: (expected)     | :heavy_check_mark: |


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing**:
  - added cases to the `template_hook` tests to exercise the new code there
  - fixed E2E tests to make sure we were actually covering the intended case (this was covering up the bug described in NMD-1338 
- [x] **Documentation** https://github.com/hashicorp/web-unified-docs/pull/2637

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
