### PR TITLE
cli: accept an abbreviated key ID in operator root keyring remove

### DIFF
--- a/.changelog/24148.txt
+++ b/.changelog/24148.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+cli: Fixed a bug where `nomad operator root keyring remove` would not accept an abbreviated key ID
+```

--- a/command/operator_root_keyring_remove.go
+++ b/command/operator_root_keyring_remove.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/nomad/api"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/posener/complete"
 )
 
@@ -72,18 +73,48 @@ func (c *OperatorRootKeyringRemoveCommand) Run(args []string) int {
 	}
 
 	args = flags.Args()
-	if len(args) != 1 {
+	if len(args) != 1 || args[0] == "" {
 		c.Ui.Error("This command requires one argument: <key ID>")
 		c.Ui.Error(commandErrorText(c))
 		return 1
 	}
-	removeKey := args[0]
+	removeKey := strings.ToLower(args[0])
 
 	client, err := c.Meta.Client()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error creating nomad cli client: %s", err))
 		return 1
 	}
+
+	// Resolve an abbreviated key ID to the full ID
+	if !helper.IsUUID(removeKey) {
+		keys, _, err := client.Keyring().List(nil)
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("error: %s", err))
+			return 1
+		}
+
+		var matches []*api.RootKeyMeta
+		for _, k := range keys {
+			if strings.HasPrefix(k.KeyID, removeKey) {
+				matches = append(matches, k)
+			}
+		}
+
+		if len(matches) == 0 {
+			c.Ui.Error(fmt.Sprintf("No encryption key(s) with prefix or ID %q found", removeKey))
+			return 1
+		}
+
+		if len(matches) > 1 {
+			c.Ui.Error(fmt.Sprintf("Prefix matched multiple keys\n\n%s",
+				renderVariablesKeysResponse(matches, true)))
+			return 1
+		}
+
+		removeKey = matches[0].KeyID
+	}
+
 	_, err = client.Keyring().Delete(&api.KeyringDeleteOptions{
 		KeyID: removeKey,
 		Force: force,

--- a/command/operator_root_keyring_test.go
+++ b/command/operator_root_keyring_test.go
@@ -1,0 +1,82 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/cli"
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/uuid"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+func TestOperatorRootKeyringRemoveCommand_Implements(t *testing.T) {
+	ci.Parallel(t)
+	var _ cli.Command = &OperatorRootKeyringRemoveCommand{}
+}
+
+func TestOperatorRootKeyringRemoveCommand_Run(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, client, addr := testServer(t, false, nil)
+	defer srv.Shutdown()
+	store := srv.Agent.Server().State()
+
+	// Insert two inactive keys whose IDs share an 8-char prefix
+	longID := uuid.Generate()
+	longID2 := longID[0:8] + uuid.Generate()[8:]
+
+	for i, id := range []string{longID, longID2} {
+		meta := structs.NewRootKeyMeta()
+		meta.KeyID = id
+		key := structs.NewRootKey(meta).MakeInactive()
+		must.NoError(t, store.UpsertRootKey(uint64(1000+i), key, false))
+	}
+
+	ui := cli.NewMockUi()
+	c := &OperatorRootKeyringRemoveCommand{Meta: Meta{Ui: ui}}
+
+	// An empty ID is rejected before any lookup
+	code := c.Run([]string{"-address=" + addr, ""})
+	must.One(t, code)
+	must.StrContains(t, ui.ErrorWriter.String(), "This command requires one argument")
+	ui.ErrorWriter.Reset()
+
+	// An ambiguous prefix must not remove anything
+	code = c.Run([]string{"-address=" + addr, longID[0:8]})
+	must.One(t, code)
+	must.StrContains(t, ui.ErrorWriter.String(), "Prefix matched multiple keys")
+	must.StrContains(t, ui.ErrorWriter.String(), longID)
+	must.StrContains(t, ui.ErrorWriter.String(), longID2)
+	keys, _, err := client.Keyring().List(nil)
+	must.NoError(t, err)
+	must.Len(t, 3, keys)
+	ui.ErrorWriter.Reset()
+
+	// A non-hex prefix can never match a key ID
+	code = c.Run([]string{"-address=" + addr, "zzzzzzzz"})
+	must.One(t, code)
+	must.StrContains(t, ui.ErrorWriter.String(), "No encryption key(s)")
+	ui.ErrorWriter.Reset()
+
+	// A UUID-shaped argument is passed through without resolution
+	code = c.Run([]string{"-address=" + addr, longID2})
+	must.Zero(t, code, must.Sprintf("expected exit 0, got err: %s", ui.ErrorWriter.String()))
+	ui.OutputWriter.Reset()
+
+	// The abbreviated ID, now unique, resolves to the full key regardless
+	// of case
+	code = c.Run([]string{"-address=" + addr, strings.ToUpper(longID[0:8])})
+	must.Zero(t, code, must.Sprintf("expected exit 0, got err: %s", ui.ErrorWriter.String()))
+	must.StrContains(t, ui.OutputWriter.String(), longID)
+
+	keys, _, err = client.Keyring().List(nil)
+	must.NoError(t, err)
+	must.Len(t, 1, keys)
+	must.NotEq(t, longID, keys[0].KeyID)
+	must.NotEq(t, longID2, keys[0].KeyID)
+}


### PR DESCRIPTION
### Description

`nomad operator root keyring list` prints keys with 8-char short IDs, but `keyring remove` passes its argument straight to the delete RPC, which matches only full-length IDs. Removing a key by the copied short ID fails with `root key not found`.

The CLI now resolves the prefix against the keyring list, as tgross suggested on the issue, and calls the delete RPC with the full-length ID. A UUID-shaped argument skips the list call, since it can never be a prefix of another key. Deleting by full ID keeps working with a token that only has `keyring-delete`.

An ambiguous prefix prints the matching keys and removes nothing. An empty argument is rejected up front because an empty prefix would match every key.

### Testing & Reproduction steps

On a fresh agent, run `nomad operator root keyring rotate -now`, then `nomad operator root keyring remove` with the short ID printed by `keyring list`. Before the change this fails with `500 (root key not found)` and the key stays. After it the key is removed. Added `TestOperatorRootKeyringRemoveCommand_Run`, which runs against a test server and covers ambiguous prefixes, prefixes that match nothing, mixed case, a full-length ID, and an empty argument.

### Links

Fixes #24148

### Contributor Checklist
- [x] **Changelog Entry** Added at `.changelog/24148.txt`.
- [x] **Testing** Added `TestOperatorRootKeyringRemoveCommand_Run`.
- [ ] **Documentation** No doc change. Sibling commands do not document prefix support either.
- [x] **LLM Usage** Read and followed the AI usage guide.

This contribution was developed with AI assistance (Claude Code), used to trace the delete RPC's exact-match lookup and to draft the fix and tests.
