### PR TITLE
scheduler: resolve known test flake

### DIFF
--- a/scheduler/scheduler_system_test.go
+++ b/scheduler/scheduler_system_test.go
@@ -4167,7 +4167,8 @@ func TestSystemSched_evictUnneededCanaries(t *testing.T) {
 		tgName                  string
 		nodeAllocation          map[string][]*structs.Allocation
 		expectedDesiredCanaries int
-		expectedNodeAllocation  []string
+		expectedNodeAllocCount  int      // total allocs to remain after eviction
+		expectedNodeAllocation  []string // specific alloc IDs expected to be present
 	}{
 		{
 			name:                    "no required canaries",
@@ -4175,6 +4176,7 @@ func TestSystemSched_evictUnneededCanaries(t *testing.T) {
 			tgName:                  "foo",
 			nodeAllocation:          nil,
 			expectedDesiredCanaries: 0,
+			expectedNodeAllocCount:  0,
 			expectedNodeAllocation:  nil,
 		},
 		{
@@ -4208,6 +4210,7 @@ func TestSystemSched_evictUnneededCanaries(t *testing.T) {
 				},
 			},
 			expectedDesiredCanaries: 0,
+			expectedNodeAllocCount:  4,
 			expectedNodeAllocation:  []string{"tg1_alloc1", "tg1_alloc2", "tg2_alloc1", "tg2_alloc2"},
 		},
 		{
@@ -4241,7 +4244,8 @@ func TestSystemSched_evictUnneededCanaries(t *testing.T) {
 				},
 			},
 			expectedDesiredCanaries: 1,
-			expectedNodeAllocation:  []string{"tg1_alloc1", "tg2_alloc1", "tg2_alloc2"},
+			expectedNodeAllocCount:  3, // 1 random surviving tg1 canary + 2 tg2 canaries
+			expectedNodeAllocation:  []string{"tg2_alloc1", "tg2_alloc2"},
 		},
 	}
 	for _, tt := range tests {
@@ -4256,8 +4260,8 @@ func TestSystemSched_evictUnneededCanaries(t *testing.T) {
 			for _, a := range s.plan.NodeAllocation {
 				allocsOnNodes = append(allocsOnNodes, a...)
 			}
-			// TODO: this test is flaky since it depends on map ordering which is not supported
-			must.SliceContainsAllFunc(t, allocsOnNodes, tt.expectedNodeAllocation,
+			must.Len(t, tt.expectedNodeAllocCount, allocsOnNodes, must.Sprint("unexpected number of remaining allocs"))
+			must.SliceContainsSubsetFunc(t, allocsOnNodes, tt.expectedNodeAllocation,
 				func(a *structs.Allocation, id string) bool {
 					return a.ID == id
 				})


### PR DESCRIPTION
When evicting only one of two unneeded canaries we're going to get a random because of map iteration, but our test asserts a specific one. Make the test assertion more accurate.


### Contributor Checklist
- [x] **Changelog Entry** n/a
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
