### PR TITLE
api: Remove pointerOf and use builtin new function with Go 1.26.

### DIFF
--- a/.changelog/28460.txt
+++ b/.changelog/28460.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+api: Updated the Go module to require at least 1.26.0
+```

--- a/api/allocations_test.go
+++ b/api/allocations_test.go
@@ -222,13 +222,13 @@ func TestAllocations_RescheduleInfo(t *testing.T) {
 
 	// Create a job, task group and alloc
 	job := &Job{
-		Name:      pointerOf("foo"),
-		Namespace: pointerOf(DefaultNamespace),
-		ID:        pointerOf("bar"),
-		ParentID:  pointerOf("lol"),
+		Name:      new("foo"),
+		Namespace: new(DefaultNamespace),
+		ID:        new("bar"),
+		ParentID:  new("lol"),
 		TaskGroups: []*TaskGroup{
 			{
-				Name: pointerOf("bar"),
+				Name: new("bar"),
 				Tasks: []*Task{
 					{
 						Name: "task1",
@@ -268,8 +268,8 @@ func TestAllocations_RescheduleInfo(t *testing.T) {
 		{
 			desc: "no reschedule events",
 			reschedulePolicy: &ReschedulePolicy{
-				Attempts: pointerOf(3),
-				Interval: pointerOf(15 * time.Minute),
+				Attempts: new(3),
+				Interval: new(15 * time.Minute),
 			},
 			expAttempted: 0,
 			expTotal:     3,
@@ -277,8 +277,8 @@ func TestAllocations_RescheduleInfo(t *testing.T) {
 		{
 			desc: "all reschedule events within interval",
 			reschedulePolicy: &ReschedulePolicy{
-				Attempts: pointerOf(3),
-				Interval: pointerOf(15 * time.Minute),
+				Attempts: new(3),
+				Interval: new(15 * time.Minute),
 			},
 			time: time.Now(),
 			rescheduleTracker: &RescheduleTracker{
@@ -294,8 +294,8 @@ func TestAllocations_RescheduleInfo(t *testing.T) {
 		{
 			desc: "some reschedule events outside interval",
 			reschedulePolicy: &ReschedulePolicy{
-				Attempts: pointerOf(3),
-				Interval: pointerOf(15 * time.Minute),
+				Attempts: new(3),
+				Interval: new(15 * time.Minute),
 			},
 			time: time.Now(),
 			rescheduleTracker: &RescheduleTracker{
@@ -440,13 +440,13 @@ func TestAllocations_ExecErrors(t *testing.T) {
 	a := c.Allocations()
 
 	job := &Job{
-		Name:      pointerOf("foo"),
-		Namespace: pointerOf(DefaultNamespace),
-		ID:        pointerOf("bar"),
-		ParentID:  pointerOf("lol"),
+		Name:      new("foo"),
+		Namespace: new(DefaultNamespace),
+		ID:        new("bar"),
+		ParentID:  new("lol"),
 		TaskGroups: []*TaskGroup{
 			{
-				Name: pointerOf("bar"),
+				Name: new("bar"),
 				Tasks: []*Task{
 					{
 						Name: "task1",
@@ -557,41 +557,41 @@ func TestAllocation_ClientTerminalStatus(t *testing.T) {
 func TestAllocations_ShouldMigrate(t *testing.T) {
 	testutil.Parallel(t)
 
-	must.True(t, DesiredTransition{Migrate: pointerOf(true)}.ShouldMigrate())
+	must.True(t, DesiredTransition{Migrate: new(true)}.ShouldMigrate())
 	must.False(t, DesiredTransition{}.ShouldMigrate())
-	must.False(t, DesiredTransition{Migrate: pointerOf(false)}.ShouldMigrate())
+	must.False(t, DesiredTransition{Migrate: new(false)}.ShouldMigrate())
 }
 
 func TestAllocations_ShouldReschedule(t *testing.T) {
 	testutil.Parallel(t)
 
-	must.True(t, DesiredTransition{Reschedule: pointerOf(true)}.ShouldReschedule())
+	must.True(t, DesiredTransition{Reschedule: new(true)}.ShouldReschedule())
 	must.False(t, DesiredTransition{}.ShouldReschedule())
-	must.False(t, DesiredTransition{Reschedule: pointerOf(false)}.ShouldReschedule())
+	must.False(t, DesiredTransition{Reschedule: new(false)}.ShouldReschedule())
 }
 
 func TestAllocations_ShouldForceReschedule(t *testing.T) {
 	testutil.Parallel(t)
 
-	must.True(t, DesiredTransition{ForceReschedule: pointerOf(true)}.ShouldForceReschedule())
+	must.True(t, DesiredTransition{ForceReschedule: new(true)}.ShouldForceReschedule())
 	must.False(t, DesiredTransition{}.ShouldForceReschedule())
-	must.False(t, DesiredTransition{ForceReschedule: pointerOf(false)}.ShouldForceReschedule())
+	must.False(t, DesiredTransition{ForceReschedule: new(false)}.ShouldForceReschedule())
 }
 
 func TestAllocations_ShouldIgnoreShutdownDelay(t *testing.T) {
 	testutil.Parallel(t)
 
-	must.True(t, DesiredTransition{NoShutdownDelay: pointerOf(true)}.ShouldIgnoreShutdownDelay())
+	must.True(t, DesiredTransition{NoShutdownDelay: new(true)}.ShouldIgnoreShutdownDelay())
 	must.False(t, DesiredTransition{}.ShouldIgnoreShutdownDelay())
-	must.False(t, DesiredTransition{NoShutdownDelay: pointerOf(false)}.ShouldIgnoreShutdownDelay())
+	must.False(t, DesiredTransition{NoShutdownDelay: new(false)}.ShouldIgnoreShutdownDelay())
 }
 
 func TestAllocations_ShouldDisableMigrationPlacement(t *testing.T) {
 	testutil.Parallel(t)
 
-	must.True(t, DesiredTransition{MigrateDisablePlacement: pointerOf(true)}.ShouldDisableMigrationPlacement())
+	must.True(t, DesiredTransition{MigrateDisablePlacement: new(true)}.ShouldDisableMigrationPlacement())
 	must.False(t, DesiredTransition{}.ShouldDisableMigrationPlacement())
-	must.False(t, DesiredTransition{MigrateDisablePlacement: pointerOf(false)}.ShouldDisableMigrationPlacement())
+	must.False(t, DesiredTransition{MigrateDisablePlacement: new(false)}.ShouldDisableMigrationPlacement())
 }
 
 func TestAllocations_Services(t *testing.T) {

--- a/api/compose_test.go
+++ b/api/compose_test.go
@@ -18,13 +18,13 @@ func TestCompose(t *testing.T) {
 		SetMeta("foo", "bar").
 		Constrain(NewConstraint("kernel.name", "=", "linux")).
 		Require(&Resources{
-			CPU:      pointerOf(1250),
-			MemoryMB: pointerOf(1024),
-			DiskMB:   pointerOf(2048),
+			CPU:      new(1250),
+			MemoryMB: new(1024),
+			DiskMB:   new(2048),
 			Networks: []*NetworkResource{
 				{
 					CIDR:          "0.0.0.0/0",
-					MBits:         pointerOf(100),
+					MBits:         new(100),
 					ReservedPorts: []Port{{Label: "", Value: 80}, {Label: "", Value: 443}},
 				},
 			},
@@ -50,11 +50,11 @@ func TestCompose(t *testing.T) {
 
 	// Check that the composed result looks correct
 	expect := &Job{
-		Region:   pointerOf("global"),
-		ID:       pointerOf("job1"),
-		Name:     pointerOf("myjob"),
-		Type:     pointerOf(JobTypeService),
-		Priority: pointerOf(2),
+		Region:   new("global"),
+		ID:       new("job1"),
+		Name:     new("myjob"),
+		Type:     new(JobTypeService),
+		Priority: new(2),
 		Datacenters: []string{
 			"dc1",
 		},
@@ -70,8 +70,8 @@ func TestCompose(t *testing.T) {
 		},
 		TaskGroups: []*TaskGroup{
 			{
-				Name:  pointerOf("grp1"),
-				Count: pointerOf(2),
+				Name:  new("grp1"),
+				Count: new(2),
 				Constraints: []*Constraint{
 					{
 						LTarget: "kernel.name",
@@ -84,13 +84,13 @@ func TestCompose(t *testing.T) {
 						LTarget: "${node.class}",
 						RTarget: "large",
 						Operand: "=",
-						Weight:  pointerOf(int8(50)),
+						Weight:  new(int8(50)),
 					},
 				},
 				Spreads: []*Spread{
 					{
 						Attribute: "${node.datacenter}",
-						Weight:    pointerOf(int8(30)),
+						Weight:    new(int8(30)),
 						SpreadTarget: []*SpreadTarget{
 							{
 								Value:   "dc1",
@@ -108,13 +108,13 @@ func TestCompose(t *testing.T) {
 						Name:   "task1",
 						Driver: "exec",
 						Resources: &Resources{
-							CPU:      pointerOf(1250),
-							MemoryMB: pointerOf(1024),
-							DiskMB:   pointerOf(2048),
+							CPU:      new(1250),
+							MemoryMB: new(1024),
+							DiskMB:   new(2048),
 							Networks: []*NetworkResource{
 								{
 									CIDR:  "0.0.0.0/0",
-									MBits: pointerOf(100),
+									MBits: new(100),
 									ReservedPorts: []Port{
 										{Label: "", Value: 80},
 										{Label: "", Value: 443},

--- a/api/consul.go
+++ b/api/consul.go
@@ -149,11 +149,11 @@ func (st *SidecarTask) Canonicalize() {
 	}
 
 	if st.KillTimeout == nil {
-		st.KillTimeout = pointerOf(5 * time.Second)
+		st.KillTimeout = new(5 * time.Second)
 	}
 
 	if st.ShutdownDelay == nil {
-		st.ShutdownDelay = pointerOf(time.Duration(0))
+		st.ShutdownDelay = new(time.Duration(0))
 	}
 
 	for _, vm := range st.VolumeMounts {
@@ -418,7 +418,7 @@ func (p *ConsulGatewayProxy) Canonicalize() {
 
 	if p.ConnectTimeout == nil {
 		// same as the default from consul
-		p.ConnectTimeout = pointerOf(defaultGatewayConnectTimeout)
+		p.ConnectTimeout = new(defaultGatewayConnectTimeout)
 	}
 
 	if len(p.EnvoyGatewayBindAddresses) == 0 {
@@ -448,7 +448,7 @@ func (p *ConsulGatewayProxy) Copy() *ConsulGatewayProxy {
 	}
 
 	return &ConsulGatewayProxy{
-		ConnectTimeout:                  pointerOf(*p.ConnectTimeout),
+		ConnectTimeout:                  new(*p.ConnectTimeout),
 		EnvoyGatewayBindTaggedAddresses: p.EnvoyGatewayBindTaggedAddresses,
 		EnvoyGatewayBindAddresses:       binds,
 		EnvoyGatewayNoDefaultBind:       p.EnvoyGatewayNoDefaultBind,

--- a/api/consul_test.go
+++ b/api/consul_test.go
@@ -45,7 +45,7 @@ func TestConsul_MergeNamespace(t *testing.T) {
 
 	t.Run("already set", func(t *testing.T) {
 		a := &Consul{Namespace: "foo"}
-		ns := pointerOf("bar")
+		ns := new("bar")
 		a.MergeNamespace(ns)
 		must.Eq(t, "foo", a.Namespace)
 		must.Eq(t, "bar", *ns)
@@ -53,7 +53,7 @@ func TestConsul_MergeNamespace(t *testing.T) {
 
 	t.Run("inherit", func(t *testing.T) {
 		a := &Consul{Namespace: ""}
-		ns := pointerOf("bar")
+		ns := new("bar")
 		a.MergeNamespace(ns)
 		must.Eq(t, "bar", a.Namespace)
 		must.Eq(t, "bar", *ns)
@@ -257,9 +257,9 @@ func TestSidecarTask_Canonicalize(t *testing.T) {
 
 	t.Run("non empty sidecar_task resources", func(t *testing.T) {
 		exp := DefaultResources()
-		exp.MemoryMB = pointerOf(333)
+		exp.MemoryMB = new(333)
 		st := &SidecarTask{
-			Resources: &Resources{MemoryMB: pointerOf(333)},
+			Resources: &Resources{MemoryMB: new(333)},
 		}
 		st.Canonicalize()
 		must.Eq(t, exp, st.Resources)
@@ -286,14 +286,14 @@ func TestSidecarTask_Canonicalize(t *testing.T) {
 	t.Run("non empty sidecar_task volume_mount", func(t *testing.T) {
 		st := &SidecarTask{
 			VolumeMounts: []*VolumeMount{{
-				Volume:      pointerOf("vol0"),
-				Destination: pointerOf("/local/foo"),
+				Volume:      new("vol0"),
+				Destination: new("/local/foo"),
 			}},
 		}
 		st.Canonicalize()
-		must.Eq(t, pointerOf(false), st.VolumeMounts[0].ReadOnly)
-		must.Eq(t, pointerOf("private"), st.VolumeMounts[0].PropagationMode)
-		must.Eq(t, pointerOf(""), st.VolumeMounts[0].SELinuxLabel)
+		must.Eq(t, new(false), st.VolumeMounts[0].ReadOnly)
+		must.Eq(t, new("private"), st.VolumeMounts[0].PropagationMode)
+		must.Eq(t, new(""), st.VolumeMounts[0].SELinuxLabel)
 	})
 
 }
@@ -324,7 +324,7 @@ func TestConsulGateway_Canonicalize(t *testing.T) {
 			},
 		}
 		cg.Canonicalize()
-		must.Eq(t, pointerOf(5*time.Second), cg.Proxy.ConnectTimeout)
+		must.Eq(t, new(5*time.Second), cg.Proxy.ConnectTimeout)
 		must.True(t, cg.Proxy.EnvoyGatewayBindTaggedAddresses)
 		must.Nil(t, cg.Proxy.EnvoyGatewayBindAddresses)
 		must.True(t, cg.Proxy.EnvoyGatewayNoDefaultBind)
@@ -344,7 +344,7 @@ func TestConsulGateway_Copy(t *testing.T) {
 
 	gateway := &ConsulGateway{
 		Proxy: &ConsulGatewayProxy{
-			ConnectTimeout:                  pointerOf(3 * time.Second),
+			ConnectTimeout:                  new(3 * time.Second),
 			EnvoyGatewayBindTaggedAddresses: true,
 			EnvoyGatewayBindAddresses: map[string]*ConsulGatewayBindAddress{
 				"listener1": {Address: "10.0.0.1", Port: 2000},
@@ -473,9 +473,9 @@ func TestConsulIngressConfigEntry_Copy(t *testing.T) {
 					},
 					Remove: []string{"test2"},
 				},
-				MaxConnections:        pointerOf(uint32(5120)),
-				MaxPendingRequests:    pointerOf(uint32(512)),
-				MaxConcurrentRequests: pointerOf(uint32(2048)),
+				MaxConnections:        new(uint32(5120)),
+				MaxPendingRequests:    new(uint32(512)),
+				MaxConcurrentRequests: new(uint32(2048)),
 			}, {
 				Name:  "service2",
 				Hosts: []string{"2.2.2.2"},

--- a/api/event_stream_test.go
+++ b/api/event_stream_test.go
@@ -342,8 +342,8 @@ func TestEventStream_PayloadValueHelpers(t *testing.T) {
 				j, err := event.Job()
 				must.NoError(t, err)
 				must.Eq(t, &Job{
-					ID:        pointerOf("some-id"),
-					Namespace: pointerOf("some-namespace-id"),
+					ID:        new("some-id"),
+					Namespace: new("some-namespace-id"),
 				}, j)
 			},
 		},
@@ -356,8 +356,8 @@ func TestEventStream_PayloadValueHelpers(t *testing.T) {
 				must.NoError(t, err)
 				must.True(t, deleted, must.Sprint("did not populated Deleted value"))
 				must.Eq(t, &Job{
-					ID:        pointerOf("some-id"),
-					Namespace: pointerOf("some-namespace-id"),
+					ID:        new("some-id"),
+					Namespace: new("some-namespace-id"),
 				}, j)
 			},
 		},

--- a/api/fs_test.go
+++ b/api/fs_test.go
@@ -38,13 +38,13 @@ func TestFS_Logs(t *testing.T) {
 	}
 
 	job := &Job{
-		ID:          pointerOf("TestFS_Logs"),
-		Region:      pointerOf("global"),
+		ID:          new("TestFS_Logs"),
+		Region:      new("global"),
 		Datacenters: []string{"dc1"},
-		Type:        pointerOf("batch"),
+		Type:        new("batch"),
 		TaskGroups: []*TaskGroup{
 			{
-				Name: pointerOf("TestFS_LogsGroup"),
+				Name: new("TestFS_LogsGroup"),
 				Tasks: []*Task{
 					{
 						Name:   "logger",

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/nomad/api
 
-go 1.25
+go 1.26
 
 require (
 	github.com/docker/go-units v0.5.0

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -220,7 +220,7 @@ func (j *Jobs) Scale(jobID, group string, count *int, message string, error bool
 
 	var count64 *int64
 	if count != nil {
-		count64 = pointerOf(int64(*count))
+		count64 = new(int64(*count))
 	}
 	req := &ScalingRequest{
 		Count: count64,
@@ -636,15 +636,15 @@ type UpdateStrategy struct {
 // jobs with the old policy or for populating field defaults.
 func DefaultUpdateStrategy() *UpdateStrategy {
 	return &UpdateStrategy{
-		Stagger:          pointerOf(30 * time.Second),
-		MaxParallel:      pointerOf(1),
-		HealthCheck:      pointerOf("checks"),
-		MinHealthyTime:   pointerOf(10 * time.Second),
-		HealthyDeadline:  pointerOf(5 * time.Minute),
-		ProgressDeadline: pointerOf(10 * time.Minute),
-		AutoRevert:       pointerOf(false),
-		Canary:           pointerOf(0),
-		AutoPromote:      pointerOf(false),
+		Stagger:          new(30 * time.Second),
+		MaxParallel:      new(1),
+		HealthCheck:      new("checks"),
+		MinHealthyTime:   new(10 * time.Second),
+		HealthyDeadline:  new(5 * time.Minute),
+		ProgressDeadline: new(10 * time.Minute),
+		AutoRevert:       new(false),
+		Canary:           new(0),
+		AutoPromote:      new(false),
 	}
 }
 
@@ -656,39 +656,39 @@ func (u *UpdateStrategy) Copy() *UpdateStrategy {
 	copy := new(UpdateStrategy)
 
 	if u.Stagger != nil {
-		copy.Stagger = pointerOf(*u.Stagger)
+		copy.Stagger = new(*u.Stagger)
 	}
 
 	if u.MaxParallel != nil {
-		copy.MaxParallel = pointerOf(*u.MaxParallel)
+		copy.MaxParallel = new(*u.MaxParallel)
 	}
 
 	if u.HealthCheck != nil {
-		copy.HealthCheck = pointerOf(*u.HealthCheck)
+		copy.HealthCheck = new(*u.HealthCheck)
 	}
 
 	if u.MinHealthyTime != nil {
-		copy.MinHealthyTime = pointerOf(*u.MinHealthyTime)
+		copy.MinHealthyTime = new(*u.MinHealthyTime)
 	}
 
 	if u.HealthyDeadline != nil {
-		copy.HealthyDeadline = pointerOf(*u.HealthyDeadline)
+		copy.HealthyDeadline = new(*u.HealthyDeadline)
 	}
 
 	if u.ProgressDeadline != nil {
-		copy.ProgressDeadline = pointerOf(*u.ProgressDeadline)
+		copy.ProgressDeadline = new(*u.ProgressDeadline)
 	}
 
 	if u.AutoRevert != nil {
-		copy.AutoRevert = pointerOf(*u.AutoRevert)
+		copy.AutoRevert = new(*u.AutoRevert)
 	}
 
 	if u.Canary != nil {
-		copy.Canary = pointerOf(*u.Canary)
+		copy.Canary = new(*u.Canary)
 	}
 
 	if u.AutoPromote != nil {
-		copy.AutoPromote = pointerOf(*u.AutoPromote)
+		copy.AutoPromote = new(*u.AutoPromote)
 	}
 
 	return copy
@@ -700,39 +700,39 @@ func (u *UpdateStrategy) Merge(o *UpdateStrategy) {
 	}
 
 	if o.Stagger != nil {
-		u.Stagger = pointerOf(*o.Stagger)
+		u.Stagger = new(*o.Stagger)
 	}
 
 	if o.MaxParallel != nil {
-		u.MaxParallel = pointerOf(*o.MaxParallel)
+		u.MaxParallel = new(*o.MaxParallel)
 	}
 
 	if o.HealthCheck != nil {
-		u.HealthCheck = pointerOf(*o.HealthCheck)
+		u.HealthCheck = new(*o.HealthCheck)
 	}
 
 	if o.MinHealthyTime != nil {
-		u.MinHealthyTime = pointerOf(*o.MinHealthyTime)
+		u.MinHealthyTime = new(*o.MinHealthyTime)
 	}
 
 	if o.HealthyDeadline != nil {
-		u.HealthyDeadline = pointerOf(*o.HealthyDeadline)
+		u.HealthyDeadline = new(*o.HealthyDeadline)
 	}
 
 	if o.ProgressDeadline != nil {
-		u.ProgressDeadline = pointerOf(*o.ProgressDeadline)
+		u.ProgressDeadline = new(*o.ProgressDeadline)
 	}
 
 	if o.AutoRevert != nil {
-		u.AutoRevert = pointerOf(*o.AutoRevert)
+		u.AutoRevert = new(*o.AutoRevert)
 	}
 
 	if o.Canary != nil {
-		u.Canary = pointerOf(*o.Canary)
+		u.Canary = new(*o.Canary)
 	}
 
 	if o.AutoPromote != nil {
-		u.AutoPromote = pointerOf(*o.AutoPromote)
+		u.AutoPromote = new(*o.AutoPromote)
 	}
 }
 
@@ -829,15 +829,15 @@ type Multiregion struct {
 func (m *Multiregion) Canonicalize() {
 	if m.Strategy == nil {
 		m.Strategy = &MultiregionStrategy{
-			MaxParallel: pointerOf(0),
-			OnFailure:   pointerOf(""),
+			MaxParallel: new(0),
+			OnFailure:   new(""),
 		}
 	} else {
 		if m.Strategy.MaxParallel == nil {
-			m.Strategy.MaxParallel = pointerOf(0)
+			m.Strategy.MaxParallel = new(0)
 		}
 		if m.Strategy.OnFailure == nil {
-			m.Strategy.OnFailure = pointerOf("")
+			m.Strategy.OnFailure = new("")
 		}
 	}
 	if m.Regions == nil {
@@ -845,7 +845,7 @@ func (m *Multiregion) Canonicalize() {
 	}
 	for _, region := range m.Regions {
 		if region.Count == nil {
-			region.Count = pointerOf(1)
+			region.Count = new(1)
 		}
 		if region.Datacenters == nil {
 			region.Datacenters = []string{}
@@ -863,13 +863,13 @@ func (m *Multiregion) Copy() *Multiregion {
 	copy := new(Multiregion)
 	if m.Strategy != nil {
 		copy.Strategy = new(MultiregionStrategy)
-		copy.Strategy.MaxParallel = pointerOf(*m.Strategy.MaxParallel)
-		copy.Strategy.OnFailure = pointerOf(*m.Strategy.OnFailure)
+		copy.Strategy.MaxParallel = new(*m.Strategy.MaxParallel)
+		copy.Strategy.OnFailure = new(*m.Strategy.OnFailure)
 	}
 	for _, region := range m.Regions {
 		copyRegion := new(MultiregionRegion)
 		copyRegion.Name = region.Name
-		copyRegion.Count = pointerOf(*region.Count)
+		copyRegion.Count = new(*region.Count)
 		copyRegion.Datacenters = append(copyRegion.Datacenters, region.Datacenters...)
 		copyRegion.NodePool = region.NodePool
 		maps.Copy(copyRegion.Meta, region.Meta)
@@ -904,22 +904,22 @@ type PeriodicConfig struct {
 
 func (p *PeriodicConfig) Canonicalize() {
 	if p.Enabled == nil {
-		p.Enabled = pointerOf(true)
+		p.Enabled = new(true)
 	}
 	if p.Spec == nil {
-		p.Spec = pointerOf("")
+		p.Spec = new("")
 	}
 	if p.Specs == nil {
 		p.Specs = []string{}
 	}
 	if p.SpecType == nil {
-		p.SpecType = pointerOf(PeriodicSpecCron)
+		p.SpecType = new(PeriodicSpecCron)
 	}
 	if p.ProhibitOverlap == nil {
-		p.ProhibitOverlap = pointerOf(false)
+		p.ProhibitOverlap = new(false)
 	}
 	if p.TimeZone == nil || *p.TimeZone == "" {
-		p.TimeZone = pointerOf("UTC")
+		p.TimeZone = new("UTC")
 	}
 }
 
@@ -1163,64 +1163,64 @@ func (j *Job) IsMultiregion() bool {
 
 func (j *Job) Canonicalize() {
 	if j.ID == nil {
-		j.ID = pointerOf("")
+		j.ID = new("")
 	}
 	if j.Name == nil {
-		j.Name = pointerOf(*j.ID)
+		j.Name = new(*j.ID)
 	}
 	if j.ParentID == nil {
-		j.ParentID = pointerOf("")
+		j.ParentID = new("")
 	}
 	if j.Namespace == nil {
-		j.Namespace = pointerOf(DefaultNamespace)
+		j.Namespace = new(DefaultNamespace)
 	}
 	if j.Priority == nil {
-		j.Priority = pointerOf(JobDefaultPriority)
+		j.Priority = new(JobDefaultPriority)
 	}
 	if j.Stop == nil {
-		j.Stop = pointerOf(false)
+		j.Stop = new(false)
 	}
 	if j.Region == nil {
-		j.Region = pointerOf(GlobalRegion)
+		j.Region = new(GlobalRegion)
 	}
 	if j.NodePool == nil {
-		j.NodePool = pointerOf("")
+		j.NodePool = new("")
 	}
 	if j.Type == nil {
-		j.Type = pointerOf("service")
+		j.Type = new("service")
 	}
 	if j.AllAtOnce == nil {
-		j.AllAtOnce = pointerOf(false)
+		j.AllAtOnce = new(false)
 	}
 	if j.ConsulNamespace == nil {
-		j.ConsulNamespace = pointerOf("")
+		j.ConsulNamespace = new("")
 	}
 	if j.VaultNamespace == nil {
-		j.VaultNamespace = pointerOf("")
+		j.VaultNamespace = new("")
 	}
 	if j.NomadTokenID == nil {
-		j.NomadTokenID = pointerOf("")
+		j.NomadTokenID = new("")
 	}
 	if j.Status == nil {
-		j.Status = pointerOf("")
+		j.Status = new("")
 	}
 	if j.StatusDescription == nil {
-		j.StatusDescription = pointerOf("")
+		j.StatusDescription = new("")
 	}
 	if j.Stable == nil {
-		j.Stable = pointerOf(false)
+		j.Stable = new(false)
 	}
 	if j.Version == nil {
-		j.Version = pointerOf(uint64(0))
+		j.Version = new(uint64(0))
 	}
 	if j.CreateIndex == nil {
-		j.CreateIndex = pointerOf(uint64(0))
+		j.CreateIndex = new(uint64(0))
 	}
 	if j.ModifyIndex == nil {
-		j.ModifyIndex = pointerOf(uint64(0))
+		j.ModifyIndex = new(uint64(0))
 	}
 	if j.JobModifyIndex == nil {
-		j.JobModifyIndex = pointerOf(uint64(0))
+		j.JobModifyIndex = new(uint64(0))
 	}
 	if j.Periodic != nil {
 		j.Periodic.Canonicalize()

--- a/api/jobs_test.go
+++ b/api/jobs_test.go
@@ -61,23 +61,23 @@ func TestJobs_Register_PreserveCounts(t *testing.T) {
 	task := NewTask("task", "exec").
 		SetConfig("command", "/bin/sleep").
 		Require(&Resources{
-			CPU:      pointerOf(100),
-			MemoryMB: pointerOf(256),
+			CPU:      new(100),
+			MemoryMB: new(256),
 		}).
 		SetLogConfig(&LogConfig{
-			MaxFiles:      pointerOf(1),
-			MaxFileSizeMB: pointerOf(2),
+			MaxFiles:      new(1),
+			MaxFileSizeMB: new(2),
 		})
 
 	group1 := NewTaskGroup("group1", 1).
 		AddTask(task).
 		RequireDisk(&EphemeralDisk{
-			SizeMB: pointerOf(25),
+			SizeMB: new(25),
 		})
 	group2 := NewTaskGroup("group2", 2).
 		AddTask(task).
 		RequireDisk(&EphemeralDisk{
-			SizeMB: pointerOf(25),
+			SizeMB: new(25),
 		})
 
 	job := NewBatchJob("job", "redis", "global", 1).
@@ -94,11 +94,11 @@ func TestJobs_Register_PreserveCounts(t *testing.T) {
 
 	// Update the job, new groups to test PreserveCounts
 	group1.Count = nil
-	group2.Count = pointerOf(0)
+	group2.Count = new(0)
 	group3 := NewTaskGroup("group3", 3).
 		AddTask(task).
 		RequireDisk(&EphemeralDisk{
-			SizeMB: pointerOf(25),
+			SizeMB: new(25),
 		})
 	job.AddTaskGroup(group3)
 
@@ -132,23 +132,23 @@ func TestJobs_Register_NoPreserveCounts(t *testing.T) {
 	task := NewTask("task", "exec").
 		SetConfig("command", "/bin/sleep").
 		Require(&Resources{
-			CPU:      pointerOf(100),
-			MemoryMB: pointerOf(256),
+			CPU:      new(100),
+			MemoryMB: new(256),
 		}).
 		SetLogConfig(&LogConfig{
-			MaxFiles:      pointerOf(1),
-			MaxFileSizeMB: pointerOf(2),
+			MaxFiles:      new(1),
+			MaxFileSizeMB: new(2),
 		})
 
 	group1 := NewTaskGroup("group1", 1).
 		AddTask(task).
 		RequireDisk(&EphemeralDisk{
-			SizeMB: pointerOf(25),
+			SizeMB: new(25),
 		})
 	group2 := NewTaskGroup("group2", 2).
 		AddTask(task).
 		RequireDisk(&EphemeralDisk{
-			SizeMB: pointerOf(25),
+			SizeMB: new(25),
 		})
 
 	job := NewBatchJob("job", "redis", "global", 1).
@@ -164,12 +164,12 @@ func TestJobs_Register_NoPreserveCounts(t *testing.T) {
 	assertWriteMeta(t, wm)
 
 	// Update the job, new groups to test PreserveCounts
-	group1.Count = pointerOf(0)
+	group1.Count = new(0)
 	group2.Count = nil
 	group3 := NewTaskGroup("group3", 3).
 		AddTask(task).
 		RequireDisk(&EphemeralDisk{
-			SizeMB: pointerOf(25),
+			SizeMB: new(25),
 		})
 	job.AddTaskGroup(group3)
 
@@ -202,14 +202,14 @@ func TestJobs_Register_PreserveResources(t *testing.T) {
 	task := NewTask("task", "exec").
 		SetConfig("command", "/bin/echo").
 		SetLogConfig(&LogConfig{
-			MaxFiles:      pointerOf(1),
-			MaxFileSizeMB: pointerOf(2),
+			MaxFiles:      new(1),
+			MaxFileSizeMB: new(2),
 		})
 
 	group1 := NewTaskGroup("group1", 1).
 		AddTask(task).
 		RequireDisk(&EphemeralDisk{
-			SizeMB: pointerOf(25),
+			SizeMB: new(25),
 		})
 
 	job := NewBatchJob("job", "redis", "global", 1).
@@ -225,8 +225,8 @@ func TestJobs_Register_PreserveResources(t *testing.T) {
 
 	// Update the job, new groups to test PreserveCounts
 	task.Resources = &Resources{
-		CPU:      pointerOf(50),
-		MemoryMB: pointerOf(128),
+		CPU:      new(50),
+		MemoryMB: new(128),
 	}
 
 	// Update the job, with PreserveResources = true
@@ -258,14 +258,14 @@ func TestJobs_Register_NoPreserveResources(t *testing.T) {
 	task := NewTask("task", "exec").
 		SetConfig("command", "/bin/echo").
 		SetLogConfig(&LogConfig{
-			MaxFiles:      pointerOf(1),
-			MaxFileSizeMB: pointerOf(2),
+			MaxFiles:      new(1),
+			MaxFileSizeMB: new(2),
 		})
 
 	group1 := NewTaskGroup("group1", 1).
 		AddTask(task).
 		RequireDisk(&EphemeralDisk{
-			SizeMB: pointerOf(25),
+			SizeMB: new(25),
 		})
 
 	job := NewBatchJob("job", "redis", "global", 1).
@@ -281,8 +281,8 @@ func TestJobs_Register_NoPreserveResources(t *testing.T) {
 
 	// Update the job, new groups to test PreserveCounts
 	task.Resources = &Resources{
-		CPU:      pointerOf(50),
-		MemoryMB: pointerOf(128),
+		CPU:      new(50),
+		MemoryMB: new(128),
 	}
 
 	// Update the job, with PreserveResources = true
@@ -389,76 +389,76 @@ func TestJobs_Canonicalize(t *testing.T) {
 				},
 			},
 			expected: &Job{
-				ID:                pointerOf(""),
-				Name:              pointerOf(""),
-				Region:            pointerOf("global"),
-				Namespace:         pointerOf(DefaultNamespace),
-				Type:              pointerOf("service"),
-				ParentID:          pointerOf(""),
-				Priority:          pointerOf(JobDefaultPriority),
-				NodePool:          pointerOf(""),
-				AllAtOnce:         pointerOf(false),
-				ConsulNamespace:   pointerOf(""),
-				VaultNamespace:    pointerOf(""),
-				NomadTokenID:      pointerOf(""),
-				Status:            pointerOf(""),
-				StatusDescription: pointerOf(""),
-				Stop:              pointerOf(false),
-				Stable:            pointerOf(false),
-				Version:           pointerOf(uint64(0)),
-				CreateIndex:       pointerOf(uint64(0)),
-				ModifyIndex:       pointerOf(uint64(0)),
-				JobModifyIndex:    pointerOf(uint64(0)),
+				ID:                new(""),
+				Name:              new(""),
+				Region:            new("global"),
+				Namespace:         new(DefaultNamespace),
+				Type:              new("service"),
+				ParentID:          new(""),
+				Priority:          new(JobDefaultPriority),
+				NodePool:          new(""),
+				AllAtOnce:         new(false),
+				ConsulNamespace:   new(""),
+				VaultNamespace:    new(""),
+				NomadTokenID:      new(""),
+				Status:            new(""),
+				StatusDescription: new(""),
+				Stop:              new(false),
+				Stable:            new(false),
+				Version:           new(uint64(0)),
+				CreateIndex:       new(uint64(0)),
+				ModifyIndex:       new(uint64(0)),
+				JobModifyIndex:    new(uint64(0)),
 				Update: &UpdateStrategy{
-					Stagger:          pointerOf(30 * time.Second),
-					MaxParallel:      pointerOf(1),
-					HealthCheck:      pointerOf("checks"),
-					MinHealthyTime:   pointerOf(10 * time.Second),
-					HealthyDeadline:  pointerOf(5 * time.Minute),
-					ProgressDeadline: pointerOf(10 * time.Minute),
-					AutoRevert:       pointerOf(false),
-					Canary:           pointerOf(0),
-					AutoPromote:      pointerOf(false),
+					Stagger:          new(30 * time.Second),
+					MaxParallel:      new(1),
+					HealthCheck:      new("checks"),
+					MinHealthyTime:   new(10 * time.Second),
+					HealthyDeadline:  new(5 * time.Minute),
+					ProgressDeadline: new(10 * time.Minute),
+					AutoRevert:       new(false),
+					Canary:           new(0),
+					AutoPromote:      new(false),
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf(""),
-						Count: pointerOf(1),
+						Name:  new(""),
+						Count: new(1),
 						EphemeralDisk: &EphemeralDisk{
-							Sticky:  pointerOf(false),
-							Migrate: pointerOf(false),
-							SizeMB:  pointerOf(300),
+							Sticky:  new(false),
+							Migrate: new(false),
+							SizeMB:  new(300),
 						},
 						RestartPolicy: &RestartPolicy{
-							Delay:           pointerOf(15 * time.Second),
-							Attempts:        pointerOf(2),
-							Interval:        pointerOf(30 * time.Minute),
-							Mode:            pointerOf("fail"),
-							RenderTemplates: pointerOf(false),
+							Delay:           new(15 * time.Second),
+							Attempts:        new(2),
+							Interval:        new(30 * time.Minute),
+							Mode:            new("fail"),
+							RenderTemplates: new(false),
 						},
 						ReschedulePolicy: &ReschedulePolicy{
-							Attempts:      pointerOf(0),
-							Interval:      pointerOf(time.Duration(0)),
-							DelayFunction: pointerOf("exponential"),
-							Delay:         pointerOf(30 * time.Second),
-							MaxDelay:      pointerOf(1 * time.Hour),
-							Unlimited:     pointerOf(true),
+							Attempts:      new(0),
+							Interval:      new(time.Duration(0)),
+							DelayFunction: new("exponential"),
+							Delay:         new(30 * time.Second),
+							MaxDelay:      new(1 * time.Hour),
+							Unlimited:     new(true),
 						},
 						Update: &UpdateStrategy{
-							Stagger:          pointerOf(30 * time.Second),
-							MaxParallel:      pointerOf(1),
-							HealthCheck:      pointerOf("checks"),
-							MinHealthyTime:   pointerOf(10 * time.Second),
-							HealthyDeadline:  pointerOf(5 * time.Minute),
-							ProgressDeadline: pointerOf(10 * time.Minute),
-							AutoRevert:       pointerOf(false),
-							Canary:           pointerOf(0),
-							AutoPromote:      pointerOf(false),
+							Stagger:          new(30 * time.Second),
+							MaxParallel:      new(1),
+							HealthCheck:      new("checks"),
+							MinHealthyTime:   new(10 * time.Second),
+							HealthyDeadline:  new(5 * time.Minute),
+							ProgressDeadline: new(10 * time.Minute),
+							AutoRevert:       new(false),
+							Canary:           new(0),
+							AutoPromote:      new(false),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{
 							{
-								KillTimeout:   pointerOf(5 * time.Second),
+								KillTimeout:   new(5 * time.Second),
 								LogConfig:     DefaultLogConfig(),
 								Resources:     DefaultResources(),
 								RestartPolicy: defaultServiceJobRestartPolicy(),
@@ -471,7 +471,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 		{
 			name: "batch",
 			input: &Job{
-				Type: pointerOf("batch"),
+				Type: new("batch"),
 				TaskGroups: []*TaskGroup{
 					{
 						Tasks: []*Task{
@@ -481,53 +481,53 @@ func TestJobs_Canonicalize(t *testing.T) {
 				},
 			},
 			expected: &Job{
-				ID:                pointerOf(""),
-				Name:              pointerOf(""),
-				Region:            pointerOf("global"),
-				Namespace:         pointerOf(DefaultNamespace),
-				Type:              pointerOf("batch"),
-				ParentID:          pointerOf(""),
-				Priority:          pointerOf(JobDefaultPriority),
-				NodePool:          pointerOf(""),
-				AllAtOnce:         pointerOf(false),
-				ConsulNamespace:   pointerOf(""),
-				VaultNamespace:    pointerOf(""),
-				NomadTokenID:      pointerOf(""),
-				Status:            pointerOf(""),
-				StatusDescription: pointerOf(""),
-				Stop:              pointerOf(false),
-				Stable:            pointerOf(false),
-				Version:           pointerOf(uint64(0)),
-				CreateIndex:       pointerOf(uint64(0)),
-				ModifyIndex:       pointerOf(uint64(0)),
-				JobModifyIndex:    pointerOf(uint64(0)),
+				ID:                new(""),
+				Name:              new(""),
+				Region:            new("global"),
+				Namespace:         new(DefaultNamespace),
+				Type:              new("batch"),
+				ParentID:          new(""),
+				Priority:          new(JobDefaultPriority),
+				NodePool:          new(""),
+				AllAtOnce:         new(false),
+				ConsulNamespace:   new(""),
+				VaultNamespace:    new(""),
+				NomadTokenID:      new(""),
+				Status:            new(""),
+				StatusDescription: new(""),
+				Stop:              new(false),
+				Stable:            new(false),
+				Version:           new(uint64(0)),
+				CreateIndex:       new(uint64(0)),
+				ModifyIndex:       new(uint64(0)),
+				JobModifyIndex:    new(uint64(0)),
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf(""),
-						Count: pointerOf(1),
+						Name:  new(""),
+						Count: new(1),
 						EphemeralDisk: &EphemeralDisk{
-							Sticky:  pointerOf(false),
-							Migrate: pointerOf(false),
-							SizeMB:  pointerOf(300),
+							Sticky:  new(false),
+							Migrate: new(false),
+							SizeMB:  new(300),
 						},
 						RestartPolicy: &RestartPolicy{
-							Delay:           pointerOf(15 * time.Second),
-							Attempts:        pointerOf(3),
-							Interval:        pointerOf(24 * time.Hour),
-							Mode:            pointerOf("fail"),
-							RenderTemplates: pointerOf(false),
+							Delay:           new(15 * time.Second),
+							Attempts:        new(3),
+							Interval:        new(24 * time.Hour),
+							Mode:            new("fail"),
+							RenderTemplates: new(false),
 						},
 						ReschedulePolicy: &ReschedulePolicy{
-							Attempts:      pointerOf(1),
-							Interval:      pointerOf(24 * time.Hour),
-							DelayFunction: pointerOf("constant"),
-							Delay:         pointerOf(5 * time.Second),
-							MaxDelay:      pointerOf(time.Duration(0)),
-							Unlimited:     pointerOf(false),
+							Attempts:      new(1),
+							Interval:      new(24 * time.Hour),
+							DelayFunction: new("constant"),
+							Delay:         new(5 * time.Second),
+							MaxDelay:      new(time.Duration(0)),
+							Unlimited:     new(false),
 						},
 						Tasks: []*Task{
 							{
-								KillTimeout:   pointerOf(5 * time.Second),
+								KillTimeout:   new(5 * time.Second),
 								LogConfig:     DefaultLogConfig(),
 								Resources:     DefaultResources(),
 								RestartPolicy: defaultBatchJobRestartPolicy(),
@@ -540,13 +540,13 @@ func TestJobs_Canonicalize(t *testing.T) {
 		{
 			name: "partial",
 			input: &Job{
-				Name:      pointerOf("foo"),
-				Namespace: pointerOf("bar"),
-				ID:        pointerOf("bar"),
-				ParentID:  pointerOf("lol"),
+				Name:      new("foo"),
+				Namespace: new("bar"),
+				ID:        new("bar"),
+				ParentID:  new("lol"),
 				TaskGroups: []*TaskGroup{
 					{
-						Name: pointerOf("bar"),
+						Name: new("bar"),
 						Tasks: []*Task{
 							{
 								Name: "task1",
@@ -556,71 +556,71 @@ func TestJobs_Canonicalize(t *testing.T) {
 				},
 			},
 			expected: &Job{
-				Namespace:         pointerOf("bar"),
-				ID:                pointerOf("bar"),
-				Name:              pointerOf("foo"),
-				Region:            pointerOf("global"),
-				Type:              pointerOf("service"),
-				ParentID:          pointerOf("lol"),
-				Priority:          pointerOf(JobDefaultPriority),
-				NodePool:          pointerOf(""),
-				AllAtOnce:         pointerOf(false),
-				ConsulNamespace:   pointerOf(""),
-				VaultNamespace:    pointerOf(""),
-				NomadTokenID:      pointerOf(""),
-				Stop:              pointerOf(false),
-				Stable:            pointerOf(false),
-				Version:           pointerOf(uint64(0)),
-				Status:            pointerOf(""),
-				StatusDescription: pointerOf(""),
-				CreateIndex:       pointerOf(uint64(0)),
-				ModifyIndex:       pointerOf(uint64(0)),
-				JobModifyIndex:    pointerOf(uint64(0)),
+				Namespace:         new("bar"),
+				ID:                new("bar"),
+				Name:              new("foo"),
+				Region:            new("global"),
+				Type:              new("service"),
+				ParentID:          new("lol"),
+				Priority:          new(JobDefaultPriority),
+				NodePool:          new(""),
+				AllAtOnce:         new(false),
+				ConsulNamespace:   new(""),
+				VaultNamespace:    new(""),
+				NomadTokenID:      new(""),
+				Stop:              new(false),
+				Stable:            new(false),
+				Version:           new(uint64(0)),
+				Status:            new(""),
+				StatusDescription: new(""),
+				CreateIndex:       new(uint64(0)),
+				ModifyIndex:       new(uint64(0)),
+				JobModifyIndex:    new(uint64(0)),
 				Update: &UpdateStrategy{
-					Stagger:          pointerOf(30 * time.Second),
-					MaxParallel:      pointerOf(1),
-					HealthCheck:      pointerOf("checks"),
-					MinHealthyTime:   pointerOf(10 * time.Second),
-					HealthyDeadline:  pointerOf(5 * time.Minute),
-					ProgressDeadline: pointerOf(10 * time.Minute),
-					AutoRevert:       pointerOf(false),
-					Canary:           pointerOf(0),
-					AutoPromote:      pointerOf(false),
+					Stagger:          new(30 * time.Second),
+					MaxParallel:      new(1),
+					HealthCheck:      new("checks"),
+					MinHealthyTime:   new(10 * time.Second),
+					HealthyDeadline:  new(5 * time.Minute),
+					ProgressDeadline: new(10 * time.Minute),
+					AutoRevert:       new(false),
+					Canary:           new(0),
+					AutoPromote:      new(false),
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf("bar"),
-						Count: pointerOf(1),
+						Name:  new("bar"),
+						Count: new(1),
 						EphemeralDisk: &EphemeralDisk{
-							Sticky:  pointerOf(false),
-							Migrate: pointerOf(false),
-							SizeMB:  pointerOf(300),
+							Sticky:  new(false),
+							Migrate: new(false),
+							SizeMB:  new(300),
 						},
 						RestartPolicy: &RestartPolicy{
-							Delay:           pointerOf(15 * time.Second),
-							Attempts:        pointerOf(2),
-							Interval:        pointerOf(30 * time.Minute),
-							Mode:            pointerOf("fail"),
-							RenderTemplates: pointerOf(false),
+							Delay:           new(15 * time.Second),
+							Attempts:        new(2),
+							Interval:        new(30 * time.Minute),
+							Mode:            new("fail"),
+							RenderTemplates: new(false),
 						},
 						ReschedulePolicy: &ReschedulePolicy{
-							Attempts:      pointerOf(0),
-							Interval:      pointerOf(time.Duration(0)),
-							DelayFunction: pointerOf("exponential"),
-							Delay:         pointerOf(30 * time.Second),
-							MaxDelay:      pointerOf(1 * time.Hour),
-							Unlimited:     pointerOf(true),
+							Attempts:      new(0),
+							Interval:      new(time.Duration(0)),
+							DelayFunction: new("exponential"),
+							Delay:         new(30 * time.Second),
+							MaxDelay:      new(1 * time.Hour),
+							Unlimited:     new(true),
 						},
 						Update: &UpdateStrategy{
-							Stagger:          pointerOf(30 * time.Second),
-							MaxParallel:      pointerOf(1),
-							HealthCheck:      pointerOf("checks"),
-							MinHealthyTime:   pointerOf(10 * time.Second),
-							HealthyDeadline:  pointerOf(5 * time.Minute),
-							ProgressDeadline: pointerOf(10 * time.Minute),
-							AutoRevert:       pointerOf(false),
-							Canary:           pointerOf(0),
-							AutoPromote:      pointerOf(false),
+							Stagger:          new(30 * time.Second),
+							MaxParallel:      new(1),
+							HealthCheck:      new("checks"),
+							MinHealthyTime:   new(10 * time.Second),
+							HealthyDeadline:  new(5 * time.Minute),
+							ProgressDeadline: new(10 * time.Minute),
+							AutoRevert:       new(false),
+							Canary:           new(0),
+							AutoPromote:      new(false),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{
@@ -628,7 +628,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 								Name:          "task1",
 								LogConfig:     DefaultLogConfig(),
 								Resources:     DefaultResources(),
-								KillTimeout:   pointerOf(5 * time.Second),
+								KillTimeout:   new(5 * time.Second),
 								RestartPolicy: defaultServiceJobRestartPolicy(),
 							},
 						},
@@ -639,29 +639,29 @@ func TestJobs_Canonicalize(t *testing.T) {
 		{
 			name: "example_template",
 			input: &Job{
-				ID:          pointerOf("example_template"),
-				Name:        pointerOf("example_template"),
+				ID:          new("example_template"),
+				Name:        new("example_template"),
 				Datacenters: []string{"dc1"},
-				Type:        pointerOf("service"),
+				Type:        new("service"),
 				Update: &UpdateStrategy{
-					MaxParallel: pointerOf(1),
-					AutoPromote: pointerOf(true),
+					MaxParallel: new(1),
+					AutoPromote: new(true),
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf("cache"),
-						Count: pointerOf(1),
+						Name:  new("cache"),
+						Count: new(1),
 						RestartPolicy: &RestartPolicy{
-							Interval: pointerOf(5 * time.Minute),
-							Attempts: pointerOf(10),
-							Delay:    pointerOf(25 * time.Second),
-							Mode:     pointerOf("delay"),
+							Interval: new(5 * time.Minute),
+							Attempts: new(10),
+							Delay:    new(25 * time.Second),
+							Mode:     new("delay"),
 						},
 						Update: &UpdateStrategy{
-							AutoRevert: pointerOf(true),
+							AutoRevert: new(true),
 						},
 						EphemeralDisk: &EphemeralDisk{
-							SizeMB: pointerOf(300),
+							SizeMB: new(300),
 						},
 						Tasks: []*Task{
 							{
@@ -675,14 +675,14 @@ func TestJobs_Canonicalize(t *testing.T) {
 								},
 								RestartPolicy: &RestartPolicy{
 									// inherit other values from TG
-									Attempts: pointerOf(20),
+									Attempts: new(20),
 								},
 								Resources: &Resources{
-									CPU:      pointerOf(500),
-									MemoryMB: pointerOf(256),
+									CPU:      new(500),
+									MemoryMB: new(256),
 									Networks: []*NetworkResource{
 										{
-											MBits: pointerOf(10),
+											MBits: new(10),
 											DynamicPorts: []Port{
 												{
 													Label: "db",
@@ -709,13 +709,13 @@ func TestJobs_Canonicalize(t *testing.T) {
 								},
 								Templates: []*Template{
 									{
-										EmbeddedTmpl: pointerOf("---"),
-										DestPath:     pointerOf("local/file.yml"),
+										EmbeddedTmpl: new("---"),
+										DestPath:     new("local/file.yml"),
 									},
 									{
-										EmbeddedTmpl: pointerOf("FOO=bar\n"),
-										DestPath:     pointerOf("local/file.env"),
-										Envvars:      pointerOf(true),
+										EmbeddedTmpl: new("FOO=bar\n"),
+										DestPath:     new("local/file.env"),
+										Envvars:      new(true),
 									},
 								},
 							},
@@ -724,72 +724,72 @@ func TestJobs_Canonicalize(t *testing.T) {
 				},
 			},
 			expected: &Job{
-				Namespace:         pointerOf(DefaultNamespace),
-				ID:                pointerOf("example_template"),
-				Name:              pointerOf("example_template"),
-				ParentID:          pointerOf(""),
-				Priority:          pointerOf(JobDefaultPriority),
-				NodePool:          pointerOf(""),
-				Region:            pointerOf("global"),
-				Type:              pointerOf("service"),
-				AllAtOnce:         pointerOf(false),
-				ConsulNamespace:   pointerOf(""),
-				VaultNamespace:    pointerOf(""),
-				NomadTokenID:      pointerOf(""),
-				Stop:              pointerOf(false),
-				Stable:            pointerOf(false),
-				Version:           pointerOf(uint64(0)),
-				Status:            pointerOf(""),
-				StatusDescription: pointerOf(""),
-				CreateIndex:       pointerOf(uint64(0)),
-				ModifyIndex:       pointerOf(uint64(0)),
-				JobModifyIndex:    pointerOf(uint64(0)),
+				Namespace:         new(DefaultNamespace),
+				ID:                new("example_template"),
+				Name:              new("example_template"),
+				ParentID:          new(""),
+				Priority:          new(JobDefaultPriority),
+				NodePool:          new(""),
+				Region:            new("global"),
+				Type:              new("service"),
+				AllAtOnce:         new(false),
+				ConsulNamespace:   new(""),
+				VaultNamespace:    new(""),
+				NomadTokenID:      new(""),
+				Stop:              new(false),
+				Stable:            new(false),
+				Version:           new(uint64(0)),
+				Status:            new(""),
+				StatusDescription: new(""),
+				CreateIndex:       new(uint64(0)),
+				ModifyIndex:       new(uint64(0)),
+				JobModifyIndex:    new(uint64(0)),
 				Datacenters:       []string{"dc1"},
 				Update: &UpdateStrategy{
-					Stagger:          pointerOf(30 * time.Second),
-					MaxParallel:      pointerOf(1),
-					HealthCheck:      pointerOf("checks"),
-					MinHealthyTime:   pointerOf(10 * time.Second),
-					HealthyDeadline:  pointerOf(5 * time.Minute),
-					ProgressDeadline: pointerOf(10 * time.Minute),
-					AutoRevert:       pointerOf(false),
-					Canary:           pointerOf(0),
-					AutoPromote:      pointerOf(true),
+					Stagger:          new(30 * time.Second),
+					MaxParallel:      new(1),
+					HealthCheck:      new("checks"),
+					MinHealthyTime:   new(10 * time.Second),
+					HealthyDeadline:  new(5 * time.Minute),
+					ProgressDeadline: new(10 * time.Minute),
+					AutoRevert:       new(false),
+					Canary:           new(0),
+					AutoPromote:      new(true),
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf("cache"),
-						Count: pointerOf(1),
+						Name:  new("cache"),
+						Count: new(1),
 						RestartPolicy: &RestartPolicy{
-							Interval:        pointerOf(5 * time.Minute),
-							Attempts:        pointerOf(10),
-							Delay:           pointerOf(25 * time.Second),
-							Mode:            pointerOf("delay"),
-							RenderTemplates: pointerOf(false),
+							Interval:        new(5 * time.Minute),
+							Attempts:        new(10),
+							Delay:           new(25 * time.Second),
+							Mode:            new("delay"),
+							RenderTemplates: new(false),
 						},
 						ReschedulePolicy: &ReschedulePolicy{
-							Attempts:      pointerOf(0),
-							Interval:      pointerOf(time.Duration(0)),
-							DelayFunction: pointerOf("exponential"),
-							Delay:         pointerOf(30 * time.Second),
-							MaxDelay:      pointerOf(1 * time.Hour),
-							Unlimited:     pointerOf(true),
+							Attempts:      new(0),
+							Interval:      new(time.Duration(0)),
+							DelayFunction: new("exponential"),
+							Delay:         new(30 * time.Second),
+							MaxDelay:      new(1 * time.Hour),
+							Unlimited:     new(true),
 						},
 						EphemeralDisk: &EphemeralDisk{
-							Sticky:  pointerOf(false),
-							Migrate: pointerOf(false),
-							SizeMB:  pointerOf(300),
+							Sticky:  new(false),
+							Migrate: new(false),
+							SizeMB:  new(300),
 						},
 						Update: &UpdateStrategy{
-							Stagger:          pointerOf(30 * time.Second),
-							MaxParallel:      pointerOf(1),
-							HealthCheck:      pointerOf("checks"),
-							MinHealthyTime:   pointerOf(10 * time.Second),
-							HealthyDeadline:  pointerOf(5 * time.Minute),
-							ProgressDeadline: pointerOf(10 * time.Minute),
-							AutoRevert:       pointerOf(true),
-							Canary:           pointerOf(0),
-							AutoPromote:      pointerOf(true),
+							Stagger:          new(30 * time.Second),
+							MaxParallel:      new(1),
+							HealthCheck:      new("checks"),
+							MinHealthyTime:   new(10 * time.Second),
+							HealthyDeadline:  new(5 * time.Minute),
+							ProgressDeadline: new(10 * time.Minute),
+							AutoRevert:       new(true),
+							Canary:           new(0),
+							AutoPromote:      new(true),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{
@@ -803,19 +803,19 @@ func TestJobs_Canonicalize(t *testing.T) {
 									}},
 								},
 								RestartPolicy: &RestartPolicy{
-									Interval:        pointerOf(5 * time.Minute),
-									Attempts:        pointerOf(20),
-									Delay:           pointerOf(25 * time.Second),
-									Mode:            pointerOf("delay"),
-									RenderTemplates: pointerOf(false),
+									Interval:        new(5 * time.Minute),
+									Attempts:        new(20),
+									Delay:           new(25 * time.Second),
+									Mode:            new("delay"),
+									RenderTemplates: new(false),
 								},
 								Resources: &Resources{
-									CPU:      pointerOf(500),
-									Cores:    pointerOf(0),
-									MemoryMB: pointerOf(256),
+									CPU:      new(500),
+									Cores:    new(0),
+									MemoryMB: new(256),
 									Networks: []*NetworkResource{
 										{
-											MBits: pointerOf(10),
+											MBits: new(10),
 											DynamicPorts: []Port{
 												{
 													Label: "db",
@@ -845,38 +845,38 @@ func TestJobs_Canonicalize(t *testing.T) {
 										},
 									},
 								},
-								KillTimeout: pointerOf(5 * time.Second),
+								KillTimeout: new(5 * time.Second),
 								LogConfig:   DefaultLogConfig(),
 								Templates: []*Template{
 									{
-										SourcePath:    pointerOf(""),
-										DestPath:      pointerOf("local/file.yml"),
-										EmbeddedTmpl:  pointerOf("---"),
-										ChangeMode:    pointerOf("restart"),
-										ChangeSignal:  pointerOf(""),
-										Splay:         pointerOf(5 * time.Second),
-										Perms:         pointerOf("0644"),
-										LeftDelim:     pointerOf("{{"),
-										RightDelim:    pointerOf("}}"),
-										Envvars:       pointerOf(false),
-										VaultGrace:    pointerOf(time.Duration(0)),
-										ErrMissingKey: pointerOf(false),
-										Once:          pointerOf(false),
+										SourcePath:    new(""),
+										DestPath:      new("local/file.yml"),
+										EmbeddedTmpl:  new("---"),
+										ChangeMode:    new("restart"),
+										ChangeSignal:  new(""),
+										Splay:         new(5 * time.Second),
+										Perms:         new("0644"),
+										LeftDelim:     new("{{"),
+										RightDelim:    new("}}"),
+										Envvars:       new(false),
+										VaultGrace:    new(time.Duration(0)),
+										ErrMissingKey: new(false),
+										Once:          new(false),
 									},
 									{
-										SourcePath:    pointerOf(""),
-										DestPath:      pointerOf("local/file.env"),
-										EmbeddedTmpl:  pointerOf("FOO=bar\n"),
-										ChangeMode:    pointerOf("restart"),
-										ChangeSignal:  pointerOf(""),
-										Splay:         pointerOf(5 * time.Second),
-										Perms:         pointerOf("0644"),
-										LeftDelim:     pointerOf("{{"),
-										RightDelim:    pointerOf("}}"),
-										Envvars:       pointerOf(true),
-										VaultGrace:    pointerOf(time.Duration(0)),
-										ErrMissingKey: pointerOf(false),
-										Once:          pointerOf(false),
+										SourcePath:    new(""),
+										DestPath:      new("local/file.env"),
+										EmbeddedTmpl:  new("FOO=bar\n"),
+										ChangeMode:    new("restart"),
+										ChangeSignal:  new(""),
+										Splay:         new(5 * time.Second),
+										Perms:         new("0644"),
+										LeftDelim:     new("{{"),
+										RightDelim:    new("}}"),
+										Envvars:       new(true),
+										VaultGrace:    new(time.Duration(0)),
+										ErrMissingKey: new(false),
+										Once:          new(false),
 									},
 								},
 							},
@@ -888,82 +888,82 @@ func TestJobs_Canonicalize(t *testing.T) {
 		{
 			name: "periodic",
 			input: &Job{
-				ID:       pointerOf("bar"),
+				ID:       new("bar"),
 				Periodic: &PeriodicConfig{},
 			},
 			expected: &Job{
-				Namespace:         pointerOf(DefaultNamespace),
-				ID:                pointerOf("bar"),
-				ParentID:          pointerOf(""),
-				Name:              pointerOf("bar"),
-				Region:            pointerOf("global"),
-				Type:              pointerOf("service"),
-				Priority:          pointerOf(JobDefaultPriority),
-				NodePool:          pointerOf(""),
-				AllAtOnce:         pointerOf(false),
-				ConsulNamespace:   pointerOf(""),
-				VaultNamespace:    pointerOf(""),
-				NomadTokenID:      pointerOf(""),
-				Stop:              pointerOf(false),
-				Stable:            pointerOf(false),
-				Version:           pointerOf(uint64(0)),
-				Status:            pointerOf(""),
-				StatusDescription: pointerOf(""),
-				CreateIndex:       pointerOf(uint64(0)),
-				ModifyIndex:       pointerOf(uint64(0)),
-				JobModifyIndex:    pointerOf(uint64(0)),
+				Namespace:         new(DefaultNamespace),
+				ID:                new("bar"),
+				ParentID:          new(""),
+				Name:              new("bar"),
+				Region:            new("global"),
+				Type:              new("service"),
+				Priority:          new(JobDefaultPriority),
+				NodePool:          new(""),
+				AllAtOnce:         new(false),
+				ConsulNamespace:   new(""),
+				VaultNamespace:    new(""),
+				NomadTokenID:      new(""),
+				Stop:              new(false),
+				Stable:            new(false),
+				Version:           new(uint64(0)),
+				Status:            new(""),
+				StatusDescription: new(""),
+				CreateIndex:       new(uint64(0)),
+				ModifyIndex:       new(uint64(0)),
+				JobModifyIndex:    new(uint64(0)),
 				Update: &UpdateStrategy{
-					Stagger:          pointerOf(30 * time.Second),
-					MaxParallel:      pointerOf(1),
-					HealthCheck:      pointerOf("checks"),
-					MinHealthyTime:   pointerOf(10 * time.Second),
-					HealthyDeadline:  pointerOf(5 * time.Minute),
-					ProgressDeadline: pointerOf(10 * time.Minute),
-					AutoRevert:       pointerOf(false),
-					Canary:           pointerOf(0),
-					AutoPromote:      pointerOf(false),
+					Stagger:          new(30 * time.Second),
+					MaxParallel:      new(1),
+					HealthCheck:      new("checks"),
+					MinHealthyTime:   new(10 * time.Second),
+					HealthyDeadline:  new(5 * time.Minute),
+					ProgressDeadline: new(10 * time.Minute),
+					AutoRevert:       new(false),
+					Canary:           new(0),
+					AutoPromote:      new(false),
 				},
 				Periodic: &PeriodicConfig{
-					Enabled:         pointerOf(true),
-					Spec:            pointerOf(""),
+					Enabled:         new(true),
+					Spec:            new(""),
 					Specs:           []string{},
-					SpecType:        pointerOf(PeriodicSpecCron),
-					ProhibitOverlap: pointerOf(false),
-					TimeZone:        pointerOf("UTC"),
+					SpecType:        new(PeriodicSpecCron),
+					ProhibitOverlap: new(false),
+					TimeZone:        new("UTC"),
 				},
 			},
 		},
 		{
 			name: "update_merge",
 			input: &Job{
-				Name:     pointerOf("foo"),
-				ID:       pointerOf("bar"),
-				ParentID: pointerOf("lol"),
+				Name:     new("foo"),
+				ID:       new("bar"),
+				ParentID: new("lol"),
 				Update: &UpdateStrategy{
-					Stagger:          pointerOf(1 * time.Second),
-					MaxParallel:      pointerOf(1),
-					HealthCheck:      pointerOf("checks"),
-					MinHealthyTime:   pointerOf(10 * time.Second),
-					HealthyDeadline:  pointerOf(6 * time.Minute),
-					ProgressDeadline: pointerOf(7 * time.Minute),
-					AutoRevert:       pointerOf(false),
-					Canary:           pointerOf(0),
-					AutoPromote:      pointerOf(false),
+					Stagger:          new(1 * time.Second),
+					MaxParallel:      new(1),
+					HealthCheck:      new("checks"),
+					MinHealthyTime:   new(10 * time.Second),
+					HealthyDeadline:  new(6 * time.Minute),
+					ProgressDeadline: new(7 * time.Minute),
+					AutoRevert:       new(false),
+					Canary:           new(0),
+					AutoPromote:      new(false),
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name: pointerOf("bar"),
+						Name: new("bar"),
 						Consul: &Consul{
 							Namespace: "",
 						},
 						Update: &UpdateStrategy{
-							Stagger:        pointerOf(2 * time.Second),
-							MaxParallel:    pointerOf(2),
-							HealthCheck:    pointerOf("manual"),
-							MinHealthyTime: pointerOf(1 * time.Second),
-							AutoRevert:     pointerOf(true),
-							Canary:         pointerOf(1),
-							AutoPromote:    pointerOf(true),
+							Stagger:        new(2 * time.Second),
+							MaxParallel:    new(2),
+							HealthCheck:    new("manual"),
+							MinHealthyTime: new(1 * time.Second),
+							AutoRevert:     new(true),
+							Canary:         new(1),
+							AutoPromote:    new(true),
 						},
 						Tasks: []*Task{
 							{
@@ -972,7 +972,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 						},
 					},
 					{
-						Name: pointerOf("baz"),
+						Name: new("baz"),
 						Tasks: []*Task{
 							{
 								Name: "task1",
@@ -982,75 +982,75 @@ func TestJobs_Canonicalize(t *testing.T) {
 				},
 			},
 			expected: &Job{
-				Namespace:         pointerOf(DefaultNamespace),
-				ID:                pointerOf("bar"),
-				Name:              pointerOf("foo"),
-				Region:            pointerOf("global"),
-				Type:              pointerOf("service"),
-				ParentID:          pointerOf("lol"),
-				Priority:          pointerOf(JobDefaultPriority),
-				NodePool:          pointerOf(""),
-				AllAtOnce:         pointerOf(false),
-				ConsulNamespace:   pointerOf(""),
-				VaultNamespace:    pointerOf(""),
-				NomadTokenID:      pointerOf(""),
-				Stop:              pointerOf(false),
-				Stable:            pointerOf(false),
-				Version:           pointerOf(uint64(0)),
-				Status:            pointerOf(""),
-				StatusDescription: pointerOf(""),
-				CreateIndex:       pointerOf(uint64(0)),
-				ModifyIndex:       pointerOf(uint64(0)),
-				JobModifyIndex:    pointerOf(uint64(0)),
+				Namespace:         new(DefaultNamespace),
+				ID:                new("bar"),
+				Name:              new("foo"),
+				Region:            new("global"),
+				Type:              new("service"),
+				ParentID:          new("lol"),
+				Priority:          new(JobDefaultPriority),
+				NodePool:          new(""),
+				AllAtOnce:         new(false),
+				ConsulNamespace:   new(""),
+				VaultNamespace:    new(""),
+				NomadTokenID:      new(""),
+				Stop:              new(false),
+				Stable:            new(false),
+				Version:           new(uint64(0)),
+				Status:            new(""),
+				StatusDescription: new(""),
+				CreateIndex:       new(uint64(0)),
+				ModifyIndex:       new(uint64(0)),
+				JobModifyIndex:    new(uint64(0)),
 				Update: &UpdateStrategy{
-					Stagger:          pointerOf(1 * time.Second),
-					MaxParallel:      pointerOf(1),
-					HealthCheck:      pointerOf("checks"),
-					MinHealthyTime:   pointerOf(10 * time.Second),
-					HealthyDeadline:  pointerOf(6 * time.Minute),
-					ProgressDeadline: pointerOf(7 * time.Minute),
-					AutoRevert:       pointerOf(false),
-					Canary:           pointerOf(0),
-					AutoPromote:      pointerOf(false),
+					Stagger:          new(1 * time.Second),
+					MaxParallel:      new(1),
+					HealthCheck:      new("checks"),
+					MinHealthyTime:   new(10 * time.Second),
+					HealthyDeadline:  new(6 * time.Minute),
+					ProgressDeadline: new(7 * time.Minute),
+					AutoRevert:       new(false),
+					Canary:           new(0),
+					AutoPromote:      new(false),
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf("bar"),
-						Count: pointerOf(1),
+						Name:  new("bar"),
+						Count: new(1),
 						EphemeralDisk: &EphemeralDisk{
-							Sticky:  pointerOf(false),
-							Migrate: pointerOf(false),
-							SizeMB:  pointerOf(300),
+							Sticky:  new(false),
+							Migrate: new(false),
+							SizeMB:  new(300),
 						},
 						RestartPolicy: &RestartPolicy{
-							Delay:           pointerOf(15 * time.Second),
-							Attempts:        pointerOf(2),
-							Interval:        pointerOf(30 * time.Minute),
-							Mode:            pointerOf("fail"),
-							RenderTemplates: pointerOf(false),
+							Delay:           new(15 * time.Second),
+							Attempts:        new(2),
+							Interval:        new(30 * time.Minute),
+							Mode:            new("fail"),
+							RenderTemplates: new(false),
 						},
 						ReschedulePolicy: &ReschedulePolicy{
-							Attempts:      pointerOf(0),
-							Interval:      pointerOf(time.Duration(0)),
-							DelayFunction: pointerOf("exponential"),
-							Delay:         pointerOf(30 * time.Second),
-							MaxDelay:      pointerOf(1 * time.Hour),
-							Unlimited:     pointerOf(true),
+							Attempts:      new(0),
+							Interval:      new(time.Duration(0)),
+							DelayFunction: new("exponential"),
+							Delay:         new(30 * time.Second),
+							MaxDelay:      new(1 * time.Hour),
+							Unlimited:     new(true),
 						},
 						Consul: &Consul{
 							Namespace: "",
 							Cluster:   "default",
 						},
 						Update: &UpdateStrategy{
-							Stagger:          pointerOf(2 * time.Second),
-							MaxParallel:      pointerOf(2),
-							HealthCheck:      pointerOf("manual"),
-							MinHealthyTime:   pointerOf(1 * time.Second),
-							HealthyDeadline:  pointerOf(6 * time.Minute),
-							ProgressDeadline: pointerOf(7 * time.Minute),
-							AutoRevert:       pointerOf(true),
-							Canary:           pointerOf(1),
-							AutoPromote:      pointerOf(true),
+							Stagger:          new(2 * time.Second),
+							MaxParallel:      new(2),
+							HealthCheck:      new("manual"),
+							MinHealthyTime:   new(1 * time.Second),
+							HealthyDeadline:  new(6 * time.Minute),
+							ProgressDeadline: new(7 * time.Minute),
+							AutoRevert:       new(true),
+							Canary:           new(1),
+							AutoPromote:      new(true),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{
@@ -1058,44 +1058,44 @@ func TestJobs_Canonicalize(t *testing.T) {
 								Name:          "task1",
 								LogConfig:     DefaultLogConfig(),
 								Resources:     DefaultResources(),
-								KillTimeout:   pointerOf(5 * time.Second),
+								KillTimeout:   new(5 * time.Second),
 								RestartPolicy: defaultServiceJobRestartPolicy(),
 							},
 						},
 					},
 					{
-						Name:  pointerOf("baz"),
-						Count: pointerOf(1),
+						Name:  new("baz"),
+						Count: new(1),
 						EphemeralDisk: &EphemeralDisk{
-							Sticky:  pointerOf(false),
-							Migrate: pointerOf(false),
-							SizeMB:  pointerOf(300),
+							Sticky:  new(false),
+							Migrate: new(false),
+							SizeMB:  new(300),
 						},
 						RestartPolicy: &RestartPolicy{
-							Delay:           pointerOf(15 * time.Second),
-							Attempts:        pointerOf(2),
-							Interval:        pointerOf(30 * time.Minute),
-							Mode:            pointerOf("fail"),
-							RenderTemplates: pointerOf(false),
+							Delay:           new(15 * time.Second),
+							Attempts:        new(2),
+							Interval:        new(30 * time.Minute),
+							Mode:            new("fail"),
+							RenderTemplates: new(false),
 						},
 						ReschedulePolicy: &ReschedulePolicy{
-							Attempts:      pointerOf(0),
-							Interval:      pointerOf(time.Duration(0)),
-							DelayFunction: pointerOf("exponential"),
-							Delay:         pointerOf(30 * time.Second),
-							MaxDelay:      pointerOf(1 * time.Hour),
-							Unlimited:     pointerOf(true),
+							Attempts:      new(0),
+							Interval:      new(time.Duration(0)),
+							DelayFunction: new("exponential"),
+							Delay:         new(30 * time.Second),
+							MaxDelay:      new(1 * time.Hour),
+							Unlimited:     new(true),
 						},
 						Update: &UpdateStrategy{
-							Stagger:          pointerOf(1 * time.Second),
-							MaxParallel:      pointerOf(1),
-							HealthCheck:      pointerOf("checks"),
-							MinHealthyTime:   pointerOf(10 * time.Second),
-							HealthyDeadline:  pointerOf(6 * time.Minute),
-							ProgressDeadline: pointerOf(7 * time.Minute),
-							AutoRevert:       pointerOf(false),
-							Canary:           pointerOf(0),
-							AutoPromote:      pointerOf(false),
+							Stagger:          new(1 * time.Second),
+							MaxParallel:      new(1),
+							HealthCheck:      new("checks"),
+							MinHealthyTime:   new(10 * time.Second),
+							HealthyDeadline:  new(6 * time.Minute),
+							ProgressDeadline: new(7 * time.Minute),
+							AutoRevert:       new(false),
+							Canary:           new(0),
+							AutoPromote:      new(false),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{
@@ -1103,7 +1103,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 								Name:          "task1",
 								LogConfig:     DefaultLogConfig(),
 								Resources:     DefaultResources(),
-								KillTimeout:   pointerOf(5 * time.Second),
+								KillTimeout:   new(5 * time.Second),
 								RestartPolicy: defaultServiceJobRestartPolicy(),
 							},
 						},
@@ -1114,13 +1114,13 @@ func TestJobs_Canonicalize(t *testing.T) {
 		{
 			name: "missing update for system job",
 			input: &Job{
-				Name:     pointerOf("foo"),
-				ID:       pointerOf("bar"),
-				ParentID: pointerOf("lol"),
-				Type:     pointerOf(JobTypeSystem),
+				Name:     new("foo"),
+				ID:       new("bar"),
+				ParentID: new("lol"),
+				Type:     new(JobTypeSystem),
 				TaskGroups: []*TaskGroup{
 					{
-						Name: pointerOf("bar"),
+						Name: new("bar"),
 						Tasks: []*Task{
 							{
 								Name: "task1",
@@ -1130,36 +1130,36 @@ func TestJobs_Canonicalize(t *testing.T) {
 				},
 			},
 			expected: &Job{
-				Namespace:         pointerOf(DefaultNamespace),
-				ID:                pointerOf("bar"),
-				ParentID:          pointerOf("lol"),
-				Name:              pointerOf("foo"),
-				Region:            pointerOf("global"),
-				Type:              pointerOf(JobTypeSystem),
-				Priority:          pointerOf(JobDefaultPriority),
-				NodePool:          pointerOf(""),
-				AllAtOnce:         pointerOf(false),
-				ConsulNamespace:   pointerOf(""),
-				VaultNamespace:    pointerOf(""),
-				NomadTokenID:      pointerOf(""),
-				Stop:              pointerOf(false),
-				Stable:            pointerOf(false),
-				Version:           pointerOf(uint64(0)),
-				Status:            pointerOf(""),
-				StatusDescription: pointerOf(""),
-				CreateIndex:       pointerOf(uint64(0)),
-				ModifyIndex:       pointerOf(uint64(0)),
-				JobModifyIndex:    pointerOf(uint64(0)),
+				Namespace:         new(DefaultNamespace),
+				ID:                new("bar"),
+				ParentID:          new("lol"),
+				Name:              new("foo"),
+				Region:            new("global"),
+				Type:              new(JobTypeSystem),
+				Priority:          new(JobDefaultPriority),
+				NodePool:          new(""),
+				AllAtOnce:         new(false),
+				ConsulNamespace:   new(""),
+				VaultNamespace:    new(""),
+				NomadTokenID:      new(""),
+				Stop:              new(false),
+				Stable:            new(false),
+				Version:           new(uint64(0)),
+				Status:            new(""),
+				StatusDescription: new(""),
+				CreateIndex:       new(uint64(0)),
+				ModifyIndex:       new(uint64(0)),
+				JobModifyIndex:    new(uint64(0)),
 				Update:            DefaultUpdateStrategy(),
 				TaskGroups: []*TaskGroup{
 					{
-						Name:          pointerOf("bar"),
-						Count:         pointerOf(1),
+						Name:          new("bar"),
+						Count:         new(1),
 						RestartPolicy: defaultServiceJobRestartPolicy(),
 						EphemeralDisk: &EphemeralDisk{
-							Sticky:  pointerOf(false),
-							Migrate: pointerOf(false),
-							SizeMB:  pointerOf(300),
+							Sticky:  new(false),
+							Migrate: new(false),
+							SizeMB:  new(300),
 						},
 						Update: DefaultUpdateStrategy(),
 						Tasks: []*Task{
@@ -1167,7 +1167,7 @@ func TestJobs_Canonicalize(t *testing.T) {
 								Name:          "task1",
 								LogConfig:     DefaultLogConfig(),
 								Resources:     DefaultResources(),
-								KillTimeout:   pointerOf(5 * time.Second),
+								KillTimeout:   new(5 * time.Second),
 								RestartPolicy: defaultServiceJobRestartPolicy(),
 							},
 						},
@@ -1178,36 +1178,36 @@ func TestJobs_Canonicalize(t *testing.T) {
 		{
 			name: "restart_merge",
 			input: &Job{
-				Name:     pointerOf("foo"),
-				ID:       pointerOf("bar"),
-				ParentID: pointerOf("lol"),
+				Name:     new("foo"),
+				ID:       new("bar"),
+				ParentID: new("lol"),
 				TaskGroups: []*TaskGroup{
 					{
-						Name: pointerOf("bar"),
+						Name: new("bar"),
 						RestartPolicy: &RestartPolicy{
-							Delay:    pointerOf(15 * time.Second),
-							Attempts: pointerOf(2),
-							Interval: pointerOf(30 * time.Minute),
-							Mode:     pointerOf("fail"),
+							Delay:    new(15 * time.Second),
+							Attempts: new(2),
+							Interval: new(30 * time.Minute),
+							Mode:     new("fail"),
 						},
 						Tasks: []*Task{
 							{
 								Name: "task1",
 								RestartPolicy: &RestartPolicy{
-									Attempts:        pointerOf(5),
-									Delay:           pointerOf(1 * time.Second),
-									RenderTemplates: pointerOf(true),
+									Attempts:        new(5),
+									Delay:           new(1 * time.Second),
+									RenderTemplates: new(true),
 								},
 							},
 						},
 					},
 					{
-						Name: pointerOf("baz"),
+						Name: new("baz"),
 						RestartPolicy: &RestartPolicy{
-							Delay:    pointerOf(20 * time.Second),
-							Attempts: pointerOf(2),
-							Interval: pointerOf(30 * time.Minute),
-							Mode:     pointerOf("fail"),
+							Delay:    new(20 * time.Second),
+							Attempts: new(2),
+							Interval: new(30 * time.Minute),
+							Mode:     new("fail"),
 						},
 						Consul: &Consul{
 							Namespace: "",
@@ -1221,71 +1221,71 @@ func TestJobs_Canonicalize(t *testing.T) {
 				},
 			},
 			expected: &Job{
-				Namespace:         pointerOf(DefaultNamespace),
-				ID:                pointerOf("bar"),
-				Name:              pointerOf("foo"),
-				Region:            pointerOf("global"),
-				Type:              pointerOf("service"),
-				ParentID:          pointerOf("lol"),
-				NodePool:          pointerOf(""),
-				Priority:          pointerOf(JobDefaultPriority),
-				AllAtOnce:         pointerOf(false),
-				ConsulNamespace:   pointerOf(""),
-				VaultNamespace:    pointerOf(""),
-				NomadTokenID:      pointerOf(""),
-				Stop:              pointerOf(false),
-				Stable:            pointerOf(false),
-				Version:           pointerOf(uint64(0)),
-				Status:            pointerOf(""),
-				StatusDescription: pointerOf(""),
-				CreateIndex:       pointerOf(uint64(0)),
-				ModifyIndex:       pointerOf(uint64(0)),
-				JobModifyIndex:    pointerOf(uint64(0)),
+				Namespace:         new(DefaultNamespace),
+				ID:                new("bar"),
+				Name:              new("foo"),
+				Region:            new("global"),
+				Type:              new("service"),
+				ParentID:          new("lol"),
+				NodePool:          new(""),
+				Priority:          new(JobDefaultPriority),
+				AllAtOnce:         new(false),
+				ConsulNamespace:   new(""),
+				VaultNamespace:    new(""),
+				NomadTokenID:      new(""),
+				Stop:              new(false),
+				Stable:            new(false),
+				Version:           new(uint64(0)),
+				Status:            new(""),
+				StatusDescription: new(""),
+				CreateIndex:       new(uint64(0)),
+				ModifyIndex:       new(uint64(0)),
+				JobModifyIndex:    new(uint64(0)),
 				Update: &UpdateStrategy{
-					Stagger:          pointerOf(30 * time.Second),
-					MaxParallel:      pointerOf(1),
-					HealthCheck:      pointerOf("checks"),
-					MinHealthyTime:   pointerOf(10 * time.Second),
-					HealthyDeadline:  pointerOf(5 * time.Minute),
-					ProgressDeadline: pointerOf(10 * time.Minute),
-					AutoRevert:       pointerOf(false),
-					Canary:           pointerOf(0),
-					AutoPromote:      pointerOf(false),
+					Stagger:          new(30 * time.Second),
+					MaxParallel:      new(1),
+					HealthCheck:      new("checks"),
+					MinHealthyTime:   new(10 * time.Second),
+					HealthyDeadline:  new(5 * time.Minute),
+					ProgressDeadline: new(10 * time.Minute),
+					AutoRevert:       new(false),
+					Canary:           new(0),
+					AutoPromote:      new(false),
 				},
 				TaskGroups: []*TaskGroup{
 					{
-						Name:  pointerOf("bar"),
-						Count: pointerOf(1),
+						Name:  new("bar"),
+						Count: new(1),
 						EphemeralDisk: &EphemeralDisk{
-							Sticky:  pointerOf(false),
-							Migrate: pointerOf(false),
-							SizeMB:  pointerOf(300),
+							Sticky:  new(false),
+							Migrate: new(false),
+							SizeMB:  new(300),
 						},
 						RestartPolicy: &RestartPolicy{
-							Delay:           pointerOf(15 * time.Second),
-							Attempts:        pointerOf(2),
-							Interval:        pointerOf(30 * time.Minute),
-							Mode:            pointerOf("fail"),
-							RenderTemplates: pointerOf(false),
+							Delay:           new(15 * time.Second),
+							Attempts:        new(2),
+							Interval:        new(30 * time.Minute),
+							Mode:            new("fail"),
+							RenderTemplates: new(false),
 						},
 						ReschedulePolicy: &ReschedulePolicy{
-							Attempts:      pointerOf(0),
-							Interval:      pointerOf(time.Duration(0)),
-							DelayFunction: pointerOf("exponential"),
-							Delay:         pointerOf(30 * time.Second),
-							MaxDelay:      pointerOf(1 * time.Hour),
-							Unlimited:     pointerOf(true),
+							Attempts:      new(0),
+							Interval:      new(time.Duration(0)),
+							DelayFunction: new("exponential"),
+							Delay:         new(30 * time.Second),
+							MaxDelay:      new(1 * time.Hour),
+							Unlimited:     new(true),
 						},
 						Update: &UpdateStrategy{
-							Stagger:          pointerOf(30 * time.Second),
-							MaxParallel:      pointerOf(1),
-							HealthCheck:      pointerOf("checks"),
-							MinHealthyTime:   pointerOf(10 * time.Second),
-							HealthyDeadline:  pointerOf(5 * time.Minute),
-							ProgressDeadline: pointerOf(10 * time.Minute),
-							AutoRevert:       pointerOf(false),
-							Canary:           pointerOf(0),
-							AutoPromote:      pointerOf(false),
+							Stagger:          new(30 * time.Second),
+							MaxParallel:      new(1),
+							HealthCheck:      new("checks"),
+							MinHealthyTime:   new(10 * time.Second),
+							HealthyDeadline:  new(5 * time.Minute),
+							ProgressDeadline: new(10 * time.Minute),
+							AutoRevert:       new(false),
+							Canary:           new(0),
+							AutoPromote:      new(false),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{
@@ -1293,54 +1293,54 @@ func TestJobs_Canonicalize(t *testing.T) {
 								Name:        "task1",
 								LogConfig:   DefaultLogConfig(),
 								Resources:   DefaultResources(),
-								KillTimeout: pointerOf(5 * time.Second),
+								KillTimeout: new(5 * time.Second),
 								RestartPolicy: &RestartPolicy{
-									Attempts:        pointerOf(5),
-									Delay:           pointerOf(1 * time.Second),
-									Interval:        pointerOf(30 * time.Minute),
-									Mode:            pointerOf("fail"),
-									RenderTemplates: pointerOf(true),
+									Attempts:        new(5),
+									Delay:           new(1 * time.Second),
+									Interval:        new(30 * time.Minute),
+									Mode:            new("fail"),
+									RenderTemplates: new(true),
 								},
 							},
 						},
 					},
 					{
-						Name:  pointerOf("baz"),
-						Count: pointerOf(1),
+						Name:  new("baz"),
+						Count: new(1),
 						EphemeralDisk: &EphemeralDisk{
-							Sticky:  pointerOf(false),
-							Migrate: pointerOf(false),
-							SizeMB:  pointerOf(300),
+							Sticky:  new(false),
+							Migrate: new(false),
+							SizeMB:  new(300),
 						},
 						RestartPolicy: &RestartPolicy{
-							Delay:           pointerOf(20 * time.Second),
-							Attempts:        pointerOf(2),
-							Interval:        pointerOf(30 * time.Minute),
-							Mode:            pointerOf("fail"),
-							RenderTemplates: pointerOf(false),
+							Delay:           new(20 * time.Second),
+							Attempts:        new(2),
+							Interval:        new(30 * time.Minute),
+							Mode:            new("fail"),
+							RenderTemplates: new(false),
 						},
 						ReschedulePolicy: &ReschedulePolicy{
-							Attempts:      pointerOf(0),
-							Interval:      pointerOf(time.Duration(0)),
-							DelayFunction: pointerOf("exponential"),
-							Delay:         pointerOf(30 * time.Second),
-							MaxDelay:      pointerOf(1 * time.Hour),
-							Unlimited:     pointerOf(true),
+							Attempts:      new(0),
+							Interval:      new(time.Duration(0)),
+							DelayFunction: new("exponential"),
+							Delay:         new(30 * time.Second),
+							MaxDelay:      new(1 * time.Hour),
+							Unlimited:     new(true),
 						},
 						Consul: &Consul{
 							Namespace: "",
 							Cluster:   "default",
 						},
 						Update: &UpdateStrategy{
-							Stagger:          pointerOf(30 * time.Second),
-							MaxParallel:      pointerOf(1),
-							HealthCheck:      pointerOf("checks"),
-							MinHealthyTime:   pointerOf(10 * time.Second),
-							HealthyDeadline:  pointerOf(5 * time.Minute),
-							ProgressDeadline: pointerOf(10 * time.Minute),
-							AutoRevert:       pointerOf(false),
-							Canary:           pointerOf(0),
-							AutoPromote:      pointerOf(false),
+							Stagger:          new(30 * time.Second),
+							MaxParallel:      new(1),
+							HealthCheck:      new("checks"),
+							MinHealthyTime:   new(10 * time.Second),
+							HealthyDeadline:  new(5 * time.Minute),
+							ProgressDeadline: new(10 * time.Minute),
+							AutoRevert:       new(false),
+							Canary:           new(0),
+							AutoPromote:      new(false),
 						},
 						Migrate: DefaultMigrateStrategy(),
 						Tasks: []*Task{
@@ -1348,13 +1348,13 @@ func TestJobs_Canonicalize(t *testing.T) {
 								Name:        "task1",
 								LogConfig:   DefaultLogConfig(),
 								Resources:   DefaultResources(),
-								KillTimeout: pointerOf(5 * time.Second),
+								KillTimeout: new(5 * time.Second),
 								RestartPolicy: &RestartPolicy{
-									Delay:           pointerOf(20 * time.Second),
-									Attempts:        pointerOf(2),
-									Interval:        pointerOf(30 * time.Minute),
-									Mode:            pointerOf("fail"),
-									RenderTemplates: pointerOf(false),
+									Delay:           new(20 * time.Second),
+									Attempts:        new(2),
+									Interval:        new(30 * time.Minute),
+									Mode:            new("fail"),
+									RenderTemplates: new(false),
 								},
 							},
 						},
@@ -1365,14 +1365,14 @@ func TestJobs_Canonicalize(t *testing.T) {
 		{
 			name: "multiregion",
 			input: &Job{
-				Name:     pointerOf("foo"),
-				ID:       pointerOf("bar"),
-				ParentID: pointerOf("lol"),
+				Name:     new("foo"),
+				ID:       new("bar"),
+				ParentID: new("lol"),
 				Multiregion: &Multiregion{
 					Regions: []*MultiregionRegion{
 						{
 							Name:  "west",
-							Count: pointerOf(1),
+							Count: new(1),
 						},
 					},
 				},
@@ -1380,48 +1380,48 @@ func TestJobs_Canonicalize(t *testing.T) {
 			expected: &Job{
 				Multiregion: &Multiregion{
 					Strategy: &MultiregionStrategy{
-						MaxParallel: pointerOf(0),
-						OnFailure:   pointerOf(""),
+						MaxParallel: new(0),
+						OnFailure:   new(""),
 					},
 					Regions: []*MultiregionRegion{
 						{
 							Name:        "west",
-							Count:       pointerOf(1),
+							Count:       new(1),
 							Datacenters: []string{},
 							Meta:        map[string]string{},
 						},
 					},
 				},
-				Namespace:         pointerOf(DefaultNamespace),
-				ID:                pointerOf("bar"),
-				Name:              pointerOf("foo"),
-				Region:            pointerOf("global"),
-				Type:              pointerOf("service"),
-				ParentID:          pointerOf("lol"),
-				Priority:          pointerOf(JobDefaultPriority),
-				NodePool:          pointerOf(""),
-				AllAtOnce:         pointerOf(false),
-				ConsulNamespace:   pointerOf(""),
-				VaultNamespace:    pointerOf(""),
-				NomadTokenID:      pointerOf(""),
-				Stop:              pointerOf(false),
-				Stable:            pointerOf(false),
-				Version:           pointerOf(uint64(0)),
-				Status:            pointerOf(""),
-				StatusDescription: pointerOf(""),
-				CreateIndex:       pointerOf(uint64(0)),
-				ModifyIndex:       pointerOf(uint64(0)),
-				JobModifyIndex:    pointerOf(uint64(0)),
+				Namespace:         new(DefaultNamespace),
+				ID:                new("bar"),
+				Name:              new("foo"),
+				Region:            new("global"),
+				Type:              new("service"),
+				ParentID:          new("lol"),
+				Priority:          new(JobDefaultPriority),
+				NodePool:          new(""),
+				AllAtOnce:         new(false),
+				ConsulNamespace:   new(""),
+				VaultNamespace:    new(""),
+				NomadTokenID:      new(""),
+				Stop:              new(false),
+				Stable:            new(false),
+				Version:           new(uint64(0)),
+				Status:            new(""),
+				StatusDescription: new(""),
+				CreateIndex:       new(uint64(0)),
+				ModifyIndex:       new(uint64(0)),
+				JobModifyIndex:    new(uint64(0)),
 				Update: &UpdateStrategy{
-					Stagger:          pointerOf(30 * time.Second),
-					MaxParallel:      pointerOf(1),
-					HealthCheck:      pointerOf("checks"),
-					MinHealthyTime:   pointerOf(10 * time.Second),
-					HealthyDeadline:  pointerOf(5 * time.Minute),
-					ProgressDeadline: pointerOf(10 * time.Minute),
-					AutoRevert:       pointerOf(false),
-					Canary:           pointerOf(0),
-					AutoPromote:      pointerOf(false),
+					Stagger:          new(30 * time.Second),
+					MaxParallel:      new(1),
+					HealthCheck:      new("checks"),
+					MinHealthyTime:   new(10 * time.Second),
+					HealthyDeadline:  new(5 * time.Minute),
+					ProgressDeadline: new(10 * time.Minute),
+					AutoRevert:       new(false),
+					Canary:           new(0),
+					AutoPromote:      new(false),
 				},
 			},
 		},
@@ -1500,11 +1500,11 @@ func TestJobs_Revert(t *testing.T) {
 	assertWriteMeta(t, wm)
 
 	// Fail revert at incorrect enforce
-	_, _, err = jobs.Revert(*job.ID, 0, pointerOf(uint64(10)), nil, "", "")
+	_, _, err = jobs.Revert(*job.ID, 0, new(uint64(10)), nil, "", "")
 	must.ErrorContains(t, err, "enforcing version")
 
 	// Works at correct index
-	revertResp, wm, err := jobs.Revert(*job.ID, 0, pointerOf(uint64(1)), nil, "", "")
+	revertResp, wm, err := jobs.Revert(*job.ID, 0, new(uint64(1)), nil, "", "")
 	must.NoError(t, err)
 	must.UUIDv4(t, revertResp.EvalID)
 	must.Positive(t, revertResp.EvalCreateIndex)
@@ -1567,13 +1567,13 @@ func TestJobs_ScaleInvalidAction(t *testing.T) {
 
 	// Register test job
 	job := testJob()
-	job.ID = pointerOf("TestJobs_Scale")
+	job.ID = new("TestJobs_Scale")
 	_, wm, err := jobs.Register(job, nil)
 	must.NoError(t, err)
 	assertWriteMeta(t, wm)
 
 	// Perform a scaling action with bad group name, verify error
-	_, _, err = jobs.Scale(*job.ID, "incorrect-group-name", pointerOf(2),
+	_, _, err = jobs.Scale(*job.ID, "incorrect-group-name", new(2),
 		"because", false, nil, nil)
 	must.ErrorContains(t, err, "does not exist")
 }
@@ -1683,7 +1683,7 @@ func TestJobs_Submission_versions(t *testing.T) {
 
 	job := testJob()
 	jobID := *job.ID                       // job1
-	job.TaskGroups[0].Count = pointerOf(0) // no need to actually run
+	job.TaskGroups[0].Count = new(0) // no need to actually run
 
 	// trying to retrieve a version before job is submitted returns a Not Found
 	_, _, nfErr := jobs.Submission(jobID, 0, nil)
@@ -1783,8 +1783,8 @@ func TestJobs_Submission_namespaces(t *testing.T) {
 	commonJobID := "common"
 
 	job := testJob()
-	job.ID = pointerOf(commonJobID)
-	job.TaskGroups[0].Count = pointerOf(0)
+	job.ID = new(commonJobID)
+	job.TaskGroups[0].Count = new(0)
 
 	// register our test job into first namespace
 	_, wm, err := jobs.RegisterOpts(job, &RegisterOptions{
@@ -1813,9 +1813,9 @@ func TestJobs_Submission_namespaces(t *testing.T) {
 
 	// create a second test job for our second namespace
 	job2 := testJob()
-	job2.ID = pointerOf(commonJobID)
+	job2.ID = new(commonJobID)
 	// keep job name redis to prove we write to correct namespace
-	job.TaskGroups[0].Count = pointerOf(0)
+	job.TaskGroups[0].Count = new(0)
 
 	// register our second job into the second namespace
 	_, wm, err = jobs.RegisterOpts(job2, &RegisterOptions{
@@ -1871,7 +1871,7 @@ func TestJobs_Submission_delete(t *testing.T) {
 	jobs := c.Jobs()
 	job := testJob()
 	jobID := *job.ID
-	job.TaskGroups[0].Count = pointerOf(0)
+	job.TaskGroups[0].Count = new(0)
 	job.Meta = map[string]string{"version": "0"}
 
 	// register our test job into first namespace
@@ -2297,11 +2297,11 @@ func TestJobs_NewBatchJob(t *testing.T) {
 
 	job := NewBatchJob("job1", "myjob", "global", 5)
 	expect := &Job{
-		Region:   pointerOf("global"),
-		ID:       pointerOf("job1"),
-		Name:     pointerOf("myjob"),
-		Type:     pointerOf(JobTypeBatch),
-		Priority: pointerOf(5),
+		Region:   new("global"),
+		ID:       new("job1"),
+		Name:     new("myjob"),
+		Type:     new(JobTypeBatch),
+		Priority: new(5),
 	}
 	must.Eq(t, expect, job)
 }
@@ -2311,11 +2311,11 @@ func TestJobs_NewServiceJob(t *testing.T) {
 
 	job := NewServiceJob("job1", "myjob", "global", 5)
 	expect := &Job{
-		Region:   pointerOf("global"),
-		ID:       pointerOf("job1"),
-		Name:     pointerOf("myjob"),
-		Type:     pointerOf(JobTypeService),
-		Priority: pointerOf(5),
+		Region:   new("global"),
+		ID:       new("job1"),
+		Name:     new("myjob"),
+		Type:     new(JobTypeService),
+		Priority: new(5),
 	}
 	must.Eq(t, expect, job)
 }
@@ -2325,11 +2325,11 @@ func TestJobs_NewSystemJob(t *testing.T) {
 
 	job := NewSystemJob("job1", "myjob", "global", 5)
 	expect := &Job{
-		Region:   pointerOf("global"),
-		ID:       pointerOf("job1"),
-		Name:     pointerOf("myjob"),
-		Type:     pointerOf(JobTypeSystem),
-		Priority: pointerOf(5),
+		Region:   new("global"),
+		ID:       new("job1"),
+		Name:     new("myjob"),
+		Type:     new(JobTypeSystem),
+		Priority: new(5),
 	}
 	must.Eq(t, expect, job)
 }
@@ -2339,11 +2339,11 @@ func TestJobs_NewSysbatchJob(t *testing.T) {
 
 	job := NewSysbatchJob("job1", "myjob", "global", 5)
 	expect := &Job{
-		Region:   pointerOf("global"),
-		ID:       pointerOf("job1"),
-		Name:     pointerOf("myjob"),
-		Type:     pointerOf(JobTypeSysbatch),
-		Priority: pointerOf(5),
+		Region:   new("global"),
+		ID:       new("job1"),
+		Name:     new("myjob"),
+		Type:     new(JobTypeSysbatch),
+		Priority: new(5),
 	}
 	must.Eq(t, expect, job)
 }
@@ -2413,13 +2413,13 @@ func TestJobs_AddAffinity(t *testing.T) {
 			LTarget: "kernel.version",
 			RTarget: "4.6",
 			Operand: "=",
-			Weight:  pointerOf(int8(100)),
+			Weight:  new(int8(100)),
 		},
 		{
 			LTarget: "${node.datacenter}",
 			RTarget: "dc2",
 			Operand: "=",
-			Weight:  pointerOf(int8(50)),
+			Weight:  new(int8(50)),
 		},
 	}
 	must.Eq(t, expect, job.Affinities)
@@ -2467,7 +2467,7 @@ func TestJobs_AddSpread(t *testing.T) {
 	expect := []*Spread{
 		{
 			Attribute: "${meta.rack}",
-			Weight:    pointerOf(int8(100)),
+			Weight:    new(int8(100)),
 			SpreadTarget: []*SpreadTarget{
 				{
 					Value:   "r1",
@@ -2477,7 +2477,7 @@ func TestJobs_AddSpread(t *testing.T) {
 		},
 		{
 			Attribute: "${node.datacenter}",
-			Weight:    pointerOf(int8(100)),
+			Weight:    new(int8(100)),
 			SpreadTarget: []*SpreadTarget{
 				{
 					Value:   "dc1",
@@ -2505,7 +2505,7 @@ func TestJobs_ScaleAction(t *testing.T) {
 	newCount := origCount + 1
 
 	// Trying to scale against a target before it exists returns an error
-	_, _, err := jobs.Scale(id, "missing", pointerOf(newCount), "this won't work", false, nil, nil)
+	_, _, err := jobs.Scale(id, "missing", new(newCount), "this won't work", false, nil, nil)
 	must.ErrorContains(t, err, "not found")
 
 	// Register the job
@@ -2515,7 +2515,7 @@ func TestJobs_ScaleAction(t *testing.T) {
 
 	// Perform scaling action
 	scalingResp, wm, err := jobs.Scale(id, groupName,
-		pointerOf(newCount), "need more instances", false,
+		new(newCount), "need more instances", false,
 		map[string]any{
 			"meta": "data",
 		}, nil)

--- a/api/node_meta_test.go
+++ b/api/node_meta_test.go
@@ -42,7 +42,7 @@ func TestNodeMeta_Apply(t *testing.T) {
 		NodeID: node.ID,
 		Meta: map[string]*string{
 			staticKey: nil,
-			"foo":     pointerOf("bar"),
+			"foo":     new("bar"),
 		},
 	}
 

--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -565,15 +565,15 @@ func TestNodeStatValueFormatting(t *testing.T) {
 	}{
 		{
 			"true",
-			StatValue{BoolVal: pointerOf(true)},
+			StatValue{BoolVal: new(true)},
 		},
 		{
 			"false",
-			StatValue{BoolVal: pointerOf(false)},
+			StatValue{BoolVal: new(false)},
 		},
 		{
 			"myvalue",
-			StatValue{StringVal: pointerOf("myvalue")},
+			StatValue{StringVal: new("myvalue")},
 		},
 		{
 			"2.718",
@@ -606,28 +606,28 @@ func TestNodeStatValueFormatting(t *testing.T) {
 		{
 			"2",
 			StatValue{
-				IntNumeratorVal: pointerOf(int64(2)),
+				IntNumeratorVal: new(int64(2)),
 			},
 		},
 		{
 			"2 / 3",
 			StatValue{
-				IntNumeratorVal:   pointerOf(int64(2)),
-				IntDenominatorVal: pointerOf(int64(3)),
+				IntNumeratorVal:   new(int64(2)),
+				IntDenominatorVal: new(int64(3)),
 			},
 		},
 		{
 			"2 MHz",
 			StatValue{
-				IntNumeratorVal: pointerOf(int64(2)),
+				IntNumeratorVal: new(int64(2)),
 				Unit:            "MHz",
 			},
 		},
 		{
 			"2 / 3 MHz",
 			StatValue{
-				IntNumeratorVal:   pointerOf(int64(2)),
-				IntDenominatorVal: pointerOf(int64(3)),
+				IntNumeratorVal:   new(int64(2)),
+				IntDenominatorVal: new(int64(3)),
 				Unit:              "MHz",
 			},
 		},

--- a/api/resources.go
+++ b/api/resources.go
@@ -44,7 +44,7 @@ func (r *Resources) Canonicalize() {
 	// CPU will be set to the default if cores is nil above.
 	// If cpu is nil here then cores has been set and cpu should be 0
 	if r.CPU == nil {
-		r.CPU = pointerOf(0)
+		r.CPU = new(0)
 	}
 
 	if r.MemoryMB == nil {
@@ -63,9 +63,9 @@ func (r *Resources) Canonicalize() {
 // and should be kept in sync.
 func DefaultResources() *Resources {
 	return &Resources{
-		CPU:      pointerOf(100),
-		Cores:    pointerOf(0),
-		MemoryMB: pointerOf(300),
+		CPU:      new(100),
+		Cores:    new(0),
+		MemoryMB: new(300),
 	}
 }
 
@@ -76,9 +76,9 @@ func DefaultResources() *Resources {
 // IN nomad/structs/structs.go and should be kept in sync.
 func MinResources() *Resources {
 	return &Resources{
-		CPU:      pointerOf(1),
-		Cores:    pointerOf(0),
-		MemoryMB: pointerOf(10),
+		CPU:      new(1),
+		Cores:    new(0),
+		MemoryMB: new(10),
 	}
 }
 
@@ -323,7 +323,7 @@ type RequestedDevice struct {
 
 func (d *RequestedDevice) Canonicalize() {
 	if d.Count == nil {
-		d.Count = pointerOf(uint64(1))
+		d.Count = new(uint64(1))
 	}
 
 	for _, a := range d.Affinities {

--- a/api/resources_test.go
+++ b/api/resources_test.go
@@ -25,25 +25,25 @@ func TestResources_Canonicalize(t *testing.T) {
 		{
 			name: "cores",
 			input: &Resources{
-				Cores:    pointerOf(2),
-				MemoryMB: pointerOf(1024),
+				Cores:    new(2),
+				MemoryMB: new(1024),
 			},
 			expected: &Resources{
-				CPU:      pointerOf(0),
-				Cores:    pointerOf(2),
-				MemoryMB: pointerOf(1024),
+				CPU:      new(0),
+				Cores:    new(2),
+				MemoryMB: new(1024),
 			},
 		},
 		{
 			name: "cpu",
 			input: &Resources{
-				CPU:      pointerOf(500),
-				MemoryMB: pointerOf(1024),
+				CPU:      new(500),
+				MemoryMB: new(1024),
 			},
 			expected: &Resources{
-				CPU:      pointerOf(500),
-				Cores:    pointerOf(0),
-				MemoryMB: pointerOf(1024),
+				CPU:      new(500),
+				Cores:    new(0),
+				MemoryMB: new(1024),
 			},
 		},
 	}

--- a/api/scaling.go
+++ b/api/scaling.go
@@ -38,7 +38,7 @@ func (s *Scaling) GetPolicy(id string, q *QueryOptions) (*ScalingPolicy, *QueryM
 
 func (p *ScalingPolicy) Canonicalize(taskGroupCount int) {
 	if p.Enabled == nil {
-		p.Enabled = pointerOf(true)
+		p.Enabled = new(true)
 	}
 	if p.Min == nil {
 		var m int64 = int64(taskGroupCount)

--- a/api/scaling_test.go
+++ b/api/scaling_test.go
@@ -26,7 +26,7 @@ func TestScalingPolicies_ListPolicies(t *testing.T) {
 	// Register a job with a scaling policy
 	job := testJob()
 	job.TaskGroups[0].Scaling = &ScalingPolicy{
-		Max: pointerOf(int64(100)),
+		Max: new(int64(100)),
 	}
 	_, _, err = jobs.Register(job, nil)
 	must.NoError(t, err)
@@ -74,9 +74,9 @@ func TestScalingPolicies_GetPolicy(t *testing.T) {
 	// Register a job with a scaling policy
 	job := testJob()
 	policy := &ScalingPolicy{
-		Enabled: pointerOf(true),
-		Min:     pointerOf(int64(1)),
-		Max:     pointerOf(int64(1)),
+		Enabled: new(true),
+		Min:     new(int64(1)),
+		Max:     new(int64(1)),
 		Policy: map[string]any{
 			"key": "value",
 		},

--- a/api/services.go
+++ b/api/services.go
@@ -147,7 +147,7 @@ func (c *CheckRestart) Canonicalize() {
 	}
 
 	if c.Grace == nil {
-		c.Grace = pointerOf(1 * time.Second)
+		c.Grace = new(1 * time.Second)
 	}
 }
 

--- a/api/services_test.go
+++ b/api/services_test.go
@@ -27,8 +27,8 @@ func TestServiceRegistrations_Delete(t *testing.T) {
 func TestService_Canonicalize(t *testing.T) {
 	testutil.Parallel(t)
 
-	j := &Job{Name: pointerOf("job")}
-	tg := &TaskGroup{Name: pointerOf("group")}
+	j := &Job{Name: new("job")}
+	tg := &TaskGroup{Name: new("group")}
 	task := &Task{Name: "task"}
 	s := &Service{
 		TaggedAddresses: make(map[string]string),
@@ -48,8 +48,8 @@ func TestService_Canonicalize(t *testing.T) {
 func TestServiceCheck_Canonicalize(t *testing.T) {
 	testutil.Parallel(t)
 
-	j := &Job{Name: pointerOf("job")}
-	tg := &TaskGroup{Name: pointerOf("group")}
+	j := &Job{Name: new("job")}
+	tg := &TaskGroup{Name: new("group")}
 	task := &Task{Name: "task"}
 	s := &Service{
 		Checks: []ServiceCheck{
@@ -66,8 +66,8 @@ func TestServiceCheck_Canonicalize(t *testing.T) {
 func TestService_Check_PassFail(t *testing.T) {
 	testutil.Parallel(t)
 
-	job := &Job{Name: pointerOf("job")}
-	tg := &TaskGroup{Name: pointerOf("group")}
+	job := &Job{Name: new("job")}
+	tg := &TaskGroup{Name: new("group")}
 	task := &Task{Name: "task"}
 
 	t.Run("enforce minimums", func(t *testing.T) {
@@ -106,13 +106,13 @@ func TestService_Check_PassFail(t *testing.T) {
 func TestService_CheckRestart(t *testing.T) {
 	testutil.Parallel(t)
 
-	job := &Job{Name: pointerOf("job")}
-	tg := &TaskGroup{Name: pointerOf("group")}
+	job := &Job{Name: new("job")}
+	tg := &TaskGroup{Name: new("group")}
 	task := &Task{Name: "task"}
 	service := &Service{
 		CheckRestart: &CheckRestart{
 			Limit:          11,
-			Grace:          pointerOf(11 * time.Second),
+			Grace:          new(11 * time.Second),
 			IgnoreWarnings: true,
 		},
 		Checks: []ServiceCheck{
@@ -120,7 +120,7 @@ func TestService_CheckRestart(t *testing.T) {
 				Name: "all-set",
 				CheckRestart: &CheckRestart{
 					Limit:          22,
-					Grace:          pointerOf(22 * time.Second),
+					Grace:          new(22 * time.Second),
 					IgnoreWarnings: true,
 				},
 			},
@@ -128,7 +128,7 @@ func TestService_CheckRestart(t *testing.T) {
 				Name: "some-set",
 				CheckRestart: &CheckRestart{
 					Limit: 33,
-					Grace: pointerOf(33 * time.Second),
+					Grace: new(33 * time.Second),
 				},
 			},
 			{
@@ -154,8 +154,8 @@ func TestService_CheckRestart(t *testing.T) {
 func TestService_Connect_proxy_settings(t *testing.T) {
 	testutil.Parallel(t)
 
-	job := &Job{Name: pointerOf("job")}
-	tg := &TaskGroup{Name: pointerOf("group")}
+	job := &Job{Name: new("job")}
+	tg := &TaskGroup{Name: new("group")}
 	task := &Task{Name: "task"}
 	service := &Service{
 		Connect: &ConsulConnect{
@@ -188,8 +188,8 @@ func TestService_Tags(t *testing.T) {
 	testutil.Parallel(t)
 
 	// canonicalize does not modify eto or tags
-	job := &Job{Name: pointerOf("job")}
-	tg := &TaskGroup{Name: pointerOf("group")}
+	job := &Job{Name: new("job")}
+	tg := &TaskGroup{Name: new("group")}
 	task := &Task{Name: "task"}
 	service := &Service{
 		Tags:              []string{"a", "b"},

--- a/api/tasks.go
+++ b/api/tasks.go
@@ -146,11 +146,11 @@ type DisconnectStrategy struct {
 
 func (ds *DisconnectStrategy) Canonicalize() {
 	if ds.Replace == nil {
-		ds.Replace = pointerOf(true)
+		ds.Replace = new(true)
 	}
 
 	if ds.Reconcile == nil {
-		ds.Reconcile = pointerOf(ReconcileOptionBestScore)
+		ds.Reconcile = new(ReconcileOptionBestScore)
 	}
 }
 
@@ -239,21 +239,21 @@ func NewAffinity(lTarget string, operand string, rTarget string, weight int8) *A
 		LTarget: lTarget,
 		RTarget: rTarget,
 		Operand: operand,
-		Weight:  pointerOf(weight),
+		Weight:  new(weight),
 	}
 }
 
 func (a *Affinity) Canonicalize() {
 	if a.Weight == nil {
-		a.Weight = pointerOf(int8(50))
+		a.Weight = new(int8(50))
 	}
 }
 
 func NewDefaultDisconnectStrategy() *DisconnectStrategy {
 	return &DisconnectStrategy{
-		LostAfter: pointerOf(0 * time.Minute),
-		Replace:   pointerOf(true),
-		Reconcile: pointerOf(ReconcileOptionBestScore),
+		LostAfter: new(0 * time.Minute),
+		Replace:   new(true),
+		Reconcile: new(ReconcileOptionBestScore),
 	}
 }
 
@@ -264,25 +264,25 @@ func NewDefaultReschedulePolicy(jobType string) *ReschedulePolicy {
 		// This needs to be in sync with DefaultServiceJobReschedulePolicy
 		// in nomad/structs/structs.go
 		dp = &ReschedulePolicy{
-			Delay:         pointerOf(30 * time.Second),
-			DelayFunction: pointerOf("exponential"),
-			MaxDelay:      pointerOf(1 * time.Hour),
-			Unlimited:     pointerOf(true),
+			Delay:         new(30 * time.Second),
+			DelayFunction: new("exponential"),
+			MaxDelay:      new(1 * time.Hour),
+			Unlimited:     new(true),
 
-			Attempts: pointerOf(0),
-			Interval: pointerOf(time.Duration(0)),
+			Attempts: new(0),
+			Interval: new(time.Duration(0)),
 		}
 	case "batch":
 		// This needs to be in sync with DefaultBatchJobReschedulePolicy
 		// in nomad/structs/structs.go
 		dp = &ReschedulePolicy{
-			Attempts:      pointerOf(1),
-			Interval:      pointerOf(24 * time.Hour),
-			Delay:         pointerOf(5 * time.Second),
-			DelayFunction: pointerOf("constant"),
+			Attempts:      new(1),
+			Interval:      new(24 * time.Hour),
+			Delay:         new(5 * time.Second),
+			DelayFunction: new("constant"),
 
-			MaxDelay:  pointerOf(time.Duration(0)),
-			Unlimited: pointerOf(false),
+			MaxDelay:  new(time.Duration(0)),
+			Unlimited: new(false),
 		}
 
 	default:
@@ -292,12 +292,12 @@ func NewDefaultReschedulePolicy(jobType string) *ReschedulePolicy {
 		// This also applies to batch/sysbatch jobs, which do not reschedule;
 		// we still want to return a safe object.
 		dp = &ReschedulePolicy{
-			Attempts:      pointerOf(0),
-			Interval:      pointerOf(time.Duration(0)),
-			Delay:         pointerOf(time.Duration(0)),
-			DelayFunction: pointerOf(""),
-			MaxDelay:      pointerOf(time.Duration(0)),
-			Unlimited:     pointerOf(false),
+			Attempts:      new(0),
+			Interval:      new(time.Duration(0)),
+			Delay:         new(time.Duration(0)),
+			DelayFunction: new(""),
+			MaxDelay:      new(time.Duration(0)),
+			Unlimited:     new(false),
 		}
 	}
 	return dp
@@ -345,14 +345,14 @@ func NewSpreadTarget(value string, percent uint8) *SpreadTarget {
 func NewSpread(attribute string, weight int8, spreadTargets []*SpreadTarget) *Spread {
 	return &Spread{
 		Attribute:    attribute,
-		Weight:       pointerOf(weight),
+		Weight:       new(weight),
 		SpreadTarget: spreadTargets,
 	}
 }
 
 func (s *Spread) Canonicalize() {
 	if s.Weight == nil {
-		s.Weight = pointerOf(int8(50))
+		s.Weight = new(int8(50))
 	}
 }
 
@@ -365,21 +365,21 @@ type EphemeralDisk struct {
 
 func DefaultEphemeralDisk() *EphemeralDisk {
 	return &EphemeralDisk{
-		Sticky:  pointerOf(false),
-		Migrate: pointerOf(false),
-		SizeMB:  pointerOf(300),
+		Sticky:  new(false),
+		Migrate: new(false),
+		SizeMB:  new(300),
 	}
 }
 
 func (e *EphemeralDisk) Canonicalize() {
 	if e.Sticky == nil {
-		e.Sticky = pointerOf(false)
+		e.Sticky = new(false)
 	}
 	if e.Migrate == nil {
-		e.Migrate = pointerOf(false)
+		e.Migrate = new(false)
 	}
 	if e.SizeMB == nil {
-		e.SizeMB = pointerOf(300)
+		e.SizeMB = new(300)
 	}
 }
 
@@ -394,10 +394,10 @@ type MigrateStrategy struct {
 
 func DefaultMigrateStrategy() *MigrateStrategy {
 	return &MigrateStrategy{
-		MaxParallel:     pointerOf(1),
-		HealthCheck:     pointerOf("checks"),
-		MinHealthyTime:  pointerOf(10 * time.Second),
-		HealthyDeadline: pointerOf(5 * time.Minute),
+		MaxParallel:     new(1),
+		HealthCheck:     new("checks"),
+		MinHealthyTime:  new(10 * time.Second),
+		HealthyDeadline: new(5 * time.Minute),
 	}
 }
 
@@ -476,15 +476,15 @@ type VolumeMount struct {
 
 func (vm *VolumeMount) Canonicalize() {
 	if vm.PropagationMode == nil {
-		vm.PropagationMode = pointerOf(VolumeMountPropagationPrivate)
+		vm.PropagationMode = new(VolumeMountPropagationPrivate)
 	}
 
 	if vm.ReadOnly == nil {
-		vm.ReadOnly = pointerOf(false)
+		vm.ReadOnly = new(false)
 	}
 
 	if vm.SELinuxLabel == nil {
-		vm.SELinuxLabel = pointerOf("")
+		vm.SELinuxLabel = new("")
 	}
 }
 
@@ -521,22 +521,22 @@ type TaskGroup struct {
 // NewTaskGroup creates a new TaskGroup.
 func NewTaskGroup(name string, count int) *TaskGroup {
 	return &TaskGroup{
-		Name:  pointerOf(name),
-		Count: pointerOf(count),
+		Name:  new(name),
+		Count: new(count),
 	}
 }
 
 // Canonicalize sets defaults and merges settings that should be inherited from the job
 func (g *TaskGroup) Canonicalize(job *Job) {
 	if g.Name == nil {
-		g.Name = pointerOf("")
+		g.Name = new("")
 	}
 
 	if g.Count == nil {
 		if g.Scaling != nil && g.Scaling.Min != nil {
-			g.Count = pointerOf(int(*g.Scaling.Min))
+			g.Count = new(int(*g.Scaling.Min))
 		} else {
-			g.Count = pointerOf(1)
+			g.Count = new(1)
 		}
 	}
 	if g.Scaling != nil {
@@ -641,11 +641,11 @@ func (g *TaskGroup) Canonicalize(job *Job) {
 // in nomad/structs/structs.go
 func defaultServiceJobRestartPolicy() *RestartPolicy {
 	return &RestartPolicy{
-		Delay:           pointerOf(15 * time.Second),
-		Attempts:        pointerOf(2),
-		Interval:        pointerOf(30 * time.Minute),
-		Mode:            pointerOf(RestartPolicyModeFail),
-		RenderTemplates: pointerOf(false),
+		Delay:           new(15 * time.Second),
+		Attempts:        new(2),
+		Interval:        new(30 * time.Minute),
+		Mode:            new(RestartPolicyModeFail),
+		RenderTemplates: new(false),
 	}
 }
 
@@ -653,11 +653,11 @@ func defaultServiceJobRestartPolicy() *RestartPolicy {
 // in nomad/structs/structs.go
 func defaultBatchJobRestartPolicy() *RestartPolicy {
 	return &RestartPolicy{
-		Delay:           pointerOf(15 * time.Second),
-		Attempts:        pointerOf(3),
-		Interval:        pointerOf(24 * time.Hour),
-		Mode:            pointerOf(RestartPolicyModeFail),
-		RenderTemplates: pointerOf(false),
+		Delay:           new(15 * time.Second),
+		Attempts:        new(3),
+		Interval:        new(24 * time.Hour),
+		Mode:            new(RestartPolicyModeFail),
+		RenderTemplates: new(false),
 	}
 }
 
@@ -720,21 +720,21 @@ type LogConfig struct {
 
 func DefaultLogConfig() *LogConfig {
 	return &LogConfig{
-		MaxFiles:      pointerOf(10),
-		MaxFileSizeMB: pointerOf(10),
-		Disabled:      pointerOf(false),
+		MaxFiles:      new(10),
+		MaxFileSizeMB: new(10),
+		Disabled:      new(false),
 	}
 }
 
 func (l *LogConfig) Canonicalize() {
 	if l.MaxFiles == nil {
-		l.MaxFiles = pointerOf(10)
+		l.MaxFiles = new(10)
 	}
 	if l.MaxFileSizeMB == nil {
-		l.MaxFileSizeMB = pointerOf(10)
+		l.MaxFileSizeMB = new(10)
 	}
 	if l.Disabled == nil {
-		l.Disabled = pointerOf(false)
+		l.Disabled = new(false)
 	}
 }
 
@@ -808,7 +808,7 @@ func (t *Task) Canonicalize(tg *TaskGroup, job *Job) {
 	t.Resources.Canonicalize()
 
 	if t.KillTimeout == nil {
-		t.KillTimeout = pointerOf(5 * time.Second)
+		t.KillTimeout = new(5 * time.Second)
 	}
 	if t.LogConfig == nil {
 		t.LogConfig = DefaultLogConfig()
@@ -868,14 +868,14 @@ type TaskArtifact struct {
 
 func (a *TaskArtifact) Canonicalize() {
 	if a.GetterMode == nil {
-		a.GetterMode = pointerOf("any")
+		a.GetterMode = new("any")
 	}
 	if a.GetterInsecure == nil {
-		a.GetterInsecure = pointerOf(false)
+		a.GetterInsecure = new(false)
 	}
 	if a.GetterSource == nil {
 		// Shouldn't be possible, but we don't want to panic
-		a.GetterSource = pointerOf("")
+		a.GetterSource = new("")
 	}
 	if len(a.GetterOptions) == 0 {
 		a.GetterOptions = nil
@@ -893,7 +893,7 @@ func (a *TaskArtifact) Canonicalize() {
 			a.RelativeDest = &dest
 		default:
 			// Default to a directory
-			a.RelativeDest = pointerOf("local/")
+			a.RelativeDest = new("local/")
 		}
 	}
 }
@@ -926,19 +926,19 @@ type ChangeScript struct {
 
 func (ch *ChangeScript) Canonicalize() {
 	if ch.Command == nil {
-		ch.Command = pointerOf("")
+		ch.Command = new("")
 	}
 	if ch.Args == nil {
 		ch.Args = []string{}
 	}
 	if ch.Timeout == nil {
-		ch.Timeout = pointerOf(5 * time.Second)
+		ch.Timeout = new(5 * time.Second)
 	}
 	if ch.FailOnError == nil {
-		ch.FailOnError = pointerOf(false)
+		ch.FailOnError = new(false)
 	}
 	if ch.RunOnFirstRender == nil {
-		ch.RunOnFirstRender = pointerOf(false)
+		ch.RunOnFirstRender = new(false)
 	}
 }
 
@@ -964,54 +964,54 @@ type Template struct {
 
 func (tmpl *Template) Canonicalize() {
 	if tmpl.SourcePath == nil {
-		tmpl.SourcePath = pointerOf("")
+		tmpl.SourcePath = new("")
 	}
 	if tmpl.DestPath == nil {
-		tmpl.DestPath = pointerOf("")
+		tmpl.DestPath = new("")
 	}
 	if tmpl.EmbeddedTmpl == nil {
-		tmpl.EmbeddedTmpl = pointerOf("")
+		tmpl.EmbeddedTmpl = new("")
 	}
 	if tmpl.ChangeMode == nil {
-		tmpl.ChangeMode = pointerOf("restart")
+		tmpl.ChangeMode = new("restart")
 	}
 	if tmpl.ChangeSignal == nil {
 		if *tmpl.ChangeMode == "signal" {
-			tmpl.ChangeSignal = pointerOf("SIGHUP")
+			tmpl.ChangeSignal = new("SIGHUP")
 		} else {
-			tmpl.ChangeSignal = pointerOf("")
+			tmpl.ChangeSignal = new("")
 		}
 	} else {
 		sig := *tmpl.ChangeSignal
-		tmpl.ChangeSignal = pointerOf(strings.ToUpper(sig))
+		tmpl.ChangeSignal = new(strings.ToUpper(sig))
 	}
 	if tmpl.ChangeScript != nil {
 		tmpl.ChangeScript.Canonicalize()
 	}
 	if tmpl.Once == nil {
-		tmpl.Once = pointerOf(false)
+		tmpl.Once = new(false)
 	}
 	if tmpl.Splay == nil {
-		tmpl.Splay = pointerOf(5 * time.Second)
+		tmpl.Splay = new(5 * time.Second)
 	}
 	if tmpl.Perms == nil {
-		tmpl.Perms = pointerOf("0644")
+		tmpl.Perms = new("0644")
 	}
 	if tmpl.LeftDelim == nil {
-		tmpl.LeftDelim = pointerOf("{{")
+		tmpl.LeftDelim = new("{{")
 	}
 	if tmpl.RightDelim == nil {
-		tmpl.RightDelim = pointerOf("}}")
+		tmpl.RightDelim = new("}}")
 	}
 	if tmpl.Envvars == nil {
-		tmpl.Envvars = pointerOf(false)
+		tmpl.Envvars = new(false)
 	}
 	if tmpl.ErrMissingKey == nil {
-		tmpl.ErrMissingKey = pointerOf(false)
+		tmpl.ErrMissingKey = new(false)
 	}
 	//COMPAT(0.12) VaultGrace is deprecated and unused as of Vault 0.5
 	if tmpl.VaultGrace == nil {
-		tmpl.VaultGrace = pointerOf(time.Duration(0))
+		tmpl.VaultGrace = new(time.Duration(0))
 	}
 }
 
@@ -1029,25 +1029,25 @@ type Vault struct {
 
 func (v *Vault) Canonicalize() {
 	if v.Env == nil {
-		v.Env = pointerOf(true)
+		v.Env = new(true)
 	}
 	if v.DisableFile == nil {
-		v.DisableFile = pointerOf(false)
+		v.DisableFile = new(false)
 	}
 	if v.Namespace == nil {
-		v.Namespace = pointerOf("")
+		v.Namespace = new("")
 	}
 	if v.Cluster == "" {
 		v.Cluster = "default"
 	}
 	if v.ChangeMode == nil {
-		v.ChangeMode = pointerOf("restart")
+		v.ChangeMode = new("restart")
 	}
 	if v.ChangeSignal == nil {
-		v.ChangeSignal = pointerOf("SIGHUP")
+		v.ChangeSignal = new("SIGHUP")
 	}
 	if v.AllowTokenExpiration == nil {
-		v.AllowTokenExpiration = pointerOf(false)
+		v.AllowTokenExpiration = new(false)
 	}
 }
 

--- a/api/tasks_test.go
+++ b/api/tasks_test.go
@@ -17,8 +17,8 @@ func TestTaskGroup_NewTaskGroup(t *testing.T) {
 
 	grp := NewTaskGroup("grp1", 2)
 	expect := &TaskGroup{
-		Name:  pointerOf("grp1"),
-		Count: pointerOf(2),
+		Name:  new("grp1"),
+		Count: new(2),
 	}
 	must.Eq(t, expect, grp)
 }
@@ -71,13 +71,13 @@ func TestTaskGroup_AddAffinity(t *testing.T) {
 			LTarget: "kernel.version",
 			RTarget: "4.6",
 			Operand: "=",
-			Weight:  pointerOf(int8(100)),
+			Weight:  new(int8(100)),
 		},
 		{
 			LTarget: "${node.affinity}",
 			RTarget: "dc2",
 			Operand: "=",
-			Weight:  pointerOf(int8(50)),
+			Weight:  new(int8(50)),
 		},
 	}
 	must.Eq(t, expect, grp.Affinities)
@@ -125,7 +125,7 @@ func TestTaskGroup_AddSpread(t *testing.T) {
 	expect := []*Spread{
 		{
 			Attribute: "${meta.rack}",
-			Weight:    pointerOf(int8(100)),
+			Weight:    new(int8(100)),
 			SpreadTarget: []*SpreadTarget{
 				{
 					Value:   "r1",
@@ -135,7 +135,7 @@ func TestTaskGroup_AddSpread(t *testing.T) {
 		},
 		{
 			Attribute: "${node.datacenter}",
-			Weight:    pointerOf(int8(100)),
+			Weight:    new(int8(100)),
 			SpreadTarget: []*SpreadTarget{
 				{
 					Value:   "dc1",
@@ -228,13 +228,13 @@ func TestTask_Require(t *testing.T) {
 
 	// Create some require resources
 	resources := &Resources{
-		CPU:      pointerOf(1250),
-		MemoryMB: pointerOf(128),
-		DiskMB:   pointerOf(2048),
+		CPU:      new(1250),
+		MemoryMB: new(128),
+		DiskMB:   new(2048),
 		Networks: []*NetworkResource{
 			{
 				CIDR:          "0.0.0.0/0",
-				MBits:         pointerOf(100),
+				MBits:         new(100),
 				ReservedPorts: []Port{{Label: "", Value: 80}, {Label: "", Value: 443}},
 			},
 		},
@@ -294,13 +294,13 @@ func TestTask_AddAffinity(t *testing.T) {
 			LTarget: "kernel.version",
 			RTarget: "4.6",
 			Operand: "=",
-			Weight:  pointerOf(int8(100)),
+			Weight:  new(int8(100)),
 		},
 		{
 			LTarget: "${node.datacenter}",
 			RTarget: "dc2",
 			Operand: "=",
-			Weight:  pointerOf(int8(50)),
+			Weight:  new(int8(50)),
 		},
 	}
 	must.Eq(t, expect, task.Affinities)
@@ -310,8 +310,8 @@ func TestTask_Artifact(t *testing.T) {
 	testutil.Parallel(t)
 
 	a := TaskArtifact{
-		GetterSource:  pointerOf("http://localhost/foo.txt"),
-		GetterMode:    pointerOf("file"),
+		GetterSource:  new("http://localhost/foo.txt"),
+		GetterMode:    new("file"),
 		GetterHeaders: make(map[string]string),
 		GetterOptions: make(map[string]string),
 	}
@@ -379,10 +379,10 @@ func TestTask_Canonicalize_TaskLifecycle(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tg := &TaskGroup{
-				Name: pointerOf("foo"),
+				Name: new("foo"),
 			}
 			j := &Job{
-				ID: pointerOf("test"),
+				ID: new("test"),
 			}
 			tc.task.Canonicalize(tg, j)
 			must.Eq(t, tc.expected, tc.task.Lifecycle)
@@ -412,16 +412,16 @@ func TestTask_Template_WaitConfig_Canonicalize_and_Copy(t *testing.T) {
 		{
 			name: "all-fields",
 			task: taskWithWait(&WaitConfig{
-				Min: pointerOf(time.Duration(5)),
-				Max: pointerOf(time.Duration(10)),
+				Min: new(time.Duration(5)),
+				Max: new(time.Duration(10)),
 			}),
 			canonicalized: &WaitConfig{
-				Min: pointerOf(time.Duration(5)),
-				Max: pointerOf(time.Duration(10)),
+				Min: new(time.Duration(5)),
+				Max: new(time.Duration(10)),
 			},
 			copied: &WaitConfig{
-				Min: pointerOf(time.Duration(5)),
-				Max: pointerOf(time.Duration(10)),
+				Min: new(time.Duration(5)),
+				Max: new(time.Duration(10)),
 			},
 		},
 		{
@@ -439,25 +439,25 @@ func TestTask_Template_WaitConfig_Canonicalize_and_Copy(t *testing.T) {
 		{
 			name: "min-only",
 			task: taskWithWait(&WaitConfig{
-				Min: pointerOf(time.Duration(5)),
+				Min: new(time.Duration(5)),
 			}),
 			canonicalized: &WaitConfig{
-				Min: pointerOf(time.Duration(5)),
+				Min: new(time.Duration(5)),
 			},
 			copied: &WaitConfig{
-				Min: pointerOf(time.Duration(5)),
+				Min: new(time.Duration(5)),
 			},
 		},
 		{
 			name: "max-only",
 			task: taskWithWait(&WaitConfig{
-				Max: pointerOf(time.Duration(10)),
+				Max: new(time.Duration(10)),
 			}),
 			canonicalized: &WaitConfig{
-				Max: pointerOf(time.Duration(10)),
+				Max: new(time.Duration(10)),
 			},
 			copied: &WaitConfig{
-				Max: pointerOf(time.Duration(10)),
+				Max: new(time.Duration(10)),
 			},
 		},
 	}
@@ -465,10 +465,10 @@ func TestTask_Template_WaitConfig_Canonicalize_and_Copy(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tg := &TaskGroup{
-				Name: pointerOf("foo"),
+				Name: new("foo"),
 			}
 			j := &Job{
-				ID: pointerOf("test"),
+				ID: new("test"),
 			}
 			must.Eq(t, tc.copied, tc.task.Templates[0].Wait.Copy())
 			tc.task.Canonicalize(tg, j)
@@ -487,13 +487,13 @@ func TestTask_Canonicalize_Vault(t *testing.T) {
 			name:  "empty",
 			input: &Vault{},
 			expected: &Vault{
-				Env:                  pointerOf(true),
-				DisableFile:          pointerOf(false),
-				Namespace:            pointerOf(""),
+				Env:                  new(true),
+				DisableFile:          new(false),
+				Namespace:            new(""),
 				Cluster:              "default",
-				ChangeMode:           pointerOf("restart"),
-				ChangeSignal:         pointerOf("SIGHUP"),
-				AllowTokenExpiration: pointerOf(false),
+				ChangeMode:           new("restart"),
+				ChangeSignal:         new("SIGHUP"),
+				AllowTokenExpiration: new(false),
 			},
 		},
 	}
@@ -535,22 +535,22 @@ func TestTaskGroup_Canonicalize_Update(t *testing.T) {
 
 	// Job with an Empty() Update
 	job := &Job{
-		ID: pointerOf("test"),
+		ID: new("test"),
 		Update: &UpdateStrategy{
-			AutoRevert:       pointerOf(false),
-			AutoPromote:      pointerOf(false),
-			Canary:           pointerOf(0),
-			HealthCheck:      pointerOf(""),
-			HealthyDeadline:  pointerOf(time.Duration(0)),
-			ProgressDeadline: pointerOf(time.Duration(0)),
-			MaxParallel:      pointerOf(0),
-			MinHealthyTime:   pointerOf(time.Duration(0)),
-			Stagger:          pointerOf(time.Duration(0)),
+			AutoRevert:       new(false),
+			AutoPromote:      new(false),
+			Canary:           new(0),
+			HealthCheck:      new(""),
+			HealthyDeadline:  new(time.Duration(0)),
+			ProgressDeadline: new(time.Duration(0)),
+			MaxParallel:      new(0),
+			MinHealthyTime:   new(time.Duration(0)),
+			Stagger:          new(time.Duration(0)),
 		},
 	}
 	job.Canonicalize()
 	tg := &TaskGroup{
-		Name: pointerOf("foo"),
+		Name: new("foo"),
 	}
 	tg.Canonicalize(job)
 	must.NotNil(t, job.Update)
@@ -561,15 +561,15 @@ func TestTaskGroup_Canonicalize_Scaling(t *testing.T) {
 	testutil.Parallel(t)
 
 	job := &Job{
-		ID: pointerOf("test"),
+		ID: new("test"),
 	}
 	job.Canonicalize()
 	tg := &TaskGroup{
-		Name:  pointerOf("foo"),
+		Name:  new("foo"),
 		Count: nil,
 		Scaling: &ScalingPolicy{
 			Min:         nil,
-			Max:         pointerOf(int64(10)),
+			Max:         new(int64(10)),
 			Policy:      nil,
 			Enabled:     nil,
 			CreateIndex: 0,
@@ -587,7 +587,7 @@ func TestTaskGroup_Canonicalize_Scaling(t *testing.T) {
 
 	// count == nil => count = Scaling.Min
 	tg.Count = nil
-	tg.Scaling.Min = pointerOf(int64(5))
+	tg.Scaling.Min = new(int64(5))
 	tg.Canonicalize(job)
 	must.Positive(t, *tg.Count)
 	must.NotNil(t, tg.Scaling.Min)
@@ -595,7 +595,7 @@ func TestTaskGroup_Canonicalize_Scaling(t *testing.T) {
 	must.Eq(t, int64(*tg.Count), *tg.Scaling.Min)
 
 	// Scaling.Min == nil => Scaling.Min == count
-	tg.Count = pointerOf(5)
+	tg.Count = new(5)
 	tg.Scaling.Min = nil
 	tg.Canonicalize(job)
 	must.Positive(t, *tg.Count)
@@ -604,8 +604,8 @@ func TestTaskGroup_Canonicalize_Scaling(t *testing.T) {
 	must.Eq(t, int64(*tg.Count), *tg.Scaling.Min)
 
 	// both present, both persisted
-	tg.Count = pointerOf(5)
-	tg.Scaling.Min = pointerOf(int64(1))
+	tg.Count = new(5)
+	tg.Scaling.Min = new(int64(1))
 	tg.Canonicalize(job)
 	must.Positive(t, *tg.Count)
 	must.NotNil(t, tg.Scaling.Min)
@@ -617,32 +617,32 @@ func TestTaskGroup_Merge_Update(t *testing.T) {
 	testutil.Parallel(t)
 
 	job := &Job{
-		ID:     pointerOf("test"),
+		ID:     new("test"),
 		Update: &UpdateStrategy{},
 	}
 	job.Canonicalize()
 
 	// Merge and canonicalize part of an update block
 	tg := &TaskGroup{
-		Name: pointerOf("foo"),
+		Name: new("foo"),
 		Update: &UpdateStrategy{
-			AutoRevert:  pointerOf(true),
-			Canary:      pointerOf(5),
-			HealthCheck: pointerOf("foo"),
+			AutoRevert:  new(true),
+			Canary:      new(5),
+			HealthCheck: new("foo"),
 		},
 	}
 
 	tg.Canonicalize(job)
 	must.Eq(t, &UpdateStrategy{
-		AutoRevert:       pointerOf(true),
-		AutoPromote:      pointerOf(false),
-		Canary:           pointerOf(5),
-		HealthCheck:      pointerOf("foo"),
-		HealthyDeadline:  pointerOf(5 * time.Minute),
-		ProgressDeadline: pointerOf(10 * time.Minute),
-		MaxParallel:      pointerOf(1),
-		MinHealthyTime:   pointerOf(10 * time.Second),
-		Stagger:          pointerOf(30 * time.Second),
+		AutoRevert:       new(true),
+		AutoPromote:      new(false),
+		Canary:           new(5),
+		HealthCheck:      new("foo"),
+		HealthyDeadline:  new(5 * time.Minute),
+		ProgressDeadline: new(10 * time.Minute),
+		MaxParallel:      new(1),
+		MinHealthyTime:   new(10 * time.Second),
+		Stagger:          new(30 * time.Second),
 	}, tg.Update)
 }
 
@@ -672,44 +672,44 @@ func TestTaskGroup_Canonicalize_MigrateStrategy(t *testing.T) {
 			jobMigrate:  nil,
 			taskMigrate: nil,
 			expected: &MigrateStrategy{
-				MaxParallel:     pointerOf(1),
-				HealthCheck:     pointerOf("checks"),
-				MinHealthyTime:  pointerOf(10 * time.Second),
-				HealthyDeadline: pointerOf(5 * time.Minute),
+				MaxParallel:     new(1),
+				HealthCheck:     new("checks"),
+				MinHealthyTime:  new(10 * time.Second),
+				HealthyDeadline: new(5 * time.Minute),
 			},
 		},
 		{
 			desc:    "Empty job migrate strategy",
 			jobType: "service",
 			jobMigrate: &MigrateStrategy{
-				MaxParallel:     pointerOf(0),
-				HealthCheck:     pointerOf(""),
-				MinHealthyTime:  pointerOf(time.Duration(0)),
-				HealthyDeadline: pointerOf(time.Duration(0)),
+				MaxParallel:     new(0),
+				HealthCheck:     new(""),
+				MinHealthyTime:  new(time.Duration(0)),
+				HealthyDeadline: new(time.Duration(0)),
 			},
 			taskMigrate: nil,
 			expected: &MigrateStrategy{
-				MaxParallel:     pointerOf(0),
-				HealthCheck:     pointerOf(""),
-				MinHealthyTime:  pointerOf(time.Duration(0)),
-				HealthyDeadline: pointerOf(time.Duration(0)),
+				MaxParallel:     new(0),
+				HealthCheck:     new(""),
+				MinHealthyTime:  new(time.Duration(0)),
+				HealthyDeadline: new(time.Duration(0)),
 			},
 		},
 		{
 			desc:    "Inherit from job",
 			jobType: "service",
 			jobMigrate: &MigrateStrategy{
-				MaxParallel:     pointerOf(3),
-				HealthCheck:     pointerOf("checks"),
-				MinHealthyTime:  pointerOf(time.Duration(2)),
-				HealthyDeadline: pointerOf(time.Duration(2)),
+				MaxParallel:     new(3),
+				HealthCheck:     new("checks"),
+				MinHealthyTime:  new(time.Duration(2)),
+				HealthyDeadline: new(time.Duration(2)),
 			},
 			taskMigrate: nil,
 			expected: &MigrateStrategy{
-				MaxParallel:     pointerOf(3),
-				HealthCheck:     pointerOf("checks"),
-				MinHealthyTime:  pointerOf(time.Duration(2)),
-				HealthyDeadline: pointerOf(time.Duration(2)),
+				MaxParallel:     new(3),
+				HealthCheck:     new("checks"),
+				MinHealthyTime:  new(time.Duration(2)),
+				HealthyDeadline: new(time.Duration(2)),
 			},
 		},
 		{
@@ -717,67 +717,67 @@ func TestTaskGroup_Canonicalize_MigrateStrategy(t *testing.T) {
 			jobType:    "service",
 			jobMigrate: nil,
 			taskMigrate: &MigrateStrategy{
-				MaxParallel:     pointerOf(3),
-				HealthCheck:     pointerOf("checks"),
-				MinHealthyTime:  pointerOf(time.Duration(2)),
-				HealthyDeadline: pointerOf(time.Duration(2)),
+				MaxParallel:     new(3),
+				HealthCheck:     new("checks"),
+				MinHealthyTime:  new(time.Duration(2)),
+				HealthyDeadline: new(time.Duration(2)),
 			},
 			expected: &MigrateStrategy{
-				MaxParallel:     pointerOf(3),
-				HealthCheck:     pointerOf("checks"),
-				MinHealthyTime:  pointerOf(time.Duration(2)),
-				HealthyDeadline: pointerOf(time.Duration(2)),
+				MaxParallel:     new(3),
+				HealthCheck:     new("checks"),
+				MinHealthyTime:  new(time.Duration(2)),
+				HealthyDeadline: new(time.Duration(2)),
 			},
 		},
 		{
 			desc:    "Merge from job",
 			jobType: "service",
 			jobMigrate: &MigrateStrategy{
-				MaxParallel: pointerOf(11),
+				MaxParallel: new(11),
 			},
 			taskMigrate: &MigrateStrategy{
-				HealthCheck:     pointerOf("checks"),
-				MinHealthyTime:  pointerOf(time.Duration(2)),
-				HealthyDeadline: pointerOf(time.Duration(2)),
+				HealthCheck:     new("checks"),
+				MinHealthyTime:  new(time.Duration(2)),
+				HealthyDeadline: new(time.Duration(2)),
 			},
 			expected: &MigrateStrategy{
-				MaxParallel:     pointerOf(11),
-				HealthCheck:     pointerOf("checks"),
-				MinHealthyTime:  pointerOf(time.Duration(2)),
-				HealthyDeadline: pointerOf(time.Duration(2)),
+				MaxParallel:     new(11),
+				HealthCheck:     new("checks"),
+				MinHealthyTime:  new(time.Duration(2)),
+				HealthyDeadline: new(time.Duration(2)),
 			},
 		},
 		{
 			desc:    "Override from group",
 			jobType: "service",
 			jobMigrate: &MigrateStrategy{
-				MaxParallel: pointerOf(11),
+				MaxParallel: new(11),
 			},
 			taskMigrate: &MigrateStrategy{
-				MaxParallel:     pointerOf(5),
-				HealthCheck:     pointerOf("checks"),
-				MinHealthyTime:  pointerOf(time.Duration(2)),
-				HealthyDeadline: pointerOf(time.Duration(2)),
+				MaxParallel:     new(5),
+				HealthCheck:     new("checks"),
+				MinHealthyTime:  new(time.Duration(2)),
+				HealthyDeadline: new(time.Duration(2)),
 			},
 			expected: &MigrateStrategy{
-				MaxParallel:     pointerOf(5),
-				HealthCheck:     pointerOf("checks"),
-				MinHealthyTime:  pointerOf(time.Duration(2)),
-				HealthyDeadline: pointerOf(time.Duration(2)),
+				MaxParallel:     new(5),
+				HealthCheck:     new("checks"),
+				MinHealthyTime:  new(time.Duration(2)),
+				HealthyDeadline: new(time.Duration(2)),
 			},
 		},
 		{
 			desc:    "Parallel from job, defaulting",
 			jobType: "service",
 			jobMigrate: &MigrateStrategy{
-				MaxParallel: pointerOf(5),
+				MaxParallel: new(5),
 			},
 			taskMigrate: nil,
 			expected: &MigrateStrategy{
-				MaxParallel:     pointerOf(5),
-				HealthCheck:     pointerOf("checks"),
-				MinHealthyTime:  pointerOf(10 * time.Second),
-				HealthyDeadline: pointerOf(5 * time.Minute),
+				MaxParallel:     new(5),
+				HealthCheck:     new("checks"),
+				MinHealthyTime:  new(10 * time.Second),
+				HealthyDeadline: new(5 * time.Minute),
 			},
 		},
 	}
@@ -785,13 +785,13 @@ func TestTaskGroup_Canonicalize_MigrateStrategy(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			job := &Job{
-				ID:      pointerOf("test"),
+				ID:      new("test"),
 				Migrate: tc.jobMigrate,
-				Type:    pointerOf(tc.jobType),
+				Type:    new(tc.jobType),
 			}
 			job.Canonicalize()
 			tg := &TaskGroup{
-				Name:    pointerOf("foo"),
+				Name:    new("foo"),
 				Migrate: tc.taskMigrate,
 			}
 			tg.Canonicalize(job)
@@ -805,12 +805,12 @@ func TestSpread_Canonicalize(t *testing.T) {
 	testutil.Parallel(t)
 
 	job := &Job{
-		ID:   pointerOf("test"),
-		Type: pointerOf("batch"),
+		ID:   new("test"),
+		Type: new("batch"),
 	}
 	job.Canonicalize()
 	tg := &TaskGroup{
-		Name: pointerOf("foo"),
+		Name: new("foo"),
 	}
 	type testCase struct {
 		desc           string
@@ -830,7 +830,7 @@ func TestSpread_Canonicalize(t *testing.T) {
 			"Zero spread",
 			&Spread{
 				Attribute: "test",
-				Weight:    pointerOf(int8(0)),
+				Weight:    new(int8(0)),
 			},
 			0,
 		},
@@ -838,7 +838,7 @@ func TestSpread_Canonicalize(t *testing.T) {
 			"Non Zero spread",
 			&Spread{
 				Attribute: "test",
-				Weight:    pointerOf(int8(100)),
+				Weight:    new(int8(100)),
 			},
 			100,
 		},
@@ -867,48 +867,48 @@ func Test_NewDefaultReschedulePolicy(t *testing.T) {
 			desc:         "service job type",
 			inputJobType: "service",
 			expected: &ReschedulePolicy{
-				Attempts:      pointerOf(0),
-				Interval:      pointerOf(time.Duration(0)),
-				Delay:         pointerOf(30 * time.Second),
-				DelayFunction: pointerOf("exponential"),
-				MaxDelay:      pointerOf(1 * time.Hour),
-				Unlimited:     pointerOf(true),
+				Attempts:      new(0),
+				Interval:      new(time.Duration(0)),
+				Delay:         new(30 * time.Second),
+				DelayFunction: new("exponential"),
+				MaxDelay:      new(1 * time.Hour),
+				Unlimited:     new(true),
 			},
 		},
 		{
 			desc:         "batch job type",
 			inputJobType: "batch",
 			expected: &ReschedulePolicy{
-				Attempts:      pointerOf(1),
-				Interval:      pointerOf(24 * time.Hour),
-				Delay:         pointerOf(5 * time.Second),
-				DelayFunction: pointerOf("constant"),
-				MaxDelay:      pointerOf(time.Duration(0)),
-				Unlimited:     pointerOf(false),
+				Attempts:      new(1),
+				Interval:      new(24 * time.Hour),
+				Delay:         new(5 * time.Second),
+				DelayFunction: new("constant"),
+				MaxDelay:      new(time.Duration(0)),
+				Unlimited:     new(false),
 			},
 		},
 		{
 			desc:         "system job type",
 			inputJobType: "system",
 			expected: &ReschedulePolicy{
-				Attempts:      pointerOf(0),
-				Interval:      pointerOf(time.Duration(0)),
-				Delay:         pointerOf(time.Duration(0)),
-				DelayFunction: pointerOf(""),
-				MaxDelay:      pointerOf(time.Duration(0)),
-				Unlimited:     pointerOf(false),
+				Attempts:      new(0),
+				Interval:      new(time.Duration(0)),
+				Delay:         new(time.Duration(0)),
+				DelayFunction: new(""),
+				MaxDelay:      new(time.Duration(0)),
+				Unlimited:     new(false),
 			},
 		},
 		{
 			desc:         "unrecognised job type",
 			inputJobType: "unrecognised",
 			expected: &ReschedulePolicy{
-				Attempts:      pointerOf(0),
-				Interval:      pointerOf(time.Duration(0)),
-				Delay:         pointerOf(time.Duration(0)),
-				DelayFunction: pointerOf(""),
-				MaxDelay:      pointerOf(time.Duration(0)),
-				Unlimited:     pointerOf(false),
+				Attempts:      new(0),
+				Interval:      new(time.Duration(0)),
+				Delay:         new(time.Duration(0)),
+				DelayFunction: new(""),
+				MaxDelay:      new(time.Duration(0)),
+				Unlimited:     new(false),
 			},
 		},
 	}
@@ -926,13 +926,13 @@ func TestTaskGroup_Canonicalize_Consul(t *testing.T) {
 
 	t.Run("override job consul in group", func(t *testing.T) {
 		job := &Job{
-			ID:              pointerOf("job"),
-			ConsulNamespace: pointerOf("ns1"),
+			ID:              new("job"),
+			ConsulNamespace: new("ns1"),
 		}
 		job.Canonicalize()
 
 		tg := &TaskGroup{
-			Name:   pointerOf("group"),
+			Name:   new("group"),
 			Consul: &Consul{Namespace: "ns2"},
 		}
 		tg.Canonicalize(job)
@@ -943,13 +943,13 @@ func TestTaskGroup_Canonicalize_Consul(t *testing.T) {
 
 	t.Run("set in group only", func(t *testing.T) {
 		job := &Job{
-			ID:              pointerOf("job"),
+			ID:              new("job"),
 			ConsulNamespace: nil,
 		}
 		job.Canonicalize()
 
 		tg := &TaskGroup{
-			Name:   pointerOf("group"),
+			Name:   new("group"),
 			Consul: &Consul{Namespace: "ns2"},
 		}
 		tg.Canonicalize(job)

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -27,18 +27,18 @@ func testJob() *Job {
 	task := NewTask("task1", "raw_exec").
 		SetConfig("command", "/bin/sleep").
 		Require(&Resources{
-			CPU:      pointerOf(100),
-			MemoryMB: pointerOf(256),
+			CPU:      new(100),
+			MemoryMB: new(256),
 		}).
 		SetLogConfig(&LogConfig{
-			MaxFiles:      pointerOf(1),
-			MaxFileSizeMB: pointerOf(2),
+			MaxFiles:      new(1),
+			MaxFileSizeMB: new(2),
 		})
 
 	group := NewTaskGroup("group1", 1).
 		AddTask(task).
 		RequireDisk(&EphemeralDisk{
-			SizeMB: pointerOf(25),
+			SizeMB: new(25),
 		})
 
 	job := NewBatchJob("job1", "redis", "global", 1).
@@ -60,18 +60,18 @@ func testJobWithScalingPolicy() *Job {
 	job := testJob()
 	job.TaskGroups[0].Scaling = &ScalingPolicy{
 		Policy:  map[string]any{},
-		Min:     pointerOf(int64(1)),
-		Max:     pointerOf(int64(5)),
-		Enabled: pointerOf(true),
+		Min:     new(int64(1)),
+		Max:     new(int64(5)),
+		Enabled: new(true),
 	}
 	return job
 }
 
 func testPeriodicJob() *Job {
 	job := testJob().AddPeriodicConfig(&PeriodicConfig{
-		Enabled:  pointerOf(true),
-		Spec:     pointerOf("*/30 * * * *"),
-		SpecType: pointerOf("cron"),
+		Enabled:  new(true),
+		Spec:     new("*/30 * * * *"),
+		SpecType: new("cron"),
 	})
 	return job
 }
@@ -117,11 +117,11 @@ func testQuotaSpec() *QuotaSpec {
 			{
 				Region: "global",
 				RegionLimit: &QuotaResources{
-					CPU:      pointerOf(2000),
-					MemoryMB: pointerOf(2000),
+					CPU:      new(2000),
+					MemoryMB: new(2000),
 					Devices: []*RequestedDevice{{
 						Name:  "nvidia/gpu/1080ti",
-						Count: pointerOf(uint64(2)),
+						Count: new(uint64(2)),
 					}},
 				},
 			},

--- a/api/utils.go
+++ b/api/utils.go
@@ -26,11 +26,6 @@ func formatFloat(f float64, maxPrec int) string {
 	return v[:sublen]
 }
 
-// pointerOf returns a pointer to a.
-func pointerOf[A any](a A) *A {
-	return &a
-}
-
 // pointerCopy returns a new pointer to a.
 func pointerCopy[A any](a *A) *A {
 	if a == nil {

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -43,14 +43,3 @@ func TestFormatRoundedFloat(t *testing.T) {
 		must.Eq(t, c.expected, formatFloat(c.input, 3))
 	}
 }
-
-func Test_PointerOf(t *testing.T) {
-	s := "hello"
-	sPtr := pointerOf(s)
-
-	must.Eq(t, s, *sPtr)
-
-	b := "bye"
-	sPtr = &b
-	must.NotEq(t, s, *sPtr)
-}


### PR DESCRIPTION
In Go 1.26 we can now use the new builtin to generate pointer to objects. This allows us to remove the use of the pointerOf function.

To enable this, the Go module is updated to require at least 1.26, which is the current oldstable version.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

