### PR TITLE
e2e/ui: avoid prerelease Playwright Docker images.

### DIFF
--- a/e2e/ui/run.sh
+++ b/e2e/ui/run.sh
@@ -39,12 +39,12 @@ IMAGE="mcr.microsoft.com/playwright"
 # since playwright looks for latest browser(s),
 # it will throw an error in non-latest containers.
 # so, instead of constantly changing the image
-# tag manually, pull it from the registry API.
+# tag manually, pull the latest stable tag from the registry API.
 get_image_tag() {
   1>&2 echo 'detecting playwright image tag'
-  local os='noble'
+  local os='jammy'
   curl -sS 'https://mcr.microsoft.com/api/v1/catalog/playwright/tags?reg=mar' \
-  | jq -r '[ .[].name | select(match("^v.*-jammy$")) ] | last '
+  | jq -r --arg os "$os" '[ .[].name | select(match("^v[0-9]+\\.[0-9]+\\.[0-9]+-" + $os + "$")) ] | last '
   # '[ ..query.. ] | last' gets the bottom one in the api response
   # that matches the regex. the api returns them sorted oldest to newest.
 }


### PR DESCRIPTION
Restrict the Playwright image tag lookup to stable semver tags, so the runner does not select prerelease images like v1.62.0-next-jammy. This keeps the Docker image aligned with the installed Playwright package.

Manual filter test:
```console
printf '%s
' '[{"name":"v1.61.1-jammy"},{"name":"v1.62.0-next-jammy"},{"name":"v1.61.1-noble"}]' | jq -r '[ .[].name | select(match("^v[0-9]+\\.[0-9]+\\.[0-9]+-jammy$")) ] | last'
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

