### PR TITLE
CI: update BPA to v0.6.1

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-22.04
-    container: hashicorpdev/backport-assistant:v0.5.7
+    container: hashicorpdev/backport-assistant:v0.6.1
     steps:
       - name: Backport changes to stable-website
         run: |


### PR DESCRIPTION
Our version of backport assistant is on an older Alpine Linux which doesn't seem to be compatible with the version of Node that we need to be running for Actions now.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
