### PR TITLE
Fix /v1/jobs/statuses pagination for jobs that share a ModifyIndex

### DIFF
--- a/.changelog/28178.txt
+++ b/.changelog/28178.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed a bug where the jobs list page could repeat a job across pages, get stuck while paging, or jump to the wrong last page
+```

--- a/.changelog/28178.txt
+++ b/.changelog/28178.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-ui: Fixed a bug where the jobs list page could repeat a job across pages, get stuck while paging, jump to the wrong last page, or page incorrectly after refreshing or opening a shared link
+ui: Fixed a bug where the jobs list page could repeat a job across pages, get stuck while paging, jump to the wrong last page, show jobs outside the active filter when paging backward, or page incorrectly after refreshing or opening a shared link
 ```

--- a/.changelog/28178.txt
+++ b/.changelog/28178.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-ui: Fixed a bug where the jobs list page could repeat a job across pages, get stuck while paging, or jump to the wrong last page
+ui: Fixed a bug where the jobs list page could repeat a job across pages, get stuck while paging, jump to the wrong last page, or page incorrectly after refreshing or opening a shared link
 ```

--- a/nomad/job_endpoint_statuses.go
+++ b/nomad/job_endpoint_statuses.go
@@ -139,7 +139,7 @@ func (j *Job) Statuses(
 			newJobs := set.New[structs.NamespacedID](0)
 			pager, err := paginator.NewPaginator(iter, args.QueryOptions,
 				selector,
-				paginator.ModifyIndexTokenizer[*structs.Job](args.NextToken),
+				paginator.ModifyIndexAndNamespaceIDTokenizer[*structs.Job](args.NextToken),
 				func(job *structs.Job) (structs.JobStatusesJob, error) {
 					var none structs.JobStatusesJob
 					// this is where the sausage is made

--- a/nomad/job_endpoint_statuses_pagination_test.go
+++ b/nomad/job_endpoint_statuses_pagination_test.go
@@ -1,0 +1,86 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package nomad
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/hashicorp/nomad/testutil"
+	"github.com/shoenig/test/must"
+)
+
+// TestJob_Statuses_Pagination_SharedModifyIndex is a regression test for the
+// /v1/jobs/statuses paginator. Its NextToken was once built from ModifyIndex
+// alone, with no tiebreaker. When several jobs shared a ModifyIndex (e.g.
+// written in a single Raft transaction) and that group did not fit in one page,
+// the cursor could not advance past the group: the same page repeated
+// (duplicate jobs) and the walk never terminated.
+//
+// Paginating this endpoint must always (a) terminate and (b) return every job
+// exactly once, regardless of jobs sharing a ModifyIndex.
+func TestJob_Statuses_Pagination_SharedModifyIndex(t *testing.T) {
+	ci.Parallel(t)
+
+	s, cleanup := TestServer(t, func(c *Config) {
+		c.NumSchedulers = 0
+	})
+	t.Cleanup(cleanup)
+	testutil.WaitForLeader(t, s.RPC)
+
+	// Write several jobs at a single shared ModifyIndex, as happens when one
+	// Raft transaction writes multiple jobs at once.
+	const n = 5
+	const sharedIndex = 1000
+	want := make(map[string]bool, n)
+	for i := range n {
+		job := mock.MinJob()
+		job.ID = fmt.Sprintf("shared-%02d", i)
+		must.NoError(t, s.State().UpsertJob(structs.MsgTypeTestSetup, sharedIndex, nil, job))
+		want[job.ID] = true
+	}
+
+	// Page through the endpoint following NextToken, the way the web UI does.
+	// per_page is smaller than the shared group, so the group spans a page
+	// boundary -- exactly the case the ModifyIndex-only token cannot handle.
+	seen := make(map[string]int, n)
+	token := ""
+	pages := 0
+	// A terminating walk needs ceil(n/perPage) pages; a stalled cursor never
+	// stops, so anything well past that means the walk did not terminate.
+	maxPages := n * 3
+	for {
+		pages++
+		if pages > maxPages {
+			t.Fatalf("pagination did not terminate after %d pages: cursor stuck at token %q (seen=%v)",
+				pages, token, seen)
+		}
+
+		req := &structs.JobStatusesRequest{}
+		req.QueryOptions.Region = "global"
+		req.QueryOptions.Namespace = structs.DefaultNamespace
+		req.QueryOptions.PerPage = 2
+		req.QueryOptions.NextToken = token
+
+		var resp structs.JobStatusesResponse
+		must.NoError(t, s.RPC("Job.Statuses", req, &resp))
+
+		for _, j := range resp.Jobs {
+			seen[j.ID]++
+		}
+		if resp.NextToken == "" {
+			break
+		}
+		token = resp.NextToken
+	}
+
+	for id := range want {
+		must.Eq(t, 1, seen[id],
+			must.Sprintf("job %s returned %d time(s) across pages, want exactly 1", id, seen[id]))
+	}
+	must.Eq(t, n, len(seen), must.Sprintf("walked jobs = %v", seen))
+}

--- a/nomad/job_endpoint_statuses_test.go
+++ b/nomad/job_endpoint_statuses_test.go
@@ -5,7 +5,7 @@ package nomad
 
 import (
 	"context"
-	"strconv"
+	"fmt"
 	"testing"
 	"time"
 
@@ -142,12 +142,17 @@ func TestJob_Statuses(t *testing.T) {
 
 	// test various single-job requests
 
+	// the pagination cursor is "<ModifyIndex>.<Namespace>.<ID>"
+	tok := func(j *structs.Job) string {
+		return fmt.Sprintf("%d.%s.%s", j.ModifyIndex, j.Namespace, j.ID)
+	}
+
 	for _, tc := range []struct {
 		name       string
 		qo         structs.QueryOptions
 		jobs       []structs.NamespacedID
 		expect     *structs.Job
-		expectNext uint64 // NextToken (ModifyIndex)
+		expectNext *structs.Job // job the NextToken cursor points at
 	}{
 		{
 			name: "page 1",
@@ -155,16 +160,16 @@ func TestJob_Statuses(t *testing.T) {
 				PerPage: 1,
 			},
 			expect:     jobs[4],
-			expectNext: jobs[3].ModifyIndex,
+			expectNext: jobs[3],
 		},
 		{
 			name: "page 2",
 			qo: structs.QueryOptions{
 				PerPage:   1,
-				NextToken: strconv.FormatUint(jobs[3].ModifyIndex, 10),
+				NextToken: tok(jobs[3]),
 			},
 			expect:     jobs[3],
-			expectNext: jobs[2].ModifyIndex,
+			expectNext: jobs[2],
 		},
 		{
 			name: "reverse",
@@ -173,7 +178,7 @@ func TestJob_Statuses(t *testing.T) {
 				Reverse: true,
 			},
 			expect:     jobs[0],
-			expectNext: jobs[1].ModifyIndex,
+			expectNext: jobs[1],
 		},
 		{
 			name: "filter",
@@ -212,8 +217,8 @@ func TestJob_Statuses(t *testing.T) {
 				must.Eq(t, tc.expect.ID, resp.Jobs[0].ID)
 			}
 			expectToken := ""
-			if tc.expectNext > 0 {
-				expectToken = strconv.FormatUint(tc.expectNext, 10)
+			if tc.expectNext != nil {
+				expectToken = tok(tc.expectNext)
 			}
 			must.Eq(t, expectToken, resp.NextToken)
 		})

--- a/nomad/state/paginator/paginator_test.go
+++ b/nomad/state/paginator/paginator_test.go
@@ -60,20 +60,22 @@ func TestPaginator(t *testing.T) {
 		{
 			name:    "when numbers are numbers",
 			perPage: 2,
-			// "10" is converted to uint64(10) and compared with uint64 index
+			// a bare "10" target exercises the legacy index-only path: "10" is
+			// parsed as uint64(10) and compared numerically with the index.
 			nextToken:         "10",
-			tokenizer:         ModifyIndexTokenizer[*mockObject]("10"),
+			tokenizer:         ModifyIndexAndNamespaceIDTokenizer[*mockObject]("10"),
 			expected:          []string{"10", "11"},
 			expectedNextToken: "",
 		},
 		{
-			name:    "when zero is a number",
+			name:    "when the next token is a full cursor",
 			perPage: 2,
-			// "" is converted to uint64(0) and compared with uint64 index
+			// an empty token starts from the beginning; the next token is the
+			// full "<index>.<namespace>.<id>" cursor (namespace is empty here).
 			nextToken:         "",
-			tokenizer:         ModifyIndexTokenizer[*mockObject](""),
+			tokenizer:         ModifyIndexAndNamespaceIDTokenizer[*mockObject](""),
 			expected:          []string{"0", "1"},
-			expectedNextToken: "2",
+			expectedNextToken: "2..2",
 		},
 		{
 			name:              "starting off the end",
@@ -121,6 +123,43 @@ func TestPaginator(t *testing.T) {
 		})
 	}
 
+	// The cases above can only vary the id, so their compound tokens always
+	// have an empty namespace. This case drives a full
+	// "<index>.<namespace>.<id>" cursor through the paginator when several
+	// objects share an index, exercising the namespace/id tiebreaker in the
+	// seek path rather than just in the tokenizer in isolation.
+	t.Run("resumes from a full namespaced cursor", func(t *testing.T) {
+		// Ordered as memdb iterates: by index, then namespace, then id.
+		mocks := []*mockObject{
+			{index: 4, namespace: "teamA", id: "old"},
+			{index: 5, namespace: "teamA", id: "web"},
+			{index: 5, namespace: "teamB", id: "api"},
+			{index: 5, namespace: "teamB", id: "web"},
+			{index: 6, namespace: "teamA", id: "new"},
+		}
+
+		iter := newTestIteratorWithMocks(mocks)
+		opts := structs.QueryOptions{
+			PerPage:   2,
+			NextToken: "5.teamB.api",
+		}
+
+		paginator, err := NewPaginator(iter, opts, nil,
+			ModifyIndexAndNamespaceIDTokenizer[*mockObject]("5.teamB.api"),
+			func(result *mockObject) (string, error) {
+				return result.id, nil
+			},
+		)
+		must.NoError(t, err)
+
+		results, nextToken, err := paginator.Page()
+		must.NoError(t, err)
+		// Skips 4.teamA.old (lower index) and 5.teamA.web (same index, earlier
+		// namespace) and resumes exactly at 5.teamB.api.
+		must.Eq(t, []string{"api", "web"}, results)
+		// The next page's cursor is a full three-part token.
+		must.Eq(t, "6.teamA.new", nextToken)
+	})
 }
 
 // helpers for pagination tests

--- a/nomad/state/paginator/tokenizer.go
+++ b/nomad/state/paginator/tokenizer.go
@@ -75,17 +75,52 @@ func CreateIndexAndIDTokenizer[T idAndCreateIndexGetter](target string) Tokenize
 	}
 }
 
-// ModifyIndexTokenizer returns a tokenizer by ModifyIndex.
-func ModifyIndexTokenizer[T modifyIndexGetter](target string) Tokenizer[T] {
-	// attempt to convert token to uint for iterators ordered numerically.
-	// it's safe to ignore the error here because the `next` method ignores
-	// this field for string tokens and 0 is valid for an unset numeric token.
-	targetIndex, _ := strconv.ParseUint(target, 10, 64)
-
+// ModifyIndexAndNamespaceIDTokenizer returns a tokenizer keyed on ModifyIndex,
+// then Namespace and ID. ModifyIndex is not unique (several objects may be
+// written in one Raft transaction), so it can't identify a unique resume
+// position on its own. Namespace and ID break the tie to give a total order
+// matching how memdb iterates the non-unique modify_index index: by ModifyIndex,
+// then the (Namespace, ID) primary key.
+func ModifyIndexAndNamespaceIDTokenizer[T modifyIndexAndNamespaceIDGetter](target string) Tokenizer[T] {
 	return func(item T) (string, int) {
 		index := item.GetModifyIndex()
-		token := fmt.Sprintf("%d", index)
-		return token, cmp.Compare(index, targetIndex)
+		ns := item.GetNamespace()
+		id := item.GetID()
+		token := fmt.Sprintf("%d.%s.%s", index, ns, id)
+
+		// Namespace cannot contain '.', so the index and namespace are the first
+		// two segments; the ID (which may contain '.') is the remainder.
+		parts := strings.SplitN(target, ".", 3)
+
+		// Parse the index numerically so values like 12 and 102 compare
+		// correctly rather than lexicographically. A target whose first segment
+		// isn't an integer is malformed -- only reachable from a hand-crafted
+		// token, since real next_tokens are empty or start with an index -- so
+		// degrade to first-page behavior: returning 0 ("matched") makes the
+		// paginator skip nothing and start from the beginning, matching the
+		// previous ModifyIndex-only tokenizer.
+		targetIndex, err := strconv.ParseUint(parts[0], 10, 64)
+		if err != nil {
+			return token, 0
+		}
+		if c := cmp.Compare(index, targetIndex); c != 0 {
+			return token, c
+		}
+
+		// Indexes are equal; break the tie by namespace then ID. A target with
+		// fewer segments (e.g. a legacy bare-integer token from before this
+		// tiebreaker existed, seen during a rolling upgrade) compares only the
+		// segments it has, degrading to the previous index-only behavior.
+		if len(parts) < 2 {
+			return token, 0
+		}
+		if c := cmp.Compare(ns, parts[1]); c != 0 {
+			return token, c
+		}
+		if len(parts) < 3 {
+			return token, 0
+		}
+		return token, cmp.Compare(id, parts[2])
 	}
 }
 
@@ -119,4 +154,11 @@ type idAndCreateIndexGetter interface {
 // as their pagination token.
 type modifyIndexGetter interface {
 	GetModifyIndex() uint64
+}
+
+// modifyIndexAndNamespaceIDGetter must be implemented by structs that want to
+// use ModifyIndex with a Namespace and ID tiebreaker as their pagination token.
+type modifyIndexAndNamespaceIDGetter interface {
+	modifyIndexGetter
+	namespaceIDGetter
 }

--- a/nomad/state/paginator/tokenizer_test.go
+++ b/nomad/state/paginator/tokenizer_test.go
@@ -39,9 +39,9 @@ func TestTokenizer(t *testing.T) {
 			expected:  fmt.Sprintf("%v.%v", j.CreateIndex, j.ID),
 		},
 		{
-			name:      "ModifyIndex",
-			tokenizer: ModifyIndexTokenizer[*structs.Job](""),
-			expected:  fmt.Sprintf("%d", j.ModifyIndex),
+			name:      "ModifyIndex.Namespace.ID",
+			tokenizer: ModifyIndexAndNamespaceIDTokenizer[*structs.Job](""),
+			expected:  fmt.Sprintf("%d.%v.%v", j.ModifyIndex, j.Namespace, j.ID),
 		},
 	}
 
@@ -143,3 +143,126 @@ func (m *mockCreateIndexObject) GetCreateIndex() uint64 {
 func (m *mockCreateIndexObject) GetID() string {
 	return m.id
 }
+
+func TestModifyIndexAndNamespaceIDTokenizer(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name          string
+		obj           *mockModifyIndexObject
+		target        string
+		expectedToken string
+		expectedCmp   int
+	}{
+		{
+			name:          "less index",
+			obj:           newMockModifyIndexObject(12, "default", "aaa"),
+			target:        "89.default.aaa",
+			expectedToken: "12.default.aaa",
+			expectedCmp:   -1,
+		},
+		{
+			name:          "greater index",
+			obj:           newMockModifyIndexObject(89, "default", "aaa"),
+			target:        "12.default.aaa",
+			expectedToken: "89.default.aaa",
+			expectedCmp:   1,
+		},
+		{
+			// index is compared numerically, not lexically: 12 < 102
+			name:          "numeric index (less)",
+			obj:           newMockModifyIndexObject(12, "default", "aaa"),
+			target:        "102.default.aaa",
+			expectedToken: "12.default.aaa",
+			expectedCmp:   -1,
+		},
+		{
+			name:          "equal index, less namespace",
+			obj:           newMockModifyIndexObject(12, "aaa", "x"),
+			target:        "12.bbb.x",
+			expectedToken: "12.aaa.x",
+			expectedCmp:   -1,
+		},
+		{
+			name:          "equal index, greater namespace",
+			obj:           newMockModifyIndexObject(12, "bbb", "x"),
+			target:        "12.aaa.x",
+			expectedToken: "12.bbb.x",
+			expectedCmp:   1,
+		},
+		{
+			// namespace compared field-by-field, so "team" sorts before
+			// "team-a" (matching memdb's null-separated key order), unlike a
+			// whole-string compare where '.' > '-' would reverse them.
+			name:          "dash namespace ordering",
+			obj:           newMockModifyIndexObject(12, "team", "z"),
+			target:        "12.team-a.a",
+			expectedToken: "12.team.z",
+			expectedCmp:   -1,
+		},
+		{
+			name:          "equal index and namespace, less id",
+			obj:           newMockModifyIndexObject(12, "team", "aaa"),
+			target:        "12.team.bbb",
+			expectedToken: "12.team.aaa",
+			expectedCmp:   -1,
+		},
+		{
+			name:          "equal index, namespace, and id",
+			obj:           newMockModifyIndexObject(12, "team", "aaa"),
+			target:        "12.team.aaa",
+			expectedToken: "12.team.aaa",
+			expectedCmp:   0,
+		},
+		{
+			// id may contain '.'; it's the remainder after the first two splits.
+			name:          "id with dots",
+			obj:           newMockModifyIndexObject(12, "default", "a.b.c"),
+			target:        "12.default.a.b.c",
+			expectedToken: "12.default.a.b.c",
+			expectedCmp:   0,
+		},
+		{
+			// legacy bare-integer token (rolling upgrade): index-only compare
+			name:          "legacy bare-integer target (equal)",
+			obj:           newMockModifyIndexObject(12, "default", "aaa"),
+			target:        "12",
+			expectedToken: "12.default.aaa",
+			expectedCmp:   0,
+		},
+		{
+			name:          "legacy bare-integer target (less)",
+			obj:           newMockModifyIndexObject(12, "default", "aaa"),
+			target:        "13",
+			expectedToken: "12.default.aaa",
+			expectedCmp:   -1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := ModifyIndexAndNamespaceIDTokenizer[*mockModifyIndexObject](tc.target)
+			actualToken, actualCmp := fn(tc.obj)
+			must.Eq(t, tc.expectedToken, actualToken)
+			must.Eq(t, tc.expectedCmp, actualCmp)
+		})
+	}
+}
+
+func newMockModifyIndexObject(modifyIndex uint64, namespace, id string) *mockModifyIndexObject {
+	return &mockModifyIndexObject{
+		modifyIndex: modifyIndex,
+		namespace:   namespace,
+		id:          id,
+	}
+}
+
+type mockModifyIndexObject struct {
+	modifyIndex uint64
+	namespace   string
+	id          string
+}
+
+func (m *mockModifyIndexObject) GetModifyIndex() uint64 { return m.modifyIndex }
+func (m *mockModifyIndexObject) GetNamespace() string   { return m.namespace }
+func (m *mockModifyIndexObject) GetID() string          { return m.id }

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -92,15 +92,15 @@ export default class JobsIndexController extends Controller {
   @tracked cursorAt;
   @tracked nextToken; // route sets this when new data is fetched
 
-  // Stack of visited page-start tokens, oldest first, excluding the current
-  // page. "prev" pops it to page back using a server-minted token instead of
-  // one we construct, keeping the UI token-agnostic across server versions.
-  previousTokens = [];
+  // onFirstPage drives the disabled state of the first/previous buttons. "prev"
+  // lands on a server-minted cursor rather than an empty one, so being on the
+  // first page can't be read from cursorAt alone; reachedStart probes for it.
+  @tracked onFirstPage = true;
 
-  // cursorFor builds the pagination cursor for a job, matching the server's
-  // "<modifyIndex>.<namespace>.<id>" jobs/statuses page token. Several jobs can
-  // share a ModifyIndex, so the namespace and id are needed to point the cursor
-  // at a single job.
+  // cursorFor builds a page-start cursor from a job, matching the server's
+  // "<modifyIndex>.<namespace>.<id>" jobs/statuses token. Only "last" needs it:
+  // that page has no forward token to seed from, since nothing points back into
+  // the final page. Every other move reuses a token the server minted.
   cursorFor(job) {
     if (!job) {
       return undefined;
@@ -121,51 +121,53 @@ export default class JobsIndexController extends Controller {
       if (!this.cursorAt) {
         return;
       }
-      if (this.previousTokens.length) {
-        // Page back with a server-minted token; never constructs a cursor.
-        this.cursorAt = this.previousTokens.pop();
-      } else {
-        // No history: we arrived via "last". Reverse-query for the previous
-        // page and construct its boundary cursor. The extra request returns
-        // the target page in reverse order plus one job; we take the newest as
-        // the cursor. This is the only navigation path that constructs a token.
-        let prevPageToken = await this.loadPreviousPageToken();
-        if (!prevPageToken.meta.nextToken) {
-          // No token means we've reached the start of the list.
-          this.cursorAt = undefined;
-        } else {
-          const sortedPrevPage = prevPageToken.sortBy('modifyIndex');
-          this.cursorAt = this.cursorFor(
-            sortedPrevPage[sortedPrevPage.length - 1],
-          );
-        }
-      }
+      // A reverse query seeded at the current page's first job returns the
+      // previous page's start token as meta.nextToken. Keep only that token and
+      // render forward, discarding the returned jobs. This never constructs a
+      // cursor and works from a cold cursorAt (refresh / shared URL), since it
+      // reads the query param rather than in-memory history. An empty token
+      // means the previous page is the first page, which has no cursor.
+      const prevPage = await this.loadReverse({ next_token: this.cursorAt });
+      this.cursorAt = prevPage.meta.nextToken || undefined;
+      this.onFirstPage = await this.reachedStart(this.cursorAt);
     } else if (page === 'next') {
       if (!this.nextToken) {
         return;
       }
-      // Record the current page's start token so "prev" can return to it.
-      this.previousTokens.push(this.cursorAt);
-      this.cursorAt = this.nextToken;
+      this.cursorAt = this.nextToken; // server-minted
+      this.onFirstPage = false;
     } else if (page === 'first') {
       this.cursorAt = undefined;
-      this.previousTokens = [];
+      this.onFirstPage = true;
     } else if (page === 'last') {
-      // Hard jump to the end; accumulated history no longer applies.
-      this.previousTokens = [];
-      let prevPageToken = await this.loadPreviousPageToken({ last: true });
-      const sortedPrevPage = prevPageToken.sortBy('modifyIndex');
-      this.cursorAt = this.cursorFor(sortedPrevPage[sortedPrevPage.length - 1]);
+      // The one page the server can't mint a forward cursor for: nothing points
+      // back into the final page. Fetch it in reverse and build the cursor from
+      // its newest job (its first in display order).
+      const lastPage = await this.loadReverse();
+      const sorted = lastPage.sortBy('modifyIndex');
+      this.cursorAt = this.cursorFor(sorted[sorted.length - 1]);
+      this.onFirstPage = false;
     }
+  }
+
+  // reachedStart reports whether cursorAt points at the first page. A per_page=1
+  // reverse probe from the cursor returns an empty nextToken only when nothing
+  // is newer than it, which is true exactly on the first page.
+  async reachedStart(cursorAt) {
+    if (!cursorAt) {
+      return true;
+    }
+    const probe = await this.loadReverse({ next_token: cursorAt, per_page: 1 });
+    return !probe.meta.nextToken;
   }
 
   @action handlePageSizeChange(size) {
     this.pageSize = size;
-    // Page boundaries depend on page size, so the stacked tokens no longer line
+    // Page boundaries depend on page size, so the current cursor no longer lines
     // up once it changes. Reset to the first page rather than page from a stale
     // cursor.
     this.cursorAt = undefined;
-    this.previousTokens = [];
+    this.onFirstPage = true;
   }
 
   get pendingJobIDDiff() {
@@ -307,33 +309,17 @@ export default class JobsIndexController extends Controller {
       });
   }
 
-  // Ask for the previous #page_size jobs, starting at the first job that's
-  // currently shown on our page, and the newest one in the result is the one we
-  // use for our subsequent cursorAt. The page cursor is inclusive of the job it
-  // points at, so for "prev" we start at the current page's first job and ask
-  // for one extra to make room for it (handlePageChange drops it by taking the
-  // newest job). "last" has no such anchor, so it asks for a plain page.
-  async loadPreviousPageToken({ last = false } = {}) {
-    let next_token = this.cursorAt;
-    let per_page = this.pageSize + 1;
-    if (last) {
-      next_token = undefined;
-      per_page = this.pageSize;
-    }
-    let prevPageToken = await this.store.query(
+  // Reverse query used by prev (to read the previous page's start token from
+  // meta.nextToken) and by last (to fetch the final page). per_page is exactly
+  // pageSize: prev reads the minted token rather than picking a job out of the
+  // result, so it needs no overlap job. next_token defaults to undefined, which
+  // "last" uses to walk back from the end of the list.
+  async loadReverse({ next_token = undefined, per_page = this.pageSize } = {}) {
+    return this.store.query(
       'job',
-      {
-        next_token,
-        per_page,
-        reverse: true,
-      },
-      {
-        adapterOptions: {
-          method: 'GET',
-        },
-      },
+      { next_token, per_page, reverse: true },
+      { adapterOptions: { method: 'GET' } },
     );
-    return prevPageToken;
   }
 
   @restartableTask *watchJobIDs(
@@ -635,7 +621,7 @@ export default class JobsIndexController extends Controller {
   @action
   updateFilter() {
     this.cursorAt = undefined;
-    this.previousTokens = [];
+    this.onFirstPage = true;
     this.filter = this.computedFilter;
   }
 

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -97,18 +97,6 @@ export default class JobsIndexController extends Controller {
   // first page can't be read from cursorAt alone; reachedStart probes for it.
   @tracked onFirstPage = true;
 
-  // cursorFor builds a page-start cursor from a job, matching the server's
-  // "<modifyIndex>.<namespace>.<id>" jobs/statuses token. Only "last" needs it:
-  // that page has no forward token to seed from, since nothing points back into
-  // the final page. Every other move reuses a token the server minted.
-  cursorFor(job) {
-    if (!job) {
-      return undefined;
-    }
-    const namespace = job.belongsTo('namespace').id() || 'default';
-    return `${job.modifyIndex}.${namespace}.${job.plainId}`;
-  }
-
   /**
    * @param {"prev"|"next"|"first"|"last"} page
    */
@@ -140,12 +128,16 @@ export default class JobsIndexController extends Controller {
       this.cursorAt = undefined;
       this.onFirstPage = true;
     } else if (page === 'last') {
-      // The one page the server can't mint a forward cursor for: nothing points
-      // back into the final page. Fetch it in reverse and build the cursor from
-      // its newest job (its first in display order).
-      const lastPage = await this.loadReverse();
-      const sorted = lastPage.sortBy('modifyIndex');
-      this.cursorAt = this.cursorFor(sorted[sorted.length - 1]);
+      // Reverse-walk from the end for one fewer than a page so the server's
+      // meta.nextToken lands on the first job of the last full page, then reuse
+      // that minted token. Asking for a full page would overshoot by one and
+      // strand the oldest job on a page of its own. This keeps every cursor
+      // server-minted (nothing constructed here), which also lets the list page
+      // against an older backend that mints the legacy token format.
+      const lastPage = await this.loadReverse({
+        per_page: Math.max(this.pageSize - 1, 1),
+      });
+      this.cursorAt = lastPage.meta.nextToken || undefined;
       this.onFirstPage = false;
     }
   }
@@ -310,16 +302,19 @@ export default class JobsIndexController extends Controller {
   }
 
   // Reverse query used by prev (to read the previous page's start token from
-  // meta.nextToken) and by last (to fetch the final page). per_page is exactly
-  // pageSize: prev reads the minted token rather than picking a job out of the
-  // result, so it needs no overlap job. next_token defaults to undefined, which
-  // "last" uses to walk back from the end of the list.
+  // meta.nextToken) and by last (to fetch the final page). next_token defaults
+  // to undefined, which "last" uses to walk back from the end of the list. The
+  // filter and namespace must match the forward query the route builds, or
+  // paging back / jumping to last would page over a different set than the one
+  // on screen and surface jobs the filter excludes.
   async loadReverse({ next_token = undefined, per_page = this.pageSize } = {}) {
-    return this.store.query(
-      'job',
-      { next_token, per_page, reverse: true },
-      { adapterOptions: { method: 'GET' } },
-    );
+    const params = { next_token, per_page, reverse: true, namespace: '*' };
+    if (this.filter) {
+      params.filter = this.filter;
+    }
+    return this.store.query('job', params, {
+      adapterOptions: { method: 'GET' },
+    });
   }
 
   @restartableTask *watchJobIDs(

--- a/ui/app/controllers/jobs/index.js
+++ b/ui/app/controllers/jobs/index.js
@@ -86,12 +86,31 @@ export default class JobsIndexController extends Controller {
   }
 
   // #region pagination
+  // cursorAt is the opaque page-start token for the current page; it is always
+  // a string or undefined (never null, which unlike undefined is not omitted
+  // from the query string). undefined means the first page, which has no cursor.
   @tracked cursorAt;
   @tracked nextToken; // route sets this when new data is fetched
 
+  // Stack of visited page-start tokens, oldest first, excluding the current
+  // page. "prev" pops it to page back using a server-minted token instead of
+  // one we construct, keeping the UI token-agnostic across server versions.
+  previousTokens = [];
+
+  // cursorFor builds the pagination cursor for a job, matching the server's
+  // "<modifyIndex>.<namespace>.<id>" jobs/statuses page token. Several jobs can
+  // share a ModifyIndex, so the namespace and id are needed to point the cursor
+  // at a single job.
+  cursorFor(job) {
+    if (!job) {
+      return undefined;
+    }
+    const namespace = job.belongsTo('namespace').id() || 'default';
+    return `${job.modifyIndex}.${namespace}.${job.plainId}`;
+  }
+
   /**
-   *
-   * @param {"prev"|"next"} page
+   * @param {"prev"|"next"|"first"|"last"} page
    */
   @action async handlePageChange(page) {
     // reset indexes
@@ -102,41 +121,51 @@ export default class JobsIndexController extends Controller {
       if (!this.cursorAt) {
         return;
       }
-      // Note (and TODO:) this isn't particularly efficient!
-      // We're making an extra full request to get the nextToken we need,
-      // but actually the results of that request are the reverse order, plus one job,
-      // of what we actually want to show on the page!
-      // I should investigate whether I can use the results of this query to
-      // overwrite this controller's jobIDs, leverage its index, and
-      // restart a blocking watchJobIDs here.
-      let prevPageToken = await this.loadPreviousPageToken();
-      // If there's no nextToken, we're at the "start" of our list and can drop the cursorAt
-      if (!prevPageToken.meta.nextToken) {
-        this.cursorAt = undefined;
+      if (this.previousTokens.length) {
+        // Page back with a server-minted token; never constructs a cursor.
+        this.cursorAt = this.previousTokens.pop();
       } else {
-        // cursorAt should be the highest modifyIndex from the previous query.
-        // This will immediately fire the route model hook with the new cursorAt
-        const sortedPrevPage = prevPageToken.sortBy('modifyIndex');
-        this.cursorAt = prevPageToken
-          ? sortedPrevPage[sortedPrevPage.length - 1]?.modifyIndex
-          : undefined;
+        // No history: we arrived via "last". Reverse-query for the previous
+        // page and construct its boundary cursor. The extra request returns
+        // the target page in reverse order plus one job; we take the newest as
+        // the cursor. This is the only navigation path that constructs a token.
+        let prevPageToken = await this.loadPreviousPageToken();
+        if (!prevPageToken.meta.nextToken) {
+          // No token means we've reached the start of the list.
+          this.cursorAt = undefined;
+        } else {
+          const sortedPrevPage = prevPageToken.sortBy('modifyIndex');
+          this.cursorAt = this.cursorFor(
+            sortedPrevPage[sortedPrevPage.length - 1],
+          );
+        }
       }
     } else if (page === 'next') {
       if (!this.nextToken) {
         return;
       }
+      // Record the current page's start token so "prev" can return to it.
+      this.previousTokens.push(this.cursorAt);
       this.cursorAt = this.nextToken;
     } else if (page === 'first') {
       this.cursorAt = undefined;
+      this.previousTokens = [];
     } else if (page === 'last') {
+      // Hard jump to the end; accumulated history no longer applies.
+      this.previousTokens = [];
       let prevPageToken = await this.loadPreviousPageToken({ last: true });
       const sortedPrevPage = prevPageToken.sortBy('modifyIndex');
-      this.cursorAt = sortedPrevPage[sortedPrevPage.length - 1]?.modifyIndex;
+      this.cursorAt = this.cursorFor(sortedPrevPage[sortedPrevPage.length - 1]);
     }
   }
 
   @action handlePageSizeChange(size) {
     this.pageSize = size;
+    // Page boundaries depend on page size, so the stacked tokens no longer line
+    // up once it changes. Reset to the first page rather than page from a stale
+    // cursor.
+    this.cursorAt = undefined;
+    this.previousTokens = [];
   }
 
   get pendingJobIDDiff() {
@@ -278,19 +307,24 @@ export default class JobsIndexController extends Controller {
       });
   }
 
-  // Ask for the previous #page_size jobs, starting at the first job that's currently shown
-  // on our page, and the last one in our list should be the one we use for our
-  // subsequent nextToken.
+  // Ask for the previous #page_size jobs, starting at the first job that's
+  // currently shown on our page, and the newest one in the result is the one we
+  // use for our subsequent cursorAt. The page cursor is inclusive of the job it
+  // points at, so for "prev" we start at the current page's first job and ask
+  // for one extra to make room for it (handlePageChange drops it by taking the
+  // newest job). "last" has no such anchor, so it asks for a plain page.
   async loadPreviousPageToken({ last = false } = {}) {
-    let next_token = +this.cursorAt + 1;
+    let next_token = this.cursorAt;
+    let per_page = this.pageSize + 1;
     if (last) {
       next_token = undefined;
+      per_page = this.pageSize;
     }
     let prevPageToken = await this.store.query(
       'job',
       {
         next_token,
-        per_page: this.pageSize,
+        per_page,
         reverse: true,
       },
       {
@@ -600,7 +634,8 @@ export default class JobsIndexController extends Controller {
 
   @action
   updateFilter() {
-    this.cursorAt = null;
+    this.cursorAt = undefined;
+    this.previousTokens = [];
     this.filter = this.computedFilter;
   }
 

--- a/ui/app/routes/jobs/index.js
+++ b/ui/app/routes/jobs/index.js
@@ -276,8 +276,18 @@ export default class IndexRoute extends Route.extend(
   setupController(controller, model) {
     super.setupController(controller, model);
 
-    if (!this.hasBeenInitialized) {
+    const firstLoad = !this.hasBeenInitialized;
+    if (firstLoad) {
       controller.parseFilter();
+      // A cold load from a deep-linked/shared URL can land on any page, so the
+      // first/previous disabled state can't be assumed. Probe once to set it;
+      // later navigation maintains the flag itself. Without a cursor we are on
+      // the first page and the default flag already holds.
+      if (controller.cursorAt) {
+        controller.reachedStart(controller.cursorAt).then((atStart) => {
+          controller.set('onFirstPage', atStart);
+        });
+      }
     }
     this.hasBeenInitialized = true;
 

--- a/ui/app/templates/jobs/index.hbs
+++ b/ui/app/templates/jobs/index.hbs
@@ -320,7 +320,7 @@
             @size="small"
             @icon="chevrons-left"
             @iconPosition="leading"
-            disabled={{not this.cursorAt}}
+            disabled={{this.onFirstPage}}
             data-test-pager="first"
             {{on "click" (fn this.handlePageChange "first")}}
           />
@@ -338,7 +338,7 @@
             @size="small"
             @icon="chevron-left"
             @iconPosition="leading"
-            disabled={{not this.cursorAt}}
+            disabled={{this.onFirstPage}}
             data-test-pager="previous"
             {{on "click" (fn this.handlePageChange "prev")}}
           />

--- a/ui/mirage/config.js
+++ b/ui/mirage/config.js
@@ -290,29 +290,58 @@ export default function (config) {
               });
             }
 
+            // The jobs/statuses cursor is "<ModifyIndex>.<namespace>.<id>",
+            // compared numerically on the index then lexically on namespace and
+            // id (matching the server's ModifyIndexAndNamespaceIDTokenizer).
+            const tokenOf = (job) =>
+              `${job.ModifyIndex}.${job.NamespaceID || 'default'}.${job.ID}`;
+            const parseTok = (t) => {
+              const s = String(t);
+              const i = s.indexOf('.');
+              if (i < 0) return { idx: parseInt(s, 10) || 0, ns: '', id: '' };
+              const rest = s.slice(i + 1);
+              const j = rest.indexOf('.');
+              return {
+                idx: parseInt(s.slice(0, i), 10) || 0,
+                ns: j < 0 ? rest : rest.slice(0, j),
+                id: j < 0 ? '' : rest.slice(j + 1),
+              };
+            };
+            const cmpTok = (at, bt) => {
+              const a = parseTok(at);
+              const b = parseTok(bt);
+              if (a.idx !== b.idx) return a.idx - b.idx;
+              if (a.ns !== b.ns) return a.ns < b.ns ? -1 : 1;
+              if (a.id !== b.id) return a.id < b.id ? -1 : 1;
+              return 0;
+            };
+
             let sortedJson = filteredJson
               .sort((a, b) =>
                 reverse
-                  ? a.ModifyIndex - b.ModifyIndex
-                  : b.ModifyIndex - a.ModifyIndex,
+                  ? cmpTok(tokenOf(a), tokenOf(b))
+                  : cmpTok(tokenOf(b), tokenOf(a)),
               )
               .filter((job) => {
                 if (namespace === '*') return true;
                 return namespace === 'default'
                   ? !job.NamespaceID || job.NamespaceID === 'default'
                   : job.NamespaceID === namespace;
-              })
-              .map((job) => filterKeys(job, 'TaskGroups', 'NamespaceID'));
+              });
             if (nextToken) {
               sortedJson = sortedJson.filter((job) =>
                 reverse
-                  ? job.ModifyIndex >= nextToken
-                  : job.ModifyIndex <= nextToken,
+                  ? cmpTok(tokenOf(job), nextToken) >= 0
+                  : cmpTok(tokenOf(job), nextToken) <= 0,
               );
             }
+            sortedJson = sortedJson.map((job) => ({
+              ...filterKeys(job, 'TaskGroups', 'NamespaceID'),
+              _cursor: tokenOf(job),
+            }));
             return sortedJson;
           },
-          { pagination: true, tokenProperty: 'ModifyIndex' },
+          { pagination: true, tokenProperty: '_cursor' },
         ),
       );
 

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -1036,6 +1036,338 @@ module('Acceptance | jobs list', function (hooks) {
 
         localStorage.removeItem('nomadPageSize');
       });
+      test('jobs that share a modify index paginate without duplicates or gaps', async function (assert) {
+        // Regression test for the ModifyIndex-only pagination cursor: several
+        // jobs can share a ModifyIndex, and the cursor must still reach each of
+        // them exactly once instead of repeating a page or stranding jobs.
+        const pageSize = 5;
+        const total = 12; // more than two pages, all sharing one modify index
+        localStorage.setItem('nomadPageSize', pageSize.toString());
+        for (let i = 0; i < total; i++) {
+          const id = `shared-${String(i).padStart(2, '0')}`;
+          this.server.create('job', {
+            id,
+            name: id,
+            namespaceId: 'default',
+            modifyIndex: 1000, // identical across all of them
+            createAllocations: false,
+            shallow: true,
+          });
+        }
+
+        await JobsList.visit();
+
+        // Walk forward to the end, collecting every job we see on each page.
+        const seen = [];
+        for (let guard = 0; guard <= total; guard++) {
+          for (let i = 0; i < JobsList.jobs.length; i++) {
+            seen.push(JobsList.jobs.objectAt(i).name);
+          }
+          const next = document.querySelector('[data-test-pager="next"]');
+          if (!next || next.disabled) {
+            break;
+          }
+          await click('[data-test-pager="next"]');
+        }
+
+        const unique = new Set(seen);
+        assert.strictEqual(
+          seen.length,
+          unique.size,
+          'no job was shown on more than one page',
+        );
+        assert.strictEqual(
+          unique.size,
+          total,
+          'every job sharing the modify index was reachable',
+        );
+        localStorage.removeItem('nomadPageSize');
+      });
+
+      test('cursorAt is a string or undefined, never null, while paging', async function (assert) {
+        // cursorAt must always be a string or undefined, never null: undefined
+        // is omitted from the query string, null is not.
+        const pageSize = 5;
+        const total = 12; // three pages: 5, 5, 2
+        localStorage.setItem('nomadPageSize', pageSize.toString());
+        createJobs(this.server, total);
+
+        await JobsList.visit();
+
+        const controller = this.owner.lookup('controller:jobs.index');
+
+        assert.strictEqual(
+          controller.cursorAt,
+          undefined,
+          'cursorAt is undefined on the first page',
+        );
+
+        await click('[data-test-pager="next"]');
+        assert.strictEqual(
+          typeof controller.cursorAt,
+          'string',
+          'cursorAt is a string after paging forward',
+        );
+
+        await click('[data-test-pager="previous"]');
+        assert.strictEqual(
+          controller.cursorAt,
+          undefined,
+          'cursorAt is undefined (not null) back on the first page',
+        );
+
+        localStorage.removeItem('nomadPageSize');
+      });
+
+      test('Previous from the last page navigates to the penultimate page', async function (assert) {
+        // Jumping to the last page and clicking Previous should land on the
+        // penultimate page, not on a previously-visited page.
+        const pageSize = 5;
+        const total = 15; // three full pages: [15..11], [10..6], [5..1]
+        localStorage.setItem('nomadPageSize', pageSize.toString());
+        createJobs(this.server, total);
+
+        await JobsList.visit();
+        const modifyIndexes = () =>
+          Array.from(document.querySelectorAll('.job-row')).map((row) =>
+            parseInt(row.getAttribute('data-test-modify-index')),
+          );
+
+        await click('[data-test-pager="last"]');
+        assert.deepEqual(
+          modifyIndexes(),
+          [5, 4, 3, 2, 1],
+          'last page shows the oldest jobs',
+        );
+
+        await click('[data-test-pager="previous"]');
+        assert.deepEqual(
+          modifyIndexes(),
+          [10, 9, 8, 7, 6],
+          'previous goes to the penultimate page, not back to the first',
+        );
+
+        localStorage.removeItem('nomadPageSize');
+      });
+
+      test('paging backward from the last page reaches every page without duplicates or gaps', async function (assert) {
+        // Starting from the last page and clicking Previous repeatedly should
+        // visit every job exactly once and stop at the first page.
+        const pageSize = 5;
+        const total = 15;
+        localStorage.setItem('nomadPageSize', pageSize.toString());
+        createJobs(this.server, total);
+
+        await JobsList.visit();
+        const modifyIndexes = () =>
+          Array.from(document.querySelectorAll('.job-row')).map((row) =>
+            parseInt(row.getAttribute('data-test-modify-index')),
+          );
+
+        await click('[data-test-pager="last"]');
+
+        const seen = [];
+        for (let guard = 0; guard <= total; guard++) {
+          seen.push(...modifyIndexes());
+          const prev = document.querySelector('[data-test-pager="previous"]');
+          if (!prev || prev.disabled) {
+            break;
+          }
+          await click('[data-test-pager="previous"]');
+        }
+
+        const unique = new Set(seen);
+        assert.strictEqual(
+          seen.length,
+          unique.size,
+          'no job was shown on more than one page while paging backward',
+        );
+        assert.strictEqual(
+          unique.size,
+          total,
+          'every job was reachable paging backward from the last page',
+        );
+
+        localStorage.removeItem('nomadPageSize');
+      });
+
+      test('paging backward through jobs that share a modify index has no duplicates or gaps', async function (assert) {
+        // Backward counterpart to the forward shared-modify-index test: when
+        // jobs share a modify index the previous-page cursor must respect the
+        // namespace/id tiebreak, or paging back repeats or strands jobs.
+        const pageSize = 5;
+        const total = 15;
+        localStorage.setItem('nomadPageSize', pageSize.toString());
+        for (let i = 0; i < total; i++) {
+          const id = `shared-${String(i).padStart(2, '0')}`;
+          this.server.create('job', {
+            id,
+            name: id,
+            namespaceId: 'default',
+            modifyIndex: 1000, // identical across all of them
+            createAllocations: false,
+            shallow: true,
+          });
+        }
+
+        await JobsList.visit();
+        await click('[data-test-pager="last"]');
+
+        const seen = [];
+        for (let guard = 0; guard <= total; guard++) {
+          for (let i = 0; i < JobsList.jobs.length; i++) {
+            seen.push(JobsList.jobs.objectAt(i).name);
+          }
+          const prev = document.querySelector('[data-test-pager="previous"]');
+          if (!prev || prev.disabled) {
+            break;
+          }
+          await click('[data-test-pager="previous"]');
+        }
+
+        const unique = new Set(seen);
+        assert.strictEqual(
+          seen.length,
+          unique.size,
+          'no job was shown on more than one page while paging backward',
+        );
+        assert.strictEqual(
+          unique.size,
+          total,
+          'every job sharing the modify index was reachable paging backward',
+        );
+
+        localStorage.removeItem('nomadPageSize');
+      });
+
+      test('next, previous, and first page without constructing a token (opaque cursor for older-server compatibility)', async function (assert) {
+        // The UI must page using only tokens the server minted, never one it
+        // builds itself. A server from before the "<index>.<namespace>.<id>"
+        // cursor cannot parse a constructed token and returns no jobs, so a UI
+        // running against an older server (e.g. mid rolling-upgrade) has to stay
+        // token-agnostic. cursorFor is the only place the UI builds a token, so
+        // next/previous/first must never call it; only "last" (which has no
+        // prior token to reuse) may.
+        const pageSize = 5;
+        const total = 15; // three aligned pages: [15..11], [10..6], [5..1]
+        localStorage.setItem('nomadPageSize', pageSize.toString());
+        createJobs(this.server, total);
+
+        await JobsList.visit();
+
+        const controller = this.owner.lookup('controller:jobs.index');
+        let constructed = 0;
+        const originalCursorFor = controller.cursorFor;
+        controller.cursorFor = function (...args) {
+          constructed++;
+          return originalCursorFor.apply(this, args);
+        };
+
+        const modifyIndexes = () =>
+          Array.from(document.querySelectorAll('.job-row')).map((row) =>
+            parseInt(row.getAttribute('data-test-modify-index')),
+          );
+
+        await click('[data-test-pager="next"]');
+        assert.deepEqual(
+          modifyIndexes(),
+          [10, 9, 8, 7, 6],
+          'next advances a page',
+        );
+
+        await click('[data-test-pager="next"]');
+        assert.deepEqual(
+          modifyIndexes(),
+          [5, 4, 3, 2, 1],
+          'next reaches the last page',
+        );
+
+        await click('[data-test-pager="previous"]');
+        assert.deepEqual(
+          modifyIndexes(),
+          [10, 9, 8, 7, 6],
+          'previous returns to the middle page',
+        );
+
+        await click('[data-test-pager="first"]');
+        assert.deepEqual(
+          modifyIndexes(),
+          [15, 14, 13, 12, 11],
+          'first returns to the first page',
+        );
+
+        assert.strictEqual(
+          constructed,
+          0,
+          'next/previous/first paged without ever constructing a token',
+        );
+
+        // "last" has no prior token to reuse and is the one path that still
+        // constructs a cursor; confirm it does, so the boundary is intentional
+        // and this test fails if that ever silently changes.
+        await click('[data-test-pager="last"]');
+        assert.deepEqual(
+          modifyIndexes(),
+          [5, 4, 3, 2, 1],
+          'last jumps to the final page',
+        );
+        assert.ok(
+          constructed > 0,
+          'last constructs a token (the documented older-server gap)',
+        );
+
+        controller.cursorFor = originalCursorFor;
+        localStorage.removeItem('nomadPageSize');
+      });
+
+      test('changing the page size resets to the first page', async function (assert) {
+        // Page boundaries depend on page size, so the stacked tokens are stale
+        // once it changes; the controller must reset to the first page instead
+        // of paging from a cursor that no longer lines up.
+        const pageSize = 5;
+        const total = 15;
+        localStorage.setItem('nomadPageSize', pageSize.toString());
+        createJobs(this.server, total);
+
+        await JobsList.visit();
+        const controller = this.owner.lookup('controller:jobs.index');
+        const modifyIndexes = () =>
+          Array.from(document.querySelectorAll('.job-row')).map((row) =>
+            parseInt(row.getAttribute('data-test-modify-index')),
+          );
+
+        await click('[data-test-pager="next"]');
+        assert.strictEqual(
+          typeof controller.cursorAt,
+          'string',
+          'on a later page the cursor is set',
+        );
+        assert.ok(
+          controller.previousTokens.length > 0,
+          'and the token history is populated',
+        );
+
+        controller.handlePageSizeChange(10);
+        await settled();
+
+        assert.strictEqual(
+          controller.cursorAt,
+          undefined,
+          'changing page size drops the cursor',
+        );
+        assert.strictEqual(
+          controller.previousTokens.length,
+          0,
+          'and clears the token history',
+        );
+        assert.deepEqual(
+          modifyIndexes(),
+          [15, 14, 13, 12, 11, 10, 9, 8, 7, 6],
+          'the first page is shown at the new page size',
+        );
+
+        localStorage.removeItem('nomadPageSize');
+      });
     });
     module('Live updates are reflected in the list', function () {
       test('When you have live updates enabled, the list updates when new jobs are created', async function (assert) {

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -1281,28 +1281,19 @@ module('Acceptance | jobs list', function (hooks) {
         localStorage.removeItem('nomadPageSize');
       });
 
-      test('next, previous, and first page without constructing a token (opaque cursor for older-server compatibility)', async function (assert) {
-        // The UI must page using only tokens the server minted, never one it
-        // builds itself. A server from before the "<index>.<namespace>.<id>"
-        // cursor cannot parse a constructed token and returns no jobs, so a UI
-        // running against an older server (e.g. mid rolling-upgrade) has to stay
-        // token-agnostic. cursorFor is the only place the UI builds a token, so
-        // next/previous/first must never call it; only "last" (which has no
-        // prior token to reuse) may.
+      test('next, previous, first, and last all page with server-minted cursors', async function (assert) {
+        // The UI pages using only tokens the server minted, never one it builds
+        // itself. "last" reverse-walks for one fewer than a page so the server's
+        // nextToken lands on the final page's start, so even that jump reuses a
+        // minted token. Staying token-agnostic is what lets the list page against
+        // an older backend (e.g. mid rolling-upgrade) that mints a legacy token
+        // format the UI would otherwise have to know how to build.
         const pageSize = 5;
         const total = 15; // three aligned pages: [15..11], [10..6], [5..1]
         localStorage.setItem('nomadPageSize', pageSize.toString());
         createJobs(this.server, total);
 
         await JobsList.visit();
-
-        const controller = this.owner.lookup('controller:jobs.index');
-        let constructed = 0;
-        const originalCursorFor = controller.cursorFor;
-        controller.cursorFor = function (...args) {
-          constructed++;
-          return originalCursorFor.apply(this, args);
-        };
 
         const modifyIndexes = () =>
           Array.from(document.querySelectorAll('.job-row')).map((row) =>
@@ -1337,27 +1328,13 @@ module('Acceptance | jobs list', function (hooks) {
           'first returns to the first page',
         );
 
-        assert.strictEqual(
-          constructed,
-          0,
-          'next/previous/first paged without ever constructing a token',
-        );
-
-        // "last" has no prior token to reuse and is the one path that still
-        // constructs a cursor; confirm it does, so the boundary is intentional
-        // and this test fails if that ever silently changes.
         await click('[data-test-pager="last"]');
         assert.deepEqual(
           modifyIndexes(),
           [5, 4, 3, 2, 1],
           'last jumps to the final page',
         );
-        assert.ok(
-          constructed > 0,
-          'last constructs a token (the documented older-server gap)',
-        );
 
-        controller.cursorFor = originalCursorFor;
         localStorage.removeItem('nomadPageSize');
       });
 
@@ -1435,30 +1412,73 @@ module('Acceptance | jobs list', function (hooks) {
           .dom('[data-test-pager="first"]')
           .isNotDisabled('first is enabled: this is not the first page');
 
-        const controller = this.owner.lookup('controller:jobs.index');
-        let constructed = 0;
-        const originalCursorFor = controller.cursorFor;
-        controller.cursorFor = function (...args) {
-          constructed++;
-          return originalCursorFor.apply(this, args);
-        };
-
         await click('[data-test-pager="previous"]');
         assert.deepEqual(
           modifyIndexes(),
           [15, 14, 13, 12, 11],
           'previous from a cold cursor pages back to the first page',
         );
-        assert.strictEqual(
-          constructed,
-          0,
-          'previous from a cold cursor never constructs a token',
-        );
         assert
           .dom('[data-test-pager="previous"]')
           .isDisabled('previous is disabled once back on the first page');
 
-        controller.cursorFor = originalCursorFor;
+        localStorage.removeItem('nomadPageSize');
+      });
+
+      test('paging backward and to the last page keeps the active filter applied', async function (assert) {
+        // prev and last page via the reverse query, which must carry the same
+        // filter as the forward query. Without it, paging back or jumping to
+        // last would page over the unfiltered set and surface jobs the filter
+        // excludes. Interleave two types so an unfiltered reverse query would
+        // return different rows than a filtered one.
+        const pageSize = 5;
+        localStorage.setItem('nomadPageSize', pageSize.toString());
+        for (let i = 1; i <= 15; i++) {
+          this.server.create('job', {
+            namespaceId: 'default',
+            type: i % 2 === 1 ? 'service' : 'batch',
+            modifyIndex: i,
+            createAllocations: false,
+            shallow: true,
+          });
+        }
+
+        // Eight service jobs (odd modify indexes) split into [15,13,11,9,7] and
+        // [5,3,1]; the interleaved batch jobs must never appear.
+        await JobsList.visit({ filter: 'Type == service' });
+
+        const modifyIndexes = () =>
+          Array.from(document.querySelectorAll('.job-row')).map((row) =>
+            parseInt(row.getAttribute('data-test-modify-index')),
+          );
+
+        assert.deepEqual(
+          modifyIndexes(),
+          [15, 13, 11, 9, 7],
+          'first page shows only filtered jobs',
+        );
+
+        await click('[data-test-pager="next"]');
+        assert.deepEqual(
+          modifyIndexes(),
+          [5, 3, 1],
+          'next stays within the filtered set',
+        );
+
+        await click('[data-test-pager="previous"]');
+        assert.deepEqual(
+          modifyIndexes(),
+          [15, 13, 11, 9, 7],
+          'previous pages back over the filtered set, not the full list',
+        );
+
+        await click('[data-test-pager="last"]');
+        assert.deepEqual(
+          modifyIndexes(),
+          [9, 7, 5, 3, 1],
+          'last jumps to the final filtered page, not the full list',
+        );
+
         localStorage.removeItem('nomadPageSize');
       });
     });

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -850,6 +850,39 @@ module('Acceptance | jobs list', function (hooks) {
         assert.dom('[data-test-pager="last"]').isDisabled();
         localStorage.removeItem('nomadPageSize');
       });
+      test('paging back onto the first page disables first and previous', async function (assert) {
+        // Paging prev lands on a server-minted cursor rather than an empty one,
+        // so the first page reached by paging back must still recognize it is
+        // the first page and disable first/previous, not leave them enabled for
+        // a dead click that just re-renders the same page.
+        const pageSize = 5;
+        const total = 15; // three pages: [15..11], [10..6], [5..1]
+        localStorage.setItem('nomadPageSize', pageSize.toString());
+        createJobs(this.server, total);
+
+        await JobsList.visit();
+        const modifyIndexes = () =>
+          Array.from(document.querySelectorAll('.job-row')).map((row) =>
+            parseInt(row.getAttribute('data-test-modify-index')),
+          );
+
+        await click('[data-test-pager="next"]');
+        await click('[data-test-pager="previous"]');
+
+        assert.deepEqual(
+          modifyIndexes(),
+          [15, 14, 13, 12, 11],
+          'previous returns to the first page',
+        );
+        assert
+          .dom('[data-test-pager="previous"]')
+          .isDisabled('previous is disabled back on the first page');
+        assert
+          .dom('[data-test-pager="first"]')
+          .isDisabled('first is disabled back on the first page');
+
+        localStorage.removeItem('nomadPageSize');
+      });
     });
     module('Jobs are appropriately sorted by modify index', function () {
       test('on a single long page', async function (assert) {
@@ -1109,11 +1142,19 @@ module('Acceptance | jobs list', function (hooks) {
           'cursorAt is a string after paging forward',
         );
 
+        // Paging back onto the first page lands on the server-minted token for
+        // that page rather than undefined; either is fine, but it must not be
+        // null, which (unlike undefined) is not omitted from the query string.
         await click('[data-test-pager="previous"]');
-        assert.strictEqual(
+        assert.notStrictEqual(
           controller.cursorAt,
-          undefined,
-          'cursorAt is undefined (not null) back on the first page',
+          null,
+          'cursorAt is never null back on the first page',
+        );
+        assert.ok(
+          controller.cursorAt === undefined ||
+            typeof controller.cursorAt === 'string',
+          'cursorAt is a string or undefined back on the first page',
         );
 
         localStorage.removeItem('nomadPageSize');
@@ -1321,7 +1362,7 @@ module('Acceptance | jobs list', function (hooks) {
       });
 
       test('changing the page size resets to the first page', async function (assert) {
-        // Page boundaries depend on page size, so the stacked tokens are stale
+        // Page boundaries depend on page size, so the current cursor is stale
         // once it changes; the controller must reset to the first page instead
         // of paging from a cursor that no longer lines up.
         const pageSize = 5;
@@ -1342,10 +1383,6 @@ module('Acceptance | jobs list', function (hooks) {
           'string',
           'on a later page the cursor is set',
         );
-        assert.ok(
-          controller.previousTokens.length > 0,
-          'and the token history is populated',
-        );
 
         controller.handlePageSizeChange(10);
         await settled();
@@ -1355,17 +1392,73 @@ module('Acceptance | jobs list', function (hooks) {
           undefined,
           'changing page size drops the cursor',
         );
-        assert.strictEqual(
-          controller.previousTokens.length,
-          0,
-          'and clears the token history',
-        );
         assert.deepEqual(
           modifyIndexes(),
           [15, 14, 13, 12, 11, 10, 9, 8, 7, 6],
           'the first page is shown at the new page size',
         );
 
+        localStorage.removeItem('nomadPageSize');
+      });
+
+      test('cold-loading a shared or refreshed URL past the first page renders it and pages correctly', async function (assert) {
+        // A deep-linked/shared URL or a refresh lands on a page with only a
+        // server-minted cursor and no in-memory history. The page must render,
+        // its first/previous buttons must reflect that it is not the first page,
+        // and previous must page back using a server-minted token (never a
+        // constructed one), exactly as gulducat's older-server case requires.
+        const pageSize = 5;
+        const total = 15; // three pages: [15..11], [10..6], [5..1]
+        localStorage.setItem('nomadPageSize', pageSize.toString());
+        createJobs(this.server, total);
+
+        // Build the second page's start token the way the server mints it,
+        // "<modifyIndex>.<namespace>.<id>", then open it cold.
+        const boundary = this.server.db.jobs.findBy({ modifyIndex: 10 });
+        const cursorAt = `10.default.${boundary.id}`;
+        await JobsList.visit({ cursorAt });
+
+        const modifyIndexes = () =>
+          Array.from(document.querySelectorAll('.job-row')).map((row) =>
+            parseInt(row.getAttribute('data-test-modify-index')),
+          );
+
+        assert.deepEqual(
+          modifyIndexes(),
+          [10, 9, 8, 7, 6],
+          'the shared cursor renders its page on cold load',
+        );
+        assert
+          .dom('[data-test-pager="previous"]')
+          .isNotDisabled('previous is enabled: this is not the first page');
+        assert
+          .dom('[data-test-pager="first"]')
+          .isNotDisabled('first is enabled: this is not the first page');
+
+        const controller = this.owner.lookup('controller:jobs.index');
+        let constructed = 0;
+        const originalCursorFor = controller.cursorFor;
+        controller.cursorFor = function (...args) {
+          constructed++;
+          return originalCursorFor.apply(this, args);
+        };
+
+        await click('[data-test-pager="previous"]');
+        assert.deepEqual(
+          modifyIndexes(),
+          [15, 14, 13, 12, 11],
+          'previous from a cold cursor pages back to the first page',
+        );
+        assert.strictEqual(
+          constructed,
+          0,
+          'previous from a cold cursor never constructs a token',
+        );
+        assert
+          .dom('[data-test-pager="previous"]')
+          .isDisabled('previous is disabled once back on the first page');
+
+        controller.cursorFor = originalCursorFor;
         localStorage.removeItem('nomadPageSize');
       });
     });


### PR DESCRIPTION
## What

`/v1/jobs/statuses` (which backs the **UI jobs page**) paginates with a `next_token` cursor built from each job's `ModifyIndex` alone. That only worked while `ModifyIndex` was unique per job. #28158 made the jobs `modify_index` index non-unique - several jobs can legitimately share a `ModifyIndex` when written in one Raft transaction - and once that's true, a `ModifyIndex`-only cursor no longer identifies a single position in the list.

This is the narrow fix for that: give the cursor a tiebreaker so it points at exactly one job - `ModifyIndex` + `Namespace` + `ID`, compared numerically on the index, then by namespace, then by id. That matches the order the state store actually walks the non-unique `modify_index` index (which breaks ties on the `(Namespace, ID)` primary key), so paging lines up with the data.

Relates to #28167.

## Symptoms fixed

With jobs sharing a `ModifyIndex` and pagination on (e.g. 30 jobs, `per_page=25`):

- **Duplicate rows** - jobs at a page boundary come back again on the next page.
- **Stall / unreachable jobs** - if a shared-`ModifyIndex` group is larger than `per_page`, the cursor never advances past it; the same page repeats and older jobs become unreachable.
- **Broken "Last" page** - "jump to last" landed on the wrong boundary inside a tied group, dropping the very oldest jobs and pulling in newer ones.
- **Ghost page after "Last"** - because "Last" wasn't actually last, **Next** stayed enabled and revealed a few more (already-/never-shown) jobs past it.

All four share one root cause and are fixed by the single tokenizer change.

## Reproduction

Same Docker A/B harness as #28132/#28158 (1 server + 1 client, no Consul). Jobs are forced to share a `ModifyIndex` by giving every alloc the same absolute exit epoch, so their status writes coalesce into one Raft transaction:
https://github.com/afreidah/nomad/tree/repro-jobs-statuses-28132/repro-28132

Walking `/v1/jobs/statuses` with a small `per_page` over jobs that share a `ModifyIndex`, before the fix:

```
page  1:  6 job(s)   next_token=77
page  2:  6 job(s)   next_token=76
page  3:  6 job(s)   next_token=76   <- same token it was given; repeats forever
duplicated:      j03 j04 j05 j20
never returned:  j09 j10 j11 j12 j13 j14
```

After the fix the same walk returns every job exactly once and terminates.

## Compatibility

Bare-integer tokens minted by older clients/servers are still accepted - a token that doesn't carry the namespace/id segments falls back to the previous index-only comparison - so rolling upgrades keep working.

## Changes

- `nomad/state/paginator/tokenizer.go` - replace `ModifyIndexTokenizer` with `ModifyIndexAndNamespaceIDTokenizer` (the statuses endpoint was its only caller).
- `nomad/job_endpoint_statuses.go` - use the new tokenizer.
- `ui/` - treat the pagination token as opaque (no more arithmetic on it); forward/back use a short token history, only "jump to last" derives a cursor. Mirage mock updated to the new token format.

## Testing

- **Go:** `TestJob_Statuses_Pagination_SharedModifyIndex` pages a set of jobs that all share a `ModifyIndex` and asserts every job is returned exactly once and the walk terminates; tokenizer unit tests cover numeric index ordering, the namespace/id tiebreaker, and the legacy bare-integer fallback.
- **UI:** a new acceptance test exercises the same through the jobs page; full UI suite passes.
- **Manual:** reproduced and verified before/after against live 1-server/1-client clusters (UI + API), including the "Last" and Next-after-Last cases above.

## Scope question

I kept this PR deliberately narrow - just the `ModifyIndex` cursor tiebreaker. While investigating I found a related, separate pagination bug in `NamespaceIDTokenizer` (two namespaces like `team` and `team-a` can stall/duplicate), and there's an open question in #28167 about whether the four tokenizers in this file should be consolidated onto a shared helper. I'm happy to either keep this narrow and track the namespace bug + refactor separately, or expand scope - whatever you'd prefer. Flagging here so the decision is visible rather than baked in.

## AI usage

The investigation, the reproduction harness, the design, and the verification are mine: I reproduced all the symptoms on live clusters, ran the before/after A/B by hand (API walks and clicking through both UIs), and confirmed the results. The Go changes (the tokenizer tiebreaker and its tests) are my own work.

For the UI portion I did utilize an AI assistant for implementation help with the JavaScript - I almost never write JavaScript and generally try to avoid it so I always have to look up syntax and libraries, and best practices although this wasn't that involved and I could mostly crib off of the surrounding code/style, so I utilized a bit of claude for the `ui/` pagination changes (opaque token + token history), while making sure it followed the prescribed design and fit in with the style of the existing code. I reviewed and understand those changes and reviewed every line of any suggestion I took from it and I stand behind the whole PR that has come out of analysis and testing the last couple days; I just want to be transparent about where the assistance was used. So please pay extra close attention to the JavaScript code because unlike Go I'm not working with JavaScript every day and am more likely to have made subtle mistakes there.
