### PR TITLE
deps: replace go-kms-wrapping with temporary fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.26.5
 // Pinned dependencies are noted in github.com/hashicorp/nomad/issues/11826.
 replace (
 	github.com/Microsoft/go-winio => github.com/endocrimes/go-winio v0.4.13-0.20190628114223-fb47a8b41948
+	github.com/hashicorp/go-kms-wrapping/v2 => github.com/tgross/go-kms-wrapping/v2 v2.0.0-20260804111501-651ec6543396
+	github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2 => github.com/tgross/go-kms-wrapping/wrappers/aead/v2 v2.0.0-20260804111501-651ec6543396
 	github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.1-nomad-1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -460,10 +460,6 @@ github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJ
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix/v2 v2.1.0 h1:CUW5RYIcysz+D3B+l1mDeXrQ7fUvGGCwJfdASSzbrfo=
 github.com/hashicorp/go-immutable-radix/v2 v2.1.0/go.mod h1:hgdqLXA4f6NIjRVisM1TJ9aOJVNRqKZj+xDGF6m7PBw=
-github.com/hashicorp/go-kms-wrapping/v2 v2.0.23 h1:HZOdsAP0hZMIF/61v4B31DBbKx7NbtWmgBS6WEUOZvU=
-github.com/hashicorp/go-kms-wrapping/v2 v2.0.23/go.mod h1:NeK2Ul15t1zutp/dZzt28XQrGZHosbxE/QLNNfaWObM=
-github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2 v2.0.10 h1:am7ai27sEGpfOefHhUShbWAOa6EvkBaiMpB7zZ/PUyo=
-github.com/hashicorp/go-kms-wrapping/wrappers/aead/v2 v2.0.10/go.mod h1:sYX07HI7wMCFe9+FmxMOCwJ7q5CD4aq3VI+KoB8FYZY=
 github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v2 v2.0.11 h1:J9zGa9SlcOHT3SQTj0Vv3shHo0anWbs58weURGCgChI=
 github.com/hashicorp/go-kms-wrapping/wrappers/awskms/v2 v2.0.11/go.mod h1:iAOCu7/lG5eugg8+k7NVvQt0IpWT8s2Q9wnMtC/guM4=
 github.com/hashicorp/go-kms-wrapping/wrappers/azurekeyvault/v2 v2.0.15 h1:Y73Tv263K936w0jdmHUPLHsf7fQdDpIyvz9z98JsvCE=
@@ -872,6 +868,10 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tencentcloud/tencentcloud-sdk-go v1.0.162 h1:8fDzz4GuVg4skjY2B0nMN7h6uN61EDVkuLyI2+qGHhI=
 github.com/tencentcloud/tencentcloud-sdk-go v1.0.162/go.mod h1:asUz5BPXxgoPGaRgZaVm1iGcUAuHyYUo1nXqKa83cvI=
+github.com/tgross/go-kms-wrapping/v2 v2.0.0-20260804111501-651ec6543396 h1:VACxGUHyDpVoGgEOjZON1RGuSbk5LyppMt486YjleB4=
+github.com/tgross/go-kms-wrapping/v2 v2.0.0-20260804111501-651ec6543396/go.mod h1:NeK2Ul15t1zutp/dZzt28XQrGZHosbxE/QLNNfaWObM=
+github.com/tgross/go-kms-wrapping/wrappers/aead/v2 v2.0.0-20260804111501-651ec6543396 h1:dHWpd/VCOfOys63+CpiQ4+PyoZgpl0KrPKuTJBZeltg=
+github.com/tgross/go-kms-wrapping/wrappers/aead/v2 v2.0.0-20260804111501-651ec6543396/go.mod h1:LNUXc3vWpmlwLQw6X0DsZiNb44AJ3ApQ90+Dz1txAbM=
 github.com/tj/go-spin v1.1.0 h1:lhdWZsvImxvZ3q1C5OIB7d72DuOwP4O2NdBg9PyzNds=
 github.com/tj/go-spin v1.1.0/go.mod h1:Mg1mzmePZm4dva8Qz60H2lHwmJ2loum4VIrLgVnKwh4=
 github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFAEVmqU=


### PR DESCRIPTION
When built with the Go Cryptographic Module for FIPS-140 compliance, and running in "enforcing mode" of `GODEBUG=fips140=only`, AEAD and envelope operations will fail.

Our patch to fix this in `go-kms-wrapping` has been approved but not released. While we're waiting for that to happen, we'd like to move on to comprehensive end-to-end build and feature testing. Temporarily replace the go.mod directives for this library.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://github.com/hashicorp/go-kms-wrapping/pull/331


### Contributor Checklist
- [x] **Changelog Entry** n/a
- [x] **Testing**
  - in addition to CI, `go test ./nomad/ -run Encrypt` and `go test ./nomad/ -run Encrypt` both pass in enforcing mode.
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
  - Note we're backporting this even though its only intended for testing, so that we have it in Nomad Enterprise release branches. We'll backport the real library version bump when it's available, unless that risks shipping 2.0.5, in which case we'll ship with this as-is.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
