### PR TITLE
Add visibility to oversubscription fail

### DIFF
--- a/e2e/oversubscription/oversubscription_test.go
+++ b/e2e/oversubscription/oversubscription_test.go
@@ -37,20 +37,42 @@ func TestOversubscription(t *testing.T) {
 	// enable memory oversubscription for these tests
 	enableMemoryOversubscription(t)
 
-	t.Run("testDocker", testDocker)
-	t.Run("testExec", testExec)
-	t.Run("testRawExec", testRawExec)
-	t.Run("testRawExecMax", testRawExecMax)
+	runWithSchedulerConfigLog(t, "testDocker", testDocker)
+	runWithSchedulerConfigLog(t, "testExec", testExec)
+	runWithSchedulerConfigLog(t, "testRawExec", testRawExec)
+	runWithSchedulerConfigLog(t, "testRawExecMax", testRawExecMax)
+}
+
+func runWithSchedulerConfigLog(t *testing.T, name string, testFn func(t *testing.T)) {
+	t.Run(name, func(t *testing.T) {
+		schedulerConfig := getSchedulerConfiguration(t)
+		t.Logf("scheduler MemoryOversubscriptionEnabled before %s: %t", name, schedulerConfig.MemoryOversubscriptionEnabled)
+		testFn(t)
+	})
 }
 
 func testDocker(t *testing.T) {
+	waitForMemoryOversubscriptionEnabled(t)
+
 	job, jobCleanup := jobs3.Submit(t, "./input/docker.hcl")
 	t.Cleanup(jobCleanup)
 
-	// job will cat /sys/fs/cgroup/memory.max which should be
-	// set to the 30 megabyte memory_max value
-	logs := job.TaskLogs("group", "task")
-	must.StrContains(t, logs.Stdout, "31457280")
+	testFunc := func() error {
+		// job will cat /sys/fs/cgroup/memory.max which should be
+		// set to the 30 megabyte memory_max value
+		expect := "31457280"
+		logs := job.TaskLogs("group", "task")
+		if !strings.Contains(logs.Stdout, expect) {
+			return fmt.Errorf("expect '%s' in stdout, got: '%s'\n%s", expect, logs.Stdout, oversubscriptionDebugInfo(t, job.JobID()))
+		}
+		return nil
+	}
+
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(testFunc),
+		wait.Timeout(time.Second*60),
+		wait.Gap(time.Second*2),
+	))
 }
 
 func testExec(t *testing.T) {
@@ -124,8 +146,14 @@ func enableMemoryOversubscription(t *testing.T) {
 	schedulerConfig := getSchedulerConfiguration(t)
 	schedulerConfig.MemoryOversubscriptionEnabled = true
 	operatorAPI := e2eutil.NomadClient(t).Operator()
-	_, _, err := operatorAPI.SchedulerCASConfiguration(schedulerConfig, nil)
+	casResp, _, err := operatorAPI.SchedulerCASConfiguration(schedulerConfig, nil)
 	must.NoError(t, err)
+
+	if !casResp.Updated {
+		current := getSchedulerConfiguration(t)
+		must.True(t, current.MemoryOversubscriptionEnabled,
+			must.Sprint("SchedulerCASConfiguration was not updated and memory oversubscription remains disabled"))
+	}
 
 	waitForMemoryOversubscriptionEnabled(t)
 }
@@ -168,32 +196,6 @@ func getSchedulerConfiguration(t *testing.T) *api.SchedulerConfiguration {
 }
 
 func oversubscriptionDebugInfo(t *testing.T, jobID string) string {
-	nomadClient := e2eutil.NomadClient(t)
-
 	global := getSchedulerConfiguration(t)
-	globalEnabled := global.MemoryOversubscriptionEnabled
-
-	nodePoolName := api.NodePoolDefault
-	job, _, err := nomadClient.Jobs().Info(jobID, nil)
-	if err != nil {
-		return fmt.Sprintf("oversub-debug: failed job info for %q: %v (global_enabled=%t)", jobID, err, globalEnabled)
-	}
-	if job != nil && job.NodePool != nil && *job.NodePool != "" {
-		nodePoolName = *job.NodePool
-	}
-
-	pool, _, err := nomadClient.NodePools().Info(nodePoolName, nil)
-	if err != nil {
-		return fmt.Sprintf("oversub-debug: job_id=%s node_pool=%s global_enabled=%t pool_read_error=%v", jobID, nodePoolName, globalEnabled, err)
-	}
-
-	poolOverride := "unset"
-	effectiveEnabled := globalEnabled
-	if pool != nil && pool.SchedulerConfiguration != nil && pool.SchedulerConfiguration.MemoryOversubscriptionEnabled != nil {
-		override := *pool.SchedulerConfiguration.MemoryOversubscriptionEnabled
-		poolOverride = fmt.Sprintf("%t", override)
-		effectiveEnabled = override
-	}
-
-	return fmt.Sprintf("oversub-debug: job_id=%s node_pool=%s global_enabled=%t pool_override=%s effective_enabled=%t", jobID, nodePoolName, globalEnabled, poolOverride, effectiveEnabled)
+	return fmt.Sprintf("oversub-debug: job_id=%s global_memory_oversubscription_enabled=%t", jobID, global.MemoryOversubscriptionEnabled)
 }

--- a/e2e/oversubscription/oversubscription_test.go
+++ b/e2e/oversubscription/oversubscription_test.go
@@ -86,21 +86,26 @@ func testRawExec(t *testing.T) {
 }
 
 func testRawExecMax(t *testing.T) {
+	waitForMemoryOversubscriptionEnabled(t)
+
 	job, cleanup := jobs3.Submit(t, "./input/rawexecmax.hcl")
 	t.Cleanup(cleanup)
 
 	testFunc := func() error {
 		logs := job.TaskLogs("group", "cat")
+
 		logsRe := regexp.MustCompile(`67108864\s+max`)
 		if !logsRe.MatchString(logs.Stdout) {
-			return fmt.Errorf("expect '%s' in stdout, got: '%s'", logsRe.String(), logs.Stdout)
+			return fmt.Errorf("expect '%s' in stdout, got: '%s'\n%s", logsRe.String(), logs.Stdout, oversubscriptionDebugInfo(t, job.JobID()))
 		}
 		return nil
 	}
 
+	// wait for poststart to run, up to 60 seconds.
+	// this accounts for variability in exec task start time.
 	must.Wait(t, wait.InitialSuccess(
 		wait.ErrorFunc(testFunc),
-		wait.Timeout(time.Second*20),
+		wait.Timeout(time.Second*60),
 		wait.Gap(time.Second*2),
 	))
 }
@@ -121,6 +126,38 @@ func enableMemoryOversubscription(t *testing.T) {
 	operatorAPI := e2eutil.NomadClient(t).Operator()
 	_, _, err := operatorAPI.SchedulerCASConfiguration(schedulerConfig, nil)
 	must.NoError(t, err)
+
+	waitForMemoryOversubscriptionEnabled(t)
+}
+
+func waitForMemoryOversubscriptionEnabled(t *testing.T) {
+	testFunc := func() error {
+		nodePool := api.NodePoolDefault
+		schedulerConfig := getSchedulerConfiguration(t)
+		if !schedulerConfig.MemoryOversubscriptionEnabled {
+			return fmt.Errorf("memory oversubscription expected enabled but was disabled")
+		}
+
+		nomadClient := e2eutil.NomadClient(t)
+		pool, _, err := nomadClient.NodePools().Info(nodePool, nil)
+		if err != nil {
+			return fmt.Errorf("failed reading node pool %q: %w", nodePool, err)
+		}
+
+		if pool.SchedulerConfiguration != nil &&
+			pool.SchedulerConfiguration.MemoryOversubscriptionEnabled != nil &&
+			!*pool.SchedulerConfiguration.MemoryOversubscriptionEnabled {
+			return fmt.Errorf("memory oversubscription disabled by node pool %q override", nodePool)
+		}
+
+		return nil
+	}
+
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(testFunc),
+		wait.Timeout(time.Second*30),
+		wait.Gap(time.Second),
+	))
 }
 
 func getSchedulerConfiguration(t *testing.T) *api.SchedulerConfiguration {
@@ -128,4 +165,35 @@ func getSchedulerConfiguration(t *testing.T) *api.SchedulerConfiguration {
 	resp, _, err := operatorAPI.SchedulerGetConfiguration(nil)
 	must.NoError(t, err)
 	return resp.SchedulerConfig
+}
+
+func oversubscriptionDebugInfo(t *testing.T, jobID string) string {
+	nomadClient := e2eutil.NomadClient(t)
+
+	global := getSchedulerConfiguration(t)
+	globalEnabled := global.MemoryOversubscriptionEnabled
+
+	nodePoolName := api.NodePoolDefault
+	job, _, err := nomadClient.Jobs().Info(jobID, nil)
+	if err != nil {
+		return fmt.Sprintf("oversub-debug: failed job info for %q: %v (global_enabled=%t)", jobID, err, globalEnabled)
+	}
+	if job != nil && job.NodePool != nil && *job.NodePool != "" {
+		nodePoolName = *job.NodePool
+	}
+
+	pool, _, err := nomadClient.NodePools().Info(nodePoolName, nil)
+	if err != nil {
+		return fmt.Sprintf("oversub-debug: job_id=%s node_pool=%s global_enabled=%t pool_read_error=%v", jobID, nodePoolName, globalEnabled, err)
+	}
+
+	poolOverride := "unset"
+	effectiveEnabled := globalEnabled
+	if pool != nil && pool.SchedulerConfiguration != nil && pool.SchedulerConfiguration.MemoryOversubscriptionEnabled != nil {
+		override := *pool.SchedulerConfiguration.MemoryOversubscriptionEnabled
+		poolOverride = fmt.Sprintf("%t", override)
+		effectiveEnabled = override
+	}
+
+	return fmt.Sprintf("oversub-debug: job_id=%s node_pool=%s global_enabled=%t pool_override=%s effective_enabled=%t", jobID, nodePoolName, globalEnabled, poolOverride, effectiveEnabled)
 }


### PR DESCRIPTION
### Description
From the error on the logs of the nightly run:

```
RUN   TestOversubscription/testRawExecMax
2026-06-25T07:20:41.8105218Z     oversubscription_test.go:89: submitting job: "./input/rawexecmax.hcl"
2026-06-25T07:21:03.3364334Z     oversubscription_test.go:101: 
2026-06-25T07:21:03.3365775Z         oversubscription_test.go:101: expected condition to pass within wait context
2026-06-25T07:21:03.3367255Z         ↪ error: wait: timeout exceeded: expect '67108864\s+max' in stdout, got: '0
2026-06-25T07:21:03.3367844Z         67108864
2026-06-25T07:21:03.3368187Z         '
2026-06-25T07:21:03.6814450Z --- FAIL: TestOversubscription/testRawExecMax (21.87s)
```

It is noticeable that the results are what would be expected if the memory oversubscription was not enabled, a hypothesis is that some other test running in parallel could be modifying the global configuration of the scheduler 
and messing up the test. This PR includes some logs that check and print the configuration of the scheduler before running each test. The fact that it is always the same test is not a good sign of a race condition but it could be a good start. 

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
