### PR TITLE
ui: refetch license when signing in with token

### DIFF
--- a/.changelog/28284.txt
+++ b/.changelog/28284.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: refetch nomad license when logging in with new token
+```

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -159,7 +159,7 @@ export default class Tokens extends Controller {
 
       // Set bearer token instead of findSelf etc.
       TokenAdapter.loginJWT(secret, methodName).then(
-        await (token) => {
+        async (token) => {
           this.token.setProperties({
             secret: token.secret,
             tokenNotFound: false,
@@ -188,7 +188,7 @@ export default class Tokens extends Controller {
       this.set('secret', null);
 
       TokenAdapter.findSelf().then(
-        await () => {
+        async () => {
           // Clear out all data to ensure only data the new token is privileged to see is shown
           this.resetStore();
 

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -172,7 +172,7 @@ export default class Tokens extends Controller {
           // Refetch the token and associated policies
           await this.token.get('fetchSelfTokenAndPolicies').perform().catch();
           // When signing in, we should refetch the license
-          await this.system.get('fetchLicense').perform().catch()
+          await this.system.get('fetchLicense').perform().catch();
 
           this.signInStatus = 'success';
           this.optionallyRedirectPathAfterSignIn();
@@ -195,7 +195,7 @@ export default class Tokens extends Controller {
           // Refetch the token and associated policies
           await this.token.get('fetchSelfTokenAndPolicies').perform().catch();
           // When signing in, we should refetch the license
-          await this.system.get('fetchLicense').perform().catch()
+          await this.system.get('fetchLicense').perform().catch();
 
           if (!this.system.activeRegion) {
             this.system.get('defaultRegion').then((res) => {

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -159,7 +159,7 @@ export default class Tokens extends Controller {
 
       // Set bearer token instead of findSelf etc.
       TokenAdapter.loginJWT(secret, methodName).then(
-        async (token) => {
+        (token) => {
           this.token.setProperties({
             secret: token.secret,
             tokenNotFound: false,
@@ -170,9 +170,9 @@ export default class Tokens extends Controller {
           this.resetStore();
 
           // Refetch the token and associated policies
-          await this.token.get('fetchSelfTokenAndPolicies').perform().catch();
+          this.token.get('fetchSelfTokenAndPolicies').perform().catch();
           // When signing in, we should refetch the license
-          await this.system.get('fetchLicense').perform().catch();
+          this.system.get('fetchLicense').perform().catch();
 
           this.signInStatus = 'success';
           this.optionallyRedirectPathAfterSignIn();
@@ -188,14 +188,14 @@ export default class Tokens extends Controller {
       this.set('secret', null);
 
       TokenAdapter.findSelf().then(
-        async () => {
+        () => {
           // Clear out all data to ensure only data the new token is privileged to see is shown
           this.resetStore();
 
           // Refetch the token and associated policies
-          await this.token.get('fetchSelfTokenAndPolicies').perform().catch();
+          this.token.get('fetchSelfTokenAndPolicies').perform().catch();
           // When signing in, we should refetch the license
-          await this.system.get('fetchLicense').perform().catch();
+          this.system.get('fetchLicense').perform().catch();
 
           if (!this.system.activeRegion) {
             this.system.get('defaultRegion').then((res) => {

--- a/ui/app/controllers/settings/tokens.js
+++ b/ui/app/controllers/settings/tokens.js
@@ -159,7 +159,7 @@ export default class Tokens extends Controller {
 
       // Set bearer token instead of findSelf etc.
       TokenAdapter.loginJWT(secret, methodName).then(
-        (token) => {
+        await (token) => {
           this.token.setProperties({
             secret: token.secret,
             tokenNotFound: false,
@@ -170,7 +170,9 @@ export default class Tokens extends Controller {
           this.resetStore();
 
           // Refetch the token and associated policies
-          this.token.get('fetchSelfTokenAndPolicies').perform().catch();
+          await this.token.get('fetchSelfTokenAndPolicies').perform().catch();
+          // When signing in, we should refetch the license
+          await this.system.get('fetchLicense').perform().catch()
 
           this.signInStatus = 'success';
           this.optionallyRedirectPathAfterSignIn();
@@ -186,12 +188,14 @@ export default class Tokens extends Controller {
       this.set('secret', null);
 
       TokenAdapter.findSelf().then(
-        () => {
+        await () => {
           // Clear out all data to ensure only data the new token is privileged to see is shown
           this.resetStore();
 
           // Refetch the token and associated policies
-          this.token.get('fetchSelfTokenAndPolicies').perform().catch();
+          await this.token.get('fetchSelfTokenAndPolicies').perform().catch();
+          // When signing in, we should refetch the license
+          await this.system.get('fetchLicense').perform().catch()
 
           if (!this.system.activeRegion) {
             this.system.get('defaultRegion').then((res) => {


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
When the UI starts it fetches the license, but it does not refetch the license when a user logs in via a token. We should always re-fetch the token in this instance because the previous token may have had different license privileges.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes https://github.com/hashicorp/nomad/issues/23176

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
