### PR TITLE
alloc watcher: stop looping on terminal errors (#28093)

### DIFF
--- a/.changelog/28191.txt
+++ b/.changelog/28191.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where the previous allocation watcher would retry forever when the server returned a permanent error during data migration
+```

--- a/client/allocwatcher/alloc_watcher.go
+++ b/client/allocwatcher/alloc_watcher.go
@@ -375,6 +375,12 @@ func (p *remotePrevAlloc) Wait(ctx context.Context) error {
 		resp := structs.SingleAllocResponse{}
 		err := p.rpc.RPC("Alloc.GetAlloc", &req, &resp)
 		if err != nil {
+			if structs.IsErrPermissionDenied(err) || structs.IsErrUnknownAllocation(err) {
+				p.logger.Warn("unable to read previous alloc; skipping data migration",
+					"error", err)
+				return nil
+			}
+
 			retry := getRemoteRetryIntv + helper.RandomStagger(getRemoteRetryIntv)
 			timer, stop := helper.NewSafeTimer(retry)
 			p.logger.Error("error querying previous alloc", "error", err, "wait", retry)

--- a/client/allocwatcher/alloc_watcher_test.go
+++ b/client/allocwatcher/alloc_watcher_test.go
@@ -18,6 +18,7 @@ import (
 	hclog "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/allocdir"
+	"github.com/hashicorp/nomad/client/config"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/nomad/mock"
@@ -60,6 +61,18 @@ func (f *fakeAllocRunner) Listener() *cstructs.AllocListener {
 
 func (f *fakeAllocRunner) Alloc() *structs.Allocation {
 	return f.alloc
+}
+
+// countingRPCer implements RPCer, recording the number of calls and returning
+// a fixed error.
+type countingRPCer struct {
+	err   error
+	calls int
+}
+
+func (c *countingRPCer) RPC(method string, args interface{}, reply interface{}) error {
+	c.calls++
+	return c.err
 }
 
 // newConfig returns a new Config and cleanup func
@@ -311,4 +324,39 @@ func TestPrevAlloc_StreamAllocDir_FileEscape(t *testing.T) {
 	dest := t.TempDir()
 	err = prevAlloc.streamAllocDir(context.Background(), io.NopCloser(tarBuf), dest)
 	must.EqError(t, err, "archive contains object that escapes alloc dir")
+}
+
+// TestPrevAlloc_Remote_Wait_TerminalError asserts that Wait stops watching
+// rather than retrying forever when the server returns a terminal error.
+func TestPrevAlloc_Remote_Wait_TerminalError(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name string
+		err  error
+	}{
+		{name: "permission denied", err: structs.ErrPermissionDenied},
+		{name: "unknown allocation", err: structs.NewErrUnknownAllocation("abc")},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rpc := &countingRPCer{err: tc.err}
+			prevAlloc := &remotePrevAlloc{
+				logger:      testlog.HCLogger(t),
+				allocID:     "123",
+				prevAllocID: "abc",
+				migrate:     true,
+				rpc:         rpc,
+				config:      &config.Config{Region: "global", Node: &structs.Node{}},
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			// Wait must return nil promptly without looping on the RPC.
+			must.NoError(t, prevAlloc.Wait(ctx))
+			must.Eq(t, 1, rpc.calls)
+		})
+	}
 }


### PR DESCRIPTION
### Description
Fixes the client-side previous-allocation watcher so it stops retrying forever when the server returns a permanent error.

The remote previous-allocation watcher polls `Alloc.GetAlloc` to wait for a previous allocation to terminate before migrating its ephemeral disk data. It treated every RPC error as transient and retried on an interval indefinitely.

When a previous allocation belongs to a node pool the requesting client can no longer read (for example after the node changed pools), the server returns a permanent `Permission denied` or `Unknown allocation` error. Retrying never succeeds, so the watcher spun on the RPC and flooded the logs.

How I fixed it:
* Updated `remotePrevAlloc.Wait` in `client/allocwatcher/alloc_watcher.go` to detect terminal errors with `structs.IsErrPermissionDenied` and `structs.IsErrUnknownAllocation`.
* On a terminal error, log a single warning and stop watching (return `nil`) instead of retrying, letting the new allocation start with an empty data dir.
* Data migration is best-effort, so abandoning it cleanly matches the existing behavior for a GC'd previous allocation. Transient errors continue to retry as before.

### Testing & Reproduction steps
Added `TestPrevAlloc_Remote_Wait_TerminalError` in `client/allocwatcher/alloc_watcher_test.go`:
* Uses a `countingRPCer` mock that records how many times the RPC is called.
* Verified that for both `Permission denied` and `Unknown allocation`, `Wait` returns `nil` after exactly one call (no retry loop).

To run:
```bash
GOTOOLCHAIN=auto go test -v ./client/allocwatcher -run TestPrevAlloc_Remote_Wait_TerminalError
```

To reproduce the original bug:
* Run an allocation on a node, then move that node into a different node pool without restarting the job, so the allocation's job node pool no longer matches the node's pool.
* Reschedule the allocation to another node with `migrate = true` ephemeral disk. The destination client logs `rpc error: Permission denied` / `Unknown allocation` for `Alloc.GetAlloc` at a high rate and never gives up.

### Links
* Fixes #28093

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality...

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations.

---

## Changes to Security Controls

**Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.**

No changes to access controls or encryption. The server still makes the same authorization decision; this PR only changes how the client reacts to a denial. Instead of retrying a permanently denied request forever, the client now logs one warning and stops, which reduces log noise rather than weakening any control.
