### PR TITLE
client: add a vault default lease duration knob to nomad client config

### DIFF
--- a/.changelog/28199.txt
+++ b/.changelog/28199.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+client: Add tunable for Vault default lease duration on templates for paths without leases.
+```

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -999,6 +999,11 @@ func newRunnerConfig(config *TaskTemplateManagerConfig,
 			}
 		}
 
+		// Set the user-specificed Vault DefaultLeaseDuration
+                if cc.TemplateConfig.VaultDefaultLeaseDuration != nil {
+			conf.Vault.DefaultLeaseDuration = cc.TemplateConfig.VaultDefaultLeaseDuration
+		}
+
 		// Set the user-specified Vault RetryConfig
 		if cc.TemplateConfig.VaultRetry != nil {
 			var err error

--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -1000,7 +1000,7 @@ func newRunnerConfig(config *TaskTemplateManagerConfig,
 		}
 
 		// Set the user-specificed Vault DefaultLeaseDuration
-                if cc.TemplateConfig.VaultDefaultLeaseDuration != nil {
+		if cc.TemplateConfig.VaultDefaultLeaseDuration != nil {
 			conf.Vault.DefaultLeaseDuration = cc.TemplateConfig.VaultDefaultLeaseDuration
 		}
 

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -2463,13 +2463,13 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 		{
 			"basic-wait-config",
 			&config.ClientTemplateConfig{
-				MaxStale:           new(5 * time.Second),
-				BlockQueryWaitTime: new(60 * time.Second),
+				MaxStale:                  new(5 * time.Second),
+				BlockQueryWaitTime:        new(60 * time.Second),
 				VaultDefaultLeaseDuration: new(60 * time.Second),
-				Wait:               waitConfig.Copy(),
-				ConsulRetry:        retryConfig.Copy(),
-				VaultRetry:         retryConfig.Copy(),
-				NomadRetry:         retryConfig.Copy(),
+				Wait:                      waitConfig.Copy(),
+				ConsulRetry:               retryConfig.Copy(),
+				VaultRetry:                retryConfig.Copy(),
+				NomadRetry:                retryConfig.Copy(),
 			},
 			&TaskTemplateManagerConfig{
 				ClientConfig: clientConfig,
@@ -2480,13 +2480,13 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 			},
 			&config.Config{
 				TemplateConfig: &config.ClientTemplateConfig{
-					MaxStale:           new(5 * time.Second),
-					BlockQueryWaitTime: new(60 * time.Second),
+					MaxStale:                  new(5 * time.Second),
+					BlockQueryWaitTime:        new(60 * time.Second),
 					VaultDefaultLeaseDuration: new(60 * time.Second),
-					Wait:               waitConfig.Copy(),
-					ConsulRetry:        retryConfig.Copy(),
-					VaultRetry:         retryConfig.Copy(),
-					NomadRetry:         retryConfig.Copy(),
+					Wait:                      waitConfig.Copy(),
+					ConsulRetry:               retryConfig.Copy(),
+					VaultRetry:                retryConfig.Copy(),
+					NomadRetry:                retryConfig.Copy(),
 				},
 			},
 			&templateconfig.TemplateConfig{
@@ -2500,13 +2500,13 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 		{
 			"template-override",
 			&config.ClientTemplateConfig{
-				MaxStale:           new(5 * time.Second),
-				BlockQueryWaitTime: new(60 * time.Second),
+				MaxStale:                  new(5 * time.Second),
+				BlockQueryWaitTime:        new(60 * time.Second),
 				VaultDefaultLeaseDuration: new(60 * time.Second),
-				Wait:               waitConfig.Copy(),
-				ConsulRetry:        retryConfig.Copy(),
-				VaultRetry:         retryConfig.Copy(),
-				NomadRetry:         retryConfig.Copy(),
+				Wait:                      waitConfig.Copy(),
+				ConsulRetry:               retryConfig.Copy(),
+				VaultRetry:                retryConfig.Copy(),
+				NomadRetry:                retryConfig.Copy(),
 			},
 			&TaskTemplateManagerConfig{
 				ClientConfig: clientConfig,
@@ -2517,13 +2517,13 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 			},
 			&config.Config{
 				TemplateConfig: &config.ClientTemplateConfig{
-					MaxStale:           new(5 * time.Second),
-					BlockQueryWaitTime: new(60 * time.Second),
+					MaxStale:                  new(5 * time.Second),
+					BlockQueryWaitTime:        new(60 * time.Second),
 					VaultDefaultLeaseDuration: new(60 * time.Second),
-					Wait:               waitConfig.Copy(),
-					ConsulRetry:        retryConfig.Copy(),
-					VaultRetry:         retryConfig.Copy(),
-					NomadRetry:         retryConfig.Copy(),
+					Wait:                      waitConfig.Copy(),
+					ConsulRetry:               retryConfig.Copy(),
+					VaultRetry:                retryConfig.Copy(),
+					NomadRetry:                retryConfig.Copy(),
 				},
 			},
 			&templateconfig.TemplateConfig{
@@ -2537,10 +2537,10 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 		{
 			"bounds-override",
 			&config.ClientTemplateConfig{
-				MaxStale:           new(5 * time.Second),
-				BlockQueryWaitTime: new(60 * time.Second),
+				MaxStale:                  new(5 * time.Second),
+				BlockQueryWaitTime:        new(60 * time.Second),
 				VaultDefaultLeaseDuration: new(60 * time.Second),
-				Wait:               waitConfig.Copy(),
+				Wait:                      waitConfig.Copy(),
 				WaitBounds: &config.WaitConfig{
 					Min: new(3 * time.Second),
 					Max: new(11 * time.Second),
@@ -2566,10 +2566,10 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 			},
 			&config.Config{
 				TemplateConfig: &config.ClientTemplateConfig{
-					MaxStale:           new(5 * time.Second),
-					BlockQueryWaitTime: new(60 * time.Second),
+					MaxStale:                  new(5 * time.Second),
+					BlockQueryWaitTime:        new(60 * time.Second),
 					VaultDefaultLeaseDuration: new(60 * time.Second),
-					Wait:               waitConfig.Copy(),
+					Wait:                      waitConfig.Copy(),
 					WaitBounds: &config.WaitConfig{
 						Min: new(3 * time.Second),
 						Max: new(11 * time.Second),

--- a/client/allocrunner/taskrunner/template/template_test.go
+++ b/client/allocrunner/taskrunner/template/template_test.go
@@ -2436,6 +2436,7 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 
 	clientConfig.TemplateConfig.MaxStale = new(5 * time.Second)
 	clientConfig.TemplateConfig.BlockQueryWaitTime = new(60 * time.Second)
+	clientConfig.TemplateConfig.VaultDefaultLeaseDuration = new(60 * time.Second)
 	clientConfig.TemplateConfig.Wait = waitConfig.Copy()
 	clientConfig.TemplateConfig.ConsulRetry = retryConfig.Copy()
 	clientConfig.TemplateConfig.VaultRetry = retryConfig.Copy()
@@ -2464,6 +2465,7 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 			&config.ClientTemplateConfig{
 				MaxStale:           new(5 * time.Second),
 				BlockQueryWaitTime: new(60 * time.Second),
+				VaultDefaultLeaseDuration: new(60 * time.Second),
 				Wait:               waitConfig.Copy(),
 				ConsulRetry:        retryConfig.Copy(),
 				VaultRetry:         retryConfig.Copy(),
@@ -2480,6 +2482,7 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 				TemplateConfig: &config.ClientTemplateConfig{
 					MaxStale:           new(5 * time.Second),
 					BlockQueryWaitTime: new(60 * time.Second),
+					VaultDefaultLeaseDuration: new(60 * time.Second),
 					Wait:               waitConfig.Copy(),
 					ConsulRetry:        retryConfig.Copy(),
 					VaultRetry:         retryConfig.Copy(),
@@ -2499,6 +2502,7 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 			&config.ClientTemplateConfig{
 				MaxStale:           new(5 * time.Second),
 				BlockQueryWaitTime: new(60 * time.Second),
+				VaultDefaultLeaseDuration: new(60 * time.Second),
 				Wait:               waitConfig.Copy(),
 				ConsulRetry:        retryConfig.Copy(),
 				VaultRetry:         retryConfig.Copy(),
@@ -2515,6 +2519,7 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 				TemplateConfig: &config.ClientTemplateConfig{
 					MaxStale:           new(5 * time.Second),
 					BlockQueryWaitTime: new(60 * time.Second),
+					VaultDefaultLeaseDuration: new(60 * time.Second),
 					Wait:               waitConfig.Copy(),
 					ConsulRetry:        retryConfig.Copy(),
 					VaultRetry:         retryConfig.Copy(),
@@ -2534,6 +2539,7 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 			&config.ClientTemplateConfig{
 				MaxStale:           new(5 * time.Second),
 				BlockQueryWaitTime: new(60 * time.Second),
+				VaultDefaultLeaseDuration: new(60 * time.Second),
 				Wait:               waitConfig.Copy(),
 				WaitBounds: &config.WaitConfig{
 					Min: new(3 * time.Second),
@@ -2562,6 +2568,7 @@ func TestTaskTemplateManager_ClientTemplateConfig_Set(t *testing.T) {
 				TemplateConfig: &config.ClientTemplateConfig{
 					MaxStale:           new(5 * time.Second),
 					BlockQueryWaitTime: new(60 * time.Second),
+					VaultDefaultLeaseDuration: new(60 * time.Second),
 					Wait:               waitConfig.Copy(),
 					WaitBounds: &config.WaitConfig{
 						Min: new(3 * time.Second),

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -475,6 +475,14 @@ type ClientTemplateConfig struct {
 	// systems.
 	ConsulRetry *RetryConfig `hcl:"consul_retry,optional"`
 
+	// This controls how often non-renewable, non-leased secrets from Vault are
+	// re-polled.  In practice this will primarily be KVv2 secrets.
+	// Consul Template is opinionated by default and sets this value to 5 minutes 
+	// which is a very safe level.  In low-write situations with many polling 
+	// clients in a large cluster this may be overall too aggressive.
+        VaultDefaultLeaseDuration    *time.Duration `hcl:"-"`
+        VaultDefaultLeaseDurationHCL string	    `hcl:"vault_default_lease_duration,optional"`
+
 	// This controls the retry behavior when an error is returned from Vault.
 	// Consul Template is highly fault tolerant, meaning it does not exit in the
 	// face of failure. Instead, it uses exponential back-off and retry functions
@@ -509,6 +517,7 @@ func DefaultTemplateConfig() *ClientTemplateConfig {
 			Backoff:    new(time.Millisecond * 250),
 			MaxBackoff: new(time.Minute),
 		},
+		VaultDefaultLeaseDuration: new(5 * time.Minute), // match Consul Template default
 		VaultRetry: &RetryConfig{
 			Attempts:   new(12),
 			Backoff:    new(time.Millisecond * 250),
@@ -555,6 +564,10 @@ func (c *ClientTemplateConfig) Copy() *ClientTemplateConfig {
 		nc.ConsulRetry = c.ConsulRetry.Copy()
 	}
 
+	if c.VaultDefaultLeaseDuration != nil {
+		nc.VaultDefaultLeaseDuration = &*c.VaultDefaultLeaseDuration
+	}
+
 	if c.VaultRetry != nil {
 		nc.VaultRetry = c.VaultRetry.Copy()
 	}
@@ -580,6 +593,8 @@ func (c *ClientTemplateConfig) IsEmpty() bool {
 		c.MaxStaleHCL == "" &&
 		c.Wait.IsEmpty() &&
 		c.ConsulRetry.IsEmpty() &&
+		c.VaultDefaultLeaseDuration == nil &&
+		c.VaultDefaultLeaseDurationHCL == "" &&
 		c.VaultRetry.IsEmpty() &&
 		c.NomadRetry.IsEmpty() &&
 		!c.UseClientConsulToken
@@ -619,6 +634,7 @@ func (c *ClientTemplateConfig) Merge(o *ClientTemplateConfig) *ClientTemplateCon
 	if o.ConsulRetry != nil {
 		result.ConsulRetry = c.ConsulRetry.Merge(o.ConsulRetry)
 	}
+	o.VaultDefaultLeaseDuration = pointer.Merge(result.VaultDefaultLeaseDuration, o.VaultDefaultLeaseDuration)
 	if o.VaultRetry != nil {
 		result.VaultRetry = c.VaultRetry.Merge(o.VaultRetry)
 	}

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -477,11 +477,11 @@ type ClientTemplateConfig struct {
 
 	// This controls how often non-renewable, non-leased secrets from Vault are
 	// re-polled.  In practice this will primarily be KVv2 secrets.
-	// Consul Template is opinionated by default and sets this value to 5 minutes 
-	// which is a very safe level.  In low-write situations with many polling 
+	// Consul Template is opinionated by default and sets this value to 5 minutes
+	// which is a very safe level.  In low-write situations with many polling
 	// clients in a large cluster this may be overall too aggressive.
-        VaultDefaultLeaseDuration    *time.Duration `hcl:"-"`
-        VaultDefaultLeaseDurationHCL string	    `hcl:"vault_default_lease_duration,optional"`
+	VaultDefaultLeaseDuration    *time.Duration `hcl:"-"`
+	VaultDefaultLeaseDurationHCL string         `hcl:"vault_default_lease_duration,optional"`
 
 	// This controls the retry behavior when an error is returned from Vault.
 	// Consul Template is highly fault tolerant, meaning it does not exit in the

--- a/client/config/config.go
+++ b/client/config/config.go
@@ -634,7 +634,7 @@ func (c *ClientTemplateConfig) Merge(o *ClientTemplateConfig) *ClientTemplateCon
 	if o.ConsulRetry != nil {
 		result.ConsulRetry = c.ConsulRetry.Merge(o.ConsulRetry)
 	}
-	o.VaultDefaultLeaseDuration = pointer.Merge(result.VaultDefaultLeaseDuration, o.VaultDefaultLeaseDuration)
+	result.VaultDefaultLeaseDuration = pointer.Merge(result.VaultDefaultLeaseDuration, o.VaultDefaultLeaseDuration)
 	if o.VaultRetry != nil {
 		result.VaultRetry = c.VaultRetry.Merge(o.VaultRetry)
 	}

--- a/command/agent/config_parse.go
+++ b/command/agent/config_parse.go
@@ -163,6 +163,11 @@ func ParseConfigFile(path string) (*Config, error) {
 				c.Client.TemplateConfig.ConsulRetry.MaxBackoff = d
 			},
 		},
+		{"client.template.vault_default_lease_duration", nil, &c.Client.TemplateConfig.VaultDefaultLeaseDurationHCL,
+			func(d *time.Duration) {
+				c.Client.TemplateConfig.VaultDefaultLeaseDuration = d
+			},
+		},
 		{"client.template.vault_retry.backoff", nil, &c.Client.TemplateConfig.VaultRetry.BackoffHCL,
 			func(d *time.Duration) {
 				c.Client.TemplateConfig.VaultRetry.Backoff = d

--- a/command/agent/config_parse_test.go
+++ b/command/agent/config_parse_test.go
@@ -1221,6 +1221,7 @@ func TestConfig_Template(t *testing.T) {
 			must.Eq(t, new(550*time.Millisecond), cfg.Client.TemplateConfig.ConsulRetry.Backoff)
 			must.Eq(t, new(10*time.Minute), cfg.Client.TemplateConfig.ConsulRetry.MaxBackoff)
 
+			must.NotNil(t, cfg.Client.TemplateConfig.VaultDefaultLeaseDuration)
 			must.NotNil(t, cfg.Client.TemplateConfig.VaultRetry)
 			must.Eq(t, 6, *cfg.Client.TemplateConfig.VaultRetry.Attempts)
 			must.Eq(t, new(550*time.Millisecond), cfg.Client.TemplateConfig.VaultRetry.Backoff)

--- a/command/agent/config_test.go
+++ b/command/agent/config_test.go
@@ -329,10 +329,11 @@ func TestConfig_Merge(t *testing.T) {
 			MaxKillTimeout:    "50s",
 			DisableRemoteExec: false,
 			TemplateConfig: &client.ClientTemplateConfig{
-				FunctionDenylist:   client.DefaultTemplateFunctionDenylist,
-				DisableSandbox:     false,
-				BlockQueryWaitTime: new(5 * time.Minute),
-				MaxStale:           new(client.DefaultTemplateMaxStale),
+				FunctionDenylist:          client.DefaultTemplateFunctionDenylist,
+				DisableSandbox:            false,
+				BlockQueryWaitTime:        new(5 * time.Minute),
+				VaultDefaultLeaseDuration: new(5 * time.Minute),
+				MaxStale:                  new(client.DefaultTemplateMaxStale),
 				Wait: &client.WaitConfig{
 					Min: new(5 * time.Second),
 					Max: new(4 * time.Minute),
@@ -1703,6 +1704,7 @@ func TestConfig_LoadConsulTemplateConfig(t *testing.T) {
 		// check all the complex defaults
 		must.Eq(t, 87600*time.Hour, *templateConfig.MaxStale)
 		must.Eq(t, 5*time.Minute, *templateConfig.BlockQueryWaitTime)
+		must.Eq(t, 5*time.Minute, *templateConfig.VaultDefaultLeaseDuration)
 
 		// Wait
 		must.NotNil(t, templateConfig.Wait)


### PR DESCRIPTION
### Description
This adds a Vault default lease duration tunable into the Nomad client configuration.  This is necessary as we're running into interesting scenarios where users are doing what we're asking them to do (a long overdue kvv1 to kvv2 migration) however, in doing so, they're massively increasing their usage on Vault.  In almost all of these cases, at least for us, setting this to 10 or even 30 minutes would not matter, and would also completely remove our scaling issues.

There will be a follow-up PR to this one adding an override into template blocks directly.  I want to ensure this one lands first, however.

### Testing & Reproduction steps
Use any template block with any kvv2 reference, it will always refresh every 80-95% of 5 minutes.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

