### PR TITLE
bjq: Handle jobs that are blocked on constraints

### DIFF
--- a/api/batch_job_queue.go
+++ b/api/batch_job_queue.go
@@ -45,6 +45,7 @@ type DynamicPriorityWorkload struct {
 	AgeAdjustment    int
 	SizeAdjustment   int
 	CreatedAt        int64
+	Status           string
 }
 
 type DynamicPriorityTenant struct {

--- a/api/batch_job_queue.go
+++ b/api/batch_job_queue.go
@@ -45,7 +45,6 @@ type DynamicPriorityWorkload struct {
 	AgeAdjustment    int
 	SizeAdjustment   int
 	CreatedAt        int64
-	Status           string
 }
 
 type DynamicPriorityTenant struct {

--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -345,6 +345,7 @@ func (d *DynamicPriorityQueue) generateWorkload(e *structs.Evaluation, job *stru
 		tid:                tid,
 		priority:           0,
 		eval:               e,
+		status:             "queued",
 		requestedResources: requestedResources,
 		waitOnRestore:      false,
 	}

--- a/nomad/queues/dynamic_priority/workload.go
+++ b/nomad/queues/dynamic_priority/workload.go
@@ -3,7 +3,11 @@
 
 package dynamic
 
-import "github.com/hashicorp/nomad/nomad/structs"
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
 
 type dynamicPriorityWorkload struct {
 	// id uniquely identifies this workload
@@ -26,6 +30,9 @@ type dynamicPriorityWorkload struct {
 	// By doing this, we can ensure at most 1 queue workloads blocked
 	// due to resource contraints even in the event of queue restores.
 	waitOnRestore bool
+
+	status      string
+	description string
 }
 
 func (w *dynamicPriorityWorkload) GetEval() *structs.Evaluation {
@@ -38,4 +45,16 @@ func (w *dynamicPriorityWorkload) WaitOnRestore() bool {
 
 func (w *dynamicPriorityWorkload) SetEval(e *structs.Evaluation) {
 	w.eval = e
+}
+
+func (w *dynamicPriorityWorkload) GetStatus() string {
+	if w.description != "" {
+		return fmt.Sprintf("%s (%s)", w.status, w.description)
+	}
+	return w.status
+}
+
+func (w *dynamicPriorityWorkload) SetStatus(s, description string) {
+	w.status = s
+	w.description = description
 }

--- a/nomad/queues/fifo/queue.go
+++ b/nomad/queues/fifo/queue.go
@@ -220,9 +220,11 @@ func (f *FifoQueue) Type() structs.BatchQueueType {
 func (f *FifoQueue) Jobs(sortOrder structs.SortOrder) *queue.WorkloadIter {
 	f.qMux.Lock()
 	sortedWorkloads := f.queue.Slice()
-	defer f.qMux.Unlock()
+	f.qMux.Unlock()
 
 	workloads := []structs.QueueWorkload{}
+
+	// Add queued workloads
 	for pos, workload := range sortedWorkloads {
 		eval := workload.GetEval()
 		workloads = append(workloads, &structs.Workload{

--- a/nomad/queues/fifo/workload.go
+++ b/nomad/queues/fifo/workload.go
@@ -3,13 +3,19 @@
 
 package fifo
 
-import "github.com/hashicorp/nomad/nomad/structs"
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
 
 type fifoWorkload struct {
 	id            string
 	counter       uint64
 	eval          *structs.Evaluation
 	waitOnRestore bool
+	status        string
+	description   string
 }
 
 func newFifoWorkload(e *structs.Evaluation) *fifoWorkload {
@@ -29,4 +35,15 @@ func (f *fifoWorkload) SetEval(e *structs.Evaluation) {
 
 func (f *fifoWorkload) WaitOnRestore() bool {
 	return f.waitOnRestore
+}
+
+func (f *fifoWorkload) SetStatus(s, description string) {
+	f.status = s
+	f.description = description
+}
+func (f *fifoWorkload) GetStatus() string {
+	if f.description != "" {
+		return fmt.Sprintf("%s (%s)", f.status, f.description)
+	}
+	return f.status
 }

--- a/nomad/queues/queue/interface.go
+++ b/nomad/queues/queue/interface.go
@@ -27,6 +27,8 @@ type Broker interface {
 type Workload interface {
 	GetEval() *structs.Evaluation
 	SetEval(*structs.Evaluation)
+	GetStatus() string
+	SetStatus(string, string)
 	WaitOnRestore() bool
 }
 

--- a/nomad/queues/queue/workload_watcher.go
+++ b/nomad/queues/queue/workload_watcher.go
@@ -103,10 +103,8 @@ func (w *WorkloadWatcher) UntrackPlacement(workload Workload) {
 	// constrained.
 	if !strings.Contains(workload.GetStatus(), "constrained") {
 		w.currentPlacements--
-	} else {
-		if w.strictConstraints || w.dropConstrainedPlacements {
-			w.currentPlacements--
-		}
+	} else if w.strictConstraints || w.dropConstrainedPlacements {
+		w.currentPlacements--
 	}
 
 	// If the eval was blocked and then unblocked, the eval will not match in

--- a/nomad/queues/queue/workload_watcher.go
+++ b/nomad/queues/queue/workload_watcher.go
@@ -86,13 +86,27 @@ func (w *WorkloadWatcher) WaitForPlacement(ctx context.Context, workload Workloa
 		err := w.waitWithTimeout(ctx, workload, ws)
 
 		if err == context.DeadlineExceeded {
+			// Check if timeout was due to non-resource constraints
+			if w.isConstraintFailure(workload) {
+				// Send result and stop waiting - constraint failures won't resolve
+				w.mu.Lock()
+				w.currentPlacements--
+				w.mu.Unlock()
+
+				w.results <- PlacementResult{
+					Workload: workload,
+					TimedOut: true,
+				}
+				return
+			}
+
 			// Send result of the timeout
 			w.results <- PlacementResult{
 				Workload: workload,
 				TimedOut: true,
 			}
 
-			// Continue waiting for placement to complete
+			// Continue waiting for placement to complete (resource exhaustion may resolve)
 			err = w.wait(ctx, workload, ws)
 		}
 
@@ -172,6 +186,39 @@ func (w *WorkloadWatcher) wait(ctx context.Context, workload Workload, ws memdb.
 	}
 
 	return nil
+}
+
+// isConstraintFailure checks if the evaluation failed due to non-resource constraints
+// (e.g., constraint filters) rather than resource exhaustion (CPU, memory, etc).
+// Returns true if the failure is constraint-related and unlikely to resolve with time.
+func (w *WorkloadWatcher) isConstraintFailure(workload Workload) bool {
+	eval := workload.GetEval()
+	if eval == nil || eval.FailedTGAllocs == nil {
+		return false
+	}
+
+	// Check each task group's allocation metrics
+	for _, metric := range eval.FailedTGAllocs {
+		if metric == nil {
+			continue
+		}
+
+		// If there are constraint filters but no resource exhaustion, it's a constraint failure
+		hasConstraintFilters := len(metric.ConstraintFiltered) > 0
+		hasResourceExhaustion := metric.NodesExhausted > 0 ||
+			len(metric.ClassExhausted) > 0 ||
+			len(metric.DimensionExhausted) > 0 ||
+			len(metric.QuotaExhausted) > 0
+
+		if hasConstraintFilters && !hasResourceExhaustion {
+			w.logger.Debug("detected constraint failure",
+				"eval_id", eval.ID,
+				"constraint_filtered", metric.ConstraintFiltered)
+			return true
+		}
+	}
+
+	return false
 }
 
 // IsSchedulingComplete detects whether a workload was actually placed by following the

--- a/nomad/queues/queue/workload_watcher.go
+++ b/nomad/queues/queue/workload_watcher.go
@@ -5,6 +5,8 @@ package queue
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,22 +19,30 @@ type WorkloadWatcher struct {
 	stateStore Snapshotter
 	config     *structs.BatchQueue
 	logger     hclog.Logger
+	mu         sync.Mutex
 
 	// results channel for communicating placement completions to queues
 	results chan PlacementResult
 
-	// Concurrency control
-	mu                      sync.Mutex
+	// concurrency control
 	workloadTimeout         time.Duration
-	currentPlacements       int
 	maxConcurrentPlacements int
+
+	// placement tracking
+	currentPlacements         int
+	inProgressWorkloads       map[string]Workload
+	strictConstraints         bool
+	dropConstrainedPlacements bool
 }
 
 func NewWorkloadWatcher(s Snapshotter, logger hclog.Logger, config *structs.BatchQueue) *WorkloadWatcher {
 	w := &WorkloadWatcher{
-		stateStore: s,
-		config:     config,
-		logger:     logger.Named("workload_watcher"),
+		stateStore:                s,
+		config:                    config,
+		logger:                    logger.Named("workload_watcher"),
+		inProgressWorkloads:       make(map[string]Workload),
+		strictConstraints:         config.StrictConstraints,
+		dropConstrainedPlacements: config.DropWorkloads,
 	}
 
 	if config.WorkloadTimeout != 0 {
@@ -63,6 +73,7 @@ func (w *WorkloadWatcher) CanAttemptPlacement() bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	canAttemptPlacement := w.currentPlacements < w.maxConcurrentPlacements
+
 	if !canAttemptPlacement {
 		w.logger.Error("queue is at max concurrent placements")
 	}
@@ -74,30 +85,87 @@ func (w *WorkloadWatcher) Results() <-chan PlacementResult {
 	return w.results
 }
 
+// TrackPlacement increments the currentPlacements counter, sets the workload
+// status, and adds a workload to the in-progress tracking map.
+func (w *WorkloadWatcher) TrackPlacement(workload Workload) {
+	w.currentPlacements++
+	workload.SetStatus("pending", "")
+	w.inProgressWorkloads[workload.GetEval().ID] = workload
+}
+
+// UntrackPlacement decrements the currentPlacements counter and removes a workload from the in-progress tracking map.
+func (w *WorkloadWatcher) UntrackPlacement(workload Workload) {
+	eval := workload.GetEval()
+
+	// When strict_constraints is not set, the currentPlacements was already
+	// decremented when the workload was marked as constrained. If the watcher
+	// is set to drop placements, we want the workload dropped when its
+	// constrained.
+	if !strings.Contains(workload.GetStatus(), "constrained") {
+		w.currentPlacements--
+	} else {
+		if w.strictConstraints || w.dropConstrainedPlacements {
+			w.currentPlacements--
+		}
+	}
+
+	// If the eval was blocked and then unblocked, the eval will not match in
+	// the map. Attempt to use the PreviousEval in that case.
+	id := eval.ID
+	_, ok := w.inProgressWorkloads[id]
+	if !ok {
+		id = eval.PreviousEval
+		if id == "" {
+			return
+		}
+	}
+	delete(w.inProgressWorkloads, id)
+}
+
+// GetInProgressWorkloads returns a copy of all workloads currently being watched for placement.
+func (w *WorkloadWatcher) GetInProgressWorkloads() map[string]Workload {
+	return w.inProgressWorkloads
+}
+
 // WaitForPlacement watches an evaluation until it reaches a terminal state or times out.
 // It runs async and sends the result to the Results() channel.
 func (w *WorkloadWatcher) WaitForPlacement(ctx context.Context, workload Workload, ws memdb.WatchSet) {
 	// Track this placement
 	w.mu.Lock()
-	w.currentPlacements++
+	w.TrackPlacement(workload)
 	w.mu.Unlock()
 
 	go func() {
+
 		err := w.waitWithTimeout(ctx, workload, ws)
 
 		if err == context.DeadlineExceeded {
 			// Check if timeout was due to non-resource constraints
 			if w.isConstraintFailure(workload) {
-				// Send result and stop waiting - constraint failures won't resolve
 				w.mu.Lock()
-				w.currentPlacements--
-				w.mu.Unlock()
 
-				w.results <- PlacementResult{
-					Workload: workload,
-					TimedOut: true,
+				workload.SetStatus("constrained", w.ConstraintDescription(workload))
+
+				if w.dropConstrainedPlacements {
+					w.results <- PlacementResult{
+						Workload: workload,
+						TimedOut: true,
+						Err:      fmt.Errorf("workload dropped due to constraints"),
+					}
+
+					w.UntrackPlacement(workload)
+					w.mu.Unlock()
+					return
 				}
-				return
+
+				// only release a placement spot if strict constraints are not required
+				if !w.strictConstraints {
+					w.currentPlacements--
+				}
+
+				w.mu.Unlock()
+			} else {
+				workload.SetStatus("blocked", "timed out")
 			}
 
 			// Send result of the timeout
@@ -106,13 +174,15 @@ func (w *WorkloadWatcher) WaitForPlacement(ctx context.Context, workload Workloa
 				TimedOut: true,
 			}
 
-			// Continue waiting for placement to complete (resource exhaustion may resolve)
+			// Continue waiting for placement to complete. Resource exhaustion
+			// may resolve, or stopping the constrained placement will remove it
+			// from tracking
 			err = w.wait(ctx, workload, ws)
 		}
 
-		// Release this placement slot
+		// Release this placement slot and remove the workload from tracking
 		w.mu.Lock()
-		w.currentPlacements--
+		w.UntrackPlacement(workload)
 		w.mu.Unlock()
 
 		// Send result
@@ -189,15 +259,14 @@ func (w *WorkloadWatcher) wait(ctx context.Context, workload Workload, ws memdb.
 }
 
 // isConstraintFailure checks if the evaluation failed due to non-resource constraints
-// (e.g., constraint filters) rather than resource exhaustion (CPU, memory, etc).
-// Returns true if the failure is constraint-related and unlikely to resolve with time.
+// (e.g., constraint filters) rather than resource exhaustion.
+// Returns true if the failure is constraint-related (and unlikely to resolve with time)
 func (w *WorkloadWatcher) isConstraintFailure(workload Workload) bool {
 	eval := workload.GetEval()
 	if eval == nil || eval.FailedTGAllocs == nil {
 		return false
 	}
 
-	// Check each task group's allocation metrics
 	for _, metric := range eval.FailedTGAllocs {
 		if metric == nil {
 			continue
@@ -211,7 +280,7 @@ func (w *WorkloadWatcher) isConstraintFailure(workload Workload) bool {
 			len(metric.QuotaExhausted) > 0
 
 		if hasConstraintFilters && !hasResourceExhaustion {
-			w.logger.Debug("detected constraint failure",
+			w.logger.Debug("constraint failure",
 				"eval_id", eval.ID,
 				"constraint_filtered", metric.ConstraintFiltered)
 			return true
@@ -219,6 +288,28 @@ func (w *WorkloadWatcher) isConstraintFailure(workload Workload) bool {
 	}
 
 	return false
+}
+
+// ConstraintDescription returns the constraint filtered causing the workload to not be placed.
+func (w *WorkloadWatcher) ConstraintDescription(workload Workload) string {
+	eval := workload.GetEval()
+
+	var s string
+	for _, metric := range eval.FailedTGAllocs {
+		if metric == nil {
+			continue
+		}
+
+		for constraint := range metric.ConstraintFiltered {
+			if s != "" {
+				s = fmt.Sprintf("%s, %s", s, constraint)
+			} else {
+				s = constraint
+			}
+		}
+	}
+
+	return s
 }
 
 // IsSchedulingComplete detects whether a workload was actually placed by following the

--- a/nomad/queues/queue/workload_watcher_test.go
+++ b/nomad/queues/queue/workload_watcher_test.go
@@ -20,6 +20,7 @@ import (
 type testWorkload struct {
 	eval *structs.Evaluation
 	wait bool
+	s    string
 }
 
 func (w *testWorkload) GetEval() *structs.Evaluation {
@@ -27,6 +28,13 @@ func (w *testWorkload) GetEval() *structs.Evaluation {
 }
 func (w *testWorkload) SetEval(e *structs.Evaluation) {
 	w.eval = e
+}
+func (w *testWorkload) GetStatus() string {
+	return w.s
+}
+func (w *testWorkload) SetStatus(s, d string) {
+	w.s = fmt.Sprintf("%s %s", s, d)
+
 }
 func (w *testWorkload) WaitOnRestore() bool {
 	return w.wait
@@ -45,10 +53,17 @@ func TestWorkloadWatcher_WaitForPlacement(t *testing.T) {
 		workload := &testWorkload{eval: testEval.Copy()}
 		watcher.WaitForPlacement(t.Context(), workload, ws)
 
+		inProgress := watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval.ID])
+
 		testEval.Status = structs.EvalStatusComplete
 		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
 
 		result := <-resultsCh
+
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 0, len(inProgress))
 
 		must.NoError(t, result.Err)
 	})
@@ -94,6 +109,7 @@ func TestWorkloadWatcher_WaitForPlacement(t *testing.T) {
 
 		result := <-resultsCh
 		must.NoError(t, result.Err)
+
 	})
 
 	t.Run("continues watching next evals after eval failure", func(t *testing.T) {
@@ -155,10 +171,18 @@ func TestWorkloadWatcher_WaitForPlacement(t *testing.T) {
 		watcher.WaitForPlacement(t.Context(), workload, ws)
 		must.False(t, watcher.CanAttemptPlacement())
 
+		inProgress := watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval.ID])
+
 		result := <-resultsCh
 
 		must.True(t, result.TimedOut)
 		must.False(t, watcher.CanAttemptPlacement())
+
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval.ID])
 
 		testEval.Status = structs.EvalStatusComplete
 		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
@@ -168,6 +192,8 @@ func TestWorkloadWatcher_WaitForPlacement(t *testing.T) {
 		must.False(t, result.TimedOut)
 		must.True(t, watcher.CanAttemptPlacement())
 
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 0, len(inProgress))
 	})
 
 	t.Run("tracks concurrent placements", func(t *testing.T) {
@@ -212,6 +238,190 @@ func TestWorkloadWatcher_WaitForPlacement(t *testing.T) {
 
 		result2 := <-resultsCh
 		must.NoError(t, result2.Err)
+	})
+	t.Run("stops waiting on constraint failure timeout", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{
+			WorkloadTimeout:      50 * time.Millisecond,
+			ConcurrentPlacements: 1,
+		})
+		resultsCh := watcher.Results()
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{
+					"${attr.kernel.name} == linux": 5,
+				},
+				NodesExhausted: 0,
+			},
+		}
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		ws := memdb.NewWatchSet()
+		workload := &testWorkload{eval: testEval.Copy()}
+		watcher.WaitForPlacement(t.Context(), workload, ws)
+
+		inProgress := watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval.ID])
+
+		// Should receive timeout result
+		result := <-resultsCh
+		must.True(t, result.TimedOut)
+
+		// Should have released the placement slot immediately
+		time.Sleep(20 * time.Millisecond)
+		must.True(t, watcher.CanAttemptPlacement())
+
+		// Should NOT receive another result (watcher stopped)
+		select {
+		case <-resultsCh:
+			t.Fatal("should not have received second result for constraint failure")
+		case <-time.After(100 * time.Millisecond):
+			// Expected - no second result
+		}
+	})
+
+	t.Run("continues waiting on resource exhaustion timeout", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{
+			WorkloadTimeout:      50 * time.Millisecond,
+			ConcurrentPlacements: 1,
+		})
+		resultsCh := watcher.Results()
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				NodesExhausted:     10,
+				DimensionExhausted: map[string]int{"cpu": 5},
+			},
+		}
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		ws := memdb.NewWatchSet()
+		workload := &testWorkload{eval: testEval.Copy()}
+		watcher.WaitForPlacement(t.Context(), workload, ws)
+
+		// Should receive timeout result
+		result := <-resultsCh
+		must.True(t, result.TimedOut)
+
+		// Should still be waiting (placement slot not released yet)
+		time.Sleep(20 * time.Millisecond)
+		must.False(t, watcher.CanAttemptPlacement())
+
+		inProgress := watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval.ID])
+
+		// Complete the eval
+		testEval.Status = structs.EvalStatusComplete
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
+
+		// Should receive completion result
+		result = <-resultsCh
+		must.False(t, result.TimedOut)
+		must.NoError(t, result.Err)
+
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 0, len(inProgress))
+
+		// Now placement slot should be released
+		time.Sleep(20 * time.Millisecond)
+		must.True(t, watcher.CanAttemptPlacement())
+	})
+
+	t.Run("strict_constraint does not release placement when blocked on a constraint", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{
+			WorkloadTimeout:      50 * time.Millisecond,
+			ConcurrentPlacements: 1,
+			StrictConstraints:    true,
+		})
+		resultsCh := watcher.Results()
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{
+					"${attr.kernel.name} == linux": 5,
+				},
+				NodesExhausted: 0,
+			},
+		}
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		ws := memdb.NewWatchSet()
+		workload := &testWorkload{eval: testEval.Copy()}
+		watcher.WaitForPlacement(t.Context(), workload, ws)
+
+		inProgress := watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval.ID])
+
+		// Should receive timeout result
+		result := <-resultsCh
+		must.True(t, result.TimedOut)
+		must.Eq(t, result.Workload.GetStatus(), "constrained ${attr.kernel.name} == linux")
+
+		// Should not release the placement slot
+		time.Sleep(20 * time.Millisecond)
+		must.False(t, watcher.CanAttemptPlacement())
+
+		// Complete the eval
+		testEval.Status = structs.EvalStatusComplete
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
+
+		// Should receive completion result
+		result = <-resultsCh
+		must.False(t, result.TimedOut)
+		must.NoError(t, result.Err)
+		time.Sleep(20 * time.Millisecond)
+		must.True(t, watcher.CanAttemptPlacement())
+	})
+
+	t.Run("drop_workloads does not continue to track workloads", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{
+			WorkloadTimeout:      50 * time.Millisecond,
+			ConcurrentPlacements: 1,
+			DropWorkloads:        true,
+		})
+		resultsCh := watcher.Results()
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{
+					"${attr.kernel.name} == linux": 5,
+				},
+				NodesExhausted: 0,
+			},
+		}
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		ws := memdb.NewWatchSet()
+		workload := &testWorkload{eval: testEval.Copy()}
+		watcher.WaitForPlacement(t.Context(), workload, ws)
+
+		inProgress := watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval.ID])
+
+		// Should receive timeout result
+		result := <-resultsCh
+		must.True(t, result.TimedOut)
+		must.Eq(t, result.Workload.GetStatus(), "constrained ${attr.kernel.name} == linux")
+		must.EqError(t, result.Err, "workload dropped due to constraints")
+
+		// Should release the placement slot
+		time.Sleep(20 * time.Millisecond)
+		must.True(t, watcher.CanAttemptPlacement())
+
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 0, len(inProgress))
 	})
 }
 
