### PR TITLE
CSI: unblock evals on volume registration

### DIFF
--- a/.changelog/28275.txt
+++ b/.changelog/28275.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+csi: Fixed a bug where evals blocked on missing CSI volumes would not unblock
+```

--- a/api/evaluations.go
+++ b/api/evaluations.go
@@ -97,36 +97,37 @@ const (
 
 // Evaluation is used to serialize an evaluation.
 type Evaluation struct {
-	ID                   string
-	Priority             int
-	Type                 string
-	TriggeredBy          string
-	Namespace            string
-	JobID                string
-	JobModifyIndex       uint64
-	NodeID               string
-	NodeModifyIndex      uint64
-	DeploymentID         string
-	Status               string
-	StatusDescription    string
-	Wait                 time.Duration
-	WaitUntil            time.Time
-	NextEval             string
-	PreviousEval         string
-	BlockedEval          string
-	RelatedEvals         []*EvaluationStub
-	FailedTGAllocs       map[string]*AllocationMetric
-	PlanAnnotations      *PlanAnnotations
-	ClassEligibility     map[string]bool
-	EscapedComputedClass bool
-	QuotaLimitReached    string
-	AnnotatePlan         bool
-	QueuedAllocations    map[string]int
-	SnapshotIndex        uint64
-	CreateIndex          uint64
-	ModifyIndex          uint64
-	CreateTime           int64
-	ModifyTime           int64
+	ID                      string
+	Priority                int
+	Type                    string
+	TriggeredBy             string
+	Namespace               string
+	JobID                   string
+	JobModifyIndex          uint64
+	NodeID                  string
+	NodeModifyIndex         uint64
+	DeploymentID            string
+	Status                  string
+	StatusDescription       string
+	Wait                    time.Duration
+	WaitUntil               time.Time
+	NextEval                string
+	PreviousEval            string
+	BlockedEval             string
+	RelatedEvals            []*EvaluationStub
+	FailedTGAllocs          map[string]*AllocationMetric
+	PlanAnnotations         *PlanAnnotations
+	ClassEligibility        map[string]bool
+	EscapedComputedClass    bool
+	QuotaLimitReached       string
+	MissingNonNodeResources []string
+	AnnotatePlan            bool
+	QueuedAllocations       map[string]int
+	SnapshotIndex           uint64
+	CreateIndex             uint64
+	ModifyIndex             uint64
+	CreateTime              int64
+	ModifyTime              int64
 }
 
 // EvaluationStub is used to serialize parts of an evaluation returned in the

--- a/command/eval_status.go
+++ b/command/eval_status.go
@@ -293,13 +293,19 @@ func (c *EvalStatusCommand) formatEvalStatus(eval *api.Evaluation, placedAllocs 
 			c.Ui.Output(fmt.Sprintf("Task Group %q (failed to place %d %s):",
 				tg, metrics.CoalescedFailures+1, noun))
 			c.Ui.Output(formatAllocMetrics(metrics, c.Colorize(), false, "  "))
-			c.Ui.Output("")
 		}
 
 		if eval.BlockedEval != "" {
 			c.Ui.Output(fmt.Sprintf(
-				"Evaluation %q waiting for additional capacity to place remainder",
+				"\nEvaluation %q waiting for additional capacity to place remainder",
 				limit(eval.BlockedEval, length)))
+		}
+
+		if len(eval.MissingNonNodeResources) > 0 {
+			c.Ui.Output(c.Colorize().Color("\n[bold]Missing Resources[reset]"))
+			for _, resource := range eval.MissingNonNodeResources {
+				c.Ui.Output("  " + resource)
+			}
 		}
 	}
 }

--- a/nomad/blocked_evals.go
+++ b/nomad/blocked_evals.go
@@ -4,6 +4,7 @@
 package nomad
 
 import (
+	"slices"
 	"sync"
 	"time"
 
@@ -102,9 +103,10 @@ type unblockEvent struct {
 
 // capacityUpdate stores unblock data.
 type capacityUpdate struct {
-	computedClass string
-	quotaChange   string
-	nodeID        string
+	computedClass    string
+	quotaChange      string
+	nodeID           string
+	nonNodeResources []string
 
 	blockedEval  *structs.Evaluation
 	blockToken   string
@@ -382,6 +384,14 @@ func (b *BlockedEvals) missedUnblock(eval *structs.Evaluation) bool {
 			return false
 		}
 
+		for _, missing := range eval.MissingNonNodeResources {
+			if missing == id && eval.SnapshotIndex < u.index {
+				// The evaluation was processed before the missing resource was
+				// updated, so unblock the evaluation
+				return true
+			}
+		}
+
 		elig, ok := eval.ClassEligibility[id]
 		if !ok && eval.SnapshotIndex < u.index {
 			// The evaluation was processed and did not encounter this class
@@ -600,6 +610,40 @@ func (b *BlockedEvals) UnblockNode(nodeID string) chan struct{} {
 	return fut
 }
 
+// UnblockNonNodeResources causes evaluation to be enqueued in the eval broker
+// if they escape a node class but could potentially make progress on capacity
+// changes to specific non-node resources (ex. CSI volumes added).
+func (b *BlockedEvals) UnblockNonNodeResources(resources []string, index uint64) chan struct{} {
+	fut := make(chan struct{})
+
+	b.flushLock.RLock()
+	defer b.flushLock.RUnlock()
+	if !b.enabled {
+		close(fut)
+		return fut
+	}
+	// Capture chan in flushlock as Flush overwrites it
+	ch := b.capacityChangeCh
+	done := b.stopCh
+
+	// Store the index in which the unblock happened. We use this on subsequent
+	// block calls in case the evaluation was in the scheduler when a trigger
+	// occurred.
+	b.unblockIndexesLock.Lock()
+	now := time.Now().UTC()
+	for _, resource := range resources {
+		b.unblockIndexes[resource] = unblockEvent{index, now}
+	}
+	b.unblockIndexesLock.Unlock()
+
+	select {
+	case <-done:
+	case ch <- &capacityUpdate{nonNodeResources: resources, future: fut}:
+	}
+
+	return fut
+}
+
 // watchCapacity is a long lived function that watches for capacity changes in
 // nodes and unblocks the correct set of evals.
 func (b *BlockedEvals) watchCapacity(
@@ -622,13 +666,13 @@ func (b *BlockedEvals) watchCapacity(
 				continue
 			}
 
-			b.unblock(update.computedClass, update.quotaChange, update.nodeID)
+			b.unblock(update.computedClass, update.quotaChange, update.nodeID, update.nonNodeResources)
 			close(update.future)
 		}
 	}
 }
 
-func (b *BlockedEvals) unblock(computedClass, quota, nodeID string) {
+func (b *BlockedEvals) unblock(computedClass, quota, nodeID string, resources []string) {
 
 	// Protect against the case of a flush.
 	b.flushLock.RLock()
@@ -645,8 +689,18 @@ func (b *BlockedEvals) unblock(computedClass, quota, nodeID string) {
 	numEscaped := len(b.escaped)
 	unblocked := make(map[*structs.Evaluation]string, max(uint64(numEscaped), 4))
 
-	if numEscaped != 0 && computedClass != "" {
+	if numEscaped != 0 && (computedClass != "" || len(resources) > 0) {
 		for id, wrapped := range b.escaped {
+			if len(resources) > 0 {
+				// this is an unblock for a specific set of resources and we
+				// unblock the eval if any of its missing non-node resources
+				// overlap, to account for cases where multiple required
+				// resources are added across separate Raft updates
+				if !foundAnyMissingResources(wrapped.eval.MissingNonNodeResources, resources) {
+					continue // the resources were not present
+				}
+			}
+
 			unblocked[wrapped.eval] = wrapped.token
 			delete(b.escaped, id)
 			delete(b.jobs, structs.NewNamespacedID(wrapped.eval.JobID, wrapped.eval.Namespace))
@@ -699,6 +753,18 @@ SKIP_TO_NODE:
 		// Enqueue all the unblocked evals into the broker.
 		b.evalBroker.EnqueueAll(unblocked)
 	}
+}
+
+func foundAnyMissingResources(missing, updated []string) bool {
+	if len(missing) == 0 {
+		return true
+	}
+	for _, m := range missing {
+		if slices.Contains(updated, m) {
+			return true
+		}
+	}
+	return false
 }
 
 // UnblockFailed unblocks all blocked evaluation that were due to scheduler

--- a/nomad/blocked_evals.go
+++ b/nomad/blocked_evals.go
@@ -385,10 +385,11 @@ func (b *BlockedEvals) missedUnblock(eval *structs.Evaluation) bool {
 		}
 
 		for _, missing := range eval.MissingNonNodeResources {
-			if missing == id && eval.SnapshotIndex < u.index {
-				// The evaluation was processed before the missing resource was
-				// updated, so unblock the evaluation
-				return true
+			if missing == id {
+				// If the evaluation was processed before the missing resource
+				// was updated, unblock it. Otherwise the evaluation processed
+				// having seen all changes to the resource
+				return eval.SnapshotIndex < u.index
 			}
 		}
 
@@ -686,24 +687,28 @@ func (b *BlockedEvals) unblock(computedClass, quota, nodeID string, resources []
 
 	// Every eval that has escaped computed node class has to be unblocked
 	// because any node could potentially be feasible.
-	numEscaped := len(b.escaped)
-	unblocked := make(map[*structs.Evaluation]string, max(uint64(numEscaped), 4))
+	unblocked := make(map[*structs.Evaluation]string, max(uint64(len(b.escaped)), 4))
 
-	if numEscaped != 0 && (computedClass != "" || len(resources) > 0) {
+	// If we're unblocking because nodes in a computed class changed, we have to
+	// unblock every eval that has escaped computed node class, because any node
+	// could potentially be feasible.
+	if computedClass != "" {
 		for id, wrapped := range b.escaped {
-			if len(resources) > 0 {
-				// this is an unblock for a specific set of resources and we
-				// unblock the eval if any of its missing non-node resources
-				// overlap, to account for cases where multiple required
-				// resources are added across separate Raft updates
-				if !foundAnyMissingResources(wrapped.eval.MissingNonNodeResources, resources) {
-					continue // the resources were not present
-				}
-			}
-
 			unblocked[wrapped.eval] = wrapped.token
 			delete(b.escaped, id)
 			delete(b.jobs, structs.NewNamespacedID(wrapped.eval.JobID, wrapped.eval.Namespace))
+		}
+	}
+
+	// If we're unblocking because of non-node resource changes, we unblock the
+	// evals waiting on any of those resources.
+	if len(resources) > 0 {
+		for id, wrapped := range b.escaped {
+			if foundAnyMissingResources(wrapped.eval.MissingNonNodeResources, resources) {
+				unblocked[wrapped.eval] = wrapped.token
+				delete(b.escaped, id)
+				delete(b.jobs, structs.NewNamespacedID(wrapped.eval.JobID, wrapped.eval.Namespace))
+			}
 		}
 	}
 
@@ -756,9 +761,6 @@ SKIP_TO_NODE:
 }
 
 func foundAnyMissingResources(missing, updated []string) bool {
-	if len(missing) == 0 {
-		return true
-	}
 	for _, m := range missing {
 		if slices.Contains(updated, m) {
 			return true

--- a/nomad/blocked_evals_test.go
+++ b/nomad/blocked_evals_test.go
@@ -654,6 +654,44 @@ func TestBlockedEvals_UnblockNode(t *testing.T) {
 	must.MapLen(t, 0, stats.BlockedResources.ByJob)
 }
 
+func TestBlockedEvals_UnblockNonNodeResource(t *testing.T) {
+	ci.Parallel(t)
+
+	blocked, broker := testBlockedEvals(t)
+
+	e0 := mock.BlockedEval()
+	e0.Namespace = "foo"
+	e0.SnapshotIndex = 999
+	e0.EscapedComputedClass = true
+	e0.MissingNonNodeResources = []string{"csi-volume:foo", "whatever:bar"}
+	<-blocked.Block(e0)
+
+	// Verify block did track
+	stats := blocked.Stats()
+	must.Eq(t, 1, stats.TotalBlocked)
+	must.MapLen(t, 1, stats.BlockedResources.ByJob)
+	must.MapLen(t, 1, blocked.escaped)
+
+	<-blocked.UnblockNonNodeResources([]string{"csi-volume:foo", "whatever:bar"}, 1001)
+	requireBlockedEvalsEnqueued(t, blocked, broker, 1)
+
+	e1 := mock.BlockedEval()
+	e1.Namespace = "bar"
+	e1.SnapshotIndex = 1000 // newer than previous eval, older than unblock
+	e1.MissingNonNodeResources = []string{"csi-volume:foo", "whatever:bar"}
+	e1.EscapedComputedClass = true
+
+	fut := blocked.Block(e1)
+	select {
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected block to be immediately enqueued because of newer unblock")
+	case <-fut:
+	}
+
+	brokerStats := broker.Stats()
+	must.Eq(t, 2, brokerStats.TotalReady)
+}
+
 func TestBlockedEvals_SystemUntrack(t *testing.T) {
 	ci.Parallel(t)
 	blocked, _ := testBlockedEvals(t)

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-memdb"
 	metrics "github.com/hashicorp/go-metrics/compat"
 	"github.com/hashicorp/go-msgpack/v2/codec"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -1424,6 +1425,11 @@ func (n *nomadFSM) applyCSIVolumeRegister(buf []byte, index uint64) interface{} 
 		return err
 	}
 
+	// unblock evals waiting on these volumes
+	resources := helper.ConvertSlice(req.Volumes,
+		func(v *structs.CSIVolume) string { return "csi-volume:" + v.Namespace + ":" + v.ID })
+
+	n.blockedEvals.UnblockNonNodeResources(resources, index)
 	return nil
 }
 

--- a/nomad/structs/eval.go
+++ b/nomad/structs/eval.go
@@ -5,6 +5,7 @@ package structs
 
 import (
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/hashicorp/nomad/helper/uuid"
@@ -199,6 +200,10 @@ type Evaluation struct {
 	// evaluation.
 	QuotaLimitReached string
 
+	// MissingNonNodeResources marks whether we could not find a resource not
+	// tied to a specific node (ex. CSI volume) when processing the eval.
+	MissingNonNodeResources []string
+
 	// EscapedComputedClass marks whether the job has constraints that are not
 	// captured by computed node classes.
 	EscapedComputedClass bool
@@ -372,6 +377,8 @@ func (e *Evaluation) Copy() *Evaluation {
 		ne.QueuedAllocations = queuedAllocations
 	}
 
+	ne.MissingNonNodeResources = slices.Clone(e.MissingNonNodeResources)
+
 	return ne
 }
 
@@ -446,24 +453,25 @@ func (e *Evaluation) NextRollingEval(wait time.Duration) *Evaluation {
 // ineligible, whether the job has escaped computed node classes and whether the
 // quota limit was reached.
 func (e *Evaluation) CreateBlockedEval(classEligibility map[string]bool,
-	escaped bool, quotaReached string, failedTGAllocs map[string]*AllocMetric) *Evaluation {
+	escaped bool, quotaReached string, failedTGAllocs map[string]*AllocMetric, missing []string) *Evaluation {
 	now := time.Now().UTC().UnixNano()
 	return &Evaluation{
-		ID:                   uuid.Generate(),
-		Namespace:            e.Namespace,
-		Priority:             e.Priority,
-		Type:                 e.Type,
-		TriggeredBy:          EvalTriggerQueuedAllocs,
-		JobID:                e.JobID,
-		JobModifyIndex:       e.JobModifyIndex,
-		Status:               EvalStatusBlocked,
-		PreviousEval:         e.ID,
-		FailedTGAllocs:       failedTGAllocs,
-		ClassEligibility:     classEligibility,
-		EscapedComputedClass: escaped,
-		QuotaLimitReached:    quotaReached,
-		CreateTime:           now,
-		ModifyTime:           now,
+		ID:                      uuid.Generate(),
+		Namespace:               e.Namespace,
+		Priority:                e.Priority,
+		Type:                    e.Type,
+		TriggeredBy:             EvalTriggerQueuedAllocs,
+		JobID:                   e.JobID,
+		JobModifyIndex:          e.JobModifyIndex,
+		Status:                  EvalStatusBlocked,
+		PreviousEval:            e.ID,
+		FailedTGAllocs:          failedTGAllocs,
+		ClassEligibility:        classEligibility,
+		EscapedComputedClass:    escaped,
+		QuotaLimitReached:       quotaReached,
+		MissingNonNodeResources: missing,
+		CreateTime:              now,
+		ModifyTime:              now,
 	}
 }
 

--- a/scheduler/feasible/context.go
+++ b/scheduler/feasible/context.go
@@ -5,10 +5,12 @@ package feasible
 
 import (
 	"regexp"
+	"slices"
 	"testing"
 
 	log "github.com/hashicorp/go-hclog"
 	memdb "github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/go-set/v3"
 	"github.com/hashicorp/nomad/helper/testlog"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/state"
@@ -241,6 +243,10 @@ type EvalEligibility struct {
 	// quotaReached marks that the quota limit has been reached for the given
 	// quota
 	quotaReached string
+
+	// missingResources marks that the cluster is missing some non-node resource
+	// that's needed by the job, like a CSI volume
+	missingResources *set.Set[string]
 }
 
 // NewEvalEligibility returns an eligibility tracker for the context of an evaluation.
@@ -249,6 +255,7 @@ func NewEvalEligibility() *EvalEligibility {
 		job:                  make(map[string]ComputedClassFeasibility),
 		taskGroups:           make(map[string]map[string]ComputedClassFeasibility),
 		tgEscapedConstraints: make(map[string]bool),
+		missingResources:     set.New[string](0),
 	}
 }
 
@@ -257,6 +264,7 @@ func (e *EvalEligibility) Reset() {
 	e.job = make(map[string]ComputedClassFeasibility)
 	e.taskGroups = make(map[string]map[string]ComputedClassFeasibility)
 	e.tgEscapedConstraints = make(map[string]bool)
+	e.missingResources = set.New[string](0)
 }
 
 // SetJob takes the job being evaluated and calculates the escaped constraints
@@ -271,8 +279,20 @@ func (e *EvalEligibility) SetJob(job *structs.Job) {
 		for _, task := range tg.Tasks {
 			constraints = append(constraints, task.Constraints...)
 		}
+		if len(structs.EscapedConstraints(constraints)) > 0 {
+			e.tgEscapedConstraints[tg.Name] = true
+			continue
+		}
 
-		e.tgEscapedConstraints[tg.Name] = len(structs.EscapedConstraints(constraints)) != 0
+		// CSI volume requests always escape node class because the volume may
+		// not *currently* be on the node
+		csiVolsCount := 0
+		for _, vol := range tg.Volumes {
+			if vol.Type == structs.VolumeTypeCSI {
+				csiVolsCount++
+			}
+		}
+		e.tgEscapedConstraints[tg.Name] = csiVolsCount != 0
 	}
 }
 
@@ -396,6 +416,17 @@ func (e *EvalEligibility) SetQuotaLimitReached(quota string) {
 // QuotaLimitReached returns the quota name if the quota limit has been reached.
 func (e *EvalEligibility) QuotaLimitReached() string {
 	return e.quotaReached
+}
+
+// SetMissingResources marks that the cluster is missing some non-node resource
+// required by the job (ex. CSI volume)
+func (e *EvalEligibility) SetMissingResources(resources []string) {
+	e.missingResources.InsertSlice(resources)
+}
+
+// MissingResources returns a list of missing non-node resources, if any
+func (e *EvalEligibility) MissingResources() []string {
+	return slices.Sorted(e.missingResources.Items())
 }
 
 func MockContext(t testing.TB) (*state.StateStore, *EvalContext) {

--- a/scheduler/feasible/feasible.go
+++ b/scheduler/feasible/feasible.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/nomad/helper"
 	"github.com/hashicorp/nomad/helper/constraints/semver"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -28,7 +29,7 @@ const (
 	FilterConstraintCSIPluginUnhealthyTemplate     = "CSI plugin %s is unhealthy on client %s"
 	FilterConstraintCSIPluginMaxVolumesTemplate    = "CSI plugin %s has the maximum number of volumes on client %s"
 	FilterConstraintCSIVolumesLookupFailed         = "CSI volume lookup failed"
-	FilterConstraintCSIVolumeNotFoundTemplate      = "missing CSI Volume %s"
+	FilterConstraintCSIVolumeNotFoundTemplate      = "missing CSI volume(s) %s"
 	FilterConstraintCSIVolumeNoReadTemplate        = "CSI volume %s is unschedulable or has exhausted its available reader claims"
 	FilterConstraintCSIVolumeNoWriteTemplate       = "CSI volume %s is unschedulable or is read-only"
 	FilterConstraintCSIVolumeInUseTemplate         = "CSI volume %s has exhausted its available writer claims"
@@ -490,10 +491,12 @@ func (h *HostVolumeChecker) hostVolumeIsAvailable(
 }
 
 type CSIVolumeChecker struct {
-	ctx       Context
-	namespace string
-	jobID     string
-	volumes   map[string]*structs.VolumeRequest
+	ctx        Context
+	namespace  string
+	jobID      string
+	volumeReqs map[string]*structs.VolumeRequest
+	volumes    map[string]*structs.CSIVolume
+	missing    []string
 }
 
 func NewCSIVolumeChecker(ctx Context) *CSIVolumeChecker {
@@ -510,28 +513,51 @@ func (c *CSIVolumeChecker) SetNamespace(namespace string) {
 	c.namespace = namespace
 }
 
-func (c *CSIVolumeChecker) SetVolumes(allocName string, volumes map[string]*structs.VolumeRequest) {
+func (c *CSIVolumeChecker) SetVolumes(allocName string, volumeReqs map[string]*structs.VolumeRequest) {
 
-	xs := make(map[string]*structs.VolumeRequest)
+	reqs := make(map[string]*structs.VolumeRequest, len(volumeReqs))
+	vols := make(map[string]*structs.CSIVolume, len(volumeReqs))
+	missing := []string{}
 
-	// Filter to only CSI Volumes
-	for alias, req := range volumes {
+	for alias, req := range volumeReqs {
 		if req.Type != structs.VolumeTypeCSI {
-			continue
+			continue // filter to only CSI volumes
 		}
+		id := req.Source
 		if req.PerAlloc {
 			// provide a unique volume source per allocation
 			copied := req.Copy()
 			copied.Source = copied.Source + structs.AllocSuffix(allocName)
-			xs[alias] = copied
+			id = copied.Source
+			reqs[alias] = copied
 		} else {
-			xs[alias] = req
+			reqs[alias] = req
 		}
+
+		vol, err := c.ctx.State().CSIVolumeByID(nil, c.namespace, id)
+		if vol == nil || err != nil {
+			missing = append(missing, id)
+			continue
+		}
+		vols[alias] = vol
 	}
-	c.volumes = xs
+	c.volumes = vols
+	c.volumeReqs = reqs
+	c.missing = missing
 }
 
 func (c *CSIVolumeChecker) Feasible(n *structs.Node) bool {
+	if len(c.missing) > 0 {
+		missing := helper.ConvertSlice(c.missing, func(id string) string {
+			return fmt.Sprintf("csi-volume:%s:%s", c.namespace, id)
+		})
+
+		c.ctx.Eligibility().SetMissingResources(missing)
+		c.ctx.Metrics().FilterNode(n, fmt.Sprintf(FilterConstraintCSIVolumeNotFoundTemplate,
+			strings.Join(c.missing, ", ")))
+		return false
+	}
+
 	ok, failReason := c.isFeasible(n)
 	if ok {
 		return true
@@ -548,7 +574,7 @@ func (c *CSIVolumeChecker) isFeasible(n *structs.Node) (bool, string) {
 	// - this node is running the node plugin, implies matching topology
 
 	// Fast path: Requested no volumes. No need to check further.
-	if len(c.volumes) == 0 {
+	if len(c.volumeReqs) == 0 {
 		return true, ""
 	}
 
@@ -573,12 +599,9 @@ func (c *CSIVolumeChecker) isFeasible(n *structs.Node) (bool, string) {
 	}
 
 	// For volume requests, find volumes and determine feasibility
-	for _, req := range c.volumes {
-		vol, err := c.ctx.State().CSIVolumeByID(ws, c.namespace, req.Source)
-		if err != nil {
-			return false, FilterConstraintCSIVolumesLookupFailed
-		}
-		if vol == nil {
+	for alias, req := range c.volumeReqs {
+		vol, ok := c.volumes[alias]
+		if !ok {
 			return false, fmt.Sprintf(FilterConstraintCSIVolumeNotFoundTemplate, req.Source)
 		}
 
@@ -1496,8 +1519,9 @@ OUTER:
 			evalElig.SetTaskGroupEligibility(true, w.tg, option.ComputedClass)
 		}
 
-		// tgAvailable handlers are available transiently, so we test them without
-		// affecting the computed class
+		// tgAvailable handlers are available transiently (ex. volumes which can
+		// have a maximum number of claims), so we test them without affecting
+		// the computed class
 		if !w.available(option) {
 			continue OUTER
 		}
@@ -1510,11 +1534,6 @@ OUTER:
 // e.g. the health status of a plugin or driver, or that are not considered in node
 // computed class, e.g. host volumes.
 func (w *FeasibilityWrapper) available(option *structs.Node) bool {
-	// If we don't have any availability checks, we're available
-	if len(w.tgAvailable) == 0 {
-		return true
-	}
-
 	for _, check := range w.tgAvailable {
 		if !check.Feasible(option) {
 			return false

--- a/scheduler/feasible/feasible_test.go
+++ b/scheduler/feasible/feasible_test.go
@@ -5,6 +5,7 @@ package feasible
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -1161,6 +1162,111 @@ func TestCSIVolumeChecker(t *testing.T) {
 		must.False(t, act, must.Sprint("request with missing volume should never be feasible"))
 	}
 
+}
+
+func TestCSIVolumeChecker_PerAllocBlocking(t *testing.T) {
+	ci.Parallel(t)
+	state, ctx := MockContext(t)
+
+	nodes := []*structs.Node{
+		mock.Node(),
+		mock.Node(),
+		mock.Node(),
+	}
+
+	nodes[0].CSINodePlugins = map[string]*structs.CSIInfo{
+		"foo": {
+			PluginID: "foo",
+			Healthy:  true,
+			NodeInfo: &structs.CSINodeInfo{
+				MaxVolumes: 1,
+				AccessibleTopology: &structs.CSITopology{
+					Segments: map[string]string{"rack": "R1"},
+				},
+			},
+		},
+	}
+	nodes[1].CSINodePlugins = maps.Clone(nodes[0].CSINodePlugins)
+	nodes[2].CSINodePlugins = maps.Clone(nodes[0].CSINodePlugins)
+
+	// Create the plugins in the state store
+	index := uint64(999)
+	for _, node := range nodes {
+		err := state.UpsertNode(structs.MsgTypeTestSetup, index, node)
+		must.NoError(t, err)
+		index++
+	}
+
+	vid2 := "test-volume"
+	reqs := map[string]*structs.VolumeRequest{
+		vid2: {
+			Name:     vid2,
+			Type:     "csi",
+			Source:   vid2,
+			PerAlloc: true,
+		},
+	}
+
+	job := mock.MinJob()
+	job.TaskGroups[0].Count = 2
+	job.TaskGroups[0].Volumes = reqs
+	allocName0 := job.TaskGroups[0].Name + "[0]"
+	allocName1 := job.TaskGroups[0].Name + "[1]"
+
+	err := state.UpsertJob(structs.MsgTypeTestSetup, index, nil, job)
+	must.NoError(t, err)
+	index++
+	summary := mock.JobSummary(job.ID)
+	must.NoError(t, state.UpsertJobSummary(index, summary))
+	index++
+
+	checker := NewCSIVolumeChecker(ctx)
+	checker.SetNamespace(structs.DefaultNamespace)
+
+	for _, node := range nodes {
+		checker.SetVolumes(allocName0, reqs)
+		act := checker.Feasible(node)
+		must.False(t, act, must.Sprint("request with missing volume should never be feasible"))
+
+		checker.SetVolumes(allocName1, reqs)
+		act = checker.Feasible(node)
+		must.False(t, act, must.Sprint("request with missing volume should never be feasible"))
+	}
+
+	must.Eq(t, []string{
+		"csi-volume:default:test-volume[0]",
+		"csi-volume:default:test-volume[1]",
+	}, ctx.Eligibility().MissingResources())
+
+	// Create the volume in the state store
+	vid := "test-volume[1]"
+	vol := structs.NewCSIVolume(vid, index)
+	vol.PluginID = "foo"
+	vol.Namespace = structs.DefaultNamespace
+	vol.AccessMode = structs.CSIVolumeAccessModeMultiNodeMultiWriter
+	vol.AttachmentMode = structs.CSIVolumeAttachmentModeFilesystem
+	err = state.UpsertCSIVolume(index, []*structs.CSIVolume{vol})
+	must.NoError(t, err)
+	index++
+
+	ctx.Reset()
+	ctx.Eligibility().Reset()
+	checker = NewCSIVolumeChecker(ctx)
+	checker.SetNamespace(structs.DefaultNamespace)
+
+	for _, node := range nodes {
+		checker.SetVolumes(allocName0, reqs)
+		act := checker.Feasible(node)
+		must.False(t, act, must.Sprint("request with missing volume should never be feasible"))
+
+		checker.SetVolumes(allocName1, reqs)
+		act = checker.Feasible(node)
+		must.True(t, act) // , must.Sprint("request with missing volume should never be feasible"))
+	}
+
+	must.Eq(t, []string{
+		"csi-volume:default:test-volume[0]",
+	}, ctx.Eligibility().MissingResources())
 }
 
 func TestNetworkChecker(t *testing.T) {

--- a/scheduler/feasible/feasible_test.go
+++ b/scheduler/feasible/feasible_test.go
@@ -1261,7 +1261,7 @@ func TestCSIVolumeChecker_PerAllocBlocking(t *testing.T) {
 
 		checker.SetVolumes(allocName1, reqs)
 		act = checker.Feasible(node)
-		must.True(t, act) // , must.Sprint("request with missing volume should never be feasible"))
+		must.True(t, act, must.Sprint("request with missing volume should never be feasible"))
 	}
 
 	must.Eq(t, []string{

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -166,6 +166,7 @@ func (s *GenericScheduler) Process(eval *structs.Evaluation) (err error) {
 		newEval.EscapedComputedClass = e.HasEscaped()
 		newEval.ClassEligibility = e.GetClasses()
 		newEval.QuotaLimitReached = e.QuotaLimitReached()
+		newEval.MissingNonNodeResources = e.MissingResources()
 		return s.planner.ReblockEval(newEval)
 	}
 
@@ -187,7 +188,7 @@ func (s *GenericScheduler) createBlockedEval(planFailure bool) error {
 		classEligibility = e.GetClasses()
 	}
 
-	s.blocked = s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs)
+	s.blocked = s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs, e.MissingResources())
 	if planFailure {
 		s.blocked.TriggeredBy = structs.EvalTriggerMaxPlans
 		s.blocked.StatusDescription = sstructs.DescBlockedEvalMaxPlan

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -7718,7 +7718,7 @@ func TestServiceSched_CSIVolumesPerAlloc(t *testing.T) {
 		must.Sprint("expected a blocked eval to be spawned"))
 	must.Eq(t, 2, h.Evals[1].QueuedAllocations["web"], must.Sprint("expected 2 queued allocs"))
 	must.Eq(t, 5, h.Evals[1].FailedTGAllocs["web"].
-		ConstraintFiltered["missing CSI Volume volume-unique[3]"])
+		ConstraintFiltered["missing CSI volume(s) volume-unique[3]"])
 
 	// Upsert 2 more per-alloc volumes
 	vol4 := vol0.Copy()

--- a/scheduler/scheduler_sysbatch.go
+++ b/scheduler/scheduler_sysbatch.go
@@ -482,7 +482,7 @@ func (s *SysBatchScheduler) addBlocked(node *structs.Node) error {
 		classEligibility = e.GetClasses()
 	}
 
-	blocked := s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs)
+	blocked := s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs, e.MissingResources())
 	blocked.StatusDescription = sstructs.DescBlockedEvalFailedPlacements
 	blocked.NodeID = node.ID
 

--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -660,7 +660,7 @@ func (s *SystemScheduler) addBlocked(node *structs.Node) error {
 		classEligibility = e.GetClasses()
 	}
 
-	blocked := s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs)
+	blocked := s.eval.CreateBlockedEval(classEligibility, escaped, e.QuotaLimitReached(), s.failedTGAllocs, e.MissingResources())
 	blocked.StatusDescription = sstructs.DescBlockedEvalFailedPlacements
 	blocked.NodeID = node.ID
 


### PR DESCRIPTION
When a CSI volume is created or registered, any blocked evaluations waiting on those volumes are not unblocked because we only unblock evals from the FSM when we upsert a node. Because a CSI volume is not tied to a specific node, we can't use this to unblock evals that are waiting on them.

Add support for unblocking when a CSI volume is created or registered. There are a few components to this.

Currently we don't count CSI volumes as a constraint that escaped "computed class", which they should because they're unique resources not tied to a specific node. We'll update the feasibility checker to ensure we have.

When a CSI volume is missing, we have no good way of surfacing that information to the blocked evals queue for later unblocking. The only other "resources" that aren't associated with a node or node class are quotas, and we special case that with a field on the eval. Rather than adding a new special case field, we'll add a new `MissingNonNodeResources` field on evals that let us track CSI volumes and any similar resources in the future.

Lastly, we'll `UnblockNonNodeResources` method on the blocked evals queue that gets called from the FSM when we create/register a volume. Any eval that escaped computed classes gets checked if it matches at least one of the missing resources. This lets us cheaply filter the set of evals that we unblock without reimplementing parts of the scheduler in the blocked evals queue.

Ref: https://hashicorp.atlassian.net/browse/NMD-469
Ref: https://github.com/hashicorp/nomad/issues/28285
Fixes: https://github.com/hashicorp/nomad/issues/25245

### Testing & Reproduction Steps

We can use the hostpath plugin found in the `./demo/csi/hostpath` directory. Run the plugin:

```
$ nomad job run ./plugin.nomad
```

Run the following jobspect, without having created its volumes first.

<details><summary>jobspec</summary>

```hcl
job "example" {

  group "cache" {

    volume "volume0" {
      type            = "csi"
      source          = "test-volume[0]"
      attachment_mode = "file-system"
      access_mode     = "single-node-reader-only"
      read_only       = true
    }

    volume "volume1" {
      type            = "csi"
      source          = "test-volume[1]"
      attachment_mode = "file-system"
      access_mode     = "single-node-reader-only"
      read_only       = true
    }

    network {
      port "db" {
        to = 6379
      }
    }

    task "redis" {
      driver = "docker"

      config {
        image = "redis:7"
        ports = ["db"]
      }

      volume_mount {
        volume      = "volume0"
        destination = "${NOMAD_ALLOC_DIR}/volume0"
      }

      volume_mount {
        volume      = "volume1"
        destination = "${NOMAD_ALLOC_DIR}/volume1"
      }

      resources {
        cpu    = 500
        memory = 256
      }
    }
  }
}
```

</details>

```
$ nomad job run ./example.nomad.hcl
==> 2026-07-22T15:14:19-04:00: Monitoring evaluation "f4dfe075"
    2026-07-22T15:14:19-04:00: Evaluation triggered by job "example"
    2026-07-22T15:14:20-04:00: Evaluation within deployment: "4f80142a"
    2026-07-22T15:14:20-04:00: Evaluation status changed: "pending" -> "complete"
