### PR TITLE
structs: accept file:<url> artifact checksums

### DIFF
--- a/.changelog/9764.txt
+++ b/.changelog/9764.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed a bug where an artifact `checksum` of the form `file:<url>` (fetching the checksum from a remote file) was rejected during job validation
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9934,14 +9934,12 @@ func (ta *TaskArtifact) validateChecksum() error {
 		return fmt.Errorf("checksum value cannot be empty")
 	}
 
-	// Split on the first colon only: a "file:<url>" checksum carries a URL
+	// Cut on the first colon only: a "file:<url>" checksum carries a URL
 	// value that may itself contain colons (e.g. a port).
-	parts := strings.SplitN(check, ":", 2)
-	if l := len(parts); l != 2 {
+	checksumType, checksumVal, ok := strings.Cut(check, ":")
+	if !ok {
 		return fmt.Errorf(`checksum must be given as "type:value"; got %q`, check)
 	}
-
-	checksumType := parts[0]
 
 	// A "file:<url>" checksum tells go-getter to read the checksum from a
 	// remote file rather than supplying a hex digest inline, so there is no
@@ -9950,7 +9948,6 @@ func (ta *TaskArtifact) validateChecksum() error {
 		return nil
 	}
 
-	checksumVal := parts[1]
 	checksumBytes, err := hex.DecodeString(checksumVal)
 	if err != nil {
 		return fmt.Errorf("invalid checksum: %v", err)

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -9934,9 +9934,20 @@ func (ta *TaskArtifact) validateChecksum() error {
 		return fmt.Errorf("checksum value cannot be empty")
 	}
 
-	parts := strings.Split(check, ":")
+	// Split on the first colon only: a "file:<url>" checksum carries a URL
+	// value that may itself contain colons (e.g. a port).
+	parts := strings.SplitN(check, ":", 2)
 	if l := len(parts); l != 2 {
 		return fmt.Errorf(`checksum must be given as "type:value"; got %q`, check)
+	}
+
+	checksumType := parts[0]
+
+	// A "file:<url>" checksum tells go-getter to read the checksum from a
+	// remote file rather than supplying a hex digest inline, so there is no
+	// digest to validate here; the getter resolves it at fetch time.
+	if checksumType == "file" {
+		return nil
 	}
 
 	checksumVal := parts[1]
@@ -9945,7 +9956,6 @@ func (ta *TaskArtifact) validateChecksum() error {
 		return fmt.Errorf("invalid checksum: %v", err)
 	}
 
-	checksumType := parts[0]
 	expectedLength := 0
 	switch checksumType {
 	case "md5":

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -5518,6 +5518,28 @@ func TestTaskArtifact_Validate_Checksum(t *testing.T) {
 			},
 			false,
 		},
+		{
+			// A file:<url> checksum tells go-getter to read the checksum
+			// from a remote file; the value is a URL, not a hex digest.
+			&TaskArtifact{
+				GetterSource: "foo.com",
+				GetterOptions: map[string]string{
+					"checksum": "file:http://example.com/checksums.sha256",
+				},
+			},
+			false,
+		},
+		{
+			// The checksum URL may contain a port (multiple colons); it must
+			// not be split into extra "type:value" segments.
+			&TaskArtifact{
+				GetterSource: "foo.com",
+				GetterOptions: map[string]string{
+					"checksum": "file:http://example.com:9086/path.md5",
+				},
+			},
+			false,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION

### Description
---go-getter supports fetching a checksum from a remote file with checksum=file:<url>, currently Nomad rejects it during job validation before the artifact is fetched.

Currently validateChecksum had: 

- strings.Split(check, ":") splits on colons which causes file:http://host:9086/x.md5 to become four parts and fails the type:value check.
- file isn't handled in the checksum-type switch.

Switched to SplitN(check, ":", 2) and return early for the file type


### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
Fixes #9764

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
