### PR TITLE
scheduler: Remove generated deployment when plan refreshes state.

### DIFF
--- a/.changelog/28307.txt
+++ b/.changelog/28307.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Ensure deployment IDs are not written to an evaluation when the generated deployment is not persisted to state due to plan apply retries
+```

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -298,10 +298,15 @@ func (s *GenericScheduler) process() (bool, error) {
 	// number of allocations successfully placed
 	adjustQueuedAllocations(s.logger, result, s.queuedAllocs)
 
-	// If we got a state refresh, try again since we have stale data
+	// If we got a state refresh, try again since we have stale data.
+	//
+	// Clear the in-memory deployment because the plan was rejected and nothing
+	// was persisted; the next process() iteration will reload from state or
+	// generate a new deployment if needed.
 	if newState != nil {
 		s.logger.Debug("refresh forced")
 		s.state = newState
+		s.deployment = nil
 		return false, nil
 	}
 

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -4732,6 +4732,53 @@ func TestServiceSched_RetryLimit(t *testing.T) {
 	h.AssertEvalStatus(t, structs.EvalStatusFailed)
 }
 
+// TestServiceSched_RetryLimit_DeploymentIDCleared ensures that when all plan
+// submissions are rejected (e.g. due to quota exhaustion), the final eval does
+// not carry a deployment ID referencing a deployment that was never persisted
+// to state.
+func TestServiceSched_RetryLimit_DeploymentIDCleared(t *testing.T) {
+	ci.Parallel(t)
+
+	// Setup a harness with a planner that rejects all plans, so that the
+	// scheduler will hit the retry limit.
+	h := tests.NewHarness(t)
+	h.Planner = &tests.RejectPlan{Harness: h}
+
+	// Create nodes so that placement is actually attempted.
+	for range 10 {
+		node := mock.Node()
+		must.NoError(t, h.State.UpsertNode(structs.MsgTypeTestSetup, h.NextIndex(), node))
+	}
+
+	// Use a job with an update strategy so that the reconciler creates a
+	// deployment object in memory during scheduling.
+	job := mock.Job()
+	update := *structs.DefaultUpdateStrategy
+	job.Update = update
+	job.TaskGroups[0].Update = &update
+	must.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
+
+	eval := &structs.Evaluation{
+		Namespace:   structs.DefaultNamespace,
+		ID:          uuid.Generate(),
+		Priority:    job.Priority,
+		TriggeredBy: structs.EvalTriggerJobRegister,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+	must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup, h.NextIndex(), []*structs.Evaluation{eval}))
+
+	must.NoError(t, h.Process(NewServiceScheduler, eval))
+
+	// The eval should have been marked failed as it would have hit the retry
+	// limit after all plan submissions were rejected.
+	h.AssertEvalStatus(t, structs.EvalStatusFailed)
+
+	// The final eval must not reference a deployment that was never persisted.
+	must.Len(t, 1, h.Evals)
+	must.StrEqFold(t, "", h.Evals[0].DeploymentID)
+}
+
 func TestServiceSched_Reschedule_OnceNow(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
The plan apply worker can return an refreshed state if it believes the applier process should be retried on a newer state snapshot. This can occur because the quota is blocking the placement or if the follower submitting the plan has an FSM that is lagging behind the rest of the quorum. In this situation the plan apply might be retried, or it might have exhausted its retries and be rejected.

If retries are exhausted, the scheduler will create a blocked eval and set the status details of the evaluation which includes the generated deployment ID. This deployment ID is then persisted to state even though no deployment has been created or itself persisted to state. If the plan and apply was driven by the CLI, this can result in the CLI attempting to monitor a deployment that does not exist.

This change clears the in-memory scheduler deployment object when a state refresh triggers a plan applier retry. If the apply can be retried, this information will be repopulated. If the process has reached the maximum number of retries, this change means the eval no longer references a non-existent deployment.

### Testing & Reproduction steps
It's tricky to test manually using CE only code and requires artificially slowing down a follower and ensuring this follower is submitting plans to the leader that will be rejected due to stale state. The linked enterprise PR can be used as a reference on how to manually test this using quota rejections. The unit test covers the scenario quite well. 

### Links
found while testing: https://github.com/hashicorp/nomad-enterprise/pull/4259

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