==> 2026-07-22T15:14:20-04:00: Evaluation "f4dfe075" finished with status "complete" but failed to place all allocations:
    2026-07-22T15:14:20-04:00: Task Group "cache" (failed to place 1 allocation):
      * Constraint "missing CSI volume(s) test-volume[0], test-volume[1]": 1 nodes excluded by filter
    2026-07-22T15:14:20-04:00: Evaluation "49dc88d6" waiting for additional capacity to place remainder
==> 2026-07-22T15:14:20-04:00: Monitoring deployment "4f80142a"
  ⠸ Deployment "4f80142a" in progress...

    2026-07-22T15:14:20-04:00
    ID          = 4f80142a
    Job ID      = example
    Job Version = 0
    Status      = running
    Description = Deployment is running

    Deployed
    Task Group  Desired  Placed  Healthy  Unhealthy  Progress Deadline
    cache       1        0       0        0          N/A^C

$ nomad eval status 49dc88d6
ID                 = 49dc88d6
Create Time        = 42s ago
Modify Time        = 42s ago
Status             = blocked
Status Description = created to place remaining allocations
Type               = service
TriggeredBy        = queued-allocs
Job ID             = example
Namespace          = default
Priority           = 50
Placement Failures = N/A - In Progress
Previous Eval      = f4dfe075
Next Eval          = <none>
Blocked Eval       = <none>

