### PR TITLE
plugins: kill launched plugin processes when client setup fails

### DIFF
--- a/.changelog/28286.txt
+++ b/.changelog/28286.txt
@@ -1,0 +1,3 @@
+```release-note: bug
+plugins: Fixed a bug where the logmon, executor, or docker_logger plugin process was leaked when the plugin client failed during setup
+```

--- a/client/logmon/plugin.go
+++ b/client/logmon/plugin.go
@@ -49,13 +49,24 @@ func LaunchLogMon(logger hclog.Logger, reattachConfig *plugin.ReattachConfig) (L
 
 	client := plugin.NewClient(conf)
 
+	// If we launched a new plugin process and fail before returning
+	// successfully, kill it so it is not leaked. Reattached processes are left
+	// running as they may not be plugins at all (see #24798).
+	cleanup := func() {
+		if reattachConfig == nil {
+			client.Kill()
+		}
+	}
+
 	rpcClient, err := client.Client()
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 
 	raw, err := rpcClient.Dispense("logmon")
 	if err != nil {
+		cleanup()
 		return nil, nil, err
 	}
 

--- a/drivers/docker/docklog/plugin.go
+++ b/drivers/docker/docklog/plugin.go
@@ -39,11 +39,14 @@ func LaunchDockerLogger(logger hclog.Logger) (DockerLogger, *plugin.Client, erro
 
 	rpcClient, err := client.Client()
 	if err != nil {
+		// Kill the launched plugin process so it is not leaked.
+		client.Kill()
 		return nil, nil, err
 	}
 
 	raw, err := rpcClient.Dispense(PluginName)
 	if err != nil {
+		client.Kill()
 		return nil, nil, err
 	}
 

--- a/drivers/shared/executor/utils.go
+++ b/drivers/shared/executor/utils.go
@@ -101,17 +101,30 @@ func ReattachToExecutor(reattachConfig *plugin.ReattachConfig, logger hclog.Logg
 
 func newExecutorClient(config *plugin.ClientConfig, logger hclog.Logger) (Executor, *plugin.Client, error) {
 	executorClient := plugin.NewClient(config)
+
+	// If we launched a new plugin process and fail before returning
+	// successfully, kill it so it is not leaked. Reattached processes are left
+	// running as they may not be plugins at all (see #24538).
+	cleanup := func() {
+		if config.Reattach == nil {
+			executorClient.Kill()
+		}
+	}
+
 	rpcClient, err := executorClient.Client()
 	if err != nil {
+		cleanup()
 		return nil, nil, fmt.Errorf("error creating rpc client for executor plugin: %v", err)
 	}
 
 	raw, err := rpcClient.Dispense("executor")
 	if err != nil {
+		cleanup()
 		return nil, nil, fmt.Errorf("unable to dispense the executor plugin: %v", err)
 	}
 	executorPlugin, ok := raw.(Executor)
 	if !ok {
+		cleanup()
 		return nil, nil, fmt.Errorf("unexpected executor rpc type: %T", raw)
 	}
 	return executorPlugin, executorClient, nil


### PR DESCRIPTION
### Description
When launching the `logmon`, `executor`, or `docker_logger` plugin, a failure in `client.Client()` or `rpcClient.Dispense()` returned without ever calling `plugin.Client.Kill()`. go-plugin only cleans up the child process when the error occurs inside `Start()` (handshake), so in these later error paths the already-spawned plugin process was left running forever.

These orphaned processes accumulate over time. On Windows this is particularly problematic: each process consumes a share of the (fixed-size) desktop heap, and once it is exhausted no further processes can be launched on that client at all — every subsequent task fails with `logmon: Unrecognized remote plugin message` until the Nomad client (and, when running interactively, its console) is torn down. This matches the long-standing reports in #11939.

This PR kills the plugin process in these error paths when we launched it ourselves. Reattach code paths are deliberately left untouched: the process listening on a reattach address may not be our plugin at all (see #24538 / #24798), so killing it would risk terminating an unrelated process.

### Testing & Reproduction steps
- `go build` / `go vet` on the affected packages
- `go test ./drivers/shared/executor/` passes; `./client/logmon/` has a pre-existing failure on macOS (`TestLogmon_Start_restart`) that also fails on unmodified `main`
- The leak can be observed by making the gRPC dial fail after a successful handshake (e.g. blocking the loopback connection on Windows) and watching `nomad logmon` processes accumulate in the process list; with this change they are terminated

### Links
- #11939 (Windows: `logmon: Unrecognized remote plugin message`, client unable to launch further processes)
- #24538, #24798 (why reattach paths must not kill)

### Contributor Checklist
- [x] **Changelog Entry** Added `.changelog/28286.txt`
- [ ] **Testing** No new test added; the affected error paths require failure injection into go-plugin internals. Happy to add one if maintainers have a preferred pattern.
- [x] **Documentation** Not user-facing beyond the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
