### PR TITLE
config: Remove remaining md5 from TLS checksum

### DIFF
--- a/nomad/structs/config/tls.go
+++ b/nomad/structs/config/tls.go
@@ -4,11 +4,11 @@
 package config
 
 import (
-	"crypto/md5"
 	"crypto/sha256"
 	"crypto/tls"
 	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 	"os"
 	"sync"
@@ -267,30 +267,28 @@ func (t *TLSConfig) SetChecksum() error {
 	return nil
 }
 
-func getFileChecksum(filepath string) (string, error) {
+func getFileChecksum(h hash.Hash, filepath string) error {
 	f, err := os.Open(filepath)
 	if err != nil {
-		return "", err
+		return err
 	}
 	defer f.Close()
 
-	h := md5.New()
 	if _, err := io.Copy(h, f); err != nil {
-		return "", err
+		return err
 	}
 
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return nil
 }
 
 func createChecksumOfFiles(inputs ...string) (string, error) {
 	h := sha256.New()
 
 	for _, input := range inputs {
-		checksum, err := getFileChecksum(input)
+		err := getFileChecksum(h, input)
 		if err != nil {
 			return "", err
 		}
-		io.WriteString(h, checksum)
 	}
 
 	return hex.EncodeToString(h.Sum(nil)), nil


### PR DESCRIPTION
In #28355 we intended to remove the use of md5 from the checksum used to detect TLS configuration changes. But we missed a second use fo the function deeper in the callstack. Remove the md5 function by not setting up the inner hash function in the first place.

Ref: https://github.com/hashicorp/nomad/pull/28355
Ref: https://hashicorp.atlassian.net/browse/NMD-1658

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
