### PR TITLE
secrets_hook: don't set hook response to done to allow re-fetch

### DIFF
--- a/.changelog/28237.txt
+++ b/.changelog/28237.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+secrets: Fixed hooks to allow refetch during prestart
+```

--- a/client/allocrunner/taskrunner/secrets_hook.go
+++ b/client/allocrunner/taskrunner/secrets_hook.go
@@ -78,6 +78,9 @@ type secretsHook struct {
 
 	// secrets to be fetched and populated for interpolation
 	secrets []*structs.Secret
+
+	// firstRun stores whether it is the first run for the hook
+	firstRun bool
 }
 
 func newSecretsHook(conf *secretsHookConfig, secrets []*structs.Secret) *secretsHook {
@@ -90,6 +93,7 @@ func newSecretsHook(conf *secretsHookConfig, secrets []*structs.Secret) *secrets
 		nomadNamespace: conf.nomadNamespace,
 		jobId:          conf.jobId,
 		secrets:        secrets,
+		firstRun:       true,
 	}
 }
 
@@ -98,6 +102,12 @@ func (h *secretsHook) Name() string {
 }
 
 func (h *secretsHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
+	first := h.firstRun
+	h.firstRun = false
+	if !first {
+		return nil
+	}
+
 	tmplProvider, pluginProvider, err := h.buildSecretProviders(req.TaskDir.SecretsDir)
 	if err != nil {
 		return err
@@ -180,7 +190,6 @@ func (h *secretsHook) Prestart(ctx context.Context, req *interfaces.TaskPrestart
 		h.envBuilder.SetSecrets(vars)
 	}
 
-	resp.Done = true
 	return nil
 }
 

--- a/client/allocrunner/taskrunner/secrets_hook_test.go
+++ b/client/allocrunner/taskrunner/secrets_hook_test.go
@@ -103,7 +103,14 @@ func TestSecretsHook_Prestart_Nomad(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		t.Cleanup(cancel)
 
-		err := secretHook.Prestart(ctx, req, &interfaces.TaskPrestartResponse{})
+		resp := &interfaces.TaskPrestartResponse{}
+		err := secretHook.Prestart(ctx, req, resp)
+
+		// PrestartDone must be false so we can recover tokens.
+		// firstRun is used to prevent multiple executions.
+		must.False(t, resp.Done)
+		must.False(t, secretHook.firstRun)
+
 		must.NoError(t, err)
 
 		expected := map[string]string{
@@ -181,6 +188,7 @@ func TestSecretsHook_Prestart_Nomad(t *testing.T) {
 		cancel() // cancel context to simulate task being stopped
 
 		err := secretHook.Prestart(ctx, req, &interfaces.TaskPrestartResponse{})
+
 		must.NoError(t, err)
 
 		expected := map[string]string{}
@@ -222,7 +230,7 @@ func TestSecretsHook_Prestart_Nomad(t *testing.T) {
 		}
 
 		// Prestart should error and return after building secrets
-		err := secretHook.Prestart(context.Background(), req, nil)
+		err := secretHook.Prestart(context.Background(), req, &interfaces.TaskPrestartResponse{})
 		must.Error(t, err)
 
 		expected := map[string]string{}
@@ -308,7 +316,13 @@ func TestSecretsHook_Prestart_Vault(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	t.Cleanup(cancel)
 
-	err := secretHook.Prestart(ctx, req, &interfaces.TaskPrestartResponse{})
+	resp := &interfaces.TaskPrestartResponse{}
+	err := secretHook.Prestart(ctx, req, resp)
+	// PrestartDone must be false so we can recover tokens.
+	// firstRun is used to prevent multiple executions.
+	must.False(t, resp.Done)
+	must.False(t, secretHook.firstRun)
+
 	must.NoError(t, err)
 
 	exp := map[string]string{
@@ -394,8 +408,14 @@ fi`
 		ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 		t.Cleanup(cancel)
 
-		err = secretHook.Prestart(ctx, req, &interfaces.TaskPrestartResponse{})
+		resp := &interfaces.TaskPrestartResponse{}
+		err = secretHook.Prestart(ctx, req, resp)
 		must.NoError(t, err)
+
+		// PrestartDone must be false so we can recover tokens.
+		// firstRun is used to prevent multiple executions.
+		must.False(t, resp.Done)
+		must.False(t, secretHook.firstRun)
 
 		exp := map[string]string{
 			"secret.test_secret0.jobID":     "test-jobid",


### PR DESCRIPTION
### Description
Updates the secret hooks to never return a `Done` status so that they will always fetch during the prestart stage of an allocation. 

This copies the logic used by other hooks (vault, identity) to track if this is the first run of a hook and returning if it isn't, instead of sending back `Done` in the response. This should allow allocations that are recovered to always attempt to fetch the secrets, because they may no longer be in memory (like after a client reboot & recovery). 

### Testing & Reproduction steps
Updated the tests, and manually tested according to the PR issue

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes https://github.com/hashicorp/nomad/issues/28213

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
