### PR TITLE
Check websocket upgrade headers correctly with multiple values

### DIFF
--- a/.changelog/28234.txt
+++ b/.changelog/28234.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: check websocket upgrade headers with multiple values
+```

--- a/command/agent/websockets.go
+++ b/command/agent/websockets.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/gorilla/websocket"
 )
@@ -18,10 +17,9 @@ const (
 	ctxKeyWebSocketAuthToken = "ws_auth_token"
 )
 
-// isWebsocketUpgrade checks if the request is a websocket upgrade request
+// isWebsocketUpgrade checks if the request is a websocket upgrade request.
 func isWebsocketUpgrade(req *http.Request) bool {
-	return strings.EqualFold(req.Header.Get("Upgrade"), "websocket") &&
-		strings.EqualFold(req.Header.Get("Connection"), "upgrade")
+	return websocket.IsWebSocketUpgrade(req)
 }
 
 // wrapWebsocketHandler upgrades the HTTP connection to a websocket. Auditing

--- a/command/agent/websockets_test.go
+++ b/command/agent/websockets_test.go
@@ -220,3 +220,53 @@ func TestHTTP_ReadWsHandshake(t *testing.T) {
 		})
 	}
 }
+
+func TestIsWebsocketUpgrade_TokenListMismatch(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name               string
+		connectionHeader   string
+		upgradeHeader      string
+		isWebsocketUpgrade bool
+	}{
+		{
+			name:               "standard upgrade",
+			connectionHeader:   "Upgrade",
+			upgradeHeader:      "websocket",
+			isWebsocketUpgrade: true,
+		},
+		{
+			name:               "comma-separated connection header",
+			connectionHeader:   "keep-alive, Upgrade",
+			upgradeHeader:      "websocket",
+			isWebsocketUpgrade: true,
+		},
+		{
+			name:               "not a websocket upgrade",
+			connectionHeader:   "keep-alive",
+			upgradeHeader:      "h2c",
+			isWebsocketUpgrade: false,
+		},
+		{
+			name:               "missing upgrade header",
+			connectionHeader:   "upgrade",
+			isWebsocketUpgrade: false,
+		},
+		{
+			name:               "missing connection header",
+			upgradeHeader:      "websocket",
+			isWebsocketUpgrade: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/v1/client/allocation/abc/exec", nil)
+			req.Header.Set("Connection", tc.connectionHeader)
+			req.Header.Set("Upgrade", tc.upgradeHeader)
+
+			must.Eq(t, tc.isWebsocketUpgrade, isWebsocketUpgrade(req))
+		})
+	}
+}


### PR DESCRIPTION
### Description
Some browsers will add additional `Connection` headers, (`keep-alive`), and send them as a comma separated list, which won't parse correctly by just using `req.Header.Get`. Updates the header check to use gorilla/websockets logic to ensure we can support these headers, and add tests to prevent regressions.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
Added test to highlight the problem, even though it ends up testing the gorilla/websocket package. It's more to highlight that we should be able to handle these types of headers.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes https://github.com/hashicorp/nomad/issues/28216 

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
