### PR TITLE
jobspec2: support optional() object type attributes in variables

### DIFF
--- a/.changelog/28424.txt
+++ b/.changelog/28424.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+jobspec2: support optional() object type attributes in variables
+```

--- a/jobspec2/parse_test.go
+++ b/jobspec2/parse_test.go
@@ -212,17 +212,17 @@ job "example" {
 			Body:    []byte(hcl),
 			AllowFS: true,
 		})
-		require.NoError(t, err)
-		require.NotNil(t, out.Meta)
-		require.Equal(t, "api", out.Meta["service_name"])
-		require.Equal(t, "8080", out.Meta["service_port"])
-		require.Equal(t, "", out.Meta["service_tags"])
-		require.Equal(t, "yes", out.Meta["service_meta_null"])
-		require.Equal(t, "yes", out.Meta["upstream_null"])
-		require.Equal(t, "a.example.com", out.Meta["backend0_host"])
-		require.Equal(t, "443", out.Meta["backend0_port"])
-		require.Equal(t, "b.example.com", out.Meta["backend1_host"])
-		require.Equal(t, "8443", out.Meta["backend1_port"])
+		must.NoError(t, err)
+		must.NotNil(t, out.Meta)
+		must.Eq(t, "api", out.Meta["service_name"])
+		must.Eq(t, "8080", out.Meta["service_port"])
+		must.Eq(t, "", out.Meta["service_tags"])
+		must.Eq(t, "yes", out.Meta["service_meta_null"])
+		must.Eq(t, "yes", out.Meta["upstream_null"])
+		must.Eq(t, "a.example.com", out.Meta["backend0_host"])
+		must.Eq(t, "443", out.Meta["backend0_port"])
+		must.Eq(t, "b.example.com", out.Meta["backend1_host"])
+		must.Eq(t, "8443", out.Meta["backend1_port"])
 	})
 
 	t.Run("explicit values override optional defaults", func(t *testing.T) {
@@ -232,19 +232,19 @@ job "example" {
 			ArgVars: []string{`service={name="web", port=9090, tags=["a","b"], meta={env="prod"}, upstream={address="127.0.0.1"}}`},
 			AllowFS: true,
 		})
-		require.NoError(t, err)
-		require.NotNil(t, out.Meta)
-		require.Equal(t, "web", out.Meta["service_name"])
-		require.Equal(t, "9090", out.Meta["service_port"])
-		require.Equal(t, "a,b", out.Meta["service_tags"])
-		require.Equal(t, "no", out.Meta["service_meta_null"])
-		require.Equal(t, "no", out.Meta["upstream_null"])
+		must.NoError(t, err)
+		must.NotNil(t, out.Meta)
+		must.Eq(t, "web", out.Meta["service_name"])
+		must.Eq(t, "9090", out.Meta["service_port"])
+		must.Eq(t, "a,b", out.Meta["service_tags"])
+		must.Eq(t, "no", out.Meta["service_meta_null"])
+		must.Eq(t, "no", out.Meta["upstream_null"])
 	})
 
 	t.Run("nested optional defaults applied via var-file", func(t *testing.T) {
 		varFile, err := os.CreateTemp("", "*.vars")
-		require.NoError(t, err)
-		defer os.Remove(varFile.Name())
+		must.NoError(t, err)
+		t.Cleanup(func() { _ = os.Remove(varFile.Name()) })
 
 		_, err = varFile.WriteString(`
 service = {
@@ -254,8 +254,8 @@ service = {
   }
 }
 `)
-		require.NoError(t, err)
-		require.NoError(t, varFile.Close())
+		must.NoError(t, err)
+		must.NoError(t, varFile.Close())
 
 		// Use a job that reads nested upstream.port default
 		nestedHCL := `
@@ -284,10 +284,10 @@ job "example" {
 			VarFiles: []string{varFile.Name()},
 			AllowFS:  true,
 		})
-		require.NoError(t, err)
-		require.Equal(t, "from-file", out.Meta["name"])
-		require.Equal(t, "10.0.0.1", out.Meta["addr"])
-		require.Equal(t, "80", out.Meta["port"])
+		must.NoError(t, err)
+		must.Eq(t, "from-file", out.Meta["name"])
+		must.Eq(t, "10.0.0.1", out.Meta["addr"])
+		must.Eq(t, "80", out.Meta["port"])
 	})
 
 	t.Run("missing required attribute still errors", func(t *testing.T) {
@@ -297,8 +297,7 @@ job "example" {
 			ArgVars: []string{`service={port=1}`},
 			AllowFS: true,
 		})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "not compatible with the variable's type constraint")
+		must.ErrorContains(t, err, "not compatible with the variable's type constraint")
 	})
 }
 

--- a/jobspec2/parse_test.go
+++ b/jobspec2/parse_test.go
@@ -154,6 +154,154 @@ job "example" {
 	})
 }
 
