### PR TITLE
Fix nomad plan using workload identity

### DIFF
--- a/.changelog/28139.txt
+++ b/.changelog/28139.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: allow using WI tokens on plan endpoint
+```

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -1811,11 +1811,6 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 		return err
 	}
 
-	// Enforce Sentinel policies
-	nomadACLToken, err := snap.ACLTokenBySecretID(nil, args.AuthToken)
-	if err != nil && !strings.Contains(err.Error(), "missing secret id") {
-		return err
-	}
 	ns, err := snap.NamespaceByName(nil, args.RequestNamespace())
 	if err != nil {
 		return err
@@ -1828,7 +1823,8 @@ func (j *Job) Plan(args *structs.JobPlanRequest, reply *structs.JobPlanResponse)
 		return err
 	}
 
-	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job, existingJob, nomadACLToken, ns)
+	policyWarnings, err := j.enforceSubmitJob(args.PolicyOverride, args.Job.Copy(),
+		existingJob, args.GetIdentity().GetACLToken(), ns)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

Currently, when doing `nomad plan` with a workload identity token, nomad fails with: `Error during plan: Unexpected response code: 500 (rpc error: acl token lookup failed: index error: UUID must be 36 characters)`

This PR fixes this. I mostly copied the same call to `.enforceSubmitJob` that is made on the register endpoint.