### PR TITLE
Apply deployment UpdatedAt to all status messages

### DIFF
--- a/.changelog/28225.txt
+++ b/.changelog/28225.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+deployments: Fix garbage collection to respect threshold
+```

--- a/nomad/deploymentwatcher/deployment_watcher.go
+++ b/nomad/deploymentwatcher/deployment_watcher.go
@@ -887,16 +887,11 @@ func (w *deploymentWatcher) getEval() *structs.Evaluation {
 
 // getDeploymentStatusUpdate returns a deployment status update
 func (w *deploymentWatcher) getDeploymentStatusUpdate(status, desc string) *structs.DeploymentStatusUpdate {
-	// only pass UpdatedAt value for paused deployments
-	var updatedAt int64
-	if status == structs.DeploymentStatusPaused || status == structs.DeploymentStatusRunning {
-		updatedAt = time.Now().UTC().UnixNano()
-	}
 	return &structs.DeploymentStatusUpdate{
 		DeploymentID:      w.deploymentID,
 		Status:            status,
 		StatusDescription: desc,
-		UpdatedAt:         updatedAt,
+		UpdatedAt:         time.Now().UTC().UnixNano(),
 	}
 }
 

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -506,6 +506,8 @@ func addComputedAllocAttrs(allocs []*structs.Allocation, job *structs.Job) {
 // updates.
 func (s *StateStore) upsertDeploymentUpdates(index uint64, now int64, updates []*structs.DeploymentStatusUpdate, txn *txn) error {
 	for _, u := range updates {
+		u.UpdatedAt = now
+
 		if err := s.updateDeploymentStatusImpl(index, u, txn); err != nil {
 			return err
 		}
@@ -4815,16 +4817,19 @@ func (s *StateStore) updateDeploymentStatusImpl(index uint64, u *structs.Deploym
 	copy.ModifyTime = u.UpdatedAt
 
 	// check each TaskGroup for ProgressDeadline and reset RequireProgressBy
-	// to u.UpdatedAt + ProgressDeadline if neither equal 0
+	// to ProgressDeadline if the deployment is running or paused. This is to
+	// ensure that the RequireProgressBy is reset on a deployment that has been
+	// paused and resumed.
 	for _, dState := range copy.TaskGroups {
-		if dState == nil {
+		if dState == nil || dState.ProgressDeadline == 0 {
 			continue
 		}
-		if u.UpdatedAt != 0 && dState.ProgressDeadline != 0 {
-			updateTime := time.Unix(0, u.UpdatedAt)
-			dState.RequireProgressBy = updateTime.Add(dState.ProgressDeadline)
+
+		if copy.Status == structs.DeploymentStatusPaused || copy.Status == structs.DeploymentStatusRunning {
+			dState.RequireProgressBy = time.Unix(0, u.UpdatedAt).Add(dState.ProgressDeadline)
 		}
 	}
+
 	// Insert the deployment
 	if err := txn.Insert("deployment", copy); err != nil {
 		return err

--- a/nomad/state/state_store_test.go
+++ b/nomad/state/state_store_test.go
@@ -461,6 +461,7 @@ func TestStateStore_UpsertPlanResults_DeploymentUpdates(t *testing.T) {
 		Deployment:        dnew,
 		DeploymentUpdates: []*structs.DeploymentStatusUpdate{update},
 		EvalID:            eval.ID,
+		UpdatedAt:         time.Now().UnixNano(),
 	}
 
 	err := state.UpsertPlanResults(structs.MsgTypeTestSetup, 1000, &res)
@@ -483,6 +484,7 @@ func TestStateStore_UpsertPlanResults_DeploymentUpdates(t *testing.T) {
 	test.Eq(t, update.Status, doutstandingout.Status)
 	test.Eq(t, update.StatusDescription, doutstandingout.StatusDescription)
 	test.Eq(t, 1000, doutstandingout.ModifyIndex)
+	test.NotEq(t, 0, doutstandingout.ModifyTime)
 
 	evalOut, err := state.EvalByID(ws, eval.ID)
 	must.NoError(t, err)

--- a/scheduler/structs/structs.go
+++ b/scheduler/structs/structs.go
@@ -163,6 +163,7 @@ func (p *PlanBuilder) SubmitPlan(plan *structs.Plan) (*structs.PlanResult, State
 		Deployment:        plan.Deployment,
 		DeploymentUpdates: plan.DeploymentUpdates,
 		EvalID:            plan.EvalID,
+		UpdatedAt:         now,
 	}
 
 	if p.noSubmit {


### PR DESCRIPTION
### Description
When the change from using a TimeTable to using object timestamps was made, populating the `UpdatedAt` fields in `DeploymentStatusUpdate` objects was missed. This has been causing deployments to overwrite their `ModifyTime` fields to 0 each time the deployment status is updated, which only really matters for garbage collection. Sometimes, the deployment would get the Alloc's time passed in, but it would eventually be updated back to 0. 

This was surfaced by the deployments getting garbage collected immediately after the deployment was finished (or when the interval was up to gc), because it appeared that the deployment was always older than the threshold value (set to either an hour or whatever `deployment_gc_threshold` was set to). This appears to be the only thing that is impacted by this timestamp.

This PR populates the `UpdatedAt` field for every status update, and moves some logic from https://github.com/hashicorp/nomad/pull/27804 around to preserve it. 

### Testing & Reproduction steps
I verified that the tests were still testing the relevant logic, and tested manually to observe the garbage collection. 

### Links
Fixes: https://github.com/hashicorp/nomad/issues/28210 

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
