### PR TITLE
ui: fix error getting task logs when refreshing page

### DIFF
--- a/.changelog/28137.txt
+++ b/.changelog/28137.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: fixes an issue where streaming task logs would error
+```

--- a/ui/app/routes/allocations/allocation/task/logs.js
+++ b/ui/app/routes/allocations/allocation/task/logs.js
@@ -16,7 +16,7 @@ export default class LogsRoute extends Route {
     // An alternative option here is to use just allocation.node
     // as the computed property for logUrl()
     if (this.abilities.can('read client')) {
-      return task.get('allocation.node').then(() => task);
+      return task && task.get('allocation.node').then(() => task);
     }
     return task;
   }

--- a/ui/app/routes/allocations/allocation/task/logs.js
+++ b/ui/app/routes/allocations/allocation/task/logs.js
@@ -4,9 +4,20 @@
  */
 
 import Route from '@ember/routing/route';
+import { service } from '@ember/service';
 
 export default class LogsRoute extends Route {
+  @service abilities;
   model() {
-    return this.modelFor('allocations.allocation.task');
+    const task = this.modelFor('allocations.allocation.task')
+    // streaming logs can require the node object to be loaded
+    // in order for the logUrl() function to correctly use the
+    // allocation.node.httpAddr property.
+    // An alternative option here is to use just allocation.node
+    // as the computed property for logUrl()
+    if (this.abilities.can('read client')){
+      return task.get('allocation.node').then(() => task)
+    }
+    return task
   }
 }

--- a/ui/app/routes/allocations/allocation/task/logs.js
+++ b/ui/app/routes/allocations/allocation/task/logs.js
@@ -9,15 +9,15 @@ import { service } from '@ember/service';
 export default class LogsRoute extends Route {
   @service abilities;
   model() {
-    const task = this.modelFor('allocations.allocation.task')
+    const task = this.modelFor('allocations.allocation.task');
     // streaming logs can require the node object to be loaded
     // in order for the logUrl() function to correctly use the
     // allocation.node.httpAddr property.
     // An alternative option here is to use just allocation.node
     // as the computed property for logUrl()
-    if (this.abilities.can('read client')){
-      return task.get('allocation.node').then(() => task)
+    if (this.abilities.can('read client')) {
+      return task.get('allocation.node').then(() => task);
     }
-    return task
+    return task;
   }
 }


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
https://github.com/hashicorp/nomad/pull/24973 removed the api request for the allocation's node as it was causing permission denied errors. However, it introduced issues with the computed property of the `logUrl()` method under certain circumstances. For example, when refreshing the page, the node.httpAddr is undefined and ember component never renders correctly.

This issue is fixed by reverting this change but also adding a the same guard around the API request that is used in the `logUrl()` method.

An alternative fix for this issue is to use the `allocation.node` instead of `allocation.node.httpAddr` as the computing property of `logUrl()`.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

As far back as 1.9.6, run a job, view the task logs, then refresh the page. See that it does not load the logs.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes: https://github.com/hashicorp/nomad/issues/27821
Potentially Fixes: https://github.com/hashicorp/nomad/issues/28112

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
