### PR TITLE
scheduler: fix failedTGAllocs handling for per_alloc volume task groups

### DIFF
--- a/.changelog/28422.txt
+++ b/.changelog/28422.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fixed a bug where task groups with `per_alloc` volumes could skip real feasibility checks for allocs after the first placement failure in the same task group
+```

--- a/nomad/structs/diff.go
+++ b/nomad/structs/diff.go
@@ -223,7 +223,7 @@ type TaskGroupDiff struct {
 func (tg *TaskGroup) Diff(other *TaskGroup, contextual bool) (*TaskGroupDiff, error) {
 	diff := &TaskGroupDiff{Type: DiffTypeNone}
 	var oldPrimitiveFlat, newPrimitiveFlat map[string]string
-	filter := []string{"Name"}
+	filter := []string{"Name", "HasPerAllocVolumes"}
 
 	if tg == nil && other == nil {
 		return diff, nil

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6932,6 +6932,12 @@ type TaskGroup struct {
 	// Volumes is a map of volumes that have been requested by the task group.
 	Volumes map[string]*VolumeRequest
 
+	// HasPerAllocVolumes records whether any entry in Volumes is per_alloc —
+	// i.e. each alloc in the group gets an independently feasible/infeasible
+	// volume rather than sharing one. Computed once in Canonicalize instead
+	// of rescanning Volumes on every placement attempt in computePlacements.
+	HasPerAllocVolumes bool
+
 	// ShutdownDelay is the amount of time to wait between deregistering
 	// group services in consul and stopping tasks.
 	ShutdownDelay *time.Duration
@@ -7073,6 +7079,13 @@ func (tg *TaskGroup) Canonicalize(job *Job) {
 
 	for _, task := range tg.Tasks {
 		task.Canonicalize(job, tg)
+	}
+
+	for _, v := range tg.Volumes {
+		if v.PerAlloc {
+			tg.HasPerAllocVolumes = true
+			break
+		}
 	}
 }
 

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -537,9 +537,19 @@ func (s *GenericScheduler) computePlacements(
 					s.logger.Debug("failed to find appropriate job; using the latest", "expected_version", missing.MinJobVersion, "found_version", jobVersion)
 				}
 			}
+			
+			// Check if the volumes in the taskgroup has per_alloc enabled 
+			hasPerAlloc := false
+
+			for _, volume := range tg.Volumes {
+				if volume.PerAlloc {
+					hasPerAlloc = true
+					break
+				}
+			}
 
 			// Check if this task group has already failed
-			if metric, ok := s.failedTGAllocs[tg.Name]; ok {
+			if metric, ok := s.failedTGAllocs[tg.Name]; ok  &&  !hasPerAlloc { // skip only when no per alloc in volume
 				metric.CoalescedFailures += 1
 				metric.ExhaustResources(tg)
 				continue

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -537,8 +537,8 @@ func (s *GenericScheduler) computePlacements(
 					s.logger.Debug("failed to find appropriate job; using the latest", "expected_version", missing.MinJobVersion, "found_version", jobVersion)
 				}
 			}
-			
-			// Check if the volumes in the taskgroup has per_alloc enabled 
+
+			// Check if the volumes in the taskgroup have per_alloc enabled
 			hasPerAlloc := false
 
 			for _, volume := range tg.Volumes {
@@ -549,7 +549,7 @@ func (s *GenericScheduler) computePlacements(
 			}
 
 			// Check if this task group has already failed
-			if metric, ok := s.failedTGAllocs[tg.Name]; ok  &&  !hasPerAlloc { // skip only when no per alloc in volume
+			if metric, ok := s.failedTGAllocs[tg.Name]; ok && !hasPerAlloc { // skip only when no per alloc in volume
 				metric.CoalescedFailures += 1
 				metric.ExhaustResources(tg)
 				continue
@@ -705,8 +705,28 @@ func (s *GenericScheduler) computePlacements(
 				// Update metrics with the resources requested by the task group.
 				s.ctx.Metrics().ExhaustResources(tg)
 
-				// Track the fact that we didn't find a placement
-				s.failedTGAllocs[tg.Name] = s.ctx.Metrics()
+				prevMetrics, ok := s.failedTGAllocs[tg.Name]
+				currentMetrics := s.ctx.Metrics()
+
+				if !ok || !hasPerAlloc {
+					s.failedTGAllocs[tg.Name] = currentMetrics
+				} else {
+					winner, loser := prevMetrics, currentMetrics
+					if currentMetrics.NodesExhausted > prevMetrics.NodesExhausted {
+						winner, loser = currentMetrics, prevMetrics
+					}
+
+					if winner.ConstraintFiltered == nil {
+						winner.ConstraintFiltered = make(map[string]int)
+					}
+
+					for reason, count := range loser.ConstraintFiltered {
+						winner.ConstraintFiltered[reason] += count
+					}
+
+					// Track the fact that we didn't find a placement
+					s.failedTGAllocs[tg.Name] = winner
+				}
 
 				// If we weren't able to find a placement for the allocation, back
 				// out the fact that we asked to stop the allocation.

--- a/scheduler/generic_sched.go
+++ b/scheduler/generic_sched.go
@@ -538,15 +538,7 @@ func (s *GenericScheduler) computePlacements(
 				}
 			}
 
-			// Check if the volumes in the taskgroup have per_alloc enabled
-			hasPerAlloc := false
-
-			for _, volume := range tg.Volumes {
-				if volume.PerAlloc {
-					hasPerAlloc = true
-					break
-				}
-			}
+			hasPerAlloc := tg.HasPerAllocVolumes
 
 			// Check if this task group has already failed
 			if metric, ok := s.failedTGAllocs[tg.Name]; ok && !hasPerAlloc { // skip only when no per alloc in volume
@@ -708,24 +700,32 @@ func (s *GenericScheduler) computePlacements(
 				prevMetrics, ok := s.failedTGAllocs[tg.Name]
 				currentMetrics := s.ctx.Metrics()
 
+				// Only the first failure for a task group short-circuits into
+				// the fast path (metric = current, no merge): either this is
+				// the group's first failure this eval (!ok), or the group has
+				// no per_alloc volume so every alloc's failure reason is
+				// interchangeable (!hasPerAlloc). A later failure in a
+				// per_alloc group (ok && hasPerAlloc) falls through to the
+				// merge branch below, since each alloc's per-alloc volume can
+				// fail for a distinct reason that must be preserved.
 				if !ok || !hasPerAlloc {
 					s.failedTGAllocs[tg.Name] = currentMetrics
 				} else {
-					winner, loser := prevMetrics, currentMetrics
+					reporting, dropping := prevMetrics, currentMetrics
 					if currentMetrics.NodesExhausted > prevMetrics.NodesExhausted {
-						winner, loser = currentMetrics, prevMetrics
+						reporting, dropping = currentMetrics, prevMetrics
 					}
 
-					if winner.ConstraintFiltered == nil {
-						winner.ConstraintFiltered = make(map[string]int)
+					if reporting.ConstraintFiltered == nil {
+						reporting.ConstraintFiltered = make(map[string]int)
 					}
 
-					for reason, count := range loser.ConstraintFiltered {
-						winner.ConstraintFiltered[reason] += count
+					for reason, count := range dropping.ConstraintFiltered {
+						reporting.ConstraintFiltered[reason] += count
 					}
 
 					// Track the fact that we didn't find a placement
-					s.failedTGAllocs[tg.Name] = winner
+					s.failedTGAllocs[tg.Name] = reporting
 				}
 
 				// If we weren't able to find a placement for the allocation, back

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -7819,7 +7819,7 @@ func TestServiceSched_CSIVolumesPerAlloc_MergedFailures(t *testing.T) {
 	// Create nodes running the CSI plugin, capped so that placement fails
 	// only because the per-alloc volumes are missing, not because of
 	// unrelated resource exhaustion.
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		node := mock.Node()
 		node.CSINodePlugins = map[string]*structs.CSIInfo{
 			"test-plugin": {
@@ -7854,6 +7854,10 @@ func TestServiceSched_CSIVolumesPerAlloc_MergedFailures(t *testing.T) {
 			PerAlloc: true,
 		},
 	}
+	// Volumes were added after mock.Job() already canonicalized the job, so
+	// HasPerAllocVolumes must be recomputed here to match what real job
+	// registration does (Job.Register always canonicalizes on the way in).
+	job.Canonicalize()
 	must.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
 
 	eval := &structs.Evaluation{

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -7808,6 +7808,89 @@ func TestServiceSched_CSIVolumesPerAlloc(t *testing.T) {
 
 }
 
+// Tests that when more than one alloc in a per_alloc-volume task group
+// fails placement in the same eval, FailedTGAllocs reflects all of the
+// distinct failures, not just whichever alloc was evaluated last.
+func TestServiceSched_CSIVolumesPerAlloc_MergedFailures(t *testing.T) {
+	ci.Parallel(t)
+
+	h := tests.NewHarness(t)
+
+	// Create nodes running the CSI plugin, capped so that placement fails
+	// only because the per-alloc volumes are missing, not because of
+	// unrelated resource exhaustion.
+	for i := 0; i < 5; i++ {
+		node := mock.Node()
+		node.CSINodePlugins = map[string]*structs.CSIInfo{
+			"test-plugin": {
+				PluginID: "test-plugin",
+				Healthy:  true,
+				NodeInfo: &structs.CSINodeInfo{MaxVolumes: 2},
+			},
+		}
+		must.NoError(t, h.State.UpsertNode(
+			structs.MsgTypeTestSetup, h.NextIndex(), node))
+	}
+
+	// Only volume-unique[0] exists. A 3-count job needs indices 0, 1, and 2,
+	// so allocs for index 1 and index 2 will both fail to place, each for a
+	// different missing volume.
+	vol0 := structs.NewCSIVolume("volume-unique[0]", 0)
+	vol0.PluginID = "test-plugin"
+	vol0.Namespace = structs.DefaultNamespace
+	vol0.AccessMode = structs.CSIVolumeAccessModeSingleNodeWriter
+	vol0.AttachmentMode = structs.CSIVolumeAttachmentModeFilesystem
+
+	must.NoError(t, h.State.UpsertCSIVolume(
+		h.NextIndex(), []*structs.CSIVolume{vol0}))
+
+	job := mock.Job()
+	job.TaskGroups[0].Count = 3
+	job.TaskGroups[0].Volumes = map[string]*structs.VolumeRequest{
+		"unique": {
+			Type:     "csi",
+			Name:     "unique",
+			Source:   "volume-unique",
+			PerAlloc: true,
+		},
+	}
+	must.NoError(t, h.State.UpsertJob(structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
+
+	eval := &structs.Evaluation{
+		Namespace:   structs.DefaultNamespace,
+		ID:          uuid.Generate(),
+		Priority:    job.Priority,
+		TriggeredBy: structs.EvalTriggerJobRegister,
+		JobID:       job.ID,
+		Status:      structs.EvalStatusPending,
+	}
+	must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup,
+		h.NextIndex(), []*structs.Evaluation{eval}))
+
+	err := h.Process(NewServiceScheduler, eval)
+	must.NoError(t, err)
+	must.Len(t, 1, h.Evals, must.Sprint("expected one eval"))
+
+	// Only one alloc (index 0) should have placed.
+	out, err := h.State.AllocsByJob(nil, job.Namespace, job.ID, false)
+	must.NoError(t, err)
+	must.Len(t, 1, out, must.Sprint("expected 1 placed allocation"))
+
+	// Expect a blocked eval, since 2 allocs are still queued.
+	must.NotEq(t, "", h.Evals[0].BlockedEval,
+		must.Sprint("expected a blocked eval to be spawned"))
+	must.Eq(t, 2, h.Evals[0].QueuedAllocations["web"],
+		must.Sprint("expected 2 queued allocs"))
+
+	// Both missing-volume failures should be present in the merged metric.
+	metric := h.Evals[0].FailedTGAllocs["web"]
+	must.NotNil(t, metric, must.Sprint("expected a failed TG alloc metric for \"web\""))
+	must.Eq(t, 5, metric.ConstraintFiltered["missing CSI volume(s) volume-unique[1]"],
+		must.Sprint("expected the index 1 volume failure to be present in the merged metric"))
+	must.Eq(t, 5, metric.ConstraintFiltered["missing CSI volume(s) volume-unique[2]"],
+		must.Sprint("expected the index 2 volume failure to be present in the merged metric"))
+}
+
 func TestServiceSched_CSITopology(t *testing.T) {
 	ci.Parallel(t)
 	h := tests.NewHarness(t)


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

Task groups with a `per_alloc` volume were treated as one pass/fail unit by `computePlacements`'s `failedTGAllocs` fast path: once one alloc in the group failed, every later alloc in that group was skipped without a real feasibility check, even though each alloc's per-alloc volume (`<source>[<index>]`) is independently feasible or not.

Two-part fix (per the approach discussed in #28285):
1. Skip the fast-path short-circuit for task groups that have any `per_alloc` volume request, so every alloc always gets placed/evaluated for real.
2. When multiple allocs in the same `per_alloc` group fail in one eval, merge their `AllocMetric` into `failedTGAllocs` instead of overwriting one with the next: keep one whole snapshot for bin-packing-state fields (picked by comparing `NodesExhausted`) and additively merge `ConstraintFiltered` (alloc-independent) across the failures.

Non-`per_alloc` groups are unaffected. Same fast-path skip and overwrite behavior as before.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

Added `TestServiceSched_CSIVolumesPerAlloc_MergedFailures`: a 3-count `per_alloc` CSI job where only volume index 0 exists, so allocs 1 and 2 each fail for a different missing volume. Asserts both failure reasons survive in the merged `FailedTGAllocs` metric. Confirmed the test catches the regression by reverting the merge to a flat overwrite and seeing it fail, then restoring.

`go build ./scheduler/...` and the existing `TestServiceSched_CSIVolumesPerAlloc` pass unchanged.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

Fixes #28285

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI, and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge" in the majority of situations. The main exceptions are long-lived feature branches or merges where history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None.
