### PR TITLE
planner: skip eval update in optimistic snapshot

### DIFF
--- a/.changelog/28452.txt
+++ b/.changelog/28452.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+planner: Fixed a bug where valid evaluations could be unnecessarily retried, delaying workload placement under load
+```

--- a/nomad/plan_apply.go
+++ b/nomad/plan_apply.go
@@ -392,8 +392,16 @@ func (p *planner) applyPlan(plan *structs.Plan, result *structs.PlanResult, snap
 	// Optimistically apply to our state view
 	if snap != nil {
 		defer metrics.MeasureSince(metricPlanOptimisiticApply, time.Now())
+
+		// A plan can reference an evaluation registered after this snapshot was
+		// created. Skip the evaluation's ModifyIndex update in the snapshot, where
+		// the evaluation may be absent. The Raft request still performs the update
+		// in canonical state.
+		optimisticReq := req
+		optimisticReq.EvalID = ""
+
 		nextIdx := p.srv.raft.AppliedIndex() + 1
-		if err := snap.UpsertPlanResults(structs.ApplyPlanResultsRequestType, nextIdx, &req); err != nil {
+		if err := snap.UpsertPlanResults(structs.ApplyPlanResultsRequestType, nextIdx, &optimisticReq); err != nil {
 			return future, err
 		}
 	}

--- a/nomad/plan_apply_test.go
+++ b/nomad/plan_apply_test.go
@@ -1446,3 +1446,72 @@ func TestPlanApply_PipelinedPlans(t *testing.T) {
 	}
 	must.Greater(t, 0.0, maxInFlight, must.Sprint("expected pipelined plans"))
 }
+
+func TestPlanApply_applyPlan_StaleSnapshotMissingEval(t *testing.T) {
+	ci.Parallel(t)
+
+	srv, cleanup := TestServer(t, nil)
+	defer cleanup()
+	testutil.WaitForKeyring(t, srv.RPC, srv.Region())
+
+	// Register node
+	node := mock.Node()
+	testRegisterNode(t, srv, node)
+
+	// Seed the job needed by the allocation and plan
+	alloc := mock.Alloc()
+	alloc.NodeID = node.ID
+	setupIndex := srv.raft.AppliedIndex()
+	must.NoError(t, srv.State().UpsertJobSummary(setupIndex, mock.JobSummary(alloc.JobID)))
+	must.NoError(t, srv.State().UpsertJob(structs.MsgTypeTestSetup, setupIndex, nil, alloc.Job))
+
+	// Take the planner's optimistic snapshot before registering the eval
+	snap, err := srv.State().Snapshot()
+	must.NoError(t, err)
+
+	// Register eval - canonical state now contains the evaluation, but the older
+	// optimistic snapshot does not
+	eval := mock.Eval()
+	eval.JobID = alloc.JobID
+	eval.Namespace = alloc.Namespace
+	alloc.EvalID = eval.ID
+	must.NoError(t, srv.State().UpsertEvals(
+		structs.MsgTypeTestSetup,
+		setupIndex,
+		[]*structs.Evaluation{eval},
+	))
+
+	// Verify the snapshot reproduces the missing evaluation condition
+	snapshotEval, err := snap.EvalByID(nil, eval.ID)
+	must.NoError(t, err)
+	must.Nil(t, snapshotEval)
+
+	plan := &structs.Plan{
+		Job:    alloc.Job,
+		EvalID: eval.ID,
+	}
+	result := &structs.PlanResult{
+		NodeAllocation: map[string][]*structs.Allocation{
+			node.ID: {alloc},
+		},
+	}
+
+	// Applying the plan must succeed despite the evaluation being absent from the
+	// optimistic snapshot
+	future, err := srv.applyPlan(plan, result, snap)
+	must.NoError(t, err)
+	must.NoError(t, future.Error())
+	must.Nil(t, future.Response())
+
+	// Verify the rest of the plan was applied to the optimistic snapshot
+	optimisticAlloc, err := snap.AllocByID(nil, alloc.ID)
+	must.NoError(t, err)
+	must.NotNil(t, optimisticAlloc)
+
+	// Verify the Raft request retained EvalID and advanced the eval's ModifyIndex
+	// in canonical state
+	canonicalEval, err := srv.State().EvalByID(nil, eval.ID)
+	must.NoError(t, err)
+	must.NotNil(t, canonicalEval)
+	must.Eq(t, future.Index(), canonicalEval.ModifyIndex)
+}


### PR DESCRIPTION
### Description
The plan applier retains an optimistic StateSnapshot while plan-result Raft writes are in flight. If an evaluation is registered through Raft after that snapshot was created, it exists in canonical state but not in the snapshot. Applying the plan result then attempts to update the missing evaluation, rejects an otherwise valid plan, and NACKs the evaluation until its retry delay of 1s expires.

This change skips the evaluation update only when applying the plan result to the optimistic snapshot, while preserving it in the canonical Raft request. The remaining plan results are still applied optimistically.

The primary impact here is reduced placement latency under load, which was verified with load testing described in the section below.

### Testing & Reproduction steps
Added a unit test case `TestPlanApply_applyPlan_StaleSnapshotMissingEval` to `plan_apply_test.go` which reproduces the issue, and validates the patch contained in this PR.

### Load testing
Two load test trials were executed against one of our clusters:

1. Nomad servers built with https://github.com/vercel/nomad/commit/aa026cc99cfb74a77e519a1c1f0c78ba1b452705 (baseline)
2. Nomad servers built with this patch cherry-picked on top of aa026cc99cfb74a77e519a1c1f0c78ba1b452705

Both trials used the following `server.hcl` configuration on the Nomad servers running on `c8g.8xlarge` EC2 instance types:

```hcl
server {
  enabled          = true
  bootstrap_expect = 3

  # Based on https://developer.hashicorp.com/nomad/docs/configuration/server_join#cloud-auto-join
  # and https://github.com/hashicorp/go-discover
  server_join {
    retry_join = ["provider=aws tag_key=Role tag_value=<<SNIPPED>>"]
  }

  job_gc_interval         = "10s"
  plan_apply_pipeline     = 16
  raft_snapshot_interval  = "30s"
  raft_snapshot_threshold = 50000
  raft_trailing_logs      = 10000

  node_gc_threshold       = "5m"
  job_gc_threshold        = "10s"
  eval_gc_threshold       = "10s"
  batch_eval_gc_threshold = "2m"

  raft_logstore {
    backend = "wal"

    wal {
      segment_size_mb = 64
    }
  }
}