+// TestParse_OptionalObjectAttributes asserts that optional(...) type constraints
+// work for object attributes, including default values nested in lists/objects.
+func TestParse_OptionalObjectAttributes(t *testing.T) {
+	t.Parallel()
+
+	hcl := `
+variable "service" {
+  type = object({
+    name     = string
+    port     = optional(number, 8080)
+    tags     = optional(list(string), [])
+    meta     = optional(map(string))
+    upstream = optional(object({
+      address = string
+      port    = optional(number, 80)
+    }))
+  })
+  default = {
+    name = "api"
+  }
+}
+
+variable "backends" {
+  type = list(object({
+    host = string
+    port = optional(number, 443)
+  }))
+  default = [
+    { host = "a.example.com" },
+    { host = "b.example.com", port = 8443 },
+  ]
+}
+
+job "example" {
+  datacenters = ["dc1"]
+
+  meta {
+    service_name = var.service.name
+    service_port = format("%d", var.service.port)
+    service_tags = join(",", var.service.tags)
+    # meta is optional without a default; omitted values are null
+    service_meta_null = var.service.meta == null ? "yes" : "no"
+    # nested optional object omitted entirely
+    upstream_null = var.service.upstream == null ? "yes" : "no"
+    backend0_host = var.backends[0].host
+    backend0_port = format("%d", var.backends[0].port)
+    backend1_host = var.backends[1].host
+    backend1_port = format("%d", var.backends[1].port)
+  }
+}
+`
+
+	t.Run("defaults fill optional attributes", func(t *testing.T) {
+		out, err := ParseWithConfig(&ParseConfig{
+			Path:    "input.hcl",
+			Body:    []byte(hcl),
+			AllowFS: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out.Meta)
+		require.Equal(t, "api", out.Meta["service_name"])
+		require.Equal(t, "8080", out.Meta["service_port"])
+		require.Equal(t, "", out.Meta["service_tags"])
+		require.Equal(t, "yes", out.Meta["service_meta_null"])
+		require.Equal(t, "yes", out.Meta["upstream_null"])
+		require.Equal(t, "a.example.com", out.Meta["backend0_host"])
+		require.Equal(t, "443", out.Meta["backend0_port"])
+		require.Equal(t, "b.example.com", out.Meta["backend1_host"])
+		require.Equal(t, "8443", out.Meta["backend1_port"])
+	})
+
+	t.Run("explicit values override optional defaults", func(t *testing.T) {
+		out, err := ParseWithConfig(&ParseConfig{
+			Path:    "input.hcl",
+			Body:    []byte(hcl),
+			ArgVars: []string{`service={name="web", port=9090, tags=["a","b"], meta={env="prod"}, upstream={address="127.0.0.1"}}`},
+			AllowFS: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, out.Meta)
+		require.Equal(t, "web", out.Meta["service_name"])
+		require.Equal(t, "9090", out.Meta["service_port"])
+		require.Equal(t, "a,b", out.Meta["service_tags"])
+		require.Equal(t, "no", out.Meta["service_meta_null"])
+		require.Equal(t, "no", out.Meta["upstream_null"])
+	})
+
+	t.Run("nested optional defaults applied via var-file", func(t *testing.T) {
+		varFile, err := os.CreateTemp("", "*.vars")
+		require.NoError(t, err)
+		defer os.Remove(varFile.Name())
+
+		_, err = varFile.WriteString(`
+service = {
+  name = "from-file"
+  upstream = {
+    address = "10.0.0.1"
+  }
+}
+`)
+		require.NoError(t, err)
+		require.NoError(t, varFile.Close())
+
+		// Use a job that reads nested upstream.port default
+		nestedHCL := `
+variable "service" {
+  type = object({
+    name     = string
+    upstream = optional(object({
+      address = string
+      port    = optional(number, 80)
+    }))
+  })
+}
+
+job "example" {
+  datacenters = ["dc1"]
+  meta {
+    name = var.service.name
+    addr = var.service.upstream.address
+    port = format("%d", var.service.upstream.port)
+  }
+}
+`
+		out, err := ParseWithConfig(&ParseConfig{
+			Path:     "input.hcl",
+			Body:     []byte(nestedHCL),
+			VarFiles: []string{varFile.Name()},
+			AllowFS:  true,
+		})
+		require.NoError(t, err)
+		require.Equal(t, "from-file", out.Meta["name"])
+		require.Equal(t, "10.0.0.1", out.Meta["addr"])
+		require.Equal(t, "80", out.Meta["port"])
+	})
+
+	t.Run("missing required attribute still errors", func(t *testing.T) {
+		_, err := ParseWithConfig(&ParseConfig{
+			Path:    "input.hcl",
+			Body:    []byte(hcl),
+			ArgVars: []string{`service={port=1}`},
+			AllowFS: true,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not compatible with the variable's type constraint")
+	})
+}
+
 // TestParse_UnknownVariables asserts that unknown variables are left intact for further processing
 func TestParse_UnknownVariables(t *testing.T) {
 	t.Parallel()

--- a/jobspec2/types.variables.go
+++ b/jobspec2/types.variables.go
@@ -60,12 +60,14 @@ type Variable struct {
 	// declaration, the type of the default variable will be used. This will
 	// allow to ensure that users set this variable correctly.
 	Type cty.Type
+
 	// TypeDefaults holds the default values declared through optional()
 	// attribute modifiers within the variable's type constraint, if any. It is
 	// nil when the type constraint declares no such defaults. These defaults
 	// must be applied to a value before it is converted to Type so that any
 	// omitted optional attributes are populated with their declared defaults.
 	TypeDefaults *typeexpr.Defaults
+	
 	// Common name of the variable
 	Name string
 	// Description of the variable

--- a/jobspec2/types.variables.go
+++ b/jobspec2/types.variables.go
@@ -60,6 +60,12 @@ type Variable struct {
 	// declaration, the type of the default variable will be used. This will
 	// allow to ensure that users set this variable correctly.
 	Type cty.Type
+	// TypeDefaults holds the default values declared through optional()
+	// attribute modifiers within the variable's type constraint, if any. It is
+	// nil when the type constraint declares no such defaults. These defaults
+	// must be applied to a value before it is converted to Type so that any
+	// omitted optional attributes are populated with their declared defaults.
+	TypeDefaults *typeexpr.Defaults
 	// Common name of the variable
 	Name string
 	// Description of the variable
@@ -76,6 +82,18 @@ func (v *Variable) GoString() string {
 	}
 	fmt.Fprintf(b, "}")
 	return b.String()
+}
+
+// applyTypeDefaults applies the default values declared through optional()
+// attribute modifiers in the variable's type constraint. It is a no-op when the
+// type declares no such defaults or when the value is null. Defaults must be
+// applied before converting a value to the variable's type so that omitted
+// optional attributes are populated with their declared defaults.
+func (v *Variable) applyTypeDefaults(val cty.Value) cty.Value {
+	if v.TypeDefaults == nil || val.IsNull() {
+		return val
+	}
+	return v.TypeDefaults.Apply(val)
 }
 
 // validateValue ensures that all of the configured custom validations for a
@@ -288,13 +306,14 @@ func (variables *Variables) decodeVariableBlock(block *hcl.Block, ectx *hcl.Eval
 	}
 
 	if t, ok := content.Attributes["type"]; ok {
-		tp, moreDiags := typeexpr.Type(t.Expr)
+		tp, typeDefaults, moreDiags := typeexpr.TypeConstraintWithDefaults(t.Expr)
 		diags = append(diags, moreDiags...)
 		if moreDiags.HasErrors() {
 			return diags
 		}
 
 		v.Type = tp
+		v.TypeDefaults = typeDefaults
 	}
 
 	if def, ok := content.Attributes["default"]; ok {
@@ -306,6 +325,7 @@ func (variables *Variables) decodeVariableBlock(block *hcl.Block, ectx *hcl.Eval
 
 		if v.Type != cty.NilType {
 			var err error
+			defaultValue = v.applyTypeDefaults(defaultValue)
 			defaultValue, err = convert.Convert(defaultValue, v.Type)
 			if err != nil {
 				diags = append(diags, &hcl.Diagnostic{
@@ -485,6 +505,7 @@ func (c *jobConfig) collectInputVariableValues(env []string, files []*hcl.File, 
 		diags = append(diags, valDiags...)
 		if variable.Type != cty.NilType {
 			var err error
+			val = variable.applyTypeDefaults(val)
 			val, err = convert.Convert(val, variable.Type)
 			if err != nil {
 				diags = append(diags, &hcl.Diagnostic{
@@ -574,6 +595,7 @@ func (c *jobConfig) collectInputVariableValues(env []string, files []*hcl.File, 
 
 			if variable.Type != cty.NilType {
 				var err error
+				val = variable.applyTypeDefaults(val)
 				val, err = convert.Convert(val, variable.Type)
 				if err != nil {
 					diags = append(diags, &hcl.Diagnostic{
@@ -622,6 +644,7 @@ func (c *jobConfig) collectInputVariableValues(env []string, files []*hcl.File, 
 
 		if variable.Type != cty.NilType {
 			var err error
+			val = variable.applyTypeDefaults(val)
 			val, err = convert.Convert(val, variable.Type)
 			if err != nil {
 				diags = append(diags, &hcl.Diagnostic{


### PR DESCRIPTION
## Summary

Support `optional(...)` object type attributes in Nomad HCL variables, matching Terraform/Packer behavior.

Variable type expressions are now parsed with `typeexpr.TypeConstraintWithDefaults` instead of `typeexpr.Type`. Defaults declared via `optional(type, default)` are applied before type conversion for:

- variable `default` values
- environment variables (`NOMAD_VAR_*`)
- `.var` / `-var-file` assignments
- `-var` CLI flags

Example:

```hcl
variable "service" {
  type = object({
    name = string
    port = optional(number, 8080)
    tags = optional(list(string), [])
    meta = optional(map(string))
  })
  default = {
    name = "api"
  }
}
```

## Testing

- `go test ./jobspec2/ -run TestParse_OptionalObjectAttributes`
- Existing variable parse tests (`TestParse_VariablesDefaultsAndSet`, `TestParse_VarsAndFunctions`, validation tests)

Fixes #25317
