### PR TITLE
plugins: remove `DriverNetwork.Hash` method

### DIFF
--- a/.changelog/28342.txt
+++ b/.changelog/28342.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+plugin: The `DriverNetwork.Hash` method has been removed from the `plugin/drivers` package.
+```

--- a/plugins/drivers/driver.go
+++ b/plugins/drivers/driver.go
@@ -5,13 +5,11 @@ package drivers
 
 import (
 	"context"
-	"crypto/md5"
 	"fmt"
 	"io"
 	"maps"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"time"
 
 	"github.com/hashicorp/nomad/client/allocdir"
@@ -581,22 +579,6 @@ func (d *DriverNetwork) Copy() *DriverNetwork {
 		IP:            d.IP,
 		AutoAdvertise: d.AutoAdvertise,
 	}
-}
-
-// Hash the contents of a DriverNetwork struct to detect changes. If it is nil,
-// an empty slice is returned.
-func (d *DriverNetwork) Hash() []byte {
-	if d == nil {
-		return []byte{}
-	}
-	h := md5.New()
-	io.WriteString(h, d.IP)
-	io.WriteString(h, strconv.FormatBool(d.AutoAdvertise))
-	for k, v := range d.PortMap {
-		io.WriteString(h, k)
-		io.WriteString(h, strconv.Itoa(v))
-	}
-	return h.Sum(nil)
 }
 
 //// helper types for operating on raw exec operation


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module. In `GODEBUG=fips140=only` mode ("enforcing"), the md5 hash function is disallowed and will panic the agent if you try to call `md5.New()`.

The `DriverNetwork` object is used only by the `docker` driver and we never use the `Hash` function in Nomad. The method was originally introduced in v0.6.0, (ref 4117c8b3a2e) where it was used as part of an optimization meant to reduce writes to the client state database. When the client was reworked in 0.9 it was moved into the plugins package, where it no longer had a purpose.

Unfortunately this method is exposed to external drivers that import the `plugins/drivers` package even though this isn't a tagged released package intended for import. (Including our own external drivers.) I've reviewed all known community drivers for use of this method, and none of them use it. I considered switching this to a SHA256 hash, but that would silently break private plugins we don't know about, as opposed to removing the `Hash()` method and breaking them at compile time, which should be an easily fixed situation. Another alterative would be to leave the method in place because it's not going to be called inside our binary and therefore safe for FIPS builds, but that's just asking for trouble by having someone use it later.

Remove the unused method.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** n/a
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
