### PR TITLE
scheduler: Fix memory_max unlimited under oversubscription.

### DIFF
--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2411,9 +2411,9 @@ func (r *Resources) DiskInBytes() int64 {
 }
 
 const (
-	// memoryNoLimit is a sentinel value indicating there is no upper hard
+	// MemoryNoLimit is a sentinel value indicating there is no upper hard
 	// memory limit
-	memoryNoLimit = -1
+	MemoryNoLimit = -1
 )
 
 func (r *Resources) Validate() error {
@@ -2457,7 +2457,7 @@ func (r *Resources) Validate() error {
 
 	// Ensure memory_max is greater than memory, unless it is set to 0 or -1 which
 	// are both sentinel values
-	if (r.MemoryMaxMB != 0 && r.MemoryMaxMB != memoryNoLimit) && r.MemoryMaxMB < r.MemoryMB {
+	if (r.MemoryMaxMB != 0 && r.MemoryMaxMB != MemoryNoLimit) && r.MemoryMaxMB < r.MemoryMB {
 		mErr.Errors = append(mErr.Errors, fmt.Errorf("MemoryMaxMB value (%d) should be larger than MemoryMB value (%d)", r.MemoryMaxMB, r.MemoryMB))
 	}
 

--- a/scheduler/feasible/rank.go
+++ b/scheduler/feasible/rank.go
@@ -381,9 +381,20 @@ NEXTNODE:
 				},
 			}
 
-			if iter.memoryOversubscription && task.Resources.MemoryMaxMB > 0 {
-				taskResources.Memory.MemoryMaxMB = safemath.Add(
-					int64(task.Resources.MemoryMaxMB), int64(task.Resources.SecretsMB))
+			if iter.memoryOversubscription {
+
+				// If the max memory value is a positive number, then we will
+				// add the secrets memory to it. If the max memory value is -1,
+				// then we will set the max memory value to -1 meaning no limit.
+				// If the max memory value is 0, then we will not set a max
+				// memory value.
+				if task.Resources.MemoryMaxMB > 0 {
+					taskResources.Memory.MemoryMaxMB = safemath.Add(
+						int64(task.Resources.MemoryMaxMB), int64(task.Resources.SecretsMB))
+
+				} else if task.Resources.MemoryMaxMB == structs.MemoryNoLimit {
+					taskResources.Memory.MemoryMaxMB = structs.MemoryNoLimit
+				}
 			}
 
 			// Check if we need a network resource

--- a/scheduler/feasible/rank_test.go
+++ b/scheduler/feasible/rank_test.go
@@ -147,6 +147,70 @@ func TestBinPackIterator_NoExistingAlloc(t *testing.T) {
 	}
 }
 
+// TestBinPackIterator_memoryMax asserts that the memory_max value of a task is
+// propagated to the allocated task resources when memory oversubscription is
+// enabled, including the -1 sentinel that indicates there is no hard memory
+// limit.
+func TestBinPackIterator_memoryMax(t *testing.T) {
+	ci.Parallel(t)
+
+	legacyCpuResources, processorResources := tests.CpuResources(4096)
+
+	cases := []struct {
+		name        string
+		memoryMaxMB int
+		expected    int64
+	}{
+		{name: "no max", memoryMaxMB: 0, expected: 0},
+		{name: "explicit max", memoryMaxMB: 2048, expected: 2048},
+		{name: "no limit", memoryMaxMB: structs.MemoryNoLimit, expected: structs.MemoryNoLimit},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, ctx := MockContext(t)
+
+			nodes := []*RankedNode{
+				{
+					Node: &structs.Node{
+						NodeResources: &structs.NodeResources{
+							Processors: processorResources,
+							Cpu:        legacyCpuResources,
+							Memory: structs.NodeMemoryResources{
+								MemoryMB: 4096,
+							},
+						},
+					},
+				},
+			}
+			static := NewStaticRankIterator(ctx, nodes)
+
+			taskGroup := &structs.TaskGroup{
+				EphemeralDisk: &structs.EphemeralDisk{},
+				Tasks: []*structs.Task{
+					{
+						Name: "web",
+						Resources: &structs.Resources{
+							CPU:         1024,
+							MemoryMB:    1024,
+							MemoryMaxMB: tc.memoryMaxMB,
+						},
+					},
+				},
+			}
+
+			binp := NewBinPackIterator(ctx, static, false, 0)
+			binp.SetTaskGroup(taskGroup)
+			binp.SetSchedulerConfiguration(testSchedulerConfig)
+
+			out := binp.Next()
+			must.NotNil(t, out)
+			must.MapContainsKey(t, out.TaskResources, "web")
+			must.Eq(t, tc.expected, out.TaskResources["web"].Memory.MemoryMaxMB)
+		})
+	}
+}
+
 // TestBinPackIterator_NoExistingAlloc_MixedReserve asserts that node's with
 // reserved resources are scored equivalent to as if they had a lower amount of
 // resources.


### PR DESCRIPTION
When memory oversubscription is enabled and a task is configured with `memory_max = -1`, the value should be treated as a sentinel indicating there is no hard memory limit and `memory` should be used as a reservation only.

In #28140 the bin packing iterator was changed to only propagate the memory_max value into the allocated task resources when it was greater than zero. This guard correctly skips the unset case, but it also discarded the -1 sentinel, so the client received a value of zero and configured the cgroup with `memory` as a hard limit rather than a reservation.

This change restores handling of the -1 sentinel, so that it is preserved in the allocated resources and the client sets the cgroup `memory.max` to "max". The sentinel value is also exported from the structs package so it can be shared by the scheduler.

No changelog required as the initial change is not part of a release binary and was caught by our automated e2e testing.

### Testing & Reproduction steps
The e2e test failure can be reproduced before/after this change using a dev agent and running:
```console
$ go test -v -run TestOversubscription/testRawExecMax e2e/oversubscription/oversubscription_test.go
=== RUN   TestOversubscription
=== RUN   TestOversubscription/testRawExecMax
    oversubscription_test.go:89: submitting job: "./input/rawexecmax.hcl"
--- PASS: TestOversubscription (1.04s)
    --- PASS: TestOversubscription/testRawExecMax (1.04s)
PASS
ok      command-line-arguments  1.054s
```

Before:
```console
$ go test -v -run TestOversubscription/testRawExecMax e2e/oversubscription/oversubscription_test.go
=== RUN   TestOversubscription/testRawExecMax
    oversubscription_test.go:89: submitting job: "./input/rawexecmax.hcl"
    oversubscription_test.go:101:
        oversubscription_test.go:101: expected condition to pass within wait context
        ↪ error: wait: timeout exceeded: expect '67108864\s+max' in stdout, got: '0
        67108864
        '
--- FAIL: TestOversubscription (24.24s)
```

### Links
Related: https://github.com/hashicorp/nomad/pull/28140
e2e example failure: https://github.com/hashicorp/nomad-e2e/actions/runs/28221136133/job/83602697536

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