@@ -277,7 +487,6 @@ func TestWorkloadWatcher_isSchedulingComplete(t *testing.T) {
 		must.True(t, complete)
 	})
 }
-
 
 func TestWorkloadWatcher_isConstraintFailure(t *testing.T) {
 	t.Run("detects constraint failure without resource exhaustion", func(t *testing.T) {
@@ -367,88 +576,35 @@ func TestWorkloadWatcher_isConstraintFailure(t *testing.T) {
 	})
 }
 
-func TestWorkloadWatcher_WaitForPlacement_ConstraintTimeout(t *testing.T) {
-	t.Run("stops waiting on constraint failure timeout", func(t *testing.T) {
+func TestWorkloadWatcher_TrackPlacement(t *testing.T) {
+	t.Run("tracks and untracks workloads", func(t *testing.T) {
 		ss := state.TestStateStore(t)
-		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{
-			WorkloadTimeout:      50 * time.Millisecond,
-			ConcurrentPlacements: 1,
-		})
-		resultsCh := watcher.Results()
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
 
-		testEval := mock.Eval()
-		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
-			"web": {
-				ConstraintFiltered: map[string]int{
-					"${attr.kernel.name} == linux": 5,
-				},
-				NodesExhausted: 0,
-			},
-		}
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+		testEval1 := mock.Eval()
+		testEval2 := mock.Eval()
+		workload1 := &testWorkload{eval: testEval1}
+		workload2 := &testWorkload{eval: testEval2}
 
-		ws := memdb.NewWatchSet()
-		workload := &testWorkload{eval: testEval.Copy()}
-		watcher.WaitForPlacement(t.Context(), workload, ws)
+		inProgress := watcher.GetInProgressWorkloads()
+		must.Eq(t, 0, len(inProgress))
 
-		// Should receive timeout result
-		result := <-resultsCh
-		must.True(t, result.TimedOut)
+		watcher.TrackPlacement(workload1)
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval1.ID])
 
-		// Should have released the placement slot immediately
-		time.Sleep(20 * time.Millisecond)
-		must.True(t, watcher.CanAttemptPlacement())
+		watcher.TrackPlacement(workload2)
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 2, len(inProgress))
 
-		// Should NOT receive another result (watcher stopped)
-		select {
-		case <-resultsCh:
-			t.Fatal("should not have received second result for constraint failure")
-		case <-time.After(100 * time.Millisecond):
-			// Expected - no second result
-		}
-	})
+		watcher.UntrackPlacement(workload1)
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval2.ID])
 
