### PR TITLE
agent: server ID in banner should be persistent

### DIFF
--- a/.changelog/28276.txt
+++ b/.changelog/28276.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+agent: Fixed a bug where the startup banner would display the wrong node ID for servers after restart
+```

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -917,10 +917,7 @@ func (c *Command) Run(args []string) int {
 	info["bind addrs"] = c.getBindAddrSynopsis()
 	info["advertise addrs"] = c.getAdvertiseAddrSynopsis()
 	if config.Server.Enabled {
-		serverConfig, err := c.agent.serverConfig()
-		if err == nil {
-			info["node id"] = serverConfig.NodeID
-		}
+		info["node id"] = c.agent.server.GetConfig().NodeID
 	}
 
 	// Sort the keys for output


### PR DESCRIPTION
During agent startup on a server, we log the server node ID in the banner. But instead of using the node ID we got during the initial setup (or from the persistent ID on disk), we regenerate the ID. In fact, we regenerate the entire configuration for the purpose of displaying this one log line and then throw it out!

Fix this by using the node ID already available on the server.

### Testing & Reproduction steps

```
$ nomad server members -json | jq '.[0].Tags.id'
"3d90ad98-70a1-7366-9e30-b980c4bea01c"
```

Logs:

```
==> Loaded configuration from /home/tim/ws/nomad/etc/local/server.hcl
==> Starting Nomad agent...
==> Nomad agent configuration:

       Advertise Addrs: HTTP: 192.168.1.194:4646; RPC: 192.168.1.194:4647; Serf: 192.168.1.194:4648
            Bind Addrs: HTTP: [0.0.0.0:4646]; RPC: 0.0.0.0:4647; Serf: 0.0.0.0:4648
                Client: false
             Log Level: debug
               Node Id: 3d90ad98-70a1-7366-9e30-b980c4bea01c
                Region: philly (DC: dc1)
                Server: true
               Version: 2.0.5-dev
```

Logs after restart:

```
==> Nomad agent configuration:

       Advertise Addrs: HTTP: 192.168.1.194:4646; RPC: 192.168.1.194:4647; Serf: 192.168.1.194:4648
            Bind Addrs: HTTP: [0.0.0.0:4646]; RPC: 0.0.0.0:4647; Serf: 0.0.0.0:4648
                Client: false
             Log Level: debug
               Node Id: 3d90ad98-70a1-7366-9e30-b980c4bea01c
                Region: philly (DC: dc1)
                Server: true
               Version: 2.0.5-dev
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** see above
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
