### PR TITLE
allocs rpc: fix client panic on nil allocs

### DIFF
--- a/.changelog/28185.txt
+++ b/.changelog/28185.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where a client could panic after an alloc is GC'd
+```

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -6,6 +6,7 @@ package nomad
 import (
 	"fmt"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/go-hclog"
@@ -199,6 +200,7 @@ func (a *Alloc) GetAllocs(args *structs.AllocsGetRequest,
 	}
 	defer metrics.MeasureSince([]string{"nomad", "alloc", "get_allocs"}, time.Now())
 
+	// The *maximum* we'll return is the number requested.
 	allocs := make([]*structs.Allocation, len(args.AllocIDs))
 
 	// Setup the blocking query. We wait for at least one of the requested
@@ -249,6 +251,10 @@ func (a *Alloc) GetAllocs(args *structs.AllocsGetRequest,
 
 			// Setup the output
 			if thresholdMet {
+				// Filter out nils, only if there are any to avoid superfluous mallocs.
+				if slices.Contains(allocs, nil) {
+					allocs = slices.DeleteFunc(allocs, func(a *structs.Allocation) bool { return a == nil })
+				}
 				reply.Allocs = allocs
 				reply.Index = maxIndex
 			} else {

--- a/nomad/alloc_endpoint_test.go
+++ b/nomad/alloc_endpoint_test.go
@@ -989,6 +989,20 @@ func TestAllocEndpoint_GetAllocs(t *testing.T) {
 	if err := msgpackrpc.CallWithCodec(codec, "Alloc.GetAllocs", get, &resp); err == nil {
 		t.Fatalf("expect error")
 	}
+
+	// Lookup mixed existing and not-existing allocs to assert partial results.
+	get = &structs.AllocsGetRequest{
+		AllocIDs: []string{alloc.ID, "00000000-0000-0000-0000-000000000000", alloc2.ID},
+		QueryOptions: structs.QueryOptions{
+			Region:    "global",
+			AuthToken: node.SecretID,
+		},
+	}
+	must.NoError(t, msgpackrpc.CallWithCodec(codec, "Alloc.GetAllocs", get, &resp))
+	// The reply should include only the 2 real allocs, and importantly *not* any nils.
+	must.Len(t, 2, resp.Allocs, must.Sprint("should only include the two existing allocs"))
+	must.NotNil(t, resp.Allocs[0], must.Sprint("alloc should not be nil"))
+	must.NotNil(t, resp.Allocs[1], must.Sprint("alloc should not be nil"))
 }
 
 func TestAllocEndpoint_GetAllocs_Blocking(t *testing.T) {


### PR DESCRIPTION
### Description

A client can panic on a nil alloc sent by the server if the alloc gets GC'd at an innoportune moment, namely between two distinct RPC calls in the same loop.

The server should never return a nil alloc. Instead, return a partial slice that is shorter than the number of allocs requested.

Fixes: https://github.com/hashicorp/nomad/issues/28172

Note: At this time, the client does not make use of the partial list; it simply discards the results and retries in a couple seconds (client/client.go line 2683). Potential client optimizations may be revisited as a follow-up.

### Testing

Server-side unit tests ensures no `nil` allocs in the response. I'll explore Client-side tests, but it'll take some extra doing to set up mocks for the RPC calls.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
