### PR TITLE
ui: fix version and deployment loading

### DIFF
--- a/.changelog/28294.txt
+++ b/.changelog/28294.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed version diff display and missing deployment version numbers
+```

--- a/ui/app/serializers/deployment.js
+++ b/ui/app/serializers/deployment.js
@@ -17,6 +17,10 @@ export default class DeploymentSerializer extends ApplicationSerializer {
 
   normalize(typeHash, hash) {
     if (hash) {
+      // Construct the version ID so the deployment record properly links
+      // to the version.
+      hash.VersionID = `${hash.JobID}-${hash.JobVersion}`;
+
       hash.PlainJobId = hash.JobID;
       hash.Namespace =
         hash.Namespace || get(hash, 'Job.Namespace') || 'default';

--- a/ui/app/serializers/job-version.js
+++ b/ui/app/serializers/job-version.js
@@ -26,11 +26,9 @@ export default class JobVersionSerializer extends ApplicationSerializer {
         ID: `${version.ID}-${version.Version}`,
         SubmitTime: Math.floor(version.SubmitTime / 1000000),
         SubmitTimeNanos: version.SubmitTime % 1000000,
+        // Contruct the JobID so version properly links to the job.
+        JobID: JSON.stringify([version.ID, version.Namespace || 'default']),
       });
-
-      // Versions are loaded from a parent job.hasMany("versions") request,
-      // so omit ambiguous JobID payload data and let Ember Data bind back to parent.
-      delete normalizedVersion.JobID;
 
       return normalizedVersion;
     });

--- a/ui/app/templates/jobs/job/versions.hbs
+++ b/ui/app/templates/jobs/job/versions.hbs
@@ -4,7 +4,8 @@
 ~}}
 
 {{page-title "Job " this.job.name " versions"}}
-{{did-update-helper this.versionsDidUpdate this.job.versions}}
+
+{{this.versionsDidUpdate this.job.versions}}
 <JobSubnav @job={{this.job}} />
 <section class="section">
 
@@ -68,7 +69,7 @@
   {{/if}}
 
   <JobVersionsStream
-    @versions={{this.model.versions}}
+    @versions={{this.job.versions}}
     @diffs={{this.diffs}}
     @verbose={{true}}
     @handleError={{this.handleError}}

--- a/ui/tests/acceptance/job-versions-test.js
+++ b/ui/tests/acceptance/job-versions-test.js
@@ -43,10 +43,12 @@ module('Acceptance | job versions', function (hooks) {
     // Create some versions
     this.server.create('job-version', {
       job: job,
+      namespace: namespace.id,
       version: 0,
     });
     this.server.create('job-version', {
       job: job,
+      namespace: namespace.id,
       version: 1,
       versionTag: {
         Name: 'test-tag',
@@ -335,12 +337,14 @@ module('Acceptance | job versions (clone and edit)', function (hooks) {
     // remove auto-created versions and create 3 of them, one with a tag
     this.server.db.jobVersions.remove();
     this.server.create('job-version', {
-      job,
+      job: job,
+      namespace: namespace.id,
       version: 99,
       submitTime: 1731101785761339000,
     });
     this.server.create('job-version', {
       job,
+      namespace: namespace.id,
       version: 98,
       submitTime: 1731101685761339000,
       versionTag: {
@@ -350,6 +354,7 @@ module('Acceptance | job versions (clone and edit)', function (hooks) {
     });
     this.server.create('job-version', {
       job,
+      namespace: namespace.id,
       version: 0,
       submitTime: 1731101585761339000,
     });
@@ -500,10 +505,12 @@ module('Acceptance | job versions (with client token)', function (hooks) {
     // Create some versions
     this.server.create('job-version', {
       job: job,
+      namespace: namespace.id,
       version: 0,
     });
     this.server.create('job-version', {
       job: job,
+      namespace: namespace.id,
       version: 1,
       versionTag: {
         Name: 'test-tag',
@@ -522,10 +529,12 @@ module('Acceptance | job versions (with client token)', function (hooks) {
     // Create job2 versions
     this.server.create('job-version', {
       job: job2,
+      namespace: namespace2.id,
       version: 0,
     });
     this.server.create('job-version', {
       job: job2,
+      namespace: namespace2.id,
       version: 1,
       versionTag: {
         Name: 'test-tag',
@@ -544,10 +553,12 @@ module('Acceptance | job versions (with client token)', function (hooks) {
     // Create job3 versions
     this.server.create('job-version', {
       job: job3,
+      namespace: namespace3.id,
       version: 0,
     });
     this.server.create('job-version', {
       job: job3,
+      namespace: namespace3.id,
       version: 1,
       versionTag: {
         Name: 'test-tag',


### PR DESCRIPTION
Construct a `JobID` when normalizing a job version in the serializer so it is properly related to its job when new versions are pushed directly into the store. Also construct a `VersionID` when normalizing a deployment in the serializer so the version is correctly related to it when pushed directly into the store. This fixes display issues with live additions of new versions and deployments.

Since versions are eager loaded, run the `versionsDidUpdate` action directly instead of with the `did-update-helper` so diffs are properly loaded and displayed.

### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links

Fixes #28240

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
