### PR TITLE
Add stable allocation log offsets

### DIFF
--- a/api/fs.go
+++ b/api/fs.go
@@ -43,10 +43,22 @@ type AllocFileInfo struct {
 
 // StreamFrame is used to frame data of a file when streaming
 type StreamFrame struct {
+	// Offset is the next file offset after Data.
 	Offset    int64  `json:",omitempty"`
 	Data      []byte `json:",omitempty"`
 	File      string `json:",omitempty"`
 	FileEvent string `json:",omitempty"`
+
+	// GlobalOffset is the next allocation-lifetime stable offset after this frame.
+	// It can be supplied as the offset to LogsWithGlobalOffset to resume after
+	// this frame, even if task logs have rotated.
+	GlobalOffset int64 `json:",omitempty"`
+
+	// FileIndex indicates which rotation file this data came from (0, 1, 2...)
+	FileIndex int64 `json:",omitempty"`
+
+	// ByteOffset is the next offset within the specific file after this frame.
+	ByteOffset int64 `json:",omitempty"`
 }
 
 // IsHeartbeat returns if the frame is a heartbeat frame
@@ -321,6 +333,58 @@ func (a *AllocFS) Logs(alloc *Allocation, follow bool, task, logType, origin str
 	}()
 
 	return frames, errCh
+}
+
+// LogsWithGlobalOffset streams the content of a tasks logs with global offset support.
+// This method enables stable offset tracking across log file rotations, allowing reliable
+// resumption after disconnections.
+//
+// The parameters are:
+//   - allocation: the allocation to stream from.
+//   - follow: Whether the logs should be followed.
+//   - task: the tasks name to stream logs for.
+//   - logType: Either "stdout" or "stderr"
+//   - origin: Either "start" or "end" and defines from where the offset is applied.
+//   - offset: The global offset to start streaming data at when origin is "start".
+//     With origin "end", offset keeps the existing end-relative byte semantics
+//     while returned frames still include global offsets for future resumes.
+//   - cancel: A channel that when closed, streaming will end.
+//
+// The return value is a channel that will emit StreamFrames as they are read.
+// Each StreamFrame will include GlobalOffset, FileIndex, and ByteOffset fields
+// for stable resumption capabilities.
+//
+// Example usage:
+//
+//	frames, errors := client.AllocFS().LogsWithGlobalOffset(
+//	    alloc, true, "web", "stdout", "start", 0, cancel, nil)
+//
+//	var lastGlobalOffset int64
+//	for frame := range frames {
+//	    // Process log data
+//	    fmt.Print(string(frame.Data))
+//
+//	    // Track global offset for resumption
+//	    if frame.GlobalOffset > lastGlobalOffset {
+//	        lastGlobalOffset = frame.GlobalOffset
+//	    }
+//	}
+//
+//	// To resume later, use lastGlobalOffset as the offset parameter
+//
+// Note: for cluster topologies where API consumers don't have network access to
+// Nomad clients, set api.ClientConnTimeout to a small value (ex 1ms) to avoid
+// long pauses on this API call.
+func (a *AllocFS) LogsWithGlobalOffset(alloc *Allocation, follow bool, task, logType, origin string,
+	offset int64, cancel <-chan struct{}, q *QueryOptions) (<-chan *StreamFrame, <-chan error) {
+	if q == nil {
+		q = &QueryOptions{}
+	}
+	if q.Params == nil {
+		q.Params = make(map[string]string)
+	}
+	q.Params["useGlobalOffset"] = "true"
+	return a.Logs(alloc, follow, task, logType, origin, offset, cancel, q)
 }
 
 // FrameReader is used to convert a stream of frames into a read closer.

