### PR TITLE
Add a time buffer to the max memory oversubscripton test

### DIFF
--- a/e2e/oversubscription/oversubscription_test.go
+++ b/e2e/oversubscription/oversubscription_test.go
@@ -89,10 +89,26 @@ func testRawExecMax(t *testing.T) {
 	job, cleanup := jobs3.Submit(t, "./input/rawexecmax.hcl")
 	t.Cleanup(cleanup)
 
-	// will print memory.low then memory.max
-	logs := job.TaskLogs("group", "cat")
+testFunc := func() error {
+		logs := job.TaskLogs("group", "cat")
+
 	logsRe := regexp.MustCompile(`67108864\s+max`)
 	must.RegexMatch(t, logsRe, logs.Stdout)
+		return nil
+	}
+
+
+	// wait for poststart to run, up to 60 seconds.
+	// this accounts for variability in exec task start time.
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(testFunc),
+		wait.Timeout(time.Second*60),
+		wait.Gap(time.Second*2),
+	))
+
+
+	// will print memory.low then memory.max
+
 }
 
 func captureSchedulerConfiguration(t *testing.T) {

--- a/e2e/oversubscription/oversubscription_test.go
+++ b/e2e/oversubscription/oversubscription_test.go
@@ -89,26 +89,20 @@ func testRawExecMax(t *testing.T) {
 	job, cleanup := jobs3.Submit(t, "./input/rawexecmax.hcl")
 	t.Cleanup(cleanup)
 
-testFunc := func() error {
+	testFunc := func() error {
 		logs := job.TaskLogs("group", "cat")
-
-	logsRe := regexp.MustCompile(`67108864\s+max`)
-	must.RegexMatch(t, logsRe, logs.Stdout)
+		logsRe := regexp.MustCompile(`67108864\s+max`)
+		if !logsRe.MatchString(logs.Stdout) {
+			return fmt.Errorf("expect '%s' in stdout, got: '%s'", logsRe.String(), logs.Stdout)
+		}
 		return nil
 	}
 
-
-	// wait for poststart to run, up to 60 seconds.
-	// this accounts for variability in exec task start time.
 	must.Wait(t, wait.InitialSuccess(
 		wait.ErrorFunc(testFunc),
-		wait.Timeout(time.Second*60),
+		wait.Timeout(time.Second*20),
 		wait.Gap(time.Second*2),
 	))
-
-
-	// will print memory.low then memory.max
-
 }
 
 func captureSchedulerConfiguration(t *testing.T) {


### PR DESCRIPTION
### Description

The test for memory oversubscription has been failing for the past few days, a local reproduction was not possible. This PR adds a buffer to the test to eliminate possible time related problems by using the testFunc mechanism.
### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
