### PR TITLE
api: Remove go-units dep used for two consts only.

### DIFF
--- a/api/fs_test.go
+++ b/api/fs_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/docker/go-units"
 	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/shoenig/test/must"
 	"github.com/shoenig/test/wait"
@@ -31,8 +30,8 @@ func TestFS_Logs(t *testing.T) {
 	index := node.ModifyIndex
 
 	var input strings.Builder
-	input.Grow(units.MB)
-	lines := 80 * units.KB
+	input.Grow(1_000_000)
+	lines := 80 * 1000
 	for i := range lines {
 		_, _ = fmt.Fprintf(&input, "%d\n", i)
 	}

--- a/api/go.mod
+++ b/api/go.mod
@@ -3,7 +3,6 @@ module github.com/hashicorp/nomad/api
 go 1.26
 
 require (
-	github.com/docker/go-units v0.5.0
 	github.com/felixge/httpsnoop v1.1.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/gorilla/websocket v1.5.3

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,8 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
-github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=

--- a/jobspec2/go.sum
+++ b/jobspec2/go.sum
@@ -10,8 +10,6 @@ github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQ
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
-github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=


### PR DESCRIPTION
The go-units dependency was used in two places only for test details that do not require explicit unit manipulation. This change remove the whole depdendency in favour of using hardcoded values in the one test it was used.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

