### PR TITLE
state: make jobs modify_index index non-unique

### DIFF
--- a/.changelog/28132.txt
+++ b/.changelog/28132.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed a bug where jobs that share a ModifyIndex (for example, several jobs rescheduled in a single Raft transaction after a node failure) were omitted from the jobs page and the `/v1/jobs/statuses` endpoint
+```

--- a/nomad/state/schema.go
+++ b/nomad/state/schema.go
@@ -269,11 +269,16 @@ func jobTableSchema() *memdb.TableSchema {
 					Field: "NodePool",
 				},
 			},
-			// ModifyIndex allows sorting by last-changed
+			// ModifyIndex allows sorting by last-changed. This index is NOT
+			// unique: when a single Raft transaction writes multiple jobs (e.g.
+			// rescheduling several allocations after a node goes down), those
+			// jobs share a ModifyIndex. Marking it Unique would collapse them
+			// into a single index entry and drop the rest from any query that
+			// iterates this index (e.g. Job.Statuses, backing the UI jobs page).
 			"modify_index": {
 				Name:         "modify_index",
 				AllowMissing: false,
-				Unique:       true,
+				Unique:       false,
 				Indexer: &memdb.UintFieldIndex{
 					Field: "ModifyIndex",
 				},

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -3440,6 +3440,58 @@ func TestStateStore_JobsByGC(t *testing.T) {
 	must.False(t, watchFired(ws), must.Sprint("watch should not have fired"))
 }
 
+// TestStateStore_JobsByModifyIndex_SharedModifyIndex is a regression test for
+// jobs sharing a ModifyIndex being dropped from JobsByModifyIndex, which backs
+// the Job.Statuses RPC and the UI jobs page.
+//
+// Several jobs can share a ModifyIndex when a single Raft transaction writes
+// them together (for example, rescheduling allocations after a node goes down).
+// The jobs-table "modify_index" index must therefore be non-unique; if it is
+// marked Unique, colliding jobs collapse into a single index entry and the rest
+// silently disappear from any query that iterates this index, while remaining
+// visible via the unique "id" index (used by /v1/jobs and the CLI).
+func TestStateStore_JobsByModifyIndex_SharedModifyIndex(t *testing.T) {
+	ci.Parallel(t)
+
+	for _, n := range []int{2, 3, 7} {
+		t.Run(fmt.Sprintf("cluster_of_%d", n), func(t *testing.T) {
+			state := testStateStore(t)
+
+			// n jobs written at the same index => identical ModifyIndex.
+			const sharedIndex = 1000
+			want := make([]string, 0, n+2)
+			for i := range n {
+				job := mock.Job()
+				job.ID = fmt.Sprintf("shared-%d", i)
+				want = append(want, job.ID)
+				must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, sharedIndex, nil, job))
+			}
+			// a couple of control jobs with their own unique indexes.
+			for i, idx := range []uint64{1001, 1002} {
+				job := mock.Job()
+				job.ID = fmt.Sprintf("unique-%d", i)
+				want = append(want, job.ID)
+				must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, idx, nil, job))
+			}
+
+			ws := memdb.NewWatchSet()
+			iter, err := state.JobsByModifyIndex(ws, SortDefault)
+			must.NoError(t, err)
+
+			got := make([]string, 0, len(want))
+			for raw := iter.Next(); raw != nil; raw = iter.Next() {
+				got = append(got, raw.(*structs.Job).ID)
+			}
+
+			// every job must be returned; none dropped due to a shared index.
+			must.SliceContainsAll(t, want, got,
+				must.Sprintf("JobsByModifyIndex dropped jobs sharing a ModifyIndex: want %v, got %v", want, got))
+			must.Len(t, len(want), got,
+				must.Sprintf("expected %d jobs, got %d: %v", len(want), len(got), got))
+		})
+	}
+}
+
 func TestStateStore_UpsertPeriodicLaunch(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
## What

The jobs-table `modify_index` memdb index was declared `Unique: true`, but `ModifyIndex` is **not** unique across jobs. When a single Raft transaction writes several jobs at once (e.g. rescheduling allocations after a node goes down), those jobs share a `ModifyIndex`. A unique memdb index can only hold one object per key, so colliding jobs were silently dropped from any query that iterates this index — notably `Job.Statuses`, which backs the `/v1/jobs/statuses` endpoint and the **UI jobs page** — while remaining visible via the unique `id` index used by `/v1/jobs` and the CLI.

This change marks the index non-unique and adds a regression test.

Fixes #28132.

## Reproduction (on a live cluster)

Jobs sharing a `ModifyIndex` (one Raft txn) vanish from `statuses` but not `/v1/jobs`, even on a single unpaginated page:

```
$ curl -s "$NOMAD_ADDR/v1/jobs?namespace=*" | jq -r '.[].ModifyIndex' | sort | uniq -d
2019281
2020598

$ curl -s "$NOMAD_ADDR/v1/jobs/statuses?namespace=*&per_page=200" | jq length
52
$ curl -s "$NOMAD_ADDR/v1/jobs?namespace=*&per_page=200" | jq length
60
```

The 8 missing jobs are exactly the ones sharing `ModifyIndex` 2020598 (7 jobs) and 2019281 (1 of the pair).

A self-contained Docker A/B harness that reproduces this and verifies the fix (1 server + 1 client, no Consul) is here: https://github.com/afreidah/nomad/tree/repro-jobs-statuses-28132/repro-28132

## Root cause

`nomad/state/schema.go`, `jobTableSchema()` — the `modify_index` index used `Unique: true` on a non-unique field. `Job.Statuses` iterates it via `JobsByModifyIndex` (`getSorted(txn, sort, "jobs", "modify_index")`); `/v1/jobs` iterates the unique `id` index and is unaffected. The index was born `Unique: true` in #20130 (May 2024) and never changed, so this has been latent since the statuses endpoint shipped.

## Testing

`TestStateStore_JobsByModifyIndex_SharedModifyIndex` asserts every job sharing a `ModifyIndex` is returned. It fails before the fix (only the last writer survives) and passes after:

```
go test ./nomad/state/ -run TestStateStore_JobsByModifyIndex_SharedModifyIndex -v
```

## AI usage

I found this on my own cluster and personally dug through my logs/metrics/etc to try and figure it out and used an AI assistant to help dig through the state/paginator source to quickly find the relevant parts of the code I wanted to look at based on my analysis and theories until I was confident I had reached the root cause after chasing a few red herrings and had what I needed to setup the reproduction + test to prove it existed and what condition would cause it. I Manually verified the issue against my live v2.0.3 cluster with nomad cli and curl commands because the issue is actively persisting until I re-deploy those jobs. No AI assistance is relevant in the actual go source changes since the entire fix is flipping a bool on one line.  I 100% stand behind everything in this PR as the result of personal analysis and debugging on my real homelab cluster.
