### PR TITLE
services: use sha256 for rendezvous hashing

### DIFF
--- a/.changelog/28363.txt
+++ b/.changelog/28363.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+services: rendezvous hashes are now SHA256
+```

--- a/nomad/service_registration_endpoint_test.go
+++ b/nomad/service_registration_endpoint_test.go
@@ -1448,8 +1448,8 @@ func TestServiceRegistration_GetService(t *testing.T) {
 				result := serviceRegResp.Services
 
 				must.Len(t, 2, result)
-				must.Eq(t, "10.0.0.3", result[0].Address)
-				must.Eq(t, "10.0.0.2", result[1].Address)
+				must.Eq(t, "10.0.0.1", result[0].Address)
+				must.Eq(t, "10.0.0.3", result[1].Address)
 			},
 		},
 		{
@@ -1512,8 +1512,8 @@ func TestServiceRegistration_GetService(t *testing.T) {
 				result := serviceRegResp.Services
 
 				must.Len(t, 2, result)
-				must.Eq(t, "10.0.0.2", result[0].Address)
-				must.Eq(t, "10.0.0.1", result[1].Address)
+				must.Eq(t, "10.0.0.1", result[0].Address)
+				must.Eq(t, "10.0.0.2", result[1].Address)
 			},
 		},
 	}
@@ -1554,6 +1554,7 @@ func TestServiceRegistration_choose(t *testing.T) {
 
 	sr := (*ServiceRegistration)(nil)
 	try := func(input, exp []*structs.ServiceRegistration, parameter string) {
+		t.Helper()
 		result, err := sr.choose(input, parameter)
 		must.NoError(t, err)
 		must.Eq(t, exp, result)
@@ -1572,20 +1573,20 @@ func TestServiceRegistration_choose(t *testing.T) {
 
 	// same key, increasing n -> maintains order (n=1)
 	try(regs, []*structs.ServiceRegistration{
-		{ID: "abc002", ServiceName: "s1"},
+		{ID: "abc003", ServiceName: "s1"},
 	}, "1|aaa")
 
 	// same key, increasing n -> maintains order (n=2)
 	try(regs, []*structs.ServiceRegistration{
-		{ID: "abc002", ServiceName: "s1"},
 		{ID: "abc003", ServiceName: "s1"},
+		{ID: "abc001", ServiceName: "s1"},
 	}, "2|aaa")
 
 	// same key, increasing n -> maintains order (n=3)
 	try(regs, []*structs.ServiceRegistration{
-		{ID: "abc002", ServiceName: "s1"},
 		{ID: "abc003", ServiceName: "s1"},
 		{ID: "abc001", ServiceName: "s1"},
+		{ID: "abc002", ServiceName: "s1"},
 	}, "3|aaa")
 
 	// unique key -> different orders
@@ -1593,12 +1594,12 @@ func TestServiceRegistration_choose(t *testing.T) {
 		{ID: "abc001", ServiceName: "s1"},
 		{ID: "abc002", ServiceName: "s1"},
 		{ID: "abc003", ServiceName: "s1"},
-	}, "3|bbb")
+	}, "3|ddd")
 
 	// another key -> another order
 	try(regs, []*structs.ServiceRegistration{
-		{ID: "abc002", ServiceName: "s1"},
 		{ID: "abc003", ServiceName: "s1"},
+		{ID: "abc002", ServiceName: "s1"},
 		{ID: "abc001", ServiceName: "s1"},
 	}, "3|ccc")
 }

--- a/nomad/structs/service_registration.go
+++ b/nomad/structs/service_registration.go
@@ -4,7 +4,7 @@
 package structs
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"slices"
@@ -187,7 +187,8 @@ func (s *ServiceRegistration) HashWith(key string) string {
 	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf, uint64(s.Port))
 
-	sum := md5.New()
+	sum := sha256.New()
+
 	sum.Write(buf)
 	sum.Write([]byte(s.AllocID))
 	sum.Write([]byte(s.ID))


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module. In `GODEBUG=fips140=only` mode ("enforcing"), the md5 hash function is disallowed and will panic the agent if you try to call md5.New().

Nomad native service checks use as the hash input for rendezvous hashing. These hashes are not persisted and are updated on each query. Update them to SHA256.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** note that test outputs changed here because we changed the hash
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
