### PR TITLE
scheduler: guard against nil job in host volume feasibility check

### DIFF
--- a/.changelog/28301.txt
+++ b/.changelog/28301.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fixed a bug where the scheduler could panic with a nil pointer dereference when checking host volume feasibility for an allocation whose job had been purged
+```

--- a/scheduler/feasible/feasible.go
+++ b/scheduler/feasible/feasible.go
@@ -473,7 +473,18 @@ func (h *HostVolumeChecker) hostVolumeIsAvailable(
 			if err != nil {
 				return false
 			}
-			for _, req := range job.LookupTaskGroup(alloc.TaskGroup).Volumes {
+			// The job may have been purged or garbage collected (JobByID
+			// returns nil, nil), or the alloc's task group may no longer exist.
+			// We cannot prove this allocation is not using the volume, so treat
+			// it as unavailable rather than dereference the nil job.
+			if job == nil {
+				return false
+			}
+			tg := job.LookupTaskGroup(alloc.TaskGroup)
+			if tg == nil {
+				return false
+			}
+			for _, req := range tg.Volumes {
 				if vol.MatchesRequestSource(req, alloc) {
 					if !req.ReadOnly {
 						return false

--- a/scheduler/feasible/feasible_test.go
+++ b/scheduler/feasible/feasible_test.go
@@ -902,6 +902,36 @@ func TestDynamicHostVolumeIsAvailable(t *testing.T) {
 
 }
 
+func TestDynamicHostVolumeIsAvailable_PurgedJob(t *testing.T) {
+	ci.Parallel(t)
+
+	_, ctx := MockContext(t)
+	checker := NewHostVolumeChecker(ctx)
+
+	vol := &structs.HostVolume{
+		Name:  "example",
+		State: structs.HostVolumeStateReady,
+		RequestedCapabilities: []*structs.HostVolumeCapability{{
+			AttachmentMode: structs.HostVolumeAttachmentModeFilesystem,
+			AccessMode:     structs.HostVolumeAccessModeSingleNodeSingleWriter,
+		}},
+	}
+
+	// A proposed alloc whose job has been purged or garbage collected: JobByID
+	// returns nil, nil. The checker cannot prove the alloc is not using the
+	// volume, so it must report the volume unavailable rather than dereference
+	// the nil job (#28301).
+	orphan := mock.Alloc()
+
+	must.False(t, checker.hostVolumeIsAvailable(
+		vol,
+		structs.HostVolumeAccessModeSingleNodeSingleWriter,
+		structs.HostVolumeAttachmentModeFilesystem,
+		false,
+		[]*structs.Allocation{orphan},
+	))
+}
+
 func TestCSIVolumeChecker(t *testing.T) {
 	ci.Parallel(t)
 	state, ctx := MockContext(t)


### PR DESCRIPTION


### Description

`hostVolumeIsAvailable` looked up each proposed alloc's job from the state store and dereferenced `job.LookupTaskGroup(...)` directly. For a purged or garbage-collected job `JobByID` returns nil, nil, so the checker panicked with a nil pointer dereference. Skip the alloc when its job or task group is no longer present.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links

Fixes #28301


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
