### PR TITLE
consul: switch to SHA256 hashes in IDs

### DIFF
--- a/.changelog/28362.txt
+++ b/.changelog/28362.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+consul: Check IDs are now derived from SHA256 instead of SHA1
+```

--- a/command/agent/consul/service_client.go
+++ b/command/agent/consul/service_client.go
@@ -1133,8 +1133,10 @@ func (c *ServiceClient) sync(reason syncReason) error {
 			continue
 		}
 
-		// Ignore unknown services during probation
-		if inProbation && !c.explicitlyDeregisteredChecks.Contains(id) {
+		// Ignore unknown checks during probation unless they are the legacy
+		if inProbation &&
+			!c.explicitlyDeregisteredChecks.Contains(id) &&
+			nonLegacyCheckRe.MatchString(id) {
 			continue
 		}
 
@@ -1183,6 +1185,10 @@ func (c *ServiceClient) sync(reason syncReason) error {
 	}
 	return mErr.ErrorOrNil()
 }
+
+// nonLegacyCheckRe gets used to check for current check ID formats, so we can
+// clean up old check IDs sync
+var nonLegacyCheckRe = regexp.MustCompile("_nomad-check-[0-9a-f]{64}")
 
 // syncRemoveService removes an unwanted service from Consul. If the service has
 // a sidecar, we need to remove the sidecar first, otherwise Consul will produce
@@ -1243,6 +1249,20 @@ func (c *ServiceClient) RegisterAgent(role string, services []*structs.Service) 
 			},
 		}
 		ops.regServices = append(ops.regServices, serviceReg)
+
+		// older agents use SHA-1 hashes as part of the service name instead of
+		// SHA-256, but we can't guarantee they've shutdown gracefully and
+		// deregistered themselves on upgrade. Remove any legacy service IDs
+		// that might be lingering
+		//
+		// COMPAT: remove once upgrades from pre-FIPS-compatible agents are no longer
+		// supported. Upgrading agents in-place to FIPS-enabled is unsupported.
+		legacyID := service.LegacyAgentID(role)
+		if legacyID != "" {
+			// we intentionally swallow this error because these services likely
+			// no longer exist
+			_ = c.agentAPI.ServiceDeregisterOpts(legacyID, nil)
+		}
 
 		for _, check := range service.Checks {
 			checkID := MakeCheckID(id, check)

--- a/nomad/structs/services.go
+++ b/nomad/structs/services.go
@@ -4,7 +4,9 @@
 package structs
 
 import (
+	"crypto/fips140"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -483,7 +485,8 @@ func (sc *ServiceCheck) TriggersRestarts() bool {
 // the PortLabel is blank, the Service's PortLabel will be used after Hash is
 // called.
 func (sc *ServiceCheck) Hash(serviceID string) string {
-	h := sha1.New()
+	h := sha256.New()
+
 	hashString(h, serviceID)
 	hashString(h, sc.Name)
 	hashString(h, sc.Type)
@@ -953,11 +956,34 @@ func (s *Service) ValidateName(name string) error {
 	return nil
 }
 
+// LegacyAgentID is used only for generating the ID for services registered by a
+// pre-FIPS-compatible Nomad agent, so that if the agent was not shutdown
+// gracefully before upgrading, it can still deregister its old services.
+//
+// COMPAT: remove once upgrades from pre-FIPS-compatible agents are no longer
+// supported. Upgrading agents in-place to FIPS-enabled is unsupported.
+func (s *Service) LegacyAgentID(role string) string {
+	if fips140.Enabled() {
+		return ""
+	}
+	h := sha1.New()
+	x := s.hashImpl(h, role, "", false)
+	return fmt.Sprintf("_nomad-%s-%s", role, x)
+}
+
 // Hash returns a base32 encoded hash of a Service's contents excluding checks
 // as they're hashed independently and the provider in order to not cause churn
 // during cluster upgrades.
+//
+// This hash is used for internal in-memory comparisons and for generating the
+// Nomad agent's own service IDs that it registers with Consul, but is not used
+// for registering workload services.
 func (s *Service) Hash(allocID, taskName string, canary bool) string {
-	h := sha1.New()
+	h := sha256.New()
+	return s.hashImpl(h, allocID, taskName, canary)[:52]
+}
+
+func (s *Service) hashImpl(h hash.Hash, allocID, taskName string, canary bool) string {
 	hashString(h, allocID)
 	hashString(h, taskName)
 	hashString(h, s.Name)


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module. In `GODEBUG=fips140=only` mode ("enforcing"), the sha1 hash function is disallowed and will panic the agent if you try to call sha1.New().

Nomad's Consul integration uses the forbidden hash in two ways, which we'll address here:
* As part of the service ID that agents register for themselves. Agents deregister themselves when shutdown gracefully, but we'll need to assume that not all agents manage to shutdown gracefully during upgrade. Have the agent deregister its own legacy service ID if running in non-FIPS mode.
* As part of the check ID for checks. Migrate these to SHA256, and clean up any Nomad-owned check IDs that don't belong in the local Consul agent when syncing.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140

### Testing & Reproduction steps

<details><summary>jobspec</summary>

```hcl
job "example" {

  group "web" {

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
    }

    service {
      name     = "httpd-web"
      provider = "consul"
      port     = "www"
      check {
        type     = "tcp"
        interval = "3s"
        timeout  = "1s"
      }
    }

    task "http" {

      driver = "docker"

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}
```
</details>

Consul checks before:

```
$ curl -sH "X-Consul-Token: $CONSUL_HTTP_TOKEN" "http://localhost:8500/v1/agent/checks" | jq -r '.[] | select(.Name == "service: \"httpd-web\" check").CheckID'
_nomad-check-efc2a3f1d80e32e79e89431cb423871aac3e0310
```

After update:

```
$ curl -sH "X-Consul-Token: $CONSUL_HTTP_TOKEN" "http://localhost:8500/v1/agent/checks" | jq -r '.[] | select(.Name == "service: \"httpd-web\" check").CheckID'
_nomad-check-214b5758dff352c723462075479b72e6bd1ab865c5e06d39b5dcdbe71e7f0aa3
```


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
