### PR TITLE
api: Modernize the API package.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -145,7 +145,7 @@ deps:  ## Install build and development dependencies
 .PHONY: lint-deps
 lint-deps: ## Install linter dependencies
 	@echo "==> Updating linter dependencies..."
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.5.0
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 	go install github.com/client9/misspell/cmd/misspell@v0.3.4
 	go install github.com/hashicorp/go-hclog/hclogvet@bd6194f1f5b126dbad2a3fdf3b9b6556cc3496c3
 
@@ -162,7 +162,9 @@ check: ## Lint the source code
 	@golangci-lint run --build-tags "$(GO_TAGS)"
 
 	@echo "==> Linting ./api source code..."
-	@cd ./api && golangci-lint run --config ../.golangci.yml --build-tags "$(GO_TAGS)"
+	@cd ./api && golangci-lint run \
+	  --enable modernize \
+	  --config ../.golangci.yml --build-tags "$(GO_TAGS)"
 
 	@echo "==> Linting hclog statements..."
 	@GOFLAGS="-tags=$(GO_TAGS_COMMA)" hclogvet ./...

--- a/api/agent.go
+++ b/api/agent.go
@@ -469,7 +469,7 @@ type ServerMembers struct {
 }
 
 type AgentSelf struct {
-	Config map[string]interface{}       `json:"config"`
+	Config map[string]any               `json:"config"`
 	Member AgentMember                  `json:"member"`
 	Stats  map[string]map[string]string `json:"stats"`
 }

