### PR TITLE
CLI: convert complex var flags to var file content at submit time

### DIFF
--- a/.changelog/28138.txt
+++ b/.changelog/28138.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug where complex HCL variables passed via -var flag could not be edited in the web UI
+```

--- a/command/helpers.go
+++ b/command/helpers.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"maps"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -562,114 +561,30 @@ func (j *JobGetter) Get(jpath string) (*api.JobSubmission, *api.Job, error) {
 			return nil, nil, fmt.Errorf("Failed to parse HCL job: %w", err)
 		}
 
-		// Perform the environment listing here as it is used twice beyond this
-		// point.
-		osEnv := os.Environ()
-
-		// we are parsing HCL2, whether from a file or stdio
-		jobStruct, err = jobspec2.ParseWithConfig(&jobspec2.ParseConfig{
+		// we are parsing HCL2, whether from a file or stdio. We'll use the
+		// extended parser that includes the submission object
+		parseResult, err := jobspec2.ParseWithConfigEx(&jobspec2.ParseConfig{
 			Path:     pathName,
 			Body:     source.Bytes(),
 			ArgVars:  j.Vars,
 			AllowFS:  true,
 			VarFiles: j.VarFiles,
-			Envs:     osEnv,
+			Envs:     os.Environ(),
 			Strict:   j.Strict,
 		})
-
-		var varFileCat string
-		var readVarFileErr error
-		if err == nil {
-			// combine any -var-file data into one big blob
-			varFileCat, readVarFileErr = extractVarFiles(j.VarFiles)
-			if readVarFileErr != nil {
-				return nil, nil, fmt.Errorf("Failed to read var file(s): %w", readVarFileErr)
-			}
+		if err != nil {
+			return nil, nil, fmt.Errorf("Error parsing job file from %s:\n%w", jpath, err)
 		}
 
-		// Extract variables declared by the -var flag and as environment
-		// variables.
-		extractedVarFlags := extractVarFlags(j.Vars)
-		extractedEnvVars := extractJobSpecEnvVars(osEnv)
-
-		// Merge the two maps ensuring that variables defined by -var flags
-		// take precedence.
-		maps.Copy(extractedEnvVars, extractedVarFlags)
-
-		// submit the job with the submission with content from -var flags
-		jobSubmission = &api.JobSubmission{
-			VariableFlags: extractedEnvVars,
-			Variables:     varFileCat,
-			Source:        source.String(),
-			Format:        formatHCL2,
-		}
+		jobStruct = parseResult.Job
+		jobSubmission = parseResult.Submission
 	}
 
 	if err != nil {
-		return nil, nil, fmt.Errorf("Error parsing job file from %s:\n%v", jpath, err)
+		return nil, nil, fmt.Errorf("Error parsing job file from %s:\n%w", jpath, err)
 	}
 
 	return jobSubmission, jobStruct, nil
-}
-
-// extractVarFiles concatenates the content of each file in filenames and
-// returns it all as one big content blob
-func extractVarFiles(filenames []string) (string, error) {
-	var sb strings.Builder
-	for _, filename := range filenames {
-		b, err := os.ReadFile(filename)
-		if err != nil {
-			return "", err
-		}
-		sb.WriteString(string(b))
-		sb.WriteString("\n")
-	}
-	return sb.String(), nil
-}
-
-// extractVarFlags is used to parse the values of -var command line arguments
-// and turn them into a map to be used for submission. The result is never
-// nil for convenience.
-func extractVarFlags(slice []string) map[string]string {
-	m := make(map[string]string, len(slice))
-	for _, s := range slice {
-		if tokens := strings.SplitN(s, "=", 2); len(tokens) == 1 {
-			m[tokens[0]] = ""
-		} else {
-			m[tokens[0]] = tokens[1]
-		}
-	}
-	return m
-}
-
-// extractJobSpecEnvVars is used to extract Nomad specific HCL variables from
-// the OS environment. The input envVars parameter is expected to be generated
-// from the os.Environment function call. The result is never nil for
-// convenience.
-func extractJobSpecEnvVars(envVars []string) map[string]string {
-
-	m := make(map[string]string)
-
-	for _, raw := range envVars {
-		if !strings.HasPrefix(raw, jobspec2.VarEnvPrefix) {
-			continue
-		}
-
-		// Trim the prefix, so we just have the raw key=value variable
-		// remaining.
-		raw = raw[len(jobspec2.VarEnvPrefix):]
-
-		// Identify the index of the equals sign which is where we split the
-		// variable k/v pair. -1 indicates the equals sign is not found and
-		// therefore the var is not valid.
-		if eq := strings.Index(raw, "="); eq == -1 {
-			continue
-		} else if raw[:eq] != "" {
-			m[raw[:eq]] = raw[eq+1:]
-		}
-	}
-
-	return m
 }
 
 // mergeAutocompleteFlags is used to join multiple flag completion sets.

--- a/command/helpers_test.go
+++ b/command/helpers_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/cli"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/ci"
-	"github.com/hashicorp/nomad/client/testutil"
 	"github.com/hashicorp/nomad/helper/flatmap"
 	"github.com/kr/pretty"
 	"github.com/shoenig/test/must"
@@ -392,6 +391,215 @@ unsedVar2 = "from-varfile"
 	must.Eq(t, expected, j.Datacenters)
 }
 
+func TestJobGetter_HCL2_Variables_ListsAndObjects(t *testing.T) {
+
+	jobspec := `
+variable "datacenters" {
+  type = list(string)
+}
+
+variable "env" {
+  type = object({
+    foo = string
+    bar = string
+  })
+}
+
+variable "count" {
+  type = number
+}
+
+variable "user" {
+  type = string
+}
+
+job "example" {
+  datacenters = var.datacenters
+
+  group "g" {
+    count = var.count
+    task "t" {
+      user = var.user
+      env = var.env
+    }
+  }
+}
+`
+
+	testCases := []struct {
+		name        string
+		fileVars    string
+		cliVarFlags []string
+
+		expectErrMsgs     []string
+		expectVariables   string
+		expectVarFlags    map[string]string
+		expectCount       int
+		expectDatacenters []string
+		expectUser        string
+		expectEnv         map[string]string
+	}{
+		{
+			name: "file only unescaped",
+			fileVars: `
+datacenters = ["dc1", "dc2"]
+count = 2
+user = "www-data"
+env = {
+  foo = "foo1"
+  bar = "bar1"
+}
+`,
+			cliVarFlags:    nil,
+			expectVarFlags: map[string]string{},
+			expectVariables: `
+datacenters = ["dc1", "dc2"]
+count = 2
+user = "www-data"
+env = {
+  foo = "foo1"
+  bar = "bar1"
+}
+
+`,
+			expectCount:       2,
+			expectDatacenters: []string{"dc1", "dc2"},
+			expectUser:        "www-data",
+			expectEnv:         map[string]string{"foo": "foo1", "bar": "bar1"},
+		},
+		{
+			name: "collections in file with primitive flags",
+			fileVars: `
+datacenters = ["dc1", "dc2"]
+env = {
+  foo = "foo1"
+  bar = "bar1"
+}
+`,
+			cliVarFlags:    []string{`count=2`, `user=www-data`},
+			expectVarFlags: map[string]string{"count": "2", "user": "www-data"},
+			expectVariables: `
+datacenters = ["dc1", "dc2"]
+env = {
+  foo = "foo1"
+  bar = "bar1"
+}
+
+`,
+			// simple types (count, user) go to VariableFlags, while complex
+			// types (datacenters, env) stay in Variables
+			expectCount:       2,
+			expectDatacenters: []string{"dc1", "dc2"},
+			expectUser:        "www-data",
+			expectEnv:         map[string]string{"foo": "foo1", "bar": "bar1"},
+		},
+		{
+			name: "incorrectly escaped collection for flags",
+			// this is the equivalent of:
+			// -var 'datacenters="[\"dc1\", \"dc2\"]"'
+			cliVarFlags: []string{
+				`count=2`,
+				`user=www-data`,
+				`datacenters="[\"dc1\", \"dc2\"]"`,
+				`env="{foo=\"foo1\", bar=\"bar1\"}"`,
+			},
+			expectErrMsgs: []string{
+				"list of string required, but have string",
+				"object required, but have string",
+			},
+		},
+		{
+			name: "collections for unescaped flags from shell",
+			fileVars: `
+env = {
+  foo = "foo1"
+  bar = "bar1"
+}
+`,
+			// this is the equivalent of:
+			// -var datacenters="$(printf "[\"dc1\", \"dc2\"]")"
+			cliVarFlags: []string{
+				`count=2`,
+				`user=www-data`,
+				`datacenters=["dc1", "dc2"]`,
+			},
+			// complex types (datacenters) are moved to Variables in HCL format,
+			// while simple types stay in VariableFlags
+			expectVarFlags: map[string]string{"count": "2", "user": "www-data"},
+			expectVariables: `
+env = {
+  foo = "foo1"
+  bar = "bar1"
+}
+
+datacenters = ["dc1", "dc2"]`,
+			expectCount:       2,
+			expectDatacenters: []string{"dc1", "dc2"},
+			expectUser:        "www-data",
+			expectEnv:         map[string]string{"foo": "foo1", "bar": "bar1"},
+		},
+		{
+			name: "collections in file with json-escaped primitives",
+			fileVars: `
+datacenters = ["dc1", "dc2"]
+count = 2
+user = "{\"name\": \"www-data\"}"
+env = {
+  foo = "foo1"
+  bar = "bar1"
+}
+`,
+			expectVarFlags: map[string]string{},
+			expectVariables: `
+datacenters = ["dc1", "dc2"]
+count = 2
+user = "{\"name\": \"www-data\"}"
+env = {
+  foo = "foo1"
+  bar = "bar1"
+}
+
+`,
+			expectCount:       2,
+			expectDatacenters: []string{"dc1", "dc2"},
+			expectUser:        `{"name": "www-data"}`,
+			expectEnv:         map[string]string{"foo": "foo1", "bar": "bar1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpdir := t.TempDir()
+			varFileName := filepath.Join(tmpdir, "vars.hcl")
+			specFileName := filepath.Join(tmpdir, "example.nomad.hcl")
+
+			must.NoError(t, os.WriteFile(varFileName, []byte(tc.fileVars), 0700))
+			must.NoError(t, os.WriteFile(specFileName, []byte(jobspec), 0700))
+
+			jg := &JobGetter{
+				Vars:     tc.cliVarFlags,
+				VarFiles: []string{varFileName},
+				Strict:   false,
+			}
+
+			sub, j, err := jg.Get(specFileName)
+			if len(tc.expectErrMsgs) > 0 {
+				for _, errMsg := range tc.expectErrMsgs {
+					must.ErrorContains(t, err, errMsg)
+				}
+				return
+			}
+
+			must.NoError(t, err)
+			must.NotNil(t, j)
+			must.Eq(t, tc.expectDatacenters, j.Datacenters)
+
+			must.Eq(t, tc.expectVariables, sub.Variables)
+			must.MapEq(t, tc.expectVarFlags, sub.VariableFlags)
+		})
+	}
+}
+
 // Test StructJob with jobfile from HTTP Server
 func TestJobGetter_HTTPServer(t *testing.T) {
 	ci.Parallel(t)
@@ -588,107 +796,6 @@ func TestUiErrorWriter(t *testing.T) {
 
 	expectedErr += "and thensome more\n"
 	must.Eq(t, expectedErr, errBuf.String())
-}
-
-func Test_extractVarFiles(t *testing.T) {
-	ci.Parallel(t)
-
-	t.Run("none", func(t *testing.T) {
-		result, err := extractVarFiles(nil)
-		must.NoError(t, err)
-		must.Eq(t, "", result)
-	})
-
-	t.Run("files", func(t *testing.T) {
-		d := t.TempDir()
-		fileOne := filepath.Join(d, "one.hcl")
-		fileTwo := filepath.Join(d, "two.hcl")
-
-		must.NoError(t, os.WriteFile(fileOne, []byte(`foo = "bar"`), 0o644))
-		must.NoError(t, os.WriteFile(fileTwo, []byte(`baz = 42`), 0o644))
-
-		result, err := extractVarFiles([]string{fileOne, fileTwo})
-		must.NoError(t, err)
-		must.Eq(t, "foo = \"bar\"\nbaz = 42\n", result)
-	})
-
-	t.Run("unreadble", func(t *testing.T) {
-		testutil.RequireNonRoot(t)
-
-		d := t.TempDir()
-		fileOne := filepath.Join(d, "one.hcl")
-
-		must.NoError(t, os.WriteFile(fileOne, []byte(`foo = "bar"`), 0o200))
-
-		_, err := extractVarFiles([]string{fileOne})
-		must.ErrorContains(t, err, "permission denied")
-	})
-}
-
-func Test_extractVarFlags(t *testing.T) {
-	ci.Parallel(t)
-
-	t.Run("nil", func(t *testing.T) {
-		result := extractVarFlags(nil)
-		must.MapEmpty(t, result)
-	})
-
-	t.Run("complete", func(t *testing.T) {
-		result := extractVarFlags([]string{"one=1", "two=2", "three"})
-		must.Eq(t, map[string]string{
-			"one":   "1",
-			"two":   "2",
-			"three": "",
-		}, result)
-	})
-}
-
-func Test_extractJobSpecEnvVars(t *testing.T) {
-	ci.Parallel(t)
-
-	t.Run("nil", func(t *testing.T) {
-		must.MapEmpty(t, extractJobSpecEnvVars(nil))
-	})
-
-	t.Run("complete", func(t *testing.T) {
-		result := extractJobSpecEnvVars([]string{
-			"NOMAD_VAR_count=13",
-			"GOPATH=/Users/jrasell/go",
-			"NOMAD_VAR_image=redis:7",
-		})
-		must.Eq(t, map[string]string{
-			"count": "13",
-			"image": "redis:7",
-		}, result)
-	})
-
-	t.Run("whitespace", func(t *testing.T) {
-		result := extractJobSpecEnvVars([]string{
-			"NOMAD_VAR_count = 13",
-			"GOPATH = /Users/jrasell/go",
-		})
-		must.Eq(t, map[string]string{
-			"count ": " 13",
-		}, result)
-	})
-
-	t.Run("empty key", func(t *testing.T) {
-		result := extractJobSpecEnvVars([]string{
-			"NOMAD_VAR_=13",
-			"=/Users/jrasell/go",
-		})
-		must.Eq(t, map[string]string{}, result)
-	})
-
-	t.Run("empty value", func(t *testing.T) {
-		result := extractJobSpecEnvVars([]string{
-			"NOMAD_VAR_count=",
-			"GOPATH=",
-		})
-		must.Eq(t, map[string]string{
-			"count": "",
-		}, result)
-	})
 }
 
 // TestHelperGetByPrefix exercises the generic getByPrefix function used by

--- a/jobspec2/parse.go
+++ b/jobspec2/parse.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	hcljson "github.com/hashicorp/hcl/v2/json"
 	"github.com/hashicorp/nomad/api"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func Parse(path string, r io.Reader) (*api.Job, error) {
@@ -39,7 +41,46 @@ func Parse(path string, r io.Reader) (*api.Job, error) {
 	})
 }
 
+// ParseResult contains the result of parsing a job specification,
+// including the job itself and metadata about declared variables.
+type ParseResult struct {
+	Job        *api.Job
+	Submission *api.JobSubmission
+	Variables  Variables
+}
+
+// ParseWithConfig returns the parsed job and any diagnostic errors. This will
+// get used for the Job Parse API or similar consumers.
 func ParseWithConfig(args *ParseConfig) (*api.Job, error) {
+	c, err := parseWithConfigImpl(args)
+	if err != nil {
+		return nil, err
+	}
+	return c.Job, nil
+}
+
+// ParseWithConfigEx is an extended version of ParseWithConfig that returns
+// additional HCL variable type information. This allows callers like the `job
+// run` CLI or the Terraform provider to distinguish between simple and complex
+// variable types when constructing JobSubmission objects.
+func ParseWithConfigEx(args *ParseConfig) (*ParseResult, error) {
+	c, err := parseWithConfigImpl(args)
+	if err != nil {
+		return nil, err
+	}
+	sub, err := submissionFromJob(args, c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ParseResult{
+		Job:        c.Job,
+		Variables:  c.InputVariables,
+		Submission: sub,
+	}, nil
+}
+
+func parseWithConfigImpl(args *ParseConfig) (*jobConfig, error) {
 	args.normalize()
 
 	c := newJobConfig(args)
@@ -49,7 +90,7 @@ func ParseWithConfig(args *ParseConfig) (*api.Job, error) {
 	}
 
 	normalizeJob(c)
-	return c.Job, nil
+	return c, nil
 }
 
 type ParseConfig struct {
@@ -174,4 +215,149 @@ func isJSON(src []byte) bool {
 		return c == '{'
 	}
 	return false
+}
+
+const (
+	formatJSON = "json"
+	formatHCL2 = "hcl2"
+)
+
+func submissionFromJob(args *ParseConfig, j *jobConfig) (*api.JobSubmission, error) {
+	format := formatHCL2
+	if isJSON(args.Body) {
+		format = formatJSON
+	}
+
+	// combine any -var-file data into one big blob
+	varFileCat, readVarFileErr := extractVarFiles(args.VarFiles)
+	if readVarFileErr != nil {
+		return nil, fmt.Errorf("Failed to read var file(s): %w", readVarFileErr)
+	}
+
+	if varFileCat != "" && args.VarContent != "" {
+		varFileCat = strings.TrimRight(varFileCat, "\n") + "\n\n" + args.VarContent
+	} else if varFileCat == "" {
+		varFileCat = args.VarContent
+	}
+
+	// Extract variables declared by the -var flag and as environment
+	// variables. Merge the two maps ensuring that variables defined by -var
+	// flags take precedence over the environment
+	extractedVarFlags := extractVarFlags(args.ArgVars)
+	extractedEnvVars := extractJobSpecEnvVars(args.Envs)
+	maps.Copy(extractedEnvVars, extractedVarFlags)
+
+	// Separate simple and complex variables from -var based on types from
+	// schema. Simple types (string, number, bool) go to VariableFlags as
+	// strings. Complex types (lists, maps, objects) go to Variables in HCL
+	// format.
+	simpleVars, complexVarsHCL := separateVariables(extractedEnvVars, j.InputVariables)
+
+	// Combine var-file with complex variables from flags
+
+	if varFileCat != "" && complexVarsHCL != "" {
+		varFileCat = strings.TrimRight(varFileCat, "\n") + "\n\n" + complexVarsHCL
+	} else if varFileCat == "" {
+		varFileCat = complexVarsHCL
+	}
+
+	sub := &api.JobSubmission{
+		Source:        string(args.Body),
+		Format:        format,
+		VariableFlags: simpleVars,
+		Variables:     varFileCat,
+	}
+	return sub, nil
+}
+
+// extractVarFlags is used to parse the values of -var command line arguments
+// and turn them into a map to be used for submission. The result is never
+// nil for convenience.
+func extractVarFlags(slice []string) map[string]string {
+	m := make(map[string]string, len(slice))
+	for _, s := range slice {
+		if tokens := strings.SplitN(s, "=", 2); len(tokens) == 1 {
+			m[tokens[0]] = ""
+		} else {
+			m[tokens[0]] = tokens[1]
+		}
+	}
+	return m
+}
+
+// extractJobSpecEnvVars is used to extract Nomad specific HCL variables from
+// the OS environment. The input envVars parameter is expected to be generated
+// from the os.Environment function call. The result is never nil for
+// convenience.
+func extractJobSpecEnvVars(envVars []string) map[string]string {
+
+	m := make(map[string]string)
+
+	for _, raw := range envVars {
+		if !strings.HasPrefix(raw, VarEnvPrefix) {
+			continue
+		}
+
+		// Trim the prefix, so we just have the raw key=value variable
+		// remaining.
+		raw = raw[len(VarEnvPrefix):]
+
+		// Identify the index of the equals sign which is where we split the
+		// variable k/v pair. -1 indicates the equals sign is not found and
+		// therefore the var is not valid.
+		if eq := strings.Index(raw, "="); eq == -1 {
+			continue
+		} else if raw[:eq] != "" {
+			m[raw[:eq]] = raw[eq+1:]
+		}
+	}
+
+	return m
+}
+
+// extractVarFiles concatenates the content of each file in filenames and
+// returns it all as one big content blob
+func extractVarFiles(filenames []string) (string, error) {
+	var sb strings.Builder
+	for _, filename := range filenames {
+		b, err := os.ReadFile(filename)
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(string(b))
+		sb.WriteString("\n")
+	}
+	return sb.String(), nil
+}
+
+// separateVariables splits variables into simple (string-safe) and complex
+// (HCL-required) based on their schema.
+func separateVariables(varFlags map[string]string, declaredVars Variables) (simple map[string]string, complex string) {
+	simple = make(map[string]string)
+	var complexVars []string
+
+	for name, value := range varFlags {
+		variable, declared := declaredVars[name]
+		if !declared {
+			simple[name] = value
+			continue
+		}
+		// Simple types can be safely represented as strings in
+		// VariableFlags. Complex types (lists, maps, objects) require HCL
+		// format in the Variables field to preserve their structure and type
+		// information.
+		switch variable.Type {
+		case cty.NilType, cty.String, cty.Number, cty.Bool:
+			simple[name] = value
+		default:
+			// unquoted HCL format for appending to Variables field
+			complexVars = append(complexVars, fmt.Sprintf("%s = %s", name, value))
+		}
+	}
+
+	if len(complexVars) > 0 {
+		complex = strings.Join(complexVars, "\n")
+	}
+
+	return simple, complex
 }

--- a/jobspec2/parse_test.go
+++ b/jobspec2/parse_test.go
@@ -5,7 +5,9 @@ package jobspec2
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -1179,4 +1181,171 @@ func TestIdentity(t *testing.T) {
 	must.Eq(t, "signal", altID.ChangeMode)
 	must.Eq(t, "sighup", altID.ChangeSignal)
 	must.Eq(t, 2*time.Hour, altID.TTL)
+}
+
+func TestParse_VariablesSubmission(t *testing.T) {
+	t.Parallel()
+
+	hcl := `
+# will come from -var args, overriding env
+variable "region" {
+  type = string
+}
+
+# will come from env
+variable "pool" {
+  type = string
+}
+
+# will come from var content
+variable "datacenters" {
+  type = list(string)
+}
+
+# will come from var file
+variable "ns" {
+  type = string
+}
+
+job "example" {
+  datacenters = var.datacenters
+  region      = var.region
+  node_pool   = var.pool
+  namespace   = var.ns
+}
+`
+
+	tmpDir := t.TempDir()
+	varFile := filepath.Join(tmpDir, "vars.hcl")
+	must.NoError(t, os.WriteFile(varFile, []byte(`ns = "infra"`), 0666))
+
+	out, err := ParseWithConfigEx(&ParseConfig{
+		Path:       "input.hcl",
+		Body:       []byte(hcl),
+		ArgVars:    []string{"region=philly", "pool=prod"}, // overrides env
+		VarContent: `datacenters = ["dc1", "dc2"]`,
+		VarFiles:   []string{varFile},
+		Envs:       []string{"NOMAD_VAR_region=seattle"},
+		Strict:     false,
+	})
+	must.NoError(t, err)
+
+	must.NotNil(t, out.Job.Namespace)
+	must.Eq(t, "infra", *out.Job.Namespace)
+
+	must.NotNil(t, out.Job.NodePool)
+	must.Eq(t, "prod", *out.Job.NodePool)
+
+	must.Eq(t, []string{"dc1", "dc2"}, out.Job.Datacenters)
+
+	must.NotNil(t, out.Job.Region)
+	must.Eq(t, "philly", *out.Job.Region)
+
+	must.Eq(t, `ns = "infra"
+
+datacenters = ["dc1", "dc2"]`, out.Submission.Variables)
+
+	must.MapEq(t, map[string]string{"region": "philly", "pool": "prod"}, out.Submission.VariableFlags)
+}
+
+func Test_extractVarFiles(t *testing.T) {
+	t.Parallel()
+
+	t.Run("none", func(t *testing.T) {
+		result, err := extractVarFiles(nil)
+		must.NoError(t, err)
+		must.Eq(t, "", result)
+	})
+
+	t.Run("files", func(t *testing.T) {
+		d := t.TempDir()
+		fileOne := filepath.Join(d, "one.hcl")
+		fileTwo := filepath.Join(d, "two.hcl")
+
+		must.NoError(t, os.WriteFile(fileOne, []byte(`foo = "bar"`), 0o644))
+		must.NoError(t, os.WriteFile(fileTwo, []byte(`baz = 42`), 0o644))
+
+		result, err := extractVarFiles([]string{fileOne, fileTwo})
+		must.NoError(t, err)
+		must.Eq(t, "foo = \"bar\"\nbaz = 42\n", result)
+	})
+
+	t.Run("unreadable", func(t *testing.T) {
+		if syscall.Geteuid() == 0 {
+			t.Skip("Test requires non-root")
+		}
+		d := t.TempDir()
+		fileOne := filepath.Join(d, "one.hcl")
+
+		must.NoError(t, os.WriteFile(fileOne, []byte(`foo = "bar"`), 0o200))
+
+		_, err := extractVarFiles([]string{fileOne})
+		must.ErrorContains(t, err, "permission denied")
+	})
+}
+
+func Test_extractVarFlags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		result := extractVarFlags(nil)
+		must.MapEmpty(t, result)
+	})
+
+	t.Run("complete", func(t *testing.T) {
+		result := extractVarFlags([]string{"one=1", "two=2", "three"})
+		must.Eq(t, map[string]string{
+			"one":   "1",
+			"two":   "2",
+			"three": "",
+		}, result)
+	})
+}
+
+func Test_extractJobSpecEnvVars(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		must.MapEmpty(t, extractJobSpecEnvVars(nil))
+	})
+
+	t.Run("complete", func(t *testing.T) {
+		result := extractJobSpecEnvVars([]string{
+			"NOMAD_VAR_count=13",
+			"GOPATH=/Users/jrasell/go",
+			"NOMAD_VAR_image=redis:7",
+		})
+		must.Eq(t, map[string]string{
+			"count": "13",
+			"image": "redis:7",
+		}, result)
+	})
+
+	t.Run("whitespace", func(t *testing.T) {
+		result := extractJobSpecEnvVars([]string{
+			"NOMAD_VAR_count = 13",
+			"GOPATH = /Users/jrasell/go",
+		})
+		must.Eq(t, map[string]string{
+			"count ": " 13",
+		}, result)
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		result := extractJobSpecEnvVars([]string{
+			"NOMAD_VAR_=13",
+			"=/Users/jrasell/go",
+		})
+		must.Eq(t, map[string]string{}, result)
+	})
+
+	t.Run("empty value", func(t *testing.T) {
+		result := extractJobSpecEnvVars([]string{
+			"NOMAD_VAR_count=",
+			"GOPATH=",
+		})
+		must.Eq(t, map[string]string{
+			"count": "",
+		}, result)
+	})
 }


