### PR TITLE
UI: Show pending for batch jobs that haven't started

### DIFF
--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -89,7 +89,7 @@ export default class Job extends Model {
 
   /**
    * @typedef {Object} CurrentStatus
-   * @property {"Healthy"|"Failed"|"Deploying"|"Degraded"|"Recovering"|"Complete"|"Running"|"Removed"|"Stopped"|"Scaled Down"} label - The current status of the job
+   * @property {"Healthy"|"Failed"|"Deploying"|"Degraded"|"Recovering"|"Complete"|"Running"|"Removed"|"Stopped"|"Scaled Down"|"Pending"} label - The current status of the job
    * @property {"highlight"|"success"|"warning"|"critical"|"neutral"} state -
    */
 
@@ -280,7 +280,7 @@ export default class Job extends Model {
         return { label: 'Running', state: 'success' };
       }
 
-      if (this.allocations?.length === 0 && this.status === 'pending') {
+      if (this.type === 'batch' && this.status === 'pending') {
         return { label: 'Pending', state: 'neutral' };
       }
     }

--- a/ui/app/models/job.js
+++ b/ui/app/models/job.js
@@ -226,6 +226,7 @@ export default class Job extends Model {
    * - Removed: The job appeared in our initial query, but has since been garbage collected
    * - Stopped: The job has been manually stopped (and not purged or yet garbage collected) by a user
    * - Scaled Down: The job is intentionally scaled down to 0 desired allocations (all task groups have count=0)
+   * - Pending: The job is pending and has not yet started running
    * @returns {CurrentStatus}
    */
   /**
@@ -277,6 +278,10 @@ export default class Job extends Model {
       const healthyAllocs = this.allocBlocks.running?.healthy?.nonCanary;
       if (healthyAllocs?.length + completeAllocs?.length === totalAllocs) {
         return { label: 'Running', state: 'success' };
+      }
+
+      if (this.allocations?.length === 0 && this.status === 'pending') {
+        return { label: 'Pending', state: 'neutral' };
       }
     }
 

--- a/ui/tests/acceptance/jobs-list-test.js
+++ b/ui/tests/acceptance/jobs-list-test.js
@@ -665,6 +665,24 @@ module('Acceptance | jobs list', function (hooks) {
 
     this.server.create('job', {
       ...defaultJobParams,
+      id: 'queued-batch-job',
+      type: 'batch',
+      status: 'pending',
+      createAllocations: false,
+      groupAllocCount: 10,
+    });
+
+    this.server.create('job', {
+      ...defaultJobParams,
+      id: 'pending-sysbatch-job',
+      type: 'sysbatch',
+      status: 'pending',
+      createAllocations: false,
+      groupAllocCount: 10,
+    });
+
+    this.server.create('job', {
+      ...defaultJobParams,
       id: 'failed-job',
       allocStatusDistribution: {
         failed: 1,
@@ -736,6 +754,15 @@ module('Acceptance | jobs list', function (hooks) {
     assert
       .dom('[data-test-job-row="running-job"] [data-test-job-status]')
       .hasText('Running', 'Running job is running');
+    assert
+      .dom('[data-test-job-row="queued-batch-job"] [data-test-job-status]')
+      .hasText('Pending', 'Queued batch job is pending');
+    assert
+      .dom('[data-test-job-row="pending-sysbatch-job"] [data-test-job-status]')
+      .doesNotIncludeText(
+        'Pending',
+        'Pending sysbatch job should not use the queued-batch pending label',
+      );
     assert
       .dom('[data-test-job-row="failed-job"] [data-test-job-status]')
       .hasText('Failed', 'Failed job is failed');

--- a/ui/tests/unit/models/job-test.js
+++ b/ui/tests/unit/models/job-test.js
@@ -254,6 +254,77 @@ module('Unit | Model | job', function (hooks) {
     );
   });
 
+  module('#aggregateAllocStatus', function () {
+    test('pending batch jobs are labeled pending', function (assert) {
+      const store = this.owner.lookup('service:store');
+      const job = run(() =>
+        store.createRecord('job', {
+          name: 'queued-batch',
+          type: 'batch',
+          status: 'pending',
+          groupCountSum: 1,
+        }),
+      );
+
+      assert.deepEqual(job.aggregateAllocStatus, {
+        label: 'Pending',
+        state: 'neutral',
+      });
+    });
+
+    test('complete batch jobs are not relabeled pending', function (assert) {
+      const store = this.owner.lookup('service:store');
+      const job = run(() => {
+        const job = store.createRecord('job', {
+          name: 'complete-batch',
+          type: 'batch',
+          status: 'pending',
+          groupCountSum: 1,
+        });
+
+        store.createRecord('allocation', {
+          id: 'complete-batch-allocation',
+          job,
+          clientStatus: 'complete',
+          jobVersion: 1,
+        });
+
+        return job;
+      });
+
+      assert.deepEqual(job.aggregateAllocStatus, {
+        label: 'Complete',
+        state: 'success',
+      });
+    });
+
+    test('pending sysbatch jobs are not labeled pending', function (assert) {
+      const store = this.owner.lookup('service:store');
+      const job = run(() => {
+        const job = store.createRecord('job', {
+          name: 'pending-sysbatch',
+          type: 'sysbatch',
+          status: 'pending',
+        });
+
+        store.createRecord('allocation', {
+          id: 'pending-sysbatch-allocation',
+          job,
+          clientStatus: 'pending',
+          jobVersion: 1,
+          nodeID: 'node-1',
+        });
+
+        return job;
+      });
+
+      assert.deepEqual(job.aggregateAllocStatus, {
+        label: 'Recovering',
+        state: 'highlight',
+      });
+    });
+  });
+
   module('#parse', function () {
     test('it parses JSON', async function (assert) {
       const store = this.owner.lookup('service:store');


### PR DESCRIPTION
### Description
Attempt to fix the UI so that queued batch jobs are shown as pending instead of failed

<img width="1482" height="1411" alt="Screenshot 2026-07-02 at 3 19 10 PM" src="https://github.com/user-attachments/assets/1fb53484-e365-446a-aeed-f7841720fb77" />


### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