--- a/api/allocations.go
+++ b/api/allocations.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -505,8 +506,8 @@ func (a Allocation) RescheduleInfo(t time.Time) (int, int) {
 
 	// Loop over reschedule tracker to find attempts within the restart policy's interval
 	if a.RescheduleTracker != nil && availableAttempts > 0 && interval > 0 {
-		for j := len(a.RescheduleTracker.Events) - 1; j >= 0; j-- {
-			lastAttempt := a.RescheduleTracker.Events[j].RescheduleTime
+		for _, v := range slices.Backward(a.RescheduleTracker.Events) {
+			lastAttempt := v.RescheduleTime
 			timeDiff := t.UTC().UnixNano() - lastAttempt
 			if timeDiff < interval.Nanoseconds() {
 				attempted += 1

--- a/api/api.go
+++ b/api/api.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"net"
 	"net/http"
@@ -679,7 +680,7 @@ type request struct {
 	params url.Values
 	token  string
 	body   io.Reader
-	obj    interface{}
+	obj    any
 	ctx    context.Context
 	header http.Header
 }
@@ -860,9 +861,7 @@ func (c *Client) newRequest(method, path string) (*request, error) {
 		}
 	}
 
-	for key, values := range c.config.Headers {
-		r.header[key] = values
-	}
+	maps.Copy(r.header, c.config.Headers)
 
 	return r, nil
 }
@@ -1224,7 +1223,7 @@ func parseWriteMeta(resp *http.Response, q *WriteMeta) error {
 }
 
 // decodeBody is used to JSON decode a body
-func decodeBody(resp *http.Response, out interface{}) error {
+func decodeBody(resp *http.Response, out any) error {
 	switch resp.ContentLength {
 	case 0:
 		if out == nil {
@@ -1241,7 +1240,7 @@ func decodeBody(resp *http.Response, out interface{}) error {
 //
 // Returns the `obj` input if it is a raw io.Reader object; otherwise
 // returns a reader of the json format of the passed argument.
-func encodeBody(obj interface{}) (io.Reader, error) {
+func encodeBody(obj any) (io.Reader, error) {
 	if reader, ok := obj.(io.Reader); ok {
 		return reader, nil
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -88,7 +88,7 @@ func TestRequestTime(t *testing.T) {
 		t.Fatalf("err: %v", err)
 	}
 
-	var out interface{}
+	var out any
 
 	qm, err := client.query("/", &out, nil)
 	if err != nil {

--- a/api/compose_test.go
+++ b/api/compose_test.go
@@ -129,7 +129,7 @@ func TestCompose(t *testing.T) {
 								Operand: "=",
 							},
 						},
-						Config: map[string]interface{}{
+						Config: map[string]any{
 							"foo": "bar",
 						},
 						Meta: map[string]string{

--- a/api/consul.go
+++ b/api/consul.go
@@ -104,19 +104,19 @@ func (css *ConsulSidecarService) Canonicalize() {
 // SidecarTask represents a subset of Task fields that can be set to override
 // the fields of the Task generated for the sidecar
 type SidecarTask struct {
-	Name          string                 `hcl:"name,optional"`
-	Driver        string                 `hcl:"driver,optional"`
-	User          string                 `hcl:"user,optional"`
-	Config        map[string]interface{} `hcl:"config,block"`
-	Env           map[string]string      `hcl:"env,block"`
-	Resources     *Resources             `hcl:"resources,block"`
-	Meta          map[string]string      `hcl:"meta,block"`
-	KillTimeout   *time.Duration         `mapstructure:"kill_timeout" hcl:"kill_timeout,optional"`
-	LogConfig     *LogConfig             `mapstructure:"logs" hcl:"logs,block"`
-	ShutdownDelay *time.Duration         `mapstructure:"shutdown_delay" hcl:"shutdown_delay,optional"`
-	KillSignal    string                 `mapstructure:"kill_signal" hcl:"kill_signal,optional"`
-	VolumeMounts  []*VolumeMount         `hcl:"volume_mount,block"`
-	Identities    []*WorkloadIdentity    `hcl:"identity,block"`
+	Name          string              `hcl:"name,optional"`
+	Driver        string              `hcl:"driver,optional"`
+	User          string              `hcl:"user,optional"`
+	Config        map[string]any      `hcl:"config,block"`
+	Env           map[string]string   `hcl:"env,block"`
+	Resources     *Resources          `hcl:"resources,block"`
+	Meta          map[string]string   `hcl:"meta,block"`
+	KillTimeout   *time.Duration      `mapstructure:"kill_timeout" hcl:"kill_timeout,optional"`
+	LogConfig     *LogConfig          `mapstructure:"logs" hcl:"logs,block"`
+	ShutdownDelay *time.Duration      `mapstructure:"shutdown_delay" hcl:"shutdown_delay,optional"`
+	KillSignal    string              `mapstructure:"kill_signal" hcl:"kill_signal,optional"`
+	VolumeMounts  []*VolumeMount      `hcl:"volume_mount,block"`
+	Identities    []*WorkloadIdentity `hcl:"identity,block"`
 }
 
 func (st *SidecarTask) Canonicalize() {
@@ -173,7 +173,7 @@ type ConsulProxy struct {
 	// proxying", which creates IP tables rules inside the network namespace to
 	// ensure traffic flows thru the Envoy proxy
 	TransparentProxy *ConsulTransparentProxy `mapstructure:"transparent_proxy" hcl:"transparent_proxy,block"`
-	Config           map[string]interface{}  `hcl:"config,block"`
+	Config           map[string]any          `hcl:"config,block"`
 }
 
 func (cp *ConsulProxy) Canonicalize() {
@@ -408,7 +408,7 @@ type ConsulGatewayProxy struct {
 	EnvoyGatewayBindAddresses       map[string]*ConsulGatewayBindAddress `mapstructure:"envoy_gateway_bind_addresses" hcl:"envoy_gateway_bind_addresses,block"`
 	EnvoyGatewayNoDefaultBind       bool                                 `mapstructure:"envoy_gateway_no_default_bind" hcl:"envoy_gateway_no_default_bind,optional"`
 	EnvoyDNSDiscoveryType           string                               `mapstructure:"envoy_dns_discovery_type" hcl:"envoy_dns_discovery_type,optional"`
-	Config                          map[string]interface{}               `hcl:"config,block"` // escape hatch envoy config
+	Config                          map[string]any                       `hcl:"config,block"` // escape hatch envoy config
 }
 
 func (p *ConsulGatewayProxy) Canonicalize() {
@@ -438,17 +438,13 @@ func (p *ConsulGatewayProxy) Copy() *ConsulGatewayProxy {
 	var binds map[string]*ConsulGatewayBindAddress = nil
 	if p.EnvoyGatewayBindAddresses != nil {
 		binds = make(map[string]*ConsulGatewayBindAddress, len(p.EnvoyGatewayBindAddresses))
-		for k, v := range p.EnvoyGatewayBindAddresses {
-			binds[k] = v
-		}
+		maps.Copy(binds, p.EnvoyGatewayBindAddresses)
 	}
 
-	var config map[string]interface{} = nil
+	var config map[string]any = nil
 	if p.Config != nil {
-		config = make(map[string]interface{}, len(p.Config))
-		for k, v := range p.Config {
-			config[k] = v
-		}
+		config = make(map[string]any, len(p.Config))
+		maps.Copy(config, p.Config)
 	}
 
 	return &ConsulGatewayProxy{
@@ -686,7 +682,7 @@ func (l *ConsulIngressListener) Copy() *ConsulIngressListener {
 	var services []*ConsulIngressService = nil
 	if n := len(l.Services); n > 0 {
 		services = make([]*ConsulIngressService, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			services[i] = l.Services[i].Copy()
 		}
 	}
@@ -738,7 +734,7 @@ func (e *ConsulIngressConfigEntry) Copy() *ConsulIngressConfigEntry {
 	var listeners []*ConsulIngressListener = nil
 	if n := len(e.Listeners); n > 0 {
 		listeners = make([]*ConsulIngressListener, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			listeners[i] = e.Listeners[i].Copy()
 		}
 	}
@@ -808,7 +804,7 @@ func (e *ConsulTerminatingConfigEntry) Copy() *ConsulTerminatingConfigEntry {
 	var services []*ConsulLinkedService = nil
 	if n := len(e.Services); n > 0 {
 		services = make([]*ConsulLinkedService, n)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			services[i] = e.Services[i].Copy()
 		}
 	}

--- a/api/consul_test.go
+++ b/api/consul_test.go
@@ -153,7 +153,7 @@ func TestConsulProxy_Canonicalize(t *testing.T) {
 			LocalServicePort:    80,
 			Expose:              new(ConsulExposeConfig),
 			Upstreams:           make([]*ConsulUpstream, 0),
-			Config:              make(map[string]interface{}),
+			Config:              make(map[string]any),
 		}
 		cp.Canonicalize()
 		must.Eq(t, "127.0.0.1", cp.LocalServiceAddress)
@@ -314,7 +314,7 @@ func TestConsulGateway_Canonicalize(t *testing.T) {
 				EnvoyGatewayBindTaggedAddresses: true,
 				EnvoyGatewayBindAddresses:       make(map[string]*ConsulGatewayBindAddress, 0),
 				EnvoyGatewayNoDefaultBind:       true,
-				Config:                          make(map[string]interface{}, 0),
+				Config:                          make(map[string]any, 0),
 			},
 			Ingress: &ConsulIngressConfigEntry{
 				TLS: &ConsulGatewayTLSConfig{
@@ -352,7 +352,7 @@ func TestConsulGateway_Copy(t *testing.T) {
 			},
 			EnvoyGatewayNoDefaultBind: true,
 			EnvoyDNSDiscoveryType:     "STRICT_DNS",
-			Config: map[string]interface{}{
+			Config: map[string]any{
 				"foo": "bar",
 				"baz": 3,
 			},

--- a/api/error_unexpected_response.go
+++ b/api/error_unexpected_response.go
@@ -163,10 +163,8 @@ func requireStatusIn(statuses ...int) doRequestWrapper {
 			return d, nil, e
 		}
 
-		for _, status := range statuses {
-			if resp.StatusCode == status {
-				return d, resp, nil
-			}
+		if slices.Contains(statuses, resp.StatusCode) {
+			return d, resp, nil
 		}
 
 		// The response technically succeeded, so we need to close the body

--- a/api/event_stream.go
+++ b/api/event_stream.go
@@ -47,7 +47,7 @@ type Event struct {
 	Key        string
 	FilterKeys []string
 	Index      uint64
-	Payload    map[string]interface{}
+	Payload    map[string]any
 }
 
 // Deployment returns a Deployment struct from a given event payload. If the

--- a/api/event_stream_test.go
+++ b/api/event_stream_test.go
@@ -104,8 +104,7 @@ func TestEvent_Stream(t *testing.T) {
 		TopicEvaluation: {},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	streamCh, err := events.Stream(ctx, topics, 0, q)
 	must.NoError(t, err)
@@ -177,8 +176,7 @@ func TestEvent_Stream_Err_InvalidQueryParam(t *testing.T) {
 		TopicEvaluation: {"::*"},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	_, err = events.Stream(ctx, topics, 0, q)
 	must.ErrorContains(t, err, "Invalid key value pair")
@@ -243,8 +241,7 @@ func TestEventStream_PayloadValue(t *testing.T) {
 		TopicNode: {"*"},
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	streamCh, err := events.Stream(ctx, topics, 0, q)
 	must.NoError(t, err)
@@ -263,7 +260,7 @@ func TestEventStream_PayloadValue(t *testing.T) {
 			// perform a raw decoding and look for:
 			// - "ID" to make sure that raw decoding is working correctly
 			// - "SecretID" to make sure it's not present
-			raw := make(map[string]map[string]interface{}, 0)
+			raw := make(map[string]map[string]any, 0)
 			cfg := &mapstructure.DecoderConfig{
 				Result: &raw,
 			}

--- a/api/fs_test.go
+++ b/api/fs_test.go
@@ -33,7 +33,7 @@ func TestFS_Logs(t *testing.T) {
 	var input strings.Builder
 	input.Grow(units.MB)
 	lines := 80 * units.KB
-	for i := 0; i < lines; i++ {
+	for i := range lines {
 		_, _ = fmt.Fprintf(&input, "%d\n", i)
 	}
 
@@ -49,7 +49,7 @@ func TestFS_Logs(t *testing.T) {
 					{
 						Name:   "logger",
 						Driver: "mock_driver",
-						Config: map[string]interface{}{
+						Config: map[string]any{
 							"stdout_string": input.String(),
 						},
 					},
@@ -107,7 +107,7 @@ func TestFS_Logs(t *testing.T) {
 	alloc, _, err := c.Allocations().Info(allocID, nil)
 	must.NoError(t, err)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
@@ -133,7 +133,7 @@ func TestFS_Logs(t *testing.T) {
 		must.Eq(t, input.Len(), result.Len())
 
 		// Check complete ordering
-		for i := 0; i < lines; i++ {
+		for i := range lines {
 			line, readErr := result.ReadBytes('\n')
 			must.NoError(t, readErr, must.Sprintf("unexpected error on line %d: %v", i, readErr))
 			must.Eq(t, fmt.Sprintf("%d\n", i), string(line))

--- a/api/internal/testutil/server.go
+++ b/api/internal/testutil/server.go
@@ -322,7 +322,7 @@ func (s *TestServer) waitForServers() {
 		}
 
 		jwks := struct {
-			Keys []interface{} `json:"keys"`
+			Keys []any `json:"keys"`
 		}{}
 		if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
 			return fmt.Errorf("error decoding jwks response: %w", err)

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -215,7 +215,7 @@ func (j *Jobs) Info(jobID string, q *QueryOptions) (*Job, *QueryMeta, error) {
 }
 
 // Scale is used to scale a job.
-func (j *Jobs) Scale(jobID, group string, count *int, message string, error bool, meta map[string]interface{},
+func (j *Jobs) Scale(jobID, group string, count *int, message string, error bool, meta map[string]any,
 	q *WriteOptions) (*JobRegisterResponse, *WriteMeta, error) {
 
 	var count64 *int64
@@ -872,9 +872,7 @@ func (m *Multiregion) Copy() *Multiregion {
 		copyRegion.Count = pointerOf(*region.Count)
 		copyRegion.Datacenters = append(copyRegion.Datacenters, region.Datacenters...)
 		copyRegion.NodePool = region.NodePool
-		for k, v := range region.Meta {
-			copyRegion.Meta[k] = v
-		}
+		maps.Copy(copyRegion.Meta, region.Meta)
 
 		copy.Regions = append(copy.Regions, copyRegion)
 	}

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -667,7 +667,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 							{
 								Name:   "redis",
 								Driver: "docker",
-								Config: map[string]interface{}{
+								Config: map[string]any{
 									"image": "redis:7",
 									"port_map": []map[string]int{{
 										"db": 6379,
@@ -796,7 +796,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 							{
 								Name:   "redis",
 								Driver: "docker",
-								Config: map[string]interface{}{
+								Config: map[string]any{
 									"image": "redis:7",
 									"port_map": []map[string]int{{
 										"db": 6379,
@@ -2516,7 +2516,7 @@ func TestJobs_ScaleAction(t *testing.T) {
 	// Perform scaling action
 	scalingResp, wm, err := jobs.Scale(id, groupName,
 		pointerOf(newCount), "need more instances", false,
-		map[string]interface{}{
+		map[string]any{
 			"meta": "data",
 		}, nil)
 
@@ -2539,7 +2539,7 @@ func TestJobs_ScaleAction(t *testing.T) {
 	scalingEvent := status.TaskGroups[groupName].Events[0]
 	must.False(t, scalingEvent.Error)
 	must.Eq(t, "need more instances", scalingEvent.Message)
-	must.MapEq(t, map[string]interface{}{"meta": "data"}, scalingEvent.Meta)
+	must.MapEq(t, map[string]any{"meta": "data"}, scalingEvent.Meta)
 	must.Positive(t, scalingEvent.Time)
 	must.UUIDv4(t, *scalingEvent.EvalID)
 	must.Eq(t, scalingResp.EvalID, *scalingEvent.EvalID)
@@ -2566,7 +2566,7 @@ func TestJobs_ScaleAction_Error(t *testing.T) {
 
 	// Perform scaling action
 	scaleResp, wm, err := jobs.Scale(id, groupName, nil, "something bad happened", true,
-		map[string]interface{}{
+		map[string]any{
 			"meta": "data",
 		}, nil)
 
@@ -2590,7 +2590,7 @@ func TestJobs_ScaleAction_Error(t *testing.T) {
 	errEvent := status.TaskGroups[groupName].Events[0]
 	must.True(t, errEvent.Error)
 	must.Eq(t, "something bad happened", errEvent.Message)
-	must.Eq(t, map[string]interface{}{"meta": "data"}, errEvent.Meta)
+	must.Eq(t, map[string]any{"meta": "data"}, errEvent.Meta)
 	must.Positive(t, errEvent.Time)
 	must.Nil(t, errEvent.EvalID)
 }
@@ -2615,7 +2615,7 @@ func TestJobs_ScaleAction_Noop(t *testing.T) {
 
 	// Perform scaling action
 	scaleResp, wm, err := jobs.Scale(id, groupName, nil, "no count, just informative",
-		false, map[string]interface{}{
+		false, map[string]any{
 			"meta": "data",
 		}, nil)
 
@@ -2639,7 +2639,7 @@ func TestJobs_ScaleAction_Noop(t *testing.T) {
 	noopEvent := status.TaskGroups[groupName].Events[0]
 	must.False(t, noopEvent.Error)
 	must.Eq(t, "no count, just informative", noopEvent.Message)
-	must.MapEq(t, map[string]interface{}{"meta": "data"}, noopEvent.Meta)
+	must.MapEq(t, map[string]any{"meta": "data"}, noopEvent.Meta)
 	must.Positive(t, noopEvent.Time)
 	must.Nil(t, noopEvent.EvalID)
 }

--- a/api/locks_test.go
+++ b/api/locks_test.go
@@ -6,6 +6,7 @@ package api
 import (
 	"context"
 	"errors"
+	"maps"
 	"sync"
 	"testing"
 	"time"
@@ -360,8 +361,7 @@ func TestFailedRenewal(t *testing.T) {
 
 	s := mockService{}
 
-	testCtx, testCancel := context.WithCancel(context.Background())
-	defer testCancel()
+	testCtx := t.Context()
 
 	// Set the renewal period to 1.5  * testLease (15 ms) to force and error.
 	hac := LockLeaser{
@@ -461,9 +461,7 @@ func TestStart_ProtectedFunctionError(t *testing.T) {
 
 func copyMap(originalMap map[string]int) map[string]int {
 	newMap := map[string]int{}
-	for k, v := range originalMap {
-		newMap[k] = v
-	}
+	maps.Copy(newMap, originalMap)
 	return newMap
 }
 

--- a/api/nodes.go
+++ b/api/nodes.go
@@ -164,7 +164,7 @@ type MonitorMessage struct {
 }
 
 // Messagef formats a new MonitorMessage.
-func Messagef(lvl MonitorMsgLevel, msg string, args ...interface{}) *MonitorMessage {
+func Messagef(lvl MonitorMsgLevel, msg string, args ...any) *MonitorMessage {
 	return &MonitorMessage{
 		Level:   lvl,
 		Message: fmt.Sprintf(msg, args...),

--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -189,7 +189,7 @@ func TestNodes_NoSecretID(t *testing.T) {
 	// perform a raw http call and make sure that:
 	// - "ID" to make sure that raw decoding is working correctly
 	// - "SecretID" to make sure it's not present
-	resp := make(map[string]interface{})
+	resp := make(map[string]any)
 	_, err := c.query("/v1/node/"+nodeID, &resp, nil)
 	must.NoError(t, err)
 	must.Eq(t, nodeID, resp["ID"].(string))
@@ -231,8 +231,7 @@ func TestNodes_ToggleDrain(t *testing.T) {
 	assertWriteMeta(t, &drainOut.WriteMeta)
 
 	// Drain may have completed before we can check, use event stream
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	streamCh, err := c.EventStream().Stream(ctx, map[Topic][]string{
 		TopicNode: {nodeID},

--- a/api/operator.go
+++ b/api/operator.go
@@ -333,7 +333,7 @@ type License struct {
 	Product string
 
 	// License Specific Flags
-	Flags map[string]interface{}
+	Flags map[string]any
 
 	// Modules is a list of the licensed enterprise modules
 	Modules []string

--- a/api/raw.go
+++ b/api/raw.go
@@ -21,7 +21,7 @@ func (c *Client) Raw() *Raw {
 // Query is used to do a GET request against an endpoint
 // and deserialize the response into an interface using
 // standard Nomad conventions.
-func (raw *Raw) Query(endpoint string, out interface{}, q *QueryOptions) (*QueryMeta, error) {
+func (raw *Raw) Query(endpoint string, out any, q *QueryOptions) (*QueryMeta, error) {
 	return raw.c.query(endpoint, out, q)
 }
 
@@ -33,13 +33,13 @@ func (raw *Raw) Response(endpoint string, q *QueryOptions) (io.ReadCloser, error
 
 // Write is used to do a PUT request against an endpoint
 // and serialize/deserialized using the standard Nomad conventions.
-func (raw *Raw) Write(endpoint string, in, out interface{}, q *WriteOptions) (*WriteMeta, error) {
+func (raw *Raw) Write(endpoint string, in, out any, q *WriteOptions) (*WriteMeta, error) {
 	return raw.c.put(endpoint, in, out, q)
 }
 
 // Delete is used to do a DELETE request against an endpoint
 // and serialize/deserialized using the standard Nomad conventions.
-func (raw *Raw) Delete(endpoint string, out interface{}, q *WriteOptions) (*WriteMeta, error) {
+func (raw *Raw) Delete(endpoint string, out any, q *WriteOptions) (*WriteMeta, error) {
 	return raw.c.delete(endpoint, nil, out, q)
 }
 

--- a/api/recommendations.go
+++ b/api/recommendations.go
@@ -84,7 +84,7 @@ type Recommendation struct {
 	Resource       string
 	Value          int
 	Current        int
-	Meta           map[string]interface{}
+	Meta           map[string]any
 	Stats          map[string]float64
 	EnforceVersion bool
 

--- a/api/scaling.go
+++ b/api/scaling.go
@@ -55,7 +55,7 @@ type ScalingRequest struct {
 	Target  map[string]string
 	Message string
 	Error   bool
-	Meta    map[string]interface{}
+	Meta    map[string]any
 	WriteRequest
 
 	// this is effectively a job update, so we need the ability to override policy.
@@ -70,11 +70,11 @@ type ScalingRequest struct {
 type ScalingPolicy struct {
 	/* fields set by user in HCL config */
 
-	Min     *int64                 `hcl:"min,optional"`
-	Max     *int64                 `hcl:"max,optional"`
-	Policy  map[string]interface{} `hcl:"policy,block"`
-	Enabled *bool                  `hcl:"enabled,optional"`
-	Type    string                 `hcl:"type,optional"`
+	Min     *int64         `hcl:"min,optional"`
+	Max     *int64         `hcl:"max,optional"`
+	Policy  map[string]any `hcl:"policy,block"`
+	Enabled *bool          `hcl:"enabled,optional"`
+	Type    string         `hcl:"type,optional"`
 
 	/* fields set by server */
 
@@ -120,7 +120,7 @@ type ScalingEvent struct {
 	PreviousCount int64
 	Error         bool
 	Message       string
-	Meta          map[string]interface{}
+	Meta          map[string]any
 	EvalID        *string
 	Time          uint64
 	CreateIndex   uint64

--- a/api/scaling_test.go
+++ b/api/scaling_test.go
@@ -77,7 +77,7 @@ func TestScalingPolicies_GetPolicy(t *testing.T) {
 		Enabled: pointerOf(true),
 		Min:     pointerOf(int64(1)),
 		Max:     pointerOf(int64(1)),
-		Policy: map[string]interface{}{
+		Policy: map[string]any{
 			"key": "value",
 		},
 	}

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -765,7 +765,7 @@ type Task struct {
 	Driver          string                 `hcl:"driver,optional"`
 	User            string                 `hcl:"user,optional"`
 	Lifecycle       *TaskLifecycle         `hcl:"lifecycle,block"`
-	Config          map[string]interface{} `hcl:"config,block"`
+	Config          map[string]any         `hcl:"config,block"`
 	Constraints     []*Constraint          `hcl:"constraint,block"`
 	Affinities      []*Affinity            `hcl:"affinity,block"`
 	Env             map[string]string      `hcl:"env,block"`
@@ -1079,9 +1079,9 @@ func NewTask(name, driver string) *Task {
 
 // SetConfig is used to configure a single k/v pair on
 // the task.
-func (t *Task) SetConfig(key string, val interface{}) *Task {
+func (t *Task) SetConfig(key string, val any) *Task {
 	if t.Config == nil {
-		t.Config = make(map[string]interface{})
+		t.Config = make(map[string]any)
 	}
 	t.Config[key] = val
 	return t

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -199,7 +199,7 @@ func TestTask_SetConfig(t *testing.T) {
 
 	// Set another config value
 	task.SetConfig("baz", "zip")
-	expect := map[string]interface{}{"foo": "bar", "baz": "zip"}
+	expect := map[string]any{"foo": "bar", "baz": "zip"}
 	must.Eq(t, expect, task.Config)
 }
 

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -59,7 +59,7 @@ func testServiceJob() *Job {
 func testJobWithScalingPolicy() *Job {
 	job := testJob()
 	job.TaskGroups[0].Scaling = &ScalingPolicy{
-		Policy:  map[string]interface{}{},
+		Policy:  map[string]any{},
 		Min:     pointerOf(int64(1)),
 		Max:     pointerOf(int64(5)),
 		Enabled: pointerOf(true),
@@ -86,7 +86,7 @@ func testRecommendation(job *Job) *Recommendation {
 		Task:      job.TaskGroups[0].Tasks[0].Name,
 		Resource:  "CPU",
 		Value:     *job.TaskGroups[0].Tasks[0].Resources.CPU * 2,
-		Meta: map[string]interface{}{
+		Meta: map[string]any{
 			"testing": true,
 			"mocked":  "also true",
 		},

--- a/api/utils.go
+++ b/api/utils.go
@@ -21,10 +21,7 @@ func formatFloat(f float64, maxPrec int) string {
 		return v
 	}
 
-	sublen := idx + maxPrec + 1
-	if sublen > len(v) {
-		sublen = len(v)
-	}
+	sublen := min(idx+maxPrec+1, len(v))
 
 	return v[:sublen]
 }

--- a/api/variables.go
+++ b/api/variables.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"strings"
 )
@@ -439,9 +440,7 @@ func NewVariable(path string) *Variable {
 func (v *Variable) Copy() *Variable {
 	var out = *v
 	out.Items = make(VariableItems)
-	for key, value := range v.Items {
-		out.Items[key] = value
-	}
+	maps.Copy(out.Items, v.Items)
 	return &out
 }
 

--- a/client/testutil/docker.go
+++ b/client/testutil/docker.go
@@ -23,7 +23,7 @@ func DockerIsConnected(t *testing.T) bool {
 		return runtime.GOOS == "windows"
 	}
 
-	client, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
+	client, err := docker.New(docker.FromEnv, docker.WithAPIVersionNegotiation())
 	if err != nil {
 		return false
 	}

--- a/command/meta.go
+++ b/command/meta.go
@@ -237,7 +237,7 @@ func (m *Meta) Colorize() *colorstring.Colorize {
 		}
 
 		v := reflect.ValueOf(ui)
-		if v.Kind() == reflect.Ptr {
+		if v.Kind() == reflect.Pointer {
 			v = v.Elem()
 		}
 		for i := 0; i < v.NumField(); i++ {

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -2083,7 +2083,7 @@ func (d *Driver) newDockerClient(timeout time.Duration) (*mclient.Client, error)
 
 		if cert+key+ca != "" {
 			d.logger.Debug("using TLS client connection", "endpoint", dockerEndpoint)
-			newClient, err = mclient.NewClientWithOpts(
+			newClient, err = mclient.New(
 				append(opts,
 					mclient.WithHost(dockerEndpoint),
 					mclient.WithTLSClientConfig(ca, cert, key),
@@ -2094,7 +2094,7 @@ func (d *Driver) newDockerClient(timeout time.Duration) (*mclient.Client, error)
 			}
 		} else {
 			d.logger.Debug("using standard client connection", "endpoint", dockerEndpoint)
-			newClient, err = mclient.NewClientWithOpts(
+			newClient, err = mclient.New(
 				append(opts,
 					mclient.WithHost(dockerEndpoint),
 				)...,
@@ -2105,9 +2105,7 @@ func (d *Driver) newDockerClient(timeout time.Duration) (*mclient.Client, error)
 		}
 	} else {
 		d.logger.Debug("using client connection initialized from environment")
-		newClient, err = mclient.NewClientWithOpts(
-			append(opts, mclient.FromEnv)...,
-		)
+		newClient, err = mclient.New(append(opts, mclient.FromEnv)...)
 		if err != nil {
 			merr.Errors = append(merr.Errors, err)
 		}

--- a/helper/flatmap/flatmap.go
+++ b/helper/flatmap/flatmap.go
@@ -45,7 +45,7 @@ func flatten(prefix string, v reflect.Value, primitiveOnly, enteredStruct bool, 
 		output[prefix] = fmt.Sprintf("%v", v.String())
 	case reflect.Invalid:
 		output[prefix] = "nil"
-	case reflect.Ptr:
+	case reflect.Pointer:
 		if primitiveOnly && enteredStruct {
 			return
 		}

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -269,7 +269,7 @@ func CheckHCLKeys(node ast.Node, valid []string) error {
 // UnusedKeys returns a pretty-printed error if any `hcl:",unusedKeys"` is not empty
 func UnusedKeys(obj interface{}) error {
 	val := reflect.ValueOf(obj)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = reflect.Indirect(val)
 	}
 	return unusedKeysImpl([]string{}, val)
@@ -284,7 +284,7 @@ func unusedKeysImpl(path []string, val reflect.Value) error {
 		name := tags[0]
 		tags = tags[1:]
 
-		if fval.Kind() == reflect.Ptr {
+		if fval.Kind() == reflect.Pointer {
 			fval = reflect.Indirect(fval)
 		}
 


### PR DESCRIPTION
This change runs modernize across the API package and runs this linter in CI and local linting runs. In order to use this linter, golangci-lint has also been updated. This update identified linter errors which has been resolved.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

