### PR TITLE
release/prepare: support existing release branch

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,7 +1,11 @@
 name: Prepare Nomad release branch
 
-# create a specific release/A.B.C branch from a long-lived
-# release/A.B.x branch and prepare it to be built.
+# prepare a release branch to be built
+#
+# normal release: cut a new branch from a long-lived release/A.B.x branch.
+#                 overwrite target release/A.B.C branch if it exists.
+#
+# security release: commit to an existing short-lived release/A.B.C branch.
 
 on:
   workflow_call:
@@ -22,7 +26,7 @@ on:
         type: string
         required: true
       source-branch:
-        description: "Source branch to cut the release branch from, e.g. release/1.11.x"
+        description: "Source branch to cut the release branch from, e.g. 'release/1.11.x', or 'release/1.11.22' to prepare an existing branch"
         type: string
         required: true
     outputs:

--- a/scripts/release/prepare
+++ b/scripts/release/prepare
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
 # run by the release-prepare.yml github action workflow
-# * start from a release/A.B.x branch
+# * start from a release/A.B.x branch (or release/A.B.C for security releases)
 # * update notification channel in ci.hcl and version in version.go
 # * generate static assets (make prerelease)
-# * commit and push changes to a new release/A.B.C branch
+# * commit and push changes to release/A.B.C branch
 # * prepare workflow will commit changes
 
 [ -n "$DEBUG" ] && set -x
@@ -55,7 +55,14 @@ echo 'Ensuring source branch'
 echo
 
 echo 'Creating new branch'
-  git switch --force-create "$NEW_BRANCH"
+  if [ "$SOURCE_BRANCH" = "$NEW_BRANCH" ]; then
+    # we may pre-create a release/A.B.C branch to make targeted changes, such as
+    # for a security release, rather than release all changes in release/A.B.x.
+    # there's no new branch in that case.
+    echo "already on release branch $NEW_BRANCH, skipping branch creation"
+  else
+    git switch --force-create "$NEW_BRANCH"
+  fi
 echo
 
 echo 'Updating version.go'


### PR DESCRIPTION
E.g. for a security release, we may pre-create `release/1.2.3` and cherry-pick specific commits.

It doesn't hurt anything as-is, but this normalizes this condition in code.