### PR TITLE
api: remove unused checksum format for snapshots

### DIFF
--- a/api/ioutil.go
+++ b/api/ioutil.go
@@ -4,7 +4,6 @@
 package api
 
 import (
-	"crypto/md5"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/base64"
@@ -51,8 +50,8 @@ func newChecksumValidatingReader(r io.ReadCloser, digest string) (io.ReadCloser,
 		hash = sha256.New()
 	case "sha-512":
 		hash = sha512.New()
-	case "md5":
-		hash = md5.New()
+	default:
+		return nil, errors.New("unsupported checksum format")
 	}
 
 	return &checksumValidatingReader{


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module. In `GODEBUG=fips140=only` mode ("enforcing"), the md5 hash function is disallowed and will panic the agent if you try to call `md5.New()`.

When we stream Raft snapshots, the checksum is always a cryptographically secure checksum, not md5, and has always been since this API feature was introduced in 0.12. Update the helper to return an error on unsupported hash functions.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140
Ref: https://github.com/hashicorp/nomad/pull/8047

### Contributor Checklist
- [x] **Changelog Entry** will get rolled-up with the other FIPS work
- [x] **Testing** see above
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
