### PR TITLE
github: Add PR template checkbox for LLM usage contributing.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,8 @@ merged.
   [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
   Please also consider whether the change requires notes within the [upgrade
   guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
+- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
+  and followed the [AI usage guide](./contributing/ai.md).
 
 ### Reviewer Checklist
 - [ ] **Backport Labels** Please add the correct backport labels as described by the internal

--- a/contributing/ai.md
+++ b/contributing/ai.md
@@ -19,7 +19,7 @@ in your Pull Request description.
 ### Accountability
 Understanding that AI usage can range along a spectrum from AI assistance to AI
 led approaches we strongly prefer an approach that leaves the contributor in the
-drivers seat. AI is a tool, not a seperate contributor. The responsibility for
+drivers seat. AI is a tool, not a separate contributor. The responsibility for
 changes submitted lies entirely with you, the human opening the PR.
 
 - Human ownership: All PRs must be submitted by a real, human-owned account. We


### PR DESCRIPTION
This change adds a new checkbox to call out our LLM usage policy and expectations. This will not stop some of the contributions we have been getting, but it at least calls out our expectations in an obvious manner and gives the maintainers agency to close out PRs that do not adhere.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

