### PR TITLE
Scheduler/plan applier memory allocation optimizations

### DIFF
--- a/nomad/mock/alloc.go
+++ b/nomad/mock/alloc.go
@@ -152,7 +152,16 @@ func AllocForNode(n *structs.Node) *structs.Allocation {
 
 }
 
-func AllocForNodeWithoutReservedPort(n *structs.Node) *structs.Allocation {
+type AllocOption func(a *structs.Allocation)
+
+func WithDynamicPort(port int) AllocOption {
+	return func(a *structs.Allocation) {
+		a.TaskResources["web"].Networks[0].DynamicPorts = []structs.Port{{Label: "http", Value: port}}
+		a.AllocatedResources.Tasks["web"].Networks[0].DynamicPorts = []structs.Port{{Label: "http", Value: port}}
+	}
+}
+
+func AllocForNodeWithoutReservedPort(n *structs.Node, opt ...AllocOption) *structs.Allocation {
 	nodeIP := n.NodeResources.NodeNetworks[0].Addresses[0].Address
 
 	dynamicPortRange := structs.DefaultMaxDynamicPort - structs.DefaultMinDynamicPort
@@ -169,6 +178,10 @@ func AllocForNodeWithoutReservedPort(n *structs.Node) *structs.Allocation {
 	// Set dynamic port to a random value.
 	alloc.TaskResources["web"].Networks[0].DynamicPorts = []structs.Port{{Label: "http", Value: randomDynamicPort}}
 	alloc.AllocatedResources.Tasks["web"].Networks[0].DynamicPorts = []structs.Port{{Label: "http", Value: randomDynamicPort}}
+
+	for _, o := range opt {
+		o(alloc)
+	}
 
 	return alloc
 }

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -755,8 +755,11 @@ func evaluateNodePlan(snap *state.StateSnapshot, plan *structs.Plan, nodeID stri
 	proposed := structs.RemoveAllocs(existingAlloc, remove)
 	proposed = append(proposed, plan.NodeAllocation[nodeID]...)
 
+	allocResources := make(structs.AllocResourceCache)
+	allocResources.Insert(proposed)
+
 	// Check if these allocations fit
-	fit, reason, _, err := structs.AllocsFit(node, proposed, nil, true)
+	fit, reason, _, err := structs.AllocsFit(node, allocResources, nil, true)
 	return fit, reason, err
 }
 

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -755,7 +755,7 @@ func evaluateNodePlan(snap *state.StateSnapshot, plan *structs.Plan, nodeID stri
 	proposed := structs.RemoveAllocs(existingAlloc, remove)
 	proposed = append(proposed, plan.NodeAllocation[nodeID]...)
 
-	allocResources := make(structs.AllocResourceCache)
+	allocResources := make(structs.AllocResourceCache, len(proposed))
 	allocResources.Insert(proposed)
 
 	// Check if these allocations fit

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -139,11 +139,11 @@ func (a TerminalByNodeByName) Get(nodeID, name string) (*Allocation, bool) {
 // If the netIdx is provided, it is assumed that the client has already
 // ensured there are no collisions. If checkDevices is set to true, we check if
 // there is a device oversubscription.
-func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevices bool) (bool, string, *ComparableResources, error) {
+func AllocsFit(node *Node, allocWithCmp AllocResourceCache, netIdx *NetworkIndex, checkDevices bool) (bool, string, *ComparableResources, error) {
 	// Compute the allocs' utilization from zero
 	used := new(ComparableResources)
 	if node.NodeMaxAllocs != 0 {
-		if node.NodeMaxAllocs < len(allocs) {
+		if node.NodeMaxAllocs < len(allocWithCmp) {
 			return false, "max allocation exceeded", used, fmt.Errorf("plan exceeds max allocation")
 		}
 	}
@@ -153,19 +153,21 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevi
 	hostVolumeClaims := map[string]int{}
 	exclusiveHostVolumeClaims := []string{}
 
+	allocs := make([]*Allocation, len(allocWithCmp))
 	// For each alloc, add the resources
-	for _, alloc := range allocs {
+	for _, a := range allocWithCmp {
 		// Do not consider the resource impact of terminal allocations
-		if alloc.ClientTerminalStatus() {
+		if a.Alloc.ClientTerminalStatus() {
 			continue
 		}
 
 		// Comparable makes a deep copy, so we can merge it with used.
-		cr := alloc.AllocatedResources.Comparable()
-		used.Merge(cr)
+		used.Merge(a.Resource)
+
+		allocs = append(allocs, a.Alloc)
 
 		// Adding the comparable resource unions reserved core sets, need to check if reserved cores overlap
-		for _, core := range cr.Flattened.Cpu.ReservedCores {
+		for _, core := range a.Resource.Flattened.Cpu.ReservedCores {
 			if _, ok := reservedCores[core]; ok {
 				coreOverlap = true
 			} else {
@@ -174,8 +176,8 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevi
 		}
 
 		// Job will be nil in the scheduler, where we're not performing this check anyways
-		if checkDevices && alloc.Job != nil {
-			group := alloc.Job.LookupTaskGroup(alloc.TaskGroup)
+		if checkDevices && a.Alloc.Job != nil {
+			group := a.Alloc.Job.LookupTaskGroup(a.Alloc.TaskGroup)
 			for _, volReq := range group.Volumes {
 				hostVolumeClaims[volReq.Source]++
 				if volReq.AccessMode ==

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -154,8 +154,14 @@ func AllocsFit(node *Node, allocWithCmp AllocResourceCache, netIdx *NetworkIndex
 	exclusiveHostVolumeClaims := []string{}
 
 	allocs := make([]*Allocation, len(allocWithCmp))
+	idx := 0
+
 	// For each alloc, add the resources
 	for _, a := range allocWithCmp {
+
+		allocs[idx] = a.Alloc
+		idx++
+
 		// Do not consider the resource impact of terminal allocations
 		if a.Alloc.ClientTerminalStatus() {
 			continue
@@ -163,8 +169,6 @@ func AllocsFit(node *Node, allocWithCmp AllocResourceCache, netIdx *NetworkIndex
 
 		// Comparable makes a deep copy, so we can merge it with used.
 		used.Merge(a.Resource)
-
-		allocs = append(allocs, a.Alloc)
 
 		// Adding the comparable resource unions reserved core sets, need to check if reserved cores overlap
 		for _, core := range a.Resource.Flattened.Cpu.ReservedCores {

--- a/nomad/structs/funcs.go
+++ b/nomad/structs/funcs.go
@@ -160,8 +160,9 @@ func AllocsFit(node *Node, allocs []*Allocation, netIdx *NetworkIndex, checkDevi
 			continue
 		}
 
+		// Comparable makes a deep copy, so we can merge it with used.
 		cr := alloc.AllocatedResources.Comparable()
-		used.Add(cr)
+		used.Merge(cr)
 
 		// Adding the comparable resource unions reserved core sets, need to check if reserved cores overlap
 		for _, core := range cr.Flattened.Cpu.ReservedCores {

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3732,6 +3732,30 @@ type NodeReservedNetworkResources struct {
 	ReservedHostPorts string
 }
 
+// AllocWithCmpResource is an object used to cache an allocation with it's
+// AllocatedResources converted into a ComparableResource.
+//
+// Converting an AllocatedResource into a ComparableResource is an expensive
+// operation so this is a use optimization instead of repeatedly calling
+// alloc.AllocatedResource.Comparable().
+type AllocWithCmpResource struct {
+	Alloc    *Allocation
+	Resource *ComparableResources
+}
+
+type AllocResourceCache map[string]AllocWithCmpResource
+
+// Insert is used to easily insert a slice of allocations into the
+// resource cache.
+func (a AllocResourceCache) Insert(allocs []*Allocation) {
+	for _, alloc := range allocs {
+		a[alloc.ID] = AllocWithCmpResource{
+			Alloc:    alloc,
+			Resource: alloc.AllocatedResources.Comparable(),
+		}
+	}
+}
+
 // AllocatedResources is the set of resources to be used by an allocation.
 type AllocatedResources struct {
 	// Tasks is a mapping of task name to the resources for the task.

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -2941,12 +2941,10 @@ func (n *NetworkResource) Copy() *NetworkResource {
 	*newR = *n
 	newR.DNS = n.DNS.Copy()
 	if n.ReservedPorts != nil {
-		newR.ReservedPorts = make([]Port, len(n.ReservedPorts))
-		copy(newR.ReservedPorts, n.ReservedPorts)
+		newR.ReservedPorts = slices.Clone(n.ReservedPorts)
 	}
 	if n.DynamicPorts != nil {
-		newR.DynamicPorts = make([]Port, len(n.DynamicPorts))
-		copy(newR.DynamicPorts, n.DynamicPorts)
+		newR.DynamicPorts = slices.Clone(n.DynamicPorts)
 	}
 	return newR
 }

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3781,6 +3781,8 @@ func (a *AllocatedResources) Copy() *AllocatedResources {
 
 // Comparable returns a comparable version of the allocations allocated
 // resources. This conversion can be lossy so care must be taken when using it.
+//
+// Comparable returns a deep copy of the values pointed to by AllocatedResources.
 func (a *AllocatedResources) Comparable() *ComparableResources {
 	if a == nil {
 		return nil
@@ -3797,37 +3799,44 @@ func (a *AllocatedResources) Comparable() *ComparableResources {
 
 	for taskName, taskResources := range a.Tasks {
 		taskLifecycle := a.TaskLifecycles[taskName]
-		fungibleTaskResources := taskResources.Copy()
+
+		// Make a shallow copy here, only turn this into a deep copy
+		// if we have reserved cores and absolutely have to.
+		trCopy := taskResources
 
 		// Reserved cores (and their respective bandwidth) are not fungible,
 		// hence we should always include it as part of the Flattened resources.
-		if len(fungibleTaskResources.Cpu.ReservedCores) > 0 {
-			c.Flattened.Cpu.Add(&fungibleTaskResources.Cpu)
-			fungibleTaskResources.Cpu = AllocatedCpuResources{}
+		if len(trCopy.Cpu.ReservedCores) > 0 {
+			// Deep copy, so we can mutate it
+			trCopy = taskResources.Copy()
+			c.Flattened.Cpu.Add(&trCopy.Cpu)
+			trCopy.Cpu = AllocatedCpuResources{}
 		}
 
 		if taskLifecycle == nil {
-			mainLifecycle.Add(fungibleTaskResources)
+			mainLifecycle.Merge(trCopy)
 		} else if taskLifecycle.Hook == TaskLifecycleHookPrestart {
 			if taskLifecycle.Sidecar {
 				// These tasks span both the prestart and main lifecycle
-				prestartLifecycle.Add(fungibleTaskResources)
-				mainLifecycle.Add(fungibleTaskResources)
+				prestartLifecycle.Merge(trCopy)
+				mainLifecycle.Merge(trCopy)
 			} else {
-				prestartLifecycle.Add(fungibleTaskResources)
+				prestartLifecycle.Merge(trCopy)
 			}
 		} else if taskLifecycle.Hook == TaskLifecycleHookPoststart {
-			mainLifecycle.Add(fungibleTaskResources)
+			mainLifecycle.Merge(trCopy)
 		} else if taskLifecycle.Hook == TaskLifecycleHookPoststop {
-			stopLifecycle.Add(fungibleTaskResources)
+			stopLifecycle.Merge(trCopy)
 		}
+
 	}
 
 	// Update the main lifecycle to reflect the largest fungible resource set
 	mainLifecycle.Max(prestartLifecycle)
 	mainLifecycle.Max(stopLifecycle)
 
-	// Add the fungible resources
+	// Add the fungible resources. Importantly, this
+	// copies mainLifecycle into Flattened.
 	c.Flattened.Add(mainLifecycle)
 
 	// Add network resources that are at the task group level
@@ -3896,7 +3905,7 @@ func (a *AllocatedTaskResources) Copy() *AllocatedTaskResources {
 	if newA.Devices != nil {
 		n := len(a.Devices)
 		newA.Devices = make([]*AllocatedDeviceResource, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			newA.Devices[i] = a.Devices[i].Copy()
 		}
 	}
@@ -3909,6 +3918,8 @@ func (a *AllocatedTaskResources) NetIndex(n *NetworkResource) int {
 	return a.Networks.NetIndex(n)
 }
 
+// Add creates deep copies of pointer values from delta and adds them to
+// the allocatedTaskResource object.
 func (a *AllocatedTaskResources) Add(delta *AllocatedTaskResources) {
 	if delta == nil {
 		return
@@ -3932,6 +3943,37 @@ func (a *AllocatedTaskResources) Add(delta *AllocatedTaskResources) {
 		idx := AllocatedDevices(a.Devices).Index(d)
 		if idx == -1 {
 			a.Devices = append(a.Devices, d.Copy())
+		} else {
+			a.Devices[idx].Add(d)
+		}
+	}
+}
+
+// Merge takes delta's pointers and merges them with a's parameters. This is useful
+// to avoid the cost of copying when doing intermediate task resource adding.
+func (a *AllocatedTaskResources) Merge(delta *AllocatedTaskResources) {
+	if delta == nil {
+		return
+	}
+
+	a.Cpu.Add(&delta.Cpu)
+	a.Memory.Add(&delta.Memory)
+
+	for _, n := range delta.Networks {
+		// Find the matching interface by IP or CIDR
+		idx := a.NetIndex(n)
+		if idx == -1 {
+			a.Networks = append(a.Networks, n)
+		} else {
+			a.Networks[idx].Add(n)
+		}
+	}
+
+	for _, d := range delta.Devices {
+		// Find the matching device
+		idx := AllocatedDevices(a.Devices).Index(d)
+		if idx == -1 {
+			a.Devices = append(a.Devices, d)
 		} else {
 			a.Devices[idx].Add(d)
 		}
@@ -4018,7 +4060,6 @@ func (a *AllocatedSharedResources) Add(delta *AllocatedSharedResources) {
 	}
 	a.Networks = append(a.Networks, delta.Networks...)
 	a.DiskMB += delta.DiskMB
-
 }
 
 func (a *AllocatedSharedResources) Subtract(delta *AllocatedSharedResources) {
@@ -4071,11 +4112,24 @@ func (a *AllocatedCpuResources) Add(delta *AllocatedCpuResources) {
 	// add cpu bandwidth
 	a.CpuShares += delta.CpuShares
 
+	seen := make(map[uint16]struct{}, len(a.ReservedCores)+len(delta.ReservedCores))
+	union := make([]uint16, 0, len(a.ReservedCores)+len(delta.ReservedCores))
+
+	for _, v := range a.ReservedCores {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			union = append(union, v)
+		}
+	}
+
+	for _, v := range delta.ReservedCores {
+		if _, ok := seen[v]; !ok {
+			seen[v] = struct{}{}
+			union = append(union, v)
+		}
+	}
 	// add cpu cores
-	cores := idset.From[uint16](a.ReservedCores)
-	deltaCores := idset.From[uint16](delta.ReservedCores)
-	cores.InsertSet(deltaCores)
-	a.ReservedCores = cores.Slice()
+	a.ReservedCores = union
 }
 
 func (a *AllocatedCpuResources) Subtract(delta *AllocatedCpuResources) {
@@ -4083,14 +4137,21 @@ func (a *AllocatedCpuResources) Subtract(delta *AllocatedCpuResources) {
 		return
 	}
 
+	tmp := map[uint16]struct{}{}
+
+	for _, v := range a.ReservedCores {
+		tmp[v] = struct{}{}
+	}
+
+	// remove cpu cores
+	for _, v := range delta.ReservedCores {
+		delete(tmp, v)
+	}
+
 	// remove cpu bandwidth
 	a.CpuShares -= delta.CpuShares
 
-	// remove cpu cores
-	cores := idset.From[uint16](a.ReservedCores)
-	deltaCores := idset.From[uint16](delta.ReservedCores)
-	cores.RemoveSet(deltaCores)
-	a.ReservedCores = cores.Slice()
+	a.ReservedCores = slices.Collect(maps.Keys(tmp))
 }
 
 func (a *AllocatedCpuResources) Max(other *AllocatedCpuResources) {
@@ -4228,6 +4289,16 @@ func (c *ComparableResources) Add(delta *ComparableResources) {
 	}
 
 	c.Flattened.Add(&delta.Flattened)
+	c.Shared.Add(&delta.Shared)
+}
+
+func (c *ComparableResources) Merge(delta *ComparableResources) {
+	if delta == nil {
+		return
+	}
+
+	c.Flattened.Merge(&delta.Flattened)
+	// Shared does not have pointers, so we can just use Add.
 	c.Shared.Add(&delta.Shared)
 }
 

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -3838,37 +3838,34 @@ func (a *AllocatedResources) Comparable() *ComparableResources {
 		}
 
 		if taskLifecycle == nil {
-			mainLifecycle.Merge(trCopy)
+			mainLifecycle.Add(trCopy)
 		} else if taskLifecycle.Hook == TaskLifecycleHookPrestart {
 			if taskLifecycle.Sidecar {
 				// These tasks span both the prestart and main lifecycle
-				prestartLifecycle.Merge(trCopy)
-				mainLifecycle.Merge(trCopy)
+				prestartLifecycle.Add(trCopy)
+				mainLifecycle.Add(trCopy)
 			} else {
-				prestartLifecycle.Merge(trCopy)
+				prestartLifecycle.Add(trCopy)
 			}
 		} else if taskLifecycle.Hook == TaskLifecycleHookPoststart {
-			mainLifecycle.Merge(trCopy)
+			mainLifecycle.Add(trCopy)
 		} else if taskLifecycle.Hook == TaskLifecycleHookPoststop {
-			stopLifecycle.Merge(trCopy)
+			stopLifecycle.Add(trCopy)
 		}
-
 	}
 
 	// Update the main lifecycle to reflect the largest fungible resource set
 	mainLifecycle.Max(prestartLifecycle)
 	mainLifecycle.Max(stopLifecycle)
 
-	// Add the fungible resources. Importantly, this
-	// copies mainLifecycle into Flattened.
-	c.Flattened.Add(mainLifecycle)
-
 	// Add network resources that are at the task group level
-	for _, network := range a.Shared.Networks {
-		c.Flattened.Add(&AllocatedTaskResources{
-			Networks: []*NetworkResource{network},
-		})
-	}
+	mainLifecycle.Add(&AllocatedTaskResources{
+		Networks: a.Shared.Networks,
+	})
+
+	// The values in mainLifecycle were copied from the tasks resources,
+	// so we can just merge them into Flattened to avoid the unnecessary copy.
+	c.Flattened.Merge(mainLifecycle)
 
 	return c
 }
@@ -4163,13 +4160,13 @@ func (a *AllocatedCpuResources) Subtract(delta *AllocatedCpuResources) {
 
 	tmp := map[uint16]struct{}{}
 
-	for _, v := range a.ReservedCores {
-		tmp[v] = struct{}{}
+	for _, core := range a.ReservedCores {
+		tmp[core] = struct{}{}
 	}
 
 	// remove cpu cores
-	for _, v := range delta.ReservedCores {
-		delete(tmp, v)
+	for _, core := range delta.ReservedCores {
+		delete(tmp, core)
 	}
 
 	// remove cpu bandwidth

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -7092,9 +7092,9 @@ func TestComparableResources_Superset(t *testing.T) {
 }
 
 func TestAllocatedResources_Comparable_Mutate(t *testing.T) {
-	allocationResources := AllocatedResources{
+	testResources := &AllocatedResources{
 		Tasks: map[string]*AllocatedTaskResources{
-			"main-task": {
+			"foo": {
 				Cpu: AllocatedCpuResources{
 					CpuShares: 2000,
 				},
@@ -7104,26 +7104,55 @@ func TestAllocatedResources_Comparable_Mutate(t *testing.T) {
 				Networks: Networks{
 					{
 						Mode: "test",
+						DynamicPorts: []Port{
+							{Label: "port", Value: 2},
+						},
 					},
 				},
 				Devices: []*AllocatedDeviceResource{
 					{
-						Vendor: "test",
+						Vendor:    "test",
+						DeviceIDs: []string{},
+					},
+				},
+			},
+			"bar": {
+				Cpu: AllocatedCpuResources{
+					CpuShares: 2000,
+				},
+				Memory: AllocatedMemoryResources{
+					MemoryMB: 2000,
+				},
+				Networks: Networks{
+					{
+						Mode: "test",
+						DynamicPorts: []Port{
+							{Label: "port", Value: 1},
+						},
+					},
+				},
+				Devices: []*AllocatedDeviceResource{
+					{
+						Vendor:    "test",
+						DeviceIDs: []string{},
 					},
 				},
 			},
 		},
 	}
 
-	res := allocationResources.Comparable()
+	// make a copy to compare later to make sure we did not mutate
+	// the original resources.
+	testResourcesCopy := testResources.Copy()
+
+	res := testResources.Comparable()
 
 	// mutate all pointers object that would be mutable if Comparable was shallow.
 	res.Flattened.Networks[0].Mode = "mutated"
 	res.Flattened.Devices[0].Vendor = "mutated"
 
 	// assert that it did not mutate the original allocationResource
-	must.NotEq(t, res.Flattened.Networks, allocationResources.Tasks["main-task"].Networks)
-	must.NotEq(t, res.Flattened.Devices, allocationResources.Tasks["main-task"].Devices)
+	must.Eq(t, testResources, testResourcesCopy)
 }
 
 func TestAllocatedResources_Comparable_Flattened(t *testing.T) {

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -7091,6 +7091,41 @@ func TestComparableResources_Superset(t *testing.T) {
 	}
 }
 
+func TestAllocatedResources_Comparable_Mutate(t *testing.T) {
+	allocationResources := AllocatedResources{
+		Tasks: map[string]*AllocatedTaskResources{
+			"main-task": {
+				Cpu: AllocatedCpuResources{
+					CpuShares: 2000,
+				},
+				Memory: AllocatedMemoryResources{
+					MemoryMB: 2000,
+				},
+				Networks: Networks{
+					{
+						Mode: "test",
+					},
+				},
+				Devices: []*AllocatedDeviceResource{
+					{
+						Vendor: "test",
+					},
+				},
+			},
+		},
+	}
+
+	res := allocationResources.Comparable()
+
+	// mutate all pointers object that would be mutable if Comparable was shallow.
+	res.Flattened.Networks[0].Mode = "mutated"
+	res.Flattened.Devices[0].Vendor = "mutated"
+
+	// assert that it did not mutate the original allocationResource
+	must.NotEq(t, res.Flattened.Networks, allocationResources.Tasks["main-task"].Networks)
+	must.NotEq(t, res.Flattened.Devices, allocationResources.Tasks["main-task"].Devices)
+}
+
 func TestAllocatedResources_Comparable_Flattened(t *testing.T) {
 	ci.Parallel(t)
 

--- a/scheduler/feasible/rank.go
+++ b/scheduler/feasible/rank.go
@@ -225,6 +225,9 @@ NEXTNODE:
 			continue
 		}
 
+		allocResources := make(structs.AllocResourceCache)
+		allocResources.Insert(proposed)
+
 		// Index the existing network usage.
 		// This should never collide, since it represents the current state of
 		// the node. If it does collide though, it means we found a bug! So
@@ -473,9 +476,8 @@ NEXTNODE:
 
 				// set of already consumed cores on this node
 				consumedCores := idset.Empty[hw.CoreID]()
-				for _, alloc := range proposed {
-					allocCores := alloc.AllocatedResources.Comparable().Flattened.Cpu.ReservedCores
-					idset.InsertSlice(consumedCores, allocCores...)
+				for _, val := range allocResources {
+					idset.InsertSlice(consumedCores, val.Resource.Flattened.Cpu.ReservedCores...)
 				}
 
 				// add cores reserved for other tasks
@@ -694,9 +696,8 @@ NEXTNODE:
 
 				// set of consumed cores on this node
 				consumedCores := idset.Empty[hw.CoreID]()
-				for _, alloc := range proposed { // proposed is existing + proposal
-					allocCores := alloc.AllocatedResources.Comparable().Flattened.Cpu.ReservedCores
-					idset.InsertSlice(consumedCores, allocCores...)
+				for _, val := range allocResources {
+					idset.InsertSlice(consumedCores, val.Resource.Flattened.Cpu.ReservedCores...)
 				}
 
 				// add cores reserved for other tasks
@@ -749,7 +750,7 @@ NEXTNODE:
 		proposed = append(proposed, &structs.Allocation{AllocatedResources: total})
 
 		// Check if these allocations fit, if they do not, simply skip this node
-		fit, dim, util, _ := structs.AllocsFit(option.Node, proposed, netIdx, false)
+		fit, dim, util, _ := structs.AllocsFit(option.Node, allocResources, netIdx, false)
 		netIdx.Release()
 		if !fit {
 			// Skip the node if evictions are not enabled

--- a/scheduler/feasible/rank.go
+++ b/scheduler/feasible/rank.go
@@ -225,7 +225,7 @@ NEXTNODE:
 			continue
 		}
 
-		allocResources := make(structs.AllocResourceCache)
+		allocResources := make(structs.AllocResourceCache, len(proposed))
 		allocResources.Insert(proposed)
 
 		// Index the existing network usage.


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
Draft until `AllocFits` tests are updated.

These changes optimize the `AllocationResources.Comparable()` method to eliminate unnecessary memory allocations, and updates the `BinpackIterator.Next()` method so it only calls this method once per node allocation.

Benchmarks:

The below benchmarks were run with a mocked cluster of 200 nodes, each with 50 existing allocations, and trying to place a service job with `count = 5`. The benchmarks start with an allocation requesting cpu/mem mhz and increasingly stress scheduler logic by requesting specific cores and finally requesting both cores and a device.

<details>
<summary>Simple Allocation</summary>
Before:

```
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/nomad/scheduler/benchmarks
cpu: Apple M3 Pro
BenchmarkServiceScheduler-12    	     163	   7819044 ns/op	 9550379 B/op	  167621 allocs/op
```
After:

```
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/nomad/scheduler/benchmarks
cpu: Apple M3 Pro
BenchmarkServiceScheduler-12    	     298	   3877881 ns/op	 4390502 B/op	   34943 allocs/op
```
</details>

<details>
<summary>Allocation with reserved cores</summary>
Before:

```
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/nomad/scheduler/benchmarks
cpu: Apple M3 Pro
BenchmarkServiceScheduler-12    	     100	  11069265 ns/op	16127775 B/op	  290313 allocs/op
```
After:

```
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/nomad/scheduler/benchmarks
cpu: Apple M3 Pro
BenchmarkServiceScheduler-12    	     274	   4177618 ns/op	 4430708 B/op	   36190 allocs/op
```
</details>

<details>
<summary>Allocation with reserved cores and device</summary>
Before:

```
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/nomad/scheduler/benchmarks
cpu: Apple M3 Pro
BenchmarkServiceScheduler-12    	      81	  14542389 ns/op	22809615 B/op	  414108 allocs/op
```
After:

```
goos: darwin
goarch: arm64
pkg: github.com/hashicorp/nomad/scheduler/benchmarks
cpu: Apple M3 Pro
BenchmarkServiceScheduler-12    	     284	   3983985 ns/op	 4577972 B/op	   38831 allocs/op
```
</details>

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
