### PR TITLE
state: fix canonicalization for alloc resource compatibility

### DIFF
--- a/.changelog/28447.txt
+++ b/.changelog/28447.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+state: Fixed a bug where plans from older versioned followers did not have allocation resource schemas upgraded when written on the leader
+```

--- a/nomad/state/state_store.go
+++ b/nomad/state/state_store.go
@@ -440,9 +440,11 @@ func (s *StateStore) UpsertPlanResults(msgType structs.MessageType, index uint64
 	allocsToUpsert = append(allocsToUpsert, allocsStopped...)
 	allocsToUpsert = append(allocsToUpsert, allocsPreempted...)
 
-	// handle upgrade path
+	// Handle the upgrade path. Note that we're intentionally not copying the
+	// allocation here. These allocs are always coming from a Plan.Submit RPC
+	// and not the state store, and the response to the RPC wants to include any
+	// mutations the FSM apply does like index updates
 	for _, alloc := range allocsToUpsert {
-		alloc = alloc.Copy()
 		alloc.Canonicalize()
 	}
 


### PR DESCRIPTION
In #19937 we attempted to fix a potential state store corruption by copying allocations we were upserting before canonicalizing them. But while I was working on #28445 I noticed that we weren't actually updating the slice that we'd then insert into the state store, which means we're throwing away the canonicalized version.

As it turns out, the original reasoning behind #19937 was faulty and we shouldn't have been copying at all. These allocations are always coming from the `Plan.Submit` RPC and not from the state store. And we send the mutated version back in the response to the RPC.

This means that we haven't been upgrading allocations or canonicalizing them on plan submit, but in practice it also hasn't mattered. Canonicalizing populates missing resources from deprecated resources, for the case where we have pre-0.11 schedulers running. And it recursively canonicalizes the `Job`, which comes over the wire as nil in the plan and gets populated on the leader anyways. So fixing this has no production impact today but keeps our behavior correct the next time we need to upgrade allocations.

Ref: https://github.com/hashicorp/nomad/pull/19937
Ref: https://github.com/hashicorp/nomad/pull/28445
Ref: https://hashicorp.atlassian.net/browse/NMD-1681

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
