### PR TITLE
jobspec: disable md5/sha1 HCL2 functions in FIPS mode

### DIFF
--- a/jobspec2/functions.go
+++ b/jobspec2/functions.go
@@ -4,6 +4,7 @@
 package jobspec2
 
 import (
+	"crypto/fips140"
 	"fmt"
 
 	"github.com/hashicorp/go-cty-funcs/cidr"
@@ -64,7 +65,6 @@ func Functions(basedir string, allowFS bool) map[string]function.Function {
 		"lookup":          stdlib.LookupFunc,
 		"lower":           stdlib.LowerFunc,
 		"max":             stdlib.MaxFunc,
-		"md5":             crypto.Md5Func,
 		"merge":           stdlib.MergeFunc,
 		"min":             stdlib.MinFunc,
 		"parseint":        stdlib.ParseIntFunc,
@@ -77,7 +77,6 @@ func Functions(basedir string, allowFS bool) map[string]function.Function {
 		"setintersection": stdlib.SetIntersectionFunc,
 		"setproduct":      stdlib.SetProductFunc,
 		"setunion":        stdlib.SetUnionFunc,
-		"sha1":            crypto.Sha1Func,
 		"sha256":          crypto.Sha256Func,
 		"sha512":          crypto.Sha512Func,
 		"signum":          stdlib.SignumFunc,
@@ -112,6 +111,11 @@ func Functions(basedir string, allowFS bool) map[string]function.Function {
 		"fileexists": guardFS(allowFS, filesystem.MakeFileExistsFunc(basedir)),
 		"fileset":    guardFS(allowFS, filesystem.MakeFileSetFunc(basedir)),
 		"pathexpand": guardFS(allowFS, filesystem.PathExpandFunc),
+	}
+
+	if !fips140.Enabled() {
+		funcs["md5"] = crypto.Md5Func
+		funcs["sha1"] = crypto.Sha1Func
 	}
 
 	return funcs

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5,6 +5,7 @@ package structs
 
 import (
 	"bytes"
+	"crypto/fips140"
 	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -9949,8 +9950,14 @@ func (ta *TaskArtifact) validateChecksum() error {
 	expectedLength := 0
 	switch checksumType {
 	case "md5":
+		if fips140.Enabled() {
+			return fmt.Errorf("md5 checksums are not supported in FIPS-140 mode")
+		}
 		expectedLength = md5.Size
 	case "sha1":
+		if fips140.Enabled() {
+			return fmt.Errorf("sha1 checksums are not supported in FIPS-140 mode")
+		}
 		expectedLength = sha1.Size
 	case "sha256":
 		expectedLength = sha256.Size


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module. In `GODEBUG=fips140=only` mode ("enforcing"), the md5 and sha1 hash functions are disallowed and will panic the agent if you try to call `md5.New()` or `sha1.New()`.

Although generally speaking we'd like to avoid having code branches for FIPS, this is existing functionality that non-FIPS users (the overwhelming majority of users) may be relying on. So we'll disable these functions in HCL2 when running on FIPS-enabled builds and attempt to provide reasonable errors rather than panicking.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140

### Testing & Reproduction Steps

<details><summary>artifact.nomad.hcl</summary>

```hcl
job "example" {

  group "group" {

    task "task" {

      driver = "docker"
      user   = "www-data"

      artifact {
        source      = "https://raw.githubusercontent.com/hashicorp/go-set/main/go.mod"
        destination = "local/downloads/go.mod"
        options {
          checksum = "md5:dd582d7121f0624d087f2c13c8b947c0"
        }
        mode        = "file"
      }

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}

```

</details>

```
$ nomad job plan ./artifact.nomad.hcl
Error during plan: Unexpected response code: 500 (1 error occurred:
	* Task group group validation failed: 1 error occurred:
	* Task task validation failed: 1 error occurred:
	* Artifact 1 validation failed: 1 error occurred:
	* md5 checksums are not supported in FIPS-140 mode)
```
<details><summary>hcl2md5.nomad.hcl</summary>

```hcl
job "example" {

  group "group" {

    task "task" {

      driver = "docker"
      user = "www-data"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
      }

      env {
        name = md5("hello world")
      }

      identity {
        env = true
        file = true
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}
```

</details>

Parsing fails with a FIPS-compliant binary. Note that if you use a non-FIPS binary to send the job, it works fine because the HCL2 jobspec parsing happens in the CLI. The server never sees the offending md5 hash function.

```
$ nomad job plan ./hcl2md5.nomad.hcl
Error getting job struct: Error parsing job file from ./hcl2md5.nomad.hcl:
hcl2md5.nomad.hcl:17,16-19: Call to unknown function; There is no function named "md5". Did you mean "max"?
hcl2md5.nomad.hcl:17,16-20: Unsuitable value type; Unsuitable value: value must be known
```


### Contributor Checklist
- [x] **Changelog Entry** no changelog needed for this until we have builds
- [x] **Testing** see above
- [x] **Documentation** I'll roll this documentation into a big docs PR for the whole FIPS feature
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
