### PR TITLE
fix(nomad): split NamespaceIDTokenizer target on dot for compare

### DIFF
--- a/nomad/state/paginator/tokenizer.go
+++ b/nomad/state/paginator/tokenizer.go
@@ -28,7 +28,18 @@ func NamespaceIDTokenizer[T namespaceIDGetter](target string) Tokenizer[T] {
 		// `a-b` and job `c` into the same token `a-b-c`, since `-` is an allowed
 		// character in namespace.
 		token := fmt.Sprintf("%s.%s", ns, id)
-		return token, cmp.Compare(token, target)
+
+		targetParts := strings.SplitN(target, ".", 2)
+		if len(targetParts) < 2 {
+			return token, cmp.Compare(token, target)
+		}
+
+		nsCmp := cmp.Compare(ns, targetParts[0])
+		if nsCmp != 0 {
+			return token, nsCmp
+		}
+
+		return token, cmp.Compare(id, targetParts[1])
 	}
 }
 


### PR DESCRIPTION
Fixes whole-string compare misordering in NamespaceIDTokenizer at tokenizer.go:30.

Bug: token cmp.Compare(token, target) on the concatenated ns.id string misorders pagination when namespaces share a prefix but differ after a hyphen, for example team vs team-a. Whole-string ordering compares dot (46) vs hyphen (45) and inverts the correct namespace order.

Fix: split target on first dot via strings.SplitN like CreateIndexAndIDTokenizer does, compare namespace and id field by field, fall back to whole-string compare if no dot is present.

Evidence:
- Standalone verification shows old code returns 1 for team.foo vs team-a.foo and -1 for the reverse, both inverted. New code returns -1 and 1 respectively, correct for lexicographic namespace ordering.
- Existing paginator tests pass RED and GREEN: go test ./nomad/state/paginator -v passes before and after.
- Blast radius is one file, gofmt clean.