### PR DESCRIPTION
When a job is submitted, the command line or API consumer can include the original HCL and any HCL variable values in the `Submission` field. The `Variables` parameter of the submission object accepts a string blob of variable values in HCL format. Whereas the `VariableFlags` parameters only accepts a map of string values.

The CLI does all the job parsing locally, including interpolating of all the variables It then creates an `api.JobSubmission` object to which it attaches the jobspec, concatenates all the `-var-file` contents into the `Variables` parameter, and adds the `-var` flags to the `VariableFlags` parameter.

But because the `-var` flags are recorded as a map of strings, they're necessarily converted to strings even if the HCL parser has just treated them as complex values (lists, object, etc.) on the basis of the HCL schema. This results in ambiguous behavior when trying to recreate the submission via the web UI's editor. The The web UI cannot parse the jobspec locally (there's no HCL2 parser for Javascript), so it calls the Job Parse API, which only has a `Variables` parameter. To do so, it has to take any `VariableFlags` from the original submission and add them to the `Variables`. So the escaped string that represents a list or object just fine in the CLI gets rejected with a type error.

We attempted to fix this in the UI in #27705 by treating the strings as potentially JSON-encoded values, but this breaks any use of the Terraform provider with list/objects, because the Terraform provider only supports the equivalent of `VariableFlags` and requires that you `jsonencode` your variables.

Rather than attempt to patch this up in the UI after the fact, we'll provide a new `ParseConfigEx` method in the `jobspec2` package. This will use the type information the HCL parser already has to return the `api.JobSubmission` directly. The submission will have the non-primitive objects as unescaped fields of the blob we send in `Variables`.

By moving this logic into the `jobspec2` package, we can also support this behavior in the Terraform provider or other downstream consumers. I'll implement that in the Terraform repository. (ref https://github.com/hashicorp/terraform-provider-nomad/pull/631)

Ref: https://hashicorp.atlassian.net/browse/NMD-531
Ref: https://github.com/hashicorp/nomad/pull/27705
Fixes: https://github.com/hashicorp/nomad/issues/23462
Fixes: https://github.com/hashicorp/nomad/issues/28082

### Testing & Reproduction steps

See below: https://github.com/hashicorp/nomad/pull/28138#issuecomment-4732193489

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** see below: https://github.com/hashicorp/nomad/pull/28138#issuecomment-4732193489
- [x] **Documentation** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
