### PR TITLE
scheduler: prevent extra reschedules from invalid states

### DIFF
--- a/.changelog/28445.txt
+++ b/.changelog/28445.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+scheduler: Improved robustness of reschedule logic for invalid states
+```

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -677,14 +677,6 @@ func (a *Allocation) Terminated() bool {
 	return false
 }
 
-// SetStop updates the allocation in place to a DesiredStatus stop, with the ClientStatus
-func (a *Allocation) SetStop(clientStatus, clientDesc string) {
-	a.DesiredStatus = AllocDesiredStatusStop
-	a.ClientStatus = clientStatus
-	a.ClientDescription = clientDesc
-	a.AppendState(AllocStateFieldClientStatus, clientStatus)
-}
-
 // AppendState creates and appends an AllocState entry recording the time of the state
 // transition. Used to mark the transition to lost
 func (a *Allocation) AppendState(field AllocStateField, value string) {
@@ -869,8 +861,7 @@ func (a *Allocation) NeedsToReconnect() bool {
 	// AllocStates are appended to the list and we only need the latest
 	// ClientStatus transition, so traverse from the end until we find one.
 	for _, s := range slices.Backward(a.AllocStates) {
-
-		if s.Field != AllocStateFieldClientStatus {
+		if s.Field != AllocStateFieldClientStatus || s.Value == "" {
 			continue
 		}
 

--- a/nomad/structs/plan.go
+++ b/nomad/structs/plan.go
@@ -177,9 +177,8 @@ func (p *Plan) AppendStoppedAlloc(alloc *Allocation, desiredDesc, clientStatus, 
 
 	if clientStatus != "" {
 		newAlloc.ClientStatus = clientStatus
+		newAlloc.AppendState(AllocStateFieldClientStatus, clientStatus)
 	}
-
-	newAlloc.AppendState(AllocStateFieldClientStatus, clientStatus)
 
 	if followupEvalID != "" {
 		newAlloc.FollowupEvalID = followupEvalID

--- a/scheduler/generic_sched_test.go
+++ b/scheduler/generic_sched_test.go
@@ -8113,3 +8113,200 @@ func initNodeAndAllocs(t *testing.T, h *tests.Harness, job *structs.Job,
 	return node, job, allocs
 
 }
+
+// TestReconciler_RescheduleBadStates is a regression test designed to catch bad
+// behavior in the scheduler when faced with states that should be impossible.
+func TestReconciler_RescheduleBadStates(t *testing.T) {
+	ci.Parallel(t)
+
+	// 2 healthy nodes and a job with a disconnect block
+	node0 := mock.Node()
+	node1 := mock.Node()
+	job := mock.Job()
+	job.TaskGroups[0].Count = 1
+	job.TaskGroups[0].Disconnect = &structs.DisconnectStrategy{
+		LostAfter: time.Hour,
+		Replace:   new(true),
+	}
+
+	eval0 := mock.Eval()
+	eval0.TriggeredBy = structs.EvalTriggerNodeUpdate
+	eval0.JobID = job.ID
+
+	alloc0 := mock.MinAllocForJob(job)
+	alloc1 := mock.MinAllocForJob(job)
+
+	alloc0.NodeID = node0.ID
+	alloc0.FollowupEvalID = eval0.ID
+	alloc0.NextAllocation = alloc1.ID
+
+	alloc1.NodeID = node1.ID
+	alloc1.PreviousAllocation = alloc0.ID
+
+	// helper for flattening placements/stops
+	unpackPlan := func(plan *structs.Plan) (place, stop []string) {
+		for _, allocs := range plan.NodeAllocation {
+			for _, alloc := range allocs {
+				place = append(place, alloc.ID[:8])
+			}
+		}
+		for _, allocs := range plan.NodeUpdate {
+			for _, alloc := range allocs {
+				stop = append(stop, alloc.ID[:8])
+			}
+		}
+		return
+	}
+
+	testCases := []struct {
+		name        string
+		setupFn     func(*structs.Allocation)
+		expectPlace int
+		expectStop  int
+	}{
+		{
+			// this state is a baseline "normal state"
+			name: "0 unknown with next allocation set",
+			setupFn: func(a0 *structs.Allocation) {
+				a0.ClientStatus = structs.AllocClientStatusUnknown
+				a0.AllocStates = []*structs.AllocState{{
+					Field: structs.AllocStateFieldClientStatus,
+					Value: "unknown",
+					Time:  time.Now(),
+				}}
+			},
+			expectPlace: 0,
+			expectStop:  1, // stop 1 because we've reconnected
+		},
+
+		{
+			name: "1 unknown with weird alloc states",
+			setupFn: func(a0 *structs.Allocation) {
+				a0.ClientStatus = structs.AllocClientStatusUnknown
+				a0.AllocStates = []*structs.AllocState{
+					{
+						Field: structs.AllocStateFieldClientStatus,
+						Value: "unknown",
+						Time:  time.Now(),
+					},
+					{
+						Field: structs.AllocStateFieldClientStatus,
+						Value: "",
+						Time:  time.Now(),
+					},
+				}
+			},
+			expectPlace: 0,
+			expectStop:  1, // stop 1 because we've reconnected
+		},
+
+		{
+			name: "2 impossible unknown with force reschedule",
+			setupFn: func(a0 *structs.Allocation) {
+				a0.ClientStatus = structs.AllocClientStatusUnknown
+				a0.DesiredTransition.ForceReschedule = new(true)
+				a0.AllocStates = []*structs.AllocState{{
+					Field: structs.AllocStateFieldClientStatus,
+					Value: "unknown",
+					Time:  time.Now(),
+				}}
+			},
+			expectPlace: 0, // should not replace because we already have 1
+			expectStop:  1, // stop 1 because we've reconnected
+		},
+
+		{
+			name: "3 impossible running with force reschedule",
+			setupFn: func(a0 *structs.Allocation) {
+				a0.ClientStatus = structs.AllocClientStatusRunning
+				a0.DesiredTransition.ForceReschedule = new(true)
+				a0.RescheduleTracker = &structs.RescheduleTracker{
+					Events:         []*structs.RescheduleEvent{{}},
+					LastReschedule: "ok",
+				}
+			},
+			expectPlace: 0, // should not replace because we already have 1
+			expectStop:  1, // stop 1 because we've reconnected
+		},
+
+		{
+			name: "4 impossible unknown with force reschedule and weird alloc states",
+			setupFn: func(a0 *structs.Allocation) {
+				a0.ClientStatus = structs.AllocClientStatusUnknown
+				a0.DesiredTransition.ForceReschedule = new(true)
+				a0.AllocStates = []*structs.AllocState{
+					{
+						Field: structs.AllocStateFieldClientStatus,
+						Value: "unknown",
+						Time:  time.Now(),
+					},
+					{
+						Field: structs.AllocStateFieldClientStatus,
+						Value: "",
+						Time:  time.Now(),
+					},
+				}
+			},
+			expectPlace: 0,
+			expectStop:  1, // stop 1 because we have 1 running
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := tests.NewHarness(t)
+			must.NoError(t, h.State.UpsertNode(
+				structs.MsgTypeTestSetup, h.NextIndex(), node0))
+			must.NoError(t, h.State.UpsertNode(
+				structs.MsgTypeTestSetup, h.NextIndex(), node1))
+			must.NoError(t, h.State.UpsertJob(
+				structs.MsgTypeTestSetup, h.NextIndex(), nil, job))
+			must.NoError(t, h.State.UpsertJobSummary(
+				h.NextIndex(), mock.JobSummary(job.ID)))
+
+			alloc0 := alloc0.Copy()
+			alloc1 := alloc1.Copy()
+			tc.setupFn(alloc0)
+
+			t.Logf("alloc0=%s", alloc0.ID[:8])
+			t.Logf("alloc1=%s", alloc1.ID[:8])
+
+			must.NoError(t, h.State.UpsertAllocs(structs.MsgTypeTestSetup,
+				h.NextIndex(), []*structs.Allocation{alloc0, alloc1}))
+
+			eval := eval0.Copy()
+			must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup,
+				h.NextIndex(), []*structs.Evaluation{eval}))
+
+			// first plan
+			must.NoError(t, h.Process(NewServiceScheduler, eval))
+			must.Len(t, 1, h.Plans, must.Sprint("expected a plan"))
+			place, stop := unpackPlan(h.Plans[0])
+			test.Len(t, tc.expectPlace, place, test.Sprint("wrong place count"))
+			test.Len(t, tc.expectStop, stop, test.Sprint("wrong stop count"))
+
+			// continue to run more evals to demonstrate extra plans and excess
+			// allocations
+			var lastPlanCount int
+			for {
+				lastPlanCount = len(h.Plans)
+				eval := mock.Eval()
+				eval.TriggeredBy = structs.EvalTriggerNodeUpdate
+				eval.JobID = job.ID
+				must.NoError(t, h.State.UpsertEvals(structs.MsgTypeTestSetup,
+					h.NextIndex(), []*structs.Evaluation{eval}))
+				must.NoError(t, h.Process(NewServiceScheduler, eval))
+				if len(h.Plans) > 5 || len(h.Plans) == lastPlanCount {
+					break // no new plan, or enough to show runaway
+				}
+			}
+			for i, plan := range h.Plans {
+				place, stop := unpackPlan(plan)
+				t.Logf("plan[%d] place=%v stop=%v", i, place, stop)
+			}
+			if lastPlanCount > 1 {
+				t.Fatal("expected at most one plan")
+			}
+		})
+	}
+}

--- a/scheduler/reconciler/filters.go
+++ b/scheduler/reconciler/filters.go
@@ -521,17 +521,20 @@ func shouldFilter(alloc *structs.Allocation, isBatch bool) (untainted, ignore bo
 	return false, false
 }
 
-// updateByReschedulable is a helper method that encapsulates logic for whether a failed allocation
-// should be rescheduled now, later or left in the untainted set
+// updateByReschedulable is a helper method that encapsulates logic for whether
+// a failed allocation should be rescheduled now, later or left in the untainted
+// set
 func updateByReschedulable(alloc *structs.Allocation, now time.Time, evalID string, d *structs.Deployment, isDisconnecting bool) (rescheduleNow, rescheduleLater bool, rescheduleTime time.Time) {
-	// If the allocation is part of an ongoing active deployment, we only allow it to reschedule
-	// if it has been marked eligible
+	// If the allocation is part of an ongoing active deployment, we only allow
+	// it to reschedule if it has been marked eligible
 	if d != nil && alloc.DeploymentID == d.ID && d.Active() && !alloc.DesiredTransition.ShouldReschedule() {
 		return
 	}
 
-	// Check if the allocation is marked as it should be force rescheduled
-	if alloc.DesiredTransition.ShouldForceReschedule() {
+	// Check if the terminal allocation is marked as it should be force
+	// rescheduled. Only terminal allocations should ever have this
+	// DesiredTransition set.
+	if alloc.DesiredTransition.ShouldForceReschedule() && alloc.ClientTerminalStatus() {
 		rescheduleNow = true
 	}
 
@@ -540,7 +543,8 @@ func updateByReschedulable(alloc *structs.Allocation, now time.Time, evalID stri
 		return
 	}
 
-	// Reschedule if the eval ID matches the alloc's followup evalID or if its close to its reschedule time
+	// Reschedule if the eval ID matches the alloc's followup evalID or if its
+	// close to its reschedule time
 	var eligible bool
 	switch {
 	case isDisconnecting:


### PR DESCRIPTION
While investigating a customer incident, we uncovered several states within the scheduler that should be impossible inputs, but that the scheduler handled badly and created potentially many extra allocations on successive evals. Note that these issues don't appear to be reachable bugs in current versions of Nomad.

Place guardrails around these states:

* Ensure that the `updateByReschedulable` only allows force-rescheduling for client-terminal allocations. This is currently guarded in the RPC handler but not in Raft. We're currently protected from write skew by making either the client view or server view canonical for a given field.

* Ensure that only valid `AllocState` entries are added to a stopped allocation, to ensure there's no code path where we can reschedule an unknown allocation multiple times by having it no longer show as unknown when we check for reconnect.

Ref: https://hashicorp.atlassian.net/browse/NMD-1681


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