-	t.Run("continues waiting on resource exhaustion timeout", func(t *testing.T) {
-		ss := state.TestStateStore(t)
-		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{
-			WorkloadTimeout:      50 * time.Millisecond,
-			ConcurrentPlacements: 1,
-		})
-		resultsCh := watcher.Results()
-
-		testEval := mock.Eval()
-		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
-			"web": {
-				NodesExhausted:     10,
-				DimensionExhausted: map[string]int{"cpu": 5},
-			},
-		}
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
-
-		ws := memdb.NewWatchSet()
-		workload := &testWorkload{eval: testEval.Copy()}
-		watcher.WaitForPlacement(t.Context(), workload, ws)
-
-		// Should receive timeout result
-		result := <-resultsCh
-		must.True(t, result.TimedOut)
-
-		// Should still be waiting (placement slot not released yet)
-		time.Sleep(20 * time.Millisecond)
-		must.False(t, watcher.CanAttemptPlacement())
-
-		// Complete the eval
-		testEval.Status = structs.EvalStatusComplete
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
-
-		// Should receive completion result
-		result = <-resultsCh
-		must.False(t, result.TimedOut)
-		must.NoError(t, result.Err)
-
-		// Now placement slot should be released
-		time.Sleep(20 * time.Millisecond)
-		must.True(t, watcher.CanAttemptPlacement())
+		watcher.UntrackPlacement(workload2)
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 0, len(inProgress))
 	})
 }
