### PR TITLE
client: Remount alloc tmpfs on client and alloc recovery.

### DIFF
--- a/.changelog/28345.txt
+++ b/.changelog/28345.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where the client would not remount the secret and private tmpfs after a restart
+```

--- a/client/allocdir/task_dir.go
+++ b/client/allocdir/task_dir.go
@@ -163,13 +163,7 @@ func (t *TaskDir) Build(fsi fsisolation.Mode, chroot map[string]string, username
 		}
 	}
 
-	// Create the secret directory
-	if err := allocMakeSecretsDir(t.SecretsDir, t.secretsInMB, fileMode777); err != nil {
-		return err
-	}
-
-	// Create the private directory
-	if err := allocMakeSecretsDir(t.PrivateDir, defaultSecretDirTmpfsSize, fileMode777); err != nil {
+	if err := t.MakeSecretsDirs(); err != nil {
 		return err
 	}
 
@@ -321,6 +315,20 @@ func (t *TaskDir) embedDirs(entries map[string]string) error {
 		return t.embedDirs(subdirs)
 	}
 
+	return nil
+}
+
+// MakeSecretsDirs ensures the secrets and private directories exist and are
+// backed by a tmpfs mount when the client is running on Linux as root. It is
+// safe to call on first build and on every subsequent restore; the marker-based
+// check in createSecretDir makes it idempotent.
+func (t *TaskDir) MakeSecretsDirs() error {
+	if err := allocMakeSecretsDir(t.SecretsDir, t.secretsInMB, fileMode777); err != nil {
+		return err
+	}
+	if err := allocMakeSecretsDir(t.PrivateDir, defaultSecretDirTmpfsSize, fileMode777); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/client/allocdir/task_dir_linux_test.go
+++ b/client/allocdir/task_dir_linux_test.go
@@ -1,0 +1,100 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build linux
+
+package allocdir
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/hashicorp/nomad/ci"
+	"github.com/hashicorp/nomad/helper/testlog"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+	"golang.org/x/sys/unix"
+)
+
+// TestMountSecretsDirs_RemountsAfterUnmount verifies that MountSecretsDirs
+// re-establishes the tmpfs mounts when they have been lost (e.g. after a host
+// reboot).
+func TestMountSecretsDirs_RemountsAfterUnmount(t *testing.T) {
+	ci.Parallel(t)
+
+	if unix.Geteuid() != 0 {
+		t.Skip("must be run as root")
+	}
+
+	tmp := t.TempDir()
+	logger := testlog.HCLogger(t)
+	d := NewAllocDir(logger, tmp, tmp, "test-alloc")
+	defer d.Destroy()
+
+	task := &structs.Task{
+		Name:      "web",
+		Resources: &structs.Resources{DiskMB: 2},
+	}
+	must.NoError(t, d.Build())
+	td := d.NewTaskDir(task)
+
+	// This is the first call, so directories do not yet exist and both tmpfs
+	// mounts are created.
+	must.NoError(t, td.MakeSecretsDirs())
+
+	_, err := isMount(td.SecretsDir)
+	must.NoError(t, err)
+
+	_, err = isMount(td.PrivateDir)
+	must.NoError(t, err)
+
+	// Write something to the tmpds mounts to test that subsequent calls to
+	// MakeSecretsDirs do not destroy the data.
+	must.NoError(t, os.WriteFile(filepath.Join(td.SecretsDir, "testfile"), []byte("testdata"), 0644))
+	must.NoError(t, os.WriteFile(filepath.Join(td.PrivateDir, "testfile"), []byte("testdata"), 0644))
+
+	// Perform a second call to ensure that this is a no-op and does not error
+	// when the tmpfs mounts already exist.
+	must.NoError(t, td.MakeSecretsDirs())
+
+	// Verify that the tmpfs mounts still exist and that the data is still
+	// there.
+	_, err = isMount(td.SecretsDir)
+	must.NoError(t, err)
+
+	content, err := os.ReadFile(filepath.Join(td.SecretsDir, "testfile"))
+	must.NoError(t, err)
+	must.Eq(t, "testdata", string(content))
+
+	_, err = isMount(td.PrivateDir)
+	must.NoError(t, err)
+
+	content, err = os.ReadFile(filepath.Join(td.PrivateDir, "testfile"))
+	must.NoError(t, err)
+	must.Eq(t, "testdata", string(content))
+
+	// Simulate a host reboot by unmounting only. The directory itself remains
+	// on disk, as it would after a reboot that drops the tmpfs mounts.
+	must.NoError(t, syscall.Unmount(td.SecretsDir, 0))
+	must.NoError(t, syscall.Unmount(td.PrivateDir, 0))
+
+	// Verify that the tmpfs mounts are gone.
+	_, err = isMount(td.SecretsDir)
+	must.ErrorIs(t, err, notFoundErr)
+
+	_, err = isMount(td.PrivateDir)
+	must.ErrorIs(t, err, notFoundErr)
+
+	// This call simulates what happens via taskDirHook.Prestart on the restore
+	// path. The directories still exist on disk but their tmpfs mounts are
+	// gone. MountSecretsDirs must re-establish the mounts.
+	must.NoError(t, td.MakeSecretsDirs())
+
+	_, err = isMount(td.SecretsDir)
+	must.NoError(t, err)
+
+	_, err = isMount(td.PrivateDir)
+	must.NoError(t, err)
+}

--- a/client/allocrunner/taskrunner/task_dir_hook.go
+++ b/client/allocrunner/taskrunner/task_dir_hook.go
@@ -48,7 +48,16 @@ func (h *taskDirHook) Name() string {
 
 func (h *taskDirHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRequest, resp *interfaces.TaskPrestartResponse) error {
 	fsi := h.runner.driverCapabilities.FSIsolation
+
+	// If the directory was previously created, we should still make a call to
+	// ensure the secrets directories are created and mounted. If they are, this
+	// will be a no-op. If the host was rebooted, this will remount the tmpfs
+	// backed secrets directories.
 	if v, ok := req.PreviousState[TaskDirHookIsDoneDataKey]; ok && v == "true" {
+
+		if err := h.runner.taskDir.MakeSecretsDirs(); err != nil {
+			return err
+		}
 		setEnvvars(h.runner.envBuilder, fsi, h.runner.taskDir, h.runner.clientConfig)
 		resp.State = map[string]string{
 			TaskDirHookIsDoneDataKey: "true",


### PR DESCRIPTION
In situations such as a client reboot, the Nomad client will recover allocations. Hook state such as the task dir hook is read from state which impacts the work done within the prestart hook.

Previously, if the task dir hook had been marked as done and prestart was called, most work would be skipped. This included creating and mounting the tmpfs directories which provide the secret and private task dirs. Client's that rebooted would therefore have recovered allocations whose secret and private dirs were not backed by tmpfs.

This change ensures the client attempts to recreate and remount the tmpfs directories when prestart is called even if the hook has been marked as done. This ensures tmpfs is remounted on client reboot and mantains idempotency through the create process that uses the marker file.

### Testing & Reproduction steps
New test case added and manual testing steps can be found in the linked issue.

### Links
Closes https://github.com/hashicorp/nomad/issues/28274
Jira https://hashicorp.atlassian.net/browse/NMD-1645

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

