### PR TITLE
client: interpolate task secrets in service check Header/Args/Tags

### DIFF
--- a/.changelog/28212.txt
+++ b/.changelog/28212.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+services: Fixed a bug where task secrets were not interpolated into service check `Header` and `Args`, or into service `Tags`
+```

--- a/client/taskenv/env.go
+++ b/client/taskenv/env.go
@@ -363,7 +363,7 @@ func (t *TaskEnv) ParseAndReplace(args []string) []string {
 
 	replaced := make([]string, len(args))
 	for i, arg := range args {
-		replaced[i] = hargs.ReplaceEnv(arg, t.EnvMap, t.NodeAttrs)
+		replaced[i] = hargs.ReplaceEnv(arg, t.EnvMap, t.NodeAttrs, t.TaskSecrets)
 	}
 
 	return replaced

--- a/client/taskenv/env_test.go
+++ b/client/taskenv/env_test.go
@@ -151,6 +151,19 @@ func TestEnvironment_ParseAndReplace_Mixed(t *testing.T) {
 	}
 }
 
+func TestEnvironment_ParseAndReplace_Secrets(t *testing.T) {
+	ci.Parallel(t)
+
+	input := []string{fmt.Sprintf("${%v}", testSecret)}
+	exp := []string{testSecret}
+	env := testEnvBuilder()
+	act := env.Build().ParseAndReplace(input)
+
+	if !reflect.DeepEqual(act, exp) {
+		t.Fatalf("ParseAndReplace(%v) returned %#v; want %#v", input, act, exp)
+	}
+}
+
 func TestEnvironment_ReplaceEnv_Mixed(t *testing.T) {
 	ci.Parallel(t)
 

--- a/client/taskenv/services_test.go
+++ b/client/taskenv/services_test.go
@@ -118,6 +118,47 @@ func TestInterpolateServices(t *testing.T) {
 	require.Equal(t, exp, interpolated)
 }
 
+// TestInterpolateServices_TaskSecrets asserts that task secrets are
+// interpolated into service check Header and Args, and service Tags, all of
+// which route through TaskEnv.ParseAndReplace.
+//
+// Regression test for https://github.com/hashicorp/nomad/issues/28195
+func TestInterpolateServices_TaskSecrets(t *testing.T) {
+	ci.Parallel(t)
+
+	services := []*structs.Service{
+		{
+			Name: "example",
+			Tags: []string{"${secret.FOO}"},
+			Checks: []*structs.ServiceCheck{
+				{
+					Name: "check",
+					Args: []string{"${secret.FOO}"},
+					Header: map[string][]string{
+						"Authorization": {"Bearer ${secret.FOO}"},
+					},
+				},
+			},
+		},
+	}
+
+	env := &TaskEnv{
+		TaskSecrets: map[string]string{
+			"secret.FOO": "s3cr3t",
+		},
+	}
+
+	interpolated := InterpolateServices(env, services)
+	require.Len(t, interpolated, 1)
+
+	check := interpolated[0].Checks[0]
+	require.Equal(t, map[string][]string{
+		"Authorization": {"Bearer s3cr3t"},
+	}, check.Header)
+	require.Equal(t, []string{"s3cr3t"}, check.Args)
+	require.Equal(t, []string{"s3cr3t"}, interpolated[0].Tags)
+}
+
 var testEnv = NewTaskEnv(
 	map[string]string{"foo": "bar", "baz": "blah"},
 	map[string]string{"foo": "bar", "baz": "blah"},


### PR DESCRIPTION
Fixes #28195.

Task secrets (`${secret.*}`) weren't interpolated into service-check `Header` blocks. As @mismithhisler and @jrasell diagnosed on the issue, `TaskEnv.ParseAndReplace` didn't pass `t.TaskSecrets` to `hargs.ReplaceEnv`, unlike its sibling `TaskEnv.ReplaceEnv`. This adds `t.TaskSecrets` to that call so `ParseAndReplace` reaches parity — every field that routes through it now resolves task secrets.

Because `check.Header`, check `Args`, and service/canary `Tags` all go through `ParseAndReplace`, this fixes secret interpolation for all of them (not only `Header`), matching the diagnosis on the issue.

### Test plan

Added `client/taskenv` tests (red before the fix, green after):
- `TestEnvironment_ParseAndReplace_Secrets` — `${secret}` resolves via `ParseAndReplace`.
- `TestInterpolateServices_TaskSecrets` — end-to-end via `InterpolateServices`: a check `Header`, check `Args`, and service `Tags` all interpolate a task secret.

`go test ./client/taskenv/...`, `go vet`, `go build ./client/...`, and `gofmt` are clean.

---

*AI disclosure: this PR was drafted with Claude Code (AI-assisted). The changes were verified locally before submitting (see the test plan above).*