### PR TITLE
scheduler: Remove system canarying deployment state tautological.

### DIFF
--- a/scheduler/scheduler_system.go
+++ b/scheduler/scheduler_system.go
@@ -411,11 +411,10 @@ func (s *SystemScheduler) computeJobAllocs() error {
 		// submitted jobs should have a non-empty update block as part of
 		// canonicalization)
 		// - canary parameter in the update block has to be positive
-		// - deployment has to be non-nil and it cannot have been promoted
+		// - deployment cannot have been promoted
 		// - this cannot be the initial job version
 		isCanarying := !tg.Update.IsEmpty() &&
 			tg.Update.Canary > 0 &&
-			dstate != nil &&
 			!dstate.Promoted &&
 			s.job.Version != 0 &&
 			s.tgDestructiveUpdateCounts[tg.Name] > 0


### PR DESCRIPTION
The deployment state is checked for nilness and the loop continues in the previous conditional. This means dstate can never be nil when the changed check is performed.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

