### PR TITLE
api: Remove barely used httpsnoop dependency.

### DIFF
--- a/api/error_unexpected_response_test.go
+++ b/api/error_unexpected_response_test.go
@@ -16,7 +16,6 @@ import (
 	"testing/iotest"
 	"time"
 
-	"github.com/felixge/httpsnoop"
 	"github.com/hashicorp/nomad/api"
 	"github.com/hashicorp/nomad/api/internal/testutil"
 	"github.com/shoenig/test/must"
@@ -212,19 +211,39 @@ func closingHandler(sc int, b string) http.Handler {
 	})
 }
 
+// captureResponseWriter wraps http.ResponseWriter to capture the status code
+// and number of bytes written by the handler.
+type captureResponseWriter struct {
+	http.ResponseWriter
+	code    int
+	written int64
+}
+
+func (c *captureResponseWriter) WriteHeader(code int) {
+	c.code = code
+	c.ResponseWriter.WriteHeader(code)
+}
+
+func (c *captureResponseWriter) Write(b []byte) (int, error) {
+	n, err := c.ResponseWriter.Write(b)
+	c.written += int64(n)
+	return n, err
+}
+
 // testLogRequestHandler wraps a http.Handler with a logger that writes to the
 // test log output
 func testLogRequestHandler(t *testing.T, h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// call the original http.Handler wrapped in a httpsnoop
-		m := httpsnoop.CaptureMetrics(h, w, r)
+		crw := &captureResponseWriter{ResponseWriter: w, code: http.StatusOK}
+		start := time.Now()
+		h.ServeHTTP(crw, r)
 		ri := httpReqInfo{
 			uri:       r.URL.String(),
 			method:    r.Method,
 			ipaddr:    ipAddrFromRemoteAddr(r.RemoteAddr),
-			code:      m.Code,
-			duration:  m.Duration,
-			size:      m.Written,
+			code:      crw.code,
+			duration:  time.Since(start),
+			size:      crw.written,
 			userAgent: r.UserAgent(),
 		}
 		t.Logf("%s", ri.String())

--- a/api/go.mod
+++ b/api/go.mod
@@ -3,7 +3,6 @@ module github.com/hashicorp/nomad/api
 go 1.26
 
 require (
-	github.com/felixge/httpsnoop v1.1.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/hashicorp/cronexpr v1.1.3

--- a/api/go.sum
+++ b/api/go.sum
@@ -1,8 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
-github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=
 github.com/go-viper/mapstructure/v2 v2.5.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/jobspec2/go.sum
+++ b/jobspec2/go.sum
@@ -10,8 +10,6 @@ github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQ
 github.com/bmatcuk/doublestar v1.3.4/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
-github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
 github.com/go-test/deep v1.0.3 h1:ZrJSEWsXzPOxaZnFteGEfooLba+ju3FYIbOrS+rQd68=
 github.com/go-test/deep v1.0.3/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-viper/mapstructure/v2 v2.5.0 h1:vM5IJoUAy3d7zRSVtIwQgBj7BiWtMPfmPEgAXnvj1Ro=


### PR DESCRIPTION
The httpsnoop dependency was not used in any real capacity to justify the full import. This change removes the dependency in favour or a minor capture response writer which gives us the same functionlity we used without the need for the library.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

