### PR TITLE
build: Add debug make target with symbols and no optimizations.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -288,6 +288,23 @@ dev: hclfmt ## Build for the current development platform
 	@cp $(PROJECT_ROOT)/$(DEV_TARGET) $(PROJECT_ROOT)/bin/
 	@cp $(PROJECT_ROOT)/$(DEV_TARGET) $(BIN)
 
+.PHONY: dev-debug
+dev-debug: GOOS=$(shell go env GOOS)
+dev-debug: GOARCH=$(shell go env GOARCH)
+dev-debug: ## Build for the current platform with debug symbols and no optimizations
+	@echo "==> Removing old development build..."
+	@rm -f $(PROJECT_ROOT)/bin/nomad
+	@rm -f $(BIN)/nomad
+	@echo "==> Done"
+	@echo "==> Building debug binary..."
+	@go build \
+	    -gcflags "all=-N -l" \
+		-ldflags "$(GO_LDFLAGS)" \
+		-tags "$(GO_TAGS) $(NOMAD_UI_TAG)" \
+		-o $(PROJECT_ROOT)/bin/nomad
+	@cp $(PROJECT_ROOT)/bin/nomad $(BIN)
+	@echo "==> Done"
+
 .PHONY: dev-static
 dev-static:
 	@$(MAKE) CGO_ENABLED=0 dev ## Build a dev binary with no CGO


### PR DESCRIPTION
The dev target and the downstream builders are not suitable for debugging as they are optimized and do not have symblos enabled.

This change adds a "dev-debug" target that can be used to build Nomad in a way that Delve can be used fully for debugging and development.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

