### PR TITLE
csi: handle spec updates for volume health

### DIFF
--- a/.changelog/28474.txt
+++ b/.changelog/28474.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+csi: Replace support for volume condition with volume health
+```

--- a/client/pluginmanager/csimanager/fingerprint.go
+++ b/client/pluginmanager/csimanager/fingerprint.go
@@ -137,6 +137,7 @@ func applyCapabilitySetToControllerInfo(cs *csi.ControllerCapabilitySet, info *s
 	info.SupportsListVolumesAttachedNodes = cs.HasListVolumesPublishedNodes
 	info.SupportsCondition = cs.HasVolumeCondition
 	info.SupportsGet = cs.HasGetVolume
+	info.SupportsGetHealth = cs.HasGetVolumeHealth
 }
 
 func (p *pluginFingerprinter) buildControllerFingerprint(ctx context.Context, base *structs.CSIInfo) (*structs.CSIInfo, error) {

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.35
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.35
 	github.com/aws/smithy-go v1.27.6
-	github.com/container-storage-interface/spec v1.12.0
+	github.com/container-storage-interface/spec v1.13.0
 	github.com/containerd/errdefs v1.0.0
 	github.com/containerd/go-cni v1.1.13
 	github.com/containerd/log v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/cockroachdb/apd v1.1.0/go.mod h1:8Sl8LxpKi29FqWXR16WEFZRNSz3SoPzUzeMeY4+DwBQ=
-github.com/container-storage-interface/spec v1.12.0 h1:zrFOEqpR5AghNaaDG4qyedwPBqU2fU0dWjLQMP/azK0=
-github.com/container-storage-interface/spec v1.12.0/go.mod h1:txsm+MA2B2WDa5kW69jNbqPnvTtfvZma7T/zsAZ9qX8=
+github.com/container-storage-interface/spec v1.13.0 h1:6ja3nYoACisewTPAAZkJ1pbf4+1ehhvt9Z/nYgWGHGw=
+github.com/container-storage-interface/spec v1.13.0/go.mod h1:fPZ7EFHYJwIwc9CMcoaT/yIhFTdToocYVtyafMG7EDM=
 github.com/containerd/console v1.0.1/go.mod h1:XUsP6YE/mKtz6bxc+I8UiKKTP04qjQL4qcS3XoQ5xkw=
 github.com/containerd/console v1.0.5 h1:R0ymNeydRqH2DmakFNdmjR2k0t7UPuiOV/N/27/qqsc=
 github.com/containerd/console v1.0.5/go.mod h1:YynlIjWYF8myEu6sdkwKIvGQq+cOckRm6So2avqoYAk=

--- a/nomad/structs/csi.go
+++ b/nomad/structs/csi.go
@@ -1242,10 +1242,18 @@ const (
 
 	// CSIControllerSupportsCondition indicates plugin support for
 	// VOLUME_CONDITION
+	//
+	// Deprecated: Volume condition feature was removed from the CSI
+	// specification and replaced with the volume health feature. This
+	// remains only for compatibility and will never be true.
+	// ref: https://github.com/container-storage-interface/spec/pull/604
 	CSIControllerSupportsCondition CSIControllerCapability = 10
 
 	// CSIControllerSupportsGet indicates plugin support for GET_VOLUME
 	CSIControllerSupportsGet CSIControllerCapability = 11
+
+	// CSIControllerSupportsGetHealth indicates plugin support for GET_VOLUME_HEALTH
+	CSIControllerSupportsGetHealth CSIControllerCapability = 12
 )
 
 type CSINodeCapability byte
@@ -1298,6 +1306,8 @@ func (p *CSIPlugin) HasControllerCapability(cap CSIControllerCapability) bool {
 			return c.ControllerInfo.SupportsCondition
 		case CSIControllerSupportsGet:
 			return c.ControllerInfo.SupportsGet
+		case CSIControllerSupportsGetHealth:
+			return c.ControllerInfo.SupportsGetHealth
 		default:
 			return false
 		}

--- a/nomad/structs/node.go
+++ b/nomad/structs/node.go
@@ -257,10 +257,18 @@ type CSIControllerInfo struct {
 	SupportsListVolumesAttachedNodes bool
 
 	// SupportsCondition indicates plugin support for VOLUME_CONDITION
+	//
+	// Deprecated: Volume condition feature was removed from the CSI
+	// specification and replaced with the volume health feature. This
+	// remains only for compatibility and will never be true.
+	// ref: https://github.com/container-storage-interface/spec/pull/604
 	SupportsCondition bool
 
 	// SupportsGet indicates plugin support for GET_VOLUME
 	SupportsGet bool
+
+	// SupportsGetHealth indicates plugin support for GET_VOLUME_HEALTH
+	SupportsGetHealth bool
 }
 
 func (c *CSIControllerInfo) Copy() *CSIControllerInfo {

--- a/plugins/csi/client.go
+++ b/plugins/csi/client.go
@@ -81,6 +81,7 @@ type CSIControllerClient interface {
 	CreateSnapshot(ctx context.Context, in *csipbv1.CreateSnapshotRequest, opts ...grpc.CallOption) (*csipbv1.CreateSnapshotResponse, error)
 	DeleteSnapshot(ctx context.Context, in *csipbv1.DeleteSnapshotRequest, opts ...grpc.CallOption) (*csipbv1.DeleteSnapshotResponse, error)
 	ListSnapshots(ctx context.Context, in *csipbv1.ListSnapshotsRequest, opts ...grpc.CallOption) (*csipbv1.ListSnapshotsResponse, error)
+	ControllerGetVolumeHealth(ctx context.Context, in *csipbv1.ControllerGetVolumeHealthRequest, opts ...grpc.CallOption) (*csipbv1.ControllerGetVolumeHealthResponse, error)
 }
 
 // CSINodeClient defines the minimal CSI Node Plugin interface used
@@ -487,7 +488,62 @@ func (c *client) ControllerListVolumes(ctx context.Context, req *ControllerListV
 		}
 		return nil, err
 	}
-	return NewListVolumesResponse(resp), nil
+
+	healthResps := map[string][]*VolumeHealthStatus{}
+HEALTH_LOOP:
+	for _, entry := range resp.Entries {
+		req := &ControllerGetVolumeHealthRequest{
+			VolumeID: entry.Volume.GetVolumeId(),
+		}
+		resp, err := c.ControllerGetVolumeHealth(ctx, req, opts...)
+		if err != nil {
+			if s, ok := status.FromError(err); ok {
+				switch s.Code() {
+				case codes.Unimplemented:
+					// The ControllerGetVolumeHealth endpoint is optional and was not implemented
+					// so stop attempting to collect health information.
+					c.logger.Warn("controller plugin does not implement volume health")
+					break HEALTH_LOOP
+				case codes.NotFound:
+					// Health information for this volume was not found, but attempt to continue
+					// collecting health information.
+					c.logger.Warn("volume health information was not found", "volume-id", req.VolumeID, "error", err)
+					continue
+				case codes.Internal:
+					return nil, fmt.Errorf(
+						"controller plugin returned an internal error, check the plugin allocation logs for more information: %v", err)
+				}
+			}
+			return nil, err
+		}
+
+		healthResps[resp.VolumeID] = resp.Statuses
+	}
+
+	return NewListVolumesResponse(resp, healthResps), nil
+}
+
+func (c *client) ControllerGetVolumeHealth(ctx context.Context, req *ControllerGetVolumeHealthRequest, opts ...grpc.CallOption) (*ControllerGetVolumeHealthResponse, error) {
+	if err := c.ensureConnected(ctx); err != nil {
+		return nil, err
+	}
+
+	creq := req.ToCSIRepresentation()
+	resp, err := c.controllerClient.ControllerGetVolumeHealth(ctx, creq, opts...)
+	if err != nil {
+		code := status.Code(err)
+		switch code {
+		case codes.Unimplemented:
+			return nil, fmt.Errorf(
+				"controller plugin does not implement ControllerGetVolumeHealth: %w", err)
+		case codes.NotFound:
+			return nil, fmt.Errorf(
+				"volume %q health status does not exist: %w", req.VolumeID, err)
+		}
+		return nil, err
+	}
+
+	return NewGetVolumeHealthResponse(resp), nil
 }
 
 func (c *client) ControllerDeleteVolume(ctx context.Context, req *ControllerDeleteVolumeRequest, opts ...grpc.CallOption) error {

--- a/plugins/csi/client_test.go
+++ b/plugins/csi/client_test.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/ci"
 	"github.com/hashicorp/nomad/nomad/structs"
 	fake "github.com/hashicorp/nomad/plugins/csi/testing"
@@ -38,6 +39,7 @@ func newTestClient(t *testing.T) (*fake.IdentityClient, *fake.ControllerClient, 
 	}
 
 	client := &client{
+		logger:           hclog.NewNullLogger(),
 		conn:             conn,
 		identityClient:   ic,
 		controllerClient: cc,
@@ -905,10 +907,11 @@ func TestClient_RPC_ControllerListVolume(t *testing.T) {
 	ci.Parallel(t)
 
 	cases := []struct {
-		Name        string
-		Request     *ControllerListVolumesRequest
-		ResponseErr error
-		ExpectedErr error
+		Name              string
+		Request           *ControllerListVolumesRequest
+		HealthResponseErr error
+		ResponseErr       error
+		ExpectedErr       error
 	}{
 		{
 			Name:        "handles underlying grpc errors",
@@ -916,16 +919,30 @@ func TestClient_RPC_ControllerListVolume(t *testing.T) {
 			ResponseErr: status.Errorf(codes.Internal, "some grpc error"),
 			ExpectedErr: fmt.Errorf("controller plugin returned an internal error, check the plugin allocation logs for more information: rpc error: code = Internal desc = some grpc error"),
 		},
-
 		{
 			Name:        "handles error invalid max entries",
 			Request:     &ControllerListVolumesRequest{MaxEntries: -1},
 			ExpectedErr: errors.New("MaxEntries cannot be negative"),
 		},
-
 		{
 			Name:    "handles success",
 			Request: &ControllerListVolumesRequest{},
+		},
+		{
+			Name:              "handles unimplemented volume health",
+			Request:           &ControllerListVolumesRequest{},
+			HealthResponseErr: status.Error(codes.Unimplemented, "not implemented"),
+		},
+		{
+			Name:              "handles volume not found",
+			Request:           &ControllerListVolumesRequest{},
+			HealthResponseErr: status.Error(codes.NotFound, "volume not found"),
+		},
+		{
+			Name:              "handles underlying volume health grpc errors",
+			Request:           &ControllerListVolumesRequest{},
+			HealthResponseErr: status.Errorf(codes.Internal, "some grpc error"),
+			ExpectedErr:       fmt.Errorf("controller plugin returned an internal error, check the plugin allocation logs for more information: rpc error: code = Internal desc = some grpc error"),
 		},
 	}
 
@@ -935,7 +952,7 @@ func TestClient_RPC_ControllerListVolume(t *testing.T) {
 			defer client.Close()
 
 			cc.NextErr = tc.ResponseErr
-			if tc.ResponseErr != nil {
+			if tc.ResponseErr == nil {
 				// note: there's nothing interesting to assert here other than
 				// that we don't throw a NPE during transformation from
 				// protobuf to our struct
@@ -984,6 +1001,15 @@ func TestClient_RPC_ControllerListVolume(t *testing.T) {
 				}
 			}
 
+			cc.NextVolumeHealthErr = tc.HealthResponseErr
+			if tc.HealthResponseErr == nil {
+				cc.NextVolumeHealthResponse = &csipbv1.ControllerGetVolumeHealthResponse{
+					VolumeHealth: &csipbv1.VolumeHealth{
+						VolumeId: "vol-id",
+					},
+				}
+			}
+
 			resp, err := client.ControllerListVolumes(context.TODO(), tc.Request)
 			if tc.ExpectedErr != nil {
 				must.EqError(t, err, tc.ExpectedErr.Error())
@@ -991,7 +1017,250 @@ func TestClient_RPC_ControllerListVolume(t *testing.T) {
 			}
 			must.NoError(t, err, must.Sprint("name", tc.Name))
 			must.NotNil(t, resp)
+		})
+	}
+}
 
+func TestClient_RPC_ControllerListVolume_Health(t *testing.T) {
+	ci.Parallel(t)
+
+	// For these tests we just want to validate that the volume health
+	// and volume condition are being set appropriately in the returned
+	// based on the volume health status response.
+	cases := []struct {
+		Name                   string
+		HealthStatusesResponse []*csipbv1.VolumeHealth_VolumeHealthEntry
+		ExpectedCondition      *VolumeCondition
+		ExpectedHealth         *VolumeHealth
+	}{
+		{
+			Name:              "ok",
+			ExpectedCondition: &VolumeCondition{Abnormal: false},
+			ExpectedHealth:    &VolumeHealth{Healthy: true},
+		},
+		{
+			Name: "single status",
+			HealthStatusesResponse: []*csipbv1.VolumeHealth_VolumeHealthEntry{
+				{
+					Status:  csipbv1.VolumeHealthErrorType_DATA_LOSS,
+					Reason:  "solar flares",
+					Message: "send foil",
+				},
+			},
+			ExpectedCondition: &VolumeCondition{
+				Abnormal: true,
+				Message:  "solar flares",
+			},
+			ExpectedHealth: &VolumeHealth{
+				Healthy: false,
+				Statuses: []*VolumeHealthStatus{
+					{
+						Status:  "DATA_LOSS",
+						Reason:  "solar flares",
+						Message: "send foil",
+					},
+				},
+			},
+		},
+		{
+			Name: "multiple statuses",
+			HealthStatusesResponse: []*csipbv1.VolumeHealth_VolumeHealthEntry{
+				{
+					Status:  csipbv1.VolumeHealthErrorType_DATA_LOSS,
+					Reason:  "solar flares",
+					Message: "send foil",
+				},
+				{
+					Status:  csipbv1.VolumeHealthErrorType_DEGRADED,
+					Reason:  "clogged pipes",
+					Message: "full of koopa troopas",
+				},
+			},
+			ExpectedCondition: &VolumeCondition{
+				Abnormal: true,
+				Message:  "solar flares, clogged pipes",
+			},
+			ExpectedHealth: &VolumeHealth{
+				Healthy: false,
+				Statuses: []*VolumeHealthStatus{
+					{
+						Status:  "DATA_LOSS",
+						Reason:  "solar flares",
+						Message: "send foil",
+					},
+					{
+						Status:  "DEGRADED",
+						Reason:  "clogged pipes",
+						Message: "full of koopa troopas",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, cc, _, client := newTestClient(t)
+			defer client.Close()
+
+			cc.NextListVolumesResponse = &csipbv1.ListVolumesResponse{
+				Entries: []*csipbv1.ListVolumesResponse_Entry{
+					{
+						Volume: &csipbv1.Volume{
+							CapacityBytes: 1000000,
+							VolumeId:      "vol-0",
+							VolumeContext: map[string]string{"foo": "bar"},
+
+							ContentSource: &csipbv1.VolumeContentSource{},
+							AccessibleTopology: []*csipbv1.Topology{
+								{
+									Segments: map[string]string{"rack": "A"},
+								},
+							},
+						},
+					},
+				},
+				NextToken: "abcdef",
+			}
+
+			cc.NextVolumeHealthResponse = &csipbv1.ControllerGetVolumeHealthResponse{
+				VolumeHealth: &csipbv1.VolumeHealth{
+					VolumeId:       "vol-0",
+					HealthStatuses: tc.HealthStatusesResponse,
+				},
+			}
+
+			resp, err := client.ControllerListVolumes(context.TODO(), &ControllerListVolumesRequest{})
+			must.NoError(t, err)
+			must.Len(t, 1, resp.Entries, must.Sprint("expected only one entry in response"))
+			entry := resp.Entries[0]
+			must.NotNil(t, entry.Status, must.Sprint("expected entry to include status"))
+			must.Eq(t, tc.ExpectedCondition, entry.Status.VolumeCondition)
+			must.Eq(t, tc.ExpectedHealth, entry.Health)
+		})
+	}
+}
+
+func TestClient_RPC_ControllerGetVolumeHealth(t *testing.T) {
+	ci.Parallel(t)
+
+	testCases := []struct {
+		name             string
+		response         *csipbv1.ControllerGetVolumeHealthResponse
+		responseErr      error
+		expectedResponse *ControllerGetVolumeHealthResponse
+		expectedErr      error
+	}{
+		{
+			name:             "ok - empty",
+			response:         &csipbv1.ControllerGetVolumeHealthResponse{},
+			expectedResponse: &ControllerGetVolumeHealthResponse{},
+		},
+		{
+			name: "ok - no statuses",
+			response: &csipbv1.ControllerGetVolumeHealthResponse{
+				VolumeHealth: &csipbv1.VolumeHealth{
+					VolumeId: "vol-0",
+				},
+			},
+			expectedResponse: &ControllerGetVolumeHealthResponse{
+				VolumeID: "vol-0",
+				Statuses: []*VolumeHealthStatus{},
+			},
+		},
+		{
+			name: "ok - with status",
+			response: &csipbv1.ControllerGetVolumeHealthResponse{
+				VolumeHealth: &csipbv1.VolumeHealth{
+					VolumeId: "vol-0",
+					HealthStatuses: []*csipbv1.VolumeHealth_VolumeHealthEntry{
+						{
+							Status:  csipbv1.VolumeHealthErrorType_DEGRADED,
+							Reason:  "clogged pipes",
+							Message: "full of koopa troopas",
+						},
+					},
+				},
+			},
+			expectedResponse: &ControllerGetVolumeHealthResponse{
+				VolumeID: "vol-0",
+				Statuses: []*VolumeHealthStatus{
+					{
+						Status:  "DEGRADED",
+						Reason:  "clogged pipes",
+						Message: "full of koopa troopas",
+					},
+				},
+			},
+		},
+		{
+			name: "ok - multiple statuses",
+			response: &csipbv1.ControllerGetVolumeHealthResponse{
+				VolumeHealth: &csipbv1.VolumeHealth{
+					VolumeId: "vol-0",
+					HealthStatuses: []*csipbv1.VolumeHealth_VolumeHealthEntry{
+						{
+							Status:  csipbv1.VolumeHealthErrorType_DATA_LOSS,
+							Reason:  "solar flares",
+							Message: "send foil",
+						},
+						{
+							Status:  csipbv1.VolumeHealthErrorType_DEGRADED,
+							Reason:  "clogged pipes",
+							Message: "full of koopa troopas",
+						},
+					},
+				},
+			},
+			expectedResponse: &ControllerGetVolumeHealthResponse{
+				VolumeID: "vol-0",
+				Statuses: []*VolumeHealthStatus{
+					{
+						Status:  "DATA_LOSS",
+						Reason:  "solar flares",
+						Message: "send foil",
+					},
+					{
+						Status:  "DEGRADED",
+						Reason:  "clogged pipes",
+						Message: "full of koopa troopas",
+					},
+				},
+			},
+		},
+		{
+			name:        "error - unimplemented",
+			responseErr: status.Error(codes.Unimplemented, "not implemented"),
+			expectedErr: errors.New("controller plugin does not implement ControllerGetVolumeHealth: rpc error: code = Unimplemented desc = not implemented"),
+		},
+		{
+			name:        "error - not found",
+			responseErr: status.Error(codes.NotFound, "volume not found"),
+			expectedErr: errors.New(`volume "vol-0" health status does not exist: rpc error: code = NotFound desc = volume not found`),
+		},
+		{
+			name:        "error",
+			responseErr: status.Error(codes.Internal, "test error"),
+			expectedErr: errors.New("rpc error: code = Internal desc = test error"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, cc, _, client := newTestClient(t)
+			defer client.Close()
+
+			cc.NextVolumeHealthResponse = tc.response
+			cc.NextVolumeHealthErr = tc.responseErr
+
+			resp, err := client.ControllerGetVolumeHealth(t.Context(), &ControllerGetVolumeHealthRequest{VolumeID: "vol-0"})
+			if tc.expectedErr != nil {
+				must.EqError(t, err, tc.expectedErr.Error())
+				return
+			}
+
+			must.NoError(t, err)
+			must.Eq(t, tc.expectedResponse, resp)
 		})
 	}
 }

--- a/plugins/csi/fake/client.go
+++ b/plugins/csi/fake/client.go
@@ -46,6 +46,10 @@ type Client struct {
 	NextControllerGetCapabilitiesErr      error
 	ControllerGetCapabilitiesCallCount    int64
 
+	NextControllerGetVolumeHealthResponse *csi.ControllerGetVolumeHealthResponse
+	NextControllerGetVolumeHealthErr      error
+	ControllerGetVolumeHealthCallCount    int64
+
 	NextControllerPublishVolumeResponse *csi.ControllerPublishVolumeResponse
 	NextControllerPublishVolumeErr      error
 	ControllerPublishVolumeCallCount    int64
@@ -171,6 +175,15 @@ func (c *Client) ControllerGetCapabilities(ctx context.Context) (*csi.Controller
 	c.ControllerGetCapabilitiesCallCount++
 
 	return c.NextControllerGetCapabilitiesResponse, c.NextControllerGetCapabilitiesErr
+}
+
+func (c *Client) ControllerGetVolumeHealth(ctx context.Context, in *csi.ControllerGetVolumeHealthRequest, opts ...grpc.CallOption) (*csi.ControllerGetVolumeHealthResponse, error) {
+	c.Mu.Lock()
+	defer c.Mu.Unlock()
+
+	c.ControllerGetVolumeHealthCallCount++
+
+	return c.NextControllerGetVolumeHealthResponse, c.NextControllerGetVolumeHealthErr
 }
 
 // ControllerPublishVolume is used to attach a remote volume to a node

--- a/plugins/csi/plugin.go
+++ b/plugins/csi/plugin.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	csipbv1 "github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/grpc"
@@ -60,6 +61,10 @@ type CSIPlugin interface {
 	// ControllerListVolumes is used to list all volumes available in the
 	// external storage provider
 	ControllerListVolumes(ctx context.Context, req *ControllerListVolumesRequest, opts ...grpc.CallOption) (*ControllerListVolumesResponse, error)
+
+	// ControllerGetVolumeHealth is used to get the health of a remove volume
+	// in the external storage provider.
+	ControllerGetVolumeHealth(ctx context.Context, req *ControllerGetVolumeHealthRequest, opts ...grpc.CallOption) (*ControllerGetVolumeHealthResponse, error)
 
 	// ControllerExpandVolume is used to expand a volume's size
 	ControllerExpandVolume(ctx context.Context, req *ControllerExpandVolumeRequest, opts ...grpc.CallOption) (*ControllerExpandVolumeResponse, error)
@@ -314,8 +319,14 @@ type ControllerCapabilitySet struct {
 	HasPublishReadonly           bool
 	HasExpandVolume              bool
 	HasListVolumesPublishedNodes bool
-	HasVolumeCondition           bool
 	HasGetVolume                 bool
+	HasGetVolumeHealth           bool
+
+	// Volume condition feature was removed from the CSI specification
+	// and replaced with the volume health feature. This remains only
+	// for compatibility and will never be true.
+	// ref: https://github.com/container-storage-interface/spec/pull/604
+	HasVolumeCondition bool
 }
 
 func NewControllerCapabilitySet(resp *csipbv1.ControllerGetCapabilitiesResponse) *ControllerCapabilitySet {
@@ -345,8 +356,8 @@ func NewControllerCapabilitySet(resp *csipbv1.ControllerGetCapabilitiesResponse)
 				cs.HasExpandVolume = true
 			case csipbv1.ControllerServiceCapability_RPC_LIST_VOLUMES_PUBLISHED_NODES:
 				cs.HasListVolumesPublishedNodes = true
-			case csipbv1.ControllerServiceCapability_RPC_VOLUME_CONDITION:
-				cs.HasVolumeCondition = true
+			case csipbv1.ControllerServiceCapability_RPC_GET_VOLUME_HEALTH:
+				cs.HasGetVolumeHealth = true
 			case csipbv1.ControllerServiceCapability_RPC_GET_VOLUME:
 				cs.HasGetVolume = true
 			default:
@@ -705,7 +716,7 @@ type ControllerListVolumesResponse struct {
 	NextToken string
 }
 
-func NewListVolumesResponse(resp *csipbv1.ListVolumesResponse) *ControllerListVolumesResponse {
+func NewListVolumesResponse(resp *csipbv1.ListVolumesResponse, volHealths map[string][]*VolumeHealthStatus) *ControllerListVolumesResponse {
 	if resp == nil {
 		return &ControllerListVolumesResponse{}
 	}
@@ -714,7 +725,7 @@ func NewListVolumesResponse(resp *csipbv1.ListVolumesResponse) *ControllerListVo
 		for _, entry := range resp.Entries {
 			vol := entry.GetVolume()
 			status := entry.GetStatus()
-			entries = append(entries, &ListVolumesResponse_Entry{
+			newEntry := &ListVolumesResponse_Entry{
 				Volume: &Volume{
 					CapacityBytes:      vol.CapacityBytes,
 					ExternalVolumeID:   vol.VolumeId,
@@ -725,11 +736,41 @@ func NewListVolumesResponse(resp *csipbv1.ListVolumesResponse) *ControllerListVo
 				Status: &ListVolumesResponse_VolumeStatus{
 					PublishedNodeIds: status.GetPublishedNodeIds(),
 					VolumeCondition: &VolumeCondition{
-						Abnormal: status.GetVolumeCondition().GetAbnormal(),
-						Message:  status.GetVolumeCondition().GetMessage(),
+						Abnormal: false,
 					},
 				},
-			})
+				Health: &VolumeHealth{
+					Healthy: true,
+				},
+			}
+
+			// Add the new entry to the list before moving on.
+			entries = append(entries, newEntry)
+
+			// If volume health information is not available, skip.
+			healthStats, ok := volHealths[vol.GetVolumeId()]
+			if !ok || len(healthStats) == 0 {
+				continue
+			}
+
+			// Collect the statuses and reasons to populate
+			// the entry.
+			messages := make([]string, len(healthStats))
+			statuses := make([]*VolumeHealthStatus, len(healthStats))
+			for i, healthStatus := range healthStats {
+				messages[i] = healthStatus.Reason
+				status := *healthStatus
+				statuses[i] = &status
+			}
+
+			// Update the health information and mark as unhealthy
+			newEntry.Health.Healthy = false
+			newEntry.Health.Statuses = statuses
+
+			// Set the volume condition in the status to retain
+			// compatibility.
+			newEntry.Status.VolumeCondition.Abnormal = true
+			newEntry.Status.VolumeCondition.Message = strings.Join(messages, ", ")
 		}
 	}
 	return &ControllerListVolumesResponse{
@@ -741,6 +782,7 @@ func NewListVolumesResponse(resp *csipbv1.ListVolumesResponse) *ControllerListVo
 type ListVolumesResponse_Entry struct {
 	Volume *Volume
 	Status *ListVolumesResponse_VolumeStatus
+	Health *VolumeHealth
 }
 
 type ListVolumesResponse_VolumeStatus struct {
@@ -751,6 +793,55 @@ type ListVolumesResponse_VolumeStatus struct {
 type VolumeCondition struct {
 	Abnormal bool
 	Message  string
+}
+
+type VolumeHealth struct {
+	Healthy  bool
+	Statuses []*VolumeHealthStatus
+}
+
+type ControllerGetVolumeHealthRequest struct {
+	VolumeID string
+	Secrets  structs.CSISecrets
+}
+
+func (r *ControllerGetVolumeHealthRequest) ToCSIRepresentation() *csipbv1.ControllerGetVolumeHealthRequest {
+	return &csipbv1.ControllerGetVolumeHealthRequest{
+		VolumeId: r.VolumeID,
+		Secrets:  r.Secrets,
+	}
+}
+
+type ControllerGetVolumeHealthResponse struct {
+	VolumeID string
+	Statuses []*VolumeHealthStatus
+}
+
+func NewGetVolumeHealthResponse(resp *csipbv1.ControllerGetVolumeHealthResponse) *ControllerGetVolumeHealthResponse {
+	result := &ControllerGetVolumeHealthResponse{}
+	if resp.GetVolumeHealth() == nil {
+		return result
+	}
+
+	health := resp.GetVolumeHealth()
+	result.VolumeID = health.GetVolumeId()
+	result.Statuses = make([]*VolumeHealthStatus, len(health.GetHealthStatuses()))
+
+	for i, status := range health.GetHealthStatuses() {
+		result.Statuses[i] = &VolumeHealthStatus{
+			Status:  status.GetStatus().String(),
+			Reason:  status.GetReason(),
+			Message: status.GetMessage(),
+		}
+	}
+
+	return result
+}
+
+type VolumeHealthStatus struct {
+	Status  string
+	Reason  string
+	Message string
 }
 
 type ControllerCreateSnapshotRequest struct {
@@ -869,7 +960,13 @@ type NodeCapabilitySet struct {
 	HasStageUnstageVolume bool
 	HasGetVolumeStats     bool
 	HasExpandVolume       bool
-	HasVolumeCondition    bool
+	HasVolumeHealth       bool
+
+	// Deprecated: Volume condition feature was removed from the CSI
+	// specification and replaced with the volume health feature. This
+	// remains only for compatibility and will never be true.
+	// ref: https://github.com/container-storage-interface/spec/pull/604
+	HasVolumeCondition bool
 }
 
 func NewNodeCapabilitySet(resp *csipbv1.NodeGetCapabilitiesResponse) *NodeCapabilitySet {
@@ -884,8 +981,8 @@ func NewNodeCapabilitySet(resp *csipbv1.NodeGetCapabilitiesResponse) *NodeCapabi
 				cs.HasGetVolumeStats = true
 			case csipbv1.NodeServiceCapability_RPC_EXPAND_VOLUME:
 				cs.HasExpandVolume = true
-			case csipbv1.NodeServiceCapability_RPC_VOLUME_CONDITION:
-				cs.HasVolumeCondition = true
+			case csipbv1.NodeServiceCapability_RPC_GET_VOLUME_HEALTH:
+				cs.HasVolumeHealth = true
 			default:
 				continue
 			}

--- a/plugins/csi/testing/client.go
+++ b/plugins/csi/testing/client.go
@@ -61,6 +61,8 @@ type ControllerClient struct {
 	NextCreateSnapshotResponse             *csipbv1.CreateSnapshotResponse
 	NextDeleteSnapshotResponse             *csipbv1.DeleteSnapshotResponse
 	NextListSnapshotsResponse              *csipbv1.ListSnapshotsResponse
+	NextVolumeHealthResponse               *csipbv1.ControllerGetVolumeHealthResponse
+	NextVolumeHealthErr                    error
 }
 
 // NewControllerClient returns a new ControllerClient
@@ -138,6 +140,10 @@ func (c *ControllerClient) DeleteSnapshot(ctx context.Context, in *csipbv1.Delet
 
 func (c *ControllerClient) ListSnapshots(ctx context.Context, in *csipbv1.ListSnapshotsRequest, opts ...grpc.CallOption) (*csipbv1.ListSnapshotsResponse, error) {
 	return c.NextListSnapshotsResponse, c.NextErr
+}
+
+func (c *ControllerClient) ControllerGetVolumeHealth(ctx context.Context, in *csipbv1.ControllerGetVolumeHealthRequest, opts ...grpc.CallOption) (*csipbv1.ControllerGetVolumeHealthResponse, error) {
+	return c.NextVolumeHealthResponse, c.NextVolumeHealthErr
 }
 
 // NodeClient is a CSI Node client used for testing


### PR DESCRIPTION
### Description

The condition of a volume is no longer reported within the status information returned in the list volume response. Instead, an endpoint now exists to query the volume health. The new endpoint is now used to include the condition of the volume if it is available.

Like the previous volume condition field, the volume health endpoint is considered alpha within the spec and may be removed or modified in the future.

Removal of volume condition and addition of volume health: [ref](https://github.com/container-storage-interface/spec/commit/0c3379008ecf676f2f2a3b0fa0d88cbd88f935fa)

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
