### PR TITLE
CI: add semgrep rule for insecure hashes

### DIFF
--- a/.semgrep/insecure_hashes.yml
+++ b/.semgrep/insecure_hashes.yml
@@ -1,0 +1,41 @@
+# Copyright IBM Corp. 2015, 2026
+# SPDX-License-Identifier: BUSL-1.1
+
+rules:
+  - id: "no-insecure-hashes"
+    message: |
+      Insecure hashes like md5 or sha1 should not be used even for
+      non-cryptographic purposes, because these are forbidden by the Go
+      Cryptographic Module in FIPS-mode builds.
+
+      If this usage is intentional and properly gated by a fips140.Enabled() check,
+      ensure the check causes an early return before the hash function is called.
+    languages:
+      - "go"
+    severity: "WARNING"
+
+    patterns:
+      # Match any usage of insecure hash functions
+      - pattern-either:
+          - pattern: sha1.New()
+          - pattern: sha1.Sum(...)
+          - pattern: md5.New()
+          - pattern: md5.Sum(...)
+
+      # exclude if we only use hash if FIPS is not enabled
+      - pattern-not-inside: |
+          if !fips140.Enabled() {
+            ...
+          }
+
+      # exclude if we return early before hash if FIPS is enabled
+      - pattern-not-inside: |
+          if fips140.Enabled() {
+            return ...
+          }
+          ...
+      - pattern-not-inside: |
+          if fips140.Enabled() {
+            return ..., ...
+          }
+          ...

--- a/client/allocrunner/consul_hook_test.go
+++ b/client/allocrunner/consul_hook_test.go
@@ -4,9 +4,9 @@
 package allocrunner
 
 import (
-	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 	"testing"
 
 	consulapi "github.com/hashicorp/consul/api"
@@ -97,13 +97,13 @@ func Test_consulHook_prepareConsulTokensForTask(t *testing.T) {
 	ti := *task.IdentityHandle(wid)
 	jwt, err := hook.widmgr.Get(ti)
 	must.NoError(t, err)
-	hashJWT1 := md5.Sum([]byte(jwt.JWT))
+	hashJWT1 := fnv.New128().Sum([]byte(jwt.JWT))
 
 	task2 := hook.alloc.LookupTask("extra")
 	ti2 := *task2.IdentityHandle(wid)
 	jwt2, err := hook.widmgr.Get(ti2)
 	must.NoError(t, err)
-	hashJWT2 := md5.Sum([]byte(jwt2.JWT))
+	hashJWT2 := fnv.New128().Sum([]byte(jwt2.JWT))
 
 	tests := []struct {
 		name           string
@@ -195,7 +195,7 @@ func Test_consulHook_prepareConsulTokensForServices(t *testing.T) {
 		jwt, err := hook.widmgr.Get(widHandle)
 		must.NoError(t, err)
 
-		hash := md5.Sum([]byte(jwt.JWT))
+		hash := fnv.New128().Sum([]byte(jwt.JWT))
 		hashedJWT[widHandle.InterpolatedWorkloadIdentifier] = hex.EncodeToString(hash[:])
 	}
 

--- a/client/consul/consul_testing.go
+++ b/client/consul/consul_testing.go
@@ -5,8 +5,8 @@ package consul
 
 import (
 	"context"
-	"crypto/md5"
 	"encoding/hex"
+	"hash/fnv"
 
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/hashicorp/go-hclog"
@@ -22,9 +22,8 @@ func NewMockConsulClient(config *config.ConsulConfig, logger hclog.Logger) (Clie
 	return &MockConsulClient{}, nil
 }
 
-// DeriveTokenWithJWT returns ACLTokens with deterministic values for testing:
-// the request ID for the AccessorID and the md5 checksum of the request ID for
-// the SecretID
+// DeriveTokenWithJWT returns ACLTokens with deterministic values for testing: a
+// hash of the request JWT for the AccessorID and SecretID
 func (mc *MockConsulClient) DeriveTokenWithJWT(req JWTLoginRequest) (*consulapi.ACLToken, error) {
 	mc.Requests = append(mc.Requests, req)
 
@@ -32,7 +31,7 @@ func (mc *MockConsulClient) DeriveTokenWithJWT(req JWTLoginRequest) (*consulapi.
 		return t, nil
 	}
 
-	hash := md5.Sum([]byte(req.JWT))
+	hash := fnv.New128().Sum([]byte(req.JWT))
 	token := &consulapi.ACLToken{
 		AccessorID: hex.EncodeToString(hash[:]),
 		SecretID:   hex.EncodeToString(hash[:]),

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -5495,7 +5495,7 @@ func TestTaskArtifact_Validate_Checksum(t *testing.T) {
 			&TaskArtifact{
 				GetterSource: "foo.com",
 				GetterOptions: map[string]string{
-					"checksum": "md5:toosmall",
+					"checksum": "sha256:toosmall",
 				},
 			},
 			true,
@@ -5513,7 +5513,7 @@ func TestTaskArtifact_Validate_Checksum(t *testing.T) {
 			&TaskArtifact{
 				GetterSource: "foo.com",
 				GetterOptions: map[string]string{
-					"checksum": "md5:${ARTIFACT_CHECKSUM}",
+					"checksum": "sha256:${ARTIFACT_CHECKSUM}",
 				},
 			},
 			false,


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module. In `GODEBUG=fips140=only` mode ("enforcing"), the sha1 and md5 hash functions are disallowed and will panic the agent if you try to call the hash constructors.

To make sure we're not introducing new uses of these functions, add a semgrep rule to disallow them unless gated by a check whether we're running in FIPS-enabled mode.

This changeset also updates a few bits of test code that have lingering uses to make the semgrep rule easier. These hashes were only used in testing and are non-cryptographic uses anyways, so switch them to FNV.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140

### Contributor Checklist
- [x] **Changelog Entry** n/a
- [x] **Testing** test-only change
- [x] **Documentation** n/a
- [x] **LLM Usage** I used Bob to help me write the semgrep rule, but I've tested it fully

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