-

--- a/nomad/queues/queue/workload_watcher_test.go
+++ b/nomad/queues/queue/workload_watcher_test.go
@@ -277,3 +277,178 @@ func TestWorkloadWatcher_isSchedulingComplete(t *testing.T) {
 		must.True(t, complete)
 	})
 }
+
+
+func TestWorkloadWatcher_isConstraintFailure(t *testing.T) {
+	t.Run("detects constraint failure without resource exhaustion", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{
+					"${attr.kernel.name} == linux": 5,
+				},
+				NodesExhausted:     0,
+				ClassExhausted:     map[string]int{},
+				DimensionExhausted: map[string]int{},
+				QuotaExhausted:     []string{},
+			},
+		}
+
+		workload := &testWorkload{eval: testEval}
+		must.True(t, watcher.isConstraintFailure(workload))
+	})
+
+	t.Run("does not detect constraint failure with resource exhaustion", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{
+					"${attr.kernel.name} == linux": 5,
+				},
+				NodesExhausted: 10,
+				ClassExhausted: map[string]int{"compute": 5},
+			},
+		}
+
+		workload := &testWorkload{eval: testEval}
+		must.False(t, watcher.isConstraintFailure(workload))
+	})
+
+	t.Run("detects pure resource exhaustion as not constraint failure", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{},
+				NodesExhausted:     15,
+				DimensionExhausted: map[string]int{"cpu": 10, "memory": 5},
+			},
+		}
+
+		workload := &testWorkload{eval: testEval}
+		must.False(t, watcher.isConstraintFailure(workload))
+	})
+
+	t.Run("handles nil FailedTGAllocs", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = nil
+
+		workload := &testWorkload{eval: testEval}
+		must.False(t, watcher.isConstraintFailure(workload))
+	})
+
+	t.Run("handles quota exhaustion as resource issue", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{
+					"${attr.kernel.name} == linux": 5,
+				},
+				QuotaExhausted: []string{"default"},
+			},
+		}
+
+		workload := &testWorkload{eval: testEval}
+		must.False(t, watcher.isConstraintFailure(workload))
+	})
+}
+
+func TestWorkloadWatcher_WaitForPlacement_ConstraintTimeout(t *testing.T) {
+	t.Run("stops waiting on constraint failure timeout", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{
+			WorkloadTimeout:      50 * time.Millisecond,
+			ConcurrentPlacements: 1,
+		})
+		resultsCh := watcher.Results()
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{
+					"${attr.kernel.name} == linux": 5,
+				},
+				NodesExhausted: 0,
+			},
+		}
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		ws := memdb.NewWatchSet()
+		workload := &testWorkload{eval: testEval.Copy()}
+		watcher.WaitForPlacement(t.Context(), workload, ws)
+
+		// Should receive timeout result
+		result := <-resultsCh
+		must.True(t, result.TimedOut)
+
+		// Should have released the placement slot immediately
+		time.Sleep(20 * time.Millisecond)
+		must.True(t, watcher.CanAttemptPlacement())
+
+		// Should NOT receive another result (watcher stopped)
+		select {
+		case <-resultsCh:
+			t.Fatal("should not have received second result for constraint failure")
+		case <-time.After(100 * time.Millisecond):
+			// Expected - no second result
+		}
+	})
+
+	t.Run("continues waiting on resource exhaustion timeout", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{
+			WorkloadTimeout:      50 * time.Millisecond,
+			ConcurrentPlacements: 1,
+		})
+		resultsCh := watcher.Results()
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				NodesExhausted:     10,
+				DimensionExhausted: map[string]int{"cpu": 5},
+			},
+		}
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		ws := memdb.NewWatchSet()
+		workload := &testWorkload{eval: testEval.Copy()}
+		watcher.WaitForPlacement(t.Context(), workload, ws)
+
+		// Should receive timeout result
+		result := <-resultsCh
+		must.True(t, result.TimedOut)
+
+		// Should still be waiting (placement slot not released yet)
+		time.Sleep(20 * time.Millisecond)
+		must.False(t, watcher.CanAttemptPlacement())
+
+		// Complete the eval
+		testEval.Status = structs.EvalStatusComplete
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
+
+		// Should receive completion result
+		result = <-resultsCh
+		must.False(t, result.TimedOut)
+		must.NoError(t, result.Err)
+
+		// Now placement slot should be released
+		time.Sleep(20 * time.Millisecond)
+		must.True(t, watcher.CanAttemptPlacement())
+	})
+}
+

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -391,6 +391,8 @@ type BatchQueue struct {
 	ConcurrentPlacements int              `hcl:"concurrent_placements"`
 	WorkloadTimeout      time.Duration
 	WorkloadTimeoutHCL   string         `hcl:"workload_timeout" json:"-"`
+	StrictConstraints    bool           `hcl:"strict"`
+	DropWorkloads        bool           `hcl:"drop_workloads"`
 	Config               map[string]any `hcl:"config"`
 }
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
This is a draft of introducing additional configuration options on top of those introduced in `f-bjq-constraints` specifically to address head-of-line blocking. By default, the behavior in this PR allow workloads in the queue to bypass a placing-but-blocked workload if it is not able to be placed due to constraint issues (specifically anything that is unrelated to resource consumption). The queue will continue to watch these constrained workloads until they are placed or stopped, and will do any follow up computation when that happens (like counting usage in the dynamic priority queue). 

It adds the following options for changing that behavior: 

```
StrictConstraints    bool           `hcl:"strict"`
DropWorkloads        bool           `hcl:"drop_workloads"`
```

`strict` applies the configuration which makes all constraints block indefinitely, and not allow anything to bypass a placing workload for any reason.

`drop_workloads` will allow bypassing, but will stop watching the jobs after. This is useful if the queue is expected to have a lot of constrained workloads, as continuing to watch the workloads takes up resources on the nomad server. 

It also adds the ability to see the placing workloads in the jobs command, but that has also been extracted to its own PR: https://github.com/hashicorp/nomad/pull/28492

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
