### PR TITLE
auth: allow nodes to sync their own allocations during node pool changes

### DIFF
--- a/.changelog/28110.txt
+++ b/.changelog/28110.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+auth: Fixed a bug where nodes could not sync allocations placed on them after being moved to a different node pool
+```

--- a/.semgrep/rpc_endpoint.yml
+++ b/.semgrep/rpc_endpoint.yml
@@ -157,7 +157,7 @@ rules:
             return structs.ErrPermissionDenied
           }
           ...
-          if err := $A.$B.AuthorizeClientAllocation(aclObj, ..., ...); err != nil {
+          if err := $A.$B.AuthorizeClientAllocation(..., aclObj, ..., ...); err != nil {
             return err
           }
           ...

--- a/nomad/acl.go
+++ b/nomad/acl.go
@@ -29,11 +29,12 @@ func (s *Server) ResolveAuthorizedClientNodePoolByNodeID(aclObj *acl.ACL, nodeID
 }
 
 func (s *Server) AuthorizeClientAllocation(
+	identity *structs.AuthenticatedIdentity,
 	aclObj *acl.ACL,
 	alloc *structs.Allocation,
 	allowNsOp func(*acl.ACL, string) bool,
 ) error {
-	return s.auth.AuthorizeClientAllocation(aclObj, alloc, allowNsOp)
+	return s.auth.AuthorizeClientAllocation(identity, aclObj, alloc, allowNsOp)
 }
 
 func (s *Server) ResolveAuthorizedClientNodePoolByServiceRegistrationID(

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -165,7 +165,7 @@ func (a *Alloc) GetAlloc(args *structs.AllocSpecificRequest,
 				reply.Alloc = out
 
 				// Re-check namespace in case it differs from request.
-				if err := a.srv.AuthorizeClientAllocation(aclObj, out, allowNsOp); err != nil {
+				if err := a.srv.AuthorizeClientAllocation(args.GetIdentity(), aclObj, out, allowNsOp); err != nil {
 					return structs.NewErrUnknownAllocation(args.AllocID)
 				}
 
@@ -231,7 +231,7 @@ func (a *Alloc) GetAllocs(args *structs.AllocsGetRequest,
 					continue
 				}
 
-				if err := a.srv.AuthorizeClientAllocation(aclObj, out, nil); err != nil {
+				if err := a.srv.AuthorizeClientAllocation(args.GetIdentity(), aclObj, out, nil); err != nil {
 					return err
 				}
 
@@ -492,7 +492,7 @@ func (a *Alloc) SignIdentities(args *structs.AllocIdentitiesRequest, reply *stru
 					continue
 				}
 
-				if err := a.srv.AuthorizeClientAllocation(aclObj, out, nil); err != nil {
+				if err := a.srv.AuthorizeClientAllocation(args.GetIdentity(), aclObj, out, nil); err != nil {
 					return err
 				}
 

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -164,7 +164,9 @@ func (a *Alloc) GetAlloc(args *structs.AllocSpecificRequest,
 				}
 				reply.Alloc = out
 
-				// Re-check namespace in case it differs from request.
+				// Authorize the caller against the alloc we found: allow the
+				// node the alloc is placed on, client ACLs for the alloc's
+				// node pool, or namespace read-job as a fallback.
 				if err := a.srv.AuthorizeClientAllocation(args.GetIdentity(), aclObj, out, allowNsOp); err != nil {
 					return structs.NewErrUnknownAllocation(args.AllocID)
 				}

--- a/nomad/auth/auth.go
+++ b/nomad/auth/auth.go
@@ -665,12 +665,17 @@ func (s *Authenticator) ResolveAuthorizedClientNodePoolByNodeID(aclObj *acl.ACL,
 // fall back to namespace-based authorization when client-scoped authorization
 // does not apply.
 func (s *Authenticator) AuthorizeClientAllocation(
+	identity *structs.AuthenticatedIdentity,
 	aclObj *acl.ACL,
 	alloc *structs.Allocation,
 	allowNsOp func(*acl.ACL, string) bool,
 ) error {
 	if alloc == nil || alloc.Job == nil {
 		return structs.ErrPermissionDenied
+	}
+
+	if identity != nil && AuthorizeSameNode(identity, alloc.NodeID) == nil {
+		return nil
 	}
 
 	if aclObj.AllowClientOp(alloc.Job.NodePool) {

--- a/nomad/auth/auth.go
+++ b/nomad/auth/auth.go
@@ -660,10 +660,10 @@ func (s *Authenticator) ResolveAuthorizedClientNodePoolByNodeID(aclObj *acl.ACL,
 	return resolveAuthorizedClientNodePoolByNodeID(snap, aclObj, nodeID)
 }
 
-// AuthorizeClientAllocation returns ErrPermissionDenied unless aclObj is
-// authorized for alloc's node pool. If allowNsOp is provided, callers may
-// fall back to namespace-based authorization when client-scoped authorization
-// does not apply.
+// AuthorizeClientAllocation returns ErrPermissionDenied unless the identity
+// is the node the alloc is placed on or aclObj is authorized for alloc's
+// node pool. If allowNsOp is provided, callers may fall back to
+// namespace-based authorization when client-scoped authorization does not apply.
 func (s *Authenticator) AuthorizeClientAllocation(
 	identity *structs.AuthenticatedIdentity,
 	aclObj *acl.ACL,
@@ -674,7 +674,7 @@ func (s *Authenticator) AuthorizeClientAllocation(
 		return structs.ErrPermissionDenied
 	}
 
-	if identity != nil && AuthorizeSameNode(identity, alloc.NodeID) == nil {
+	if alloc.NodeID != "" && AuthorizeSameNode(identity, alloc.NodeID) == nil {
 		return nil
 	}
 

--- a/nomad/auth/auth_test.go
+++ b/nomad/auth/auth_test.go
@@ -1744,6 +1744,35 @@ func TestResolveAuthorizedClientNodePoolHelpers(t *testing.T) {
 			alloc,
 			nil,
 		), structs.ErrPermissionDenied)
+
+		// A node authenticating with node identity claims rather than a
+		// client secret must also be authorized for its own allocs.
+		claimsIdentity := &structs.AuthenticatedIdentity{
+			Claims: &structs.IdentityClaims{
+				NodeIdentityClaims: &structs.NodeIdentityClaims{
+					NodeID:   node.ID,
+					NodePool: node.NodePool,
+				},
+			},
+		}
+		must.NoError(t, auth.AuthorizeClientAllocation(
+			claimsIdentity,
+			acl.NewClientACL("other-pool"),
+			alloc,
+			nil,
+		))
+
+		// An unplaced alloc must not match a non-node identity, whose
+		// authenticated node ID is also empty.
+		unplacedAlloc := mock.Alloc()
+		unplacedAlloc.Job.NodePool = "other-pool"
+		unplacedAlloc.NodeID = ""
+		must.ErrorIs(t, auth.AuthorizeClientAllocation(
+			&structs.AuthenticatedIdentity{},
+			aclObj,
+			unplacedAlloc,
+			nil,
+		), structs.ErrPermissionDenied)
 	})
 
 	t.Run("resolve by service registration id", func(t *testing.T) {

--- a/nomad/auth/auth_test.go
+++ b/nomad/auth/auth_test.go
@@ -1713,14 +1713,37 @@ func TestResolveAuthorizedClientNodePoolHelpers(t *testing.T) {
 	t.Run("authorize client allocation", func(t *testing.T) {
 		alloc := mock.Alloc()
 		alloc.Job.NodePool = node.NodePool
+		alloc.NodeID = node.ID
 
-		must.NoError(t, auth.AuthorizeClientAllocation(aclObj, alloc, nil))
-		must.ErrorIs(t, auth.AuthorizeClientAllocation(acl.NewClientACL("other-pool"), alloc, nil), structs.ErrPermissionDenied)
+		must.NoError(t, auth.AuthorizeClientAllocation(nil, aclObj, alloc, nil))
+		must.ErrorIs(t, auth.AuthorizeClientAllocation(nil, acl.NewClientACL("other-pool"), alloc, nil), structs.ErrPermissionDenied)
 		must.NoError(t, auth.AuthorizeClientAllocation(
+			nil,
 			acl.NewClientACL("other-pool"),
 			alloc,
 			func(_ *acl.ACL, ns string) bool { return ns == alloc.Namespace },
 		))
+
+		// Test identity-based authorization when node pool mismatches
+		matchingIdentity := &structs.AuthenticatedIdentity{
+			ClientID: node.ID,
+		}
+		must.NoError(t, auth.AuthorizeClientAllocation(
+			matchingIdentity,
+			acl.NewClientACL("other-pool"),
+			alloc,
+			nil,
+		))
+
+		mismatchIdentity := &structs.AuthenticatedIdentity{
+			ClientID: "other-node",
+		}
+		must.ErrorIs(t, auth.AuthorizeClientAllocation(
+			mismatchIdentity,
+			acl.NewClientACL("other-pool"),
+			alloc,
+			nil,
+		), structs.ErrPermissionDenied)
 	})
 
 	t.Run("resolve by service registration id", func(t *testing.T) {


### PR DESCRIPTION
### Description
Fixes the server-side check so that when a node's node pool changes, the node can still fetch and sync allocations that are already assigned to it. 

Right now, if the node pool names mismatch (because the old allocations are still on the old pool), the server blocks the node from syncing them. 

How I fixed it:
* Updated `AuthorizeClientAllocation` in `nomad/auth/auth.go` to take the node's `AuthenticatedIdentity`. Added a check at the top using `AuthorizeSameNode` to bypass node pool/namespace checks if the caller node matches the allocation's assigned `NodeID`.
* Updated the `Server` wrapper method in `nomad/acl.go` to match the signature.
* Passed `args.GetIdentity()` at call-sites in `nomad/alloc_endpoint.go` (inside `GetAlloc`, `GetAllocs`, and `SignIdentities`).

### Testing & Reproduction steps
Added new test cases to `TestResolveAuthorizedClientNodePoolHelpers` in `nomad/auth/auth_test.go`:
* Verified that if node pool mismatches but node ID matches, authorization passes.
* Verified that if both node pool and node ID mismatch, it fails with permission denied.

To run:
```bash
GOTOOLCHAIN=auto go test -v ./nomad/auth -run TestResolveAuthorizedClientNodePoolHelpers
```

### Links
* Fixes #28093

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality...

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations.

---

## Changes to Security Controls

**Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.**

Yes, modified `AuthorizeClientAllocation` in `nomad/auth/auth.go` to accept the caller's identity. If the caller is the same node the alloc is scheduled on, it bypasses the node pool check. This is safe since the node is already running that allocation.