Related Evaluations
ID        Priority  Triggered By  Node ID  Status    Description
f4dfe075  50        job-register  <none>   complete  <none>

Failed Placements
Task Group "cache" (failed to place 1 allocation):
  * Constraint "missing CSI volume(s) test-volume[0], test-volume[1]": 1 nodes excluded by filter

Missing Resources
  csi-volume:default:test-volume[0]
  csi-volume:default:test-volume[1]

==> View evaluation details in the Web UI: http://127.0.0.1:4646/ui/evaluations?currentEval=49dc88d6-83f8-715a-2d7e-3b1daa40441b
```

Create both volumes

```
$ nomad volume create test-volume-0.hcl
Created external volume d2bb8ca4-8601-11f1-89c7-5ac3f884415c with ID test-volume[0]
$ nomad volume create test-volume-1.hcl
Created external volume d4de5212-8601-11f1-89c7-5ac3f884415c with ID test-volume[1]
```

See that the blocked eval has been processed and the allocation is now running.

```
$ nomad eval status 49dc88d6
ID                 = 49dc88d6
Create Time        = 2m11s ago
Modify Time        = 5s ago
Status             = complete
Status Description = complete
Type               = service
TriggeredBy        = queued-allocs
Job ID             = example
Namespace          = default
Priority           = 50
Placement Failures = false
Previous Eval      = f4dfe075
Next Eval          = <none>
Blocked Eval       = <none>

Related Evaluations
ID        Priority  Triggered By  Node ID  Status    Description
f4dfe075  50        job-register  <none>   complete  <none>

Plan Annotations
Task Group  Ignore  Place  Stop  InPlace  Destructive
cache       0       1      0     0        0

Placed Allocations
ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
18ac3d6d  84d03763  cache       0        run      running  5s ago   5s ago

==> View evaluation details in the Web UI: http://127.0.0.1:4646/ui/evaluations?currentEval=49dc88d6-83f8-715a-2d7e-3b1daa40441b

$ nomad job status example
...
Allocations
ID        Node ID   Task Group  Version  Desired  Status   Created  Modified
18ac3d6d  84d03763  cache       0        run      running  16s ago  5s ago
```


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** see above
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
