### PR TITLE
agent: warn on unauthenticated server join request

### DIFF
--- a/.changelog/28176.txt
+++ b/.changelog/28176.txt
@@ -1,0 +1,3 @@
+```release-note:deprecation
+agent: Unauthenticated server join via the CLI or API is deprecated.
+```

--- a/api/agent.go
+++ b/api/agent.go
@@ -5,6 +5,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -140,6 +141,9 @@ func (a *Agent) Join(addrs ...string) (int, error) {
 	}
 	if resp.Error != "" {
 		return 0, fmt.Errorf("failed joining: %s", resp.Error)
+	}
+	if resp.Warning != "" {
+		return resp.NumJoined, errors.New(resp.Warning)
 	}
 	return resp.NumJoined, nil
 }
@@ -454,6 +458,7 @@ func (a *Agent) pprofRequest(req string, opts PprofOptions, q *QueryOptions) ([]
 type joinResponse struct {
 	NumJoined int    `json:"num_joined"`
 	Error     string `json:"error"`
+	Warning   string `json:"warning"`
 }
 
 type ServerMembers struct {

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -107,9 +107,21 @@ func (s *HTTPServer) AgentJoinRequest(resp http.ResponseWriter, req *http.Reques
 	if req.Method != http.MethodPut && req.Method != http.MethodPost {
 		return nil, CodedError(405, ErrInvalidMethod)
 	}
+
 	srv := s.agent.Server()
 	if srv == nil {
 		return nil, CodedError(501, ErrInvalidMethod)
+	}
+
+	var secret string
+	s.parseToken(req, &secret)
+
+	// COMPAT(2.1.0): this will return an error in Nomad 2.1
+	// ref https://hashicorp.atlassian.net/browse/NMD-1507
+	var warning string
+	if err := aclPermissionCheckHelper(srv, secret, func(aclObj *acl.ACL) bool { return aclObj.AllowAgentWrite() }); err != nil {
+		warning = "anonymous server join is deprecated and will be removed in a future version of Nomad"
+		s.logger.Warn(warning)
 	}
 
 	// Get the join addresses
@@ -125,7 +137,11 @@ func (s *HTTPServer) AgentJoinRequest(resp http.ResponseWriter, req *http.Reques
 	if err != nil {
 		errStr = err.Error()
 	}
-	return joinResult{num, errStr}, nil
+	return joinResult{
+		NumJoined: num,
+		Error:     errStr,
+		Warning:   warning,
+	}, nil
 }
 
 func (s *HTTPServer) AgentMembersRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {
@@ -682,6 +698,7 @@ type agentSelf struct {
 type joinResult struct {
 	NumJoined int    `json:"num_joined"`
 	Error     string `json:"error"`
+	Warning   string `json:"warning"`
 }
 
 func (s *HTTPServer) HealthRequest(resp http.ResponseWriter, req *http.Request) (interface{}, error) {

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -147,33 +147,23 @@ func TestHTTP_AgentSelf_ACL(t *testing.T) {
 
 func TestHTTP_AgentJoin(t *testing.T) {
 	ci.Parallel(t)
-	httpTest(t, nil, func(s *TestAgent) {
+	httpACLTest(t, nil, func(s *TestAgent) {
 		// Determine the join address
 		member := s.Agent.Server().LocalMember()
 		addr := net.JoinHostPort(member.Addr.String(), strconv.Itoa(int(member.Port)))
 
-		// Make the HTTP request
 		req, err := http.NewRequest(http.MethodPut,
 			fmt.Sprintf("/v1/agent/join?address=%s&address=%s", addr, addr), nil)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		must.NoError(t, err)
 		respW := httptest.NewRecorder()
 
-		// Make the request
 		obj, err := s.Server.AgentJoinRequest(respW, req)
-		if err != nil {
-			t.Fatalf("err: %v", err)
-		}
+		must.NoError(t, err)
 
-		// Check the job
 		join := obj.(joinResult)
-		if join.NumJoined != 2 {
-			t.Fatalf("bad: %#v", join)
-		}
-		if join.Error != "" {
-			t.Fatalf("bad: %#v", join)
-		}
+		must.Eq(t, 2, join.NumJoined)
+		must.Eq(t, "", join.Error)
+		must.Eq(t, "anonymous server join is deprecated and will be removed in a future version of Nomad", join.Warning)
 	})
 }
 

--- a/command/server_join.go
+++ b/command/server_join.go
@@ -70,8 +70,13 @@ func (c *ServerJoinCommand) Run(args []string) int {
 	// Attempt the join
 	n, err := client.Agent().Join(nodes...)
 	if err != nil {
-		c.Ui.Error(fmt.Sprintf("Error joining: %s", err))
-		return 1
+		if n == 0 {
+			c.Ui.Error(fmt.Sprintf("Error joining: %s", err))
+			return 1
+		} else {
+			c.Ui.Warn(fmt.Sprintf("Joined %d servers successfully but got warning: %s", n, err))
+			return 0
+		}
 	}
 
 	// Success


### PR DESCRIPTION
Using the API to join a new server agent via the `nomad server join` command is currently protected by Serf gossip encryption. Only once the agents are joined in the Serf cluster does mTLS come into play. Although both encryption types have been long-published to be required for secure configuration, we intend to make authentication mandatory for the server join API in a near-future version of Nomad (likely 2.1.0).

Add a warning to the request logs, to the API response, and to the command line when attempting to server join without an `agent:write` ACL. The warning doesn't specifically refer to this policy just in case we want to invent a new fine-grained capability by the time we remove anonymous access.

Ref: https://hashicorp.atlassian.net/browse/NMD-1507
Ref: https://hashicorp.atlassian.net/browse/SECVULN-44064

### Testing & Reproduction steps

In addition to unit tests:

```sh
# unauthenticated
$ nomad server members
Error querying servers: Unexpected response code: 403 (Permission denied)

$ nomad server join 192.168.1.194:4668
Joined 1 servers successfully but got warning: anonymous server join is deprecated and will be removed in a future version of Nomad

# bootstrap ACLs so we can see the results
$ cat token | nomad acl bootstrap -
$ export NOMAD_TOKEN=$(cat token)

$ nomad server members
Name            Address        Port  Status  Leader  Raft Version  Build      Datacenter  Region
server0.philly  192.168.1.194  4648  alive   false   3             2.0.4-dev  dc1         philly
server1.philly  192.168.1.194  4658  alive   false   3             2.0.4-dev  dc1         philly
server2.philly  192.168.1.194  4668  alive   true    3             2.0.4-dev  dc1         philly
```

### Contributor Checklist
- [x] **Changelog Entry** done
- [x] **Testing** see above
- [x] **Documentation** will be covered by https://hashicorp.atlassian.net/browse/NMD-1506
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** note this will be backported to 2.0.x only because the breaking change will obviously not be backported either
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
