### PR TITLE
e2e: Fix exec2 connect test failing due to Envoy version mismatch.

### DIFF
--- a/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
+++ b/e2e/terraform/packer/ubuntu-jammy-amd64/setup.sh
@@ -9,6 +9,20 @@ set -xeuo pipefail
 
 NOMAD_PLUGIN_DIR=/opt/nomad/plugins/
 
+# Consul and Envoy versions are pinned together and MUST stay compatible per
+# Consul's Envoy compatibility matrix:
+# https://developer.hashicorp.com/consul/docs/reference/proxy/envoy#envoy-and-consul-client-agent
+#
+# The exec2 countdash e2e test runs Envoy manually from /opt/bin/envoy and
+# therefore does not benefit from Nomad's automatic ${NOMAD_envoy_version}
+# negotiation. If Consul drifts ahead of the bundled Envoy, its xDS server
+# rejects the proxy and the sidecar never initializes.
+#
+# Keep CONSUL_VERSION in sync with the Windows client agent in
+# provision-infra/userdata/windows-2022.ps1.
+CONSUL_VERSION="2.0.1+ent-1"
+ENVOY_VERSION="1.38.3"
+
 mkdir_for_root() {
     sudo mkdir -p "$1"
     sudo chmod 755 "$1"
@@ -58,7 +72,7 @@ sudo apt-get update
 
 echo "Install Consul and Nomad"
 sudo apt-get install -y \
-     consul-enterprise \
+     consul-enterprise="${CONSUL_VERSION}" \
      nomad
 
 # Note: neither service will start on boot because we haven't enabled
@@ -139,8 +153,8 @@ sudo hc-install install --path ${NOMAD_PLUGIN_DIR} --version v0.1.0 nomad-driver
 sudo chmod +x ${NOMAD_PLUGIN_DIR}/nomad-driver-exec2
 
 # Envoy
-echo "Installing Envoy"
-sudo curl -s -S -L -o /opt/bin/envoy https://github.com/envoyproxy/envoy/releases/download/v1.34.1/envoy-1.34.1-linux-x86_64
+echo "Installing Envoy ${ENVOY_VERSION}"
+sudo curl -s -S -L -o /opt/bin/envoy "https://github.com/envoyproxy/envoy/releases/download/v${ENVOY_VERSION}/envoy-${ENVOY_VERSION}-linux-x86_64"
 sudo chmod +x /opt/bin/envoy
 
 echo "Updating boot parameters"

--- a/e2e/terraform/provision-infra/userdata/windows-2022.ps1
+++ b/e2e/terraform/provision-infra/userdata/windows-2022.ps1
@@ -32,7 +32,9 @@ Set-Location C:\opt
 
 Try {
     $releases = "https://releases.hashicorp.com"
-    $version = "1.21.1+ent"
+    # Keep this in sync with CONSUL_VERSION in
+    # packer/ubuntu-jammy-amd64/setup.sh.
+    $version = "2.0.1+ent"
     $url = "${releases}/consul/${version}/consul_${version}_windows_amd64.zip"
 
     Write-Output "Downloading Consul from: $url"


### PR DESCRIPTION
Consul has recently release 2.0.0 which updated the supported versions of Envoy, dropping 1.34.x. This meant the countdash exec2 test failed as it uses a bundled Envoy which fell out of support.

This change updates the version of Envoy installed on the Linux hosts and pins the Consul version across Linux and Windows to match.

### Testing & Reproduction steps
```console
jrasell@event-horizon:~/nomad/e2e$ go test -v -run TestExec2/testCountdash ./exec2/
=== RUN   TestExec2
=== RUN   TestExec2/testCountdash
    exec2_test.go:65: submitting job: "./input/countdash.hcl"
--- PASS: TestExec2 (13.20s)
    --- PASS: TestExec2/testCountdash (13.20s)
PASS
ok      github.com/hashicorp/nomad/e2e/exec2    13.206s
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

