### PR TITLE
disable alloc exec and job actions in FIPS mode

### DIFF
--- a/command/agent/websockets.go
+++ b/command/agent/websockets.go
@@ -5,6 +5,7 @@ package agent
 
 import (
 	"context"
+	"crypto/fips140"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -30,6 +31,10 @@ func isWebsocketUpgrade(req *http.Request) bool {
 // auth token via request context.
 func (s *HTTPServer) wrapWebsocketHandler(handler handlerFn) handlerFn {
 	return func(w http.ResponseWriter, req *http.Request) (any, error) {
+
+		if fips140.Enabled() {
+			return "", fmt.Errorf("websockets are disallowed in FIPS-140 mode")
+		}
 
 		// Upgrade the connection
 		conn, err := s.wsUpgrader.Upgrade(w, req, nil)


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module. In `GODEBUG=fips140=only` mode ("enforcing"), the sha1 hash function is disallowed and will panic the agent if you try to call `sha1.New()`.

The alloc exec and job actions feature relies on websockets. Websocket security uses a SHA1 hash function for the `Sec-WebSocket-Accept/Key` headers. Although RFC6455 points out this hash isn't used for its cryptographic properties, we obviously can't have a "panic this agent" API. Disable the APIs that require websockets in FIPS mode. Environment that require FIPS will not have access to these features unless the behavior in the Go Cryptographic Module changes.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140
Ref: https://datatracker.ietf.org/doc/html/rfc6455#section-10.8

### Testing & Reproduction

```
$ nomad alloc exec af0fb06b /bin/sh
failed to exec into task: Unexpected response code: 500 (websockets are disallowed in FIPS-140 mode)
```

### Contributor Checklist
- [x] **Changelog Entry** will get rolled-up with the other FIPS work
- [x] **Testing** see above
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
