### PR TITLE
structs: reject negative cores value in task resources

### DIFF
--- a/.changelog/10511.txt
+++ b/.changelog/10511.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+jobspec: Fixed a bug where a negative `cores` value in a task's resource block was accepted during job validation and registration
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2423,6 +2423,10 @@ func (r *Resources) Validate() error {
 		mErr.Errors = append(mErr.Errors, errors.New("Task can only ask for 'cpu' or 'cores' resource, not both."))
 	}
 
+	if r.Cores < 0 {
+		mErr.Errors = append(mErr.Errors, fmt.Errorf("cores value (%d) cannot be negative", r.Cores))
+	}
+
 	if err := r.MeetsMinResources(); err != nil {
 		mErr.Errors = append(mErr.Errors, err)
 	}

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -2490,6 +2490,14 @@ func TestTask_Validate_Resources(t *testing.T) {
 			err: "minimum CPU value is 1",
 		},
 		{
+			name: "negative cores",
+			res: &Resources{
+				Cores:    -1,
+				MemoryMB: 200,
+			},
+			err: "cores value (-1) cannot be negative",
+		},
+		{
 			name: "too little memory",
 			res: &Resources{
 				CPU:      100,


### PR DESCRIPTION
### Description
Fixes #10511

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
#10511

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
