### PR TITLE
client: honor shutdown_delay on task restart

### DIFF
--- a/.changelog/25289.txt
+++ b/.changelog/25289.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where task restart skipped `shutdown_delay`
+```

--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -5,6 +5,7 @@ package taskrunner
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	te "github.com/hashicorp/nomad/client/allocrunner/taskrunner/errors"
@@ -113,6 +114,33 @@ func (tr *TaskRunner) restartImpl(ctx context.Context, event *structs.TaskEvent,
 	waitCh, err := handle.WaitCh(ctx)
 	if err != nil {
 		return err
+	}
+
+	// Wait for ShutdownDelay after prekill hooks so services have time to
+	// drain before the task is signalled. This matches handleKill; restart
+	// previously skipped the delay (issue #25289).
+	if delay := tr.Task().ShutdownDelay; delay != 0 {
+		var ev *structs.TaskEvent
+		if tr.alloc.DesiredTransition.ShouldIgnoreShutdownDelay() {
+			tr.logger.Debug("skipping shutdown_delay", "shutdown_delay", delay)
+			ev = structs.NewTaskEvent(structs.TaskSkippingShutdownDelay).
+				SetDisplayMessage(fmt.Sprintf("Skipping shutdown_delay of %s before killing the task.", delay))
+			tr.UpdateState(structs.TaskStatePending, ev)
+		} else {
+			tr.logger.Debug("waiting before killing task", "shutdown_delay", delay)
+			ev = structs.NewTaskEvent(structs.TaskWaitingShuttingDownDelay).
+				SetDisplayMessage(fmt.Sprintf("Waiting for shutdown_delay of %s before killing the task.", delay))
+			tr.UpdateState(structs.TaskStatePending, ev)
+
+			select {
+			case <-waitCh:
+				return nil
+			case <-tr.shutdownDelayCtx.Done():
+			case <-time.After(delay):
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
 	}
 
 	// Kill the task using an exponential backoff in-case of failures.

--- a/client/allocrunner/taskrunner/lifecycle.go
+++ b/client/allocrunner/taskrunner/lifecycle.go
@@ -117,8 +117,7 @@ func (tr *TaskRunner) restartImpl(ctx context.Context, event *structs.TaskEvent,
 	}
 
 	// Wait for ShutdownDelay after prekill hooks so services have time to
-	// drain before the task is signalled. This matches handleKill; restart
-	// previously skipped the delay (issue #25289).
+	// drain before the task is signalled.
 	if delay := tr.Task().ShutdownDelay; delay != 0 {
 		var ev *structs.TaskEvent
 		if tr.alloc.DesiredTransition.ShouldIgnoreShutdownDelay() {
@@ -138,7 +137,7 @@ func (tr *TaskRunner) restartImpl(ctx context.Context, event *structs.TaskEvent,
 			case <-tr.shutdownDelayCtx.Done():
 			case <-time.After(delay):
 			case <-ctx.Done():
-				return ctx.Err()
+				return nil
 			}
 		}
 	}

--- a/client/allocrunner/taskrunner/task_runner_linux_test.go
+++ b/client/allocrunner/taskrunner/task_runner_linux_test.go
@@ -1105,6 +1105,61 @@ WAIT:
 	}
 }
 
+// TestTaskRunner_Restart_ShutdownDelay asserts services are removed from Consul
+// ${shutdown_delay} seconds before restarting the process (issue #25289).
+func TestTaskRunner_Restart_ShutdownDelay(t *testing.T) {
+	ci.Parallel(t)
+
+	alloc := mock.Alloc()
+	task := alloc.Job.TaskGroups[0].Tasks[0]
+	task.Services[0].Tags = []string{"tag1"}
+	task.Services = task.Services[:1] // only need 1 for this test
+	task.Driver = "mock_driver"
+	task.Config = map[string]interface{}{
+		"run_for": "1000s",
+	}
+
+	// No shutdown escape hatch for this delay, so don't set it too high
+	task.ShutdownDelay = 1000 * time.Duration(testutil.TestMultiplier()) * time.Millisecond
+
+	tr, conf, cleanup := runTestTaskRunner(t, alloc, task.Name)
+	defer cleanup()
+
+	mockConsul := conf.ConsulServices.(*regMock.ServiceRegistrationHandler)
+
+	// Wait for the task to start
+	testWaitForTaskToStart(t, tr)
+
+	testutil.WaitForResult(func() (bool, error) {
+		ops := mockConsul.GetOps()
+		if n := len(ops); n != 1 {
+			return false, fmt.Errorf("expected 1 consul operation. Found %d", n)
+		}
+		return ops[0].Op == "add", fmt.Errorf("consul operation was not a registration: %#v", ops[0])
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+
+	// Restart the running task and measure how long the kill takes.
+	restartSent := time.Now()
+	assert.NoError(t, tr.Restart(context.Background(), structs.NewTaskEvent(structs.TaskRestartSignal), false))
+	killDur := time.Now().Sub(restartSent)
+	if killDur < task.ShutdownDelay {
+		t.Fatalf("task killed before shutdown_delay (killed_after: %s; shutdown_delay: %s",
+			killDur, task.ShutdownDelay,
+		)
+	}
+
+	hasDelayEvent := false
+	for _, ev := range tr.TaskState().Events {
+		if ev.Type == structs.TaskWaitingShuttingDownDelay {
+			hasDelayEvent = true
+			break
+		}
+	}
+	must.True(t, hasDelayEvent)
+}
+
 // TestTaskRunner_NoShutdownDelay asserts services are removed from
 // Consul and tasks are killed without waiting for ${shutdown_delay}
 // when the alloc has the NoShutdownDelay transition flag set.

--- a/client/allocrunner/taskrunner/task_runner_linux_test.go
+++ b/client/allocrunner/taskrunner/task_runner_linux_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/kr/pretty"
 	"github.com/shoenig/test"
 	"github.com/shoenig/test/must"
+	"github.com/shoenig/test/wait"
 	"github.com/stretchr/testify/assert"
 	tmock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1123,26 +1124,22 @@ func TestTaskRunner_Restart_ShutdownDelay(t *testing.T) {
 	task.ShutdownDelay = 1000 * time.Duration(testutil.TestMultiplier()) * time.Millisecond
 
 	tr, conf, cleanup := runTestTaskRunner(t, alloc, task.Name)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	mockConsul := conf.ConsulServices.(*regMock.ServiceRegistrationHandler)
 
 	// Wait for the task to start
 	testWaitForTaskToStart(t, tr)
 
-	testutil.WaitForResult(func() (bool, error) {
+	must.Wait(t, wait.InitialSuccess(wait.BoolFunc(func() bool {
 		ops := mockConsul.GetOps()
-		if n := len(ops); n != 1 {
-			return false, fmt.Errorf("expected 1 consul operation. Found %d", n)
-		}
-		return ops[0].Op == "add", fmt.Errorf("consul operation was not a registration: %#v", ops[0])
-	}, func(err error) {
-		t.Fatalf("err: %v", err)
-	})
+		return len(ops) == 1 && ops[0].Op == "add"
+	}), wait.Gap(time.Millisecond*10),
+	), must.Sprint("expected consul registration"))
 
 	// Restart the running task and measure how long the kill takes.
 	restartSent := time.Now()
-	assert.NoError(t, tr.Restart(context.Background(), structs.NewTaskEvent(structs.TaskRestartSignal), false))
+	test.NoError(t, tr.Restart(context.Background(), structs.NewTaskEvent(structs.TaskRestartSignal), false))
 	killDur := time.Now().Sub(restartSent)
 	if killDur < task.ShutdownDelay {
 		t.Fatalf("task killed before shutdown_delay (killed_after: %s; shutdown_delay: %s",
@@ -1150,14 +1147,10 @@ func TestTaskRunner_Restart_ShutdownDelay(t *testing.T) {
 		)
 	}
 
-	hasDelayEvent := false
-	for _, ev := range tr.TaskState().Events {
-		if ev.Type == structs.TaskWaitingShuttingDownDelay {
-			hasDelayEvent = true
-			break
-		}
-	}
-	must.True(t, hasDelayEvent)
+	must.SliceContainsFunc(t,
+		tr.TaskState().Events,
+		&structs.TaskEvent{Type: structs.TaskWaitingShuttingDownDelay},
+		func(ev, want *structs.TaskEvent) bool { return ev.Type == want.Type })
 }
 
 // TestTaskRunner_NoShutdownDelay asserts services are removed from


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

Task restart (`TaskRunner.restartImpl`) ran pre-kill hooks then immediately killed the task, skipping the `shutdown_delay` wait that `handleKill` already applies on stop. In-flight requests therefore were not given time to drain on restart.

This waits `task.ShutdownDelay` after pre-kill (and emits `TaskWaitingShuttingDownDelay`) so restart matches stop. The existing ignore-delay path (`DesiredTransition.ShouldIgnoreShutdownDelay`) and `shutdownDelayCtx` cancellation are honored the same way as `handleKill`.

AI-assisted the `restartImpl` wait and `TestTaskRunner_Restart_ShutdownDelay`. I reviewed the change against `handleKill` and verified the test FAIL then PASS locally.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

Added `TestTaskRunner_Restart_ShutdownDelay` (linux): start a mock_driver task with a short `shutdown_delay`, call `Restart`, and assert the kill takes at least that delay and that a `TaskWaitingShuttingDownDelay` event is emitted.

```
go test ./client/allocrunner/taskrunner/ -run TestTaskRunner_Restart_ShutdownDelay -count=1
```

Passed locally on linux (FAIL without the `restartImpl` wait, PASS with it).

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

Fixes #25289

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and ensure regressions will be caught.
- [ ] **Documentation** n/a — no CLI/API/UI/job-spec change; `shutdown_delay` already documented. If the change impacts user-facing functionality such as the CLI, API, UI, and job configuration, please update the Nomad product documentation, which is stored in the [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read and followed the [AI usage guide](./contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge" in the majority of situations. The main exceptions are long-lived feature branches or merges where history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None.