### PR TITLE
CI: update BPA to 0.6.3

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
   backport:
     if: github.event.pull_request.merged
     runs-on: ubuntu-22.04
-    container: hashicorpdev/backport-assistant:v0.6.2
+    container: hashicorpdev/backport-assistant:v0.6.3
     steps:
       - name: Backport changes to stable-website
         run: |


### PR DESCRIPTION
We've updated the backport assistant in the CE->ENT runner, but let's update the same-repo runner for consistency.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