--- a/client/fs_endpoint.go
+++ b/client/fs_endpoint.go
@@ -6,6 +6,7 @@ package client
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -25,6 +26,7 @@ import (
 	"github.com/hashicorp/nomad/acl"
 	"github.com/hashicorp/nomad/client/allocdir"
 	sframer "github.com/hashicorp/nomad/client/lib/streamframer"
+	"github.com/hashicorp/nomad/client/logmon/logging"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
@@ -460,7 +462,7 @@ func (f *FileSystem) logs(conn io.ReadWriteCloser) {
 	// Start streaming
 	go func() {
 		if err := f.logsImpl(ctx, req.Follow, req.PlainText,
-			req.Offset, req.Origin, req.Task, req.LogType, fs, frames); err != nil {
+			req.Offset, req.Origin, req.Task, req.LogType, req.UseGlobalOffset, fs, frames); err != nil {
 			select {
 			case errCh <- err:
 			case <-ctx.Done():
@@ -508,6 +510,13 @@ OUTER:
 				break OUTER
 			}
 
+			if req.UseGlobalOffset && len(frame.Data) > 0 {
+				if err := setGlobalLogOffset(fs, req.Task, req.LogType, frame); err != nil {
+					streamErr = err
+					break OUTER
+				}
+			}
+
 			var resp cstructs.StreamErrWrapper
 			if req.PlainText {
 				resp.Payload = frame.Data
@@ -545,7 +554,7 @@ OUTER:
 // the passed frames channel and the method will return on EOF if follow is not
 // true otherwise when the context is cancelled or on an error.
 func (f *FileSystem) logsImpl(ctx context.Context, follow, plain bool, offset int64,
-	origin, task, logType string,
+	origin, task, logType string, useGlobalOffset bool,
 	fs allocdir.AllocDirFS, frames chan<- *sframer.StreamFrame) error {
 
 	// Create the framer
@@ -558,14 +567,20 @@ func (f *FileSystem) logsImpl(ctx context.Context, follow, plain bool, offset in
 
 	// nextIdx is the next index to read logs from
 	var nextIdx int64
-	switch origin {
-	case "start":
-		nextIdx = 0
-	case "end":
-		nextIdx = math.MaxInt64
-		offset *= -1
-	default:
-		return invalidOrigin
+	var fileOffset int64 = offset
+
+	resolveGlobalOffset := useGlobalOffset && origin == "start"
+	if !resolveGlobalOffset {
+		// Existing behavior
+		switch origin {
+		case "start":
+			nextIdx = 0
+		case "end":
+			nextIdx = math.MaxInt64
+			fileOffset *= -1
+		default:
+			return invalidOrigin
+		}
 	}
 
 	for {
@@ -579,6 +594,14 @@ func (f *FileSystem) logsImpl(ctx context.Context, follow, plain bool, offset in
 		if err != nil {
 			return fmt.Errorf("failed to list entries: %v", err)
 		}
+		if resolveGlobalOffset {
+			fileIdx, fileOff, err := mapGlobalLogOffset(fs, entries, task, logType, offset)
+			if err != nil {
+				return err
+			}
+			nextIdx = fileIdx
+			fileOffset = fileOff
+		}
 
 		// If we are not following logs, determine the max index for the logs we are
 		// interested in so we can stop there.
@@ -591,7 +614,7 @@ func (f *FileSystem) logsImpl(ctx context.Context, follow, plain bool, offset in
 			maxIndex = idx
 		}
 
-		logEntry, idx, openOffset, err := findClosest(entries, nextIdx, offset, task, logType)
+		logEntry, idx, openOffset, err := findClosest(entries, nextIdx, fileOffset, task, logType)
 		if err != nil {
 			return err
 		}
@@ -650,6 +673,8 @@ func (f *FileSystem) logsImpl(ctx context.Context, follow, plain bool, offset in
 
 		// Since we successfully streamed, update the overall offset/idx.
 		offset = int64(0)
+		fileOffset = int64(0)
+		resolveGlobalOffset = false
 		nextIdx = idx + 1
 	}
 }
@@ -866,6 +891,25 @@ type indexTuple struct {
 	entry *cstructs.AllocFileInfo
 }
 
+type logOffsetSegment struct {
+	idx  int64
+	base int64
+	size int64
+}
+
+type globalOffsetUnavailableErr struct {
+	offset int64
+	oldest int64
+}
+
+func (e globalOffsetUnavailableErr) Error() string {
+	return fmt.Sprintf("global log offset %d is no longer available; oldest available offset is %d", e.offset, e.oldest)
+}
+
+func (e globalOffsetUnavailableErr) Code() int {
+	return http.StatusRequestedRangeNotSatisfiable
+}
+
 type indexTupleArray []indexTuple
 
 func (a indexTupleArray) Len() int           { return len(a) }
@@ -899,6 +943,146 @@ func logIndexes(entries []*cstructs.AllocFileInfo, task, logType string) (indexT
 	}
 
 	return indexTupleArray(indexes), nil
+}
+
+func mapGlobalLogOffset(fs allocdir.AllocDirFS, entries []*cstructs.AllocFileInfo,
+	task, logType string, offset int64) (int64, int64, error) {
+
+	segments, err := logOffsetSegmentsFromEntries(fs, entries, task, logType)
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(segments) == 0 {
+		return 0, 0, notFoundErr{taskName: task, logType: logType}
+	}
+
+	oldest := segments[0].base
+	if offset < oldest {
+		return 0, 0, globalOffsetUnavailableErr{offset: offset, oldest: oldest}
+	}
+
+	for i, segment := range segments {
+		end := segment.base + segment.size
+		if offset == segment.base || offset < end || (offset == end && i == len(segments)-1) {
+			return segment.idx, offset - segment.base, nil
+		}
+		if offset == end && i+1 < len(segments) && segments[i+1].base == end {
+			continue
+		}
+		if i+1 < len(segments) && offset < segments[i+1].base {
+			return 0, 0, globalOffsetUnavailableErr{offset: offset, oldest: segments[i+1].base}
+		}
+	}
+
+	last := segments[len(segments)-1]
+	return last.idx, last.size, nil
+}
+
+func setGlobalLogOffset(fs allocdir.AllocDirFS, task, logType string, frame *sframer.StreamFrame) error {
+	idx, err := logIndexFromPath(frame.File, task, logType)
+	if err != nil {
+		return err
+	}
+	base, err := globalLogBase(fs, task, logType, idx)
+	if err != nil {
+		return err
+	}
+
+	frame.FileIndex = idx
+	frame.ByteOffset = frame.Offset
+	frame.GlobalOffset = base + frame.Offset
+	return nil
+}
+
+func globalLogBase(fs allocdir.AllocDirFS, task, logType string, idx int64) (int64, error) {
+	manifest, err := readLogOffsetManifest(fs, task, logType)
+	if err != nil && !os.IsNotExist(err) {
+		return 0, err
+	}
+	if manifest != nil {
+		if file, ok := manifest.Files[strconv.FormatInt(idx, 10)]; ok {
+			return file.Base, nil
+		}
+	}
+
+	segments, err := logOffsetSegments(fs, task, logType)
+	if err != nil {
+		return 0, err
+	}
+	for _, segment := range segments {
+		if segment.idx == idx {
+			return segment.base, nil
+		}
+	}
+	return 0, notFoundErr{taskName: task, logType: logType}
+}
+
+func logOffsetSegments(fs allocdir.AllocDirFS, task, logType string) ([]logOffsetSegment, error) {
+	logPath := filepath.Join(allocdir.SharedAllocName, allocdir.LogDirName)
+	entries, err := fs.List(logPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list entries: %v", err)
+	}
+	return logOffsetSegmentsFromEntries(fs, entries, task, logType)
+}
+
+func logOffsetSegmentsFromEntries(fs allocdir.AllocDirFS, entries []*cstructs.AllocFileInfo,
+	task, logType string) ([]logOffsetSegment, error) {
+
+	indexes, err := logIndexes(entries, task, logType)
+	if err != nil {
+		return nil, err
+	}
+	sort.Sort(indexes)
+
+	manifest, err := readLogOffsetManifest(fs, task, logType)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	segments := make([]logOffsetSegment, 0, len(indexes))
+	var reconstructedBase int64
+	for _, item := range indexes {
+		segment := logOffsetSegment{idx: item.idx, base: reconstructedBase, size: item.entry.Size}
+		if manifest != nil {
+			if file, ok := manifest.Files[strconv.FormatInt(item.idx, 10)]; ok {
+				segment.base = file.Base
+			}
+		}
+		segments = append(segments, segment)
+		reconstructedBase += item.entry.Size
+	}
+	sort.Slice(segments, func(i, j int) bool { return segments[i].idx < segments[j].idx })
+	return segments, nil
+}
+
+func readLogOffsetManifest(fs allocdir.AllocDirFS, task, logType string) (*logging.OffsetManifest, error) {
+	baseFileName := fmt.Sprintf("%s.%s", task, logType)
+	path := filepath.Join(allocdir.SharedAllocName, logging.OffsetManifestFile(baseFileName))
+	r, err := fs.ReadAt(path, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	var manifest logging.OffsetManifest
+	if err := json.NewDecoder(r).Decode(&manifest); err != nil {
+		return nil, err
+	}
+	return &manifest, nil
+}
+
+func logIndexFromPath(path, task, logType string) (int64, error) {
+	name := filepath.Base(path)
+	prefix := fmt.Sprintf("%s.%s.", task, logType)
+	idxStr := strings.TrimPrefix(name, prefix)
+	if idxStr == name {
+		return 0, fmt.Errorf("failed to extract log index from %q", path)
+	}
+	idx, err := strconv.ParseInt(idxStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to convert %q to a log index: %v", idxStr, err)
+	}
+	return idx, nil
 }
 
 // notFoundErr is returned when a log is requested but cannot be found.

--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -5,6 +5,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -25,6 +26,7 @@ import (
 	"github.com/hashicorp/nomad/client/allocdir"
 	"github.com/hashicorp/nomad/client/config"
 	sframer "github.com/hashicorp/nomad/client/lib/streamframer"
+	"github.com/hashicorp/nomad/client/logmon/logging"
 	cstructs "github.com/hashicorp/nomad/client/structs"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -2074,7 +2076,7 @@ func TestFS_logsImpl_NoFollow(t *testing.T) {
 
 	if err := c.endpoints.FileSystem.logsImpl(
 		ctx, false, false, 0,
-		OriginStart, task, logType, ad, frames); err != nil {
+		OriginStart, task, logType, false, ad, frames); err != nil {
 		t.Fatalf("logsImpl failed: %v", err)
 	}
 
@@ -2164,7 +2166,7 @@ func TestFS_logsImpl_Follow(t *testing.T) {
 	// Start streaming logs
 	go c.endpoints.FileSystem.logsImpl(
 		context.Background(), true, false, 0,
-		OriginStart, task, logType, ad, frames)
+		OriginStart, task, logType, false, ad, frames)
 
 	select {
 	case <-firstResultCh:
@@ -2185,4 +2187,90 @@ func TestFS_logsImpl_Follow(t *testing.T) {
 	case <-time.After(10 * time.Duration(testutil.TestMultiplier()) * streamBatchWindow):
 		t.Fatalf("did not receive data: got %q", string(received))
 	}
+}
+
+func TestFS_logsImpl_GlobalOffset(t *testing.T) {
+	ci.Parallel(t)
+
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
+
+	ad := tempAllocDir(t)
+	require.NoError(t, ad.Build())
+	defer ad.Destroy()
+
+	logDir := filepath.Join(ad.SharedDir, allocdir.LogDirName)
+	require.NoError(t, os.MkdirAll(logDir, 0777))
+
+	task := "foo"
+	logType := "stdout"
+	require.NoError(t, os.WriteFile(filepath.Join(logDir, "foo.stdout.0"), []byte("abc"), 0777))
+	require.NoError(t, os.WriteFile(filepath.Join(logDir, "foo.stdout.1"), []byte("def"), 0777))
+
+	manifest := logging.OffsetManifest{
+		Version:      1,
+		BaseFileName: "foo.stdout",
+		Files: map[string]logging.OffsetManifestLog{
+			"0": {Index: 0, Base: 0, Size: 3},
+			"1": {Index: 1, Base: 3, Size: 3},
+		},
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(ad.SharedDir, logging.OffsetManifestFile("foo.stdout")), manifestBytes, 0644))
+
+	frames := make(chan *sframer.StreamFrame, 4)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err = c.endpoints.FileSystem.logsImpl(ctx, false, false, 4, OriginStart, task, logType, true, ad, frames)
+	require.NoError(t, err)
+
+	var got []byte
+	var last *sframer.StreamFrame
+	for len(frames) > 0 {
+		frame := <-frames
+		if frame.IsHeartbeat() {
+			continue
+		}
+		got = append(got, frame.Data...)
+		last = frame
+	}
+
+	require.Equal(t, []byte("ef"), got)
+	require.NotNil(t, last)
+	require.Equal(t, int64(1), last.FileIndex)
+	require.Equal(t, int64(3), last.ByteOffset)
+	require.Equal(t, int64(6), last.GlobalOffset)
+}
+
+func TestFS_logsImpl_GlobalOffsetUnavailable(t *testing.T) {
+	ci.Parallel(t)
+
+	c, cleanup := TestClient(t, nil)
+	defer cleanup()
+
+	ad := tempAllocDir(t)
+	require.NoError(t, ad.Build())
+	defer ad.Destroy()
+
+	logDir := filepath.Join(ad.SharedDir, allocdir.LogDirName)
+	require.NoError(t, os.MkdirAll(logDir, 0777))
+	require.NoError(t, os.WriteFile(filepath.Join(logDir, "foo.stdout.2"), []byte("ghi"), 0777))
+
+	manifest := logging.OffsetManifest{
+		Version:      1,
+		BaseFileName: "foo.stdout",
+		Files: map[string]logging.OffsetManifestLog{
+			"2": {Index: 2, Base: 6, Size: 3},
+		},
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(ad.SharedDir, logging.OffsetManifestFile("foo.stdout")), manifestBytes, 0644))
+
+	frames := make(chan *sframer.StreamFrame, 4)
+	err = c.endpoints.FileSystem.logsImpl(context.Background(), false, false, 2, OriginStart, "foo", "stdout", true, ad, frames)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no longer available")
 }

--- a/client/fs_endpoint_test.go
+++ b/client/fs_endpoint_test.go
@@ -2227,21 +2227,50 @@ func TestFS_logsImpl_GlobalOffset(t *testing.T) {
 	require.NoError(t, err)
 
 	var got []byte
-	var last *sframer.StreamFrame
 	for len(frames) > 0 {
 		frame := <-frames
 		if frame.IsHeartbeat() {
 			continue
 		}
 		got = append(got, frame.Data...)
-		last = frame
 	}
 
 	require.Equal(t, []byte("ef"), got)
-	require.NotNil(t, last)
-	require.Equal(t, int64(1), last.FileIndex)
-	require.Equal(t, int64(3), last.ByteOffset)
-	require.Equal(t, int64(6), last.GlobalOffset)
+}
+
+func TestFS_setGlobalLogOffset(t *testing.T) {
+	ci.Parallel(t)
+
+	ad := tempAllocDir(t)
+	require.NoError(t, ad.Build())
+	defer ad.Destroy()
+
+	manifest := logging.OffsetManifest{
+		Version:      1,
+		BaseFileName: "foo.stdout",
+		Files: map[string]logging.OffsetManifestLog{
+			"0": {Index: 0, Base: 0, Size: 3},
+			"1": {Index: 1, Base: 3, Size: 3},
+		},
+	}
+	manifestBytes, err := json.Marshal(manifest)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(ad.SharedDir, logging.OffsetManifestFile("foo.stdout")),
+		manifestBytes,
+		0644,
+	))
+
+	frame := &sframer.StreamFrame{
+		File:   filepath.Join(allocdir.SharedAllocName, allocdir.LogDirName, "foo.stdout.1"),
+		Offset: 3,
+		Data:   []byte("def"),
+	}
+
+	require.NoError(t, setGlobalLogOffset(ad, "foo", "stdout", frame))
+	require.Equal(t, int64(1), frame.FileIndex)
+	require.Equal(t, int64(3), frame.ByteOffset)
+	require.Equal(t, int64(6), frame.GlobalOffset)
 }
 
 func TestFS_logsImpl_GlobalOffsetUnavailable(t *testing.T) {

--- a/client/lib/streamframer/framer.go
+++ b/client/lib/streamframer/framer.go
@@ -18,7 +18,7 @@ var (
 
 // StreamFrame is used to frame data of a file when streaming
 type StreamFrame struct {
-	// Offset is the offset the data was read from
+	// Offset is the next file offset after Data.
 	Offset int64 `json:",omitempty"`
 
 	// Data is the read data
@@ -30,6 +30,15 @@ type StreamFrame struct {
 	// FileEvent is the last file event that occurred that could cause the
 	// streams position to change or end
 	FileEvent string `json:",omitempty"`
+
+	// GlobalOffset is the next allocation-lifetime stable offset after this frame.
+	GlobalOffset int64 `json:",omitempty"`
+
+	// FileIndex indicates which rotation file this data came from (0, 1, 2...)
+	FileIndex int64 `json:",omitempty"`
+
+	// ByteOffset is the next offset within the specific file after this frame.
+	ByteOffset int64 `json:",omitempty"`
 }
 
 // IsHeartbeat returns if the frame is a heartbeat frame
@@ -42,6 +51,9 @@ func (s *StreamFrame) Clear() {
 	s.Data = nil
 	s.File = ""
 	s.FileEvent = ""
+	s.GlobalOffset = 0
+	s.FileIndex = 0
+	s.ByteOffset = 0
 }
 
 func (s *StreamFrame) IsCleared() bool {
@@ -224,7 +236,11 @@ func (s *StreamFramer) send() {
 	default:
 	}
 
+	endOffset := s.f.Offset
 	s.f.Data = s.readData()
+	if len(s.f.Data) > 0 {
+		s.f.Offset = endOffset - int64(s.data.Len())
+	}
 	select {
 	case s.out <- s.f.Copy():
 		s.f.Clear()
@@ -268,13 +284,13 @@ func (s *StreamFramer) Send(file, fileEvent string, data []byte, offset int64) e
 
 	// Store the new data as the current frame.
 	if s.f.IsCleared() {
-		s.f.Offset = offset
 		s.f.File = file
 		s.f.FileEvent = fileEvent
 	}
 
 	// Write the data to the buffer
 	s.data.Write(data)
+	s.f.Offset = offset
 
 	// Handle the delete case in which there is no data
 	force := s.data.Len() == 0 && s.f.FileEvent != ""
@@ -297,15 +313,17 @@ func (s *StreamFramer) Send(file, fileEvent string, data []byte, offset int64) e
 		}
 
 		// Create a new frame to send it
+		endOffset := s.f.Offset
 		s.f.Data = s.readData()
+		if len(s.f.Data) > 0 {
+			s.f.Offset = endOffset - int64(s.data.Len())
+		}
 		select {
 		case s.out <- s.f.Copy():
 		case <-s.exitCh:
 			return nil
 		}
-
-		// Update the offset
-		s.f.Offset += int64(len(s.f.Data))
+		s.f.Offset = endOffset
 	}
 
 	return nil
@@ -318,7 +336,11 @@ func (s *StreamFramer) IsFlushed() bool {
 func (s *StreamFramer) Flush() bool {
 	s.l.Lock()
 	// Send() may have left a partial frame. Send it now.
+	endOffset := s.f.Offset
 	s.f.Data = s.readData()
+	if len(s.f.Data) > 0 {
+		s.f.Offset = endOffset - int64(s.data.Len())
+	}
 
 	// Only send if there's actually data left
 	if len(s.f.Data) > 0 {

--- a/client/lib/streamframer/framer_test.go
+++ b/client/lib/streamframer/framer_test.go
@@ -141,6 +141,30 @@ func TestStreamFramer_Batch(t *testing.T) {
 	}
 }
 
+func TestStreamFramer_BatchOffsetUsesFrameEnd(t *testing.T) {
+	hRate, bWindow := 100*time.Millisecond, 500*time.Millisecond
+	frames := make(chan *StreamFrame, 10)
+	sf := NewStreamFramer(frames, hRate, bWindow, 3)
+	sf.Run()
+	defer sf.Destroy()
+
+	if err := sf.Send("foo", "", []byte{0xa}, 1); err != nil {
+		t.Fatalf("Send() failed %v", err)
+	}
+	if err := sf.Send("foo", "", []byte{0xb, 0xc}, 3); err != nil {
+		t.Fatalf("Send() failed %v", err)
+	}
+
+	select {
+	case frame := <-frames:
+		if frame.Offset != 3 {
+			t.Fatalf("expected frame end offset 3, got %d", frame.Offset)
+		}
+	case <-time.After(10 * time.Duration(testutil.TestMultiplier()) * bWindow):
+		t.Fatalf("did not receive batched frame")
+	}
+}
+
 func TestStreamFramer_Heartbeat(t *testing.T) {
 	// Create the stream framer
 	frames := make(chan *StreamFrame, 10)

--- a/client/logmon/logging/offset_manifest.go
+++ b/client/logmon/logging/offset_manifest.go
@@ -1,0 +1,128 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package logging
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+const offsetManifestVersion = 1
+
+// OffsetManifestFile returns the log-offset manifest filename for a task log
+// stream base name, for example ".web.stdout.offsets.json".
+func OffsetManifestFile(baseFileName string) string {
+	return fmt.Sprintf(".%s.offsets.json", baseFileName)
+}
+
+// OffsetManifestPath returns the log-offset manifest path for a task log stream.
+func OffsetManifestPath(logDir, baseFileName string) string {
+	return filepath.Join(filepath.Dir(logDir), OffsetManifestFile(baseFileName))
+}
+
+// OffsetManifest records the stable allocation-lifetime base offset for each
+// rotated log file. File sizes may be refreshed from the filesystem when the
+// manifest is read by the log streaming endpoint.
+type OffsetManifest struct {
+	Version      int                          `json:"version"`
+	BaseFileName string                       `json:"base_file_name"`
+	Files        map[string]OffsetManifestLog `json:"files"`
+}
+
+// OffsetManifestLog describes one rotated log file.
+type OffsetManifestLog struct {
+	Index int64 `json:"index"`
+	Base  int64 `json:"base"`
+	Size  int64 `json:"size"`
+}
+
+func newOffsetManifest(baseFileName string) *OffsetManifest {
+	return &OffsetManifest{
+		Version:      offsetManifestVersion,
+		BaseFileName: baseFileName,
+		Files:        make(map[string]OffsetManifestLog),
+	}
+}
+
+func loadOffsetManifest(logDir, baseFileName string) (*OffsetManifest, error) {
+	path := OffsetManifestPath(logDir, baseFileName)
+	b, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return reconstructOffsetManifest(logDir, baseFileName)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	var manifest OffsetManifest
+	if err := json.Unmarshal(b, &manifest); err != nil {
+		return nil, err
+	}
+	if manifest.Files == nil {
+		manifest.Files = make(map[string]OffsetManifestLog)
+	}
+	if manifest.BaseFileName == "" {
+		manifest.BaseFileName = baseFileName
+	}
+	return &manifest, nil
+}
+
+func saveOffsetManifest(logDir, baseFileName string, manifest *OffsetManifest) error {
+	path := OffsetManifestPath(logDir, baseFileName)
+	tmp := path + ".tmp"
+	b, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(tmp, b, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func reconstructOffsetManifest(logDir, baseFileName string) (*OffsetManifest, error) {
+	manifest := newOffsetManifest(baseFileName)
+	entries, err := os.ReadDir(logDir)
+	if err != nil {
+		return nil, err
+	}
+
+	type fileInfo struct {
+		idx  int64
+		size int64
+	}
+	var files []fileInfo
+	prefix := baseFileName + "."
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+		idx, err := strconv.ParseInt(strings.TrimPrefix(entry.Name(), prefix), 10, 64)
+		if err != nil {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, fileInfo{idx: idx, size: info.Size()})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].idx < files[j].idx })
+
+	var base int64
+	for _, file := range files {
+		manifest.Files[strconv.FormatInt(file.idx, 10)] = OffsetManifestLog{
+			Index: file.idx,
+			Base:  base,
+			Size:  file.size,
+		}
+		base += file.size
+	}
+	return manifest, nil
+}

--- a/client/logmon/logging/offset_manifest.go
+++ b/client/logmon/logging/offset_manifest.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package logging

--- a/client/logmon/logging/offset_manifest_test.go
+++ b/client/logmon/logging/offset_manifest_test.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2026
+// Copyright IBM Corp. 2015, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package logging

--- a/client/logmon/logging/offset_manifest_test.go
+++ b/client/logmon/logging/offset_manifest_test.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package logging
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/shoenig/test/must"
+)
+
+func TestFileRotator_OffsetManifestRecordsFileBases(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "logs")
+	must.NoError(t, os.MkdirAll(dir, 0755))
+	rotator, err := NewFileRotator(dir, "stdout", 3, 3, hclog.NewNullLogger())
+	must.NoError(t, err)
+
+	n, err := rotator.Write([]byte("abcdef"))
+	must.NoError(t, err)
+	must.Eq(t, 6, n)
+	must.NoError(t, rotator.Close())
+
+	raw, err := os.ReadFile(filepath.Join(filepath.Dir(dir), OffsetManifestFile("stdout")))
+	must.NoError(t, err)
+
+	var manifest OffsetManifest
+	must.NoError(t, json.Unmarshal(raw, &manifest))
+	must.Eq(t, int64(0), manifest.Files["0"].Base)
+	must.Eq(t, int64(3), manifest.Files["1"].Base)
+}

--- a/client/logmon/logging/rotator.go
+++ b/client/logmon/logging/rotator.go
@@ -57,6 +57,7 @@ type FileRotator struct {
 	logger      hclog.Logger
 	purgeCh     chan struct{}
 	doneCh      chan struct{}
+	manifest    *OffsetManifest
 }
 
 // NewFileRotator returns a new file rotator
@@ -75,6 +76,12 @@ func NewFileRotator(path string, baseFile string, maxFiles int,
 		purgeCh:     make(chan struct{}, 1),
 		doneCh:      make(chan struct{}),
 	}
+
+	manifest, err := loadOffsetManifest(path, baseFile)
+	if err != nil {
+		return nil, err
+	}
+	rotator.manifest = manifest
 
 	if err := rotator.lastFile(); err != nil {
 		return nil, err
@@ -144,7 +151,7 @@ func (f *FileRotator) Write(p []byte) (n int, err error) {
 		n += nw
 
 		// Increment the total number of bytes in the file
-		f.currentWr += int64(n)
+		f.currentWr += int64(nw)
 		if err != nil {
 			f.logger.Error("error writing to file", "error", err)
 
@@ -162,6 +169,10 @@ func (f *FileRotator) Write(p []byte) (n int, err error) {
 // nextFile opens the next file and purges older files if the number of rotated
 // files is larger than the maximum files configured by the user
 func (f *FileRotator) nextFile() error {
+	if err := f.updateManifestFile(f.logFileIdx, f.currentWr); err != nil {
+		f.logger.Error("error updating log offset manifest", "error", err)
+	}
+
 	nextFileIdx := f.logFileIdx
 	for {
 		nextFileIdx += 1
@@ -232,8 +243,37 @@ func (f *FileRotator) createFile() error {
 		return err
 	}
 	f.currentWr = fi.Size()
+	if err := f.ensureManifestFile(int64(f.logFileIdx), f.currentWr); err != nil {
+		return err
+	}
 	f.createOrResetBuffer()
 	return nil
+}
+
+func (f *FileRotator) ensureManifestFile(idx int64, size int64) error {
+	if f.manifest == nil {
+		f.manifest = newOffsetManifest(f.baseFileName)
+	}
+
+	key := strconv.FormatInt(idx, 10)
+	if file, ok := f.manifest.Files[key]; ok {
+		file.Size = size
+		f.manifest.Files[key] = file
+		return saveOffsetManifest(f.path, f.baseFileName, f.manifest)
+	}
+
+	var base int64
+	for _, file := range f.manifest.Files {
+		if file.Index < idx && file.Base+file.Size > base {
+			base = file.Base + file.Size
+		}
+	}
+	f.manifest.Files[key] = OffsetManifestLog{Index: idx, Base: base, Size: size}
+	return saveOffsetManifest(f.path, f.baseFileName, f.manifest)
+}
+
+func (f *FileRotator) updateManifestFile(idx int, size int64) error {
+	return f.ensureManifestFile(int64(idx), size)
 }
 
 // flushPeriodically flushes the buffered writer every 100ms to the underlying

--- a/client/structs/structs.go
+++ b/client/structs/structs.go
@@ -192,6 +192,11 @@ type FsLogsRequest struct {
 	// Follow follows logs.
 	Follow bool
 
+	// UseGlobalOffset returns allocation-lifetime offsets in log frames. When
+	// Origin is "start", Offset is also interpreted as an allocation-lifetime
+	// offset instead of a file-relative offset.
+	UseGlobalOffset bool
+
 	structs.QueryOptions
 }
 

--- a/command/agent/fs_endpoint.go
+++ b/command/agent/fs_endpoint.go
@@ -315,15 +315,24 @@ func (s *HTTPServer) Logs(resp http.ResponseWriter, req *http.Request) (interfac
 		return nil, invalidOrigin
 	}
 
+	// Parse useGlobalOffset parameter
+	var useGlobalOffset bool
+	if useGlobalOffsetStr := q.Get("useGlobalOffset"); useGlobalOffsetStr != "" {
+		if useGlobalOffset, err = strconv.ParseBool(useGlobalOffsetStr); err != nil {
+			return nil, CodedError(400, fmt.Sprintf("failed to parse useGlobalOffset field to boolean: %v", err))
+		}
+	}
+
 	// Create the request arguments
 	fsReq := &cstructs.FsLogsRequest{
-		AllocID:   allocID,
-		Task:      task,
-		LogType:   logType,
-		Offset:    offset,
-		Origin:    origin,
-		PlainText: plain,
-		Follow:    follow,
+		AllocID:         allocID,
+		Task:            task,
+		LogType:         logType,
+		Offset:          offset,
+		Origin:          origin,
+		PlainText:       plain,
+		Follow:          follow,
+		UseGlobalOffset: useGlobalOffset,
 	}
 	s.parse(resp, req, &fsReq.QueryOptions.Region, &fsReq.QueryOptions)
 


### PR DESCRIPTION
Closes #11655.

## Summary

- Add opt-in global offsets for task log streaming.
- Persist per-rotation-file base offsets from logmon.
- Map global offsets back to file-relative offsets on resume.
- Return the next resumable offset in streamed log frames.

## Tests

- `go test ./client/lib/streamframer ./client/logmon/logging ./client/allocrunner`
- `go test -run '^$' ./...` from `api/`