### PR TITLE
bjq: Queue Status updates

### DIFF
--- a/command/job_queue_test.go
+++ b/command/job_queue_test.go
@@ -28,13 +28,16 @@ func TestJobQueue_printDynamicQueueFormatted(t *testing.T) {
 			Tenant:           "testTenant1",
 			AdjustedPriority: 10,
 			BasePriority:     10,
+			UsageAdjustment:  10,
+			AgeAdjustment:    5,
+			SizeAdjustment:   6,
 		},
 	}
 	cmd.printDynamicQueueFormatted(testResp)
 
 	expect := "Batch Queue Workloads\n" +
 		"JobID  Tenant       Adjusted Priority  Base Priority  Usage  Age  Size\n" +
-		"123    testTenant1  10                 10             0      0    0\n"
+		"123    testTenant1  10                 10             10     5    6\n"
 
 	must.Eq(t, expect, ui.OutputWriter.String())
 }
@@ -50,11 +53,14 @@ func TestJobQueue_printDynamicQueueJSON(t *testing.T) {
 			Tenant:           "testTenant1",
 			AdjustedPriority: 10,
 			BasePriority:     10,
+			UsageAdjustment:  10,
+			AgeAdjustment:    5,
+			SizeAdjustment:   6,
 		},
 	}
 	cmd.printDynamicQueueJSON(testResp)
 
-	expect := `[{"JobID":"123","Tenant":"testTenant1","AdjustedPriority":10,"BasePriority":10,"UsageAdjustment":0,"AgeAdjustment":0,"SizeAdjustment":0}]` + "\n"
+	expect := `[{"JobID":"123","Tenant":"testTenant1","AdjustedPriority":10,"BasePriority":10,"UsageAdjustment":10,"AgeAdjustment":5,"SizeAdjustment":6}]` + "\n"
 
 	must.Eq(t, expect, ui.OutputWriter.String())
 }

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -381,7 +381,8 @@ func (d *DynamicPriorityQueue) ageAdjustment(now time.Time, w *Workload) int {
 	age := float64(elapsed) / float64(d.conf.MaxAge)
 	ageClamped := min(1.0, max(0.0, age))
 
-	return int(ageClamped * float64(d.conf.AgeWeight))
+	w.ageAdjustment = int(ageClamped * float64(d.conf.AgeWeight))
+	return w.ageAdjustment
 }
 
 func (d *DynamicPriorityQueue) sizeAdjustment(w *Workload) int {
@@ -392,7 +393,8 @@ func (d *DynamicPriorityQueue) sizeAdjustment(w *Workload) int {
 	size := w.requestedResources.resources.Total() / float64(d.conf.MaxSize)
 	sizeClamped := min(1.0, max(0.0, size))
 
-	return int((1 - sizeClamped) * float64(d.conf.SizeWeight))
+	w.sizeAdjustment = int((1 - sizeClamped) * float64(d.conf.SizeWeight))
+	return w.sizeAdjustment
 }
 
 // waitForPlacement follows a given evalutation in the state store until it, or it's nexted/blocked evals
@@ -474,7 +476,7 @@ func (d *DynamicPriorityQueue) Status() structs.QueueStatusResponse {
 			Tenant:           string(w.tid),
 			AdjustedPriority: w.priority,
 			BasePriority:     w.eval.Priority,
-			UsageAjustment:   w.usageAdjustment,
+			UsageAdjustment:  w.usageAdjustment,
 			AgeAdjustment:    w.ageAdjustment,
 			SizeAdjustment:   w.sizeAdjustment,
 		})

--- a/nomad/queues/dynamic_priority_queue_test.go
+++ b/nomad/queues/dynamic_priority_queue_test.go
@@ -542,3 +542,73 @@ func TestDynamicPriorityQueue_ageAdjustment(t *testing.T) {
 		must.Eq(t, tc.exp, testQueue.ageAdjustment(tc.nowTime, tc.workload), must.Sprint(tc.name))
 	}
 }
+
+func TestDynamicPriorityQueue_Status(t *testing.T) {
+	testCases := []struct {
+		name      string
+		workloads []*Workload
+		exp       structs.QueueStatusResponse
+	}{
+		{
+			name: "status response parses workloads correctly",
+			workloads: []*Workload{
+				{
+					id:  "eval1",
+					tid: "tenantA",
+					eval: &structs.Evaluation{
+						ID:       "eval1",
+						JobID:    "job1",
+						Priority: 50,
+					},
+					priority:        59,
+					sizeAdjustment:  2,
+					ageAdjustment:   3,
+					usageAdjustment: 4,
+				},
+				{
+					id:  "eval2",
+					tid: "tenantB",
+					eval: &structs.Evaluation{
+						ID:       "eval2",
+						JobID:    "job2",
+						Priority: 50,
+					},
+					priority:        63,
+					sizeAdjustment:  7,
+					ageAdjustment:   1,
+					usageAdjustment: 5,
+				},
+			},
+			exp: structs.QueueStatusResponse{
+				Type: structs.BatchQueueTypeDynamic,
+				Workloads: []structs.DynamicPriorityWorkload{
+					{
+						JobID:            "job1",
+						Tenant:           "tenantA",
+						AdjustedPriority: 59,
+						BasePriority:     50,
+						SizeAdjustment:   2,
+						AgeAdjustment:    3,
+						UsageAdjustment:  4,
+					},
+					{
+						JobID:            "job2",
+						Tenant:           "tenantB",
+						AdjustedPriority: 63,
+						BasePriority:     50,
+						SizeAdjustment:   7,
+						AgeAdjustment:    1,
+						UsageAdjustment:  5,
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		testQueue := &DynamicPriorityQueue{
+			queue: tc.workloads,
+		}
+		must.Eq(t, tc.exp, testQueue.Status())
+	}
+
+}

--- a/nomad/structs/queue.go
+++ b/nomad/structs/queue.go
@@ -12,7 +12,7 @@ type DynamicPriorityWorkload struct {
 	Tenant           string
 	AdjustedPriority int
 	BasePriority     int
-	UsageAjustment   int
+	UsageAdjustment  int
 	AgeAdjustment    int
 	SizeAdjustment   int
 }


### PR DESCRIPTION
### Description
Adds the adjustment values to the status output


```
$ job queue status
Batch Queue Workload
JobID   Tenant  Adjusted Priority  Base Priority  Usage  Age  Size
batch2  two     64                 50             10     0    4
batch5  three   63                 50             10     0    3
batch4  one     60                 50             0      0    10
```

```
$ job queue status
Batch Queue Workloads
JobID  Tenant  Adjusted Priority  Base Priority  Usage  Age  Size
```

This work highlights that workloads currently get "lost" when they are the one waiting to be placed, because they are removed from the queue and haven't shown up in the usage calculation yet. The size value also feels ambiguous in this format. 

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
Updated the status tests, and tested manually 

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
