### PR TITLE
Add default shared cpus

### DIFF
--- a/.changelog/28272.txt
+++ b/.changelog/28272.txt
@@ -1,3 +1,3 @@
 ```release-note:bug
-docker: add default cpuset to all containers
+docker: Fixed a bug where tasks could execute outside of their assigned cpuset range
 ```

--- a/.changelog/28272.txt
+++ b/.changelog/28272.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: add default cpuset to all containers
+```

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -996,7 +996,7 @@ func (d *Driver) cpuResources(requested int64) int64 {
 	return result
 }
 
-// cpuSet reads the avialable cores from the nomad client in order to assign
+// cpuSet reads the available cores from the nomad client in order to assign
 // them to the new container, ensuring all tasks run in nomad assigned cpus.
 func (d *Driver) cpuSet(taskResources *drivers.Resources) (string, error) {
 

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -29,6 +29,8 @@ import (
 	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/client/lib/cgroupslib"
 	"github.com/hashicorp/nomad/client/lib/cpustats"
+	"github.com/hashicorp/nomad/client/lib/idset"
+	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 	"github.com/hashicorp/nomad/client/taskenv"
 	"github.com/hashicorp/nomad/drivers/docker/docklog"
 	"github.com/hashicorp/nomad/drivers/shared/capabilities"
@@ -994,6 +996,23 @@ func (d *Driver) cpuResources(requested int64) int64 {
 	return result
 }
 
+// cpuSet reads the avialable cores from the nomad client in order to assign
+// them to the new container, ensuring all tasks run in nomad assigned cpus.
+func (d *Driver) cpuSet(taskResources *drivers.Resources) (string, error) {
+
+	//if taskResources
+	d.logger.Error("path", " **** path\n", taskResources.LinuxResources.CpusetCgroupPath)
+	source := filepath.Join(taskResources.LinuxResources.CpusetCgroupPath, effectiveCpusetFile())
+
+	// read the current value of usable cores
+	b, err := os.ReadFile(source)
+	if err != nil {
+		return "", fmt.Errorf("unable to read client cpuset: %w", err)
+	}
+
+	return idset.Parse[hw.CoreID](string(b)).String(), nil
+}
+
 func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *TaskConfig,
 	imageID string) (createContainerOptions, error) {
 
@@ -1082,6 +1101,11 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 
 	cpuShares := d.cpuResources(task.Resources.LinuxResources.CPUShares)
 
+	clientCpus, err := d.cpuSet(task.Resources)
+	if err != nil {
+		d.logger.Error("blah")
+	}
+
 	hostConfig := &containerapi.HostConfig{
 		CgroupnsMode: containerapi.CgroupnsMode(driverConfig.CgroupnsMode),
 		// do not set cgroup parent anymore
@@ -1105,8 +1129,12 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		Memory:            memory,            // hard limit
 		MemoryReservation: memoryReservation, // soft limit
 		CPUShares:         cpuShares,
-		CpusetCpus:        task.Resources.LinuxResources.CpusetCpus,
+		CpusetCpus:        clientCpus,
 		PidsLimit:         &pidsLimit,
+	}
+
+	if task.Resources.LinuxResources.CpusetCpus != "" {
+		hostConfig.Resources.CpusetCpus = task.Resources.LinuxResources.CpusetCpus
 	}
 
 	// Setting cpuset_cpus in driver config is no longer supported (it has

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1011,7 +1011,6 @@ func (d *Driver) cpuSet(taskResources *drivers.Resources) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("unable to read usable cores: %w", err)
 	}
-	d.logger.Error("taskResources.LinuxResources.CpusetCgroupPath is empty", "source", source, "value", string(b))
 
 	return idset.Parse[hw.CoreID](string(b)).String(), nil
 }
@@ -1104,11 +1103,6 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 
 	cpuShares := d.cpuResources(task.Resources.LinuxResources.CPUShares)
 
-	clientCpus, err := d.cpuSet(task.Resources)
-	if err != nil {
-		d.logger.Error("blah")
-	}
-
 	hostConfig := &containerapi.HostConfig{
 		CgroupnsMode: containerapi.CgroupnsMode(driverConfig.CgroupnsMode),
 		// do not set cgroup parent anymore
@@ -1132,12 +1126,17 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 		Memory:            memory,            // hard limit
 		MemoryReservation: memoryReservation, // soft limit
 		CPUShares:         cpuShares,
-		CpusetCpus:        clientCpus,
+		CpusetCpus:        task.Resources.LinuxResources.CpusetCpus,
 		PidsLimit:         &pidsLimit,
 	}
 
-	if task.Resources.LinuxResources.CpusetCpus != "" {
-		hostConfig.Resources.CpusetCpus = task.Resources.LinuxResources.CpusetCpus
+	if hostConfig.Resources.CpusetCpus == "" {
+		clientCpus, err := d.cpuSet(task.Resources)
+		if err != nil {
+			d.logger.Warn("failed to read cpuset from cgroup, ignoring", "error", err)
+		}
+
+		hostConfig.Resources.CpusetCpus = clientCpus
 	}
 
 	// Setting cpuset_cpus in driver config is no longer supported (it has

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -1000,15 +1000,18 @@ func (d *Driver) cpuResources(requested int64) int64 {
 // them to the new container, ensuring all tasks run in nomad assigned cpus.
 func (d *Driver) cpuSet(taskResources *drivers.Resources) (string, error) {
 
-	//if taskResources
-	d.logger.Error("path", " **** path\n", taskResources.LinuxResources.CpusetCgroupPath)
-	source := filepath.Join(taskResources.LinuxResources.CpusetCgroupPath, effectiveCpusetFile())
+	if taskResources.LinuxResources != nil &&
+		taskResources.LinuxResources.CpusetCgroupPath == "" {
+		return "", nil
+	}
 
 	// read the current value of usable cores
+	source := filepath.Join(taskResources.LinuxResources.CpusetCgroupPath, effectiveCpusetFile())
 	b, err := os.ReadFile(source)
 	if err != nil {
-		return "", fmt.Errorf("unable to read client cpuset: %w", err)
+		return "", fmt.Errorf("unable to read usable cores: %w", err)
 	}
+	d.logger.Error("taskResources.LinuxResources.CpusetCgroupPath is empty", "source", source, "value", string(b))
 
 	return idset.Parse[hw.CoreID](string(b)).String(), nil
 }

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -16,6 +16,8 @@ import (
 
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/client/testutil"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/plugins/drivers"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
 )
@@ -114,6 +116,29 @@ func TestDockerDriver_PidsLimit(t *testing.T) {
 	))
 }
 
+func TestDockerDriver_Cpuset(t *testing.T) {
+	ci.Parallel(t)
+	testutil.DockerCompatible(t)
+
+	dh := dockerDriverHarness(t, nil)
+	driver := dh.Impl().(*Driver)
+
+	task, cfg, _ := dockerTask(t)
+
+	cpusetDir := t.TempDir()
+	cpusetFile := filepath.Join(cpusetDir, effectiveCpusetFile())
+	must.NoError(t, os.WriteFile(cpusetFile, []byte("0-2"), 0o600))
+	t.Cleanup(func() {
+		_ = os.Remove(cpusetFile)
+	})
+
+	task.Resources.LinuxResources.CpusetCgroupPath = cpusetDir
+
+	opts, err := driver.createContainerConfig(task, cfg, "org/repo:0.1")
+	must.NoError(t, err)
+	must.Eq(t, "0-2", opts.Host.Resources.CpusetCpus)
+}
+
 func TestDockerDriver_NormalizeCPUShares(t *testing.T) {
 	dh := dockerDriverHarness(t, nil)
 	driver := dh.Impl().(*Driver)
@@ -137,4 +162,66 @@ func TestDockerDriver_NormalizeCPUShares(t *testing.T) {
 	driver.compute.TotalCompute = maxCPUShares * 2
 	must.Eq(t, 500, driver.cpuResources(1000))
 	must.Eq(t, maxCPUShares/2, driver.cpuResources(maxCPUShares))
+}
+
+func TestDockerDriver_CpuSet(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name             string
+		cpusetCgroupPath string
+		fileContent      string
+		createFile       bool
+		want             string
+		wantErrText      string
+	}{
+		{
+			name:             "empty cgroup path returns empty cpuset",
+			cpusetCgroupPath: "",
+			want:             "",
+		},
+		{
+			name:        "reads cpuset from cgroup file",
+			fileContent: "0-2",
+			createFile:  true,
+			want:        "0-2",
+		},
+		{
+			name:        "returns error when cpuset file is missing",
+			wantErrText: "unable to read usable cores",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := &Driver{logger: testlog.HCLogger(t)}
+
+			cpusetCgroupPath := tc.cpusetCgroupPath
+			if (cpusetCgroupPath == "" && tc.createFile) || tc.wantErrText != "" {
+				cpusetCgroupPath = t.TempDir()
+			}
+
+			resources := &drivers.Resources{LinuxResources: &drivers.LinuxResources{
+				CpusetCgroupPath: cpusetCgroupPath,
+			}}
+
+			if tc.createFile {
+				source := filepath.Join(cpusetCgroupPath, effectiveCpusetFile())
+				must.NoError(t, os.WriteFile(source, []byte(tc.fileContent), 0o600))
+				t.Cleanup(func() {
+					_ = os.Remove(source)
+				})
+			}
+
+			got, err := d.cpuSet(resources)
+			if tc.wantErrText != "" {
+				must.Error(t, err)
+				must.StrContains(t, err.Error(), tc.wantErrText)
+				return
+			}
+
+			must.NoError(t, err)
+			must.Eq(t, tc.want, got)
+		})
+	}
 }

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -215,8 +215,7 @@ func TestDockerDriver_CpuSet(t *testing.T) {
 
 			got, err := d.cpuSet(resources)
 			if tc.wantErrText != "" {
-				must.Error(t, err)
-				must.StrContains(t, err.Error(), tc.wantErrText)
+				must.ErrContains(t, err, tc.wantErrText)
 				return
 			}
 

--- a/drivers/docker/driver_linux_test.go
+++ b/drivers/docker/driver_linux_test.go
@@ -215,7 +215,7 @@ func TestDockerDriver_CpuSet(t *testing.T) {
 
 			got, err := d.cpuSet(resources)
 			if tc.wantErrText != "" {
-				must.ErrContains(t, err, tc.wantErrText)
+				must.ErrorContains(t, err, tc.wantErrText)
 				return
 			}
 


### PR DESCRIPTION
### Description
Docker does not support creating a container directly within an existing cpuset cgroup. Instead, it always creates the container under Docker's own cgroup hierarchy, inheriting the resources (including the CPU set) from Docker's parent cgroup.

To enforce CPU pinning and NUMA awareness, Nomad creates a corresponding cpuset cgroup under the Nomad hierarchy and continuously synchronizes its cpuset configuration into the cgroup created by Docker. This reconciliation loop ensures that the container's effective CPU affinity reflects Nomad's scheduling decisions, even though Docker owns the cgroup hierarchy.

The output of `ps -o pid,psr,comm` reports the processor (psr) on which the thread was last scheduled. If the process is currently sleeping, this value is accurate historically but does not necessarily reflect the CPUs on which the process is currently allowed to execute. While the process is dormant, Nomad may update the container's cpuset.cpus through the reconciliation loop. The kernel consults the current cpuset constraints only when the task is scheduled again, at which point it will observe the updated CPU mask and schedule the task accordingly. Consequently, the psr field is not updated until the process is dispatched again.

If a process is initially scheduled on a cpu that is not with in the nomad cpuset and goes to sleep before the first sync loop, it will show up as running on a cpu outside of Nomad's range.

This PR introduces a new function inside the docker driver that looks up the `effective.cpu` of the node where the container will run and add it as the shared cpu set for the containers host configuration to ensure that even if the process goes to sleep before its resources are sync, it will still be scheduled on cpus inside Nomad's range.

Initially I thought about assigning the resources from the scheduler, but the task only has room for reserved cores. I moved to the task runner but the only drivers, in the nomad core,  that could make use of this would be exec and docker, but exec creates the processes under its cgroup hierarchy. So I defaulted to the docker driver.

### Testing & Reproduction steps
To reproduce:

1. Start a nomad client with a restriction on cpu resources:
``` 
client {
    reserved {
      cores = "0-4"
    }
  }
```

2.  Start a docker task, stop and start until it is scheduled in a reserved core.
```
job "sleep" {
  group "group" {
    count = 1
    task "task" {
      driver = "docker"
      config {
        image   = "busybox:1"
        command = "/bin/sh"
        args    = ["-c", "sleep 1000"]
      }
    }
  }
}
```

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
