### PR TITLE
template: disable md5sum function in FIPS mode

### DIFF
--- a/client/allocrunner/taskrunner/template/template.go
+++ b/client/allocrunner/taskrunner/template/template.go
@@ -5,6 +5,7 @@ package template
 
 import (
 	"context"
+	"crypto/fips140"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -788,6 +789,9 @@ func parseTemplateConfigs(config *TaskTemplateManagerConfig) (map[*ctconf.Templa
 		ct.RightDelim = &tmpl.RightDelim
 		ct.ErrMissingKey = &tmpl.ErrMissingKey
 		ct.FunctionDenylist = config.ClientConfig.TemplateConfig.FunctionDenylist
+		if fips140.Enabled() {
+			ct.FunctionDenylist = append(ct.FunctionDenylist, "md5sum")
+		}
 		if sandboxEnabled {
 			ct.SandboxPath = &config.TaskDir
 		}


### PR DESCRIPTION
As part of a project to make FIPS-140 compliant binaries available for Nomad Enterprise customers, we intend to use the Go Cryptographic Module. In `GODEBUG=fips140=only mode` ("enforcing"), the md5 hash function is disallowed and will panic the agent if you try to call md5.New().

Disable the `md5sum` function in the template runner in FIPS binaries.

Ref: https://hashicorp.atlassian.net/browse/NMD-1658
Ref: https://go.dev/doc/security/fips140
Ref: https://go.dev/blog/fips140
https://github.com/hashicorp/consul-template/blob/main/docs/templating-language.md#md5sum

### Contributor Checklist
- [x] **Changelog Entry** will get rolled up into the feature changelog
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** https://github.com/hashicorp/web-unified-docs/pull/3002
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
