### PR TITLE
vault: don't trigger change_mode on renew

### DIFF
--- a/.changelog/28409.txt
+++ b/.changelog/28409.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault: Fixed a bug where a task's change_mode was triggered on each Vault token renewal
+```

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -135,7 +135,6 @@ func newVaultHook(config *vaultHookConfig) *vaultHook {
 		allowTokenExpiration: config.vaultBlock.AllowTokenExpiration,
 	}
 	h.logger = config.logger.Named(h.Name())
-
 	return h
 }
 
@@ -231,42 +230,47 @@ func (h *vaultHook) run(ctx context.Context, token string, lease time.Duration) 
 		case <-time.After(withJitter(lease)):
 			lease, err = h.renewWithBackoff(ctx, token)
 			if err != nil {
-				// failing to renew results in a triggering the change_mode
-				h.handleRenewal(ctx, "")
-				return
-			}
+				token, lease, err = h.handleRenewalFailure(ctx, "")
+				if err != nil {
+					h.logger.Error(err.Error())
+					h.lifecycle.Kill(ctx,
+						structs.NewTaskEvent(structs.TaskKilling).
+							SetFailsTask().
+							SetDisplayMessage(fmt.Sprintf("Vault: %v", err)))
 
-			h.handleRenewal(ctx, token)
+					return
+				}
+			}
 		}
 	}
 }
 
-func (h *vaultHook) handleRenewal(ctx context.Context, token string) {
+// handleRenewalFailure attempts to get a new Vault token and triggers any change_mode
+func (h *vaultHook) handleRenewalFailure(ctx context.Context, token string) (string, time.Duration, error) {
+	token, duration, err := h.deriveVaultToken(ctx)
+	if err != nil {
+		return "", 0, err
+	}
+	if err := h.writeToken(token); err != nil {
+		return "", 0, fmt.Errorf("failed to write Vault token to disk: %w", err)
+	}
+
 	var event *structs.TaskEvent
 	switch h.vaultBlock.ChangeMode {
 	case structs.VaultChangeModeSignal:
 		s, err := signals.Parse(h.vaultBlock.ChangeSignal)
 		if err != nil {
-			h.logger.Error("failed to parse signal", "error", err)
-			event = structs.NewTaskEvent(structs.TaskKilling).
-				SetFailsTask().
-				SetDisplayMessage(fmt.Sprintf("Vault: failed to parse signal: %v", err))
-			h.lifecycle.Kill(ctx, event)
-			return
+			return "", 0, fmt.Errorf("failed to parse signal: %w", err)
 		}
 
-		event := structs.NewTaskEvent(structs.TaskSignaling).SetTaskSignal(s).SetDisplayMessage("Vault: new Vault token acquired")
+		event := structs.NewTaskEvent(structs.TaskSignaling).
+			SetTaskSignal(s).SetDisplayMessage("Vault: new Vault token acquired")
 		if err := h.lifecycle.Signal(event, h.vaultBlock.ChangeSignal); err != nil {
-			h.logger.Error("failed to send signal", "error", err)
-			event = structs.NewTaskEvent(structs.TaskKilling).
-				SetFailsTask().
-				SetDisplayMessage(fmt.Sprintf("Vault: failed to send signal: %v", err))
-
-			h.lifecycle.Kill(ctx, event)
-			return
+			return "", 0, fmt.Errorf("failed to send signal: %w", err)
 		}
 	case structs.VaultChangeModeRestart:
-		event = structs.NewTaskEvent(structs.TaskRestartSignal).SetDisplayMessage("Vault: new Vault token acquired")
+		event = structs.NewTaskEvent(structs.TaskRestartSignal).
+			SetDisplayMessage("Vault: new Vault token acquired")
 		h.lifecycle.Restart(ctx, event, false)
 	case structs.VaultChangeModeNoop:
 		// True to its name, this is a noop!
@@ -274,8 +278,8 @@ func (h *vaultHook) handleRenewal(ctx context.Context, token string) {
 		h.logger.Error("invalid Vault change mode", "mode", h.vaultBlock.ChangeMode)
 	}
 
-	// Call the handler
 	h.updater.updatedVaultToken(token)
+	return token, time.Duration(time.Second * time.Duration(duration)), nil
 }
 
 func (h *vaultHook) renewWithBackoff(ctx context.Context, token string) (time.Duration, error) {

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -230,7 +230,7 @@ func (h *vaultHook) run(ctx context.Context, token string, lease time.Duration) 
 		case <-time.After(withJitter(lease)):
 			lease, err = h.renewWithBackoff(ctx, token)
 			if err != nil {
-				token, lease, err = h.handleRenewalFailure(ctx, "")
+				token, lease, err = h.handleRenewalFailure(ctx)
 				if err != nil {
 					h.logger.Error(err.Error())
 					h.lifecycle.Kill(ctx,
@@ -246,7 +246,7 @@ func (h *vaultHook) run(ctx context.Context, token string, lease time.Duration) 
 }
 
 // handleRenewalFailure attempts to get a new Vault token and triggers any change_mode
-func (h *vaultHook) handleRenewalFailure(ctx context.Context, token string) (string, time.Duration, error) {
+func (h *vaultHook) handleRenewalFailure(ctx context.Context) (string, time.Duration, error) {
 	token, duration, err := h.deriveVaultToken(ctx)
 	if err != nil {
 		return "", 0, err

--- a/client/allocrunner/taskrunner/vault_hook_test.go
+++ b/client/allocrunner/taskrunner/vault_hook_test.go
@@ -6,7 +6,6 @@ package taskrunner
 import (
 	"context"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -25,6 +24,7 @@ import (
 	nmock "github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/structs"
 	sconfig "github.com/hashicorp/nomad/nomad/structs/config"
+	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
 	"github.com/stretchr/testify/mock"
@@ -373,13 +373,32 @@ func TestVaultHook_Prestart(t *testing.T) {
 	})
 }
 
-func TestVaultHook_handleRenewal(t *testing.T) {
+func TestVaultHook_handleRenewalFailure(t *testing.T) {
 	ci.Parallel(t)
 
+	widMgr := widmgr.NewMockIdentityManager()
+	widMgr.SetIdentity(
+		structs.WIHandle{IdentityName: "vault_default",
+			WorkloadType: 0, WorkloadIdentifier: "t"},
+		&structs.SignedWorkloadIdentity{},
+	)
+	updater := &vaultTokenUpdaterMock{}
+
+	clientOk := vaultclient.NewMockVaultClient()
+	clientOk.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{}).
+		Return("testToken", true, 5, nil)
+
+	clientErr := vaultclient.NewMockVaultClient()
+	clientErr.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{}).
+		Return("", false, 0, errors.New("oops"))
+
 	testCases := []struct {
-		name                string
-		vaultBlock          *structs.Vault
-		verifyTaskLifecycle func(*trtesting.MockTaskHooks) error
+		name        string
+		vaultBlock  *structs.Vault
+		vaultClient *vaultclient.MockVaultClient
+
+		expectErrMsg        string
+		verifyTaskLifecycle func(*testing.T, *trtesting.MockTaskHooks)
 	}{
 		{
 			name: "change mode signal",
@@ -388,15 +407,31 @@ func TestVaultHook_handleRenewal(t *testing.T) {
 				ChangeMode:   structs.VaultChangeModeSignal,
 				ChangeSignal: "SIGTERM",
 			},
-			verifyTaskLifecycle: func(h *trtesting.MockTaskHooks) error {
+			vaultClient: clientOk,
+			verifyTaskLifecycle: func(t *testing.T, h *trtesting.MockTaskHooks) {
 				signals := h.Signals()
-				if len(signals) != 1 {
-					return fmt.Errorf("expected 1 signal, got %d", len(signals))
-				}
-				if signals[0] != "SIGTERM" {
-					return fmt.Errorf("expected signal to be SIGTERM, got %s", signals[0])
-				}
-				return nil
+				must.Len(t, 1, signals, must.Sprint("expected 1 signal"))
+				test.Eq(t, "SIGTERM", signals[0])
+				restarts := h.Restarts()
+				test.Eq(t, 0, restarts, test.Sprint("expected no restart"))
+				test.Nil(t, h.KillEvent(), test.Sprint("expected no kill"))
+			},
+		},
+		{
+			name: "change mode signal refresh error",
+			vaultBlock: &structs.Vault{
+				Cluster:      structs.VaultDefaultCluster,
+				ChangeMode:   structs.VaultChangeModeSignal,
+				ChangeSignal: "SIGTERM",
+			},
+			vaultClient:  clientErr,
+			expectErrMsg: "failed to derive Vault token for identity vault_default: oops",
+			verifyTaskLifecycle: func(t *testing.T, h *trtesting.MockTaskHooks) {
+				signals := h.Signals()
+				test.Len(t, 0, signals, test.Sprint("expected no signal"))
+				restarts := h.Restarts()
+				test.Eq(t, 0, restarts, test.Sprint("expected no restart"))
+				test.NotNil(t, h.KillEvent(), test.Sprint("expected kill"))
 			},
 		},
 		{
@@ -405,12 +440,13 @@ func TestVaultHook_handleRenewal(t *testing.T) {
 				Cluster:    structs.VaultDefaultCluster,
 				ChangeMode: structs.VaultChangeModeRestart,
 			},
-			verifyTaskLifecycle: func(h *trtesting.MockTaskHooks) error {
+			vaultClient: clientOk,
+			verifyTaskLifecycle: func(t *testing.T, h *trtesting.MockTaskHooks) {
+				signals := h.Signals()
+				test.Len(t, 0, signals, test.Sprint("expected no signal"))
 				restarts := h.Restarts()
-				if restarts != 1 {
-					return fmt.Errorf("expected 1 restart, got %d", restarts)
-				}
-				return nil
+				test.Eq(t, 1, restarts, test.Sprint("expected 1 restart"))
+				test.Nil(t, h.KillEvent(), test.Sprint("expected no kill"))
 			},
 		},
 		{
@@ -419,40 +455,66 @@ func TestVaultHook_handleRenewal(t *testing.T) {
 				Cluster:    structs.VaultDefaultCluster,
 				ChangeMode: structs.VaultChangeModeNoop,
 			},
-			verifyTaskLifecycle: func(h *trtesting.MockTaskHooks) error {
-				restarts := h.Restarts()
-				if restarts != 0 {
-					return fmt.Errorf("expected 0 restarts, got %d", restarts)
-				}
-
+			vaultClient: clientOk,
+			verifyTaskLifecycle: func(t *testing.T, h *trtesting.MockTaskHooks) {
 				signals := h.Signals()
-				if len(signals) != 0 {
-					return fmt.Errorf("expected 0 signals, got %d", len(signals))
-				}
-
-				return nil
+				test.Len(t, 0, signals, test.Sprint("expected no signal"))
+				restarts := h.Restarts()
+				test.Eq(t, 0, restarts, test.Sprint("expected no restart"))
+				test.Nil(t, h.KillEvent(), test.Sprint("expected no kill"))
+			},
+		},
+		{
+			name: "change mode noop refresh error",
+			vaultBlock: &structs.Vault{
+				Cluster:    structs.VaultDefaultCluster,
+				ChangeMode: structs.VaultChangeModeNoop,
+			},
+			vaultClient:  clientErr,
+			expectErrMsg: "failed to derive Vault token for identity vault_default: oops",
+			verifyTaskLifecycle: func(t *testing.T, h *trtesting.MockTaskHooks) {
+				signals := h.Signals()
+				test.Len(t, 0, signals, test.Sprint("expected no signal"))
+				restarts := h.Restarts()
+				test.Eq(t, 0, restarts, test.Sprint("expected no restart"))
+				test.NotNil(t, h.KillEvent(), test.Sprint("expected kill"))
 			},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			vaultClient := vaultclient.NewMockVaultClient()
-
-			hook := setupTestVaultHook(t, &vaultHookConfig{vaultBlock: tc.vaultBlock}, vaultClient)
-
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
 
-			hook.handleRenewal(ctx, "secret")
+			hook := setupTestVaultHook(t, &vaultHookConfig{
+				vaultBlock: tc.vaultBlock,
+				widmgr:     widMgr,
+				updater:    updater},
+				tc.vaultClient)
 
-			// Fetch derived token.
-			updater := (hook.updater).(*vaultTokenUpdaterMock)
-			token := updater.currentToken
-			must.NotEq(t, "", token)
+			// required to simulate a previous PreStart running
+			hook.client, _ = hook.clientFunc("default")
+			hook.vaultConfig = hook.vaultConfigsFunc(hook.logger)["default"]
+			hook.secretsDirTokenPath = filepath.Join(t.TempDir(), vaultTokenFile)
+			hook.privateDirTokenPath = filepath.Join(t.TempDir(), vaultTokenFile)
 
-			err := tc.verifyTaskLifecycle((hook.lifecycle).(*trtesting.MockTaskHooks))
-			must.NoError(t, err)
+			tok, lease, err := hook.handleRenewalFailure(ctx, "secret")
+
+			if tc.expectErrMsg == "" {
+				must.NoError(t, err)
+				must.Eq(t, "testToken", tok)
+				must.Eq(t, time.Duration(time.Second*5), lease)
+				updater = (hook.updater).(*vaultTokenUpdaterMock)
+				token := updater.currentToken
+				must.Eq(t, "testToken", token)
+			} else {
+				must.EqError(t, err, tc.expectErrMsg)
+				must.Eq(t, "", tok)
+				must.Eq(t, 0, lease)
+			}
+
+			tc.verifyTaskLifecycle(t, (hook.lifecycle).(*trtesting.MockTaskHooks))
 		})
 	}
 }

--- a/client/allocrunner/taskrunner/vault_hook_test.go
+++ b/client/allocrunner/taskrunner/vault_hook_test.go
@@ -499,7 +499,7 @@ func TestVaultHook_handleRenewalFailure(t *testing.T) {
 			hook.secretsDirTokenPath = filepath.Join(t.TempDir(), vaultTokenFile)
 			hook.privateDirTokenPath = filepath.Join(t.TempDir(), vaultTokenFile)
 
-			tok, lease, err := hook.handleRenewalFailure(ctx, "secret")
+			tok, lease, err := hook.handleRenewalFailure(ctx)
 
 			if tc.expectErrMsg == "" {
 				must.NoError(t, err)


### PR DESCRIPTION
When we refactored the Vault client in #28407, we wired up the change_mode to the renewal loop at the wrong spot. When we renew a Vault token, the token is unchanged so there's nothing to do. When we fail to renew a token, we should be triggering an attempt to get a new token via WI and then trigger the change_mode so that the workload can see it.

Fixes: https://github.com/hashicorp/nomad/issues/28407
Ref: https://github.com/hashicorp/nomad/pull/28302
Ref: https://hashicorp.atlassian.net/browse/NMD-1690

### Testing & Reproduction steps

Run Nomad and Vault and use the default setup. Modify this to drop the token period to 1m.

```
$ nomad setup vault -y
...
$ vault read -format=json auth/jwt-nomad/role/nomad-workloads |
      jq '.data | .token_period = "1m"' > nomad-workloads-role.json

