### PR TITLE
api: return 404 for unknown node in client allocation endpoints

### DIFF
--- a/.changelog/28261.txt
+++ b/.changelog/28261.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fixed a bug where the client allocation endpoints returned a 500 error instead of a 404 when the allocation's node could not be found
+```

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -323,7 +323,7 @@ func (s *HTTPServer) allocRestart(allocID string, resp http.ResponseWriter, req 
 	}
 
 	if rpcErr != nil {
-		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) {
+		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) || structs.IsErrUnknownNode(rpcErr) {
 			rpcErr = CodedError(404, rpcErr.Error())
 		}
 	}
@@ -355,7 +355,7 @@ func (s *HTTPServer) allocGC(allocID string, resp http.ResponseWriter, req *http
 	}
 
 	if rpcErr != nil {
-		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) {
+		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) || structs.IsErrUnknownNode(rpcErr) {
 			rpcErr = CodedError(404, rpcErr.Error())
 		}
 	}
@@ -394,7 +394,7 @@ func (s *HTTPServer) allocSignal(allocID string, resp http.ResponseWriter, req *
 	}
 
 	if rpcErr != nil {
-		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) {
+		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) || structs.IsErrUnknownNode(rpcErr) {
 			rpcErr = CodedError(404, rpcErr.Error())
 		}
 	}
@@ -439,7 +439,7 @@ func (s *HTTPServer) allocPauseGet(allocID string, resp http.ResponseWriter, req
 	}
 
 	if rpcErr != nil {
-		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) {
+		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) || structs.IsErrUnknownNode(rpcErr) {
 			rpcErr = CodedError(404, rpcErr.Error())
 		}
 	}
@@ -493,7 +493,7 @@ func (s *HTTPServer) allocPauseSet(allocID string, resp http.ResponseWriter, req
 	}
 
 	if rpcErr != nil {
-		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) {
+		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) || structs.IsErrUnknownNode(rpcErr) {
 			rpcErr = CodedError(404, rpcErr.Error())
 		}
 	}
@@ -545,7 +545,7 @@ func (s *HTTPServer) allocStats(allocID string, resp http.ResponseWriter, req *h
 	}
 
 	if rpcErr != nil {
-		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) {
+		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) || structs.IsErrUnknownNode(rpcErr) {
 			rpcErr = CodedError(404, rpcErr.Error())
 		}
 	}
@@ -578,7 +578,7 @@ func (s *HTTPServer) allocChecks(allocID string, resp http.ResponseWriter, req *
 	}
 
 	if rpcErr != nil {
-		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) {
+		if structs.IsErrNoNodeConn(rpcErr) || structs.IsErrUnknownAllocation(rpcErr) || structs.IsErrUnknownNode(rpcErr) {
 			rpcErr = CodedError(404, rpcErr.Error())
 		}
 	}

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -617,6 +617,35 @@ func TestHTTP_AllocStats(t *testing.T) {
 	})
 }
 
+// TestHTTP_AllocStats_UnknownNode asserts the client stats endpoint returns a
+// 404 rather than a 500 when the allocation's node cannot be found, matching
+// the unknown-allocation and no-path-to-node cases. See issue 26838.
+func TestHTTP_AllocStats_UnknownNode(t *testing.T) {
+	ci.Parallel(t)
+
+	httpTest(t, nil, func(s *TestAgent) {
+		// Insert an allocation whose node is not registered, so the server RPC
+		// resolves the allocation but fails to find its node.
+		state := s.Agent.server.State()
+		alloc := mock.Alloc()
+		must.NoError(t, state.UpsertJobSummary(998, mock.JobSummary(alloc.JobID)))
+		must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 999, nil, alloc.Job))
+		must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 1000, []*structs.Allocation{alloc}))
+
+		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/stats", alloc.ID), nil)
+		must.NoError(t, err)
+		respW := httptest.NewRecorder()
+
+		_, err = s.Server.ClientAllocRequest(respW, req)
+		must.Error(t, err)
+		must.True(t, structs.IsErrUnknownNode(err))
+
+		codedErr, ok := err.(HTTPCodedError)
+		must.True(t, ok)
+		must.Eq(t, 404, codedErr.Code())
+	})
+}
+
 func TestHTTP_AllocStats_ACL(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)


### PR DESCRIPTION
### Description
The client allocation HTTP handlers mapped `IsErrNoNodeConn` and `IsErrUnknownAllocation` to a 404, but omitted `IsErrUnknownNode`. As a result, a request whose allocation referenced a node that could not be found returned a 500 instead of a 404. This adds `IsErrUnknownNode` to the 404 condition in the affected `ClientAllocations.*` handlers (stats, checks, restart, gc, signal, and the two pause endpoints), matching the sibling client stats endpoint and the two error cases already handled there.

Note: the issue suggests fixing this upstream in the RPC handler with a `CodedError` rather than catching it in the HTTP handler. I kept the fix in the HTTP handler to stay consistent with the existing error handling in these endpoints, but I'm happy to move it into the RPC layer if you'd prefer that approach.

### Testing & Reproduction steps
Added `TestHTTP_AllocStats_UnknownNode`, which inserts an allocation whose node is not registered and calls the stats endpoint via the server RPC path, asserting the handler returns a 404-coded error instead of a 500. Run with:

    go test -tags hashicorpmetrics -run TestHTTP_AllocStats_UnknownNode ./command/agent/

### Links

Fixes hashicorp/nomad#26838

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
