### PR TITLE
job: Allow setting the reschedule delay as low as one second.

### DIFF
--- a/.changelog/28477.txt
+++ b/.changelog/28477.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+job: Allow setting `reschedule.delay` to values as low as 1s
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -6598,7 +6598,7 @@ func NewRestartPolicy(jobType string) *RestartPolicy {
 }
 
 const ReschedulePolicyMinInterval = 15 * time.Second
-const ReschedulePolicyMinDelay = 5 * time.Second
+const ReschedulePolicyMinDelay = 1 * time.Second
 
 var RescheduleDelayFunctions = [...]string{"constant", "exponential", "fibonacci"}
 
@@ -6641,7 +6641,7 @@ func (r *ReschedulePolicy) Enabled() bool {
 }
 
 // Validate uses different criteria to validate the reschedule policy
-// Delay must be a minimum of 5 seconds
+// Delay must be a minimum of 1 second
 // Delay Ceiling is ignored if Delay Function is "constant"
 // Number of possible attempts is validated, given the interval, delay and delay function
 func (r *ReschedulePolicy) Validate() error {
@@ -7659,6 +7659,19 @@ func (tg *TaskGroup) Warnings(j *Job) error {
 
 	if tg.PreventRescheduleOnLost {
 		mErr.Errors = append(mErr.Errors, errors.New("PreventRescheduleOnLost is deprecated and ignored in favor of Disconnect.Replace"))
+	}
+
+	// Warn about unbounded rescheduling which may cause thrashing if tasks have
+	// unlimited attempts and a low delay.
+	//
+	// The 5 second gate on the delay is used as this was the previous minimum
+	// value which did not produce a warning. It therefore feels like the right
+	// gate to use.
+	if rp := tg.ReschedulePolicy; rp != nil && rp.Unlimited && rp.Delay < 5*time.Second {
+		mErr.Errors = append(
+			mErr.Errors,
+			errors.New("Reschedule policy has unlimited attempts enabled and a low delay; reschedule thrashing possible"),
+		)
 	}
 
 	// Check for mbits network field

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -738,6 +738,44 @@ func TestJob_Warnings(t *testing.T) {
 			Expected: []string{},
 			Job:      connectSidecarServiceJob(new(time.Second)),
 		},
+		{
+			Name: "Unlimited reschedule policy and low delay warning",
+			Expected: []string{
+				"Reschedule policy has unlimited attempts enabled and a low delay; reschedule thrashing possible",
+			},
+			Job: &Job{
+				Type: JobTypeService,
+				TaskGroups: []*TaskGroup{
+					{
+						Name: "web",
+						ReschedulePolicy: &ReschedulePolicy{
+							Unlimited:     true,
+							DelayFunction: "exponential",
+							Delay:         1 * time.Second,
+							MaxDelay:      1 * time.Hour,
+						},
+					},
+				},
+			},
+		},
+		{
+			Name:     "Unlimited reschedule and high delay no warning",
+			Expected: []string{},
+			Job: &Job{
+				Type: JobTypeService,
+				TaskGroups: []*TaskGroup{
+					{
+						Name: "web",
+						ReschedulePolicy: &ReschedulePolicy{
+							Attempts:      3,
+							Interval:      30 * time.Minute,
+							Delay:         20 * time.Second,
+							DelayFunction: "constant",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -5203,6 +5241,27 @@ func TestReschedulePolicy_Validate(t *testing.T) {
 				DelayFunction: "exponential",
 				Delay:         5 * time.Second,
 				MaxDelay:      1 * time.Hour,
+			},
+		},
+		{
+			desc: "Valid minimum delay of 1 second",
+			ReschedulePolicy: &ReschedulePolicy{
+				Attempts:      1,
+				Interval:      15 * time.Second,
+				Delay:         1 * time.Second,
+				DelayFunction: "constant",
+			},
+		},
+		{
+			desc: "Invalid delay below 1 second",
+			ReschedulePolicy: &ReschedulePolicy{
+				Attempts:      1,
+				Interval:      15 * time.Second,
+				Delay:         500 * time.Millisecond,
+				DelayFunction: "constant",
+			},
+			errors: []error{
+				fmt.Errorf("Delay cannot be less than %v (got %v)", ReschedulePolicyMinDelay, 500*time.Millisecond),
 			},
 		},
 	}


### PR DESCRIPTION
In some situations, operators may want to set the reschedule delay lower than the existing minimum value of 5 seconds. This change therefore updates the minimum allowed value to 1 second.

When a value below 5 seconds is used in conjunction with unlimited attempts, a warning is returned to the client. This is to inform them of potential scheduling thrashing in situations where the allocation has an underlying problem and cannot start no matter what Nomad client it lands on.

Docs will be handled as a follow-up.

### Links
Jira: https://hashicorp.atlassian.net/browse/NMD-1598
Closes: #28185 

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

