### PR TITLE
cli: add -json-output and -t flags to nomad job plan

### DIFF
--- a/.changelog/27369.txt
+++ b/.changelog/27369.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+cli: add `-json-output` and `-t` flags to `nomad job plan` for structured plan output
+```

--- a/command/job_plan.go
+++ b/command/job_plan.go
@@ -104,6 +104,13 @@ Plan Options:
 
   -verbose
     Increase diff verbosity.
+
+  -json-output
+    Output the plan result in JSON format. This is separate from -json, which
+    controls input job file parsing.
+
+  -t
+    Format and display the plan result using a Go template.
 `
 	return strings.TrimSpace(helpText)
 }
@@ -119,10 +126,12 @@ func (c *JobPlanCommand) AutocompleteFlags() complete.Flags {
 			"-policy-override": complete.PredictNothing,
 			"-verbose":         complete.PredictNothing,
 			"-json":            complete.PredictNothing,
+			"-json-output":     complete.PredictNothing,
 			"-hcl2-strict":     complete.PredictNothing,
 			"-vault-namespace": complete.PredictAnything,
 			"-var":             complete.PredictAnything,
 			"-var-file":        complete.PredictFiles("*.var"),
+			"-t":               complete.PredictAnything,
 		})
 }
 
@@ -136,8 +145,8 @@ func (c *JobPlanCommand) AutocompleteArgs() complete.Predictor {
 
 func (c *JobPlanCommand) Name() string { return "job plan" }
 func (c *JobPlanCommand) Run(args []string) int {
-	var diff, policyOverride, verbose bool
-	var vaultNamespace string
+	var diff, policyOverride, verbose, jsonOutput bool
+	var vaultNamespace, tmpl string
 
 	flagSet := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flagSet.Usage = func() { c.Ui.Output(c.Help()) }
@@ -145,12 +154,21 @@ func (c *JobPlanCommand) Run(args []string) int {
 	flagSet.BoolVar(&policyOverride, "policy-override", false, "")
 	flagSet.BoolVar(&verbose, "verbose", false, "")
 	flagSet.BoolVar(&c.JobGetter.JSON, "json", false, "")
+	flagSet.BoolVar(&jsonOutput, "json-output", false, "")
 	flagSet.BoolVar(&c.JobGetter.Strict, "hcl2-strict", true, "")
 	flagSet.StringVar(&vaultNamespace, "vault-namespace", "", "")
+	flagSet.StringVar(&tmpl, "t", "", "")
 	flagSet.Var(&c.JobGetter.Vars, "var", "")
 	flagSet.Var(&c.JobGetter.VarFiles, "var-file", "")
 
 	if err := flagSet.Parse(args); err != nil {
+		return 255
+	}
+
+	// -json already means "parse the job file as JSON", so output uses a
+	// separate flag. -json-output and -t are mutually exclusive.
+	if jsonOutput && len(tmpl) > 0 {
+		c.Ui.Error("Both -json-output and -t formatting are not allowed")
 		return 255
 	}
 
@@ -207,7 +225,7 @@ func (c *JobPlanCommand) Run(args []string) int {
 	}
 
 	if job.IsMultiregion() {
-		return c.multiregionPlan(client, job, opts, diff, verbose)
+		return c.multiregionPlan(client, job, opts, diff, verbose, jsonOutput, tmpl)
 	}
 
 	// Submit the job
@@ -215,6 +233,19 @@ func (c *JobPlanCommand) Run(args []string) int {
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error during plan: %s", err))
 		return 255
+	}
+
+	// Machine-readable formats skip the human plan text and check-index help.
+	// JobModifyIndex and the rest of the plan response are available in the
+	// structured payload (or via -t).
+	if jsonOutput || len(tmpl) > 0 {
+		out, err := Format(jsonOutput, tmpl, resp)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 255
+		}
+		c.Ui.Output(out)
+		return getExitCode(resp)
 	}
 
 	runArgs := strings.Builder{}
@@ -242,7 +273,7 @@ func (c *JobPlanCommand) Run(args []string) int {
 	return exitCode
 }
 
-func (c *JobPlanCommand) multiregionPlan(client *api.Client, job *api.Job, opts *api.PlanOptions, diff, verbose bool) int {
+func (c *JobPlanCommand) multiregionPlan(client *api.Client, job *api.Job, opts *api.PlanOptions, diff, verbose, jsonOutput bool, tmpl string) int {
 
 	var exitCode int
 	plans := map[string]*api.JobPlanResponse{}
@@ -262,6 +293,23 @@ func (c *JobPlanCommand) multiregionPlan(client *api.Client, job *api.Job, opts 
 	}
 
 	if exitCode > 0 {
+		return exitCode
+	}
+
+	// Format the full region -> plan map when structured output is requested.
+	if jsonOutput || len(tmpl) > 0 {
+		out, err := Format(jsonOutput, tmpl, plans)
+		if err != nil {
+			c.Ui.Error(err.Error())
+			return 255
+		}
+		c.Ui.Output(out)
+		for _, resp := range plans {
+			regionExitCode := getExitCode(resp)
+			if regionExitCode > exitCode {
+				exitCode = regionExitCode
+			}
+		}
 		return exitCode
 	}
 

--- a/command/job_plan_test.go
+++ b/command/job_plan_test.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"encoding/json"
 	"os"
 	"strconv"
 	"strings"
@@ -304,4 +305,52 @@ func TestPlanCommand_JSON(t *testing.T) {
 	code := cmd.Run(args)
 	must.Eq(t, 255, code)
 	must.StrContains(t, ui.ErrorWriter.String(), "Error during plan: Put")
+}
+
+func TestPlanCommand_JsonOutputAndTemplateMutuallyExclusive(t *testing.T) {
+	ci.Parallel(t)
+	ui := cli.NewMockUi()
+	cmd := &JobPlanCommand{Meta: Meta{Ui: ui}}
+
+	code := cmd.Run([]string{
+		"-json-output",
+		"-t", "{{.JobModifyIndex}}",
+		"testdata/example-short.json",
+	})
+	must.Eq(t, 255, code)
+	must.StrContains(t, ui.ErrorWriter.String(), "Both -json-output and -t formatting are not allowed")
+}
+
+func TestPlanCommand_JsonOutput(t *testing.T) {
+	_, _, addr := testServer(t, false, nil)
+
+	ui := cli.NewMockUi()
+	cmd := &JobPlanCommand{Meta: Meta{Ui: ui}}
+	code := cmd.Run([]string{"-address", addr, "-json-output", "testdata/example-basic.nomad"})
+	// Exit 1: plan succeeds but would create/destroy allocations (no client).
+	must.Eq(t, 1, code, must.Sprintf("expected exit code 1, got %d: stderr=%s", code, ui.ErrorWriter.String()))
+
+	var resp api.JobPlanResponse
+	must.NoError(t, json.Unmarshal(ui.OutputWriter.Bytes(), &resp),
+		must.Sprintf("output should be valid JSON: %s", ui.OutputWriter.String()))
+	must.NotNil(t, resp.Diff)
+	must.Eq(t, "job1", resp.Diff.ID)
+	// Human-readable check-index help should not appear in structured output.
+	must.StrNotContains(t, ui.OutputWriter.String(), "Job Modify Index:")
+}
+
+func TestPlanCommand_TemplateOutput(t *testing.T) {
+	_, _, addr := testServer(t, false, nil)
+
+	ui := cli.NewMockUi()
+	cmd := &JobPlanCommand{Meta: Meta{Ui: ui}}
+	code := cmd.Run([]string{
+		"-address", addr,
+		"-t", "{{.Diff.ID}}",
+		"testdata/example-basic.nomad",
+	})
+	must.Eq(t, 1, code, must.Sprintf("expected exit code 1, got %d: stderr=%s", code, ui.ErrorWriter.String()))
+
+	out := strings.TrimSpace(ui.OutputWriter.String())
+	must.Eq(t, "job1", out, must.Sprintf("expected job ID 'job1', got: %s", out))
 }


### PR DESCRIPTION
## Summary

`nomad job plan` only printed human-readable output, which is awkward to parse from scripts. This adds structured output options while leaving the default text path alone.

- `-json-output` prints the full `api.JobPlanResponse` as JSON
- `-t` formats that same response with a Go template (same helper as `job inspect` / other commands)
- existing `-json` still only controls **input** jobfile parsing, so there is no flag conflict
- multi-region plans dump a `map[region]*JobPlanResponse` for both formats
- exit codes (0 / 1 / 255) are unchanged

I named the flag `-json-output` instead of reusing `-json` because plan already uses `-json` for JSON jobspecs. Happy to bikeshed the name if maintainers prefer something else (e.g. `-output=json`).

## Test plan

- [x] `TestPlanCommand_JsonOutputAndTemplateMutuallyExclusive`
- [x] `TestPlanCommand_JsonOutput` (against a test server)
- [x] `TestPlanCommand_TemplateOutput`
- [x] Existing plan tests still pass: `go test ./command/ -tags hashicorpmetrics -run TestPlanCommand_`

## Notes

CLI docs live in web-unified-docs; help text + changelog are updated here. Job modify index is available as `JobModifyIndex` in the JSON/`-t` payload, so the human "check-index" help block is skipped for structured output.

Fixes #27369