### PR TITLE
cli: add -kv-path flag to nomad setup vault

### DIFF
--- a/.changelog/28183.txt
+++ b/.changelog/28183.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: Add a `-kv-path` flag to `nomad setup vault` to configure the Vault KV mount used by the generated workload policy
+```

--- a/command/setup_vault.go
+++ b/command/setup_vault.go
@@ -47,6 +47,7 @@ type SetupVaultCommand struct {
 
 	jwksURL        string
 	jwksCACertPath string
+	kvPath         string
 
 	destroy bool
 	autoYes bool
@@ -84,6 +85,10 @@ Setup Vault options:
     Path to a CA certificate file that will be used to validate the
     JWKS URL if it uses TLS
 
+  -kv-path <path>
+    Path to the Vault KV secrets engine mount that the generated
+    workload policy grants access to. Defaults to "secret".
+
   -destroy
     Removes all configuration components this command created from the
     Vault cluster.
@@ -116,6 +121,7 @@ func (s *SetupVaultCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{
 			"-jwks-url":     complete.PredictAnything,
 			"-jwks-ca-file": complete.PredictAnything,
+			"-kv-path":      complete.PredictAnything,
 			"-destroy":      complete.PredictSet("true", "false"),
 			"-y":            complete.PredictSet("true", "false"),
 
@@ -146,6 +152,7 @@ func (s *SetupVaultCommand) Run(args []string) int {
 	flags.BoolVar(&s.autoYes, "y", false, "")
 	flags.StringVar(&s.jwksURL, "jwks-url", "http://localhost:4646/.well-known/jwks.json", "")
 	flags.StringVar(&s.jwksCACertPath, "jwks-ca-file", "", "")
+	flags.StringVar(&s.kvPath, "kv-path", "secret", "")
 
 	// Options for -check.
 	flags.BoolVar(&s.check, "check", false, "")
@@ -160,6 +167,12 @@ func (s *SetupVaultCommand) Run(args []string) int {
 	// Check that we got no arguments.
 	if len(flags.Args()) != 0 {
 		s.Ui.Error(uiMessageNoArguments)
+		s.Ui.Error(commandErrorText(s))
+		return 1
+	}
+
+	if strings.Trim(s.kvPath, "/") == "" {
+		s.Ui.Error("The -kv-path option must specify a non-empty mount path")
 		s.Ui.Error(commandErrorText(s))
 		return 1
 	}
@@ -327,8 +340,8 @@ and a policy associated with that role.
 		s.Ui.Output(fmt.Sprintf(`
 These are the rules for the policy %q that we will create. It uses a templated
 policy to allow Nomad tasks to access secrets in the path
-"secrets/data/<job namespace>/<job name>":
-`, vaultPolicyName))
+"%s/data/<job namespace>/<job name>":
+`, vaultPolicyName, strings.Trim(s.kvPath, "/")))
 
 		policyBody, err := s.renderPolicy()
 		if err != nil {
@@ -454,8 +467,13 @@ func (s *SetupVaultCommand) renderPolicy() (string, error) {
 	}
 	accessor := secret.Data["accessor"].(string)
 
-	policyTextStr := string(vaultPolicyBody)
-	return strings.ReplaceAll(policyTextStr, "auth_jwt_X", accessor), nil
+	return renderVaultPolicy(string(vaultPolicyBody), accessor, s.kvPath), nil
+}
+
+func renderVaultPolicy(policyBody, accessor, kvPath string) string {
+	policyText := strings.ReplaceAll(policyBody, "auth_jwt_X", accessor)
+	mount := strings.Trim(kvPath, "/")
+	return strings.ReplaceAll(policyText, "secret/", mount+"/")
 }
 
 func (s *SetupVaultCommand) createPolicy(policyText string) error {

--- a/command/setup_vault_test.go
+++ b/command/setup_vault_test.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/cli"
@@ -13,6 +14,55 @@ import (
 	"github.com/hashicorp/nomad/command/agent"
 	"github.com/shoenig/test/must"
 )
+
+func TestSetupVaultCommand_renderVaultPolicy(t *testing.T) {
+	ci.Parallel(t)
+
+	const accessor = "auth_jwt_0a1b2c3d"
+	policyBody := string(vaultPolicyBody)
+
+	// The default "secret" mount renders identically to substituting only the
+	// accessor, so omitting -kv-path leaves the policy byte-for-byte unchanged.
+	must.Eq(t,
+		strings.ReplaceAll(policyBody, "auth_jwt_X", accessor),
+		renderVaultPolicy(policyBody, accessor, "secret"),
+	)
+
+	testCases := []struct {
+		name   string
+		kvPath string
+		want   string
+	}{
+		{name: "custom mount", kvPath: "kv", want: "kv/data/"},
+		{name: "nested mount", kvPath: "kv/mongo", want: "kv/mongo/data/"},
+		{name: "trailing slash trimmed", kvPath: "kv/", want: "kv/data/"},
+		{name: "leading slash trimmed", kvPath: "/kv", want: `path "kv/data/`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renderVaultPolicy(policyBody, accessor, tc.kvPath)
+			must.StrContains(t, got, tc.want)
+			must.StrContains(t, got, accessor)
+			must.StrNotContains(t, got, "secret/")
+			must.StrNotContains(t, got, "auth_jwt_X")
+			// every path stanza survives the substitution
+			must.Eq(t, strings.Count(policyBody, `path "`), strings.Count(got, `path "`))
+		})
+	}
+}
+
+func TestSetupVaultCommand_Run_emptyKVPath(t *testing.T) {
+	ci.Parallel(t)
+
+	for _, kvPath := range []string{"", "/", "///"} {
+		ui := cli.NewMockUi()
+		cmd := &SetupVaultCommand{Meta: Meta{Ui: ui}}
+		rc := cmd.Run([]string{"-kv-path", kvPath})
+		must.Eq(t, 1, rc)
+		must.StrContains(t, ui.ErrorWriter.String(), "non-empty mount path")
+	}
+}
 
 func TestSetupVaultCommand_Run(t *testing.T) {
 	ci.Parallel(t)


### PR DESCRIPTION
### Description
`nomad setup vault` generates the nomad-workloads policy with the KV secrets engine mount hardcoded to "secret". Clusters that mount their KV engine somewhere else, like at kv, have to hand-edit the generated policy before it works. The new `-kv-path` flag sets the mount the policy scopes and defaults to "secret", so runs that leave it off are unchanged.

The flag value replaces the "secret" mount in the embedded policy template, alongside the existing JWT accessor substitution, and the interactive description reflects it too. Passing `-kv-path kv` scopes the policy under kv/ instead of secret/. An empty or slash-only value is rejected before the command touches Vault.

jrasell confirmed on the issue that a configurable KV path makes sense.

### Testing & Reproduction steps
`TestSetupVaultCommand_renderVaultPolicy` checks that the default mount leaves the policy byte-for-byte unchanged and that a few custom mounts rewrite all four path blocks. `TestSetupVaultCommand_Run_emptyKVPath` covers the empty-value guard.

I also ran the command against a Vault dev server. With no flag the created policy scopes secret/data as before, and with `-kv-path kv` it scopes kv/data.

### Links
Closes #27915

### AI usage
Per contributing/ai.md: I used an AI coding assistant while writing the flag wiring, the `renderVaultPolicy` helper, and the tests. I reviewed every line, confirmed the default output is unchanged, and verified the generated policy against a local Vault dev server.
