### PR TITLE
config: compare TLS files via FIPS-compliant hash function

### DIFF
--- a/nomad/structs/config/tls.go
+++ b/nomad/structs/config/tls.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"crypto/md5"
+	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
@@ -55,8 +56,8 @@ type TLSConfig struct {
 	// Verify connections to the HTTPS API
 	VerifyHTTPSClient bool `hcl:"verify_https_client"`
 
-	// Checksum is a MD5 hash of the certificate CA File, Certificate file, and
-	// key file.
+	// Checksum is a SHA256 hash of the certificate CA File, Certificate file, and
+	// key file. Used internally for comparing certificate info.
 	Checksum string
 
 	// TLSCipherSuites are operator-defined ciphers to be used in Nomad TLS
@@ -282,7 +283,7 @@ func getFileChecksum(filepath string) (string, error) {
 }
 
 func createChecksumOfFiles(inputs ...string) (string, error) {
-	h := md5.New()
+	h := sha256.New()
 
 	for _, input := range inputs {
 		checksum, err := getFileChecksum(input)


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module. In `GODEBUG=fips140=only` mode ("enforcing"), the sha1 hash function is disallowed and will panic the agent if you try to call `sha1.New()`.

This hash function in our TLS config is only used for detecting whether the TLS configuration has changed. We could probably get away with using a non-cryptographic hash like FNV here but given that the inputs to the hash are user-controlled it's probably safer to just use SHA256 in case there's some obscure attack vector we can't think of.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140
Ref: https://developer.hashicorp.com/nomad/api-docs/agent#query-self

### Testing & Reproduction steps

```
$ nomad operator api '/v1/agent/self' | jq '.config.TLSConfig'
{
  "CAFile": "/etc/nomad.d/nomad-agent-ca.pem",
  "CertFile": "/etc/nomad.d/philly-server-nomad.pem",
  "Checksum": "cbf61c2b68b6c184eca116f880afe7954f354be77bc74f8471734ba6ba3508a4",
  "EnableHTTP": true,
  "EnableRPC": true,
  "KeyFile": "/etc/nomad.d/philly-server-nomad-key.pem",
  "KeyLoader": {},
  "RPCUpgradeMode": false,
  "TLSCipherSuites": "",
  "TLSMinVersion": "",
  "VerifyHTTPSClient": false,
  "VerifyServerHostname": true
}
```

Update certs, send SIGUP.

> 2026-07-31T11:02:23.249-0400 [INFO]  agent: reloading HTTP server with new TLS configuration

```
$ nomad operator api '/v1/agent/self' | jq '.config.TLSConfig'
{
  "CAFile": "/etc/nomad.d/nomad-agent-ca.pem",
  "CertFile": "/etc/nomad.d/philly-server-nomad.pem",
  "Checksum": "a33807ec4e8f93f9c7f7f635ba9d286c7823b2704801464d1bdda48cfa7ce542",
  "EnableHTTP": true,
  "EnableRPC": true,
  "KeyFile": "/etc/nomad.d/philly-server-nomad-key.pem",
  "KeyLoader": {},
  "RPCUpgradeMode": false,
  "TLSCipherSuites": "",
  "TLSMinVersion": "",
  "VerifyHTTPSClient": false,
  "VerifyServerHostname": true
}
```

### Contributor Checklist
- [x] **Changelog Entry** will get rolled-up with the other FIPS work
- [x] **Testing** see above
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
