### PR TITLE
pipeline raft writes in plan applier

### DIFF
--- a/.changelog/28249.txt
+++ b/.changelog/28249.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+planner: Added plan_apply_pipeline configuration that allows the leader to have more outstanding Raft writes when evaluating plans
+```

--- a/command/agent/agent.go
+++ b/command/agent/agent.go
@@ -632,6 +632,7 @@ func convertServerConfig(agentConfig *Config) (*nomad.Config, error) {
 			conf.NodePlanRejectionWindow = planRejectConf.NodeWindow
 		}
 	}
+	conf.PlanApplyPipeline = agentConfig.Server.PlanApplyPipeline
 
 	// Add Enterprise license configs
 	conf.LicenseConfig = &nomad.LicenseConfig{

--- a/command/agent/config.go
+++ b/command/agent/config.go
@@ -717,6 +717,10 @@ type ServerConfig struct {
 	// detects potentially bad nodes.
 	PlanRejectionTracker *PlanRejectionTracker `hcl:"plan_rejection_tracker"`
 
+	// PlanApplyPipeline is the maximum number of outstanding plans there can be
+	// waiting on Raft apply
+	PlanApplyPipeline int `hcl:"plan_apply_pipeline"`
+
 	// EnableEventBroker configures whether this server's state store
 	// will generate events for its event stream.
 	EnableEventBroker *bool `hcl:"enable_event_broker"`
@@ -1884,6 +1888,7 @@ func DefaultConfig() *Config {
 				NodeThreshold: 100,
 				NodeWindow:    5 * time.Minute,
 			},
+			PlanApplyPipeline: 1,
 			ServerJoin: &ServerJoin{
 				RetryJoin:        []string{},
 				RetryInterval:    30 * time.Second,
@@ -2756,6 +2761,9 @@ func (s *ServerConfig) Merge(b *ServerConfig) *ServerConfig {
 
 	if b.PlanRejectionTracker != nil {
 		result.PlanRejectionTracker = result.PlanRejectionTracker.Merge(b.PlanRejectionTracker)
+	}
+	if b.PlanApplyPipeline != 0 {
+		result.PlanApplyPipeline = b.PlanApplyPipeline
 	}
 
 	if b.DefaultSchedulerConfig != nil {

--- a/nomad/config.go
+++ b/nomad/config.go
@@ -290,6 +290,10 @@ type Config struct {
 	// rejections for nodes.
 	NodePlanRejectionWindow time.Duration
 
+	// PlanApplyPipeline is the maximum number of outstanding plans there can be
+	// waiting on Raft apply
+	PlanApplyPipeline int
+
 	// MinHeartbeatTTL is the minimum time between heartbeats.
 	// This is used as a floor to prevent excessive updates.
 	MinHeartbeatTTL time.Duration

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -403,7 +403,7 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 	s.planQueue.SetEnabled(true)
 
 	// Start the plan evaluator
-	go s.planApply()
+	go s.planApply(s.GetConfig().PlanApplyPipeline)
 
 	// Start the eval broker and blocked eval broker if these are not paused by
 	// the operator.

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -101,8 +101,7 @@ func (p *planner) planApply(maxPipelineDepth int) {
 	maxPipelineDepth = max(maxPipelineDepth, 1)
 	// planIndexCh is used to track an outstanding Raft write and receive its
 	// committed index, while the snapshot holds an optimistic state that
-	// includes the plan application. The buffer size is set to roughly 2x the
-	// expected pipeline depth to reduce blocking but still provide backpressure
+	// includes the plan application.
 	planIndexCh := make(chan uint64, maxPipelineDepth)
 	var snap *state.StateSnapshot
 
@@ -213,7 +212,7 @@ func (p *planner) planApply(maxPipelineDepth int) {
 		// Apply backpressure to prevent dropping indexes because the future
 		// makes a non-blocking send; this never invalidates the snapshot
 		// because we want to optimistically update it instead
-		if inFlightPlans >= maxPipelineDepth {
+		for inFlightPlans >= maxPipelineDepth {
 			idx := <-planIndexCh
 			inFlightPlans--
 			prevPlanResultIndex = max(prevPlanResultIndex, idx)

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -97,12 +97,12 @@ func newPlanner(s *Server) (*planner, error) {
 // for Raft. Schedulers cannot proceed until their plan is committed, so
 // they will stall, but there are many schedulers and only a single plan
 // applier.
-func (p *planner) planApply() {
+func (p *planner) planApply(maxPipelineDepth int) {
+	maxPipelineDepth = max(maxPipelineDepth, 1)
 	// planIndexCh is used to track an outstanding Raft write and receive its
 	// committed index, while the snapshot holds an optimistic state that
 	// includes the plan application. The buffer size is set to roughly 2x the
 	// expected pipeline depth to reduce blocking but still provide backpressure
-	const maxPipelineDepth = 16
 	planIndexCh := make(chan uint64, maxPipelineDepth)
 	var snap *state.StateSnapshot
 

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -77,38 +77,46 @@ func newPlanner(s *Server) (*planner, error) {
 // subject to some latency. This creates a stall condition, where we are
 // not evaluating, but simply waiting for a transaction to apply.
 //
-// To avoid this, we overlap verification with apply. This means once
-// we've verified plan N we attempt to apply it. However, while waiting
-// for apply, we begin to verify plan N+1 under the assumption that plan
-// N has succeeded.
+// To avoid this, we overlap verification with apply and enable pipelining.
+// Multiple plans (roughly 6-8) can be in-flight in the Raft pipeline
+// simultaneously. We evaluate plan N+1 optimistically while plans N, N-1,
+// etc. are still being committed to Raft. We keep the state snapshot
+// optimistically updated with the plan updates, but we also track the highest
+// committed Raft index from completed plans and refresh our state snapshot to
+// include those changes once they're available.
 //
-// In this sense, we track two parallel versions of the world. One is
-// the pessimistic one driven by the Raft log which is replicated. The
-// other is optimistic and assumes our transactions will succeed. In the
-// happy path, this lets us do productive work during the latency of
-// apply.
+// In this sense, we track two parallel versions of the world. One is the
+// pessimistic one driven by the Raft log which is replicated. The other is
+// optimistic and assumes all the pipelined transactions will succeed but also
+// that no other changes that should invalidate plans arrive. In the happy path,
+// this lets us do productive work during the latency of apply because we batch
+// Raft log entries.
 //
-// In the unhappy path (Raft transaction fails), effectively we only
-// wasted work during a time we would have been waiting anyways. However,
-// in anticipation of this case we cannot respond to the plan until
-// the Raft log is updated. This means our schedulers will stall,
-// but there are many of those and only a single plan verifier.
+// In the unhappy path (Raft transaction fails), we've wasted evaluation
+// work, but this occurs during time we would have been idle anyway waiting
+// for Raft. Schedulers cannot proceed until their plan is committed, so
+// they will stall, but there are many schedulers and only a single plan
+// applier.
 func (p *planner) planApply() {
-	// planIndexCh is used to track an outstanding application and receive
-	// its committed index while snap holds an optimistic state which
-	// includes that plan application.
-	var planIndexCh chan uint64
+	// planIndexCh is used to track an outstanding Raft write and receive its
+	// committed index, while the snapshot holds an optimistic state that
+	// includes the plan application. The buffer size is set to roughly 2x the
+	// expected pipeline depth to reduce blocking but still provide backpressure
+	const maxPipelineDepth = 16
+	planIndexCh := make(chan uint64, maxPipelineDepth)
 	var snap *state.StateSnapshot
 
-	// prevPlanResultIndex is the index when the last PlanResult was
-	// committed. Since only the last plan is optimistically applied to the
-	// snapshot, it's possible the current snapshot's and plan's indexes
-	// are less than the index the previous plan result was committed at.
-	// prevPlanResultIndex also guards against the previous plan committing
-	// during Dequeue, thus causing the snapshot containing the optimistic
-	// commit to be discarded and potentially evaluating the current plan
-	// against an index older than the previous plan was committed at.
+	// prevPlanResultIndex tracks the highest Raft index we've seen from any
+	// completed plan. This ensures snapshots include all committed plans up to
+	// this index. It guards against evaluating plans against state that's
+	// missing recently committed changes.
 	var prevPlanResultIndex uint64
+
+	// inFlightPlans tracks the number of plans that have been dispatched to
+	// Raft but haven't completed yet. We use this to avoid refreshing the
+	// snapshot while plans are in-flight, as the snapshot contains optimistic
+	// updates that would be lost on refresh.
+	var inFlightPlans int
 
 	// Setup a worker pool with half the cores, with at least 1
 	poolSize := runtime.NumCPU() / 2
@@ -125,35 +133,55 @@ func (p *planner) planApply() {
 			return
 		}
 
-		// If last plan has completed get a new snapshot
-		select {
-		case idx := <-planIndexCh:
-			// Previous plan committed. Discard snapshot and ensure
-			// future snapshots include this plan. idx may be 0 if
-			// plan failed to apply, so use max(prev, idx)
-			prevPlanResultIndex = max(prevPlanResultIndex, idx)
-			planIndexCh = nil
-			snap = nil
-		default:
+		// Drain all available plan completion indexes from the channel. Plans
+		// may write their completion to this channel out of order, so we track
+		// the highest index seen. This non-blocking drain ensures we don't miss
+		// any completions and allows us to update our snapshot to include all
+		// completed plans.
+		var maxNewIndex uint64
+		for {
+			select {
+			case idx := <-planIndexCh:
+				inFlightPlans--
+				maxNewIndex = max(maxNewIndex, idx)
+			default:
+				goto DONE_DRAINING // no more ready
+			}
 		}
+	DONE_DRAINING:
 
-		if snap != nil {
-			// If snapshot doesn't contain the previous plan
-			// result's index and the current plan's snapshot it,
-			// discard it and get a new one below.
-			minIndex := max(prevPlanResultIndex, pending.plan.SnapshotIndex)
-			if idx, err := snap.LatestIndex(); err != nil || idx < minIndex {
+		inFlightPlans = max(inFlightPlans, 0)
+		metrics.AddSample(metricPlanOutstandingApply, float32(inFlightPlans))
+
+		// Update prevPlanResultIndex and invalidate snapshot if we received
+		// any new completion indexes
+		if maxNewIndex > prevPlanResultIndex {
+			prevPlanResultIndex = maxNewIndex
+			// Only invalidate snapshot if no plans are in-flight
+			// This preserves optimistic updates from in-flight plans
+			if inFlightPlans == 0 {
 				snap = nil
 			}
 		}
 
-		// Snapshot the state so that we have a consistent view of the world
-		// if no snapshot is available.
-		//  - planIndexCh will be nil if the previous plan result applied
-		//    during Dequeue
-		//  - snap will be nil if its index < max(prevIndex, curIndex)
-		if planIndexCh == nil || snap == nil {
-			snap, err = p.snapshotMinIndex(prevPlanResultIndex, pending.plan.SnapshotIndex)
+		if snap != nil {
+			// If snapshot doesn't contain the previous plan result's index
+			// or the current plan's snapshot index, discard it and get a new one below.
+			// But only if no plans are in-flight (to preserve optimistic updates).
+			minIndex := max(prevPlanResultIndex, pending.plan.SnapshotIndex)
+			if idx, err := snap.LatestIndex(); err != nil || idx < minIndex {
+				if inFlightPlans == 0 {
+					snap = nil
+				}
+			}
+		}
+		if snap == nil {
+			// Snapshot the state so that we have a consistent view of the world.
+			// The snapshot is guaranteed to include all plans up to the highest
+			// of: prevPlanResultIndex (committed plans) or pending.plan.SnapshotIndex
+			// (objects referenced by current plan).
+			minIndex := max(prevPlanResultIndex, pending.plan.SnapshotIndex)
+			snap, err = p.snapshotMinIndex(minIndex, pending.plan.SnapshotIndex)
 			if err != nil {
 				p.srv.logger.Error("failed to snapshot state", "error", err)
 				pending.respond(nil, err)
@@ -182,21 +210,22 @@ func (p *planner) planApply() {
 			continue
 		}
 
-		// Ensure any parallel apply is complete before starting the next one.
-		// This also limits how out of date our snapshot can be.
-		if planIndexCh != nil {
+		// Apply backpressure to prevent dropping indexes because the future
+		// makes a non-blocking send; this never invalidates the snapshot
+		// because we want to optimistically update it instead
+		if inFlightPlans >= maxPipelineDepth {
 			idx := <-planIndexCh
-			planIndexCh = nil
+			inFlightPlans--
 			prevPlanResultIndex = max(prevPlanResultIndex, idx)
-			snap, err = p.snapshotMinIndex(prevPlanResultIndex, pending.plan.SnapshotIndex)
-			if err != nil {
-				p.srv.logger.Error("failed to update snapshot state", "error", err)
-				pending.respond(nil, err)
-				continue
-			}
 		}
 
-		// Dispatch the Raft transaction for the plan
+		// Dispatch the Raft transaction for the plan without blocking. This
+		// enables pipelining: multiple plans can be in-flight in the Raft
+		// pipeline simultaneously, improving throughput by allowing Raft to
+		// batch log entries. The trade-off is increased snapshot staleness
+		// under heavy load (up to ~6-8 plans behind, limited by plan evaluation
+		// and alloc signing) which may increase plan rejection rates, but
+		// schedulers will refresh and retry.
 		future, err := p.applyPlan(pending.plan, result, snap)
 		if err != nil {
 			p.srv.logger.Error("failed to submit plan", "error", err)
@@ -204,18 +233,52 @@ func (p *planner) planApply() {
 			continue
 		}
 
-		// Respond to the plan in async; receive plan's committed index via chan
-		planIndexCh = make(chan uint64, 1)
+		inFlightPlans++
+
+		// Respond to the plan async; the goroutine will send the committed
+		// index on planIndexCh when the Raft apply completes. We reuse the same
+		// channel for all in-flight plans, and the draining logic above handles
+		// collecting all completed indexes.
 		go p.asyncPlanWait(planIndexCh, future, result, pending)
 	}
 }
+
+var (
+	// the span of time we wait for the Raft index to catch up while taking a
+	// snapshot with a minimum index
+	metricPlanWaitForIndex = []string{"nomad", "plan", "wait_for_index"}
+
+	// the span of time it takes to evaluate a plan
+	metricPlanEvaluate = []string{"nomad", "plan", "evaluate"}
+
+	// the span of time it takes to dispatch a Raft log (limited by
+	// MaxAppendEntries)
+	metricPlanBlockOnRaftDispatch = []string{"nomad", "plan", "raft_dispatch"}
+
+	// the span of time it takes to sign all allocation identities for a plan
+	metricPlanSignAllocIdentities = []string{"nomad", "plan", "sign_identities"}
+
+	// the span of time it takes to apply the update to our optimistic snapshot
+	metricPlanOptimisiticApply = []string{"nomad", "plan", "optimistic_apply"}
+
+	// the span of time we wait async for the Raft future to return
+	metricPlanWaitForRaft = []string{"nomad", "plan", "apply"}
+
+	// a count of how many outstanding plans we have in the Raft apply pipeline
+	// (between dispatch and when we get the index back) after we've drained as
+	// many ready indexes as we can get
+	metricPlanOutstandingApply = []string{"nomad", "plan", "outstanding_apply"}
+
+	// a count of how many times we reject a plan
+	metricPlanNodeRejected = []string{"nomad", "plan", "node_rejected"}
+)
 
 // snapshotMinIndex wraps SnapshotAfter with a 10s timeout and converts timeout
 // errors to a more descriptive error message. The snapshot is guaranteed to
 // include both the previous plan and all objects referenced by the plan or
 // return an error.
 func (p *planner) snapshotMinIndex(prevPlanResultIndex, planSnapshotIndex uint64) (*state.StateSnapshot, error) {
-	defer metrics.MeasureSince([]string{"nomad", "plan", "wait_for_index"}, time.Now())
+	defer metrics.MeasureSince(metricPlanWaitForIndex, time.Now())
 
 	// Minimum index the snapshot must include is the max of the previous
 	// plan result's and current plan's snapshot index.
@@ -237,7 +300,8 @@ func (p *planner) snapshotMinIndex(prevPlanResultIndex, planSnapshotIndex uint64
 	return snap, err
 }
 
-// applyPlan is used to apply the plan result and to return the alloc index
+// applyPlan is used to apply the plan result and to return the alloc index.
+// Returns the raft future, the optimistic index (0 if not applied), and any error.
 func (p *planner) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap *state.StateSnapshot) (raft.ApplyFuture, error) {
 	now := time.Now().UTC()
 	unixNow := now.UnixNano()
@@ -319,13 +383,16 @@ func (p *planner) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap
 	req.PreemptionEvals = evals
 
 	// Dispatch the Raft transaction
+	metricNow := time.Now().UTC()
 	future, err := p.srv.raftApplyFuture(structs.ApplyPlanResultsRequestType, &req)
 	if err != nil {
 		return nil, err
 	}
+	metrics.MeasureSince(metricPlanBlockOnRaftDispatch, metricNow)
 
 	// Optimistically apply to our state view
 	if snap != nil {
+		defer metrics.MeasureSince(metricPlanOptimisiticApply, time.Now())
 		nextIdx := p.srv.raft.AppliedIndex() + 1
 		if err := snap.UpsertPlanResults(structs.ApplyPlanResultsRequestType, nextIdx, &req); err != nil {
 			return future, err
@@ -380,6 +447,9 @@ func updateAllocTimestamps(allocations []*structs.Allocation, timestamp int64) {
 }
 
 func signAllocIdentities(signer claimSigner, job *structs.Job, allocations []*structs.Allocation, ns *structs.Namespace, now time.Time) error {
+	metricsNow := time.Now().UTC()
+	defer metrics.MeasureSince(metricPlanSignAllocIdentities, metricsNow)
+
 	for _, alloc := range allocations {
 		if alloc.SignedIdentities == nil {
 			alloc.SignedIdentities = map[string]string{}
@@ -408,18 +478,24 @@ func signAllocIdentities(signer claimSigner, job *structs.Job, allocations []*st
 	return nil
 }
 
-// asyncPlanWait is used to apply and respond to a plan async. On successful
-// commit the plan's index will be sent on the chan. On error the chan will be
-// closed.
+// asyncPlanWait is used to apply and respond to a plan async. indexCh is used
+// to send back the index the plan was applied at or 0 if it could not be
+// applied. This allows the main planning loop to track outstanding plans and
+// ensure the snapshot includes their optimistic updates. indexCh is shared
+// across all in-flight plans and must not be closed by this function.
 func (p *planner) asyncPlanWait(indexCh chan<- uint64, future raft.ApplyFuture,
 	result *structs.PlanResult, pending *pendingPlan) {
-	defer metrics.MeasureSince([]string{"nomad", "plan", "apply"}, time.Now())
-	defer close(indexCh)
+	defer metrics.MeasureSince(metricPlanWaitForRaft, time.Now())
 
 	// Wait for the plan to apply
 	if err := future.Error(); err != nil {
 		p.srv.logger.Error("failed to apply plan", "error", err)
 		pending.respond(nil, err)
+		// Send 0 to indicate failure
+		select {
+		case indexCh <- 0:
+		default:
+		}
 		return
 	}
 
@@ -435,14 +511,21 @@ func (p *planner) asyncPlanWait(indexCh chan<- uint64, future raft.ApplyFuture,
 		result.RefreshIndex = maxUint64(result.RefreshIndex, result.AllocIndex)
 	}
 	pending.respond(result, nil)
-	indexCh <- index
+
+	// Send index to channel, but don't block if channel is closed or full
+	// This can happen during server shutdown when planApply() exits
+	select {
+	case indexCh <- index:
+	default:
+		// Channel closed or full, ignore
+	}
 }
 
 // evaluatePlan is used to determine what portions of a plan
 // can be applied if any. Returns if there should be a plan application
 // which may be partial or if there was an error
 func evaluatePlan(pool *EvaluatePool, snap *state.StateSnapshot, plan *structs.Plan, logger log.Logger) (*structs.PlanResult, error) {
-	defer metrics.MeasureSince([]string{"nomad", "plan", "evaluate"}, time.Now())
+	defer metrics.MeasureSince(metricPlanEvaluate, time.Now())
 
 	logger.Trace("evaluating plan", "plan", log.Fmt("%#v", plan))
 
@@ -520,7 +603,8 @@ func evaluatePlanPlacements(pool *EvaluatePool, snap *state.StateSnapshot, plan 
 			return true
 		}
 		if !fit {
-			metrics.IncrCounterWithLabels([]string{"nomad", "plan", "node_rejected"}, 1, []metrics.Label{{Name: "node_id", Value: nodeID}})
+			metrics.IncrCounterWithLabels(metricPlanNodeRejected,
+				1, []metrics.Label{{Name: "node_id", Value: nodeID}})
 
 			// Log the reason why the node's allocations could not be made
 			if reason != "" {

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-metrics"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -1355,4 +1356,92 @@ func TestPlanApply_EvalNodePlan_Node_Disconnected(t *testing.T) {
 			require.Equal(t, tc.expectedReason, reason)
 		})
 	}
+}
+
+// TestPlanApply_PipelinedPlans tests that multiple plans can be in-flight
+// simultaneously
+func TestPlanApply_PipelinedPlans(t *testing.T) {
+	ci.Parallel(t)
+
+	// Set up sink to capture batching metrics
+	sink := metrics.NewInmemSink(10*time.Second, time.Minute)
+	cfg := metrics.DefaultConfig("nomad")
+	cfg.EnableHostname = false
+	metrics.NewGlobal(cfg, sink)
+
+	// Configure Raft to increase batching window
+	srv, cleanup := TestServer(t, func(c *Config) {
+		c.RaftConfig.CommitTimeout = 100 * time.Millisecond
+		c.RaftConfig.MaxAppendEntries = 64
+	})
+	defer cleanup()
+	testutil.WaitForKeyring(t, srv.RPC, srv.Region())
+
+	node := mock.Node()
+	testRegisterNode(t, srv, node)
+
+	job := mock.Job()
+	job.TaskGroups[0].Networks = nil
+	for _, task := range job.TaskGroups[0].Tasks {
+		task.Resources.Networks = nil
+	}
+	store := srv.State()
+	index, _ := store.LatestIndex()
+	index++
+	must.NoError(t, store.UpsertJob(structs.MsgTypeTestSetup, index, nil, job))
+
+	eval := mock.Eval()
+	eval.JobID = job.ID
+	index++
+	must.NoError(t, store.UpsertEvals(structs.MsgTypeTestSetup, index, []*structs.Evaluation{eval}))
+
+	// Submit plans and wait for them to complete
+	numPlans := 20
+	futures := make([]PlanFuture, numPlans)
+
+	for i := 0; i < numPlans; i++ {
+		alloc := mock.MinAllocForJob(job)
+		alloc.NodeID = node.ID
+		alloc.EvalID = eval.ID
+
+		plan := &structs.Plan{
+			Job: job,
+			JobInfo: &structs.PlanJobTuple{
+				Namespace: job.Namespace,
+				ID:        job.ID,
+			},
+			EvalID:         eval.ID,
+			NodeAllocation: map[string][]*structs.Allocation{node.ID: {alloc}},
+		}
+
+		future, err := srv.planQueue.Enqueue(plan)
+		must.NoError(t, err)
+		futures[i] = future
+	}
+	for i, future := range futures {
+		result, err := future.Wait()
+		must.NoError(t, err)
+		must.NotNil(t, result, must.Sprintf("plan %d result is nil", i))
+	}
+	allocs, err := store.AllocsByNode(nil, node.ID)
+	must.NoError(t, err)
+	must.Len(t, numPlans, allocs, must.Sprintf("expected %d allocations", numPlans))
+
+	// Verify that pipelining occurred by checking the batching metrics.
+	// Max > 0 means at least one plan observed another plan already in-flight,
+	// proving that pipelining occurred (multiple plans in the Raft pipeline
+	// simultaneously)
+
+	data := sink.Data()
+	must.NotEq(t, 0, len(data), must.Sprint("no metrics data collected"))
+
+	var maxInFlight float64
+	for _, interval := range data {
+		if sample, ok := interval.Samples["nomad.nomad.plan.outstanding_apply"]; ok {
+			if sample.Max > maxInFlight {
+				maxInFlight = sample.Max
+			}
+		}
+	}
+	must.Greater(t, 0.0, maxInFlight, must.Sprint("expected pipelined plans"))
 }

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -1371,6 +1371,7 @@ func TestPlanApply_PipelinedPlans(t *testing.T) {
 
 	// Configure Raft to increase batching window
 	srv, cleanup := TestServer(t, func(c *Config) {
+		c.PlanApplyPipeline = 16
 		c.RaftConfig.CommitTimeout = 100 * time.Millisecond
 		c.RaftConfig.MaxAppendEntries = 64
 	})


### PR DESCRIPTION
Plans can typically be evaluated much more quickly than they can be applied to Raft. This creates a bottleneck in the plan applier, which today we reduce by overlapping verification of one plan with applying of the next plan. In the happy path this improves plan applier performance, and in the unhappy path where the Raft txn fails, we have to throw away the evaluated plan. This also results in a known narrow race where we could be evaluating a plan, and an update for that node could arrive that should fail the plan and now doesn't because we were evaluating over the optimistic snapshot state (a false negative rejection).

But if we have a large number of jobs to process at once (ex. a busy node fails), the end-to-end placement time for those jobs is bottlenecked on this allowed pipeline depth of 1 plan. Scheduler workers become idle blocked on `Plan.SubmitPlan`.

This changeset updates the main plan applier loop to allow submitting plans to the Raft pipeline without waiting on the previous plan to complete. In benchmarking under heavy load the pipeline depth was 6-8 plans, maxing out at
10. But doing so required many scheduler goroutines to actually saturate the plan applier (I used 144 in my benchmark).

There are a few tradeoffs here:

* The size of the Raft log entry increases for each pipelined plan, which delays other Raft writes, and which increases the latency of individual plans even as we increase the throughput.
* The window in which we can see false negatives on plan rejection widens when under load from single digit ms to 10s of milliseconds (potentially up to 100-200ms on slower disks or network latency between servers).
* The already complex plan apply loop got more complex.

Ref: https://hashicorp.atlassian.net/browse/NMD-1038
Ref: https://hashicorp.atlassian.net/browse/NMD-1607

### Testing & Reproduction steps

**Setup:**
* 3 servers w/ 64 cores each (AWS EC2 `c7a.16xlarge`): this is 144 scheduler goroutines
* 2 clients

**Measurements:**
* poll server's plan applier metrics every 10s
* pull client logs on number of allocations pulled

**Run tests:**
* stop Nomad on client1, wait for it to be down, and GC it.
* Deploy 130 single-allocation jobs.
* Use `nomad eval list` to wait for the `deployment-watcher`-triggered evals to be complete, which shows that all jobs are running.
* Restart Noamd on client1
* Stop Nomad on client0

<details><summary>test jobs and scripts</summary>

jobspec

```hcl
job "NAME" {

  group "group" {

    ephemeral_disk {
      size = 10
    }

    task "task" {

      driver = "mock_driver"
      config {
        run_for = "300s"
      }

      logs {
        max_files = 1
        max_file_size = 1
        disabled = true
      }

      resources {
        cpu    = 10
        memory = 10
      }
    }
  }
}
```

Run script

```
#!/usr/bin/env bash
set -eu

