### PR TITLE
dynamic queue: Use pending usage for priority calculation?

### DIFF
--- a/api/batch_job_queue.go
+++ b/api/batch_job_queue.go
@@ -48,10 +48,13 @@ type DynamicPriorityWorkload struct {
 }
 
 type DynamicPriorityTenant struct {
-	TenantID       string
-	PercentageUsed int
-	TenantUsage    map[string]float64
-	TotalUsage     map[string]float64
+	TenantID              string
+	PercentageUsed        int
+	PercentagePendingUsed int
+	TenantUsage           map[string]float64
+	TotalUsage            map[string]float64
+	PendingTenantUsage    map[string]float64
+	PendingTotalUsage     map[string]float64
 }
 
 type Workload struct {

--- a/command/queue_tenants.go
+++ b/command/queue_tenants.go
@@ -155,6 +155,25 @@ func (c *QueueTenantsCommand) printTenants(resp *api.BatchJobQueueTenantsRespons
 			}
 			slices.Sort(resources)
 			tenantInfo = append(tenantInfo, resources...)
+			tenantInfo = append(tenantInfo, fmt.Sprintf("%s|%s|%s|%d",
+				"",
+				"",
+				"",
+				v.PercentagePendingUsed,
+			))
+
+			usageResources := make([]string, 0, len(v.PendingTenantUsage))
+			for resource, usage := range v.PendingTenantUsage {
+				usageResources = append(usageResources, fmt.Sprintf("%s|%s|%.2f / %.2f|%s",
+					"",
+					resource,
+					usage,
+					v.PendingTotalUsage[resource],
+					"",
+				))
+			}
+			slices.Sort(usageResources)
+			tenantInfo = append(tenantInfo, usageResources...)
 		}
 
 		c.Ui.Output(c.Colorize().Color("[bold]Batch Queue Tenants[reset]"))

