### PR TITLE
docs: fix link to AI policy in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ merged.
   Please also consider whether the change requires notes within the [upgrade
   guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
 - [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
-  and followed the [AI usage guide](./contributing/ai.md).
+  and followed the [AI usage guide](../contributing/ai.md).
 
 ### Reviewer Checklist
 - [ ] **Backport Labels** Please add the correct backport labels as described by the internal


### PR DESCRIPTION
The link to the AI policy in the PR template was broken because the URL is relative to the `.github/` folder. Walk back up to the root of the repo to get the correct file.

Preview: https://github.com/hashicorp/nomad/blob/9013246d45564d8f29a37878b44bb52e8e834dd1/.github/pull_request_template.md links to https://github.com/hashicorp/nomad/blob/9013246d45564d8f29a37878b44bb52e8e834dd1/contributing/ai.md

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