count=${1:-5}
for i in $(seq 1 "$count")
do
    sed "s/NAME/example-$i/" example.nomad.hcl | nomad job run -detach -
done
```

Metrics collection

```
#!/usr/bin/env bash
set -eu

srv=${1:-unknown}
addr=${2:-unknown}

if [[ $srv == "unknown" ]]; then
    echo "needs server name"
    exit 1
fi
if [[ $addr == "unknown" ]]; then
    echo "needs address"
    exit 1
fi

export NOMAD_ADDR="$addr"
mkdir -p metrics

while :
do
    now=$(date +%s)
    filename="./metrics/metrics-$srv-$now.json"
    nomad operator api '/v1/metrics' > "$filename"
    echo "wrote metrics to $filename"
    sleep 10
done
```

</details>

| Metric                                        | w/o Patch | w/ Patch p=1 | w/ Patch p=16 |
|-----------------------------------------------|-----------|--------------|---------------|
| time from 1st alloc to last alloc on client   | ~6s       | ~5s          | ~2s           |
| mean scheduling time (process/response in ms) | 707 / 709 | 715 / 718    | 224 / 226     |
| block on parallel (mean/max in ms)            | 7.0 / 8.9 | 0 / 0        | 0 / 0     |
| async wait on raft (mean/max in ms)           | 6.1 / 8.4 | 7.0 / 10.7   | 13.6 / 27.6   |
| logs per batch (mean/max in ms)               | 1.0 / 1.0 | 1.0 / 1.0    | 1.8 / 6.0     |
| plans in flight (mean/max in ms)              | 0 / 0     | 0.2 / 1.0    | 4.9 / 9.0     |


<img width="1780" height="1062" alt="Screenshot From 2026-07-15 16-31-31" src="https://github.com/user-attachments/assets/54e5b959-65d4-44a8-81a8-73e1c50eb7d5" />



### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** https://github.com/hashicorp/web-unified-docs/pull/2856
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