leave_on_terminate = true
leave_on_interrupt = true

tls {
  http = true
  rpc  = true

  verify_https_client = true

  ca_file   = "/etc/nomad.d/tls/ca.pem"
  cert_file = "/etc/nomad.d/tls/server.pem"
  key_file  = "/etc/nomad.d/tls/server-key.pem"
}
```

The cluster in both trials had `N=120` client nodes to isolate the test so that it strictly measures Nomad server placement performance.

In both trials, offered load was ramped up gradually, and goodput, badput, and placement latency was observed and measured.

#### Baseline trial

<img width="1537" height="487" alt="Screenshot 2026-08-24 at 3 28 21 PM" src="https://github.com/user-attachments/assets/df1a01a3-3485-4858-b75d-ea92999a0477" />
<img width="1534" height="487" alt="Screenshot 2026-08-24 at 3 28 29 PM" src="https://github.com/user-attachments/assets/da00dd03-aa25-4f79-9e48-2d6ddf6697c6" />
<img width="1534" height="487" alt="Screenshot 2026-08-24 at 3 28 37 PM" src="https://github.com/user-attachments/assets/c1696e30-d065-467c-8907-2d7c2c745fe5" />

#### PR #28452 trial
<img width="1540" height="499" alt="Screenshot 2026-08-24 at 3 31 05 PM" src="https://github.com/user-attachments/assets/9166dca1-207c-432f-8718-7799a0306a39" />
<img width="1554" height="502" alt="Screenshot 2026-08-24 at 3 31 13 PM" src="https://github.com/user-attachments/assets/0d7edb76-cfe8-4642-9837-1bfed2504418" />
<img width="1540" height="496" alt="Screenshot 2026-08-24 at 3 31 21 PM" src="https://github.com/user-attachments/assets/59c124fa-60cb-405c-8726-3e469d51d951" />

#### Results

As offered load increased, the baseline developed a bimodal placement-latency distribution. One mode clustered around one second, matching the default initial [`EvalNackInitialReenqueueDelay`](https://github.com/hashicorp/nomad/blob/969b24740516b8a37f283687d547c9b281393846/nomad/config.go#L671).

With this patch, the one-second mode disappeared and placement latency remained unimodal at all tested submission rates, up to 300 jobs/s. This is the expected result of preventing valid evaluations from entering the NACK retry path.

#### Further optimizations

In the presented two trials, goodput peaked at 300 jobs/s before a bottleneck in the plan-apply pipeline was encountered. By disabling workload identity signing and running the same load test, we were able to raise the ceiling even further to 600 jobs/s. Similarly, adding support for pacing [jobGC](https://github.com/hashicorp/nomad/blob/090609246069b5cfce38bf2747e3fa09ad88d316/nomad/core_sched.go#L132) operations was able to raise the ceiling even further to 780 jobs/s. These two optimizations are separate concerns from this PR, and further discussion on them will be handled through separate issues if there's interest in bringing in these kind of changes to the project.

### Links

Closes https://github.com/hashicorp/nomad/issues/28444.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None
