### PR TITLE
DHV: account for per_alloc when matching request source to volume

### DIFF
--- a/.changelog/28198.txt
+++ b/.changelog/28198.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+dynamic host volumes: Fixed a bug where allocations claiming host volumes with the per_alloc flag would not prevent the volume from being deleted
+```

--- a/nomad/state/state_store_host_volumes.go
+++ b/nomad/state/state_store_host_volumes.go
@@ -41,8 +41,8 @@ func (s *StateStore) HostVolumeByID(ws memdb.WatchSet, ns, id string, withAllocs
 		if alloc.ClientTerminalStatus() {
 			continue
 		}
-		for _, volClaim := range alloc.Job.LookupTaskGroup(alloc.TaskGroup).Volumes {
-			if volClaim.Type == structs.VolumeTypeHost && volClaim.Source == vol.Name {
+		for _, volReq := range alloc.Job.LookupTaskGroup(alloc.TaskGroup).Volumes {
+			if vol.MatchesRequestSource(volReq, alloc) {
 				vol.Allocations = append(vol.Allocations, alloc.Stub(nil))
 			}
 		}
@@ -153,8 +153,8 @@ func (s *StateStore) deleteHostVolumeTxn(txn *txn, index uint64, ns string, id s
 			if alloc.ClientTerminalStatus() {
 				continue
 			}
-			for _, volClaim := range alloc.Job.LookupTaskGroup(alloc.TaskGroup).Volumes {
-				if volClaim.Type == structs.VolumeTypeHost && volClaim.Name == vol.Name {
+			for _, volReq := range alloc.Job.LookupTaskGroup(alloc.TaskGroup).Volumes {
+				if vol.MatchesRequestSource(volReq, alloc) {
 					return fmt.Errorf("could not delete volume %s in use by alloc %s",
 						vol.ID, alloc.ID)
 				}
@@ -233,9 +233,9 @@ func (s *StateStore) HostVolumesByIDPrefix(ws memdb.WatchSet, ns, prefix string,
 	return wrappedIter, nil
 }
 
-// HostVolumesByName retrieves all host volumes of the same name
-func (s *StateStore) HostVolumesByName(ws memdb.WatchSet, ns, name string, sort SortOption) (memdb.ResultIterator, error) {
-	return s.hostVolumesIter(ws, "name_prefix", sort, ns, name)
+// HostVolumesByNamePrefix retrieves all host volumes of the same name prefix
+func (s *StateStore) HostVolumesByNamePrefix(ws memdb.WatchSet, ns, prefix string, sort SortOption) (memdb.ResultIterator, error) {
+	return s.hostVolumesIter(ws, "name_prefix", sort, ns, prefix)
 }
 
 // HostVolumesByNodeID retrieves all host volumes on the same node

--- a/nomad/state/state_store_host_volumes_test.go
+++ b/nomad/state/state_store_host_volumes_test.go
@@ -43,6 +43,7 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 		mock.HostVolume(),
 		mock.HostVolume(),
 		mock.HostVolume(),
+		mock.HostVolume(),
 	}
 	vols[0].NodeID = nodes[0].ID
 	vols[1].NodeID = nodes[1].ID
@@ -52,12 +53,16 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 	vols[3].Namespace = ns.Name
 	vols[3].NodeID = nodes[2].ID
 	vols[3].NodePool = nodes[2].NodePool
+	vols[4].NodeID = nodes[2].ID
+	vols[4].NodePool = nodes[2].NodePool
+	vols[4].Name = "example[0]" // per_alloc
 
 	index++
 	must.NoError(t, store.UpsertHostVolume(index, vols[0]))
 	must.NoError(t, store.UpsertHostVolume(index, vols[1]))
 	must.NoError(t, store.UpsertHostVolume(index, vols[2]))
 	must.NoError(t, store.UpsertHostVolume(index, vols[3]))
+	must.NoError(t, store.UpsertHostVolume(index, vols[4]))
 
 	vol, err := store.HostVolumeByID(nil, vols[0].Namespace, vols[0].ID, true)
 	must.NoError(t, err)
@@ -80,26 +85,29 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 		return got
 	}
 
-	iter, err := store.HostVolumesByName(nil, structs.DefaultNamespace, "example", SortDefault)
+	iter, err := store.HostVolumesByNamePrefix(nil, structs.DefaultNamespace, "example", SortDefault)
 	must.NoError(t, err)
 	got := consumeIter(iter)
 	must.NotNil(t, got[vols[0].ID], must.Sprint("expected vol0"))
 	must.NotNil(t, got[vols[2].ID], must.Sprint("expected vol2"))
-	must.MapLen(t, 2, got, must.Sprint(`expected 2 volumes named "example" in default namespace`))
+	must.NotNil(t, got[vols[4].ID], must.Sprint("expected vol4"))
+	must.MapLen(t, 3, got, must.Sprint(`expected 3 volumes prefixed "example" in default namespace`))
 
 	iter, err = store.HostVolumesByNodePool(nil, nodes[2].NodePool, SortDefault)
 	must.NoError(t, err)
 	got = consumeIter(iter)
 	must.NotNil(t, got[vols[2].ID], must.Sprint("expected vol2"))
 	must.NotNil(t, got[vols[3].ID], must.Sprint("expected vol3"))
-	must.MapLen(t, 2, got, must.Sprint(`expected 2 volumes in prod node pool`))
+	must.NotNil(t, got[vols[4].ID], must.Sprint("expected vol4"))
+	must.MapLen(t, 3, got, must.Sprint(`expected 3 volumes in prod node pool`))
 
 	iter, err = store.HostVolumesByNodeID(nil, nodes[2].ID, SortDefault)
 	must.NoError(t, err)
 	got = consumeIter(iter)
 	must.NotNil(t, got[vols[2].ID], must.Sprint("expected vol2"))
 	must.NotNil(t, got[vols[3].ID], must.Sprint("expected vol3"))
-	must.MapLen(t, 2, got, must.Sprint(`expected 2 volumes on node 2`))
+	must.NotNil(t, got[vols[4].ID], must.Sprint("expected vol4"))
+	must.MapLen(t, 3, got, must.Sprint(`expected 3 volumes on node 2`))
 
 	// simulate a node registering one of the volumes
 	nodes[2] = nodes[2].Copy()
@@ -120,10 +128,10 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 		must.NoError(t, store.UpsertHostVolume(index, vol))
 	}
 
-	iter, err = store.HostVolumesByName(nil, structs.DefaultNamespace, "example", SortDefault)
+	iter, err = store.HostVolumesByNamePrefix(nil, structs.DefaultNamespace, "example", SortDefault)
 	must.NoError(t, err)
 	got = consumeIter(iter)
-	must.MapLen(t, 2, got, must.Sprint(`expected 2 volumes named "example" in default namespace`))
+	must.MapLen(t, 3, got, must.Sprint(`expected 3 volumes prefixed "example" in default namespace`))
 
 	vol0 := got[vols[0].ID]
 	must.NotNil(t, vol0)
@@ -135,17 +143,26 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 		"expected volume state to be updated because its been fingerprinted by a node"))
 
 	mockJob := mock.Job()
-	mockJob.TaskGroups[0].Volumes = map[string]*structs.VolumeRequest{"example": {
-		Name:   "example",
-		Type:   structs.VolumeTypeHost,
-		Source: vols[2].Name,
-	}}
+	mockJob.TaskGroups[0].Volumes = map[string]*structs.VolumeRequest{
+		"example": {
+			Name:   "example",
+			Type:   structs.VolumeTypeHost,
+			Source: "example",
+		},
+		"example_per_alloc": {
+			Name:     "example_per_alloc",
+			Type:     structs.VolumeTypeHost,
+			Source:   "example",
+			PerAlloc: true,
+		},
+	}
 
 	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, index, nil, mockJob))
 
 	alloc := mock.AllocForNode(nodes[2])
 	alloc.Job = mockJob
 	alloc.JobID = mockJob.ID
+	alloc.Name = structs.AllocName(mockJob.ID, alloc.TaskGroup, 0)
 
 	index++
 	must.NoError(t, store.UpsertAllocs(structs.MsgTypeTestSetup,
@@ -155,6 +172,11 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 	err = store.DeleteHostVolume(index, vol2.Namespace, vols[2].ID)
 	must.EqError(t, err, fmt.Sprintf(
 		"could not delete volume %s in use by alloc %s", vols[2].ID, alloc.ID))
+
+	index++
+	err = store.DeleteHostVolume(index, vols[4].Namespace, vols[4].ID)
+	must.EqError(t, err, fmt.Sprintf(
+		"could not delete volume %s in use by alloc %s", vols[4].ID, alloc.ID))
 
 	alloc = alloc.Copy()
 	alloc.DesiredStatus = structs.AllocDesiredStatusStop
@@ -173,6 +195,12 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 		"could not delete volume %s in use by alloc %s", vols[2].ID, alloc.ID),
 		must.Sprint("allocs must be client-terminal to delete their volumes"))
 
+	index++
+	err = store.DeleteHostVolume(index, vols[4].Namespace, vols[4].ID)
+	must.EqError(t, err, fmt.Sprintf(
+		"could not delete volume %s in use by alloc %s", vols[4].ID, alloc.ID),
+		must.Sprint("allocs must be client-terminal to delete their volumes"))
+
 	err = store.DeleteHostVolume(index, vol2.Namespace, vols[1].ID)
 	must.NoError(t, err)
 	vol, err = store.HostVolumeByID(nil, vols[1].Namespace, vols[1].ID, true)
@@ -184,10 +212,15 @@ func TestStateStore_HostVolumes_CRUD(t *testing.T) {
 	must.NotNil(t, vol)
 	must.Len(t, 1, vol.Allocations)
 
+	vol, err = store.HostVolumeByID(nil, vols[4].Namespace, vols[4].ID, true)
+	must.NoError(t, err)
+	must.NotNil(t, vol)
+	must.Len(t, 1, vol.Allocations)
+
 	iter, err = store.HostVolumes(nil, SortReverse)
 	must.NoError(t, err)
 	got = consumeIter(iter)
-	must.MapLen(t, 3, got, must.Sprint(`expected 3 volumes remain`))
+	must.MapLen(t, 4, got, must.Sprint(`expected 4 volumes remain`))
 
 	prefix := vol.ID[:30] // sufficiently long prefix to avoid flakes
 	iter, err = store.HostVolumesByIDPrefix(nil, "*", prefix, SortDefault)

--- a/nomad/structs/host_volumes.go
+++ b/nomad/structs/host_volumes.go
@@ -287,6 +287,18 @@ func (hv *HostVolume) GetID() string {
 	return hv.ID
 }
 
+// MatchesRequestSource returns true if the volume request source matches the
+// volume name, accounting for the per_alloc feature
+func (hv *HostVolume) MatchesRequestSource(req *VolumeRequest, alloc *Allocation) bool {
+	if req.Type != VolumeTypeHost {
+		return false
+	}
+	if req.PerAlloc && alloc != nil {
+		return hv.Name == fmt.Sprintf("%s%s", req.Source, AllocSuffix(alloc.Name))
+	}
+	return req.Source == hv.Name
+}
+
 // HostVolumeCapability is the requested attachment and access mode for a volume
 type HostVolumeCapability struct {
 	AttachmentMode VolumeAttachmentMode

--- a/scheduler/feasible/feasible.go
+++ b/scheduler/feasible/feasible.go
@@ -452,9 +452,8 @@ func (h *HostVolumeChecker) hostVolumeIsAvailable(
 			if err != nil {
 				return false
 			}
-			tg := job.LookupTaskGroup(alloc.TaskGroup)
-			for _, req := range tg.Volumes {
-				if req.Type == structs.VolumeTypeHost && req.Source == vol.Name {
+			for _, req := range job.LookupTaskGroup(alloc.TaskGroup).Volumes {
+				if vol.MatchesRequestSource(req, alloc) {
 					if !req.ReadOnly {
 						return false
 					}


### PR DESCRIPTION
When a volume request has `per_alloc=true`, we match the name of the volume to the volume request's `source` field plus the alloc index suffix (ex. `example[0]`). But in a few places we were not properly accounting for this, making it possible to delete a dynamic host volume that's still in use or not return it in a query. Add a helper function where we need to account for this field that includes the suffix.

Fixes: https://github.com/hashicorp/nomad/issues/27896
Ref: https://hashicorp.atlassian.net/browse/NMD-1427

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
