### PR TITLE
structs: reject task group with only lifecycle tasks and no main task

### DIFF
--- a/.changelog/17570.txt
+++ b/.changelog/17570.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+jobspec: Fixed a bug where a task group containing only lifecycle tasks and no main task was accepted during job validation
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -7240,6 +7240,7 @@ func (tg *TaskGroup) Validate(j *Job) error {
 	// Check that there is only one leader task if any
 	tasks := make(map[string]int)
 	leaderTasks := 0
+	mainTasks := 0
 	for idx, task := range tg.Tasks {
 		if task.Name == "" {
 			mErr = multierror.Append(mErr, fmt.Errorf("Task %d missing name", idx+1))
@@ -7252,10 +7253,20 @@ func (tg *TaskGroup) Validate(j *Job) error {
 		if task.Leader {
 			leaderTasks++
 		}
+
+		if task.IsMain() {
+			mainTasks++
+		}
 	}
 
 	if leaderTasks > 1 {
 		mErr = multierror.Append(mErr, fmt.Errorf("Only one task may be marked as leader"))
+	}
+
+	// A task group made up entirely of lifecycle tasks (prestart, poststart, or
+	// poststop) has no main task to run, which is invalid.
+	if len(tg.Tasks) > 0 && mainTasks == 0 {
+		mErr = multierror.Append(mErr, fmt.Errorf("Task group %s must have at least one main task", tg.Name))
 	}
 
 	// Validate the volume requests

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -1962,6 +1962,32 @@ func TestTaskGroup_Validate(t *testing.T) {
 			},
 			jobType: JobTypeService,
 		},
+		{
+			name: "task group with only a poststart lifecycle task and no main task",
+			tg: &TaskGroup{
+				Name:             "group-a",
+				RestartPolicy:    NewRestartPolicy(JobTypeService),
+				ReschedulePolicy: NewReschedulePolicy(JobTypeService),
+				Migrate:          DefaultMigrateStrategy(),
+				EphemeralDisk:    DefaultEphemeralDisk(),
+				Tasks: []*Task{
+					{
+						Name:      "poststart-task",
+						Driver:    "mock_driver",
+						Resources: DefaultResources(),
+						LogConfig: DefaultLogConfig(),
+						Lifecycle: &TaskLifecycleConfig{
+							Hook:    TaskLifecycleHookPoststart,
+							Sidecar: false,
+						},
+					},
+				},
+			},
+			expErr: []string{
+				"Task group group-a must have at least one main task",
+			},
+			jobType: JobTypeService,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
### Description

 Reject task group with only lifecycle tasks /  no main task

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links

Fixes #17570

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
