### PR TITLE
BJQ: initial state restore

### DIFF
--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -565,7 +565,7 @@ func (d *DynamicPriorityQueue) waitForPlacement(ctx context.Context, workload *W
 // isSchedulingComplete detects whether a workload was actually placed by following the
 // evaluation's BlockedEvals and NextEvals.
 // Similar to waitForPlacement, isSchedulingComplete will record usage in the event an
-// actual placement occured.
+// actual placement occurred.
 //
 // TODO see if can dedup with waitForPlacement
 func (d *DynamicPriorityQueue) isSchedulingComplete(workload *Workload) (bool, error) {

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -99,7 +99,7 @@ type Workload struct {
 	ageAdjustment   int
 	usageAdjustment int
 
-	// waitOnRestore signals that is workload was previously popped off the
+	// waitOnRestore signals this workload was previously popped off the
 	// queue and is waiting to be placed. This is detected on restore
 	// and this workload will be pushed to the front of the queue and
 	// waited on before processing regular workloads.

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -131,10 +131,12 @@ func (d *DynamicPriorityQueue) Start(ctx context.Context) error {
 	return nil
 }
 
+// SetEnabled is called during leadership transfer and initiates a state restore
+// and enabled the queue to start processing evaluations.
+//
 // TODO: When disabled, we don't actually stop the producer/consumer, so SetEnabled
 // handles restoring from state on a server restart, but leadership transfers
 // will result in duplicate usage calculations.
-//
 // The fix for this is in the batch queue manager branch which starts and stops queues
 // during leadership transfers.
 func (d *DynamicPriorityQueue) SetEnabled(enabled bool, ss *state.StateStore) {

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -29,11 +29,8 @@ type DynamicPriorityQueue struct {
 
 	// queue is the main datastructure that contains all pending workloads
 	//
-	// TODO: at the moment, this is using the go stdlib container/heap package,
-	// but we may want to switch to treeset from Hashicorp's go-set.
-	// Why? Both have O(logn) push/pop. Heap has constant time peeking, but
-	// we don't use that. We do want to iterate over workloads quickly, which
-	// we can do with a red-black tree.
+	// This is using a TreeSet from Hashicorp's go-set module due to it's
+	// ability for log(n) insert and delete and allows for Top(k) lookups
 	queue WorkloadQueue
 
 	// qMux locks the queue during concurrent access
@@ -101,6 +98,14 @@ type Workload struct {
 	sizeAdjustment  int
 	ageAdjustment   int
 	usageAdjustment int
+
+	// waitOnRestore signals that is workload was previously popped off the
+	// queue and is waiting to be placed. This is detected on restore
+	// and this workload will be pushed to the front of the queue and
+	// waited on before processing regular workloads.
+	// By doing this, we can ensure at most 1 queue workloads blocked
+	// due to resource contraints even in the event of queue restores.
+	waitOnRestore bool
 }
 
 func NewDynamicPriorityQueue(broker Broker, qconf *structs.BatchQueue, conf *structs.DynamicQueueConfig, logger hclog.Logger) *DynamicPriorityQueue {
@@ -126,10 +131,92 @@ func (d *DynamicPriorityQueue) Start(ctx context.Context) error {
 	return nil
 }
 
-func (d *DynamicPriorityQueue) SetEnabled(val bool, state *state.StateStore) {
-	// rebuild internal state from statestore, unimplemented
-	d.state = state
-	d.enabled.Store(val)
+// TODO: When disabled, we don't actually stop the producer/consumer, so SetEnabled
+// handles restoring from state on a server restart, but leadership transfers
+// will result in duplicate usage calculations.
+//
+// The fix for this is in the batch queue manager branch which starts and stops queues
+// during leadership transfers.
+func (d *DynamicPriorityQueue) SetEnabled(enabled bool, ss *state.StateStore) {
+	if !enabled {
+		d.enabled.Store(false)
+		return
+	}
+
+	// set state
+	d.state = ss
+
+	snap, err := d.state.Snapshot()
+	if err != nil {
+		d.logger.Error("failed to get state snapshot", "err", err)
+		return
+	}
+
+	if err := d.restore(snap, time.Now()); err != nil {
+		return
+	}
+
+	d.enabled.Store(true)
+}
+
+// restore scans all evaluations and restores the usage state of the queue by
+// detecting which evals were already placed by a previous server
+func (d *DynamicPriorityQueue) restore(ss *state.StateSnapshot, now time.Time) error {
+	// The DPQ needs to rebuild it's internal usage state when enabled.
+	// The actual queue will be rebuilt when establishing leadership
+	// via pending eval enqueuing
+	ws := memdb.NewWatchSet()
+	iter, err := ss.Evals(ws, state.SortDefault)
+	if err != nil {
+		d.logger.Error("failed to get evals while enabling queue", "err", err)
+		return err
+	}
+
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		eval, ok := raw.(*structs.Evaluation)
+		if !ok {
+			d.logger.Error("object from eval table not an eval")
+			continue
+		}
+
+		// Skip non batch jobs
+		if eval.Type != structs.JobTypeBatch {
+			continue
+		}
+		// If the eval was not a job register, skip it
+		if eval.TriggeredBy != structs.EvalTriggerJobRegister {
+			continue
+		}
+		// Pending evals will be enqueued later in leadership transfer
+		if eval.Status == structs.EvalStatusPending {
+			continue
+		}
+
+		w := d.generateWorkload(eval)
+
+		// generate the tenant if it doesn't exist
+		d.ensureTenant(w.tid)
+
+		// When checking for workload placements, we never want to actually block
+		// in SetEnabled, but it's also entirely possible a queue eval is blocked and
+		// waiting to be placed from a previous DPQ placement. If that happens
+		// we should allow it to be processed via the initWorkload chan.
+		placed, err := d.isSchedulingComplete(w)
+		if err != nil {
+			d.logger.Error("failed to wait for placement while enabling queue", "err", err)
+		}
+
+		if !placed {
+			// if this workload has been placed, we will push it to the queue.
+			// The queue implementation will check this and force it to the top.
+			w.waitOnRestore = true
+			d.enqueueCh <- w
+		}
+	}
+
+	d.decayUsage(now, ss)
+
+	return nil
 }
 
 // Enqueue is the method used to put evaluations on the queue.
@@ -161,7 +248,9 @@ func (d *DynamicPriorityQueue) runProducer(ctx context.Context) {
 			return
 		case w := <-d.enqueueCh:
 			d.qMux.Lock()
-			d.setWorkloadPriority(time.Now(), w)
+			// use createTime so that workloads have consistent age
+			// priority calculations after restoring from state.
+			d.setWorkloadPriority(time.Unix(0, w.eval.CreateTime), w)
 			d.queue.Push(w)
 			d.qMux.Unlock()
 
@@ -197,8 +286,11 @@ func (d *DynamicPriorityQueue) runConsumer(ctx context.Context) {
 			workload := d.queue.Pop()
 			d.qMux.Unlock()
 
-			// Give the eval to the eval broker
-			d.evalBroker.Enqueue(workload.eval)
+			// We don't need to pass the waitOnRestore workload
+			// to the eval broker, that already happened.
+			if !workload.waitOnRestore {
+				d.evalBroker.Enqueue(workload.eval)
+			}
 
 			// Wait for the eval to be placed
 			err := d.waitForPlacement(ctx, workload, memdb.NewWatchSet())
@@ -260,6 +352,7 @@ func (d *DynamicPriorityQueue) generateWorkload(e *structs.Evaluation) *Workload
 		priority:           0,
 		eval:               e,
 		requestedResources: requestedResources,
+		waitOnRestore:      false,
 	}
 }
 
@@ -291,9 +384,8 @@ func (d *DynamicPriorityQueue) calculatePriorities(now time.Time) {
 
 	// Now that we have accurate tenant usage, calculate
 	// each workloads new priority and update the queue
-	d.queue.UpdateAll(func(w *Workload) *Workload {
+	d.queue.UpdateAll(func(w *Workload) {
 		d.setWorkloadPriority(now, w)
-		return w
 	})
 }
 
@@ -441,7 +533,6 @@ func (d *DynamicPriorityQueue) waitForPlacement(ctx context.Context, workload *W
 		workload.eval = eval
 
 		if eval.TerminalStatus() {
-
 			continue
 		}
 
@@ -469,14 +560,71 @@ func (d *DynamicPriorityQueue) waitForPlacement(ctx context.Context, workload *W
 	return nil
 }
 
+// isSchedulingComplete detects whether a workload was actually placed by following the
+// evaluation's BlockedEvals and NextEvals.
+// Similar to waitForPlacement, isSchedulingComplete will record usage in the event an
+// actual placement occured.
+//
+// TODO see if can dedup with waitForPlacement
+func (d *DynamicPriorityQueue) isSchedulingComplete(workload *Workload) (bool, error) {
+	snap, err := d.state.Snapshot()
+	if err != nil {
+		return false, err
+	}
+
+	ws := memdb.NewWatchSet()
+	eval := workload.eval
+	for eval.BlockedEval != "" || eval.NextEval != "" {
+		id := eval.ID
+
+		if eval.BlockedEval != "" {
+			id = eval.BlockedEval
+		} else if eval.NextEval != "" {
+			id = eval.NextEval
+		}
+
+		eval, err = snap.EvalByID(ws, id)
+		if err != nil {
+			return false, err
+		}
+		if eval == nil {
+			return false, ErrWatchedEvalNotFound
+		}
+
+		workload.eval = eval
+
+		if !eval.TerminalStatus() {
+			return false, nil
+		}
+	}
+	if eval.Status == structs.EvalStatusComplete {
+		// If the eval is terminal and has plan annotations, something might
+		// have been placed and we should update tenant usage accordingly.
+		if eval.PlanAnnotations != nil && eval.PlanAnnotations.DesiredTGUpdates != nil {
+			d.qMux.Lock()
+			d.updateUsage(workload)
+			d.qMux.Unlock()
+
+		}
+
+		// The workload placement is complete. It may not have actually resulted in a placement,
+		// but the chain of followup evals is complete
+		return true, nil
+	}
+
+	// This would only happen if an eval was not terminal and did not
+	// yet have a followup eval
+	return false, nil
+}
+
 func (d *DynamicPriorityQueue) Jobs(namespaces map[string]bool) structs.QueueJobsResponse {
 	d.qMux.Lock()
-	sortedWorkloads := d.queue.Workloads()
+	sortedWorkloads := d.queue.Slice()
 	d.qMux.Unlock()
 
 	workloads := []structs.DynamicPriorityWorkload{}
 	for pos, w := range sortedWorkloads {
-		if (namespaces != nil) && !namespaces[w.eval.Namespace] {
+		if (namespaces != nil) && !namespaces[w.eval.Namespace] || w.waitOnRestore {
 			continue
 		}
 		workloads = append(workloads, structs.DynamicPriorityWorkload{
@@ -534,7 +682,7 @@ func (d *DynamicPriorityQueue) updateUsage(workload *Workload) {
 		}
 
 		workloadResources := workload.requestedResources
-		workloadResources.start = time.Unix(0, workload.eval.ModifyTime)
+		workloadResources.start = time.Unix(0, workload.eval.ModifyTime) // TODO we should validate this
 		tenant.totalUsage = tenant.totalUsage.Add(workloadResources.resources)
 		d.totalUsage = d.totalUsage.Add(workloadResources.resources)
 

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -554,7 +554,9 @@ func (d *DynamicPriorityQueue) waitForPlacement(ctx context.Context, workload *W
 	}
 
 	if evalHasPlacement(eval) {
+		d.qMux.Lock()
 		d.updateUsage(workload)
+		d.qMux.Unlock()
 	}
 
 	return nil
@@ -657,9 +659,6 @@ func (d *DynamicPriorityQueue) Tenants() structs.QueueTenantsResponse {
 
 // updateUsage updates the tenant and total usage for a given workload.
 func (d *DynamicPriorityQueue) updateUsage(workload *Workload) {
-	d.qMux.Lock()
-	defer d.qMux.Unlock()
-
 	tenant := d.tenants[workload.tid]
 
 	_, ok := tenant.placedWorkloadById[workload.id]

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -88,12 +88,14 @@ type UsageList struct {
 }
 
 type Workload struct {
-	id                 string
+	// id uniquely identifies this workload
+	// and is set to the evaluation ID.
+	id string
+
 	tid                TenantID
 	priority           int
 	eval               *structs.Evaluation
 	requestedResources *UsageList
-	index              int
 
 	sizeAdjustment  int
 	ageAdjustment   int
@@ -167,6 +169,9 @@ func (d *DynamicPriorityQueue) restore(ss *state.StateSnapshot, now time.Time) e
 	// The DPQ needs to rebuild it's internal usage state when enabled.
 	// The actual queue will be rebuilt when establishing leadership
 	// via pending eval enqueuing
+	d.qMux.Lock()
+	defer d.qMux.Unlock()
+
 	ws := memdb.NewWatchSet()
 	iter, err := ss.Evals(ws, state.SortDefault)
 	if err != nil {
@@ -202,15 +207,13 @@ func (d *DynamicPriorityQueue) restore(ss *state.StateSnapshot, now time.Time) e
 		// When checking for workload placements, we never want to actually block
 		// in SetEnabled, but it's also entirely possible a queue eval is blocked and
 		// waiting to be placed from a previous DPQ placement. If that happens
-		// we should allow it to be processed via the initWorkload chan.
+		// we should enqueue it and push it to the front of the queue.
 		placed, err := d.isSchedulingComplete(w)
 		if err != nil {
 			d.logger.Error("failed to wait for placement while enabling queue", "err", err)
 		}
 
 		if !placed {
-			// if this workload has been placed, we will push it to the queue.
-			// The queue implementation will check this and force it to the top.
 			w.waitOnRestore = true
 			d.enqueueCh <- w
 		}
@@ -549,14 +552,9 @@ func (d *DynamicPriorityQueue) waitForPlacement(ctx context.Context, workload *W
 			delete(ws, k)
 		}
 	}
-	if eval.Status == structs.EvalStatusComplete {
-		// If the eval is terminal and has plan annotations, something might
-		// have been placed and we should update tenant usage accordingly.
-		if eval.PlanAnnotations != nil && eval.PlanAnnotations.DesiredTGUpdates != nil {
-			d.qMux.Lock()
-			d.updateUsage(workload)
-			d.qMux.Unlock()
-		}
+
+	if evalHasPlacement(eval) {
+		d.updateUsage(workload)
 	}
 
 	return nil
@@ -566,8 +564,6 @@ func (d *DynamicPriorityQueue) waitForPlacement(ctx context.Context, workload *W
 // evaluation's BlockedEvals and NextEvals.
 // Similar to waitForPlacement, isSchedulingComplete will record usage in the event an
 // actual placement occurred.
-//
-// TODO see if can dedup with waitForPlacement
 func (d *DynamicPriorityQueue) isSchedulingComplete(workload *Workload) (bool, error) {
 	snap, err := d.state.Snapshot()
 	if err != nil {
@@ -599,33 +595,26 @@ func (d *DynamicPriorityQueue) isSchedulingComplete(workload *Workload) (bool, e
 			return false, nil
 		}
 	}
+
+	if evalHasPlacement(eval) {
+		d.updateUsage(workload)
+	}
+
 	if eval.Status == structs.EvalStatusComplete {
-		// If the eval is terminal and has plan annotations, something might
-		// have been placed and we should update tenant usage accordingly.
-		if eval.PlanAnnotations != nil && eval.PlanAnnotations.DesiredTGUpdates != nil {
-			d.qMux.Lock()
-			d.updateUsage(workload)
-			d.qMux.Unlock()
-
-		}
-
-		// The workload placement is complete. It may not have actually resulted in a placement,
-		// but the chain of followup evals is complete
 		return true, nil
 	}
 
-	// This would only happen if an eval was not terminal and did not
+	// This would only happen if an eval was not complete and did not
 	// yet have a followup eval
 	return false, nil
 }
 
 func (d *DynamicPriorityQueue) Jobs(namespaces map[string]bool) structs.QueueJobsResponse {
 	d.qMux.Lock()
-	sortedWorkloads := d.queue.Slice()
-	d.qMux.Unlock()
+	defer d.qMux.Unlock()
 
 	workloads := []structs.DynamicPriorityWorkload{}
-	for pos, w := range sortedWorkloads {
+	for pos, w := range d.queue.Slice() {
 		if (namespaces != nil) && !namespaces[w.eval.Namespace] || w.waitOnRestore {
 			continue
 		}
@@ -648,6 +637,9 @@ func (d *DynamicPriorityQueue) Jobs(namespaces map[string]bool) structs.QueueJob
 }
 
 func (d *DynamicPriorityQueue) Tenants() structs.QueueTenantsResponse {
+	d.qMux.Lock()
+	defer d.qMux.Unlock()
+
 	tenants := []structs.DynamicPriorityTenant{}
 	for _, t := range d.tenants {
 		tenants = append(tenants, structs.DynamicPriorityTenant{
@@ -663,33 +655,40 @@ func (d *DynamicPriorityQueue) Tenants() structs.QueueTenantsResponse {
 	}
 }
 
-// updateUsage updates the tenant and total usage for a given workload if
-// anything has been placed.
+// updateUsage updates the tenant and total usage for a given workload.
 func (d *DynamicPriorityQueue) updateUsage(workload *Workload) {
+	d.qMux.Lock()
+	defer d.qMux.Unlock()
+
 	tenant := d.tenants[workload.tid]
-	placed := false
 
-	for _, desired := range workload.eval.PlanAnnotations.DesiredTGUpdates {
-		if desired.Place != 0 {
-			placed = true
-			break
-		}
+	_, ok := tenant.placedWorkloadById[workload.id]
+	// If the workload has already been placed, don't count the usage again.
+	if ok {
+		return
 	}
 
-	if placed {
-		_, ok := tenant.placedWorkloadById[workload.id]
-		// If the workload has already been placed, don't count the usage again.
-		if ok {
-			return
-		}
+	workloadResources := workload.requestedResources
+	// this method should only be called when a workload was successfully placed,
+	// so we can use the ModifyTime as the for when decay will start.
+	workloadResources.start = time.Unix(0, workload.eval.ModifyTime)
+	tenant.totalUsage = tenant.totalUsage.Add(workloadResources.resources)
+	d.totalUsage = d.totalUsage.Add(workloadResources.resources)
 
-		workloadResources := workload.requestedResources
-		// this method should only be called when a workload was successfully placed,
-		// so we can use the ModifyTime as the for when decay will start.
-		workloadResources.start = time.Unix(0, workload.eval.ModifyTime)
-		tenant.totalUsage = tenant.totalUsage.Add(workloadResources.resources)
-		d.totalUsage = d.totalUsage.Add(workloadResources.resources)
+	tenant.placedWorkloadById[workload.id] = workload
+}
 
-		tenant.placedWorkloadById[workload.id] = workload
+func evalHasPlacement(e *structs.Evaluation) bool {
+	if e.Status != structs.EvalStatusComplete {
+		return false
 	}
+
+	if e.PlanAnnotations != nil && e.PlanAnnotations.DesiredTGUpdates != nil {
+		for _, update := range e.PlanAnnotations.DesiredTGUpdates {
+			if update.Place > 0 {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -682,7 +682,9 @@ func (d *DynamicPriorityQueue) updateUsage(workload *Workload) {
 		}
 
 		workloadResources := workload.requestedResources
-		workloadResources.start = time.Unix(0, workload.eval.ModifyTime) // TODO we should validate this
+		// this method should only be called when a workload was successfully placed,
+		// so we can use the ModifyTime as the for when decay will start.
+		workloadResources.start = time.Unix(0, workload.eval.ModifyTime)
 		tenant.totalUsage = tenant.totalUsage.Add(workloadResources.resources)
 		d.totalUsage = d.totalUsage.Add(workloadResources.resources)
 

--- a/nomad/queues/dynamic_priority_queue_test.go
+++ b/nomad/queues/dynamic_priority_queue_test.go
@@ -822,3 +822,376 @@ func TestDynamicPriorityQueue_Tenants(t *testing.T) {
 		must.Eq(t, tc.exp, testQueue.Tenants())
 	}
 }
+
+func TestDynamicPriorityQueue_isSchedulingComplete(t *testing.T) {
+	t.Run("pending eval results in false", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		testQueue := NewDynamicPriorityQueue(nil, &structs.BatchQueue{}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
+		testQueue.SetEnabled(true, ss)
+
+		testEval := mock.Eval()
+		testEval.Status = structs.EvalStatusPending
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		workload := &Workload{
+			id:   testEval.ID,
+			tid:  TenantID("tenant"),
+			eval: testEval.Copy(),
+		}
+
+		complete, err := testQueue.isSchedulingComplete(workload)
+		must.NoError(t, err)
+		must.False(t, complete)
+	})
+
+	t.Run("eval with pending blockedEval results in false", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		testQueue := NewDynamicPriorityQueue(nil, &structs.BatchQueue{}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
+		testQueue.SetEnabled(true, ss)
+
+		testEval := mock.Eval()
+		blocked := mock.Eval()
+
+		testEval.Status = structs.EvalStatusComplete
+		testEval.BlockedEval = blocked.ID
+		blocked.Status = structs.EvalStatusPending
+
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval, blocked})
+
+		workload := &Workload{
+			id:   testEval.ID,
+			tid:  TenantID("tenant"),
+			eval: testEval.Copy(),
+		}
+
+		complete, err := testQueue.isSchedulingComplete(workload)
+		must.NoError(t, err)
+		must.False(t, complete)
+	})
+
+	t.Run("eval with complete blockedEval results in true", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		testQueue := NewDynamicPriorityQueue(nil, &structs.BatchQueue{}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
+		testQueue.SetEnabled(true, ss)
+
+		testEval := mock.Eval()
+		blocked := mock.Eval()
+
+		testEval.Status = structs.EvalStatusComplete
+		testEval.BlockedEval = blocked.ID
+		blocked.Status = structs.EvalStatusComplete
+
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval, blocked})
+
+		workload := &Workload{
+			id:   testEval.ID,
+			tid:  TenantID("tenant"),
+			eval: testEval.Copy(),
+		}
+
+		complete, err := testQueue.isSchedulingComplete(workload)
+		must.NoError(t, err)
+		must.True(t, complete)
+	})
+
+	t.Run("complete eval with placement updates usage", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		testQueue := NewDynamicPriorityQueue(nil, &structs.BatchQueue{}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
+		testQueue.SetEnabled(true, ss)
+
+		testEval := mock.Eval()
+		testEval.Status = structs.EvalStatusComplete
+		testEval.PlanAnnotations = &structs.PlanAnnotations{
+			DesiredTGUpdates: map[string]*structs.DesiredUpdates{
+				"group": {Place: 1},
+			},
+		}
+
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		workload := &Workload{
+			id:   testEval.ID,
+			tid:  TenantID("tenant"),
+			eval: testEval.Copy(),
+			requestedResources: &UsageList{
+				resources: &ResourceUsage{CPU: 100, Memory: 200},
+			},
+		}
+
+		testQueue.ensureTenant(workload.tid)
+
+		complete, err := testQueue.isSchedulingComplete(workload)
+		must.NoError(t, err)
+		must.True(t, complete)
+
+		// Verify usage was updated
+		tenant := testQueue.tenants[workload.tid]
+		must.NotNil(t, tenant.placedWorkloadById[workload.id])
+		must.Eq(t, 100.0, tenant.totalUsage.CPU)
+		must.Eq(t, 200.0, tenant.totalUsage.Memory)
+	})
+
+	t.Run("complete eval without placement does not update usage", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		testQueue := NewDynamicPriorityQueue(nil, &structs.BatchQueue{}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
+		testQueue.SetEnabled(true, ss)
+
+		testEval := mock.Eval()
+		testEval.Status = structs.EvalStatusComplete
+		testEval.PlanAnnotations = &structs.PlanAnnotations{
+			DesiredTGUpdates: map[string]*structs.DesiredUpdates{
+				"group": {Place: 0},
+			},
+		}
+
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		workload := &Workload{
+			id:   testEval.ID,
+			tid:  TenantID("tenant"),
+			eval: testEval.Copy(),
+			requestedResources: &UsageList{
+				resources: &ResourceUsage{CPU: 100, Memory: 200},
+			},
+		}
+
+		testQueue.ensureTenant(workload.tid)
+
+		complete, err := testQueue.isSchedulingComplete(workload)
+		must.NoError(t, err)
+		must.True(t, complete)
+
+		// Verify usage was NOT updated
+		tenant := testQueue.tenants[workload.tid]
+		must.Nil(t, tenant.placedWorkloadById[workload.id])
+		must.Eq(t, 0.0, tenant.totalUsage.CPU)
+		must.Eq(t, 0.0, tenant.totalUsage.Memory)
+	})
+}
+
+func TestDynamicPriorityQueue_restore(t *testing.T) {
+	t.Run("unplaced workload is enqueued", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		testQueue := NewDynamicPriorityQueue(nil, &structs.BatchQueue{
+			TenantType: "namespace",
+		}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
+
+		// Set the state store before calling restore
+		testQueue.state = ss
+
+		// Create a job and eval that hasn't been placed yet
+		job := mock.Job()
+		job.Type = structs.JobTypeBatch
+		ss.UpsertJob(structs.MsgTypeTestSetup, 0, nil, job)
+
+		now := time.Now()
+
+		testEval := mock.Eval()
+		testEval.JobID = job.ID
+		testEval.Namespace = job.Namespace
+		testEval.Type = structs.JobTypeBatch
+		testEval.TriggeredBy = structs.EvalTriggerJobRegister
+		testEval.Status = structs.EvalStatusBlocked
+		testEval.CreateTime = now.UnixNano()
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
+
+		snap, err := ss.Snapshot()
+		must.NoError(t, err)
+
+		err = testQueue.restore(snap, now)
+		must.NoError(t, err)
+
+		// Verify the workload was enqueued
+		select {
+		case w := <-testQueue.enqueueCh:
+			must.Eq(t, testEval.ID, w.id)
+			must.Eq(t, TenantID(job.Namespace), w.tid)
+			must.True(t, w.waitOnRestore)
+		default:
+			t.Fatal("expected workload in enqueueCh channel")
+		}
+	})
+
+	t.Run("skips pending/non-batch/non-register evals", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		testQueue := NewDynamicPriorityQueue(nil, &structs.BatchQueue{
+			TenantType: "namespace",
+		}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
+
+		// Set the state store before calling restore
+		testQueue.state = ss
+
+		// Create jobs for different eval types
+		batchJob := mock.Job()
+		batchJob.Type = structs.JobTypeBatch
+		ss.UpsertJob(structs.MsgTypeTestSetup, 0, nil, batchJob)
+
+		serviceJob := mock.Job()
+		serviceJob.Type = structs.JobTypeService
+		ss.UpsertJob(structs.MsgTypeTestSetup, 1, nil, serviceJob)
+
+		// Create various evals that should be skipped
+		pendingEval := mock.Eval()
+		pendingEval.JobID = batchJob.ID
+		pendingEval.Namespace = batchJob.Namespace
+		pendingEval.Type = structs.JobTypeBatch
+		pendingEval.TriggeredBy = structs.EvalTriggerJobRegister
+		pendingEval.Status = structs.EvalStatusPending
+
+		serviceEval := mock.Eval()
+		serviceEval.JobID = serviceJob.ID
+		// serviceEval.Namespace = serviceJob.Namespace
+		serviceEval.Type = structs.JobTypeService
+		// serviceEval.TriggeredBy = structs.EvalTriggerJobRegister
+		// serviceEval.Status = structs.EvalStatusComplete
+
+		nonRegisterEval := mock.Eval()
+		nonRegisterEval.JobID = batchJob.ID
+		nonRegisterEval.Namespace = batchJob.Namespace
+		nonRegisterEval.Type = structs.JobTypeBatch
+		nonRegisterEval.TriggeredBy = structs.EvalTriggerNodeUpdate
+		nonRegisterEval.Status = structs.EvalStatusComplete
+
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 2, []*structs.Evaluation{
+			pendingEval,
+			serviceEval,
+			nonRegisterEval,
+		})
+
+		snap, err := ss.Snapshot()
+		must.NoError(t, err)
+
+		err = testQueue.restore(snap, time.Now())
+		must.NoError(t, err)
+
+		// Verify no tenants were created (all evals should be skipped)
+		must.Eq(t, 0, len(testQueue.tenants))
+	})
+
+	t.Run("restores usage correctly", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		testQueue := NewDynamicPriorityQueue(nil, &structs.BatchQueue{
+			TenantType: "namespace",
+		}, &structs.DynamicQueueConfig{
+			HalfLife: 10 * time.Second,
+		}, hclog.New(hclog.DefaultOptions))
+
+		// Set the state store before calling restore
+		testQueue.state = ss
+
+		// Create a job with task resources
+		job := mock.Job()
+		job.Type = structs.JobTypeBatch
+		job.TaskGroups[0].Count = 2
+		job.TaskGroups[0].Tasks[0].Resources.CPU = 100
+		job.TaskGroups[0].Tasks[0].Resources.MemoryMB = 256
+		ss.UpsertJob(structs.MsgTypeTestSetup, 0, nil, job)
+
+		now := time.Now()
+
+		// Create a completed eval with placement
+		testEval := mock.Eval()
+		testEval.JobID = job.ID
+		testEval.Namespace = job.Namespace
+		testEval.Type = structs.JobTypeBatch
+		testEval.TriggeredBy = structs.EvalTriggerJobRegister
+		testEval.Status = structs.EvalStatusComplete
+		testEval.PlanAnnotations = &structs.PlanAnnotations{
+			DesiredTGUpdates: map[string]*structs.DesiredUpdates{
+				job.TaskGroups[0].Name: {Place: 2},
+			},
+		}
+		testEval.ModifyTime = now.UnixNano()
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
+
+		snap, err := ss.Snapshot()
+		must.NoError(t, err)
+
+		err = testQueue.restore(snap, now)
+		must.NoError(t, err)
+
+		// Verify tenant was created and usage was tracked
+		tenant, ok := testQueue.tenants[TenantID(job.Namespace)]
+		must.True(t, ok)
+		must.NotNil(t, tenant)
+
+		// Verify the workload is tracked
+		workload, ok := tenant.placedWorkloadById[testEval.ID]
+		must.True(t, ok)
+		must.NotNil(t, workload)
+
+		// Expected resources: 2 tasks * (100 CPU + 256 MB)
+		expectedCPU := 200.0
+		expectedMemory := 512.0
+
+		must.Eq(t, expectedCPU, tenant.totalUsage.CPU)
+		must.Eq(t, expectedMemory, tenant.totalUsage.Memory)
+		must.Eq(t, expectedCPU, testQueue.totalUsage.CPU)
+		must.Eq(t, expectedMemory, testQueue.totalUsage.Memory)
+	})
+
+	t.Run("decays usage properly", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		halfLife := 10 * time.Second
+		testQueue := NewDynamicPriorityQueue(nil, &structs.BatchQueue{
+			TenantType: "namespace",
+		}, &structs.DynamicQueueConfig{
+			HalfLife: halfLife,
+		}, hclog.New(hclog.DefaultOptions))
+
+		// Set the state store before calling restore
+		testQueue.state = ss
+
+		// Create a job with task resources
+		job := mock.Job()
+		job.Type = structs.JobTypeBatch
+		job.TaskGroups[0].Count = 1
+		job.TaskGroups[0].Tasks[0].Resources.CPU = 100
+		job.TaskGroups[0].Tasks[0].Resources.MemoryMB = 256
+		ss.UpsertJob(structs.MsgTypeTestSetup, 0, nil, job)
+
+		// Set restore time to be exactly one half-life after eval creation
+		now := time.Now()
+		evalCreateTime := now.Add(-halfLife)
+
+		// Create a completed eval with placement
+		testEval := mock.Eval()
+		testEval.JobID = job.ID
+		testEval.Namespace = job.Namespace
+		testEval.Type = structs.JobTypeBatch
+		testEval.TriggeredBy = structs.EvalTriggerJobRegister
+		testEval.Status = structs.EvalStatusComplete
+		testEval.PlanAnnotations = &structs.PlanAnnotations{
+			DesiredTGUpdates: map[string]*structs.DesiredUpdates{
+				job.TaskGroups[0].Name: {Place: 2},
+			},
+		}
+		testEval.ModifyTime = evalCreateTime.UnixNano()
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
+
+		snap, err := ss.Snapshot()
+		must.NoError(t, err)
+
+		err = testQueue.restore(snap, now)
+		must.NoError(t, err)
+
+		// Verify tenant was created and usage was tracked
+		tenant, ok := testQueue.tenants[TenantID(job.Namespace)]
+		must.True(t, ok)
+		must.NotNil(t, tenant)
+
+		// Verify the workload is tracked
+		workload, ok := tenant.placedWorkloadById[testEval.ID]
+		must.True(t, ok)
+		must.NotNil(t, workload)
+
+		// Expected resources after decay: 1 task (100 CPU + 256 MB) / 2 (half-life decay)
+		expectedCPU := 50.0
+		expectedMemory := 128.0
+
+		must.Eq(t, expectedCPU, tenant.totalUsage.CPU)
+		must.Eq(t, expectedMemory, tenant.totalUsage.Memory)
+		must.Eq(t, expectedCPU, testQueue.totalUsage.CPU)
+		must.Eq(t, expectedMemory, testQueue.totalUsage.Memory)
+	})
+}

--- a/nomad/queues/priority_queue.go
+++ b/nomad/queues/priority_queue.go
@@ -20,16 +20,22 @@ func (pq WorkloadQueue) Len() int { return pq.Size() }
 
 func workloadSortFn() func(i, j *Workload) int {
 	return func(a, b *Workload) int {
+		if a.waitOnRestore {
+			return -1
+		} else if b.waitOnRestore {
+			return 1
+		}
+
 		if a.priority > b.priority {
 			return -1
 		} else if a.priority < b.priority {
 			return 1
-		} else {
-			if a.eval.CreateIndex < b.eval.CreateIndex {
-				return -1
-			} else if a.eval.CreateIndex > b.eval.CreateIndex {
-				return 1
-			}
+		}
+
+		if a.eval.CreateIndex < b.eval.CreateIndex {
+			return -1
+		} else if a.eval.CreateIndex > b.eval.CreateIndex {
+			return 1
 		}
 		return 0
 	}
@@ -45,14 +51,13 @@ func (pq *WorkloadQueue) Pop() *Workload {
 	return w
 }
 
-func (pq *WorkloadQueue) Workloads() []*Workload {
-	return pq.Slice()
-}
-
-func (pq *WorkloadQueue) UpdateAll(workloadFn func(w *Workload) *Workload) {
+// UpdateAll takes a function that mutates a workload and updates
+// all workloads in the queue via this function.
+func (pq *WorkloadQueue) UpdateAll(updateFn func(w *Workload)) {
 	newQueue := NewWorkloadQueue()
-	for _, w := range pq.Workloads() {
-		newQueue.Push(workloadFn(w))
+	for _, w := range pq.Slice() {
+		updateFn(w)
+		newQueue.Push(w)
 	}
 	*pq = newQueue
 }


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes introduce state restore functionality to the DPQ. With these changes, a server can be stopped and restarted, and is able to restore tenant usage and identify batch jobs that a previous queue may have been waiting for placement.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [X] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
