### PR TITLE
build: display FIPS-compliant builds in version and startup banner

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,6 +16,7 @@ BUILD_DATE_FLAG = $(GO_MODULE)/version.BuildDate=$(BUILD_DATE)
 GO_LDFLAGS = -X $(GIT_COMMIT_FLAG) -X $(BUILD_DATE_FLAG)
 
 GOPATH := $(shell go env GOPATH)
+GOFIPS140 ?= "off"
 
 # Respect $GOBIN if set in environment or via $GOENV file.
 BIN := $(shell go env GOBIN)
@@ -92,6 +93,7 @@ ifeq (,$(findstring $(THIS_OS),$(SUPPORTED_OSES)))
 endif
 	@echo "==> Building $@ with tags $(GO_TAGS)..."
 	@CGO_ENABLED=$(CGO_ENABLED) \
+		GOFIPS140=$(GOFIPS140) \
 		GOOS=$(firstword $(subst _, ,$*)) \
 		GOARCH=$(lastword $(subst _, ,$*)) \
 		CC=$(CC) \

--- a/command/agent/command.go
+++ b/command/agent/command.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"context"
+	"crypto/fips140"
 	"flag"
 	"fmt"
 	"io"
@@ -918,6 +919,11 @@ func (c *Command) Run(args []string) int {
 	info["advertise addrs"] = c.getAdvertiseAddrSynopsis()
 	if config.Server.Enabled {
 		info["node id"] = c.agent.server.GetConfig().NodeID
+	}
+	if fips140.Enforced() {
+		info["fips mode"] = fmt.Sprintf("FIPS-140-3 enforced (version: %s)", fips140.Version())
+	} else if fips140.Enabled() {
+		info["fips mode"] = fmt.Sprintf("FIPS-140-3 enabled (version: %s)", fips140.Version())
 	}
 
 	// Sort the keys for output

--- a/version/version.go
+++ b/version/version.go
@@ -5,6 +5,7 @@ package version
 
 import (
 	"bytes"
+	"crypto/fips140"
 	"fmt"
 	"time"
 )
@@ -52,6 +53,14 @@ func GetVersion() *VersionInfo {
 	ver := Version
 	rel := VersionPrerelease
 	md := VersionMetadata
+	if fips140.Enabled() {
+		if md == "" {
+			md = "fips1403"
+		} else {
+			md = md + ".fips1403"
+		}
+	}
+
 	if GitDescribe != "" {
 		ver = GitDescribe
 	}


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module.

Add an indicator that we've built a given binary in FIPS-mode in our initial agent banner and the version string. The version string text format matches that of Vault FIPS.

This PR also adds an option to configure builds to use the module in our makefile, so this can be tested. But note that as of this PR Nomad cannot be run in enforcing mode. Later PRs will update other components to be FIPS-compliant, and once those have all landed we'll have a PR to enabled the FIPS builds in our release workflows.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140

### Testing & Reproduction steps

```
$ make dev
==> Formatting HCL
==> Removing old development build...
==> Building pkg/linux_amd64/nomad with tags ui hashicorpmetrics  ...

$ nomad version
Nomad v2.0.5-dev
BuildDate 2026-07-31T00:19:41Z
Revision d1229926a69daa739abc36911a8044e3fcede932

$ GOFIPS140=v1.0.0 make dev
==> Formatting HCL
==> Removing old development build...
==> Building pkg/linux_amd64/nomad with tags ui hashicorpmetrics  ...

$ nomad version
Nomad v2.0.5-dev+fips1403
BuildDate 2026-07-31T00:19:41Z
Revision d1229926a69daa739abc36911a8044e3fcede932

$ nomad agent -config=server.hcl
==> WARNING: mTLS is not configured - Nomad is not secure without mTLS!
==> WARNING: Bootstrap mode enabled! Potentially unsafe operation.
==> Loaded configuration from server.hcl
==> Starting Nomad agent...
==> Nomad agent configuration:

       Advertise Addrs: HTTP: 192.168.1.194:4646; RPC: 192.168.1.194:4647; Serf: 192.168.1.194:4648
            Bind Addrs: HTTP: [0.0.0.0:4646]; RPC: 0.0.0.0:4647; Serf: 0.0.0.0:4648
                Client: false
             Fips Mode: FIPS-140-3 enabled (version: v1.0.0)
             Log Level: info
               Node Id: 327f7027-32b1-1782-2c7e-318ca5a0e12f
                Region: philly (DC: dc1)
                Server: true
               Version: 2.0.5-dev+fips1403

==> Nomad agent started! Log data will stream in below:
```

Note that `GODEBUG=fips140=only` currently panics the server so I can't show enforcing mode here in the banner. That'll happen until we resolve the remaining issues, which I'm working on currently.

### Contributor Checklist
- [x] **Changelog Entry** no changelog needed for this until we have builds
- [x] **Testing** see above
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
