### PR TITLE
structs: sort diff names with numeric array indices

### DIFF
--- a/.changelog/4421.txt
+++ b/.changelog/4421.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fixed a bug where a job plan diff sorted indexed fields such as `args` lexically, listing `args[10]` before `args[2]`
+```

--- a/.changelog/4421.txt
+++ b/.changelog/4421.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed a bug where a job plan diff sorted indexed fields such as `args` lexically, listing `args[10]` before `args[2]`
+```

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -3121,6 +3121,37 @@ func (o *ObjectDiff) GoString() string {
 	return out
 }
 
+// splitIndexedName splits a name of the form "base[<index>]" into its base and
+// integer index. ok is false if name has no such well-formed suffix or an empty
+// base.
+func splitIndexedName(name string) (base string, index int, ok bool) {
+	if !strings.HasSuffix(name, "]") {
+		return "", 0, false
+	}
+	open := strings.LastIndexByte(name, '[')
+	if open <= 0 {
+		return "", 0, false
+	}
+	idx, err := strconv.Atoi(name[open+1 : len(name)-1])
+	if err != nil {
+		return "", 0, false
+	}
+	return name[:open], idx, true
+}
+
+// nameLess orders diff names. Names produced by flatmap for slice elements
+// carry a trailing "[<index>]" suffix; when two names share the same base their
+// indices are compared numerically so that e.g. "args[2]" sorts before
+// "args[10]". Otherwise the names are compared lexically.
+func nameLess(a, b string) bool {
+	aBase, aIdx, aOK := splitIndexedName(a)
+	bBase, bIdx, bOK := splitIndexedName(b)
+	if aOK && bOK && aBase == bBase {
+		return aIdx < bIdx
+	}
+	return a < b
+}
+
 func (o *ObjectDiff) Less(other *ObjectDiff) bool {
 	if reflect.DeepEqual(o, other) {
 		return false
@@ -3131,7 +3162,7 @@ func (o *ObjectDiff) Less(other *ObjectDiff) bool {
 	}
 
 	if o.Name != other.Name {
-		return o.Name < other.Name
+		return nameLess(o.Name, other.Name)
 	}
 
 	if o.Type != other.Type {
@@ -3228,7 +3259,7 @@ func (f *FieldDiff) Less(other *FieldDiff) bool {
 	}
 
 	if f.Name != other.Name {
-		return f.Name < other.Name
+		return nameLess(f.Name, other.Name)
 	} else if f.Old != other.Old {
 		return f.Old < other.Old
 	}

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -3121,6 +3121,36 @@ func (o *ObjectDiff) GoString() string {
 	return out
 }
 
+// splitIndexedName splits a name of the form "base[<index>]" into its base and
+// integer index. ok is false if name has no such well-formed suffix.
+func splitIndexedName(name string) (base string, index int, ok bool) {
+	if !strings.HasSuffix(name, "]") {
+		return "", 0, false
+	}
+	open := strings.LastIndexByte(name, '[')
+	if open < 0 {
+		return "", 0, false
+	}
+	idx, err := strconv.Atoi(name[open+1 : len(name)-1])
+	if err != nil {
+		return "", 0, false
+	}
+	return name[:open], idx, true
+}
+
+// nameLess orders diff names. Names produced by flatmap for slice elements
+// carry a trailing "[<index>]" suffix; when two names share the same base their
+// indices are compared numerically so that e.g. "args[2]" sorts before
+// "args[10]". Otherwise the names are compared lexically.
+func nameLess(a, b string) bool {
+	aBase, aIdx, aOK := splitIndexedName(a)
+	bBase, bIdx, bOK := splitIndexedName(b)
+	if aOK && bOK && aBase == bBase {
+		return aIdx < bIdx
+	}
+	return a < b
+}
+
 func (o *ObjectDiff) Less(other *ObjectDiff) bool {
 	if reflect.DeepEqual(o, other) {
 		return false
@@ -3131,7 +3161,7 @@ func (o *ObjectDiff) Less(other *ObjectDiff) bool {
 	}
 
 	if o.Name != other.Name {
-		return o.Name < other.Name
+		return nameLess(o.Name, other.Name)
 	}
 
 	if o.Type != other.Type {
@@ -3228,7 +3258,7 @@ func (f *FieldDiff) Less(other *FieldDiff) bool {
 	}
 
 	if f.Name != other.Name {
-		return f.Name < other.Name
+		return nameLess(f.Name, other.Name)
 	} else if f.Old != other.Old {
 		return f.Old < other.Old
 	}

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -4,6 +4,7 @@
 package structs
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -5358,6 +5359,65 @@ func TestTaskGroupDiff(t *testing.T) {
 				must.Eq(t, c.Expected, result)
 			}
 		})
+	}
+}
+
+func TestTaskDiff_ConfigArgsNumericOrder(t *testing.T) {
+	ci.Parallel(t)
+
+	// Slice elements are flattened to "args[<index>]" names. The diff must sort
+	// them numerically, not lexically, so args[2] comes before args[10]
+	args := make([]string, 12)
+	for i := range args {
+		args[i] = fmt.Sprintf("v%d", i)
+	}
+	old := &Task{Name: "web"}
+	updated := &Task{Name: "web", Config: map[string]any{"args": args}}
+
+	diff, err := old.Diff(updated, false)
+	must.NoError(t, err)
+
+	var cfg *ObjectDiff
+	for _, o := range diff.Objects {
+		if o.Name == "Config" {
+			cfg = o
+			break
+		}
+	}
+	must.NotNil(t, cfg)
+
+	got := make([]string, len(cfg.Fields))
+	for i, f := range cfg.Fields {
+		got[i] = f.Name
+	}
+
+	want := make([]string, 12)
+	for i := range want {
+		want[i] = fmt.Sprintf("args[%d]", i)
+	}
+	must.Eq(t, want, got)
+}
+
+func TestSplitIndexedName(t *testing.T) {
+	ci.Parallel(t)
+
+	cases := []struct {
+		name  string
+		base  string
+		index int
+		ok    bool
+	}{
+		{"args[10]", "args", 10, true},
+		{"args[0]", "args", 0, true},
+		{"args", "", 0, false},    // no index suffix
+		{"[0]", "", 0, false},     // index only, empty base
+		{"args[x]", "", 0, false}, // non-numeric index
+	}
+	for _, tc := range cases {
+		base, index, ok := splitIndexedName(tc.name)
+		must.Eq(t, tc.base, base)
+		must.Eq(t, tc.index, index)
+		must.Eq(t, tc.ok, ok)
 	}
 }
 

--- a/nomad/structs/diff_test.go
+++ b/nomad/structs/diff_test.go
@@ -4,7 +4,9 @@
 package structs
 
 import (
+	"fmt"
 	"reflect"
+	"sort"
 	"testing"
 	"time"
 
@@ -5359,6 +5361,43 @@ func TestTaskGroupDiff(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTaskDiff_ConfigArgsNumericOrder(t *testing.T) {
+	ci.Parallel(t)
+
+	// Slice elements are flattened to "args[<index>]" names. The diff must sort
+	// them numerically, not lexically, so args[2] comes before args[10] (#4421).
+	args := make([]string, 12)
+	for i := range args {
+		args[i] = fmt.Sprintf("v%d", i)
+	}
+	old := &Task{Name: "web"}
+	updated := &Task{Name: "web", Config: map[string]interface{}{"args": args}}
+
+	diff, err := old.Diff(updated, false)
+	must.NoError(t, err)
+
+	var cfg *ObjectDiff
+	for _, o := range diff.Objects {
+		if o.Name == "Config" {
+			cfg = o
+			break
+		}
+	}
+	must.NotNil(t, cfg)
+
+	sort.Sort(FieldDiffs(cfg.Fields))
+	got := make([]string, len(cfg.Fields))
+	for i, f := range cfg.Fields {
+		got[i] = f.Name
+	}
+
+	want := make([]string, 12)
+	for i := range want {
+		want[i] = fmt.Sprintf("args[%d]", i)
+	}
+	must.Eq(t, want, got)
 }
 
 func TestTaskDiff(t *testing.T) {


### PR DESCRIPTION
### Description

Diff field and object names for slice elements carry a trailing "[<index>]" suffix (e.g. args[0]). FieldDiff.Less and ObjectDiff.Less compared these lexically, so a job plan diff listed args[10] before args[2]. Compare the indices numerically when the base names are equal.

### Links

Fixes #4421

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
