### PR TITLE
fix(agent): log the running server Node ID on startup

### DIFF
--- a/.changelog/28269.txt
+++ b/.changelog/28269.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: log the running server Node ID on startup instead of a regenerated UUID
+```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -917,9 +917,11 @@ func (c *Command) Run(args []string) int {
 	info["bind addrs"] = c.getBindAddrSynopsis()
 	info["advertise addrs"] = c.getAdvertiseAddrSynopsis()
 	if config.Server.Enabled {
-		serverConfig, err := c.agent.serverConfig()
-		if err == nil {
-			info["node id"] = serverConfig.NodeID
+		// Use the running server's NodeID (loaded/persisted in setupNodeID).
+		// Calling serverConfig() again would regenerate a fresh UUID and
+		// print a different id than the live server (#28269).
+		if c.agent != nil && c.agent.server != nil {
+			info["node id"] = c.agent.server.GetConfig().NodeID
 		}
 	}
 


### PR DESCRIPTION
## Description

On server startup, the agent configuration banner printed a **new** Node ID every time, not the ID in use (the one in `data/server/node-id` / serf tags).

Root cause: the banner called `c.agent.serverConfig()`, which rebuilds a config via `convertServerConfig` and does **not** run `setupNodeID()` (that only runs during `setupServer()`). Empty `NodeID` then gets a fresh UUID, so the log lies.

## Fix

When the server is enabled and running, take `NodeID` from the live server config:

```go
info["node id"] = c.agent.server.GetConfig().NodeID
```

## Linked Issue

Closes #28269

## Checklist

- [x] Changelog Entry
