### PR TITLE
logmon: prevent leaking file descriptors

### DIFF
--- a/.changelog/28446.txt
+++ b/.changelog/28446.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Prevent logmon from leaking file descriptors of unused log pipes
+```

--- a/client/logmon/logmon.go
+++ b/client/logmon/logmon.go
@@ -21,6 +21,12 @@ const (
 	// launched process to close its stdout/stderr before we force close it. If
 	// data is written after this tolerance, we will not capture it.
 	processOutputCloseTolerance = 2 * time.Second
+
+	// processOutputReadCloseTolerance is the length of time we will wait
+	// for the read side of the pipe to close naturally. Once exceeded a
+	// dummy writer will be opened and disposed to allow the read side
+	// to progress.
+	processOutputReadCloseTolerance = 100 * time.Millisecond
 )
 
 type LogConfig struct {
@@ -275,19 +281,37 @@ func (l *logRotatorWrapper) Close() {
 	go func() {
 		defer close(closeDone)
 
-		// we must wait until reader is opened before we can close it, and cannot inteerrupt an in-flight open request
-		// The Close function uses processOutputCloseTolerance to protect against long running open called
-		// and then request will be interrupted and file will be closed on process shutdown
+		// Wait here until the read side of the pipe has been opened. An in-flight
+		// open request cannot be interrupted, so wait until it has completed before
+		// attempting to close.
 		<-l.openCompleted
 
+		// Now close the read side of the pipe. In cases where closing may block as described
+		// above, the processOutputCloseTolerance is used below to continue on. If that
+		// occurs, the pipe will be closed when the process exits.
 		if l.processOutReader != nil {
 			err := l.processOutReader.Close()
 			if err != nil && !strings.Contains(err.Error(), "file already closed") {
 				l.logger.Warn("error closing read-side of process output pipe", "error", err)
 			}
 		}
-
 	}()
+
+	// Closing the read side of the pipe can block in different ways if the write side
+	// of the pipe is never opened. On linux systems, opening the read side of the pipe
+	// will block until the write side is opened. On windows systems, the read side of
+	// the pipe will block on the copy until the write side is opened. To handle
+	// instances where the write side is never opened, we wait here temporarily for the
+	// close to occur naturally. If it does not, we open a writer and then immediately
+	// discard it to allow the read side to progress.
+	select {
+	case <-closeDone:
+	case <-time.After(processOutputReadCloseTolerance):
+		f, _ := fifo.OpenWriter(l.fifoPath)
+		if f != nil {
+			f.Close()
+		}
+	}
 
 	select {
 	case <-closeDone:
@@ -295,5 +319,8 @@ func (l *logRotatorWrapper) Close() {
 		l.logger.Warn("timed out waiting for read-side of process output pipe to close")
 	}
 
-	l.rotatorWriter.Close()
+	// If an error is encountered when closing the write side of the pipe, just log it.
+	if err := l.rotatorWriter.Close(); err != nil {
+		l.logger.Warn("error closing write-side of process output pipe", "error", err)
+	}
 }

--- a/client/logmon/logmon_test.go
+++ b/client/logmon/logmon_test.go
@@ -277,6 +277,45 @@ func TestLogmon_Start_restart(t *testing.T) {
 	})
 }
 
+func TestLogmon_Close(t *testing.T) {
+	ci.Parallel(t)
+
+	var stdoutFifoPath, stderrFifoPath string
+
+	dir := t.TempDir()
+
+	if runtime.GOOS == "windows" {
+		stdoutFifoPath = "//./pipe/test-rotate.stdout"
+		stderrFifoPath = "//./pipe/test-rotate.stderr"
+	} else {
+		stdoutFifoPath = filepath.Join(dir, "stdout.fifo")
+		stderrFifoPath = filepath.Join(dir, "stderr.fifo")
+	}
+
+	cfg := &LogConfig{
+		LogDir:        dir,
+		StdoutLogFile: "stdout",
+		StdoutFifo:    stdoutFifoPath,
+		StderrLogFile: "stderr",
+		StderrFifo:    stderrFifoPath,
+		MaxFiles:      2,
+		MaxFileSizeMB: 1,
+	}
+
+	// Create the instance directly so we can inspect the internals.
+	lm := &logmonImpl{logger: testlog.HCLogger(t)}
+	must.NoError(t, lm.Start(cfg))
+
+	// Now we'll immediately stop the instance. We are testing that
+	// once the instance is stopped both task loggers are fully
+	// closed and no longer running.
+	lm.Stop()
+
+	// The task logger should not remain running.
+	must.False(t, lm.tl.IsRunning(),
+		must.Sprint("task logger should not be running after Stop"))
+}
+
 // panicWriter panics on use
 type panicWriter struct{}
 


### PR DESCRIPTION
### Description

When stopping a logmon instance it is possible for file descriptors and goroutines to be leaked if the reader never completes the open of the fifo. This can occur if a writer never opens the fifo and the reader blocks until a writer has opened it. To prevent this behavior when closing, a writer is briefly opened and discarded which allows the reader to complete the open, unblocking the close.

Linux and Windows both present with the same problem but in slightly different ways. On Linux, the read side of the pipe will block until the write side of the pipe is opened. On Windows, however, the read side of the pipe will open successfully, but will then block on read (in the `io.Copy`) until the write side of the pipe is opened.

### Testing & Reproduction steps

Test case included. 
Details for reproduction can be found in #28439

### Links

[NMD-1697](https://hashicorp.atlassian.net/browse/NMD-1697)
Closes #28439

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


[NMD-1697]: https://hashicorp.atlassian.net/browse/NMD-1697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