### PR TITLE
keyring: migrate to using v2 wrapper library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -60,6 +60,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0
 	github.com/hashicorp/go-kms-wrapping/v2 v2.0.23
+	github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2 v2.0.10
 	github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v2 v2.0.11
 	github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault/v2 v2.0.15
 	github.com/hashicorp/go-kms-wrapping/wrappers/gcpckms/v2 v2.0.14

--- a/go.sum
+++ b/go.sum
@@ -462,6 +462,8 @@ github.com/hashicorp/go-immutable-radix/v2 v2.1.0 h1:CUW5RYIcysz+D3B+l1mDeXrQ7fU
 github.com/hashicorp/go-immutable-radix/v2 v2.1.0/go.mod h1:hgdqLXA4f6NIjRVisM1TJ9aOJVNRqKZj+xDGF6m7PBw=
 github.com/hashicorp/go-kms-wrapping/v2 v2.0.23 h1:HZOdsAP0hZMIF/61v4B31DBbKx7NbtWmgBS6WEUOZvU=
 github.com/hashicorp/go-kms-wrapping/v2 v2.0.23/go.mod h1:NeK2Ul15t1zutp/dZzt28XQrGZHosbxE/QLNNfaWObM=
+github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2 v2.0.10 h1:am7ai27sEGpfOefHhUShbWAOa6EvkBaiMpB7zZ/PUyo=
+github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2 v2.0.10/go.mod h1:sYX07HI7wMCFe9+FmxMOCwJ7q5CD4aq3VI+KoB8FYZY=
 github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v2 v2.0.11 h1:J9zGa9SlcOHT3SQTj0Vv3shHo0anWbs58weURGCgChI=
 github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v2 v2.0.11/go.mod h1:iAOCu7/lG5eugg8+k7NVvQt0IpWT8s2Q9wnMtC/guM4=
 github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault/v2 v2.0.15 h1:Y73Tv263K936w0jdmHUPLHsf7fQdDpIyvz9z98JsvCE=

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -277,7 +277,7 @@ func (e *Encrypter) Encrypt(cleartext []byte) ([]byte, string, error) {
 	keyID := cs.rootKey.Meta.KeyID
 	additional := kms.WithAad([]byte(keyID)) // include the keyID in the seal inputs
 
-	bi, err := cs.wrapper.Encrypt(context.Background(), cleartext, additional)
+	bi, err := cs.wrapper.Encrypt(e.srv.shutdownCtx, cleartext, additional)
 	if err != nil {
 		return nil, "", fmt.Errorf("could not encrypt: %w", err)
 	}

--- a/nomad/encrypter.go
+++ b/nomad/encrypter.go
@@ -5,8 +5,6 @@ package nomad
 
 import (
 	"context"
-	"crypto/aes"
-	"crypto/cipher"
 	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/x509"
@@ -24,7 +22,7 @@ import (
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/hashicorp/go-hclog"
 	kms "github.com/hashicorp/go-kms-wrapping/v2"
-	"github.com/hashicorp/go-kms-wrapping/v2/aead"
+	"github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2"
 	"github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v2"
 	"github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault/v2"
 	"github.com/hashicorp/go-kms-wrapping/wrappers/gcpckms/v2"
@@ -80,7 +78,7 @@ type Encrypter struct {
 // disambiguate which signing algorithm to use.
 type cipherSet struct {
 	rootKey           *structs.UnwrappedRootKey
-	cipher            cipher.AEAD
+	wrapper           kms.Wrapper
 	eddsaPrivateKey   ed25519.PrivateKey
 	rsaPrivateKey     *rsa.PrivateKey
 	rsaPKCS1PublicKey []byte // PKCS #1 DER encoded public key for JWKS
@@ -271,32 +269,24 @@ func (e *Encrypter) IsReady(ctx context.Context) error {
 // returns the cipher text (including the nonce), and the key ID used to encrypt
 // it
 func (e *Encrypter) Encrypt(cleartext []byte) ([]byte, string, error) {
-
 	cs, err := e.activeCipherSet()
 	if err != nil {
 		return nil, "", err
 	}
 
-	nonce, err := crypto.Bytes(cs.cipher.NonceSize())
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to generate key wrapper nonce: %v", err)
-	}
-
 	keyID := cs.rootKey.Meta.KeyID
-	additional := []byte(keyID) // include the keyID in the signature inputs
+	additional := kms.WithAad([]byte(keyID)) // include the keyID in the seal inputs
 
-	// we use the nonce as the dst buffer so that the ciphertext is appended to
-	// that buffer and we always keep the nonce and ciphertext together, and so
-	// that we're not tempted to reuse the cleartext buffer which the caller
-	// still owns
-	ciphertext := cs.cipher.Seal(nonce, nonce, cleartext, additional)
-	return ciphertext, keyID, nil
+	bi, err := cs.wrapper.Encrypt(context.Background(), cleartext, additional)
+	if err != nil {
+		return nil, "", fmt.Errorf("could not encrypt: %w", err)
+	}
+	return bi.Ciphertext, keyID, nil
 }
 
 // Decrypt takes an encrypted buffer and then root key ID. It extracts
 // the nonce, decrypts the content, and returns the cleartext data.
 func (e *Encrypter) Decrypt(ciphertext []byte, keyID string) ([]byte, error) {
-
 	ctx, cancel := context.WithTimeout(e.srv.shutdownCtx, time.Second)
 	defer cancel()
 	ks, err := e.waitForKey(ctx, keyID)
@@ -304,11 +294,11 @@ func (e *Encrypter) Decrypt(ciphertext []byte, keyID string) ([]byte, error) {
 		return nil, err
 	}
 
-	nonceSize := ks.cipher.NonceSize()
-	nonce := ciphertext[:nonceSize] // nonce was stored alongside ciphertext
-	additional := []byte(keyID)     // keyID was included in the signature inputs
-
-	return ks.cipher.Open(nil, nonce, ciphertext[nonceSize:], additional)
+	additional := kms.WithAad([]byte(keyID)) // keyID was included in the seal inputs
+	bi := &kms.BlobInfo{
+		Ciphertext: ciphertext, // nonce was stored alongside ciphertext
+	}
+	return ks.wrapper.Decrypt(ctx, bi, additional)
 }
 
 // keyIDHeader is the JWT header for the Nomad Key ID used to sign the
@@ -667,17 +657,19 @@ func (e *Encrypter) generateCipher(rootKey *structs.UnwrappedRootKey) (*cipherSe
 	if rootKey == nil || rootKey.Meta == nil {
 		return nil, fmt.Errorf("missing metadata")
 	}
-	var aeadCipher cipher.AEAD
+	var wrapper kms.Wrapper
 
 	switch rootKey.Meta.Algorithm {
 	case structs.EncryptionAlgorithmAES256GCM:
-		block, err := aes.NewCipher(rootKey.Key)
+		wrapper = aead.NewWrapper()
+		_, err := wrapper.SetConfig(context.Background(),
+			aead.WithAeadType(kms.AeadTypeAesGcm),
+			aead.WithHashType(kms.HashTypeSha256),
+			aead.WithKey(rootKey.Key),
+			kms.WithKeyId(rootKey.Meta.KeyID),
+		)
 		if err != nil {
-			return nil, fmt.Errorf("could not create cipher: %v", err)
-		}
-		aeadCipher, err = cipher.NewGCM(block)
-		if err != nil {
-			return nil, fmt.Errorf("could not create cipher: %v", err)
+			return nil, fmt.Errorf("could not configure cipher: %w", err)
 		}
 	default:
 		return nil, fmt.Errorf("invalid algorithm %s", rootKey.Meta.Algorithm)
@@ -687,7 +679,7 @@ func (e *Encrypter) generateCipher(rootKey *structs.UnwrappedRootKey) (*cipherSe
 
 	cs := cipherSet{
 		rootKey:         rootKey,
-		cipher:          aeadCipher,
+		wrapper:         wrapper,
 		eddsaPrivateKey: ed25519Key,
 	}
 
@@ -1083,14 +1075,14 @@ func (e *Encrypter) newKMSWrapper(provider *structs.KEKProviderConfig, keyID str
 
 	default: // "aead"
 		wrapper := aead.NewWrapper()
-		wrapper.SetConfig(context.Background(),
+		_, err := wrapper.SetConfig(context.Background(),
 			aead.WithAeadType(kms.AeadTypeAesGcm),
 			aead.WithHashType(kms.HashTypeSha256),
+			aead.WithKey(kek),
 			kms.WithKeyId(keyID),
 		)
-		err := wrapper.SetAesGcmKeyBytes(kek)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not configure cipher: %w", err)
 		}
 		return wrapper, nil
 	}
@@ -1108,7 +1100,8 @@ func (e *Encrypter) newKMSWrapper(provider *structs.KEKProviderConfig, keyID str
 // KeyringReplicator supports the legacy (pre-1.9.0) keyring management where
 // wrapped keys were stored outside of Raft.
 //
-// COMPAT(1.12.0) - remove in 1.12.0 LTS
+// COMPAT: remove once we can guarantee there are no 1.8.x servers upgradable to
+// current LTS
 type KeyringReplicator struct {
 	srv       *Server
 	encrypter *Encrypter


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the [Go Cryptographic Module](https://go.dev/doc/security/fips140). In `GODEBUG=fips140=only` mode ("enforcing"), the `cipher.NewGCM` function is forbidden and you need to use the `cipher.NewGCMWithNonce` function instead. This prevents applications from reusing the IV (nonce).

The keyring uses `go-kms-wrapping` as the library for setting up ciphers so that we can use AEAD, cloud KMS, or Vault transit encryption for our envelope. But we use the library's low-level AEAD setup for encrypting the message inside, and this has us making our own IV and calling into `crypto/aes` directly instead of using the vetted library functions. We've done this carefully, but doing so will throw errors in FIPS enforcing mode.

The library has not yet been migrated to use `NewGCMWithNonce` (see linked PR), but we can update our callers to use the wrapper now to do the update in stages. Later PRs will update other components to be FIPS-compliant, and once those have all landed we'll have a PR to enabled the FIPS builds.

I've tested that our keyring round-trips between 1.8.x binaries and a build using this changeset, that you can decrypt Variables encrypted by 1.8.x, and verify workload identities signed by 1.8.x, including with mixed clusters and keyring rotations.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://github.com/hashicorp/go-kms-wrapping/pull/331
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140

### Testing & Reproduction steps

See post below: https://github.com/hashicorp/nomad/pull/28338#issuecomment-5132067304

### Contributor Checklist
- [x] **Changelog Entry** no user-visible changes
- [x] **Testing** See post below
- [x] **Documentation** n/a
- [x] **LLM Usage** nope

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