--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -42,6 +42,9 @@ type DynamicPriorityQueue struct {
 	// totalUsage is the sum of all tenant usages
 	totalUsage *ResourceUsage
 
+	// totalPendingUsage is the sum of all tenant pending usages
+	totalPendingUsage *ResourceUsage
+
 	tenantType structs.BatchQueueTenant
 
 	metadataKey string
@@ -65,19 +68,20 @@ type DynamicPriorityQueue struct {
 
 func NewDynamicPriorityQueue(ss *state.StateStore, broker queue.Broker, qconf *structs.BatchQueue, conf *structs.DynamicQueueConfig, logger hclog.Logger) *DynamicPriorityQueue {
 	return &DynamicPriorityQueue{
-		queue:       queue.NewWorkloadQueue(workloadSortFn()),
-		evalBroker:  broker,
-		qMux:        sync.Mutex{},
-		tenants:     make(map[TenantID]*Tenant),
-		enqueueCh:   make(chan *dynamicPriorityWorkload, 8192),
-		qNotify:     make(chan struct{}, 1),
-		tenantType:  qconf.TenantType,
-		metadataKey: qconf.MetadataKey,
-		conf:        conf,
-		totalUsage:  &ResourceUsage{},
-		wg:          sync.WaitGroup{},
-		state:       ss,
-		logger:      logger.Named("Dynamic Priority Queue"),
+		queue:             queue.NewWorkloadQueue(workloadSortFn()),
+		evalBroker:        broker,
+		qMux:              sync.Mutex{},
+		tenants:           make(map[TenantID]*Tenant),
+		enqueueCh:         make(chan *dynamicPriorityWorkload, 8192),
+		qNotify:           make(chan struct{}, 1),
+		tenantType:        qconf.TenantType,
+		metadataKey:       qconf.MetadataKey,
+		conf:              conf,
+		totalUsage:        &ResourceUsage{},
+		totalPendingUsage: &ResourceUsage{},
+		wg:                sync.WaitGroup{},
+		state:             ss,
+		logger:            logger.Named("Dynamic Priority Queue"),
 	}
 }
 
@@ -232,6 +236,11 @@ func (d *DynamicPriorityQueue) runProducer(ctx context.Context) {
 			// use createTime so that workloads have consistent age
 			// priority calculations after restoring from state.
 			d.setWorkloadPriority(time.Unix(0, w.eval.CreateTime), w)
+
+			d.ensureTenant(w.tid)
+			d.tenants[w.tid].pendingUsage.Add(w.requestedResources.resources)
+			d.totalPendingUsage.Add(w.requestedResources.resources)
+
 			d.queue.Push(w)
 			d.qMux.Unlock()
 
@@ -346,12 +355,14 @@ func (d *DynamicPriorityQueue) ensureTenant(tid TenantID) {
 		tid:                tid,
 		placedWorkloadById: make(map[string]*dynamicPriorityWorkload),
 		totalUsage:         &ResourceUsage{},
+		pendingUsage:       &ResourceUsage{},
 	}
 }
 
 // calculatePriorities iterates over all workloads in the queue and updates
 // their priorities based on tenant usage, which is decayed according to the
-// configured half-life, and usage weight.
+// configured half-life, and usage weight. This must be done while the queue is
+// locked.
 func (d *DynamicPriorityQueue) calculatePriorities(now time.Time) {
 	state, err := d.state.Snapshot()
 	if err != nil {
@@ -362,11 +373,23 @@ func (d *DynamicPriorityQueue) calculatePriorities(now time.Time) {
 	// priority relies on its tenant's usage.
 	d.decayUsage(now, state)
 
-	// Now that we have accurate tenant usage, calculate
-	// each workloads new priority and update the queue
+	pending := make(map[TenantID]*ResourceUsage)
+
 	d.queue.UpdateAll(func(w queue.Workload) {
 		workload := w.(*dynamicPriorityWorkload)
+		tenant := d.tenants[workload.tid]
+
+		if _, ok := pending[workload.tid]; !ok {
+			pending[workload.tid] = &ResourceUsage{}
+		}
+
+		originalPending := *tenant.pendingUsage
+		tenant.pendingUsage = pending[workload.tid]
+
 		d.setWorkloadPriority(now, workload)
+		tenant.pendingUsage = &originalPending
+
+		pending[workload.tid].Add(workload.requestedResources.resources)
 	})
 }
 
@@ -379,22 +402,25 @@ func (d *DynamicPriorityQueue) setWorkloadPriority(now time.Time, w *dynamicPrio
 }
 
 // usageAdjustment calculates the adjustment to a workload's priority based on
-// it's tenant's usage relative to the total usage, and configured weight.
+// tenant usage relative to total usage. Includes both placed (totalUsage) and
+// queued (pendingUsage) workloads.
 func (d *DynamicPriorityQueue) usageAdjustment(w *dynamicPriorityWorkload) int {
 	if d.conf.UsageWeight == 0 {
 		return 0
 	}
 
 	d.ensureTenant(w.tid)
-	total := d.totalUsage.Total()
-	tenantUsage := d.tenants[w.tid].totalUsage.Total()
+	tenant := d.tenants[w.tid]
+
+	effectiveTenantUsage := tenant.totalUsage.Total() + tenant.pendingUsage.Total()
+	totalEffectiveUsage := d.totalUsage.Total() + d.totalPendingUsage.Total()
 
 	usageRatio := 0.0
-	if total > 0 {
-		usageRatio = tenantUsage / total
+	if totalEffectiveUsage > 0 {
+		usageRatio += effectiveTenantUsage / totalEffectiveUsage
 	}
-	usageAdjustment := (1 - usageRatio) * float64(d.conf.UsageWeight)
-	w.usageAdjustment = int(usageAdjustment)
+
+	w.usageAdjustment = int((1 - usageRatio) * float64(d.conf.UsageWeight))
 	return w.usageAdjustment
 }
 
@@ -522,10 +548,13 @@ func (d *DynamicPriorityQueue) Tenants() structs.QueueTenantsResponse {
 	tenants := []structs.DynamicPriorityTenant{}
 	for _, t := range d.tenants {
 		tenants = append(tenants, structs.DynamicPriorityTenant{
-			TenantID:       string(t.tid),
-			PercentageUsed: t.totalPercentageUsed(d.totalUsage),
-			TenantUsage:    t.totalUsage.UsageByResource(),
-			TotalUsage:     d.totalUsage.UsageByResource(),
+			TenantID:              string(t.tid),
+			PercentageUsed:        t.totalPercentageUsed(d.totalUsage),
+			TenantUsage:           t.totalUsage.UsageByResource(),
+			TotalUsage:            d.totalUsage.UsageByResource(),
+			PercentagePendingUsed: t.totalPendingPercentageUsed(d.totalPendingUsage),
+			PendingTenantUsage:    t.pendingUsage.UsageByResource(),
+			PendingTotalUsage:     d.totalPendingUsage.UsageByResource(),
 		})
 	}
 	return structs.QueueTenantsResponse{
@@ -541,17 +570,18 @@ func (d *DynamicPriorityQueue) updateUsage(w queue.Workload) {
 	tenant := d.tenants[workload.tid]
 
 	_, ok := tenant.placedWorkloadById[workload.id]
-	// If the workload has already been placed, don't count the usage again.
 	if ok {
 		return
 	}
 
 	workloadResources := workload.requestedResources
-	// this method should only be called when a workload was successfully placed,
-	// so we can use the ModifyTime as the for when decay will start.
 	workloadResources.start = time.Unix(0, workload.eval.ModifyTime)
+
+	tenant.pendingUsage = tenant.pendingUsage.Subtract(workloadResources.resources)
 	tenant.totalUsage = tenant.totalUsage.Add(workloadResources.resources)
+
 	d.totalUsage = d.totalUsage.Add(workloadResources.resources)
+	d.totalPendingUsage = d.totalPendingUsage.Subtract(workloadResources.resources)
 
 	tenant.placedWorkloadById[workload.id] = workload
 }

--- a/nomad/queues/dynamic_priority/queue_test.go
+++ b/nomad/queues/dynamic_priority/queue_test.go
@@ -360,7 +360,8 @@ func TestDynamicPriorityQueue_calculatePriorities(t *testing.T) {
 			placedWorkloadById: map[string]*dynamicPriorityWorkload{
 				eval1.ID: {requestedResources: &UsageList{start: ts, resources: &ResourceUsage{CPU: cpu, Memory: memory}}},
 			},
-			totalUsage: &ResourceUsage{CPU: cpu, Memory: memory},
+			totalUsage:   &ResourceUsage{CPU: cpu, Memory: memory},
+			pendingUsage: &ResourceUsage{},
 		}
 	}
 	ss := state.TestStateStore(t)

--- a/nomad/queues/dynamic_priority/resource_usage.go
+++ b/nomad/queues/dynamic_priority/resource_usage.go
@@ -21,6 +21,12 @@ func (r *ResourceUsage) Add(addedUsage *ResourceUsage) *ResourceUsage {
 	return r
 }
 
+func (r *ResourceUsage) Subtract(subtractedUsage *ResourceUsage) *ResourceUsage {
+	r.CPU -= subtractedUsage.CPU
+	r.Memory -= subtractedUsage.Memory
+	return r
+}
+
 func (r *ResourceUsage) AddCpu(amount float64) {
 	r.CPU += amount
 }

--- a/nomad/queues/dynamic_priority/tenant.go
+++ b/nomad/queues/dynamic_priority/tenant.go
@@ -7,6 +7,7 @@ type Tenant struct {
 	tid                TenantID
 	placedWorkloadById map[string]*dynamicPriorityWorkload
 	totalUsage         *ResourceUsage
+	pendingUsage       *ResourceUsage
 }
 
 func (t *Tenant) totalPercentageUsed(totalUsage *ResourceUsage) int {
@@ -15,4 +16,11 @@ func (t *Tenant) totalPercentageUsed(totalUsage *ResourceUsage) int {
 	}
 
 	return int((t.totalUsage.Total() / totalUsage.Total()) * 100)
+}
+func (t *Tenant) totalPendingPercentageUsed(totalUsage *ResourceUsage) int {
+	if totalUsage.Total() == 0 {
+		return 0
+	}
+
+	return int((t.pendingUsage.Total() / totalUsage.Total()) * 100)
 }

--- a/nomad/queues/queue/workload_queue.go
+++ b/nomad/queues/queue/workload_queue.go
@@ -4,6 +4,9 @@
 package queue
 
 import (
+	"cmp"
+	"slices"
+
 	"github.com/hashicorp/go-set/v3"
 )
 
@@ -33,7 +36,11 @@ func (pq *WorkloadQueue) Pop() Workload {
 // all workloads in the queue via this function.
 func (pq *WorkloadQueue) UpdateAll(updateFn func(w Workload)) {
 	newQueue := NewWorkloadQueue(pq.sortFn)
-	for _, w := range pq.Slice() {
+	workloads := pq.Slice()
+	slices.SortFunc(workloads, func(a, b Workload) int {
+		return cmp.Compare(a.GetEval().CreateIndex, b.GetEval().CreateIndex)
+	})
+	for _, w := range workloads {
 		updateFn(w)
 		newQueue.Push(w)
 	}

--- a/nomad/structs/queue.go
+++ b/nomad/structs/queue.go
@@ -43,10 +43,13 @@ func (w *DynamicPriorityWorkload) GetNamespace() string {
 }
 
 type DynamicPriorityTenant struct {
-	TenantID       string
-	PercentageUsed int
-	TenantUsage    map[string]float64
-	TotalUsage     map[string]float64
+	TenantID              string
+	PercentageUsed        int
+	PercentagePendingUsed int
+	TenantUsage           map[string]float64
+	TotalUsage            map[string]float64
+	PendingTenantUsage    map[string]float64
+	PendingTotalUsage     map[string]float64
 }
 
 type Workload struct {


### PR DESCRIPTION
### Description
Testing out what using the "future usage" of tenants in the batch queue for priority calculations looks like to see if it's useful. Welcoming feedback on if it's worth exploring after it was brought up at some point, but not necessarily sure it's worth 

When using the `usage_weight` and a calculation window that doesn't update often, jobs can be scheduled for a single tenant without fairly sharing the resources. This could be solved by recalculating priorities each time a job is taken off the queue and given to the eval broker, but it would require re-calculating priorities each time (high overhead). Instead, try to track the pending usage for a tenant, which doesn't decay, but gives a job a priority based on what the usage would be if all jobs ahead of it were placed. It's not fool-proof because there are many other ways a priority could be updated (age, size, etc.. that's kind of the point), but when just using usage, it provides a more stable queue order for the user watching and increases the fair-sharing between calculation intervals.

### Testing & Reproduction steps
Queue example with the change: 
```
Batch Queue Workloads
JobID     Tenant  Adjusted Priority  Base Priority  Position  Usage  Age  Size  CreatedAt
foo_0     foo     130                50             1         80     0    0     2026-07-31T16:35:55-07:00
test_0    test    130                50             2         80     0    0     2026-07-31T16:35:57-07:00
test_1_0  test_1  130                50             3         80     0    0     2026-07-31T16:35:57-07:00
test_2_0  test_2  130                50             4         80     0    0     2026-07-31T16:35:58-07:00
test_3_0  test_3  130                50             5         80     0    0     2026-07-31T16:36:00-07:00
test_4_0  test_4  130                50             6         80     0    0     2026-07-31T16:36:02-07:00
test_1_1  test_1  129                50             7         79     0    0     2026-07-31T16:35:57-07:00
test_4_1  test_4  128                50             8         78     0    0     2026-07-31T16:36:02-07:00
test_2_1  test_2  127                50             9         77     0    0     2026-07-31T16:35:59-07:00
test_3_1  test_3  127                50             10        77     0    0     2026-07-31T16:36:00-07:00
foo_1     foo     125                50             11        75     0    0     2026-07-31T16:35:55-07:00
test_4_2  test_4  125                50             12        75     0    0     2026-07-31T16:36:02-07:00
test_2    test    123                50             13        73     0    0     2026-07-31T16:36:00-07:00
test_4_3  test_4  123                50             14        73     0    0     2026-07-31T16:36:02-07:00
test_4    test    123                50             15        73     0    0     2026-07-31T16:36:03-07:00
foo_2     foo     122                50             16        72     0    0     2026-07-31T16:35:55-07:00
test_1    test    122                50             17        72     0    0     2026-07-31T16:35:58-07:00
test_3_2  test_3  122                50             18        72     0    0     2026-07-31T16:36:00-07:00
test_3    test    122                50             19        72     0    0     2026-07-31T16:36:02-07:00
test_4_4  test_4  122                50             20        72     0    0     2026-07-31T16:36:02-07:00
baz_1     baz     121                50             21        71     0    0     2026-07-31T16:35:54-07:00
test_1_2  test_1  121                50             22        71     0    0     2026-07-31T16:35:57-07:00
test_1_3  test_1  121                50             23        71     0    0     2026-07-31T16:35:57-07:00
test_2_2  test_2  121                50             24        71     0    0     2026-07-31T16:35:59-07:00
test_5    test    121                50             25        71     0    0     2026-07-31T16:36:03-07:00
test_3_3  test_3  120                50             26        70     0    0     2026-07-31T16:36:01-07:00
test_4_5  test_4  120                50             27        70     0    0     2026-07-31T16:36:03-07:00
test_4_6  test_4  120                50             28        70     0    0     2026-07-31T16:36:03-07:00
test_6    test    120                50             29        70     0    0     2026-07-31T16:36:04-07:00
test_7    test    120                50             30        70     0    0     2026-07-31T16:36:04-07:00
test_2_3  test_2  119                50             31        69     0    0     2026-07-31T16:35:59-07:00
foo_3     foo     118                50             32        68     0    0     2026-07-31T16:35:56-07:00
test_4_7  test_4  118                50             33        68     0    0     2026-07-31T16:36:03-07:00
test_8    test    118                50             34        68     0    0     2026-07-31T16:36:04-07:00
test_9    test    118                50             35        68     0    0     2026-07-31T16:36:04-07:00
test_4_8  test_4  117                50             36        67     0    0     2026-07-31T16:36:03-07:00
test_3_4  test_3  116                50             37        66     0    0     2026-07-31T16:36:01-07:00
test_4_9  test_4  116                50             38        66     0    0     2026-07-31T16:36:03-07:00
baz_2     baz     115                50             39        65     0    0     2026-07-31T16:35:54-07:00
foo_4     foo     115                50             40        65     0    0     2026-07-31T16:35:56-07:00
test_1_4  test_1  115                50             41        65     0    0     2026-07-31T16:35:57-07:00
test_1_5  test_1  115                50             42        65     0    0     2026-07-31T16:35:58-07:00
test_2_4  test_2  114                50             43        64     0    0     2026-07-31T16:35:59-07:00
test_3_5  test_3  114                50             44        64     0    0     2026-07-31T16:36:01-07:00
foo_5     foo     113                50             45        63     0    0     2026-07-31T16:35:56-07:00
test_2_5  test_2  113                50             46        63     0    0     2026-07-31T16:35:59-07:00
test_3_6  test_3  111                50             47        61     0    0     2026-07-31T16:36:01-07:00
foo_6     foo     110                50             48        60     0    0     2026-07-31T16:35:56-07:00
test_1_6  test_1  110                50             49        60     0    0     2026-07-31T16:35:58-07:00
test_3_7  test_3  110                50             50        60     0    0     2026-07-31T16:36:01-07:00
baz_3     baz     109                50             51        59     0    0     2026-07-31T16:35:54-07:00
test_1_7  test_1  109                50             52        59     0    0     2026-07-31T16:35:58-07:00
test_2_6  test_2  109                50             53        59     0    0     2026-07-31T16:35:59-07:00
foo_7     foo     108                50             54        58     0    0     2026-07-31T16:35:56-07:00
test_2_7  test_2  108                50             55        58     0    0     2026-07-31T16:35:59-07:00
test_3_8  test_3  107                50             56        57     0    0     2026-07-31T16:36:01-07:00
foo_8     foo     106                50             57        56     0    0     2026-07-31T16:35:56-07:00
test_3_9  test_3  106                50             58        56     0    0     2026-07-31T16:36:01-07:00
test_1_8  test_1  105                50             59        55     0    0     2026-07-31T16:35:58-07:00
baz_4     baz     104                50             60        54     0    0     2026-07-31T16:35:54-07:00
test_2_8  test_2  104                50             61        54     0    0     2026-07-31T16:36:00-07:00
foo_9     foo     103                50             62        53     0    0     2026-07-31T16:35:56-07:00
test_1_9  test_1  103                50             63        53     0    0     2026-07-31T16:35:58-07:00
test_2_9  test_2  103                50             64        53     0    0     2026-07-31T16:36:00-07:00
baz_5     baz     100                50             65        50     0    0     2026-07-31T16:35:54-07:00
baz_6     baz     97                 50             66        47     0    0     2026-07-31T16:35:54-07:00
baz_7     baz     94                 50             67        44     0    0     2026-07-31T16:35:55-07:00
baz_8     baz     91                 50             68        41     0    0     2026-07-31T16:35:55-07:00
baz_9     baz     89                 50             69        39     0    0     2026-07-31T16:35:55-07:00

```

Same jobs queued before the change: 
```
Batch Queue Workloads
JobID     Tenant  Adjusted Priority  Base Priority  Position  Usage  Age  Size  CreatedAt
baz_1     baz     130                50             1         80     0    0     2026-07-31T16:44:18-07:00
baz_2     baz     130                50             2         80     0    0     2026-07-31T16:44:18-07:00
baz_3     baz     130                50             3         80     0    0     2026-07-31T16:44:18-07:00
baz_4     baz     130                50             4         80     0    0     2026-07-31T16:44:18-07:00
baz_5     baz     130                50             5         80     0    0     2026-07-31T16:44:18-07:00
baz_6     baz     130                50             6         80     0    0     2026-07-31T16:44:18-07:00
baz_7     baz     130                50             7         80     0    0     2026-07-31T16:44:19-07:00
baz_8     baz     130                50             8         80     0    0     2026-07-31T16:44:19-07:00
baz_9     baz     130                50             9         80     0    0     2026-07-31T16:44:19-07:00
foo_0     foo     130                50             10        80     0    0     2026-07-31T16:44:19-07:00
foo_1     foo     130                50             11        80     0    0     2026-07-31T16:44:19-07:00
foo_2     foo     130                50             12        80     0    0     2026-07-31T16:44:19-07:00
foo_3     foo     130                50             13        80     0    0     2026-07-31T16:44:19-07:00
foo_4     foo     130                50             14        80     0    0     2026-07-31T16:44:20-07:00
foo_5     foo     130                50             15        80     0    0     2026-07-31T16:44:20-07:00
foo_6     foo     130                50             16        80     0    0     2026-07-31T16:44:20-07:00
foo_7     foo     130                50             17        80     0    0     2026-07-31T16:44:20-07:00
foo_8     foo     130                50             18        80     0    0     2026-07-31T16:44:20-07:00
foo_9     foo     130                50             19        80     0    0     2026-07-31T16:44:20-07:00
test_0    test    130                50             20        80     0    0     2026-07-31T16:44:21-07:00
test_1_0  test_1  130                50             21        80     0    0     2026-07-31T16:44:21-07:00
test_1_1  test_1  130                50             22        80     0    0     2026-07-31T16:44:21-07:00
test_1_2  test_1  130                50             23        80     0    0     2026-07-31T16:44:21-07:00
test_1_3  test_1  130                50             24        80     0    0     2026-07-31T16:44:21-07:00
test_1_4  test_1  130                50             25        80     0    0     2026-07-31T16:44:21-07:00
test_1_5  test_1  130                50             26        80     0    0     2026-07-31T16:44:21-07:00
test_1_6  test_1  130                50             27        80     0    0     2026-07-31T16:44:22-07:00
test_1_7  test_1  130                50             28        80     0    0     2026-07-31T16:44:22-07:00
test_1_8  test_1  130                50             29        80     0    0     2026-07-31T16:44:22-07:00
test_1_9  test_1  130                50             30        80     0    0     2026-07-31T16:44:22-07:00
test_1    test    130                50             31        80     0    0     2026-07-31T16:44:22-07:00
test_2_0  test_2  130                50             32        80     0    0     2026-07-31T16:44:22-07:00
test_2_1  test_2  130                50             33        80     0    0     2026-07-31T16:44:22-07:00
test_2_2  test_2  130                50             34        80     0    0     2026-07-31T16:44:23-07:00
test_2_3  test_2  130                50             35        80     0    0     2026-07-31T16:44:23-07:00
test_2_4  test_2  130                50             36        80     0    0     2026-07-31T16:44:23-07:00
test_2_5  test_2  130                50             37        80     0    0     2026-07-31T16:44:23-07:00
test_2_6  test_2  130                50             38        80     0    0     2026-07-31T16:44:23-07:00
test_2_7  test_2  130                50             39        80     0    0     2026-07-31T16:44:23-07:00
test_2_8  test_2  130                50             40        80     0    0     2026-07-31T16:44:24-07:00
test_2_9  test_2  130                50             41        80     0    0     2026-07-31T16:44:24-07:00
test_2    test    130                50             42        80     0    0     2026-07-31T16:44:24-07:00
test_3_0  test_3  130                50             43        80     0    0     2026-07-31T16:44:24-07:00
test_3_1  test_3  130                50             44        80     0    0     2026-07-31T16:44:24-07:00
test_3_2  test_3  130                50             45        80     0    0     2026-07-31T16:44:24-07:00
test_3_3  test_3  130                50             46        80     0    0     2026-07-31T16:44:24-07:00
test_3_4  test_3  130                50             47        80     0    0     2026-07-31T16:44:25-07:00
test_3_5  test_3  130                50             48        80     0    0     2026-07-31T16:44:25-07:00
test_3_6  test_3  130                50             49        80     0    0     2026-07-31T16:44:25-07:00
test_3_7  test_3  130                50             50        80     0    0     2026-07-31T16:44:25-07:00
test_3_8  test_3  130                50             51        80     0    0     2026-07-31T16:44:25-07:00
test_3_9  test_3  130                50             52        80     0    0     2026-07-31T16:44:25-07:00
test_3    test    130                50             53        80     0    0     2026-07-31T16:44:25-07:00
test_4_0  test_4  130                50             54        80     0    0     2026-07-31T16:44:26-07:00
test_4_1  test_4  130                50             55        80     0    0     2026-07-31T16:44:26-07:00
test_4_2  test_4  130                50             56        80     0    0     2026-07-31T16:44:26-07:00
test_4_3  test_4  130                50             57        80     0    0     2026-07-31T16:44:26-07:00
test_4_4  test_4  130                50             58        80     0    0     2026-07-31T16:44:26-07:00
test_4_5  test_4  130                50             59        80     0    0     2026-07-31T16:44:26-07:00
test_4_6  test_4  130                50             60        80     0    0     2026-07-31T16:44:27-07:00
test_4_7  test_4  130                50             61        80     0    0     2026-07-31T16:44:27-07:00
test_4_8  test_4  130                50             62        80     0    0     2026-07-31T16:44:27-07:00
test_4_9  test_4  130                50             63        80     0    0     2026-07-31T16:44:27-07:00
test_4    test    130                50             64        80     0    0     2026-07-31T16:44:27-07:00
test_5    test    130                50             65        80     0    0     2026-07-31T16:44:27-07:00
test_6    test    130                50             66        80     0    0     2026-07-31T16:44:27-07:00
test_7    test    130                50             67        80     0    0     2026-07-31T16:44:28-07:00
test_8    test    130                50             68        80     0    0     2026-07-31T16:44:28-07:00
test_9    test    130                50             69        80     0    0     2026-07-31T16:44:28-07:00
```

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
