### PR TITLE
BJQ: Add pagination, sort order to `queue jobs` 

### DIFF
--- a/command/agent/batch_job_queue_endpoint.go
+++ b/command/agent/batch_job_queue_endpoint.go
@@ -23,6 +23,8 @@ func (s *HTTPServer) BatchJobQueueJobsRequest(resp http.ResponseWriter, req *htt
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
 		return nil, nil
 	}
+	query := req.URL.Query()
+	args.Sort = structs.SortOrder(query.Get("sort"))
 
 	if err := s.agent.RPC("BatchJobQueue.Jobs", &args, &out); err != nil {
 		return nil, err

--- a/command/queue_jobs.go
+++ b/command/queue_jobs.go
@@ -4,10 +4,8 @@
 package command
 
 import (
-	"cmp"
 	"encoding/json"
 	"fmt"
-	"slices"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
@@ -16,7 +14,6 @@ import (
 )
 
 type QueueJobsCommand struct {
-	sortOrder string
 	Meta
 }
 
@@ -46,8 +43,8 @@ Eval Options:
   -json
     Display output as json
 
-  -sort <>
-    Sort the output by a specific field. Valid fields are: priority, created_at. Default is created_at.
+  -p 
+    Sort output by priority instead of creation time
 `
 	return strings.TrimSpace(helpText)
 }
@@ -61,7 +58,7 @@ func (c *QueueJobsCommand) AutocompleteFlags() complete.Flags {
 		complete.Flags{
 			"-verbose":    complete.PredictNothing,
 			"-json":       complete.PredictNothing,
-			"-sort":       complete.PredictAnything,
+			"-p":          complete.PredictNothing,
 			"-per-page":   complete.PredictAnything,
 			"-page-token": complete.PredictAnything,
 		})
@@ -74,14 +71,14 @@ func (c *QueueJobsCommand) AutocompleteArgs() complete.Predictor {
 func (c *QueueJobsCommand) Name() string { return "queue status" }
 
 func (c *QueueJobsCommand) Run(args []string) int {
-	var verbose, jsonOut bool
+	var verbose, jsonOut, prioritySort bool
 	var pageToken string
 	var perPage int
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.BoolVar(&verbose, "verbose", false, "")
 	flags.BoolVar(&jsonOut, "json", false, "")
-	flags.StringVar(&c.sortOrder, "sort", "created_at", "")
+	flags.BoolVar(&prioritySort, "p", false, "")
 	flags.StringVar(&pageToken, "page-token", "", "")
 	flags.IntVar(&perPage, "per-page", 0, "")
 
@@ -97,10 +94,17 @@ func (c *QueueJobsCommand) Run(args []string) int {
 	}
 
 	// Setup the options
-	qo := &api.QueryOptions{}
+	qo := &api.QueryOptions{
+		PerPage:   int32(perPage),
+		NextToken: pageToken,
+		Params: map[string]string{
+			"sort": "default",
+		},
+	}
 
-	qo.PerPage = int32(perPage)
-	qo.NextToken = pageToken
+	if prioritySort {
+		qo.Params["sort"] = "priority"
+	}
 
 	// Submit the request
 	resp, _, err := client.BatchJobQueue().Jobs(qo)
@@ -137,13 +141,6 @@ func (c *QueueJobsCommand) printDynamicQueue(resp *api.BatchJobQueueJobsResponse
 		c.Ui.Error("Invalid Status response from server")
 		return 255
 	}
-
-	slices.SortFunc(workloads, func(a, b api.DynamicPriorityWorkload) int {
-		if c.sortOrder == "priority" || a.CreatedAt == b.CreatedAt {
-			return cmp.Compare(a.Position, b.Position)
-		}
-		return cmp.Compare(a.CreatedAt, b.CreatedAt)
-	})
 
 	if jsonOut {
 		if err := c.printDynamicQueueJSON(workloads); err != nil {

--- a/command/queue_jobs.go
+++ b/command/queue_jobs.go
@@ -6,6 +6,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
@@ -107,7 +108,7 @@ func (c *QueueJobsCommand) Run(args []string) int {
 	}
 
 	// Submit the request
-	resp, _, err := client.BatchJobQueue().Jobs(qo)
+	resp, qm, err := client.BatchJobQueue().Jobs(qo)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error during batch queue request: %s", err))
 		return 255
@@ -119,7 +120,7 @@ func (c *QueueJobsCommand) Run(args []string) int {
 
 	switch resp.Type {
 	case api.BatchJobQueueTypeDynamic:
-		return c.printDynamicQueue(resp, jsonOut)
+		c.printDynamicQueue(resp, qm, jsonOut)
 	case "unset":
 		c.Ui.Output("No batch job queue configured")
 	default:
@@ -130,7 +131,7 @@ func (c *QueueJobsCommand) Run(args []string) int {
 	return 0
 }
 
-func (c *QueueJobsCommand) printDynamicQueue(resp *api.BatchJobQueueJobsResponse, jsonOut bool) int {
+func (c *QueueJobsCommand) printDynamicQueue(resp *api.BatchJobQueueJobsResponse, qm *api.QueryMeta, jsonOut bool) int {
 	workloads := []api.DynamicPriorityWorkload{}
 	bytes, err := json.Marshal(resp.Workloads)
 	if err != nil {
@@ -149,6 +150,12 @@ func (c *QueueJobsCommand) printDynamicQueue(resp *api.BatchJobQueueJobsResponse
 		}
 	} else {
 		c.printDynamicQueueFormatted(workloads)
+		if qm.NextToken != "" {
+			c.Ui.Output(fmt.Sprintf(`
+Results have been paginated. To get the next page run:
+
+%s -page-token %s`, argsWithoutPageToken(os.Args), qm.NextToken))
+		}
 	}
 	return 0
 }

--- a/command/queue_jobs.go
+++ b/command/queue_jobs.go
@@ -4,8 +4,10 @@
 package command
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
@@ -14,6 +16,7 @@ import (
 )
 
 type QueueJobsCommand struct {
+	sortOrder string
 	Meta
 }
 
@@ -31,8 +34,11 @@ General Options:
 
 Eval Options:
 
-  -limit
-    The maximum number of workloads to return
+  -per-page
+    The maximum number of workloads to return per page. If not specified, or set to 0, all results are returned.
+
+  -page-token
+    Where to start pagination
 
   -verbose
     Display full output
@@ -40,6 +46,8 @@ Eval Options:
   -json
     Display output as json
 
+  -sort <>
+    Sort the output by a specific field. Valid fields are: priority, created_at. Default is created_at.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -51,10 +59,11 @@ func (c *QueueJobsCommand) Synopsis() string {
 func (c *QueueJobsCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
-			"-verbose": complete.PredictNothing,
-			"-limit":   complete.PredictNothing,
-			"-json":    complete.PredictNothing,
-			"-tenants": complete.PredictNothing,
+			"-verbose":    complete.PredictNothing,
+			"-json":       complete.PredictNothing,
+			"-sort":       complete.PredictAnything,
+			"-per-page":   complete.PredictAnything,
+			"-page-token": complete.PredictAnything,
 		})
 }
 
@@ -65,14 +74,16 @@ func (c *QueueJobsCommand) AutocompleteArgs() complete.Predictor {
 func (c *QueueJobsCommand) Name() string { return "queue status" }
 
 func (c *QueueJobsCommand) Run(args []string) int {
-	var verbose, jsonOut, tenants bool
-	var limit int
+	var verbose, jsonOut bool
+	var pageToken string
+	var perPage int
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.BoolVar(&verbose, "verbose", false, "")
 	flags.BoolVar(&jsonOut, "json", false, "")
-	flags.BoolVar(&tenants, "tenants", false, "")
-	flags.IntVar(&limit, "limit", 0, "")
+	flags.StringVar(&c.sortOrder, "sort", "created_at", "")
+	flags.StringVar(&pageToken, "page-token", "", "")
+	flags.IntVar(&perPage, "per-page", 0, "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -88,9 +99,8 @@ func (c *QueueJobsCommand) Run(args []string) int {
 	// Setup the options
 	qo := &api.QueryOptions{}
 
-	if limit > 0 {
-		qo.PerPage = int32(limit)
-	}
+	qo.PerPage = int32(perPage)
+	qo.NextToken = pageToken
 
 	// Submit the request
 	resp, _, err := client.BatchJobQueue().Jobs(qo)
@@ -127,6 +137,13 @@ func (c *QueueJobsCommand) printDynamicQueue(resp *api.BatchJobQueueJobsResponse
 		c.Ui.Error("Invalid Status response from server")
 		return 255
 	}
+
+	slices.SortFunc(workloads, func(a, b api.DynamicPriorityWorkload) int {
+		if c.sortOrder == "priority" || a.CreatedAt == b.CreatedAt {
+			return cmp.Compare(a.Position, b.Position)
+		}
+		return cmp.Compare(a.CreatedAt, b.CreatedAt)
+	})
 
 	if jsonOut {
 		if err := c.printDynamicQueueJSON(workloads); err != nil {

--- a/nomad/batch_job_queue_endpoint.go
+++ b/nomad/batch_job_queue_endpoint.go
@@ -54,7 +54,7 @@ func (q *BatchJobQueue) Jobs(args *structs.QueueJobsRequest, reply *structs.Queu
 	}
 
 	batchJobQueue := q.srv.batchQueueMgr.Queue()
-	iter := batchJobQueue.Jobs()
+	iter := batchJobQueue.Jobs(args.Sort)
 
 	selector := func(workload structs.QueueWorkload) bool {
 		if len(allowableNamespaces) == 0 {

--- a/nomad/batch_job_queue_endpoint.go
+++ b/nomad/batch_job_queue_endpoint.go
@@ -6,6 +6,7 @@ package nomad
 import (
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/acl"
+	"github.com/hashicorp/nomad/nomad/state/paginator"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -47,15 +48,39 @@ func (q *BatchJobQueue) Jobs(args *structs.QueueJobsRequest, reply *structs.Queu
 	if err == structs.ErrPermissionDenied {
 		// return empty results if token isn't authorized for any
 		// namespace, matching other endpoints
-		reply.Workloads = make([]interface{}, 0)
-	} else if err != nil {
+		reply.Workloads = make([]any, 0)
+		q.srv.setQueryMeta(&reply.QueryMeta)
 		return err
-	} else {
-		status := q.srv.batchQueueMgr.Queue().Jobs(allowableNamespaces)
-		reply.Workloads = status.Workloads
-		reply.Type = status.Type
 	}
 
+	batchJobQueue := q.srv.batchQueueMgr.Queue()
+	iter := batchJobQueue.Jobs()
+
+	selector := func(workload structs.QueueWorkload) bool {
+		if len(allowableNamespaces) == 0 {
+			return true
+		}
+		// Filter by namespace
+		if !allowableNamespaces[workload.GetNamespace()] {
+			return false
+		}
+		return true
+	}
+
+	pager, err := paginator.NewPaginator(iter, args.QueryOptions, selector, paginator.CreateIndexAndIDTokenizer[structs.QueueWorkload](args.NextToken), func(workload structs.QueueWorkload) (structs.QueueWorkload, error) {
+		return workload, nil
+	})
+	if err != nil {
+		return err
+	}
+	workloads, token, err := pager.Page()
+	if err != nil {
+		return err
+	}
+	reply.Workloads = workloads
+
+	reply.Type = batchJobQueue.Type()
+	reply.QueryMeta.NextToken = token
 	q.srv.setQueryMeta(&reply.QueryMeta)
 
 	return nil

--- a/nomad/batch_job_queue_endpoint_test.go
+++ b/nomad/batch_job_queue_endpoint_test.go
@@ -70,6 +70,7 @@ func TestBatchJobQueue_Jobs(t *testing.T) {
 			mockQueue.On("Jobs", tmock.Anything).Return(&queues.WorkloadIter{
 				Workloads: []structs.QueueWorkload{workload1, workload2, workload3},
 			})
+			mockQueue.On("Stop")
 			s.batchQueueMgr = queues.NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, nil, queues.WithQueue(mockQueue))
 
 			reply := structs.QueueJobsResponse{}
@@ -149,6 +150,7 @@ func TestBatchJobQueue_Jobs_WithACL(t *testing.T) {
 				},
 			})
 
+			mockQueue.On("Stop")
 			resp := structs.QueueJobsResponse{}
 			s1.batchQueueMgr = queues.NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, nil, queues.WithQueue(mockQueue))
 
@@ -176,6 +178,7 @@ func TestBatchJobQueue_Tenants(t *testing.T) {
 			"ns1", "ns2",
 		},
 	})
+	mockQueue.On("Stop")
 
 	req := structs.QueueTenantsRequest{QueryOptions: structs.QueryOptions{
 		Region: "global",
@@ -233,6 +236,7 @@ func TestBatchJobQueue_Tenants_WithACL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockQueue := new(queues.MockQueue)
 			mockQueue.On("Tenants").Return(tc.resp)
+			mockQueue.On("Stop")
 
 			reply := structs.QueueTenantsResponse{}
 

--- a/nomad/batch_job_queue_endpoint_test.go
+++ b/nomad/batch_job_queue_endpoint_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/shoenig/test/must"
+	tmock "github.com/stretchr/testify/mock"
 )
 
 func TestBatchJobQueue_Jobs(t *testing.T) {
@@ -66,7 +67,7 @@ func TestBatchJobQueue_Jobs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockQueue := new(queues.MockQueue)
-			mockQueue.On("Jobs").Return(&queues.WorkloadIter{
+			mockQueue.On("Jobs", tmock.Anything).Return(&queues.WorkloadIter{
 				Workloads: []structs.QueueWorkload{workload1, workload2, workload3},
 			})
 			s.batchQueueMgr = queues.NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, nil, queues.WithQueue(mockQueue))
@@ -140,7 +141,7 @@ func TestBatchJobQueue_Jobs_WithACL(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockQueue := new(queues.MockQueue)
-			mockQueue.On("Jobs").Return(&queues.WorkloadIter{
+			mockQueue.On("Jobs", tmock.Anything).Return(&queues.WorkloadIter{
 				Workloads: []structs.QueueWorkload{
 					workload1,
 					workload3,

--- a/nomad/batch_job_queue_endpoint_test.go
+++ b/nomad/batch_job_queue_endpoint_test.go
@@ -4,7 +4,6 @@
 package nomad
 
 import (
-	"maps"
 	"testing"
 
 	"github.com/hashicorp/nomad/acl"
@@ -14,7 +13,6 @@ import (
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/hashicorp/nomad/testutil"
 	"github.com/shoenig/test/must"
-	tmock "github.com/stretchr/testify/mock"
 )
 
 func TestBatchJobQueue_Jobs(t *testing.T) {
@@ -23,30 +21,67 @@ func TestBatchJobQueue_Jobs(t *testing.T) {
 	t.Cleanup(cleanup)
 	testutil.WaitForLeader(t, s.RPC)
 
-	mockQueue := new(queues.MockQueue)
-	mockQueue.On("Jobs", tmock.MatchedBy(func(m map[string]bool) bool {
-		return m == nil
-	})).Return(structs.QueueJobsResponse{
-		Type: "test",
-		Workloads: []*structs.Evaluation{
-			{ID: "eval1"},
-			{ID: "eval2"},
+	workload1 := &structs.Evaluation{
+		ID:          "eval1",
+		Namespace:   "ns1",
+		CreateTime:  100,
+		CreateIndex: 100,
+	}
+	workload2 := &structs.Evaluation{
+		ID:          "eval2",
+		Namespace:   "ns1",
+		CreateTime:  200,
+		CreateIndex: 200,
+	}
+	workload3 := &structs.Evaluation{
+		ID:          "eval3",
+		Namespace:   "ns2",
+		CreateTime:  300,
+		CreateIndex: 300,
+	}
+
+	testCases := []struct {
+		name string
+		req  structs.QueueJobsRequest
+		err  string
+		resp structs.QueueJobsResponse
+	}{
+		{
+			name: "list all",
+			req:  structs.QueueJobsRequest{QueryOptions: structs.QueryOptions{Region: "global"}},
+			resp: structs.QueueJobsResponse{Type: "test", Workloads: []structs.QueueWorkload{workload1, workload2, workload3}, QueryMeta: structs.QueryMeta{KnownLeader: true}},
 		},
-	})
-	mockQueue.On("Stop").Return()
+		{
+			name: "paginate per-page=2 page=1",
+			req:  structs.QueueJobsRequest{QueryOptions: structs.QueryOptions{Region: "global", PerPage: 2}},
+			resp: structs.QueueJobsResponse{Type: "test", Workloads: []structs.QueueWorkload{workload1, workload2}, QueryMeta: structs.QueryMeta{KnownLeader: true, NextToken: "300.eval3"}},
+		},
+		{
+			name: "paginate per-page=1 page=3",
+			req:  structs.QueueJobsRequest{QueryOptions: structs.QueryOptions{Region: "global", PerPage: 1, NextToken: "300.eval3"}},
+			resp: structs.QueueJobsResponse{Type: "test", Workloads: []structs.QueueWorkload{workload3}, QueryMeta: structs.QueryMeta{KnownLeader: true, NextToken: ""}},
+		},
+	}
 
-	s.batchQueueMgr = queues.NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, nil, queues.WithQueue(mockQueue))
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockQueue := new(queues.MockQueue)
+			mockQueue.On("Jobs").Return(&queues.WorkloadIter{
+				Workloads: []structs.QueueWorkload{workload1, workload2, workload3},
+			})
+			s.batchQueueMgr = queues.NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, nil, queues.WithQueue(mockQueue))
 
-	req := structs.QueueJobsRequest{QueryOptions: structs.QueryOptions{
-		Region: "global",
-	}}
+			reply := structs.QueueJobsResponse{}
+			err := s.RPC("BatchJobQueue.Jobs", &tc.req, &reply)
+			if tc.err != "" {
+				must.ErrorContains(t, err, tc.err)
+				return
+			}
+			must.NoError(t, err)
+			must.Eq(t, tc.resp, reply)
+		})
 
-	reply := structs.QueueJobsResponse{}
-
-	err := s.RPC("BatchJobQueue.Jobs", &req, &reply)
-	must.NoError(t, err)
-	must.Eq(t, reply.Type, "test")
-	must.Len(t, 2, reply.Workloads.([]*structs.Evaluation))
+	}
 }
 
 func TestBatchJobQueue_Jobs_WithACL(t *testing.T) {
@@ -60,12 +95,24 @@ func TestBatchJobQueue_Jobs_WithACL(t *testing.T) {
 	err := state.UpsertNamespaces(1001, []*structs.Namespace{{Name: "ns1"}, {Name: "ns2"}})
 	must.NoError(t, err)
 
+	workload1 := &structs.Evaluation{
+		ID:        "eval1",
+		Namespace: "ns1",
+	}
+	workload2 := &structs.Evaluation{
+		ID:        "eval2",
+		Namespace: "ns1",
+	}
+	workload3 := &structs.Evaluation{
+		ID:        "eval3",
+		Namespace: "ns2",
+	}
+
 	testCases := []struct {
-		name                      string
-		req                       structs.QueueJobsRequest
-		err                       string
-		expectedAllowedNamespaces map[string]bool
-		resp                      structs.QueueJobsResponse
+		name string
+		req  structs.QueueJobsRequest
+		err  string
+		resp structs.QueueJobsResponse
 	}{
 		{
 			name: "no token",
@@ -74,32 +121,32 @@ func TestBatchJobQueue_Jobs_WithACL(t *testing.T) {
 			resp: structs.QueueJobsResponse{},
 		},
 		{
-			name:                      "management token",
-			req:                       structs.QueueJobsRequest{QueryOptions: structs.QueryOptions{Region: "global", AuthToken: root.SecretID}},
-			expectedAllowedNamespaces: nil,
-			resp:                      structs.QueueJobsResponse{Workloads: []*structs.Evaluation{{ID: "eval1"}, {ID: "eval2"}}, QueryMeta: structs.QueryMeta{KnownLeader: true}},
+			name: "management token",
+			req:  structs.QueueJobsRequest{QueryOptions: structs.QueryOptions{Region: "global", AuthToken: root.SecretID}},
+			resp: structs.QueueJobsResponse{Type: "test", Workloads: []structs.QueueWorkload{workload1, workload3, workload2}, QueryMeta: structs.QueryMeta{KnownLeader: true}},
 		},
 		{
-			name:                      "valid token without permissions for jobs on queue",
-			req:                       structs.QueueJobsRequest{QueryOptions: structs.QueryOptions{Region: "global", AuthToken: mock.CreatePolicyAndToken(t, state, 1003, "test-valid", mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs})).SecretID}},
-			expectedAllowedNamespaces: map[string]bool{"default": true},
-			resp:                      structs.QueueJobsResponse{Workloads: make([]*structs.Evaluation, 0), QueryMeta: structs.QueryMeta{KnownLeader: true}},
+			name: "valid token without permissions for jobs on queue",
+			req:  structs.QueueJobsRequest{QueryOptions: structs.QueryOptions{Region: "global", AuthToken: mock.CreatePolicyAndToken(t, state, 1003, "test-valid", mock.NamespacePolicy(structs.DefaultNamespace, "", []string{acl.NamespaceCapabilityListJobs})).SecretID}},
+			resp: structs.QueueJobsResponse{Type: "test", Workloads: make([]structs.QueueWorkload, 0), QueryMeta: structs.QueryMeta{KnownLeader: true}},
 		},
 		{
-			name:                      "valid token with permissions for one namespace",
-			req:                       structs.QueueJobsRequest{QueryOptions: structs.QueryOptions{Region: "global", AuthToken: mock.CreatePolicyAndToken(t, state, 1005, "test-valid-ns1", mock.NamespacePolicy("ns1", "", []string{acl.NamespaceCapabilityListJobs})).SecretID, Namespace: "ns1"}},
-			expectedAllowedNamespaces: map[string]bool{"ns1": true},
-			resp:                      structs.QueueJobsResponse{Workloads: []*structs.Evaluation{{ID: "eval1"}}, QueryMeta: structs.QueryMeta{KnownLeader: true}},
+			name: "valid token with permissions for one namespace",
+			req:  structs.QueueJobsRequest{QueryOptions: structs.QueryOptions{Region: "global", AuthToken: mock.CreatePolicyAndToken(t, state, 1005, "test-valid-ns1", mock.NamespacePolicy("ns2", "", []string{acl.NamespaceCapabilityListJobs})).SecretID, Namespace: "ns2"}},
+			resp: structs.QueueJobsResponse{Type: "test", Workloads: []structs.QueueWorkload{workload3}, QueryMeta: structs.QueryMeta{KnownLeader: true}},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockQueue := new(queues.MockQueue)
-			mockQueue.On("Jobs", tmock.MatchedBy(func(m map[string]bool) bool {
-				return maps.Equal(tc.expectedAllowedNamespaces, m)
-			}), tmock.Anything).Return(tc.resp)
-			mockQueue.On("Stop").Return()
+			mockQueue.On("Jobs").Return(&queues.WorkloadIter{
+				Workloads: []structs.QueueWorkload{
+					workload1,
+					workload3,
+					workload2,
+				},
+			})
 
 			resp := structs.QueueJobsResponse{}
 			s1.batchQueueMgr = queues.NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, nil, queues.WithQueue(mockQueue))
@@ -128,7 +175,6 @@ func TestBatchJobQueue_Tenants(t *testing.T) {
 			"ns1", "ns2",
 		},
 	})
-	mockQueue.On("Stop").Return()
 
 	req := structs.QueueTenantsRequest{QueryOptions: structs.QueryOptions{
 		Region: "global",
@@ -186,7 +232,6 @@ func TestBatchJobQueue_Tenants_WithACL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockQueue := new(queues.MockQueue)
 			mockQueue.On("Tenants").Return(tc.resp)
-			mockQueue.On("Stop").Return()
 
 			reply := structs.QueueTenantsResponse{}
 

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -631,7 +631,7 @@ func (d *DynamicPriorityQueue) Jobs(sortOrder structs.SortOrder) *WorkloadIter {
 	iter := NewWorkloadIter(workloads)
 
 	if sortOrder != structs.SortByPriority {
-		iter.SortByCreateIndex()
+		iter.SortByJobId()
 	}
 
 	return iter

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -600,7 +600,7 @@ func (d *DynamicPriorityQueue) isSchedulingComplete(workload *Workload) (bool, e
 	return false, nil
 }
 
-func (d *DynamicPriorityQueue) Jobs() *WorkloadIter {
+func (d *DynamicPriorityQueue) Jobs(sortOrder structs.SortOrder) *WorkloadIter {
 	d.qMux.Lock()
 	sortedWorkloads := d.queue.Slice()
 	defer d.qMux.Unlock()
@@ -625,12 +625,16 @@ func (d *DynamicPriorityQueue) Jobs() *WorkloadIter {
 			AgeAdjustment:    w.ageAdjustment,
 			SizeAdjustment:   w.sizeAdjustment,
 			CreatedAt:        w.eval.CreateTime,
+			CreateIndex:      w.eval.CreateIndex,
 		})
 	}
-	return &WorkloadIter{
-		Workloads: workloads,
-		index:     0,
+	iter := NewWorkloadIter(workloads)
+
+	if sortOrder != structs.SortByPriority {
+		iter.SortByCreateIndex()
 	}
+
+	return iter
 }
 
 func (d *DynamicPriorityQueue) Tenants() structs.QueueTenantsResponse {

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -603,7 +603,7 @@ func (d *DynamicPriorityQueue) isSchedulingComplete(workload *Workload) (bool, e
 func (d *DynamicPriorityQueue) Jobs(sortOrder structs.SortOrder) *WorkloadIter {
 	d.qMux.Lock()
 	sortedWorkloads := d.queue.Slice()
-	defer d.qMux.Unlock()
+	d.qMux.Unlock()
 
 	pos := 0
 	workloads := []structs.QueueWorkload{}

--- a/nomad/queues/dynamic_priority_queue.go
+++ b/nomad/queues/dynamic_priority_queue.go
@@ -127,6 +127,10 @@ func NewDynamicPriorityQueue(ss *state.StateStore, broker Broker, qconf *structs
 	}
 }
 
+func (d *DynamicPriorityQueue) Type() structs.BatchQueueType {
+	return structs.BatchQueueTypeDynamic
+}
+
 func (d *DynamicPriorityQueue) Start(ctx context.Context) error {
 	rCtx, cancel := context.WithCancel(ctx)
 	d.cancel = cancel
@@ -596,26 +600,24 @@ func (d *DynamicPriorityQueue) isSchedulingComplete(workload *Workload) (bool, e
 	return false, nil
 }
 
-func (d *DynamicPriorityQueue) Jobs(namespaces map[string]bool) structs.QueueJobsResponse {
+func (d *DynamicPriorityQueue) Jobs() *WorkloadIter {
 	d.qMux.Lock()
+	sortedWorkloads := d.queue.Slice()
 	defer d.qMux.Unlock()
 
 	pos := 0
-	workloads := []structs.DynamicPriorityWorkload{}
-	for _, w := range d.queue.Slice() {
+	workloads := []structs.QueueWorkload{}
+	for _, w := range sortedWorkloads {
 		// waitOnRestore does not count towards position in queue
 		if w.waitOnRestore {
 			continue
 		}
 		pos++
 
-		if (namespaces != nil) && !namespaces[w.eval.Namespace] {
-			continue
-		}
-
-		workloads = append(workloads, structs.DynamicPriorityWorkload{
+		workloads = append(workloads, &structs.DynamicPriorityWorkload{
 			JobID:            w.eval.JobID,
 			Tenant:           string(w.tid),
+			Namespace:        w.eval.Namespace,
 			Position:         pos,
 			AdjustedPriority: w.priority,
 			BasePriority:     w.eval.Priority,
@@ -625,9 +627,9 @@ func (d *DynamicPriorityQueue) Jobs(namespaces map[string]bool) structs.QueueJob
 			CreatedAt:        w.eval.CreateTime,
 		})
 	}
-	return structs.QueueJobsResponse{
-		Type:      structs.BatchQueueTypeDynamic,
+	return &WorkloadIter{
 		Workloads: workloads,
+		index:     0,
 	}
 }
 

--- a/nomad/queues/dynamic_priority_queue_test.go
+++ b/nomad/queues/dynamic_priority_queue_test.go
@@ -540,6 +540,7 @@ func TestDynamicPriorityQueue_ageAdjustment(t *testing.T) {
 }
 
 func TestDynamicPriorityQueue_Jobs(t *testing.T) {
+
 	testCases := []struct {
 		name      string
 		sortOrder structs.SortOrder
@@ -584,15 +585,15 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 			},
 		},
 		{
-			name:      "default sort returns workloads in order of createIndex",
+			name:      "default sort returns workloads in order of jobID",
 			sortOrder: structs.SortDefault,
 			workloads: []*Workload{
 				{
-					id:  "eval1",
+					id:  "eval3",
 					tid: "tenantA",
 					eval: &structs.Evaluation{
-						ID:          "eval1",
-						JobID:       "job1",
+						ID:          "eval3",
+						JobID:       "job3",
 						Priority:    50,
 						CreateIndex: 14,
 					},
@@ -616,11 +617,11 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 					usageAdjustment: 4,
 				},
 				{
-					id:  "eval3",
+					id:  "eval1",
 					tid: "tenantA",
 					eval: &structs.Evaluation{
-						ID:          "eval3",
-						JobID:       "job3",
+						ID:          "eval1",
+						JobID:       "job1",
 						Priority:    50,
 						CreateIndex: 10,
 					},
@@ -633,7 +634,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 			exp: &WorkloadIter{
 				Workloads: []structs.QueueWorkload{
 					&structs.DynamicPriorityWorkload{
-						JobID:            "job3",
+						JobID:            "job1",
 						Tenant:           "tenantA",
 						Position:         3,
 						AdjustedPriority: 51,
@@ -655,7 +656,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						CreateIndex:      12,
 					},
 					&structs.DynamicPriorityWorkload{
-						JobID:            "job1",
+						JobID:            "job3",
 						Tenant:           "tenantA",
 						Position:         2,
 						AdjustedPriority: 59,

--- a/nomad/queues/dynamic_priority_queue_test.go
+++ b/nomad/queues/dynamic_priority_queue_test.go
@@ -544,7 +544,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 		name      string
 		allowedNs map[string]bool
 		workloads []*Workload
-		exp       structs.QueueJobsResponse
+		exp       *WorkloadIter
 	}{
 		{
 			name: "status response parses workloads correctly",
@@ -589,10 +589,9 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 					usageAdjustment: 1,
 				},
 			},
-			exp: structs.QueueJobsResponse{
-				Type: structs.BatchQueueTypeDynamic,
-				Workloads: []structs.DynamicPriorityWorkload{
-					{
+			exp: &WorkloadIter{
+				Workloads: []structs.QueueWorkload{
+					&structs.DynamicPriorityWorkload{
 						JobID:            "job2",
 						Tenant:           "tenantA",
 						Position:         1,
@@ -602,7 +601,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 					},
-					{
+					&structs.DynamicPriorityWorkload{
 						JobID:            "job1",
 						Tenant:           "tenantA",
 						Position:         2,
@@ -612,7 +611,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 					},
-					{
+					&structs.DynamicPriorityWorkload{
 						JobID:            "job3",
 						Tenant:           "tenantA",
 						Position:         3,
@@ -621,79 +620,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						SizeAdjustment:   0,
 						AgeAdjustment:    0,
 						UsageAdjustment:  1,
-					},
-				},
-			},
-		},
-		{
-			name:      "status response screens workloads",
-			allowedNs: map[string]bool{"ns1": true},
-			workloads: []*Workload{
-				{
-					id:  "eval1",
-					tid: "tenantA",
-					eval: &structs.Evaluation{
-						ID:        "eval1",
-						JobID:     "job1",
-						Namespace: "ns1",
-						Priority:  50,
-					},
-					priority:        59,
-					sizeAdjustment:  2,
-					ageAdjustment:   3,
-					usageAdjustment: 4,
-				},
-				{
-					id:  "eval2",
-					tid: "tenantB",
-					eval: &structs.Evaluation{
-						ID:        "eval2",
-						JobID:     "job2",
-						Namespace: "ns2",
-						Priority:  50,
-					},
-					priority:        63,
-					sizeAdjustment:  7,
-					ageAdjustment:   1,
-					usageAdjustment: 5,
-				},
-				{
-					id:  "eval2",
-					tid: "tenantA",
-					eval: &structs.Evaluation{
-						ID:        "eval2",
-						JobID:     "job2",
-						Namespace: "ns1",
-						Priority:  50,
-					},
-					priority:        66,
-					sizeAdjustment:  7,
-					ageAdjustment:   1,
-					usageAdjustment: 5,
-				},
-			},
-			exp: structs.QueueJobsResponse{
-				Type: structs.BatchQueueTypeDynamic,
-				Workloads: []structs.DynamicPriorityWorkload{
-					{
-						JobID:            "job2",
-						Tenant:           "tenantA",
-						Position:         1,
-						AdjustedPriority: 66,
-						BasePriority:     50,
-						SizeAdjustment:   7,
-						AgeAdjustment:    1,
-						UsageAdjustment:  5,
-					},
-					{
-						JobID:            "job1",
-						Tenant:           "tenantA",
-						Position:         3,
-						AdjustedPriority: 59,
-						BasePriority:     50,
-						SizeAdjustment:   2,
-						AgeAdjustment:    3,
-						UsageAdjustment:  4,
 					},
 				},
 			},
@@ -732,10 +658,9 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 					usageAdjustment: 4,
 				},
 			},
-			exp: structs.QueueJobsResponse{
-				Type: structs.BatchQueueTypeDynamic,
-				Workloads: []structs.DynamicPriorityWorkload{
-					{
+			exp: &WorkloadIter{
+				Workloads: []structs.QueueWorkload{
+					&structs.DynamicPriorityWorkload{
 						JobID:            "job2",
 						Tenant:           "tenantA",
 						Position:         1,
@@ -746,7 +671,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						UsageAdjustment:  4,
 						CreatedAt:        time.Unix(10, 0).UnixNano(),
 					},
-					{
+					&structs.DynamicPriorityWorkload{
 						JobID:            "job1",
 						Tenant:           "tenantA",
 						Position:         2,
@@ -768,7 +693,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 		for _, w := range tc.workloads {
 			testQueue.queue.Push(w)
 		}
-		must.Eq(t, tc.exp, testQueue.Jobs(tc.allowedNs), must.Sprint(tc.name))
+		must.Eq(t, tc.exp, testQueue.Jobs(), must.Sprint(tc.name))
 	}
 
 }

--- a/nomad/queues/dynamic_priority_queue_test.go
+++ b/nomad/queues/dynamic_priority_queue_test.go
@@ -542,20 +542,59 @@ func TestDynamicPriorityQueue_ageAdjustment(t *testing.T) {
 func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 	testCases := []struct {
 		name      string
-		allowedNs map[string]bool
+		sortOrder structs.SortOrder
 		workloads []*Workload
 		exp       *WorkloadIter
 	}{
 		{
-			name: "status response parses workloads correctly",
+			name:      "status response parses workloads correctly",
+			sortOrder: structs.SortDefault,
 			workloads: []*Workload{
 				{
 					id:  "eval1",
 					tid: "tenantA",
 					eval: &structs.Evaluation{
-						ID:       "eval1",
-						JobID:    "job1",
-						Priority: 50,
+						ID:          "eval1",
+						JobID:       "job1",
+						Priority:    50,
+						CreateTime:  time.Unix(20, 0).UnixNano(),
+						CreateIndex: 10,
+					},
+					priority:        59,
+					sizeAdjustment:  2,
+					ageAdjustment:   3,
+					usageAdjustment: 4,
+				},
+			},
+			exp: &WorkloadIter{
+				Workloads: []structs.QueueWorkload{
+					&structs.DynamicPriorityWorkload{
+						JobID:            "job1",
+						Tenant:           "tenantA",
+						Position:         1,
+						AdjustedPriority: 59,
+						BasePriority:     50,
+						SizeAdjustment:   2,
+						AgeAdjustment:    3,
+						UsageAdjustment:  4,
+						CreatedAt:        time.Unix(20, 0).UnixNano(),
+						CreateIndex:      10,
+					},
+				},
+			},
+		},
+		{
+			name:      "default sort returns workloads in order of createIndex",
+			sortOrder: structs.SortDefault,
+			workloads: []*Workload{
+				{
+					id:  "eval1",
+					tid: "tenantA",
+					eval: &structs.Evaluation{
+						ID:          "eval1",
+						JobID:       "job1",
+						Priority:    50,
+						CreateIndex: 14,
 					},
 					priority:        59,
 					sizeAdjustment:  2,
@@ -566,9 +605,10 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 					id:  "eval2",
 					tid: "tenantA",
 					eval: &structs.Evaluation{
-						ID:       "eval2",
-						JobID:    "job2",
-						Priority: 50,
+						ID:          "eval2",
+						JobID:       "job2",
+						Priority:    50,
+						CreateIndex: 12,
 					},
 					priority:        66,
 					sizeAdjustment:  12,
@@ -579,9 +619,95 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 					id:  "eval3",
 					tid: "tenantA",
 					eval: &structs.Evaluation{
-						ID:       "eval3",
-						JobID:    "job3",
-						Priority: 50,
+						ID:          "eval3",
+						JobID:       "job3",
+						Priority:    50,
+						CreateIndex: 10,
+					},
+					priority:        51,
+					sizeAdjustment:  0,
+					ageAdjustment:   0,
+					usageAdjustment: 1,
+				},
+			},
+			exp: &WorkloadIter{
+				Workloads: []structs.QueueWorkload{
+					&structs.DynamicPriorityWorkload{
+						JobID:            "job3",
+						Tenant:           "tenantA",
+						Position:         3,
+						AdjustedPriority: 51,
+						BasePriority:     50,
+						SizeAdjustment:   0,
+						AgeAdjustment:    0,
+						UsageAdjustment:  1,
+						CreateIndex:      10,
+					},
+					&structs.DynamicPriorityWorkload{
+						JobID:            "job2",
+						Tenant:           "tenantA",
+						Position:         1,
+						AdjustedPriority: 66,
+						BasePriority:     50,
+						SizeAdjustment:   12,
+						AgeAdjustment:    3,
+						UsageAdjustment:  4,
+						CreateIndex:      12,
+					},
+					&structs.DynamicPriorityWorkload{
+						JobID:            "job1",
+						Tenant:           "tenantA",
+						Position:         2,
+						AdjustedPriority: 59,
+						BasePriority:     50,
+						SizeAdjustment:   2,
+						AgeAdjustment:    3,
+						UsageAdjustment:  4,
+						CreateIndex:      14,
+					},
+				},
+			},
+		},
+		{
+			name:      "priority order returns workloads in order of adjusted priority",
+			sortOrder: structs.SortByPriority,
+			workloads: []*Workload{
+				{
+					id:  "eval1",
+					tid: "tenantA",
+					eval: &structs.Evaluation{
+						ID:          "eval1",
+						JobID:       "job1",
+						Priority:    50,
+						CreateIndex: 14,
+					},
+					priority:        59,
+					sizeAdjustment:  2,
+					ageAdjustment:   3,
+					usageAdjustment: 4,
+				},
+				{
+					id:  "eval2",
+					tid: "tenantA",
+					eval: &structs.Evaluation{
+						ID:          "eval2",
+						JobID:       "job2",
+						Priority:    50,
+						CreateIndex: 12,
+					},
+					priority:        66,
+					sizeAdjustment:  12,
+					ageAdjustment:   3,
+					usageAdjustment: 4,
+				},
+				{
+					id:  "eval3",
+					tid: "tenantA",
+					eval: &structs.Evaluation{
+						ID:          "eval3",
+						JobID:       "job3",
+						Priority:    50,
+						CreateIndex: 10,
 					},
 					priority:        51,
 					sizeAdjustment:  0,
@@ -600,6 +726,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						SizeAdjustment:   12,
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
+						CreateIndex:      12,
 					},
 					&structs.DynamicPriorityWorkload{
 						JobID:            "job1",
@@ -610,6 +737,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						SizeAdjustment:   2,
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
+						CreateIndex:      14,
 					},
 					&structs.DynamicPriorityWorkload{
 						JobID:            "job3",
@@ -620,12 +748,14 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						SizeAdjustment:   0,
 						AgeAdjustment:    0,
 						UsageAdjustment:  1,
+						CreateIndex:      10,
 					},
 				},
 			},
 		},
 		{
-			name: "order falls back to createIndex if priority is equal",
+			name:      "priority order falls back to createIndex if priority is equal",
+			sortOrder: structs.SortByPriority,
 			workloads: []*Workload{
 				{
 					id:  "eval1",
@@ -635,7 +765,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						JobID:       "job1",
 						Priority:    50,
 						CreateTime:  time.Unix(20, 0).UnixNano(),
-						CreateIndex: 2,
+						CreateIndex: 12,
 					},
 					priority:        59,
 					sizeAdjustment:  2,
@@ -650,7 +780,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						JobID:       "job2",
 						Priority:    50,
 						CreateTime:  time.Unix(10, 0).UnixNano(),
-						CreateIndex: 1,
+						CreateIndex: 10,
 					},
 					priority:        59,
 					sizeAdjustment:  2,
@@ -670,6 +800,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 						CreatedAt:        time.Unix(10, 0).UnixNano(),
+						CreateIndex:      10,
 					},
 					&structs.DynamicPriorityWorkload{
 						JobID:            "job1",
@@ -681,21 +812,30 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 						CreatedAt:        time.Unix(20, 0).UnixNano(),
+						CreateIndex:      12,
 					},
 				},
 			},
 		},
 	}
 	for _, tc := range testCases {
-		testQueue := &DynamicPriorityQueue{
-			queue: NewWorkloadQueue(),
-		}
-		for _, w := range tc.workloads {
-			testQueue.queue.Push(w)
-		}
-		must.Eq(t, tc.exp, testQueue.Jobs(), must.Sprint(tc.name))
-	}
+		t.Run(tc.name, func(t *testing.T) {
+			testQueue := &DynamicPriorityQueue{
+				queue: NewWorkloadQueue(),
+			}
+			for _, w := range tc.workloads {
+				testQueue.queue.Push(w)
+			}
 
+			got := testQueue.Jobs(tc.sortOrder)
+			must.Eq(t, len(tc.exp.Workloads), len(got.Workloads))
+			for i := range tc.exp.Workloads {
+				expWorkload := tc.exp.Workloads[i].(*structs.DynamicPriorityWorkload)
+				gotWorkload := got.Workloads[i].(*structs.DynamicPriorityWorkload)
+				must.Eq(t, *expWorkload, *gotWorkload)
+			}
+		})
+	}
 }
 
 func TestDynamicPriorityQueue_Tenants(t *testing.T) {

--- a/nomad/queues/interface.go
+++ b/nomad/queues/interface.go
@@ -13,7 +13,7 @@ type Queue interface {
 	Start(context.Context) error
 	Stop()
 	Enqueue(*structs.Evaluation)
-	Jobs() *WorkloadIter
+	Jobs(structs.SortOrder) *WorkloadIter
 	Tenants() structs.QueueTenantsResponse
 	Type() structs.BatchQueueType
 }
@@ -21,18 +21,4 @@ type Queue interface {
 // Broker is the interface for an evaluation broker
 type Broker interface {
 	Enqueue(*structs.Evaluation)
-}
-
-type WorkloadIter struct {
-	Workloads []structs.QueueWorkload
-	index     int
-}
-
-func (i *WorkloadIter) Next() interface{} {
-	if i.index >= len(i.Workloads) {
-		return nil
-	}
-	w := i.Workloads[i.index]
-	i.index++
-	return w
 }

--- a/nomad/queues/interface.go
+++ b/nomad/queues/interface.go
@@ -13,11 +13,26 @@ type Queue interface {
 	Start(context.Context) error
 	Stop()
 	Enqueue(*structs.Evaluation)
-	Jobs(map[string]bool) structs.QueueJobsResponse
+	Jobs() *WorkloadIter
 	Tenants() structs.QueueTenantsResponse
+	Type() structs.BatchQueueType
 }
 
 // Broker is the interface for an evaluation broker
 type Broker interface {
 	Enqueue(*structs.Evaluation)
+}
+
+type WorkloadIter struct {
+	Workloads []structs.QueueWorkload
+	index     int
+}
+
+func (i *WorkloadIter) Next() interface{} {
+	if i.index >= len(i.Workloads) {
+		return nil
+	}
+	w := i.Workloads[i.index]
+	i.index++
+	return w
 }

--- a/nomad/queues/passthrough_queue.go
+++ b/nomad/queues/passthrough_queue.go
@@ -19,6 +19,10 @@ func NewPassthroughQueue(b Broker) *PassthroughQueue {
 	}
 }
 
+func (p *PassthroughQueue) Type() structs.BatchQueueType {
+	return "unset"
+}
+
 // Start is a noop for the passthrough implementation
 func (p *PassthroughQueue) Start(context.Context) error { return nil }
 
@@ -26,8 +30,8 @@ func (p *PassthroughQueue) Stop() {}
 
 func (p *PassthroughQueue) Enqueue(e *structs.Evaluation) { p.broker.Enqueue(e) }
 
-func (p *PassthroughQueue) Jobs(map[string]bool) structs.QueueJobsResponse {
-	return structs.QueueJobsResponse{Type: "unset"}
+func (p *PassthroughQueue) Jobs() *WorkloadIter {
+	return &WorkloadIter{}
 }
 
 func (p *PassthroughQueue) Tenants() structs.QueueTenantsResponse {

--- a/nomad/queues/passthrough_queue.go
+++ b/nomad/queues/passthrough_queue.go
@@ -30,7 +30,7 @@ func (p *PassthroughQueue) Stop() {}
 
 func (p *PassthroughQueue) Enqueue(e *structs.Evaluation) { p.broker.Enqueue(e) }
 
-func (p *PassthroughQueue) Jobs() *WorkloadIter {
+func (p *PassthroughQueue) Jobs(structs.SortOrder) *WorkloadIter {
 	return &WorkloadIter{}
 }
 

--- a/nomad/queues/testing.go
+++ b/nomad/queues/testing.go
@@ -28,8 +28,8 @@ func (m *MockQueue) Enqueue(e *structs.Evaluation) {
 	m.Called(e)
 }
 
-func (m *MockQueue) Jobs() *WorkloadIter {
-	args := m.Called()
+func (m *MockQueue) Jobs(sortOrder structs.SortOrder) *WorkloadIter {
+	args := m.Called(sortOrder)
 
 	if args.Get(0) == nil {
 		return &WorkloadIter{}

--- a/nomad/queues/testing.go
+++ b/nomad/queues/testing.go
@@ -14,25 +14,28 @@ type MockQueue struct {
 	mock.Mock
 }
 
+func (m *MockQueue) Type() structs.BatchQueueType {
+	return "test"
+}
+
 // Start is a noop for the passthrough implementation
 func (m *MockQueue) Start(context.Context) error { return nil }
 
 func (m *MockQueue) Stop() {
-	m.Called()
 }
 
 func (m *MockQueue) Enqueue(e *structs.Evaluation) {
 	m.Called(e)
 }
 
-func (m *MockQueue) Jobs(ns map[string]bool) structs.QueueJobsResponse {
-	args := m.Called(ns)
+func (m *MockQueue) Jobs() *WorkloadIter {
+	args := m.Called()
 
 	if args.Get(0) == nil {
-		return structs.QueueJobsResponse{}
+		return &WorkloadIter{}
 	}
 
-	return args.Get(0).(structs.QueueJobsResponse)
+	return args.Get(0).(*WorkloadIter)
 }
 
 func (m *MockQueue) Tenants() structs.QueueTenantsResponse {

--- a/nomad/queues/testing.go
+++ b/nomad/queues/testing.go
@@ -22,6 +22,7 @@ func (m *MockQueue) Type() structs.BatchQueueType {
 func (m *MockQueue) Start(context.Context) error { return nil }
 
 func (m *MockQueue) Stop() {
+	m.Called()
 }
 
 func (m *MockQueue) Enqueue(e *structs.Evaluation) {

--- a/nomad/queues/workload_iter.go
+++ b/nomad/queues/workload_iter.go
@@ -22,20 +22,20 @@ func NewWorkloadIter(workloads []structs.QueueWorkload) *WorkloadIter {
 	}
 }
 
-func (i *WorkloadIter) SortByCreateIndex() {
+func (i *WorkloadIter) SortByJobId() {
 	slices.SortFunc(i.Workloads, func(a, b structs.QueueWorkload) int {
-		return cmp.Compare(a.GetCreateIndex(), b.GetCreateIndex())
+		return cmp.Compare(a.GetID(), b.GetID())
 	})
 }
 
-func (i *WorkloadIter) Sort(sortFn func(i, j interface{}) int) {
+func (i *WorkloadIter) Sort(sortFn func(i, j any) int) {
 	slices.SortFunc(i.Workloads, func(a, b structs.QueueWorkload) int {
 		return sortFn(a, b)
 	})
 	i.index = 0
 }
 
-func (i *WorkloadIter) Next() interface{} {
+func (i *WorkloadIter) Next() any {
 	if i.index >= len(i.Workloads) {
 		return nil
 	}

--- a/nomad/queues/workload_iter.go
+++ b/nomad/queues/workload_iter.go
@@ -1,3 +1,6 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
 package queues
 
 import (
@@ -21,9 +24,6 @@ func NewWorkloadIter(workloads []structs.QueueWorkload) *WorkloadIter {
 
 func (i *WorkloadIter) SortByCreateIndex() {
 	slices.SortFunc(i.Workloads, func(a, b structs.QueueWorkload) int {
-		if a.GetCreateIndex() == b.GetCreateIndex() {
-			return cmp.Compare(a.GetID(), b.GetID())
-		}
 		return cmp.Compare(a.GetCreateIndex(), b.GetCreateIndex())
 	})
 }

--- a/nomad/queues/workload_iter.go
+++ b/nomad/queues/workload_iter.go
@@ -1,0 +1,45 @@
+package queues
+
+import (
+	"cmp"
+	"slices"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+type WorkloadIter struct {
+	Workloads []structs.QueueWorkload
+	index     int
+}
+
+func NewWorkloadIter(workloads []structs.QueueWorkload) *WorkloadIter {
+	return &WorkloadIter{
+		Workloads: workloads,
+		index:     0,
+	}
+}
+
+func (i *WorkloadIter) SortByCreateIndex() {
+	slices.SortFunc(i.Workloads, func(a, b structs.QueueWorkload) int {
+		if a.GetCreateIndex() == b.GetCreateIndex() {
+			return cmp.Compare(a.GetID(), b.GetID())
+		}
+		return cmp.Compare(a.GetCreateIndex(), b.GetCreateIndex())
+	})
+}
+
+func (i *WorkloadIter) Sort(sortFn func(i, j interface{}) int) {
+	slices.SortFunc(i.Workloads, func(a, b structs.QueueWorkload) int {
+		return sortFn(a, b)
+	})
+	i.index = 0
+}
+
+func (i *WorkloadIter) Next() interface{} {
+	if i.index >= len(i.Workloads) {
+		return nil
+	}
+	w := i.Workloads[i.index]
+	i.index++
+	return w
+}

--- a/nomad/structs/queue.go
+++ b/nomad/structs/queue.go
@@ -7,8 +7,14 @@ type QueueWorkload interface {
 	GetID() string
 	GetCreateIndex() uint64
 	GetNamespace() string
-	// Stub() (QueueWorkload, error)
 }
+
+type SortOrder string
+
+const (
+	SortByPriority SortOrder = "priority"
+	SortDefault    SortOrder = "default"
+)
 
 type DynamicPriorityWorkload struct {
 	JobID            string
@@ -21,6 +27,7 @@ type DynamicPriorityWorkload struct {
 	AgeAdjustment    int
 	SizeAdjustment   int
 	CreatedAt        int64
+	CreateIndex      uint64
 }
 
 func (w *DynamicPriorityWorkload) GetID() string {
@@ -28,15 +35,11 @@ func (w *DynamicPriorityWorkload) GetID() string {
 }
 
 func (w *DynamicPriorityWorkload) GetCreateIndex() uint64 {
-	return uint64(w.CreatedAt)
+	return w.CreateIndex
 }
 
 func (w *DynamicPriorityWorkload) GetNamespace() string {
 	return w.Namespace
-}
-
-func (w *DynamicPriorityWorkload) Stub() (QueueWorkload, error) {
-	return w, nil
 }
 
 type DynamicPriorityTenant struct {
@@ -61,6 +64,7 @@ type QueueTenantsResponse struct {
 }
 
 type QueueJobsRequest struct {
+	Sort SortOrder `json:"sort,omitempty"`
 	QueryOptions
 }
 

--- a/nomad/structs/queue.go
+++ b/nomad/structs/queue.go
@@ -3,9 +3,17 @@
 
 package structs
 
+type QueueWorkload interface {
+	GetID() string
+	GetCreateIndex() uint64
+	GetNamespace() string
+	// Stub() (QueueWorkload, error)
+}
+
 type DynamicPriorityWorkload struct {
 	JobID            string
 	Tenant           string
+	Namespace        string
 	Position         int
 	AdjustedPriority int
 	BasePriority     int
@@ -13,6 +21,22 @@ type DynamicPriorityWorkload struct {
 	AgeAdjustment    int
 	SizeAdjustment   int
 	CreatedAt        int64
+}
+
+func (w *DynamicPriorityWorkload) GetID() string {
+	return w.JobID
+}
+
+func (w *DynamicPriorityWorkload) GetCreateIndex() uint64 {
+	return uint64(w.CreatedAt)
+}
+
+func (w *DynamicPriorityWorkload) GetNamespace() string {
+	return w.Namespace
+}
+
+func (w *DynamicPriorityWorkload) Stub() (QueueWorkload, error) {
+	return w, nil
 }
 
 type DynamicPriorityTenant struct {


### PR DESCRIPTION
### Description
Updates the sorting order of queued jobs returned in the CLI, and adds pagination. Default sort order has been changed to be by the eval's CreateIndex, and a flag (`-p`) can be passed to instead order them by priority. Pagination was added in the same way pagination works for the rest of the CLI. 

This involved adding a new WorkloadIterator, which is what can be passed to the paginator for moving through the queue. Namespace checks have been moved out of the queue implementation itself. This will be able to be used by different queues in the future. 

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
Tests were updated, and tested manually

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
