### PR TITLE
bjq: add age and size priority adjustments

### DIFF
--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -367,6 +367,37 @@ func (d *DynamicPriorityQueue) decayWorkloadUsage(ts int64, usage *UsageList) *U
 	}
 }
 
+func (d *DynamicPriorityQueue) setWorkloadPriority(w *Workload, now int64) {
+	w.priority = w.eval.Priority +
+		d.ageAdjustment(w, now) +
+		d.sizeAdjustment(w)
+}
+
+func (d *DynamicPriorityQueue) ageAdjustment(w *Workload, now int64) int {
+	if d.conf.AgeWeight == 0 {
+		return 0
+	}
+
+	create := time.Unix(0, w.eval.CreateTime)
+	elapsed := time.Unix(0, now).Sub(create)
+
+	age := float64(elapsed) / float64(d.conf.MaxAge)
+	ageClamped := min(1.0, max(0.0, age))
+
+	return int(ageClamped * float64(d.conf.AgeWeight))
+}
+
+func (d *DynamicPriorityQueue) sizeAdjustment(w *Workload) int {
+	if d.conf.SizeWeight == 0 {
+		return 0
+	}
+
+	size := w.size / float64(d.conf.MaxSize)
+	sizeClamped := min(1.0, max(0.0, size))
+
+	return int((1 - sizeClamped) * float64(d.conf.SizeWeight))
+}
+
 // waitForPlacement follows a given evalutation in the state store until it, or it's nexted/blocked evals
 // have been marked terminal, indicating the workload has been scheduled.
 //

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -80,7 +80,7 @@ type Tenant struct {
 
 type UsageList struct {
 	resources *ResourceUsage
-	start     int64
+	start     time.Time
 }
 
 type Workload struct {
@@ -153,10 +153,8 @@ func (d *DynamicPriorityQueue) runProducer(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case w := <-d.enqueueCh:
-			d.setWorkloadPriority(w, time.Now())
-
 			d.qMux.Lock()
-			d.setWorkloadPriority(w)
+			d.setWorkloadPriority(time.Now(), w)
 			heap.Push(&d.queue, w)
 			d.qMux.Unlock()
 
@@ -275,27 +273,29 @@ func (d *DynamicPriorityQueue) ensureTenant(tid TenantID) {
 // calculatePriorities iterates over all workloads in the queue and updates
 // their priorities based on tenant usage, which is decayed according to the
 // configured half-life, and usage weight.
-func (d *DynamicPriorityQueue) calculatePriorities(ts int64) {
+func (d *DynamicPriorityQueue) calculatePriorities(now time.Time) {
 	state, err := d.state.Snapshot()
 	if err != nil {
 		d.logger.Error("failed to take state snapshot", "error", err)
 		return
 	}
-func (d *DynamicPriorityQueue) calculatePriorities(now time.Time) {
 	// Decay tenant workload usages first, because a workload's
 	// priority relies on its tenant's usage.
-	d.decayUsage(ts, state)
+	d.decayUsage(now, state)
 
 	// Now that we have accurate tenant usage, calculate
 	// each workloads new priority
 	for _, workload := range d.queue {
-		d.setWorkloadPriority(workload)
+		d.setWorkloadPriority(now, workload)
 	}
 }
 
 // setWorkloadPriority calculates an individual workload's priority based on
-func (d *DynamicPriorityQueue) setWorkloadPriority(w *Workload) {
-	w.priority = w.eval.Priority + d.usageAdjustment(w)
+func (d *DynamicPriorityQueue) setWorkloadPriority(now time.Time, w *Workload) {
+	w.priority = w.eval.Priority +
+		d.usageAdjustment(w) +
+		d.ageAdjustment(now, w) +
+		d.sizeAdjustment(w)
 }
 
 // usageAdjustment calculates the adjustment to a workload's priority based on
@@ -322,7 +322,7 @@ func (d *DynamicPriorityQueue) usageAdjustment(w *Workload) int {
 // the time elapsed since (roughly) when the eval was placed, and the configured
 // half-life. If the eval no longer exists in the state store, its workload's
 // usage is removed from the calculation.
-func (d *DynamicPriorityQueue) decayUsage(ts int64, state *state.StateSnapshot) {
+func (d *DynamicPriorityQueue) decayUsage(now time.Time, state *state.StateSnapshot) {
 	totalUsage := &ResourceUsage{}
 
 	for _, tenant := range d.tenants {
@@ -334,7 +334,7 @@ func (d *DynamicPriorityQueue) decayUsage(ts int64, state *state.StateSnapshot) 
 			if err != nil || eval == nil {
 				continue
 			}
-			decayedResources := d.decayWorkloadUsage(ts, workload.requestedResources)
+			decayedResources := d.decayWorkloadUsage(now, workload.requestedResources)
 
 			tenantTotalUsage = tenantTotalUsage.Add(decayedResources.resources)
 			totalUsage = totalUsage.Add(decayedResources.resources)
@@ -349,16 +349,17 @@ func (d *DynamicPriorityQueue) decayUsage(ts int64, state *state.StateSnapshot) 
 	d.totalUsage = totalUsage
 }
 
-func decayMultiplier(ts, createdAt int64, halfLife time.Duration) float64 {
-	elapsed := time.Unix(0, ts).Sub(time.Unix(0, createdAt)).Seconds()
-	return math.Pow(0.5, elapsed/halfLife.Seconds())
+func decayMultiplier(now, createdAt time.Time, halfLife time.Duration) float64 {
+	// elapsed := time.Unix(0, ts).Sub(time.Unix(0, createdAt)).Seconds()
+	elapsed := now.Sub(createdAt)
+	return math.Pow(0.5, elapsed.Seconds()/halfLife.Seconds())
 }
 
 // decayWorkloadUsage applies decay to an individual workload's usage based on
 // the time elapsed since (roughly) when the eval was placed, and the configured
 // half-life. It returns the decayed usage, and also updates the workload usage
-func (d *DynamicPriorityQueue) decayWorkloadUsage(ts int64, usage *UsageList) *UsageList {
-	multiplier := decayMultiplier(ts, usage.start, d.conf.HalfLife)
+func (d *DynamicPriorityQueue) decayWorkloadUsage(now time.Time, usage *UsageList) *UsageList {
+	multiplier := decayMultiplier(now, usage.start, d.conf.HalfLife)
 
 	decayed := &ResourceUsage{}
 	decayed.AddCpu(usage.resources.CPU * multiplier)
@@ -366,17 +367,11 @@ func (d *DynamicPriorityQueue) decayWorkloadUsage(ts int64, usage *UsageList) *U
 
 	return &UsageList{
 		resources: decayed,
-		start:     ts,
+		start:     now,
 	}
 }
 
-func (d *DynamicPriorityQueue) setWorkloadPriority(w *Workload, now time.Time) {
-	w.priority = w.eval.Priority +
-		d.ageAdjustment(w, now) +
-		d.sizeAdjustment(w)
-}
-
-func (d *DynamicPriorityQueue) ageAdjustment(w *Workload, now time.Time) int {
+func (d *DynamicPriorityQueue) ageAdjustment(now time.Time, w *Workload) int {
 	if d.conf.AgeWeight == 0 {
 		return 0
 	}
@@ -394,7 +389,7 @@ func (d *DynamicPriorityQueue) sizeAdjustment(w *Workload) int {
 		return 0
 	}
 
-	size := w.size / float64(d.conf.MaxSize)
+	size := w.requestedResources.resources.Total() / float64(d.conf.MaxSize)
 	sizeClamped := min(1.0, max(0.0, size))
 
 	return int((1 - sizeClamped) * float64(d.conf.SizeWeight))
@@ -510,7 +505,7 @@ func (d *DynamicPriorityQueue) updateUsage(workload *Workload) {
 		}
 
 		workloadResources := workload.requestedResources
-		workloadResources.start = workload.eval.ModifyTime
+		workloadResources.start = time.Unix(0, workload.eval.ModifyTime)
 		tenant.totalUsage = tenant.totalUsage.Add(workloadResources.resources)
 		d.totalUsage = d.totalUsage.Add(workloadResources.resources)
 

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -153,8 +153,7 @@ func (d *DynamicPriorityQueue) runProducer(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case w := <-d.enqueueCh:
-			// when first enqueuing, just use the eval create time so the age is 0
-			d.setWorkloadPriority(w, time.Now().UnixNano())
+			d.setWorkloadPriority(w, time.Now())
 
 			d.qMux.Lock()
 			d.setWorkloadPriority(w)
@@ -172,7 +171,7 @@ func (d *DynamicPriorityQueue) runProducer(ctx context.Context) {
 			}
 
 			d.qMux.Lock()
-			d.calculatePriorities(time.Now().UnixNano())
+			d.calculatePriorities(time.Now())
 			heap.Init(&d.queue)
 			d.qMux.Unlock()
 		}
@@ -282,6 +281,7 @@ func (d *DynamicPriorityQueue) calculatePriorities(ts int64) {
 		d.logger.Error("failed to take state snapshot", "error", err)
 		return
 	}
+func (d *DynamicPriorityQueue) calculatePriorities(now time.Time) {
 	// Decay tenant workload usages first, because a workload's
 	// priority relies on its tenant's usage.
 	d.decayUsage(ts, state)
@@ -370,19 +370,18 @@ func (d *DynamicPriorityQueue) decayWorkloadUsage(ts int64, usage *UsageList) *U
 	}
 }
 
-func (d *DynamicPriorityQueue) setWorkloadPriority(w *Workload, now int64) {
+func (d *DynamicPriorityQueue) setWorkloadPriority(w *Workload, now time.Time) {
 	w.priority = w.eval.Priority +
 		d.ageAdjustment(w, now) +
 		d.sizeAdjustment(w)
 }
 
-func (d *DynamicPriorityQueue) ageAdjustment(w *Workload, now int64) int {
+func (d *DynamicPriorityQueue) ageAdjustment(w *Workload, now time.Time) int {
 	if d.conf.AgeWeight == 0 {
 		return 0
 	}
 
-	create := time.Unix(0, w.eval.CreateTime)
-	elapsed := time.Unix(0, now).Sub(create)
+	elapsed := now.UnixNano() - w.eval.CreateTime
 
 	age := float64(elapsed) / float64(d.conf.MaxAge)
 	ageClamped := min(1.0, max(0.0, age))

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -153,6 +153,9 @@ func (d *DynamicPriorityQueue) runProducer(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case w := <-d.enqueueCh:
+			// when first enqueuing, just use the eval create time so the age is 0
+			d.setWorkloadPriority(w, time.Now().UnixNano())
+
 			d.qMux.Lock()
 			d.setWorkloadPriority(w)
 			heap.Push(&d.queue, w)

--- a/nomad/queues/dynamic_priority_queue_test.go
+++ b/nomad/queues/dynamic_priority_queue_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/shoenig/test/wait"
 )
 
-func TestWaitForPlacement(t *testing.T) {
+func TestDynamicPriorityQueue_waitForPlacement(t *testing.T) {
 
 	t.Run("returns if eval complete", func(t *testing.T) {
 		ss := state.TestStateStore(t)
@@ -140,7 +140,7 @@ func TestWaitForPlacement(t *testing.T) {
 	})
 }
 
-func TestDecayUsage(t *testing.T) {
+func TestDynamicPriorityQueue_decayUsage(t *testing.T) {
 	t.Run("decays usage by half after half-life", func(t *testing.T) {
 		ss := state.TestStateStore(t)
 		now := time.Unix(100, 0)
@@ -163,7 +163,7 @@ func TestDecayUsage(t *testing.T) {
 					{
 						tid: TenantID("tenant"),
 						placedWorkloadById: map[string]*Workload{
-							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second).UnixNano(), resources: &ResourceUsage{
+							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second), resources: &ResourceUsage{
 								CPU:    100,
 								Memory: 20,
 							}}},
@@ -188,10 +188,10 @@ func TestDecayUsage(t *testing.T) {
 					{
 						tid: TenantID("tenant"),
 						placedWorkloadById: map[string]*Workload{
-							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second).UnixNano(), resources: &ResourceUsage{
+							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second), resources: &ResourceUsage{
 								CPU: 80,
 							}}},
-							eval2.ID: {requestedResources: &UsageList{start: now.Add(-5 * time.Second).UnixNano(), resources: &ResourceUsage{
+							eval2.ID: {requestedResources: &UsageList{start: now.Add(-5 * time.Second), resources: &ResourceUsage{
 								CPU:    100,
 								Memory: 50,
 							}}},
@@ -216,7 +216,7 @@ func TestDecayUsage(t *testing.T) {
 					{
 						tid: TenantID("tenantA"),
 						placedWorkloadById: map[string]*Workload{
-							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second).UnixNano(), resources: &ResourceUsage{
+							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second), resources: &ResourceUsage{
 								Memory: 40,
 								CPU:    100,
 							}}},
@@ -225,7 +225,7 @@ func TestDecayUsage(t *testing.T) {
 					{
 						tid: TenantID("tenantB"),
 						placedWorkloadById: map[string]*Workload{
-							eval2.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second).UnixNano(), resources: &ResourceUsage{
+							eval2.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second), resources: &ResourceUsage{
 								Memory: 80,
 								CPU:    75,
 							}}},
@@ -254,11 +254,11 @@ func TestDecayUsage(t *testing.T) {
 					{
 						tid: TenantID("tenantA"),
 						placedWorkloadById: map[string]*Workload{
-							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second).UnixNano(), resources: &ResourceUsage{
+							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second), resources: &ResourceUsage{
 								Memory: 40,
 								CPU:    100,
 							}}},
-							eval2.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second).UnixNano(), resources: &ResourceUsage{
+							eval2.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second), resources: &ResourceUsage{
 								Memory: 80,
 								CPU:    60,
 							}}},
@@ -267,11 +267,11 @@ func TestDecayUsage(t *testing.T) {
 					{
 						tid: TenantID("tenantB"),
 						placedWorkloadById: map[string]*Workload{
-							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second).UnixNano(), resources: &ResourceUsage{
+							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second), resources: &ResourceUsage{
 								Memory: 80,
 								CPU:    75,
 							}}},
-							eval2.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second).UnixNano(), resources: &ResourceUsage{
+							eval2.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second), resources: &ResourceUsage{
 								Memory: 100,
 								CPU:    50,
 							}}},
@@ -300,7 +300,7 @@ func TestDecayUsage(t *testing.T) {
 					{
 						tid: TenantID("tenant"),
 						placedWorkloadById: map[string]*Workload{
-							missingEvalID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second).UnixNano(), resources: &ResourceUsage{
+							missingEvalID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second), resources: &ResourceUsage{
 								CPU:    100,
 								Memory: 20,
 							}}},
@@ -309,7 +309,7 @@ func TestDecayUsage(t *testing.T) {
 					{
 						tid: TenantID("tenantB"),
 						placedWorkloadById: map[string]*Workload{
-							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second).UnixNano(), resources: &ResourceUsage{
+							eval1.ID: {requestedResources: &UsageList{start: now.Add(-10 * time.Second), resources: &ResourceUsage{
 								CPU:    100,
 								Memory: 20,
 							}}},
@@ -343,7 +343,7 @@ func TestDecayUsage(t *testing.T) {
 				snapshot, err := ss.Snapshot()
 				must.NoError(t, err)
 
-				queue.decayUsage(now.UnixNano(), snapshot)
+				queue.decayUsage(now, snapshot)
 
 				for _, tenant := range tc.tenants {
 					must.Eq(t, tenant.totalUsage, tc.expectedTenantUsage[tenant.tid], must.Cmp(cmpopts.EquateApprox(0, 1e-9)))
@@ -354,9 +354,9 @@ func TestDecayUsage(t *testing.T) {
 	})
 }
 
-func TestCalculatePriorities(t *testing.T) {
+func TestDynamicPriorityQueue_calculatePriorities(t *testing.T) {
 	eval1 := mock.Eval()
-	mkTenant := func(id TenantID, ts int64, cpu, memory float64) *Tenant {
+	mkTenant := func(id TenantID, ts time.Time, cpu, memory float64) *Tenant {
 		return &Tenant{
 			tid: id,
 			placedWorkloadById: map[string]*Workload{
@@ -379,51 +379,18 @@ func TestCalculatePriorities(t *testing.T) {
 		{
 			name:                         "higher usage results in lower priority",
 			conf:                         &structs.DynamicQueueConfig{HalfLife: 10 * time.Second, UsageWeight: 10},
-			lowUsageTenant:               mkTenant(TenantID("tenant-low"), time.Unix(20, 0).UnixNano(), 0, 55),
-			highUsageTenant:              mkTenant(TenantID("tenant-high"), time.Unix(20, 0).UnixNano(), 100, 50),
+			lowUsageTenant:               mkTenant(TenantID("tenant-low"), time.Unix(20, 0), 0, 55),
+			highUsageTenant:              mkTenant(TenantID("tenant-high"), time.Unix(20, 0), 100, 50),
 			expectedHigherPriorityTenant: TenantID("tenant-low"),
 			expectedTotalUsage:           &ResourceUsage{CPU: 100, Memory: 105},
 		},
 		{
 			name:                         "decays workloads before calculating priority",
 			conf:                         &structs.DynamicQueueConfig{HalfLife: 10 * time.Second, UsageWeight: 10},
-			lowUsageTenant:               mkTenant(TenantID("tenant-decayed"), time.Unix(10, 0).UnixNano(), 100, 0),
-			highUsageTenant:              mkTenant(TenantID("tenant-recent"), time.Unix(20, 0).UnixNano(), 60, 0),
+			lowUsageTenant:               mkTenant(TenantID("tenant-decayed"), time.Unix(10, 0), 100, 0),
+			highUsageTenant:              mkTenant(TenantID("tenant-recent"), time.Unix(20, 0), 60, 0),
 			expectedHigherPriorityTenant: TenantID("tenant-decayed"),
 			expectedTotalUsage:           &ResourceUsage{CPU: 110, Memory: 0},
-func TestDynamicPriorityQueue_sizeAdjustment(t *testing.T) {
-	testCases := []struct {
-		name     string
-		conf     *structs.DynamicQueueConfig
-		workload *Workload
-		exp      int
-	}{
-		{
-			name: "larger size results in 0 adjustment",
-			conf: &structs.DynamicQueueConfig{
-				SizeWeight: 10,
-				MaxSize:    1000,
-			},
-			workload: &Workload{size: 2000},
-			exp:      0,
-		},
-		{
-			name: "half size results in expected adjustment",
-			conf: &structs.DynamicQueueConfig{
-				SizeWeight: 10,
-				MaxSize:    1000,
-			},
-			workload: &Workload{size: 100},
-			exp:      9,
-		},
-		{
-			name: "negative weight results in negative adjustment",
-			conf: &structs.DynamicQueueConfig{
-				SizeWeight: -10,
-				MaxSize:    1000,
-			},
-			workload: &Workload{size: 100},
-			exp:      -9,
 		},
 	}
 
@@ -440,7 +407,7 @@ func TestDynamicPriorityQueue_sizeAdjustment(t *testing.T) {
 			queue.tenants[tc.highUsageTenant.tid] = tc.highUsageTenant
 			queue.queue = WorkloadQueue{lowUsageWorkload, highUsageWorkload}
 
-			queue.calculatePriorities(time.Unix(20, 0).UnixNano())
+			queue.calculatePriorities(time.Unix(20, 0))
 
 			switch tc.expectedHigherPriorityTenant {
 			case tc.lowUsageTenant.tid:
@@ -453,6 +420,61 @@ func TestDynamicPriorityQueue_sizeAdjustment(t *testing.T) {
 
 			must.Eq(t, queue.totalUsage, tc.expectedTotalUsage, must.Cmp(cmpopts.EquateApprox(0, 1e-9)))
 		})
+	}
+}
+
+func TestDynamicPriorityQueue_sizeAdjustment(t *testing.T) {
+	testCases := []struct {
+		name     string
+		conf     *structs.DynamicQueueConfig
+		workload *Workload
+		exp      int
+	}{
+		{
+			name: "larger size results in 0 adjustment",
+			conf: &structs.DynamicQueueConfig{
+				SizeWeight: 10,
+				MaxSize:    1000,
+			},
+			workload: &Workload{requestedResources: &UsageList{
+				resources: &ResourceUsage{
+					CPU:    500,
+					Memory: 500,
+				},
+			}},
+			exp: 0,
+		},
+		{
+			name: "smaller sized job results in expected adjustment",
+			conf: &structs.DynamicQueueConfig{
+				SizeWeight: 10,
+				MaxSize:    1000,
+			},
+			workload: &Workload{requestedResources: &UsageList{
+				resources: &ResourceUsage{
+					CPU:    50,
+					Memory: 50,
+				},
+			}},
+			exp: 9,
+		},
+		{
+			name: "negative weight results in negative adjustment",
+			conf: &structs.DynamicQueueConfig{
+				SizeWeight: -10,
+				MaxSize:    1000,
+			},
+			workload: &Workload{requestedResources: &UsageList{
+				resources: &ResourceUsage{
+					CPU:    50,
+					Memory: 50,
+				},
+			}},
+			exp: -9,
+		},
+	}
+
+	for _, tc := range testCases {
 		testQueue := &DynamicPriorityQueue{
 			conf: tc.conf,
 		}
@@ -517,6 +539,6 @@ func TestDynamicPriorityQueue_ageAdjustment(t *testing.T) {
 		testQueue := &DynamicPriorityQueue{
 			conf: tc.conf,
 		}
-		must.Eq(t, tc.exp, testQueue.ageAdjustment(tc.workload, tc.nowTime), must.Sprint(tc.name))
+		must.Eq(t, tc.exp, testQueue.ageAdjustment(tc.nowTime, tc.workload), must.Sprint(tc.name))
 	}
 }

--- a/nomad/queues/dynamic_priority_queue_test.go
+++ b/nomad/queues/dynamic_priority_queue_test.go
@@ -465,7 +465,7 @@ func TestDynamicPriorityQueue_ageAdjustment(t *testing.T) {
 		name     string
 		conf     *structs.DynamicQueueConfig
 		workload *Workload
-		nowTime  int64
+		nowTime  time.Time
 		exp      int
 	}{
 		{
@@ -476,10 +476,10 @@ func TestDynamicPriorityQueue_ageAdjustment(t *testing.T) {
 			},
 			workload: &Workload{
 				eval: &structs.Evaluation{
-					CreateTime: 0,
+					CreateTime: time.Time{}.UnixNano(),
 				},
 			},
-			nowTime: int64(0),
+			nowTime: time.Time{},
 			exp:     0,
 		},
 		{
@@ -490,24 +490,25 @@ func TestDynamicPriorityQueue_ageAdjustment(t *testing.T) {
 			},
 			workload: &Workload{
 				eval: &structs.Evaluation{
-					CreateTime: 0,
+					CreateTime: time.Time{}.UnixNano(),
 				},
 			},
-			nowTime: int64(30 * time.Second),
+			// nowTime: 30 * time.Second,
+			nowTime: time.Time{}.Add(30 * time.Second),
 			exp:     10,
 		},
 		{
-			name: "partial age results in expected adjustment",
+			name: "aging eval results in expected adjustment",
 			conf: &structs.DynamicQueueConfig{
 				AgeWeight: 10,
 				MaxAge:    time.Second * 10,
 			},
 			workload: &Workload{
 				eval: &structs.Evaluation{
-					CreateTime: 0,
+					CreateTime: time.Time{}.UnixNano(),
 				},
 			},
-			nowTime: int64(2 * time.Second),
+			nowTime: time.Time{}.Add(2 * time.Second),
 			exp:     2,
 		},
 	}

--- a/nomad/queues/dynamic_priority_queue_test.go
+++ b/nomad/queues/dynamic_priority_queue_test.go
@@ -391,6 +391,39 @@ func TestCalculatePriorities(t *testing.T) {
 			highUsageTenant:              mkTenant(TenantID("tenant-recent"), time.Unix(20, 0).UnixNano(), 60, 0),
 			expectedHigherPriorityTenant: TenantID("tenant-decayed"),
 			expectedTotalUsage:           &ResourceUsage{CPU: 110, Memory: 0},
+func TestDynamicPriorityQueue_sizeAdjustment(t *testing.T) {
+	testCases := []struct {
+		name     string
+		conf     *structs.DynamicQueueConfig
+		workload *Workload
+		exp      int
+	}{
+		{
+			name: "larger size results in 0 adjustment",
+			conf: &structs.DynamicQueueConfig{
+				SizeWeight: 10,
+				MaxSize:    1000,
+			},
+			workload: &Workload{size: 2000},
+			exp:      0,
+		},
+		{
+			name: "half size results in expected adjustment",
+			conf: &structs.DynamicQueueConfig{
+				SizeWeight: 10,
+				MaxSize:    1000,
+			},
+			workload: &Workload{size: 100},
+			exp:      9,
+		},
+		{
+			name: "negative weight results in negative adjustment",
+			conf: &structs.DynamicQueueConfig{
+				SizeWeight: -10,
+				MaxSize:    1000,
+			},
+			workload: &Workload{size: 100},
+			exp:      -9,
 		},
 	}
 
@@ -420,5 +453,69 @@ func TestCalculatePriorities(t *testing.T) {
 
 			must.Eq(t, queue.totalUsage, tc.expectedTotalUsage, must.Cmp(cmpopts.EquateApprox(0, 1e-9)))
 		})
+		testQueue := &DynamicPriorityQueue{
+			conf: tc.conf,
+		}
+		must.Eq(t, tc.exp, testQueue.sizeAdjustment(tc.workload), must.Sprint(tc.name))
+	}
+}
+
+func TestDynamicPriorityQueue_ageAdjustment(t *testing.T) {
+	testCases := []struct {
+		name     string
+		conf     *structs.DynamicQueueConfig
+		workload *Workload
+		nowTime  int64
+		exp      int
+	}{
+		{
+			name: "createTime and now equal results in 0 age adjustment",
+			conf: &structs.DynamicQueueConfig{
+				AgeWeight: 10,
+				MaxAge:    time.Second * 10,
+			},
+			workload: &Workload{
+				eval: &structs.Evaluation{
+					CreateTime: 0,
+				},
+			},
+			nowTime: int64(0),
+			exp:     0,
+		},
+		{
+			name: "greater than max age results in max adjustment",
+			conf: &structs.DynamicQueueConfig{
+				AgeWeight: 10,
+				MaxAge:    time.Second * 10,
+			},
+			workload: &Workload{
+				eval: &structs.Evaluation{
+					CreateTime: 0,
+				},
+			},
+			nowTime: int64(30 * time.Second),
+			exp:     10,
+		},
+		{
+			name: "partial age results in expected adjustment",
+			conf: &structs.DynamicQueueConfig{
+				AgeWeight: 10,
+				MaxAge:    time.Second * 10,
+			},
+			workload: &Workload{
+				eval: &structs.Evaluation{
+					CreateTime: 0,
+				},
+			},
+			nowTime: int64(2 * time.Second),
+			exp:     2,
+		},
+	}
+
+	for _, tc := range testCases {
+		testQueue := &DynamicPriorityQueue{
+			conf: tc.conf,
+		}
+		must.Eq(t, tc.exp, testQueue.ageAdjustment(tc.workload, tc.nowTime), must.Sprint(tc.name))
 	}
 }


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes introduce the size and age priority calculations to the dynamic priority queue.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
