### PR TITLE
checks: use SHA256 for Nomad native service check IDs

### DIFF
--- a/.changelog/28361.txt
+++ b/.changelog/28361.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+checks: Nomad native service check IDs are now SHA256
+```

--- a/client/allocrunner/checks_hook.go
+++ b/client/allocrunner/checks_hook.go
@@ -140,7 +140,9 @@ func (h *checksHook) initialize(alloc *structs.Allocation) {
 	h.alloc = alloc
 }
 
-// observe will create the observer for each service in services.
+// observe will create the observer for each service in services and remove any
+// services for this alloc that should no longer exist.
+//
 // services must use only nomad service provider.
 //
 // Caller must hold h.lock.
@@ -152,6 +154,8 @@ func (h *checksHook) observe(alloc *structs.Allocation, services []*structs.Serv
 		networks = alloc.AllocatedResources.Shared.Networks
 	}
 
+	ids := []structs.CheckID{}
+
 	for _, service := range services {
 		for _, check := range service.Checks {
 
@@ -160,6 +164,7 @@ func (h *checksHook) observe(alloc *structs.Allocation, services []*structs.Serv
 
 			// create the deterministic check id for this check
 			id := structs.NomadCheckID(alloc.ID, alloc.TaskGroup, check)
+			ids = append(ids, id)
 
 			// an observer for this check already exists
 			if _, exists := h.observers[id]; exists {
@@ -196,10 +201,24 @@ func (h *checksHook) observe(alloc *structs.Allocation, services []*structs.Serv
 				h.logger.Error("failed to set initial check status", "id", h.allocID, "error", err)
 				continue
 			}
-
-			// start the observer
-			go h.observers[id].start()
 		}
+	}
+
+	// remove the IDs of any checks in state that don't exist in the job, to
+	// support in-place allocation updates or client upgrades where we update
+	// check IDs with new fields/hashes
+	remove := h.shim.Difference(h.allocID, ids)
+	for _, id := range remove {
+		if ob, ok := h.observers[id]; ok {
+			ob.stop()
+			delete(h.observers, id)
+		}
+	}
+	h.shim.Remove(h.allocID, remove)
+
+	// start the observers
+	for _, id := range ids {
+		go h.observers[id].start()
 	}
 }
 
@@ -216,12 +235,12 @@ func (h *checksHook) Prerun(allocEnv *taskenv.TaskEnv) error {
 		return nil
 	}
 
+	// get all group and task level services using nomad provider
 	interpolatedServices := taskenv.InterpolateServices(
 		allocEnv, group.NomadServices())
 
 	// create and start observers of nomad service checks in alloc
 	h.observe(h.alloc, interpolatedServices)
-
 	return nil
 }
 
@@ -238,36 +257,12 @@ func (h *checksHook) Update(request *interfaces.RunnerUpdateRequest) error {
 	interpolatedServices := taskenv.InterpolateServices(
 		request.AllocEnv, group.NomadServices())
 
-	// create a set of the updated set of checks
-	next := make([]structs.CheckID, 0, len(h.observers))
-	for _, service := range interpolatedServices {
-		for _, check := range service.Checks {
-			next = append(next, structs.NomadCheckID(
-				request.Alloc.ID,
-				request.Alloc.TaskGroup,
-				check,
-			))
-		}
-	}
-
-	// stop the observers of the checks we are removing
-	remove := h.shim.Difference(request.Alloc.ID, next)
-	for _, id := range remove {
-		h.observers[id].stop()
-		delete(h.observers, id)
-	}
-
-	// remove checks that are no longer part of the allocation
-	if err := h.shim.Remove(request.Alloc.ID, remove); err != nil {
-		return err
-	}
-
 	// remember this new alloc
 	h.alloc = request.Alloc
 
-	// ensure we are observing new checks (idempotent)
+	// ensure we are observing new checks and stopping any stale ones
+	// (idempotent)
 	h.observe(request.Alloc, interpolatedServices)
-
 	return nil
 }
 

--- a/nomad/structs/checks.go
+++ b/nomad/structs/checks.go
@@ -4,7 +4,7 @@
 package structs
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"fmt"
 	"strconv"
 )
@@ -77,7 +77,8 @@ const (
 //
 // Checks of group-level services have no task.
 func NomadCheckID(allocID, group string, c *ServiceCheck) CheckID {
-	sum := md5.New()
+	sum := sha256.New()
+
 	hashString(sum, allocID)
 	hashString(sum, group)
 	hashString(sum, c.TaskName)


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module. In `GODEBUG=fips140=only` mode ("enforcing"), the md5 hash function is disallowed and will panic the agent if you try to call `md5.New()`.

Nomad native service check IDs are generated from md5. These IDs are never persisted to the Nomad state store, but they are persisted to the client state database. Update the check ID function to SHA256, and clear any stale checks for an allocation from the client state when we start the allocation. This will transparently upgrade the IDs using old hashes during restore, as well as give us better ability to change what fields contribute to the IDs going forward.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140

### Testing & Reproduction steps

old check:

```
$ nomad alloc checks 7dedf1e5
Status of 1 Nomad Service Checks

ID         =  4bcf8efa9941f9d7ebb81dae5803d106
Name       =  service: "httpd-web" check
Group      =  example.web[0]
Task       =  (group)
Service    =  httpd-web
Status     =  success
Mode       =  healthiness
Timestamp  =  2026-07-31T13:20:21-04:00
Output     =  nomad: tcp ok
```

restart client with new binary:

```
$ nomad alloc checks 7dedf1e5
Status of 1 Nomad Service Checks

ID         =  50cfcfe9164e267948c0e7462e7b58ce1ddbee868a5dbc3ace09c2057b2d948c
Name       =  service: "httpd-web" check
Group      =  example.web[0]
Task       =  (group)
Service    =  httpd-web
Status     =  success
Mode       =  healthiness
Timestamp  =  2026-07-31T13:20:47-04:00
Output     =  nomad: tcp ok
```

### Contributor Checklist
- [x] **Changelog Entry** done
- [x] **Testing** see above
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
