### PR TITLE
ci: Fix linter config with modernize addition.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,10 +59,6 @@ linters:
         - ST1016
         - ST1020
   exclusions:
-    paths-except:
-      - "^nomad/"
-      - "^plugins/"
-      - scheduler/*
     rules:
       - path: (.+)\.go$
         text: ifElseChain
@@ -72,6 +68,9 @@ linters:
         text: assignOp
       - path: (.+)\.go$
         text: unlambda
+      - path-except: (^plugins/|^nomad/|^scheduler/)
+        linters:
+          - modernize
     paths:
       - ".*\\.generated\\.go$"
       - ".*bindata_assetfs\\.go$"

--- a/client/consul/consul_testing.go
+++ b/client/consul/consul_testing.go
@@ -33,8 +33,8 @@ func (mc *MockConsulClient) DeriveTokenWithJWT(req JWTLoginRequest) (*consulapi.
 
 	hash := fnv.New128().Sum([]byte(req.JWT))
 	token := &consulapi.ACLToken{
-		AccessorID: hex.EncodeToString(hash[:]),
-		SecretID:   hex.EncodeToString(hash[:]),
+		AccessorID: hex.EncodeToString(hash),
+		SecretID:   hex.EncodeToString(hash),
 	}
 
 	if mc.tokens == nil {


### PR DESCRIPTION
The linter config had been incorrectly updated to attempt to run the modernize linter across a subset of packages. The original change meant all linters were only run on the subset of packages.

This update correctly updates the configuration, so that the linters are run on all packages and only the modernize linter is run on selected and updated packages.

### Testing & Reproduction steps
Along with the lint fixes in this PR, I made local changes that were intended to trigger certain linters to make sure they were running on expected packages:
```console
❯ make check
==> Linting source code...
client/consul/consul_testing.go:36:34: unslice: could simplify hash[:] to hash (gocritic)
                AccessorID: hex.EncodeToString(hash[:]),
                                               ^
client/consul/consul_testing.go:37:34: unslice: could simplify hash[:] to hash (gocritic)
                SecretID:   hex.EncodeToString(hash[:]),
                                               ^
nomad/state/autopilot.go:24:28: any: interface{} can be replaced by any (modernize)
                                        Conditional: func(obj interface{}) (bool, error) { return true, nil },
                                                              ^
plugins/serve.go:16:41: any: interface{} can be replaced by any (modernize)
type PluginFactory func(log log.Logger) interface{}
                                        ^
scheduler/scheduler.go:33:50: any: interface{} can be replaced by any (modernize)
        name string, logger log.Logger, eventsCh chan<- interface{}, state structs.State, planner structs.Planner,
                                                        ^
scheduler/scheduler_system.go:151:34: `langauge` is a misspelling of `language` (misspell)
        // Reset the failed allocations langauge

6 issues:
* gocritic: 2
* misspell: 1
* modernize: 3
make: *** [check] Error 1
```

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

