### PR TITLE
oidc: disable x5t in FIPS mode

### DIFF
--- a/lib/auth/oidc/client_assertion.go
+++ b/lib/auth/oidc/client_assertion.go
@@ -5,6 +5,7 @@ package oidc
 
 import (
 	"bytes"
+	"crypto/fips140"
 	"crypto/rsa"
 
 	// sha1 is used to derive an "x5t" jwt header from an x509 certificate,
@@ -192,6 +193,10 @@ func hashKeyID(cert *x509.Certificate, header structs.OIDCClientAssertionKeyIDHe
 	var hasher hash.Hash
 	switch header {
 	case structs.OIDCClientAssertionHeaderX5t:
+		if fips140.Enabled() {
+			return "", errors.New("x5t assertion headers use SHA-1, which is forbidden in FIPS-140 mode")
+		}
+
 		hasher = sha1.New()
 	case structs.OIDCClientAssertionHeaderX5tS256:
 		hasher = sha256.New()

--- a/nomad/structs/acl.go
+++ b/nomad/structs/acl.go
@@ -5,6 +5,7 @@ package structs
 
 import (
 	"bytes"
+	"crypto/fips140"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1895,6 +1896,9 @@ func (k *OIDCClientAssertionKey) Validate() error {
 		if k.KeyIDHeader != OIDCClientAssertionHeaderX5t && k.KeyIDHeader != OIDCClientAssertionHeaderX5tS256 {
 			return fmt.Errorf("%w; certificate-derived key header must be one of: %q, %q",
 				ErrInvalidKeyIDHeader, OIDCClientAssertionHeaderX5tS256, OIDCClientAssertionHeaderX5t)
+		}
+		if fips140.Enabled() && k.KeyIDHeader == OIDCClientAssertionHeaderX5t {
+			return errors.New("x5t assertion headers use SHA-1, which is forbidden in FIPS-140 mode")
 		}
 	}
 


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module. In `GODEBUG=fips140=only` mode ("enforcing"), the sha1 hash function is disallowed and will panic the agent if you try to call `sha1.New()`.

The x5t assertion header of OIDC uses SHA1, so we need to disable it when in FIPS mode.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140

### Contributor Checklist
- [x] **Changelog Entry** will get rolled-up with the other FIPS work
- [x] **Testing** see above
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
