### PR TITLE
ui: Fix region identifier showing empty in single region clusters.

### DIFF
--- a/.changelog/28310.txt
+++ b/.changelog/28310.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+ui: Fixed the region identifier header showing as empty in single region clusters
+```

--- a/ui/app/services/system.js
+++ b/ui/app/services/system.js
@@ -87,6 +87,12 @@ export default class SystemService extends Service {
       return region;
     }
 
+    // When there is only one region and nothing is stored in localStorage,
+    // fall back to that single region so the header can display it.
+    if (regions.length === 1) {
+      return regions.objectAt(0);
+    }
+
     return null;
   }
 

--- a/ui/tests/acceptance/regions-test.js
+++ b/ui/tests/acceptance/regions-test.js
@@ -53,6 +53,11 @@ module('Acceptance | regions (only one)', function (hooks) {
 
     assert.notOk(Layout.navbar.regionSwitcher.isPresent, 'No region switcher');
     assert.ok(Layout.navbar.singleRegion.isPresent, 'Single region');
+    assert.equal(
+      Layout.navbar.singleRegion.text,
+      'Region: some-region',
+      'Single region name is shown',
+    );
   });
 
   test('pages do not include the region query param', async function (assert) {


### PR DESCRIPTION
The region picker should display the configured region when the cluster is not federated. Previously the picker would return null if a region was not stored in localstorage which in single region clusters resulted in an empty region identifier.

The change ensures this is populated with the region identifier if no region is found in localstorage and there are no federated clusters.

### Testing & Reproduction steps
Run `nomad agent -dev -region=nmd-eng` with and without this change and check the header on the UI landing page when authenticated.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