$ vault write auth/jwt-nomad/role/nomad-workloads \
      @nomad-workloads-role.json
Success! Data written to: auth/jwt-nomad/role/nomad-workloads
```

Write a secret for an example job to Vault: `vault kv put secret/default/example name=Tim` then run the following job.

<details><summary>jobspec</summary>

```hcl
job "example" {

  group "web" {

    network {
      mode = "bridge"
      port "www" {
        to = 8001
      }
    }

    service {
      provider = "nomad"
      port     = "www"
    }

    task "http" {

      driver = "docker"

      vault {
        change_mode = "restart"
      }

      config {
        image   = "busybox:1"
        command = "httpd"
        args    = ["-vv", "-f", "-p", "8001", "-h", "/local"]
        ports   = ["www"]
      }

      template {
        data = <<EOT
<html>hello, {{ with secret "secret/data/default/example" }}{{- .Data.data.name -}}{{end}}</html>
EOT

        destination = "local/index.html"
      }

      resources {
        cpu    = 100
        memory = 100
      }

    }
  }
}
```

</details>

Run `nomad alloc exec` to jump into the allocation and grab the Vault token at `/secrets/vault_token`. From either inside or outside the container, wait a few minutes and then check that the token has been renewed and that you can still read the secret:


```
$ vault token lookup
Key                  Value
---                  -----
accessor             yelIF92GPP2bNd8568irn31Y
creation_time        1786645904
creation_ttl         1m
display_name         jwt-nomad-example
entity_id            2d834d23-c5a5-6efd-2380-65d12d984b62
expire_time          2026-08-13T14:39:22.770629853-04:00
explicit_max_ttl     0s
id                   hvs.CAESIPRXou1Urldpd7uwfP9yAZAP-gFhcj0FQHpC5oURR1ofGh4KHGh2cy5qbTRHSDluTW5NaDRiWldBS3E5ZmFVUlk
issue_time           2026-08-13T14:31:44.432861562-04:00
last_renewal         2026-08-13T14:38:22.77062993-04:00
last_renewal_time    1786646302
meta                 map[nomad_job_id:example nomad_namespace:default nomad_task:http role:nomad-workloads]
num_uses             0
orphan               true
path                 auth/jwt-nomad/login
period               1m
policies             [default nomad-workloads]
renewable            true
ttl                  30s
type                 service

$ vault kv get secret/default/example
======= Secret Path =======
secret/data/default/example

======= Metadata =======
Key                Value
---                -----
created_time       2026-08-13T18:33:28.995306729Z
custom_metadata    <nil>
deletion_time      n/a
destroyed          false
version            2

==== Data ====
Key     Value
---     -----
name    Tim
```

You can also update the secret in Vault and wait for CT to eventually pick up the change (note this is much slower than Consul blocking queries).


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
  - Updated unit tests + see repro above
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
