### PR TITLE
ui: use registry for stats tracker

### DIFF
--- a/ui/app/components/allocation-row.js
+++ b/ui/app/components/allocation-row.js
@@ -10,7 +10,6 @@ import { computed as overridable } from 'ember-overridable-computed';
 import { scheduleOnce } from '@ember/runloop';
 import { task, timeout } from 'ember-concurrency';
 import { lazyClick } from '../helpers/lazy-click';
-import AllocationStatsTracker from 'nomad-ui/utils/classes/allocation-stats-tracker';
 import classic from 'ember-classic-decorator';
 import ENV from 'nomad-ui/config/environment';
 import {
@@ -30,6 +29,7 @@ import {
 export default class AllocationRow extends Component {
   @service store;
   @service token;
+  @service('stats-trackers-registry') statsTrackersRegistry;
 
   allocation = null;
 
@@ -45,10 +45,7 @@ export default class AllocationRow extends Component {
   get stats() {
     if (!this.get('allocation.isRunning')) return undefined;
 
-    return AllocationStatsTracker.create({
-      fetch: (url) => this.token.authorizedRequest(url),
-      allocation: this.allocation,
-    });
+    return this.statsTrackersRegistry.getTracker(this.allocation);
   }
 
   @computed('stats.cpu.[]')


### PR DESCRIPTION
### Description

When viewing a job overview in the UI, two stats requests are setup for polling. This occurs because multiple components are setting up the stats polling, but the main allocation row component is not using the tracker registry like the other components. This results in the allocation row component creating its own stats poller, instead of creating a shared one in the registry, which results in duplicate requests. Adjusting to use the registry removes the duplicate request.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
