### PR TITLE
batch queue: adds queue per node pool

### DIFF
--- a/command/agent/batch_job_queue_endpoint.go
+++ b/command/agent/batch_job_queue_endpoint.go
@@ -23,8 +23,10 @@ func (s *HTTPServer) BatchJobQueueJobsRequest(resp http.ResponseWriter, req *htt
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
 		return nil, nil
 	}
+
 	query := req.URL.Query()
 	args.Sort = structs.SortOrder(query.Get("sort"))
+	args.NodePool = query.Get("node_pool")
 
 	if err := s.agent.RPC("BatchJobQueue.Jobs", &args, &out); err != nil {
 		return nil, err
@@ -48,6 +50,8 @@ func (s *HTTPServer) BatchJobQueueTenantsRequest(resp http.ResponseWriter, req *
 	if s.parse(resp, req, &args.Region, &args.QueryOptions) {
 		return nil, nil
 	}
+
+	args.NodePool = req.URL.Query().Get("node_pool")
 
 	if err := s.agent.RPC("BatchJobQueue.Tenants", &args, &out); err != nil {
 		return nil, err

--- a/command/queue_jobs.go
+++ b/command/queue_jobs.go
@@ -30,7 +30,7 @@ General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `
 
-Eval Options:
+Jobs Options:
 
   -per-page
     The maximum number of workloads to return per page. If not specified, or set to 0, all results are returned.
@@ -57,6 +57,7 @@ func (c *QueueJobsCommand) Synopsis() string {
 func (c *QueueJobsCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
+			"-node-pool":  complete.PredictNothing,
 			"-verbose":    complete.PredictNothing,
 			"-json":       complete.PredictNothing,
 			"-p":          complete.PredictNothing,
@@ -73,7 +74,7 @@ func (c *QueueJobsCommand) Name() string { return "queue status" }
 
 func (c *QueueJobsCommand) Run(args []string) int {
 	var verbose, jsonOut, prioritySort bool
-	var pageToken string
+	var pageToken, nodePool string
 	var perPage int
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
@@ -81,6 +82,7 @@ func (c *QueueJobsCommand) Run(args []string) int {
 	flags.BoolVar(&jsonOut, "json", false, "")
 	flags.BoolVar(&prioritySort, "p", false, "")
 	flags.StringVar(&pageToken, "page-token", "", "")
+	flags.StringVar(&nodePool, "node-pool", "default", "")
 	flags.IntVar(&perPage, "per-page", 0, "")
 
 	if err := flags.Parse(args); err != nil {
@@ -99,7 +101,8 @@ func (c *QueueJobsCommand) Run(args []string) int {
 		PerPage:   int32(perPage),
 		NextToken: pageToken,
 		Params: map[string]string{
-			"sort": "default",
+			"sort":      "default",
+			"node_pool": nodePool,
 		},
 	}
 

--- a/command/queue_tenants.go
+++ b/command/queue_tenants.go
@@ -20,7 +20,7 @@ type QueueTenantsCommand struct {
 
 func (c *QueueTenantsCommand) Help() string {
 	helpText := `
-Usage: nomad queue status [options]
+Usage: nomad queue tenants [options]
 
   View the current status of tenants in a batch job queue.
 
@@ -30,7 +30,10 @@ General Options:
 
   ` + generalOptionsUsage(usageOptsDefault) + `
 
-Eval Options:
+Tenants Options:
+
+  -node-pool
+    The node pool queue to query
 
   -limit
     The maximum number of tenants to return
@@ -52,9 +55,10 @@ func (c *QueueTenantsCommand) Synopsis() string {
 func (c *QueueTenantsCommand) AutocompleteFlags() complete.Flags {
 	return mergeAutocompleteFlags(c.Meta.AutocompleteFlags(FlagSetClient),
 		complete.Flags{
-			"-verbose": complete.PredictNothing,
-			"-limit":   complete.PredictNothing,
-			"-json":    complete.PredictNothing,
+			"-node-pool": complete.PredictNothing,
+			"-verbose":   complete.PredictNothing,
+			"-limit":     complete.PredictNothing,
+			"-json":      complete.PredictNothing,
 		})
 }
 
@@ -67,11 +71,13 @@ func (c *QueueTenantsCommand) Name() string { return "queue status" }
 func (c *QueueTenantsCommand) Run(args []string) int {
 	var verbose, jsonOut bool
 	var limit int
+	var nodePool string
 	flags := c.Meta.FlagSet(c.Name(), FlagSetClient)
 	flags.Usage = func() { c.Ui.Output(c.Help()) }
 	flags.BoolVar(&verbose, "verbose", false, "")
 	flags.BoolVar(&jsonOut, "json", false, "")
 	flags.IntVar(&limit, "limit", 0, "")
+	flags.StringVar(&nodePool, "node-pool", "default", "")
 
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -85,7 +91,11 @@ func (c *QueueTenantsCommand) Run(args []string) int {
 	}
 
 	// Setup the options
-	qo := &api.QueryOptions{}
+	qo := &api.QueryOptions{
+		Params: map[string]string{
+			"node_pool": nodePool,
+		},
+	}
 
 	if limit > 0 {
 		qo.PerPage = int32(limit)

--- a/nomad/batch_job_queue_endpoint.go
+++ b/nomad/batch_job_queue_endpoint.go
@@ -53,7 +53,7 @@ func (q *BatchJobQueue) Jobs(args *structs.QueueJobsRequest, reply *structs.Queu
 		return err
 	}
 
-	batchJobQueue := q.srv.batchQueueMgr.Queue()
+	batchJobQueue := q.srv.batchQueueMgr.Queue(args.NodePool)
 	iter := batchJobQueue.Jobs(args.Sort)
 
 	selector := func(workload structs.QueueWorkload) bool {
@@ -103,7 +103,7 @@ func (q *BatchJobQueue) Tenants(args *structs.QueueTenantsRequest, reply *struct
 		return structs.ErrPermissionDenied
 	}
 
-	status := q.srv.batchQueueMgr.Queue().Tenants()
+	status := q.srv.batchQueueMgr.Queue(args.NodePool).Tenants()
 	reply.Tenants = status.Tenants
 	reply.Type = status.Type
 

--- a/nomad/batch_job_queue_endpoint.go
+++ b/nomad/batch_job_queue_endpoint.go
@@ -53,7 +53,12 @@ func (q *BatchJobQueue) Jobs(args *structs.QueueJobsRequest, reply *structs.Queu
 		return err
 	}
 
-	batchJobQueue := q.srv.batchQueueMgr.Queue(args.NodePool)
+	pool := args.NodePool
+	if pool == "" {
+		pool = structs.NodePoolDefault
+	}
+
+	batchJobQueue := q.srv.batchQueueMgr.Queue(pool)
 	iter := batchJobQueue.Jobs(args.Sort)
 
 	selector := func(workload structs.QueueWorkload) bool {
@@ -103,7 +108,12 @@ func (q *BatchJobQueue) Tenants(args *structs.QueueTenantsRequest, reply *struct
 		return structs.ErrPermissionDenied
 	}
 
-	status := q.srv.batchQueueMgr.Queue(args.NodePool).Tenants()
+	pool := args.NodePool
+	if pool == "" {
+		pool = structs.NodePoolDefault
+	}
+
+	status := q.srv.batchQueueMgr.Queue(pool).Tenants()
 	reply.Tenants = status.Tenants
 	reply.Type = status.Type
 

--- a/nomad/batch_job_queue_endpoint_test.go
+++ b/nomad/batch_job_queue_endpoint_test.go
@@ -72,7 +72,13 @@ func TestBatchJobQueue_Jobs(t *testing.T) {
 				Workloads: []structs.QueueWorkload{workload1, workload2, workload3},
 			})
 			mockQueue.On("Stop")
-			s.batchQueueMgr = queues.NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, nil, queues.WithQueue(mockQueue))
+			s.batchQueueMgr = queues.NewBatchQueueMgr(
+				t.Context(),
+				structs.BatchQueue{},
+				nil,
+				nil,
+				queues.WithQueue("default", mockQueue),
+			)
 
 			reply := structs.QueueJobsResponse{}
 			err := s.RPC("BatchJobQueue.Jobs", &tc.req, &reply)
@@ -153,7 +159,13 @@ func TestBatchJobQueue_Jobs_WithACL(t *testing.T) {
 
 			mockQueue.On("Stop")
 			resp := structs.QueueJobsResponse{}
-			s1.batchQueueMgr = queues.NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, nil, queues.WithQueue(mockQueue))
+			s1.batchQueueMgr = queues.NewBatchQueueMgr(
+				t.Context(),
+				structs.BatchQueue{},
+				nil,
+				nil,
+				queues.WithQueue("default", mockQueue),
+			)
 
 			err = s1.RPC("BatchJobQueue.Jobs", &tc.req, &resp)
 			if tc.err != "" {
@@ -187,7 +199,13 @@ func TestBatchJobQueue_Tenants(t *testing.T) {
 
 	reply := structs.QueueTenantsResponse{}
 
-	s.batchQueueMgr = queues.NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, nil, queues.WithQueue(mockQueue))
+	s.batchQueueMgr = queues.NewBatchQueueMgr(
+		t.Context(),
+		structs.BatchQueue{},
+		nil,
+		nil,
+		queues.WithQueue("default", mockQueue),
+	)
 
 	err := s.RPC("BatchJobQueue.Tenants", &req, &reply)
 	must.NoError(t, err)
@@ -241,7 +259,13 @@ func TestBatchJobQueue_Tenants_WithACL(t *testing.T) {
 
 			reply := structs.QueueTenantsResponse{}
 
-			s1.batchQueueMgr = queues.NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, nil, queues.WithQueue(mockQueue))
+			s1.batchQueueMgr = queues.NewBatchQueueMgr(
+				t.Context(),
+				structs.BatchQueue{},
+				nil,
+				nil,
+				queues.WithQueue("default", mockQueue),
+			)
 
 			err := s1.RPC("BatchJobQueue.Tenants", &tc.req, &reply)
 

--- a/nomad/node_pool_endpoint.go
+++ b/nomad/node_pool_endpoint.go
@@ -218,6 +218,13 @@ func (n *NodePool) UpsertNodePools(args *structs.NodePoolUpsertRequest, reply *s
 		return err
 	}
 	reply.Index = index
+
+	for _, pool := range args.NodePools {
+		if err := n.srv.batchQueueMgr.UpdateQueue(pool); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/nomad/operator_endpoint.go
+++ b/nomad/operator_endpoint.go
@@ -468,7 +468,10 @@ func (op *Operator) SchedulerSetConfiguration(args *structs.SchedulerSetConfigRe
 	// restoring into non-running brokers.
 	if reply.Updated {
 		// Update will restart a queue, restoring state, but not restoring pending evals
-		op.srv.batchQueueMgr.Update(&args.Config.BatchQueue)
+		if err := op.srv.batchQueueMgr.UpdateDefaultQueues(); err != nil {
+			op.logger.Error("failed updating batch queues with new scheduler config", "error", err)
+			return err
+		}
 
 		if op.srv.handleEvalBrokerStateChange(&args.Config) {
 			return op.srv.restoreEvals()

--- a/nomad/queues/batch_queue_manager.go
+++ b/nomad/queues/batch_queue_manager.go
@@ -88,7 +88,7 @@ func (b *BatchQueueManager) Enqueue(e *structs.Evaluation) {
 		b.broker.Enqueue(e)
 		return
 	}
-	q.Enqueue(e)
+	q.Enqueue(e, job)
 }
 
 // SetEnabled is called during leadership transfers and is responsible for starting
@@ -254,7 +254,7 @@ func (b *BatchQueueManager) enqueuePending(filterFn filter) error {
 			continue
 		}
 
-		q.Enqueue(eval)
+		q.Enqueue(eval, job)
 	}
 	return nil
 }

--- a/nomad/queues/batch_queue_manager.go
+++ b/nomad/queues/batch_queue_manager.go
@@ -137,7 +137,7 @@ func (b *BatchQueueManager) Queue(pool string) queue.Queue {
 	return b.queues[pool]
 }
 
-// UpdateDefault updates all queues to use the new default_scheduler_config.batch_queue config.
+// UpdateDefaultQueues updates all queues to use the new default_scheduler_config.batch_queue config.
 func (b *BatchQueueManager) UpdateDefaultQueues() error {
 	b.mux.Lock()
 	defer b.mux.Unlock()
@@ -183,7 +183,7 @@ func (b *BatchQueueManager) UpdateDefaultQueues() error {
 	return b.enqueuePending(withDefaultQueueFilter())
 }
 
-// UpdatePool updates an individual queues to use the provided config
+// UpdateQueue updates an individual queue to use the provided config
 func (b *BatchQueueManager) UpdateQueue(conf *structs.NodePool) error {
 	b.mux.Lock()
 	defer b.mux.Unlock()

--- a/nomad/queues/batch_queue_manager.go
+++ b/nomad/queues/batch_queue_manager.go
@@ -9,34 +9,43 @@ import (
 	"sync/atomic"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/nomad/queues/passthrough"
 	"github.com/hashicorp/nomad/nomad/queues/queue"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
+const DefaultQueue = structs.NodePoolDefault
+
+type QueueData struct {
+	queue.Queue
+	isDefaultQueue bool
+}
+
 type BatchQueueManager struct {
-	defaultQueue queue.Queue
-	defaultConf  structs.BatchQueue
-	broker       queue.Broker
-	state        *state.StateStore
-	enabled      atomic.Bool
-	shutdownCtx  context.Context
-	mux          sync.Mutex
-	logger       hclog.Logger
+	queues      map[string]*QueueData
+	defaultConf structs.BatchQueue
+	broker      queue.Broker
+	state       *state.StateStore
+	enabled     atomic.Bool
+	shutdownCtx context.Context
+	mux         sync.Mutex
+	logger      hclog.Logger
 }
 
 type QueueMgrOpt func(*BatchQueueManager)
 
-// WithQueue allows passing in a default queue in the constructor
-func WithQueue(q queue.Queue) QueueMgrOpt {
+// WithQueue allows passing in a queue in the constructor
+func WithQueue(pool string, q queue.Queue) QueueMgrOpt {
 	return func(b *BatchQueueManager) {
-		b.defaultQueue = q
+		b.queues[pool] = &QueueData{q, true}
 	}
 }
 
 func NewBatchQueueMgr(ctx context.Context, defaultConf structs.BatchQueue, broker queue.Broker, logger hclog.Logger, opt ...QueueMgrOpt) *BatchQueueManager {
 	mgr := &BatchQueueManager{
+		queues:      make(map[string]*QueueData),
 		defaultConf: defaultConf,
 		broker:      broker,
 		shutdownCtx: ctx,
@@ -56,17 +65,30 @@ func NewBatchQueueMgr(ctx context.Context, defaultConf structs.BatchQueue, broke
 func (b *BatchQueueManager) Enqueue(e *structs.Evaluation) {
 	b.mux.Lock()
 	defer b.mux.Unlock()
+
 	if !b.enabled.Load() {
 		return
 	}
 
 	// If an enqueue happens before SetEnabled = true, throw it away,
 	// it will be processed during eval restore
-	if b.state == nil || b.defaultQueue == nil {
+	if b.state == nil {
 		return
 	}
 
-	b.defaultQueue.Enqueue(e)
+	job, err := b.state.JobByID(nil, e.Namespace, e.JobID)
+	if err != nil {
+		return
+	}
+
+	q, ok := b.queues[job.NodePool]
+	if !ok {
+		// If there was an error creating a queue and it does not
+		// exist, just pass the job to the eval broker for.
+		b.broker.Enqueue(e)
+		return
+	}
+	q.Enqueue(e)
 }
 
 // SetEnabled is called during leadership transfers and is responsible for starting
@@ -84,11 +106,15 @@ func (b *BatchQueueManager) SetEnabled(enabled bool, state *state.StateStore) {
 		if b.state == nil {
 			b.state = state
 		}
-		b.startQueues()
-	} else if b.defaultQueue != nil {
+		if err := b.startQueues(); err != nil {
+			b.logger.Error("failed to start batch queues, batch jobs will be processed normally", "err", err)
+		}
+	} else {
 		// stop default queue
-		b.defaultQueue.Stop()
-		b.defaultQueue = nil
+		for p := range b.queues {
+			b.stopQueue(p)
+		}
+		b.queues = make(map[string]*QueueData)
 	}
 
 	b.enabled.Store(enabled)
@@ -96,7 +122,7 @@ func (b *BatchQueueManager) SetEnabled(enabled bool, state *state.StateStore) {
 
 // Queue returns a pointer to a queue. This is used by RPC handlers
 // to get the jobs or tenants in a queue.
-func (b *BatchQueueManager) Queue() queue.Queue {
+func (b *BatchQueueManager) Queue(pool string) queue.Queue {
 	b.mux.Lock()
 	defer b.mux.Unlock()
 
@@ -104,54 +130,185 @@ func (b *BatchQueueManager) Queue() queue.Queue {
 	// just return the default passthrough queue. This
 	// is unlikely to happen, but guards against a nil
 	// value being returned
-	if b.defaultQueue == nil {
+	if b.queues == nil || b.queues[pool] == nil {
 		return &passthrough.PassthroughQueue{}
 	}
 
-	return b.defaultQueue
+	return b.queues[pool]
 }
 
-// Update is used to either update the default queue or a specific node pools queue.
-func (b *BatchQueueManager) Update(conf *structs.BatchQueue) {
+// UpdateDefault updates all queues to use the new default_scheduler_config.batch_queue config.
+func (b *BatchQueueManager) UpdateDefaultQueues() error {
 	b.mux.Lock()
 	defer b.mux.Unlock()
 
 	if !b.enabled.Load() {
-		return
+		return nil
 	}
 
-	if b.defaultQueue != nil {
-		b.defaultQueue.Stop()
+	// If a pool has the default_scheduler.batch_queue config, we should restart it
+	for p, q := range b.queues {
+		if q.isDefaultQueue {
+			b.stopQueue(p)
+		}
 	}
 
-	queue, err := NewQueue(b.state, conf, b.broker, b.logger)
+	ws := memdb.NewWatchSet()
+	pools, err := b.state.NodePools(ws, state.SortDefault)
 	if err != nil {
-		b.logger.Error("failed to update batch queue", "err", err)
-		return
+		return err
 	}
 
-	b.defaultQueue = queue
-	b.defaultQueue.Start(b.shutdownCtx)
+	for raw := pools.Next(); raw != nil; raw = pools.Next() {
+		pool := raw.(*structs.NodePool)
+
+		// Don't create a queue for "all" node pool
+		if pool.Name == structs.NodePoolAll {
+			continue
+		}
+
+		_, isDefault, err := b.configForPool(pool)
+		if err != nil {
+			return err
+		}
+
+		if !isDefault {
+			continue
+		}
+		if err := b.startQueue(pool); err != nil {
+			return err
+		}
+	}
+
+	return b.enqueuePending(withDefaultQueueFilter())
 }
 
-func (b *BatchQueueManager) startQueues() {
-	defaultConf := b.defaultConf
-	_, conf, err := b.state.SchedulerConfig()
+// UpdatePool updates an individual queues to use the provided config
+func (b *BatchQueueManager) UpdateQueue(conf *structs.NodePool) error {
+	b.mux.Lock()
+	defer b.mux.Unlock()
+
+	if !b.enabled.Load() {
+		return nil
+	}
+
+	// stop previously running queue
+	b.stopQueue(conf.Name)
+
+	// restart queue with new config
+	if err := b.startQueue(conf); err != nil {
+		return err
+	}
+
+	// enqueue any previously pending evaluations
+	return b.enqueuePending(withNodePoolFilter(conf.Name))
+}
+
+type filter func(name string, qdata *QueueData) bool
+
+func withNodePoolFilter(pool string) filter {
+	return func(name string, qdata *QueueData) bool {
+		return pool == name
+	}
+}
+
+func withDefaultQueueFilter() filter {
+	return func(name string, qdata *QueueData) bool {
+		return qdata.isDefaultQueue
+	}
+}
+
+// enqueuePending takes any pending evaluations and enqueues them on the proper
+// queue. When a queue is updates, it's state will be wiped. Queues can rebuild
+// their internal state but do not currently rebuild their previously pending evals.
+//
+// This happens in leader.go during leadership transfer but queue updates are not
+// related to leadership transfers, so the batch queue manager must do it.
+func (b *BatchQueueManager) enqueuePending(filterFn filter) error {
+	ws := memdb.NewWatchSet()
+	iter, err := b.state.Evals(ws, state.SortDefault)
 	if err != nil {
-		b.logger.Error("failed to get scheduler config from state, skipping queue creation", "err", err)
-		return
+		return err
 	}
+	for raw := iter.Next(); raw != nil; raw = iter.Next() {
+		eval, ok := raw.(*structs.Evaluation)
+		if !ok {
+			continue
+		}
 
-	if conf != nil {
-		defaultConf = conf.BatchQueue
+		// Skip non batch jobs
+		if !eval.IsBatchQueue() {
+			continue
+		}
+
+		job, err := b.state.JobByID(nil, eval.Namespace, eval.JobID)
+		if err != nil {
+			return err
+		}
+
+		q, ok := b.queues[job.NodePool]
+		if !ok {
+			b.broker.Enqueue(eval)
+		}
+		if !filterFn(job.NodePool, q) {
+			continue
+		}
+
+		q.Enqueue(eval)
 	}
+	return nil
+}
 
-	queue, err := NewQueue(b.state, &defaultConf, b.broker, b.logger)
+// startQueues encapsulates all the logic for starting every
+// queue in the cluster.
+func (b *BatchQueueManager) startQueues() error {
+	ws := memdb.NewWatchSet()
+	pools, err := b.state.NodePools(ws, state.SortDefault)
 	if err != nil {
-		b.logger.Error("failed to create default batch queue", "err", err)
-		return
+		return err
 	}
 
-	b.defaultQueue = queue
-	b.defaultQueue.Start(b.shutdownCtx)
+	for raw := pools.Next(); raw != nil; raw = pools.Next() {
+		pool := raw.(*structs.NodePool)
+
+		// Don't create a queue for "all" node pool
+		if pool.Name == structs.NodePoolAll {
+			continue
+		}
+
+		if err = b.startQueue(pool); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// stopQueue is a helper for stopping a queue if it exists,
+// and removing it from the queue map
+func (b *BatchQueueManager) stopQueue(pool string) {
+	if q, ok := b.queues[pool]; ok {
+		q.Stop()
+		delete(b.queues, pool)
+	}
+}
+
+// startQueue is a helper for starting a queue for a given nodepool,
+// and adding it to the queue map.
+func (b *BatchQueueManager) startQueue(np *structs.NodePool) error {
+	conf, isDefault, err := b.configForPool(np)
+	if err != nil {
+		return err
+	}
+	queue, err := NewQueue(b.state, conf, b.broker, b.logger)
+	if err != nil {
+		return err
+	}
+
+	if err := queue.Start(b.shutdownCtx); err != nil {
+		return err
+	}
+
+	b.queues[np.Name] = &QueueData{queue, isDefault}
+
+	return nil
 }

--- a/nomad/queues/batch_queue_manager_ce.go
+++ b/nomad/queues/batch_queue_manager_ce.go
@@ -1,0 +1,26 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+//go:build !ent
+
+package queues
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+func (b *BatchQueueManager) configForPool(_ *structs.NodePool) (*structs.BatchQueue, bool, error) {
+	conf := b.defaultConf
+	_, stateConf, err := b.state.SchedulerConfig()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get scheduler config from state, skipping queue creation: %w", err)
+	}
+
+	if stateConf != nil {
+		conf = stateConf.BatchQueue
+	}
+
+	return &conf, true, nil
+}

--- a/nomad/queues/batch_queue_manager_ce_test.go
+++ b/nomad/queues/batch_queue_manager_ce_test.go
@@ -14,18 +14,13 @@ import (
 
 func TestBatchQueueManager_configForPool(t *testing.T) {
 	t.Run("returns default config when state config is nil", func(t *testing.T) {
-		// Setup manager with default config
 		defaultConf := structs.BatchQueue{Type: "default-type"}
 		mgr := NewBatchQueueMgr(t.Context(), defaultConf, nil, hclog.Default())
 
 		ss := state.TestStateStore(t)
 		mgr.state = ss
 
-		// Create a test node pool
-		testPool := &structs.NodePool{Name: "test-pool"}
-
-		// Call configForPool
-		conf, isDefault, err := mgr.configForPool(testPool)
+		conf, isDefault, err := mgr.configForPool(&structs.NodePool{Name: "test-pool"})
 
 		must.NoError(t, err)
 		must.True(t, isDefault)
@@ -33,23 +28,18 @@ func TestBatchQueueManager_configForPool(t *testing.T) {
 	})
 
 	t.Run("returns state config when available", func(t *testing.T) {
-		// Setup manager
 		defaultConf := structs.BatchQueue{Type: "default-type"}
 		mgr := NewBatchQueueMgr(t.Context(), defaultConf, nil, hclog.Default())
 
 		ss := state.TestStateStore(t)
-		// Insert scheduler config with batch queue settings
+		mgr.state = ss
+
 		schedConf := &structs.SchedulerConfiguration{
 			BatchQueue: structs.BatchQueue{Type: "state-type"},
 		}
 		must.NoError(t, ss.SchedulerSetConfig(1, schedConf))
-		mgr.state = ss
 
-		// Create a test node pool
-		testPool := &structs.NodePool{Name: "test-pool"}
-
-		// Call configForPool
-		conf, isDefault, err := mgr.configForPool(testPool)
+		conf, isDefault, err := mgr.configForPool(&structs.NodePool{Name: "test-pool"})
 
 		must.NoError(t, err)
 		must.True(t, isDefault)

--- a/nomad/queues/batch_queue_manager_ce_test.go
+++ b/nomad/queues/batch_queue_manager_ce_test.go
@@ -1,0 +1,58 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package queues
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+)
+
+func TestBatchQueueManager_configForPool(t *testing.T) {
+	t.Run("returns default config when state config is nil", func(t *testing.T) {
+		// Setup manager with default config
+		defaultConf := structs.BatchQueue{Type: "default-type"}
+		mgr := NewBatchQueueMgr(t.Context(), defaultConf, nil, hclog.Default())
+
+		ss := state.TestStateStore(t)
+		mgr.state = ss
+
+		// Create a test node pool
+		testPool := &structs.NodePool{Name: "test-pool"}
+
+		// Call configForPool
+		conf, isDefault, err := mgr.configForPool(testPool)
+
+		must.NoError(t, err)
+		must.True(t, isDefault)
+		must.Eq(t, "default-type", conf.Type)
+	})
+
+	t.Run("returns state config when available", func(t *testing.T) {
+		// Setup manager
+		defaultConf := structs.BatchQueue{Type: "default-type"}
+		mgr := NewBatchQueueMgr(t.Context(), defaultConf, nil, hclog.Default())
+
+		ss := state.TestStateStore(t)
+		// Insert scheduler config with batch queue settings
+		schedConf := &structs.SchedulerConfiguration{
+			BatchQueue: structs.BatchQueue{Type: "state-type"},
+		}
+		must.NoError(t, ss.SchedulerSetConfig(1, schedConf))
+		mgr.state = ss
+
+		// Create a test node pool
+		testPool := &structs.NodePool{Name: "test-pool"}
+
+		// Call configForPool
+		conf, isDefault, err := mgr.configForPool(testPool)
+
+		must.NoError(t, err)
+		must.True(t, isDefault)
+		must.Eq(t, "state-type", conf.Type)
+	})
+}

--- a/nomad/queues/batch_queue_manager_test.go
+++ b/nomad/queues/batch_queue_manager_test.go
@@ -127,13 +127,11 @@ func TestBatchQueueManager_UpdateDefaultQueues(t *testing.T) {
 		testPool := mock.NodePool()
 		must.NoError(t, ss.UpsertNodePools(structs.MsgTypeTestSetup, 1, []*structs.NodePool{testPool}))
 
-		// Create a batch job
 		job := mock.Job()
 		job.Type = structs.JobTypeBatch
 		job.NodePool = testPool.Name
 		must.NoError(t, ss.UpsertJob(structs.MsgTypeTestSetup, 2, nil, job))
 
-		// Create pending eval for job register
 		batchEval := &structs.Evaluation{
 			ID:          uuid.Generate(),
 			JobID:       job.ID,
@@ -142,7 +140,6 @@ func TestBatchQueueManager_UpdateDefaultQueues(t *testing.T) {
 			TriggeredBy: structs.EvalTriggerJobRegister,
 			Status:      structs.EvalStatusPending,
 		}
-		// Create eval that is not a batch queue eval
 		nonBatchEval := &structs.Evaluation{
 			ID:          uuid.Generate(),
 			JobID:       job.ID,

--- a/nomad/queues/batch_queue_manager_test.go
+++ b/nomad/queues/batch_queue_manager_test.go
@@ -37,7 +37,7 @@ func TestBatchQueueManager_Enqueue(t *testing.T) {
 
 		mockDefaultQueue := &MockQueue{}
 		mockTestQueue := &MockQueue{}
-		mockTestQueue.On("Enqueue", tmock.Anything).Return()
+		mockTestQueue.On("Enqueue", tmock.Anything, tmock.Anything).Return()
 		mgr.queues = map[string]*QueueData{
 			"default":         {mockDefaultQueue, true},
 			testNodePool.Name: {mockTestQueue, false},

--- a/nomad/queues/batch_queue_manager_test.go
+++ b/nomad/queues/batch_queue_manager_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -22,18 +23,25 @@ func TestBatchQueueManager_Enqueue(t *testing.T) {
 		mgr.Enqueue(&structs.Evaluation{})
 	})
 
-	t.Run("enqueues when enabled", func(t *testing.T) {
+	t.Run("enqueues on matching node pool queue", func(t *testing.T) {
 		mgr := NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, hclog.Default())
 
 		mgr.enabled.Store(true)
 		ss := state.TestStateStore(t)
+		testNodePool := mock.NodePool()
+		must.NoError(t, ss.UpsertNodePools(structs.MsgTypeTestSetup, 1, []*structs.NodePool{testNodePool}))
 		mockJob := mock.Job()
-		must.NoError(t, ss.UpsertJob(structs.MsgTypeTestSetup, 1, nil, mockJob))
+		mockJob.NodePool = testNodePool.Name
+		must.NoError(t, ss.UpsertJob(structs.MsgTypeTestSetup, 2, nil, mockJob))
 		mgr.state = ss
 
-		mockQueue := &MockQueue{}
-		mockQueue.On("Enqueue", tmock.Anything).Return()
-		mgr.defaultQueue = mockQueue
+		mockDefaultQueue := &MockQueue{}
+		mockTestQueue := &MockQueue{}
+		mockTestQueue.On("Enqueue", tmock.Anything).Return()
+		mgr.queues = map[string]*QueueData{
+			"default":         {mockDefaultQueue, true},
+			testNodePool.Name: {mockTestQueue, false},
+		}
 
 		mockEval := &structs.Evaluation{
 			JobID:     mockJob.ID,
@@ -41,6 +49,8 @@ func TestBatchQueueManager_Enqueue(t *testing.T) {
 		}
 
 		mgr.Enqueue(mockEval)
+		must.Eq(t, len(mockDefaultQueue.Calls), 0)
+		must.Eq(t, len(mockTestQueue.Calls), 1)
 	})
 }
 
@@ -61,7 +71,7 @@ func TestBatchQueueManager_SetEnabled(t *testing.T) {
 
 		mgr.SetEnabled(true, ss)
 
-		must.NotNil(t, mgr.defaultQueue)
+		must.NotNil(t, mgr.queues)
 	})
 
 	t.Run("stops queues when disabled", func(t *testing.T) {
@@ -69,7 +79,7 @@ func TestBatchQueueManager_SetEnabled(t *testing.T) {
 
 		mockQueue := &MockQueue{}
 		mockQueue.On("Stop").Return()
-		mgr.defaultQueue = mockQueue
+		mgr.queues = map[string]*QueueData{"default": {mockQueue, true}}
 
 		mgr.SetEnabled(false, nil)
 
@@ -78,25 +88,149 @@ func TestBatchQueueManager_SetEnabled(t *testing.T) {
 	})
 }
 
-func TestBatchQueueManager_Update(t *testing.T) {
-	t.Run("updates default queue given empty node pool", func(t *testing.T) {
+func TestBatchQueueManager_UpdateDefaultQueues(t *testing.T) {
+	t.Run("returns early when not enabled", func(t *testing.T) {
 		mgr := NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, hclog.Default())
+		mgr.enabled.Store(false)
+
+		err := mgr.UpdateDefaultQueues()
+		must.NoError(t, err)
+		must.MapEmpty(t, mgr.queues)
+	})
+
+	t.Run("stops and recreates default queues", func(t *testing.T) {
+		mgr := NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, hclog.Default())
+		mgr.enabled.Store(true)
+
+		ss := state.TestStateStore(t)
+		testPool := mock.NodePool()
+		must.NoError(t, ss.UpsertNodePools(structs.MsgTypeTestSetup, 1, []*structs.NodePool{testPool}))
+		mgr.state = ss
 
 		mockQueue := &MockQueue{}
 		mockQueue.On("Stop").Return()
-		mgr.defaultQueue = mockQueue
+		mgr.queues = map[string]*QueueData{testPool.Name: {mockQueue, true}}
 
-		before := mgr.defaultQueue
-		mgr.Update(&structs.BatchQueue{})
-		after := mgr.defaultQueue
+		err := mgr.UpdateDefaultQueues()
+		must.NoError(t, err)
+		must.Eq(t, 1, len(mockQueue.Calls))
+		must.NotNil(t, mgr.queues)
+	})
 
-		must.EqOp(t, before, after) // not enabled so should skip update
+	t.Run("re-enqueues batch queue evals", func(t *testing.T) {
+		broker := &MockBroker{}
+		broker.On("Enqueue", tmock.Anything).Return()
+		mgr := NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, broker, hclog.Default())
+		mgr.enabled.Store(true)
 
-		mgr.enabled.Store(true) // set enabled so update happens
-		before = mgr.defaultQueue
-		mgr.Update(&structs.BatchQueue{})
-		after = mgr.defaultQueue
+		ss := state.TestStateStore(t)
+		testPool := mock.NodePool()
+		must.NoError(t, ss.UpsertNodePools(structs.MsgTypeTestSetup, 1, []*structs.NodePool{testPool}))
 
-		must.NotEqOp(t, before, after)
+		// Create a batch job
+		job := mock.Job()
+		job.Type = structs.JobTypeBatch
+		job.NodePool = testPool.Name
+		must.NoError(t, ss.UpsertJob(structs.MsgTypeTestSetup, 2, nil, job))
+
+		// Create pending eval for job register
+		batchEval := &structs.Evaluation{
+			ID:          uuid.Generate(),
+			JobID:       job.ID,
+			Namespace:   job.Namespace,
+			Type:        structs.JobTypeBatch,
+			TriggeredBy: structs.EvalTriggerJobRegister,
+			Status:      structs.EvalStatusPending,
+		}
+		// Create eval that is not a batch queue eval
+		nonBatchEval := &structs.Evaluation{
+			ID:          uuid.Generate(),
+			JobID:       job.ID,
+			Namespace:   job.Namespace,
+			Type:        structs.JobTypeService,
+			TriggeredBy: structs.EvalTriggerJobRegister,
+			Status:      structs.EvalStatusPending,
+		}
+		must.NoError(t, ss.UpsertEvals(
+			structs.MsgTypeTestSetup,
+			3,
+			[]*structs.Evaluation{batchEval, nonBatchEval}),
+		)
+
+		mgr.state = ss
+
+		mockQueue := &MockQueue{}
+		mockQueue.On("Stop").Return()
+		mockQueue.On("Enqueue", tmock.Anything).Return()
+		mgr.queues = map[string]*QueueData{testPool.Name: {mockQueue, true}}
+
+		err := mgr.UpdateDefaultQueues()
+		must.NoError(t, err)
+
+		must.Eq(t, 1, len(mockQueue.Calls))
+	})
+
+	t.Run("only stops default scheduler conf queues", func(t *testing.T) {
+		mgr := NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, hclog.Default())
+		mgr.enabled.Store(true)
+
+		ss := state.TestStateStore(t)
+		defaultPool := mock.NodePool()
+		defaultPool.Name = "default-pool"
+		customPool := mock.NodePool()
+		customPool.Name = "custom-pool"
+		must.NoError(t, ss.UpsertNodePools(structs.MsgTypeTestSetup, 1, []*structs.NodePool{defaultPool, customPool}))
+		mgr.state = ss
+
+		mockDefaultQueue := &MockQueue{}
+		mockDefaultQueue.On("Stop").Return()
+
+		mockCustomQueue := &MockQueue{}
+
+		mgr.queues = map[string]*QueueData{
+			defaultPool.Name: {mockDefaultQueue, true},
+			customPool.Name:  {mockCustomQueue, false},
+		}
+
+		err := mgr.UpdateDefaultQueues()
+		must.NoError(t, err)
+
+		// Verify Stop was called only on default queue
+		must.Eq(t, 1, len(mockDefaultQueue.Calls))
+		must.Eq(t, "Stop", mockDefaultQueue.Calls[0].Method)
+
+		// Verify Stop was not called on custom queue
+		must.Eq(t, 0, len(mockCustomQueue.Calls))
+	})
+}
+
+func TestBatchQueueManager_UpdateQueue(t *testing.T) {
+	t.Run("returns early when not enabled", func(t *testing.T) {
+		mgr := NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, hclog.Default())
+		mgr.enabled.Store(false)
+
+		testPool := mock.NodePool()
+		err := mgr.UpdateQueue(testPool)
+		must.NoError(t, err)
+		must.MapEmpty(t, mgr.queues)
+	})
+
+	t.Run("stops and recreates queue for specific pool", func(t *testing.T) {
+		mgr := NewBatchQueueMgr(t.Context(), structs.BatchQueue{}, nil, hclog.Default())
+		mgr.enabled.Store(true)
+
+		ss := state.TestStateStore(t)
+		testPool := mock.NodePool()
+		must.NoError(t, ss.UpsertNodePools(structs.MsgTypeTestSetup, 1, []*structs.NodePool{testPool}))
+		mgr.state = ss
+
+		mockQueue := &MockQueue{}
+		mockQueue.On("Stop").Return()
+		mgr.queues = map[string]*QueueData{testPool.Name: {mockQueue, false}}
+
+		err := mgr.UpdateQueue(testPool)
+		must.NoError(t, err)
+		must.Eq(t, 1, len(mockQueue.Calls))
+		must.NotNil(t, mgr.queues)
 	})
 }

--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -175,7 +175,12 @@ func (d *DynamicPriorityQueue) restore(ss *state.StateSnapshot, now time.Time) e
 			continue
 		}
 
-		w := d.generateWorkload(eval)
+		job, err := d.state.JobByID(nil, eval.Namespace, eval.JobID)
+		if err != nil {
+			return err
+		}
+
+		w := d.generateWorkload(eval, job)
 
 		// generate the tenant if it doesn't exist
 		d.ensureTenant(w.tid)
@@ -208,8 +213,8 @@ func (d *DynamicPriorityQueue) restore(ss *state.StateSnapshot, now time.Time) e
 // It generates a workload with an empty priority, appends it
 // to an internal channel to be processed and added to the actual
 // heap container.
-func (d *DynamicPriorityQueue) Enqueue(e *structs.Evaluation) {
-	w := d.generateWorkload(e)
+func (d *DynamicPriorityQueue) Enqueue(e *structs.Evaluation, j *structs.Job) {
+	w := d.generateWorkload(e, j)
 
 	// in the event of an empty workload, just pass eval to eval broker
 	if w == nil {
@@ -295,12 +300,7 @@ func (d *DynamicPriorityQueue) runConsumer(ctx context.Context) {
 }
 
 // generateWorkload is used to create an initial workload from a given evaluation
-func (d *DynamicPriorityQueue) generateWorkload(e *structs.Evaluation) *dynamicPriorityWorkload {
-	job, err := d.state.JobByID(nil, e.Namespace, e.JobID)
-	if err != nil {
-		return nil
-	}
-
+func (d *DynamicPriorityQueue) generateWorkload(e *structs.Evaluation, job *structs.Job) *dynamicPriorityWorkload {
 	var tid TenantID
 	switch d.tenantType {
 	case "namespace":

--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -182,18 +182,18 @@ func (d *DynamicPriorityQueue) restore(ss *state.StateSnapshot, now time.Time) e
 
 		// When checking for workload placements, we never want to actually block
 		// in SetEnabled, but it's also entirely possible a queue eval is blocked and
-		// waiting to be placed from a previous DPQ placement. If that happens
+		// waiting to be completed from a previous DPQ placement. If that happens
 		// we should enqueue it and push it to the front of the queue.
-		placed, err := queue.IsSchedulingComplete(w, d.state)
+		complete, err := queue.IsSchedulingComplete(w, d.state)
 		if err != nil {
 			d.logger.Error("failed to wait for placement while enabling queue", "err", err)
 		}
 
-		if placed && evalHasPlacement(w.GetEval()) {
+		if complete && evalHasPlacement(w.GetEval()) {
 			d.updateUsage(w)
 		}
 
-		if !placed {
+		if !complete {
 			w.waitOnRestore = true
 			d.enqueueCh <- w
 		}

--- a/nomad/queues/fifo/queue.go
+++ b/nomad/queues/fifo/queue.go
@@ -67,7 +67,7 @@ func workloadSortFn() func(i, j queue.Workload) int {
 	}
 }
 
-func (f *FifoQueue) Enqueue(e *structs.Evaluation) {
+func (f *FifoQueue) Enqueue(e *structs.Evaluation, _ *structs.Job) {
 	f.enqueueCh <- newFifoWorkload(e)
 }
 

--- a/nomad/queues/passthrough/queue.go
+++ b/nomad/queues/passthrough/queue.go
@@ -31,7 +31,7 @@ func (p *PassthroughQueue) Start(context.Context) error { return nil }
 
 func (p *PassthroughQueue) Stop() {}
 
-func (p *PassthroughQueue) Enqueue(e *structs.Evaluation) { p.evalBroker.Enqueue(e) }
+func (p *PassthroughQueue) Enqueue(e *structs.Evaluation, _ *structs.Job) { p.evalBroker.Enqueue(e) }
 
 func (p *PassthroughQueue) Jobs(structs.SortOrder) *queue.WorkloadIter {
 	return &queue.WorkloadIter{}

--- a/nomad/queues/queue/interface.go
+++ b/nomad/queues/queue/interface.go
@@ -12,7 +12,7 @@ import (
 type Queue interface {
 	Start(context.Context) error
 	Stop()
-	Enqueue(*structs.Evaluation)
+	Enqueue(*structs.Evaluation, *structs.Job)
 	Jobs(structs.SortOrder) *WorkloadIter
 	Tenants() structs.QueueTenantsResponse
 	Type() structs.BatchQueueType

--- a/nomad/queues/testing.go
+++ b/nomad/queues/testing.go
@@ -34,8 +34,8 @@ func (m *MockQueue) Stop() {
 	m.Called()
 }
 
-func (m *MockQueue) Enqueue(e *structs.Evaluation) {
-	m.Called(e)
+func (m *MockQueue) Enqueue(e *structs.Evaluation, j *structs.Job) {
+	m.Called(e, j)
 }
 
 func (m *MockQueue) Jobs(sortOrder structs.SortOrder) *queue.WorkloadIter {

--- a/nomad/queues/testing.go
+++ b/nomad/queues/testing.go
@@ -15,6 +15,14 @@ type MockQueue struct {
 	mock.Mock
 }
 
+type MockBroker struct {
+	mock.Mock
+}
+
+func (m *MockBroker) Enqueue(e *structs.Evaluation) {
+	m.Called(e)
+}
+
 func (m *MockQueue) Type() structs.BatchQueueType {
 	return "test"
 }

--- a/nomad/structs/eval.go
+++ b/nomad/structs/eval.go
@@ -402,7 +402,9 @@ func (e *Evaluation) ShouldBlock() bool {
 }
 
 func (e *Evaluation) IsBatchQueue() bool {
-	return e.Type == JobTypeBatch && e.Status == EvalStatusPending
+	return e.Type == JobTypeBatch &&
+		e.Status == EvalStatusPending &&
+		e.TriggeredBy == EvalTriggerJobRegister
 }
 
 // MakePlan is used to make a plan from the given evaluation

--- a/nomad/structs/queue.go
+++ b/nomad/structs/queue.go
@@ -70,6 +70,7 @@ func (w *Workload) GetNamespace() string {
 }
 
 type QueueTenantsRequest struct {
+	NodePool string `json:"node_pool,omitempty"`
 	QueryOptions
 }
 
@@ -84,7 +85,8 @@ type QueueTenantsResponse struct {
 }
 
 type QueueJobsRequest struct {
-	Sort SortOrder `json:"sort,omitempty"`
+	Sort     SortOrder `json:"sort,omitempty"`
+	NodePool string    `json:"node_pool,omitempty"`
 	QueryOptions
 }
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes add per nodepool queues and the ability to query, and update those queues via the default scheduler config.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
