### PR TITLE
api: prefer table index on initial GetClientAllocs

### DIFF
--- a/.changelog/28394.txt
+++ b/.changelog/28394.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fix issue where deleted allocations may remain running
+```

--- a/nomad/node_endpoint.go
+++ b/nomad/node_endpoint.go
@@ -1394,8 +1394,10 @@ func (n *Node) GetClientAllocs(args *structs.NodeSpecificRequest,
 	// numOldAllocs is used to detect if there is a garbage collection event
 	// that effects the node. When an allocation is garbage collected, that does
 	// not change the modify index changes and thus the query won't unblock,
-	// even though the set of allocations on the node has changed.
-	var numOldAllocs int
+	// even though the set of allocations on the node has changed. This value
+	// is defaulted to -1 so it can be determined if the previous allocation
+	// count is known. If it's not known, we always prefer the allocs table index.
+	var numOldAllocs int = -1
 
 	// Setup the blocking query
 	opts := blockingOptions{
@@ -1428,7 +1430,9 @@ func (n *Node) GetClientAllocs(args *structs.NodeSpecificRequest,
 			preferTableIndex := true
 
 			// Setup the output
-			if numAllocs := len(allocs); numAllocs != 0 {
+			numAllocs := len(allocs)
+
+			if numAllocs > 0 {
 				preferTableIndex = false
 
 				for _, alloc := range allocs {
@@ -1464,18 +1468,20 @@ func (n *Node) GetClientAllocs(args *structs.NodeSpecificRequest,
 					reply.Index = maxUint64(reply.Index, alloc.ModifyIndex)
 				}
 
-				// Determine if we have less allocations than before. This
-				// indicates there was a garbage collection
-				if numAllocs < numOldAllocs {
+				// If the previous allocations count is less than zero, this is
+				// the first run through and the previous count is unknown. Otherwise,
+				// determine if we have less allocations than before. If so, it indicates
+				// there was a garbage collection.
+				if numOldAllocs < 0 || numAllocs < numOldAllocs {
 					preferTableIndex = true
 				}
-
-				// Store the new number of allocations
-				numOldAllocs = numAllocs
 			}
 
+			// Store the new number of allocations
+			numOldAllocs = numAllocs
+
 			if preferTableIndex {
-				// Use the last index that affected the nodes table
+				// Use the last index that affected the allocs table
 				index, err := state.Index("allocs")
 				if err != nil {
 					return err
@@ -1489,6 +1495,7 @@ func (n *Node) GetClientAllocs(args *structs.NodeSpecificRequest,
 					reply.Index = index
 				}
 			}
+
 			return nil
 		}}
 	return n.srv.blockingRPC(&opts)

--- a/nomad/node_endpoint_test.go
+++ b/nomad/node_endpoint_test.go
@@ -3076,6 +3076,72 @@ func TestClientEndpoint_GetClientAllocs(t *testing.T) {
 	})
 }
 
+func TestClientEndpoint_GetClientAllocs_PreferTableIndex(t *testing.T) {
+	ci.Parallel(t)
+
+	s1, cleanupS1 := TestServer(t, nil)
+	defer cleanupS1()
+	codec := rpcClient(t, s1)
+	testutil.WaitForLeader(t, s1.RPC)
+
+	// Create the register request
+	node := mock.Node()
+	state := s1.fsm.State()
+	must.Nil(t, state.UpsertNode(structs.MsgTypeTestSetup, 98, node))
+
+	// Inject fake evaluations
+	alloc := mock.Alloc()
+	alloc.NodeID = node.ID
+
+	must.NoError(t, state.UpsertJobSummary(98, mock.JobSummary(alloc.JobID)))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 99, nil, alloc.Job))
+	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 100, []*structs.Allocation{alloc}))
+
+	// Add a second node with an alloc
+	node2 := mock.Node()
+	must.Nil(t, state.UpsertNode(structs.MsgTypeTestSetup, 101, node2))
+
+	alloc2 := mock.Alloc()
+	alloc2.NodeID = node2.ID
+
+	must.NoError(t, state.UpsertJobSummary(101, mock.JobSummary(alloc2.JobID)))
+	must.NoError(t, state.UpsertJob(structs.MsgTypeTestSetup, 102, nil, alloc2.Job))
+	must.NoError(t, state.UpsertAllocs(structs.MsgTypeTestSetup, 103, []*structs.Allocation{alloc2}))
+
+	// Lookup the allocs specifying a minimum index matching the node's alloc index. Since
+	// the query won't have an initial value for the old allocs count, we expect this to
+	// not block and return an index equal to the allocs table index.
+	get := &structs.NodeSpecificRequest{
+		NodeID:   node.ID,
+		SecretID: node.SecretID,
+		QueryOptions: structs.QueryOptions{
+			Region:        "global",
+			AuthToken:     node.SecretID,
+			MinQueryIndex: 100,
+		},
+	}
+	var resp structs.NodeClientAllocsResponse
+
+	ch := make(chan struct{})
+	go func() {
+		must.NoError(t, msgpackrpc.CallWithCodec(codec, "Node.GetClientAllocs", get, &resp))
+		close(ch)
+	}()
+
+	select {
+	case <-ch:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("Node.GetClientAllocs should not block")
+	}
+
+	// The index should be the allocs table index, not the max alloc index
+	must.Eq(t, 103, resp.Index)
+
+	if len(resp.Allocs) != 1 || resp.Allocs[alloc.ID] != 100 {
+		t.Fatalf("bad: %#v", resp.Allocs)
+	}
+}
+
 func TestClientEndpoint_GetClientAllocs_Blocking(t *testing.T) {
 	ci.Parallel(t)
 


### PR DESCRIPTION
### Description

When the `Node.GetClientAllocs` query is initially run, the previous count of allocations is unknown. If the request is made with a minimum query index value and an allocation has just been deleted, this will not be correctly detected and the query will block. To prevent this, always prefer the allocs table index on the initial run.

This surfaced in #28242 where the existing behavior resulted in allocations that were still running after being deleted.

### Testing & Reproduction steps

Test included.

### Links

Fixes #28242

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
