### PR TITLE
scheduler: Remove refreshed state tautological conditional.

### DIFF
--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -305,14 +305,13 @@ func (s *GenericScheduler) process() (bool, error) {
 		return false, nil
 	}
 
-	// Try again if the plan was not fully committed, potential conflict
+	// Try again if the plan was not fully committed, potential conflict. The
+	// above conditional means that we are always missing a state refresh after
+	// a partial commit.
 	fullCommit, expected, actual := result.FullCommit(s.plan)
 	if !fullCommit {
 		s.logger.Debug("plan didn't fully commit", "attempted", expected, "placed", actual)
-		if newState == nil {
-			return false, fmt.Errorf("missing state refresh after partial commit")
-		}
-		return false, nil
+		return false, fmt.Errorf("missing state refresh after partial commit")
 	}
 
 	// Success!


### PR DESCRIPTION
### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

