### PR TITLE
bjq: track in-progress workflows

### DIFF
--- a/api/batch_job_queue.go
+++ b/api/batch_job_queue.go
@@ -46,6 +46,7 @@ type DynamicPriorityWorkload struct {
 	CpuAdjustment    int
 	MemoryAdjustment int
 	CreatedAt        int64
+	Status           string
 }
 
 type DynamicPriorityTenant struct {
@@ -59,6 +60,7 @@ type Workload struct {
 	JobID     string
 	Position  int
 	CreatedAt int64
+	Status    string
 }
 
 type BatchJobQueueJobsResponse struct {

--- a/api/batch_job_queue.go
+++ b/api/batch_job_queue.go
@@ -38,6 +38,7 @@ type BatchJobQueueConfig struct {
 type DynamicPriorityWorkload struct {
 	JobID            string
 	Tenant           string
+	Status           string
 	Position         int
 	AdjustedPriority int
 	BasePriority     int
@@ -46,7 +47,6 @@ type DynamicPriorityWorkload struct {
 	CpuAdjustment    int
 	MemoryAdjustment int
 	CreatedAt        int64
-	Status           string
 }
 
 type DynamicPriorityTenant struct {
@@ -59,8 +59,8 @@ type DynamicPriorityTenant struct {
 type Workload struct {
 	JobID     string
 	Position  int
-	CreatedAt int64
 	Status    string
+	CreatedAt int64
 }
 
 type BatchJobQueueJobsResponse struct {

--- a/command/queue_jobs.go
+++ b/command/queue_jobs.go
@@ -181,10 +181,10 @@ func (c *QueueJobsCommand) printDynamicQueueFormatted(resp []api.DynamicPriority
 	}
 
 	out := make([]string, len(resp)+1)
-	out[0] = "JobID|Tenant|Adjusted Priority|Base Priority|Position|Usage|Age|Cpu|Memory|CreatedAt"
+	out[0] = "JobID|Tenant|Status|Adjusted Priority|Base Priority|Position|Usage|Age|Cpu|Memory|CreatedAt"
 
 	for i, v := range resp {
-		out[i+1] = fmt.Sprintf("%s|%s|%d|%d|%d|%d|%d|%d|%d|%s",
+		out[i+1] = fmt.Sprintf("%s|%s|%s|%d|%d|%d|%d|%d|%d|%d|%s",
 			v.JobID,
 			v.Tenant,
 			v.Status,

--- a/command/queue_jobs.go
+++ b/command/queue_jobs.go
@@ -187,6 +187,7 @@ func (c *QueueJobsCommand) printDynamicQueueFormatted(resp []api.DynamicPriority
 		out[i+1] = fmt.Sprintf("%s|%s|%d|%d|%d|%d|%d|%d|%d|%s",
 			v.JobID,
 			v.Tenant,
+			v.Status,
 			v.AdjustedPriority,
 			v.BasePriority,
 			v.Position,
@@ -247,11 +248,12 @@ func (c *QueueJobsCommand) printQueueFormatted(resp []api.Workload) {
 	}
 
 	out := make([]string, len(resp)+1)
-	out[0] = "JobID|Position|CreatedAt"
+	out[0] = "JobID|Status|Position|CreatedAt"
 
 	for i, v := range resp {
-		out[i+1] = fmt.Sprintf("%s|%d|%s",
+		out[i+1] = fmt.Sprintf("%s|%s|%d|%s",
 			v.JobID,
+			v.Status,
 			v.Position,
 			formatUnixNanoTime(v.CreatedAt),
 		)

--- a/command/queue_jobs_test.go
+++ b/command/queue_jobs_test.go
@@ -28,6 +28,7 @@ func TestQueueJobsCommand_printDynamicQueueFormatted(t *testing.T) {
 		{
 			JobID:            "123",
 			Tenant:           "testTenant1",
+			Status:           "queued",
 			Position:         1,
 			AdjustedPriority: 10,
 			BasePriority:     10,
@@ -41,8 +42,8 @@ func TestQueueJobsCommand_printDynamicQueueFormatted(t *testing.T) {
 	cmd.printDynamicQueueFormatted(testResp)
 
 	expect := "Batch Queue Workloads\n" +
-		"JobID  Tenant       Adjusted Priority  Base Priority  Position  Usage  Age  Cpu  Memory  CreatedAt\n" +
-		"123    testTenant1  10                 10             1         10     5    5    5       " + fmt.Sprintf("%v\n", formatUnixNanoTime(testResp[0].CreatedAt))
+		"JobID  Tenant       Status  Adjusted Priority  Base Priority  Position  Usage  Age  Cpu  Memory  CreatedAt\n" +
+		"123    testTenant1  queued  10                 10             1         10     5    5    5       " + fmt.Sprintf("%v\n", formatUnixNanoTime(testResp[0].CreatedAt))
 
 	must.Eq(t, expect, ui.OutputWriter.String())
 }
@@ -56,6 +57,7 @@ func TestQueueJobsCommand_printDynamicQueueJSON(t *testing.T) {
 		{
 			JobID:            "123",
 			Tenant:           "testTenant1",
+			Status:           "queued",
 			Position:         1,
 			AdjustedPriority: 10,
 			BasePriority:     10,
@@ -68,7 +70,7 @@ func TestQueueJobsCommand_printDynamicQueueJSON(t *testing.T) {
 	}
 	cmd.printDynamicQueueJSON(testResp)
 
-	expect := `[{"JobID":"123","Tenant":"testTenant1","Position":1,"AdjustedPriority":10,"BasePriority":10,"UsageAdjustment":10,"AgeAdjustment":5,"CpuAdjustment":5,"MemoryAdjustment":5,"CreatedAt":` + fmt.Sprintf("%d", testResp[0].CreatedAt) + `}]` + "\n"
+	expect := `[{"JobID":"123","Tenant":"testTenant1","Status":"queued","Position":1,"AdjustedPriority":10,"BasePriority":10,"UsageAdjustment":10,"AgeAdjustment":5,"CpuAdjustment":5,"MemoryAdjustment":5,"CreatedAt":` + fmt.Sprintf("%d", testResp[0].CreatedAt) + `}]` + "\n"
 
 	must.Eq(t, expect, ui.OutputWriter.String())
 }
@@ -110,7 +112,7 @@ func TestQueueJobsCommand_printQueueJSON(t *testing.T) {
 	}
 	cmd.printQueueJSON(testResp)
 
-	expect := `[{"JobID":"123","Position":1,"CreatedAt":` + fmt.Sprintf("%d", testResp[0].CreatedAt) + `,"Status":"queued"}]` + "\n"
+	expect := `[{"JobID":"123","Position":1,"Status":"queued","CreatedAt":` + fmt.Sprintf("%d", testResp[0].CreatedAt) + `}]` + "\n"
 
 	must.Eq(t, expect, ui.OutputWriter.String())
 }

--- a/command/queue_jobs_test.go
+++ b/command/queue_jobs_test.go
@@ -82,14 +82,15 @@ func TestQueueJobsCommand_printQueueFormatted(t *testing.T) {
 		{
 			JobID:     "123",
 			Position:  1,
+			Status:    "queued",
 			CreatedAt: time.Now().UnixNano(),
 		},
 	}
 	cmd.printQueueFormatted(testResp)
 
 	expect := "Batch Queue Workloads\n" +
-		"JobID  Position  CreatedAt\n" +
-		fmt.Sprintf("123    1         %v\n", formatUnixNanoTime(testResp[0].CreatedAt))
+		"JobID  Status  Position  CreatedAt\n" +
+		fmt.Sprintf("123    queued  1         %v\n", formatUnixNanoTime(testResp[0].CreatedAt))
 
 	must.Eq(t, expect, ui.OutputWriter.String())
 }
@@ -103,12 +104,13 @@ func TestQueueJobsCommand_printQueueJSON(t *testing.T) {
 		{
 			JobID:     "123",
 			Position:  1,
+			Status:    "queued",
 			CreatedAt: time.Now().UnixNano(),
 		},
 	}
 	cmd.printQueueJSON(testResp)
 
-	expect := `[{"JobID":"123","Position":1,"CreatedAt":` + fmt.Sprintf("%d", testResp[0].CreatedAt) + `}]` + "\n"
+	expect := `[{"JobID":"123","Position":1,"CreatedAt":` + fmt.Sprintf("%d", testResp[0].CreatedAt) + `,"Status":"queued"}]` + "\n"
 
 	must.Eq(t, expect, ui.OutputWriter.String())
 }

--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -234,9 +234,9 @@ func (d *DynamicPriorityQueue) runProducer(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case w := <-d.enqueueCh:
-			// use createTime so that workloads have consistent age
-			// priority calculations after restoring from state.
-			d.setWorkloadPriority(time.Unix(0, w.eval.CreateTime), w)
+			// use time.Now() so that workloads have the most
+			// up to date age calculation
+			d.setWorkloadPriority(time.Now(), w)
 			d.queue.Push(w)
 
 			// Notify Workload consumer of new workload
@@ -322,7 +322,7 @@ func (d *DynamicPriorityQueue) generateWorkload(e *structs.Evaluation, job *stru
 		tid:                tid,
 		priority:           0,
 		eval:               e,
-		status:             "queued",
+		status:             queue.WorkloadStatusQueued,
 		requestedResources: requestedResources,
 		waitOnRestore:      false,
 	}

--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -504,6 +504,7 @@ func (d *DynamicPriorityQueue) Jobs(sortOrder structs.SortOrder) *queue.Workload
 			Tenant:           string(w.tid),
 			Namespace:        w.eval.Namespace,
 			Position:         pos,
+			Status:           w.GetStatus(),
 			AdjustedPriority: w.priority,
 			BasePriority:     w.eval.Priority,
 			UsageAdjustment:  w.usageAdjustment,

--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -491,6 +491,11 @@ func (d *DynamicPriorityQueue) Jobs(sortOrder structs.SortOrder) *queue.Workload
 	pos := 0
 	workloads := []structs.QueueWorkload{}
 
+	for _, workload := range d.watcher.GetInProgressWorkloads() {
+		w := workload.(*dynamicPriorityWorkload)
+		workloads = append(workloads, w.toStruct(0))
+	}
+
 	d.queue.Iterate(func(workload queue.Workload) {
 		w := workload.(*dynamicPriorityWorkload)
 		// waitOnRestore does not count towards position in queue
@@ -499,21 +504,7 @@ func (d *DynamicPriorityQueue) Jobs(sortOrder structs.SortOrder) *queue.Workload
 		}
 		pos++
 
-		workloads = append(workloads, &structs.DynamicPriorityWorkload{
-			JobID:            w.eval.JobID,
-			Tenant:           string(w.tid),
-			Namespace:        w.eval.Namespace,
-			Position:         pos,
-			Status:           w.GetStatus(),
-			AdjustedPriority: w.priority,
-			BasePriority:     w.eval.Priority,
-			UsageAdjustment:  w.usageAdjustment,
-			AgeAdjustment:    w.ageAdjustment,
-			CpuAdjustment:    w.cpuAdjustment,
-			MemoryAdjustment: w.memAdjustment,
-			CreatedAt:        w.eval.CreateTime,
-			CreateIndex:      w.eval.CreateIndex,
-		})
+		workloads = append(workloads, w.toStruct(pos))
 	})
 
 	iter := queue.NewWorkloadIter(workloads)

--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -61,6 +61,8 @@ type DynamicPriorityQueue struct {
 	wg     sync.WaitGroup
 
 	logger hclog.Logger
+
+	watcher *queue.WorkloadWatcher
 }
 
 func NewDynamicPriorityQueue(ss *state.StateStore, broker queue.Broker, qconf *structs.BatchQueue, conf *structs.DynamicQueueConfig, logger hclog.Logger) *DynamicPriorityQueue {
@@ -78,6 +80,7 @@ func NewDynamicPriorityQueue(ss *state.StateStore, broker queue.Broker, qconf *s
 		wg:          sync.WaitGroup{},
 		state:       ss,
 		logger:      logger.Named("Dynamic Priority Queue"),
+		watcher:     queue.NewWorkloadWatcher(ss, logger, qconf),
 	}
 }
 
@@ -187,7 +190,7 @@ func (d *DynamicPriorityQueue) restore(ss *state.StateSnapshot, now time.Time) e
 		// in SetEnabled, but it's also entirely possible a queue eval is blocked and
 		// waiting to be completed from a previous DPQ placement. If that happens
 		// we should enqueue it and push it to the front of the queue.
-		complete, err := queue.IsSchedulingComplete(w, d.state)
+		complete, err := d.watcher.IsSchedulingComplete(w)
 		if err != nil {
 			d.logger.Error("failed to wait for placement while enabling queue", "err", err)
 		}
@@ -251,12 +254,12 @@ func (d *DynamicPriorityQueue) runProducer(ctx context.Context) {
 // at a time, enqueues them onto the Eval Broker, and waits for them
 // to be placed before continuing.
 func (d *DynamicPriorityQueue) runConsumer(ctx context.Context) {
+
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-d.qNotify:
-
 			// Pop a workload off the queue if available
 			w := d.queue.Pop()
 
@@ -266,10 +269,10 @@ func (d *DynamicPriorityQueue) runConsumer(ctx context.Context) {
 				d.evalBroker.Enqueue(w.GetEval())
 			}
 
-			// Wait for the eval to be placed
-			err := queue.WaitForPlacement(ctx, w, d.state, memdb.NewWatchSet())
+			// Start watching for placement
+			err := d.watcher.WaitForPlacement(ctx, w, memdb.NewWatchSet())
 			if err != nil {
-				d.logger.Error("failure waiting for workload placement", "evalID", w.GetEval().ID)
+				d.logger.Error("failure waiting for workload placement", "evalID", w.GetEval().ID, "err", err)
 			}
 
 			if evalHasPlacement(w.GetEval()) {
@@ -277,8 +280,6 @@ func (d *DynamicPriorityQueue) runConsumer(ctx context.Context) {
 			}
 			l := d.queue.Len()
 
-			// If the queue still has work, notify self
-			// to continue.
 			if l > 0 {
 				select {
 				case d.qNotify <- struct{}{}:
@@ -321,6 +322,7 @@ func (d *DynamicPriorityQueue) generateWorkload(e *structs.Evaluation, job *stru
 		tid:                tid,
 		priority:           0,
 		eval:               e,
+		status:             "queued",
 		requestedResources: requestedResources,
 		waitOnRestore:      false,
 	}

--- a/nomad/queues/dynamic_priority/queue_test.go
+++ b/nomad/queues/dynamic_priority/queue_test.go
@@ -431,6 +431,8 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 	testCases := []struct {
 		name      string
 		sortOrder structs.SortOrder
+		placing   int
+		completed int
 		workloads []*dynamicPriorityWorkload
 		exp       *queue.WorkloadIter
 	}{
@@ -687,13 +689,152 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:      "tracks placing workloads and returns them in the results",
+			sortOrder: structs.SortByPriority,
+			placing:   1,
+			workloads: []*dynamicPriorityWorkload{
+				{
+					id:  "eval1",
+					tid: "tenantA",
+					eval: &structs.Evaluation{
+						ID:          "eval1",
+						JobID:       "job1",
+						Priority:    50,
+						CreateTime:  time.Unix(20, 0).UnixNano(),
+						CreateIndex: 12,
+					},
+					priority:        59,
+					status:          "queued",
+					sizeAdjustment:  2,
+					ageAdjustment:   3,
+					usageAdjustment: 4,
+				},
+				{
+					id:  "eval2",
+					tid: "tenantA",
+					eval: &structs.Evaluation{
+						ID:          "eval2",
+						JobID:       "job2",
+						Priority:    50,
+						CreateTime:  time.Unix(10, 0).UnixNano(),
+						CreateIndex: 10,
+					},
+					priority:        60,
+					status:          "queued",
+					sizeAdjustment:  3,
+					ageAdjustment:   3,
+					usageAdjustment: 4,
+				},
+			},
+			exp: &queue.WorkloadIter{
+				Workloads: []structs.QueueWorkload{
+					&structs.DynamicPriorityWorkload{
+						JobID:            "job2",
+						Tenant:           "tenantA",
+						Position:         0,
+						Status:           "placing",
+						AdjustedPriority: 60,
+						BasePriority:     50,
+						SizeAdjustment:   3,
+						AgeAdjustment:    3,
+						UsageAdjustment:  4,
+						CreatedAt:        time.Unix(10, 0).UnixNano(),
+						CreateIndex:      10,
+					},
+					&structs.DynamicPriorityWorkload{
+						JobID:            "job1",
+						Tenant:           "tenantA",
+						Position:         1,
+						Status:           "queued",
+						AdjustedPriority: 59,
+						BasePriority:     50,
+						SizeAdjustment:   2,
+						AgeAdjustment:    3,
+						UsageAdjustment:  4,
+						CreatedAt:        time.Unix(20, 0).UnixNano(),
+						CreateIndex:      12,
+					},
+				},
+			},
+		},
+		{
+			name:      "completed workloads are removed from output",
+			sortOrder: structs.SortByPriority,
+			placing:   2,
+			completed: 1,
+			workloads: []*dynamicPriorityWorkload{
+				{
+					id:  "eval1",
+					tid: "tenantA",
+					eval: &structs.Evaluation{
+						ID:          "eval1",
+						JobID:       "job1",
+						Priority:    50,
+						CreateTime:  time.Unix(20, 0).UnixNano(),
+						CreateIndex: 12,
+					},
+					priority:        59,
+					status:          "queued",
+					sizeAdjustment:  2,
+					ageAdjustment:   3,
+					usageAdjustment: 4,
+				},
+				{
+					id:  "eval2",
+					tid: "tenantA",
+					eval: &structs.Evaluation{
+						ID:          "eval2",
+						JobID:       "job2",
+						Priority:    50,
+						CreateTime:  time.Unix(10, 0).UnixNano(),
+						CreateIndex: 10,
+					},
+					priority:        60,
+					status:          "queued",
+					sizeAdjustment:  3,
+					ageAdjustment:   3,
+					usageAdjustment: 4,
+				},
+			},
+			exp: &queue.WorkloadIter{
+				Workloads: []structs.QueueWorkload{
+					&structs.DynamicPriorityWorkload{
+						JobID:            "job1",
+						Tenant:           "tenantA",
+						Position:         0,
+						Status:           "placing",
+						AdjustedPriority: 59,
+						BasePriority:     50,
+						SizeAdjustment:   2,
+						AgeAdjustment:    3,
+						UsageAdjustment:  4,
+						CreatedAt:        time.Unix(20, 0).UnixNano(),
+						CreateIndex:      12,
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			testQueue := &DynamicPriorityQueue{}
+			ss := state.TestStateStore(t)
+			testQueue := NewDynamicPriorityQueue(ss, nil, &structs.BatchQueue{
+				TenantType: "namespace",
+			}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
 			testQueue.queue = queue.NewWorkloadQueue(workloadSortFn())
+
 			for _, w := range tc.workloads {
 				testQueue.queue.Push(w)
+			}
+			if tc.placing > 0 {
+				for i := range tc.placing {
+					w := testQueue.queue.Pop()
+					testQueue.watcher.TrackPlacement(w)
+					if i < tc.completed {
+						testQueue.watcher.UntrackPlacement(w)
+					}
+				}
 			}
 
 			got := testQueue.Jobs(tc.sortOrder)

--- a/nomad/queues/dynamic_priority/queue_test.go
+++ b/nomad/queues/dynamic_priority/queue_test.go
@@ -4,139 +4,18 @@
 package dynamic
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/go-memdb"
 	"github.com/hashicorp/nomad/helper/uuid"
 	"github.com/hashicorp/nomad/nomad/mock"
 	"github.com/hashicorp/nomad/nomad/queues/queue"
 	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 	"github.com/shoenig/test/must"
-	"github.com/shoenig/test/wait"
 )
-
-func TestDynamicPriorityQueue_waitForPlacement(t *testing.T) {
-
-	t.Run("returns if eval complete", func(t *testing.T) {
-		ss := state.TestStateStore(t)
-		testQueue := NewDynamicPriorityQueue(ss, nil, &structs.BatchQueue{}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
-
-		testEval := mock.Eval()
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
-
-		ws := memdb.NewWatchSet()
-		doneCh := make(chan error)
-		workload := &dynamicPriorityWorkload{eval: testEval.Copy()}
-		go func() {
-			err := queue.WaitForPlacement(t.Context(), workload, testQueue.state, ws)
-			doneCh <- err
-		}()
-
-		testEval.Status = structs.EvalStatusComplete
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
-
-		done := <-doneCh
-
-		must.NoError(t, done)
-	})
-
-	t.Run("continues watching blocked evals", func(t *testing.T) {
-		ss := state.TestStateStore(t)
-		testQueue := NewDynamicPriorityQueue(ss, nil, &structs.BatchQueue{}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
-
-		testEval := mock.Eval()
-		blocked := mock.Eval()
-
-		testEval.Status = structs.EvalStatusComplete
-		testEval.BlockedEval = blocked.ID
-
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval, blocked})
-
-		ws := memdb.NewWatchSet()
-		doneCh := make(chan error)
-		workload := &dynamicPriorityWorkload{eval: testEval.Copy()}
-		go func() {
-			err := queue.WaitForPlacement(t.Context(), workload, testQueue.state, ws)
-			doneCh <- err
-		}()
-
-		// We want to make sure the testQueue has begun a watch on the blocked eval
-		// before continuing, which is indicated by the length of the watchset being >0.
-		must.Wait(t, wait.InitialSuccess(
-			wait.ErrorFunc(func() error {
-				if len(ws) == 0 {
-					return fmt.Errorf("blocking query not started yet")
-				}
-				return nil
-			}),
-			wait.Timeout(5*time.Second),
-			wait.Gap(100*time.Millisecond),
-		))
-
-		select {
-		case <-doneCh:
-			t.Fatal("should not have exited")
-		default:
-		}
-
-		blocked.Status = structs.EvalStatusComplete
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{blocked})
-
-		done := <-doneCh
-		must.NoError(t, done)
-	})
-
-	t.Run("continues watching next evals after eval failure", func(t *testing.T) {
-		ss := state.TestStateStore(t)
-		testQueue := NewDynamicPriorityQueue(ss, nil, &structs.BatchQueue{}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
-
-		testEval := mock.Eval()
-		next := mock.Eval()
-
-		testEval.Status = structs.EvalStatusFailed
-		testEval.NextEval = next.ID
-
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval, next})
-
-		ws := memdb.NewWatchSet()
-		doneCh := make(chan error)
-		workload := &dynamicPriorityWorkload{eval: testEval.Copy()}
-		go func() {
-			err := queue.WaitForPlacement(t.Context(), workload, testQueue.state, ws)
-			doneCh <- err
-		}()
-
-		// We want to make sure the testQueue has begun a watch on the blocked eval
-		// before continuing, which is indicated by the length of the watchset being >0.
-		must.Wait(t, wait.InitialSuccess(
-			wait.ErrorFunc(func() error {
-				if len(ws) == 0 {
-					return fmt.Errorf("blocking query not started yet")
-				}
-				return nil
-			}),
-			wait.Timeout(5*time.Second),
-			wait.Gap(100*time.Millisecond),
-		))
-
-		select {
-		case <-doneCh:
-			t.Fatal("should not have exited")
-		default:
-		}
-
-		next.Status = structs.EvalStatusComplete
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{next})
-
-		done := <-doneCh
-		must.NoError(t, done)
-	})
-}
 
 func TestDynamicPriorityQueue_decayUsage(t *testing.T) {
 	t.Run("decays usage by half after half-life", func(t *testing.T) {
@@ -870,75 +749,6 @@ func TestDynamicPriorityQueue_Tenants(t *testing.T) {
 		}
 		must.Eq(t, tc.exp, testQueue.Tenants())
 	}
-}
-
-func TestDynamicPriorityQueue_isSchedulingComplete(t *testing.T) {
-	t.Run("pending eval results in false", func(t *testing.T) {
-		ss := state.TestStateStore(t)
-		testQueue := NewDynamicPriorityQueue(ss, nil, &structs.BatchQueue{}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
-
-		testEval := mock.Eval()
-		testEval.Status = structs.EvalStatusPending
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
-
-		workload := &dynamicPriorityWorkload{
-			id:   testEval.ID,
-			tid:  TenantID("tenant"),
-			eval: testEval.Copy(),
-		}
-
-		complete, err := queue.IsSchedulingComplete(workload, testQueue.state)
-		must.NoError(t, err)
-		must.False(t, complete)
-	})
-
-	t.Run("eval with pending blockedEval results in false", func(t *testing.T) {
-		ss := state.TestStateStore(t)
-		testQueue := NewDynamicPriorityQueue(ss, nil, &structs.BatchQueue{}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
-
-		testEval := mock.Eval()
-		blocked := mock.Eval()
-
-		testEval.Status = structs.EvalStatusComplete
-		testEval.BlockedEval = blocked.ID
-		blocked.Status = structs.EvalStatusPending
-
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval, blocked})
-
-		workload := &dynamicPriorityWorkload{
-			id:   testEval.ID,
-			tid:  TenantID("tenant"),
-			eval: testEval.Copy(),
-		}
-
-		complete, err := queue.IsSchedulingComplete(workload, testQueue.state)
-		must.NoError(t, err)
-		must.False(t, complete)
-	})
-
-	t.Run("eval with complete blockedEval results in true", func(t *testing.T) {
-		ss := state.TestStateStore(t)
-		testQueue := NewDynamicPriorityQueue(ss, nil, &structs.BatchQueue{}, &structs.DynamicQueueConfig{}, hclog.New(hclog.DefaultOptions))
-
-		testEval := mock.Eval()
-		blocked := mock.Eval()
-
-		testEval.Status = structs.EvalStatusComplete
-		testEval.BlockedEval = blocked.ID
-		blocked.Status = structs.EvalStatusComplete
-
-		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval, blocked})
-
-		workload := &dynamicPriorityWorkload{
-			id:   testEval.ID,
-			tid:  TenantID("tenant"),
-			eval: testEval.Copy(),
-		}
-
-		complete, err := queue.IsSchedulingComplete(workload, testQueue.state)
-		must.NoError(t, err)
-		must.True(t, complete)
-	})
 }
 
 func TestDynamicPriorityQueue_restore(t *testing.T) {

--- a/nomad/queues/dynamic_priority/queue_test.go
+++ b/nomad/queues/dynamic_priority/queue_test.go
@@ -706,7 +706,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 					},
 					priority:        59,
 					status:          "queued",
-					sizeAdjustment:  2,
 					ageAdjustment:   3,
 					usageAdjustment: 4,
 				},
@@ -721,8 +720,7 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						CreateIndex: 10,
 					},
 					priority:        60,
-					status:          "queued",
-					sizeAdjustment:  3,
+					status:          "placing",
 					ageAdjustment:   3,
 					usageAdjustment: 4,
 				},
@@ -736,7 +734,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						Status:           "placing",
 						AdjustedPriority: 60,
 						BasePriority:     50,
-						SizeAdjustment:   3,
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 						CreatedAt:        time.Unix(10, 0).UnixNano(),
@@ -749,64 +746,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						Status:           "queued",
 						AdjustedPriority: 59,
 						BasePriority:     50,
-						SizeAdjustment:   2,
-						AgeAdjustment:    3,
-						UsageAdjustment:  4,
-						CreatedAt:        time.Unix(20, 0).UnixNano(),
-						CreateIndex:      12,
-					},
-				},
-			},
-		},
-		{
-			name:      "completed workloads are removed from output",
-			sortOrder: structs.SortByPriority,
-			placing:   2,
-			completed: 1,
-			workloads: []*dynamicPriorityWorkload{
-				{
-					id:  "eval1",
-					tid: "tenantA",
-					eval: &structs.Evaluation{
-						ID:          "eval1",
-						JobID:       "job1",
-						Priority:    50,
-						CreateTime:  time.Unix(20, 0).UnixNano(),
-						CreateIndex: 12,
-					},
-					priority:        59,
-					status:          "queued",
-					sizeAdjustment:  2,
-					ageAdjustment:   3,
-					usageAdjustment: 4,
-				},
-				{
-					id:  "eval2",
-					tid: "tenantA",
-					eval: &structs.Evaluation{
-						ID:          "eval2",
-						JobID:       "job2",
-						Priority:    50,
-						CreateTime:  time.Unix(10, 0).UnixNano(),
-						CreateIndex: 10,
-					},
-					priority:        60,
-					status:          "queued",
-					sizeAdjustment:  3,
-					ageAdjustment:   3,
-					usageAdjustment: 4,
-				},
-			},
-			exp: &queue.WorkloadIter{
-				Workloads: []structs.QueueWorkload{
-					&structs.DynamicPriorityWorkload{
-						JobID:            "job1",
-						Tenant:           "tenantA",
-						Position:         0,
-						Status:           "placing",
-						AdjustedPriority: 59,
-						BasePriority:     50,
-						SizeAdjustment:   2,
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 						CreatedAt:        time.Unix(20, 0).UnixNano(),
@@ -825,15 +764,10 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 			testQueue.queue = queue.NewWorkloadQueue(workloadSortFn())
 
 			for _, w := range tc.workloads {
-				testQueue.queue.Push(w)
-			}
-			if tc.placing > 0 {
-				for i := range tc.placing {
-					w := testQueue.queue.Pop()
+				if w.status == "placing" {
 					testQueue.watcher.TrackPlacement(w)
-					if i < tc.completed {
-						testQueue.watcher.UntrackPlacement(w)
-					}
+				} else {
+					testQueue.queue.Push(w)
 				}
 			}
 

--- a/nomad/queues/dynamic_priority/workload.go
+++ b/nomad/queues/dynamic_priority/workload.go
@@ -59,3 +59,21 @@ func (w *dynamicPriorityWorkload) SetStatus(s, description string) {
 	w.status = s
 	w.description = description
 }
+
+func (w *dynamicPriorityWorkload) toStruct(position int) *structs.DynamicPriorityWorkload {
+	return &structs.DynamicPriorityWorkload{
+		JobID:            w.eval.JobID,
+		Tenant:           string(w.tid),
+		Namespace:        w.eval.Namespace,
+		Position:         position,
+		Status:           w.GetStatus(),
+		AdjustedPriority: w.priority,
+		BasePriority:     w.eval.Priority,
+		UsageAdjustment:  w.usageAdjustment,
+		AgeAdjustment:    w.ageAdjustment,
+		CpuAdjustment:    w.cpuAdjustment,
+		MemoryAdjustment: w.memAdjustment,
+		CreatedAt:        w.eval.CreateTime,
+		CreateIndex:      w.eval.CreateIndex,
+	}
+}

--- a/nomad/queues/dynamic_priority/workload.go
+++ b/nomad/queues/dynamic_priority/workload.go
@@ -3,7 +3,11 @@
 
 package dynamic
 
-import "github.com/hashicorp/nomad/nomad/structs"
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
 
 type dynamicPriorityWorkload struct {
 	// id uniquely identifies this workload
@@ -27,6 +31,9 @@ type dynamicPriorityWorkload struct {
 	// By doing this, we can ensure at most 1 queue workloads blocked
 	// due to resource contraints even in the event of queue restores.
 	waitOnRestore bool
+
+	status      string
+	description string
 }
 
 func (w *dynamicPriorityWorkload) GetEval() *structs.Evaluation {
@@ -39,4 +46,16 @@ func (w *dynamicPriorityWorkload) WaitOnRestore() bool {
 
 func (w *dynamicPriorityWorkload) SetEval(e *structs.Evaluation) {
 	w.eval = e
+}
+
+func (w *dynamicPriorityWorkload) GetStatus() string {
+	if w.description != "" {
+		return fmt.Sprintf("%s (%s)", w.status, w.description)
+	}
+	return w.status
+}
+
+func (w *dynamicPriorityWorkload) SetStatus(s, description string) {
+	w.status = s
+	w.description = description
 }

--- a/nomad/queues/fifo/queue.go
+++ b/nomad/queues/fifo/queue.go
@@ -195,6 +195,20 @@ func (f *FifoQueue) Type() structs.BatchQueueType {
 func (f *FifoQueue) Jobs(sortOrder structs.SortOrder) *queue.WorkloadIter {
 	pos := 0
 	workloads := []structs.QueueWorkload{}
+
+	for _, workload := range f.watcher.GetInProgressWorkloads() {
+		w := workload.(*fifoWorkload)
+		eval := w.GetEval()
+		workloads = append(workloads, &structs.Workload{
+			JobID:       eval.JobID,
+			Namespace:   eval.Namespace,
+			Position:    0,
+			Status:      w.status,
+			CreatedAt:   eval.CreateTime,
+			CreateIndex: eval.CreateIndex,
+		})
+	}
+
 	f.queue.Iterate(func(workload queue.Workload) {
 		w := workload.(*fifoWorkload)
 		// waitOnRestore does not count towards position in queue
@@ -207,8 +221,8 @@ func (f *FifoQueue) Jobs(sortOrder structs.SortOrder) *queue.WorkloadIter {
 		workloads = append(workloads, &structs.Workload{
 			JobID:       eval.JobID,
 			Namespace:   eval.Namespace,
-			Position:    pos + 1,
-			Status:      "queued",
+			Position:    pos,
+			Status:      w.status,
 			CreatedAt:   eval.CreateTime,
 			CreateIndex: eval.CreateIndex,
 		})

--- a/nomad/queues/fifo/queue.go
+++ b/nomad/queues/fifo/queue.go
@@ -39,9 +39,11 @@ type FifoQueue struct {
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
+
+	watcher *queue.WorkloadWatcher
 }
 
-func NewFifoQueue(ss *state.StateStore, broker queue.Broker, logger hclog.Logger) *FifoQueue {
+func NewFifoQueue(ss *state.StateStore, broker queue.Broker, conf *structs.BatchQueue, logger hclog.Logger) *FifoQueue {
 	return &FifoQueue{
 		queue:      queue.NewWorkloadQueue(workloadSortFn()),
 		enqueueCh:  make(chan *fifoWorkload, 8192),
@@ -49,6 +51,7 @@ func NewFifoQueue(ss *state.StateStore, broker queue.Broker, logger hclog.Logger
 		evalBroker: broker,
 		state:      ss,
 		logger:     logger.Named("Fifo Queue"),
+		watcher:    queue.NewWorkloadWatcher(ss, logger, conf),
 	}
 }
 
@@ -112,6 +115,7 @@ func (f *FifoQueue) runProducer(ctx context.Context) {
 }
 
 func (f *FifoQueue) runConsumer(ctx context.Context) {
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -119,9 +123,11 @@ func (f *FifoQueue) runConsumer(ctx context.Context) {
 		case <-f.qNotify:
 			w := f.queue.Pop()
 
-			f.evalBroker.Enqueue(w.GetEval())
+			if !w.WaitOnRestore() {
+				f.evalBroker.Enqueue(w.GetEval())
+			}
 
-			err := queue.WaitForPlacement(ctx, w, f.state, memdb.NewWatchSet())
+			err := f.watcher.WaitForPlacement(ctx, w, memdb.NewWatchSet())
 			if err != nil {
 				f.logger.Error("failure waiting for workload placement", "evalID", w.GetEval().ID)
 			}
@@ -168,7 +174,7 @@ func (f *FifoQueue) restore(snap *state.StateSnapshot) error {
 
 		w := newFifoWorkload(eval)
 
-		placed, err := queue.IsSchedulingComplete(w, f.state)
+		placed, err := f.watcher.IsSchedulingComplete(w)
 		if err != nil {
 			f.logger.Error("failed to wait for placement while enabling queue", "err", err)
 		}

--- a/nomad/queues/fifo/queue.go
+++ b/nomad/queues/fifo/queue.go
@@ -208,6 +208,7 @@ func (f *FifoQueue) Jobs(sortOrder structs.SortOrder) *queue.WorkloadIter {
 			JobID:       eval.JobID,
 			Namespace:   eval.Namespace,
 			Position:    pos + 1,
+			Status:      "queued",
 			CreatedAt:   eval.CreateTime,
 			CreateIndex: eval.CreateIndex,
 		})

--- a/nomad/queues/fifo/queue_test.go
+++ b/nomad/queues/fifo/queue_test.go
@@ -188,3 +188,137 @@ func TestFifoQueue_runConsumer_enqueueOrder(t *testing.T) {
 	must.Eq(t, eval1.ID, first)
 	must.Eq(t, eval2.ID, second)
 }
+
+func TestFifoQueue_Jobs_WithStatus(t *testing.T) {
+	t.Run("queued workloads have status and position", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		broker := newTestBroker()
+		q := NewFifoQueue(ss, broker, &structs.BatchQueue{}, hclog.Default())
+
+		// Directly push to queue without starting (to avoid dequeuing)
+		eval1 := mock.Eval()
+		eval2 := mock.Eval()
+		eval1.CreateIndex = 1
+		eval2.CreateIndex = 2
+
+		q.qMux.Lock()
+		q.queue.Push(newFifoWorkload(eval1))
+		q.queue.Push(newFifoWorkload(eval2))
+		q.qMux.Unlock()
+
+		// Get jobs
+		iter := q.Jobs(structs.SortByPriority)
+		workloads := []*structs.Workload{}
+		for {
+			w := iter.Next()
+			if w == nil {
+				break
+			}
+			workloads = append(workloads, w.(*structs.Workload))
+		}
+
+		// Should have 2 workloads
+		must.Eq(t, 2, len(workloads))
+
+		// Both should be queued with positions 1 and 2
+		must.Eq(t, "queued", workloads[0].Status)
+		must.Eq(t, 1, workloads[0].Position)
+
+		must.Eq(t, "queued", workloads[1].Status)
+		must.Eq(t, 2, workloads[1].Position)
+	})
+
+	t.Run("in-progress workloads have placing status and position 0", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		broker := newTestBroker()
+		q := NewFifoQueue(ss, broker, &structs.BatchQueue{}, hclog.Default())
+
+		// Manually track workloads to simulate in-progress state
+		eval1 := mock.Eval()
+		eval2 := mock.Eval()
+		eval3 := mock.Eval()
+
+		w1 := newFifoWorkload(eval1)
+		w2 := newFifoWorkload(eval2)
+		w3 := newFifoWorkload(eval3)
+
+		// Add one to queue
+		q.qMux.Lock()
+		q.queue.Push(w3)
+		q.qMux.Unlock()
+
+		// Track two as in-progress
+		q.watcher.TrackPlacement(w1)
+		q.watcher.TrackPlacement(w2)
+
+		// Get jobs
+		iter := q.Jobs(structs.SortByPriority)
+		workloads := []*structs.Workload{}
+		for {
+			w := iter.Next()
+			if w == nil {
+				break
+			}
+			workloads = append(workloads, w.(*structs.Workload))
+		}
+
+		// Should have 3 workloads total (2 placing + 1 queued)
+		must.Eq(t, 3, len(workloads))
+
+		// Count by status
+		placingCount := 0
+		queuedCount := 0
+		for _, wl := range workloads {
+			if wl.Status == "placing" {
+				placingCount++
+				must.Eq(t, 0, wl.Position)
+			} else if wl.Status == "queued" {
+				queuedCount++
+				must.True(t, wl.Position > 0)
+			}
+		}
+
+		must.Eq(t, 2, placingCount)
+		must.Eq(t, 1, queuedCount)
+	})
+
+	t.Run("completed placements are removed from in-progress", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		broker := newTestBroker()
+		q := NewFifoQueue(ss, broker, &structs.BatchQueue{}, hclog.Default())
+
+		eval := mock.Eval()
+		w := newFifoWorkload(eval)
+
+		// Track as in-progress
+		q.watcher.TrackPlacement(w)
+
+		// Should have 1 placing workload
+		iter := q.Jobs(structs.SortByPriority)
+		workloads := []*structs.Workload{}
+		for {
+			w := iter.Next()
+			if w == nil {
+				break
+			}
+			workloads = append(workloads, w.(*structs.Workload))
+		}
+		must.Eq(t, 1, len(workloads))
+		must.Eq(t, "placing", workloads[0].Status)
+
+		// Untrack (simulating completion)
+		q.watcher.UntrackPlacement(w)
+
+		// Should have no workloads now
+		iter = q.Jobs(structs.SortByPriority)
+		workloads = []*structs.Workload{}
+		for {
+			w := iter.Next()
+			if w == nil {
+				break
+			}
+			workloads = append(workloads, w.(*structs.Workload))
+		}
+		must.Eq(t, 0, len(workloads))
+	})
+}

--- a/nomad/queues/fifo/queue_test.go
+++ b/nomad/queues/fifo/queue_test.go
@@ -70,7 +70,7 @@ func TestFifoQueue_workloadSortFn(t *testing.T) {
 func TestFifoQueue_restore(t *testing.T) {
 	t.Run("unplaced workload is enqueued", func(t *testing.T) {
 		ss := state.TestStateStore(t)
-		testQueue := NewFifoQueue(ss, nil, hclog.New(hclog.DefaultOptions))
+		testQueue := NewFifoQueue(ss, nil, &structs.BatchQueue{}, hclog.New(hclog.DefaultOptions))
 
 		job := mock.Job()
 		job.Type = structs.JobTypeBatch
@@ -101,7 +101,7 @@ func TestFifoQueue_restore(t *testing.T) {
 
 	t.Run("skips pending non-batch and non-register evals", func(t *testing.T) {
 		ss := state.TestStateStore(t)
-		testQueue := NewFifoQueue(ss, nil, hclog.New(hclog.DefaultOptions))
+		testQueue := NewFifoQueue(ss, nil, &structs.BatchQueue{}, hclog.New(hclog.DefaultOptions))
 
 		batchJob := mock.Job()
 		batchJob.Type = structs.JobTypeBatch
@@ -150,15 +150,17 @@ func TestFifoQueue_restore(t *testing.T) {
 func TestFifoQueue_runConsumer_enqueueOrder(t *testing.T) {
 	ss := state.TestStateStore(t)
 	broker := newTestBroker()
-	q := NewFifoQueue(ss, broker, hclog.New(hclog.DefaultOptions))
+	q := NewFifoQueue(ss, broker, &structs.BatchQueue{}, hclog.New(hclog.DefaultOptions))
 
 	ctx := t.Context()
 
 	must.NoError(t, q.Start(ctx))
 
+	job1 := mock.Job()
 	eval1 := mock.Eval()
 	eval1.Type = structs.JobTypeBatch
 	eval1.Status = structs.EvalStatusComplete
+	job2 := mock.Job()
 	eval2 := mock.Eval()
 	eval2.Type = structs.JobTypeBatch
 	eval2.Status = structs.EvalStatusComplete

--- a/nomad/queues/fifo/queue_test.go
+++ b/nomad/queues/fifo/queue_test.go
@@ -156,11 +156,10 @@ func TestFifoQueue_runConsumer_enqueueOrder(t *testing.T) {
 
 	must.NoError(t, q.Start(ctx))
 
-	job1 := mock.Job()
 	eval1 := mock.Eval()
 	eval1.Type = structs.JobTypeBatch
 	eval1.Status = structs.EvalStatusComplete
-	job2 := mock.Job()
+
 	eval2 := mock.Eval()
 	eval2.Type = structs.JobTypeBatch
 	eval2.Status = structs.EvalStatusComplete
@@ -201,10 +200,8 @@ func TestFifoQueue_Jobs_WithStatus(t *testing.T) {
 		eval1.CreateIndex = 1
 		eval2.CreateIndex = 2
 
-		q.qMux.Lock()
 		q.queue.Push(newFifoWorkload(eval1))
 		q.queue.Push(newFifoWorkload(eval2))
-		q.qMux.Unlock()
 
 		// Get jobs
 		iter := q.Jobs(structs.SortByPriority)
@@ -243,9 +240,7 @@ func TestFifoQueue_Jobs_WithStatus(t *testing.T) {
 		w3 := newFifoWorkload(eval3)
 
 		// Add one to queue
-		q.qMux.Lock()
 		q.queue.Push(w3)
-		q.qMux.Unlock()
 
 		// Track two as in-progress
 		q.watcher.TrackPlacement(w1)
@@ -269,10 +264,11 @@ func TestFifoQueue_Jobs_WithStatus(t *testing.T) {
 		placingCount := 0
 		queuedCount := 0
 		for _, wl := range workloads {
-			if wl.Status == "placing" {
+			switch wl.Status {
+			case "placing":
 				placingCount++
 				must.Eq(t, 0, wl.Position)
-			} else if wl.Status == "queued" {
+			case "queued":
 				queuedCount++
 				must.True(t, wl.Position > 0)
 			}

--- a/nomad/queues/fifo/workload.go
+++ b/nomad/queues/fifo/workload.go
@@ -3,13 +3,19 @@
 
 package fifo
 
-import "github.com/hashicorp/nomad/nomad/structs"
+import (
+	"fmt"
+
+	"github.com/hashicorp/nomad/nomad/structs"
+)
 
 type fifoWorkload struct {
 	id            string
 	counter       uint64
 	eval          *structs.Evaluation
 	waitOnRestore bool
+	status        string
+	description   string
 }
 
 func newFifoWorkload(e *structs.Evaluation) *fifoWorkload {
@@ -29,4 +35,15 @@ func (f *fifoWorkload) SetEval(e *structs.Evaluation) {
 
 func (f *fifoWorkload) WaitOnRestore() bool {
 	return f.waitOnRestore
+}
+
+func (f *fifoWorkload) SetStatus(s, description string) {
+	f.status = s
+	f.description = description
+}
+func (f *fifoWorkload) GetStatus() string {
+	if f.description != "" {
+		return fmt.Sprintf("%s (%s)", f.status, f.description)
+	}
+	return f.status
 }

--- a/nomad/queues/fifo/workload.go
+++ b/nomad/queues/fifo/workload.go
@@ -20,8 +20,9 @@ type fifoWorkload struct {
 
 func newFifoWorkload(e *structs.Evaluation) *fifoWorkload {
 	return &fifoWorkload{
-		id:   e.ID,
-		eval: e,
+		id:     e.ID,
+		eval:   e,
+		status: "queued",
 	}
 }
 

--- a/nomad/queues/fifo/workload.go
+++ b/nomad/queues/fifo/workload.go
@@ -6,6 +6,7 @@ package fifo
 import (
 	"fmt"
 
+	"github.com/hashicorp/nomad/nomad/queues/queue"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -22,7 +23,7 @@ func newFifoWorkload(e *structs.Evaluation) *fifoWorkload {
 	return &fifoWorkload{
 		id:     e.ID,
 		eval:   e,
-		status: "queued",
+		status: queue.WorkloadStatusQueued,
 	}
 }
 

--- a/nomad/queues/queue/helpers.go
+++ b/nomad/queues/queue/helpers.go
@@ -3,14 +3,6 @@
 
 package queue
 
-import (
-	"context"
-
-	"github.com/hashicorp/go-memdb"
-	"github.com/hashicorp/nomad/nomad/state"
-	"github.com/hashicorp/nomad/nomad/structs"
-)
-
 func CmpWaitOnRestore(a, b Workload) int {
 	if a.WaitOnRestore() && !b.WaitOnRestore() {
 		return -1
@@ -18,104 +10,4 @@ func CmpWaitOnRestore(a, b Workload) int {
 		return 1
 	}
 	return 0
-}
-
-// WaitForPlacement follows a given evaluation in the state store until it, or its next/blocked evals
-// have been marked terminal, indicating the workload has been scheduled.
-//
-// Note: If a job with an unsatisfiable contraint is given to the Eval Broker, this function will block
-// until a Nomad operator manually intervenes and stops the job. In the future, we can add an optional
-// configurable timeout for this blocking query.
-func WaitForPlacement(ctx context.Context, workload Workload, ss *state.StateStore, ws memdb.WatchSet) error {
-	eval := workload.GetEval()
-	for !eval.TerminalStatus() || eval.BlockedEval != "" || eval.NextEval != "" {
-		id := eval.ID
-
-		if eval.BlockedEval != "" {
-			id = eval.BlockedEval
-		} else if eval.NextEval != "" {
-			id = eval.NextEval
-		}
-
-		snap, err := ss.Snapshot()
-		if err != nil {
-			return err
-		}
-
-		// TODO: handle snapshot restores
-		abandonCh := snap.AbandonCh()
-		ws.Add(abandonCh)
-
-		eval, err = snap.EvalByID(ws, id)
-		if err != nil {
-			return err
-		}
-		if eval == nil {
-			return ErrWatchedEvalNotFound
-		}
-
-		workload.SetEval(eval)
-
-		if eval.TerminalStatus() {
-			continue
-		}
-
-		// If the latest version of the eval isn't terminal, wait for an update
-		if err = ws.WatchCtx(ctx); err != nil {
-			return err
-		}
-
-		// The watch channel will be closed, we should delete it to
-		// prevent immediately firing on the next WatchCtx
-		for k := range ws {
-			delete(ws, k)
-		}
-	}
-
-	return nil
-}
-
-// IsSchedulingComplete detects whether a workload was actually placed by following the
-// evaluation's BlockedEvals and NextEvals.
-// Similar to WaitForPlacement, IsSchedulingComplete will record usage in the event an
-// actual placement occurred.
-func IsSchedulingComplete(workload Workload, ss *state.StateStore) (bool, error) {
-	snap, err := ss.Snapshot()
-	if err != nil {
-		return false, err
-	}
-
-	ws := memdb.NewWatchSet()
-	eval := workload.GetEval()
-	for eval.BlockedEval != "" || eval.NextEval != "" {
-		id := eval.ID
-
-		if eval.BlockedEval != "" {
-			id = eval.BlockedEval
-		} else if eval.NextEval != "" {
-			id = eval.NextEval
-		}
-
-		eval, err = snap.EvalByID(ws, id)
-		if err != nil {
-			return false, err
-		}
-		if eval == nil {
-			return false, ErrWatchedEvalNotFound
-		}
-
-		workload.SetEval(eval)
-
-		if !eval.TerminalStatus() {
-			return false, nil
-		}
-	}
-
-	if eval.Status == structs.EvalStatusComplete {
-		return true, nil
-	}
-
-	// This would only happen if an eval was not complete and did not
-	// yet have a followup eval
-	return false, nil
 }

--- a/nomad/queues/queue/helpers.go
+++ b/nomad/queues/queue/helpers.go
@@ -3,6 +3,12 @@
 
 package queue
 
+const (
+	WorkloadStatusQueued  = "queued"
+	WorkloadStatusPlacing = "placing"
+	WorkloadStatusBlocked = "blocked"
+)
+
 func CmpWaitOnRestore(a, b Workload) int {
 	if a.WaitOnRestore() && !b.WaitOnRestore() {
 		return -1

--- a/nomad/queues/queue/interface.go
+++ b/nomad/queues/queue/interface.go
@@ -6,6 +6,7 @@ package queue
 import (
 	"context"
 
+	"github.com/hashicorp/nomad/nomad/state"
 	"github.com/hashicorp/nomad/nomad/structs"
 )
 
@@ -26,5 +27,11 @@ type Broker interface {
 type Workload interface {
 	GetEval() *structs.Evaluation
 	SetEval(*structs.Evaluation)
+	GetStatus() string
+	SetStatus(string, string)
 	WaitOnRestore() bool
+}
+
+type Snapshotter interface {
+	Snapshot() (*state.StateSnapshot, error)
 }

--- a/nomad/queues/queue/workload_watcher.go
+++ b/nomad/queues/queue/workload_watcher.go
@@ -1,0 +1,235 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package queue
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/structs"
+)
+
+type WorkloadWatcher struct {
+	stateStore Snapshotter
+	config     *structs.BatchQueue
+	logger     hclog.Logger
+	mu         sync.Mutex
+
+	inProgressWorkloads map[string]Workload
+}
+
+func NewWorkloadWatcher(s Snapshotter, logger hclog.Logger, config *structs.BatchQueue) *WorkloadWatcher {
+	w := &WorkloadWatcher{
+		stateStore:          s,
+		config:              config,
+		logger:              logger.Named("workload_watcher"),
+		inProgressWorkloads: make(map[string]Workload),
+	}
+
+	return w
+}
+
+// TrackPlacement increments the currentPlacements counter, sets the workload
+// status, and adds a workload to the in-progress tracking map.
+func (w *WorkloadWatcher) TrackPlacement(workload Workload) {
+	workload.SetStatus("placing", "")
+	w.inProgressWorkloads[workload.GetEval().ID] = workload
+}
+
+// UntrackPlacement decrements the currentPlacements counter and removes a workload from the in-progress tracking map.
+func (w *WorkloadWatcher) UntrackPlacement(workload Workload) {
+	eval := workload.GetEval()
+
+	// If the eval was blocked and then unblocked, the eval will not match in
+	// the map. Attempt to use the PreviousEval in that case.
+	id := eval.ID
+	_, ok := w.inProgressWorkloads[id]
+	if !ok {
+		id = eval.PreviousEval
+		if id == "" {
+			return
+		}
+	}
+	delete(w.inProgressWorkloads, id)
+}
+
+// GetInProgressWorkloads returns a copy of all workloads currently being watched for placement.
+func (w *WorkloadWatcher) GetInProgressWorkloads() map[string]Workload {
+	return w.inProgressWorkloads
+}
+
+// WaitForPlacement watches an evaluation until it reaches a terminal state or times out.
+// It runs async and sends the result to the Results() channel.
+func (w *WorkloadWatcher) WaitForPlacement(ctx context.Context, workload Workload, ws memdb.WatchSet) error {
+	// Track this placement
+	w.mu.Lock()
+	w.TrackPlacement(workload)
+	w.mu.Unlock()
+
+	err := w.wait(ctx, workload, ws)
+
+	// Remove the workload from tracking
+	w.mu.Lock()
+	w.UntrackPlacement(workload)
+	w.mu.Unlock()
+
+	return err
+}
+
+// wait blocks until the workload's evaluation reaches a terminal state.
+func (w *WorkloadWatcher) wait(ctx context.Context, workload Workload, ws memdb.WatchSet) error {
+	eval := workload.GetEval()
+
+	for !eval.TerminalStatus() || eval.BlockedEval != "" || eval.NextEval != "" {
+		// Determine which eval to follow
+		evalID := eval.ID
+		if eval.BlockedEval != "" {
+			evalID = eval.BlockedEval
+		} else if eval.NextEval != "" {
+			evalID = eval.NextEval
+		}
+
+		// Get a snapshot of the state
+		snap, err := w.stateStore.Snapshot()
+		if err != nil {
+			return err
+		}
+
+		// Watch for snapshot abandonment
+		ws.Add(snap.AbandonCh())
+
+		// Lookup the evaluation
+		eval, err = snap.EvalByID(ws, evalID)
+		if err != nil {
+			return err
+		}
+		if eval == nil {
+			return ErrWatchedEvalNotFound
+		}
+
+		workload.SetEval(eval)
+
+		// If terminal, continue to check for followup evals
+		if eval.TerminalStatus() {
+			continue
+		}
+
+		if w.isConstraintFailure(workload) {
+			workload.SetStatus("constrained", w.ConstraintDescription(workload))
+		}
+
+		// Wait for eval update or context cancellation
+		if err = ws.WatchCtx(ctx); err != nil {
+			return err
+		}
+
+		// Clear the watchset for next iteration
+		for k := range ws {
+			delete(ws, k)
+		}
+	}
+	return nil
+}
+
+// isConstraintFailure checks if the evaluation failed due to non-resource constraints
+// (e.g., constraint filters) rather than resource exhaustion.
+// Returns true if the failure is constraint-related (and unlikely to resolve with time)
+func (w *WorkloadWatcher) isConstraintFailure(workload Workload) bool {
+	eval := workload.GetEval()
+	if eval == nil || eval.FailedTGAllocs == nil {
+		return false
+	}
+
+	for _, metric := range eval.FailedTGAllocs {
+		if metric == nil {
+			continue
+		}
+
+		// If there are constraint filters but no resource exhaustion, it's a constraint failure
+		hasConstraintFilters := len(metric.ConstraintFiltered) > 0
+		hasResourceExhaustion := metric.NodesExhausted > 0 ||
+			len(metric.ClassExhausted) > 0 ||
+			len(metric.DimensionExhausted) > 0 ||
+			len(metric.QuotaExhausted) > 0
+
+		if hasConstraintFilters && !hasResourceExhaustion {
+			w.logger.Debug("constraint failure",
+				"eval_id", eval.ID,
+				"constraint_filtered", metric.ConstraintFiltered)
+			return true
+		}
+	}
+
+	return false
+}
+
+// ConstraintDescription returns the constraint filtered causing the workload to not be placed.
+func (w *WorkloadWatcher) ConstraintDescription(workload Workload) string {
+	eval := workload.GetEval()
+
+	var s string
+	for _, metric := range eval.FailedTGAllocs {
+		if metric == nil {
+			continue
+		}
+
+		for constraint := range metric.ConstraintFiltered {
+			if s != "" {
+				s = fmt.Sprintf("%s, %s", s, constraint)
+			} else {
+				s = constraint
+			}
+		}
+	}
+
+	return s
+}
+
+// IsSchedulingComplete detects whether a workload was actually placed by following the
+// evaluation's BlockedEvals and NextEvals.
+// Similar to WaitForPlacement, IsSchedulingComplete will record usage in the event an
+// actual placement occurred.
+func (w *WorkloadWatcher) IsSchedulingComplete(workload Workload) (bool, error) {
+	snap, err := w.stateStore.Snapshot()
+	if err != nil {
+		return false, err
+	}
+
+	ws := memdb.NewWatchSet()
+	eval := workload.GetEval()
+	for eval.BlockedEval != "" || eval.NextEval != "" {
+		id := eval.ID
+
+		if eval.BlockedEval != "" {
+			id = eval.BlockedEval
+		} else if eval.NextEval != "" {
+			id = eval.NextEval
+		}
+
+		eval, err = snap.EvalByID(ws, id)
+		if err != nil {
+			return false, err
+		}
+		if eval == nil {
+			return false, ErrWatchedEvalNotFound
+		}
+
+		workload.SetEval(eval)
+
+		if !eval.TerminalStatus() {
+			return false, nil
+		}
+	}
+
+	if eval.Status == structs.EvalStatusComplete {
+		return true, nil
+	}
+
+	// This would only happen if an eval was not complete and did not
+	// yet have a followup eval
+	return false, nil
+}

--- a/nomad/queues/queue/workload_watcher.go
+++ b/nomad/queues/queue/workload_watcher.go
@@ -152,7 +152,6 @@ func (w *WorkloadWatcher) isConstraintFailure(workload Workload) (bool, string) 
 		if len(metric.NodesAvailable) == 0 {
 			return true, "no nodes available"
 		}
-
 		// If there are constraint filters but no resource exhaustion, it's a constraint failure
 		hasConstraintFilters := len(metric.ConstraintFiltered) > 0
 		hasResourceExhaustion := metric.NodesExhausted > 0 ||
@@ -176,6 +175,7 @@ func (w *WorkloadWatcher) isConstraintFailure(workload Workload) (bool, string) 
 
 			return true, reason
 		}
+
 	}
 
 	return false, ""

--- a/nomad/queues/queue/workload_watcher.go
+++ b/nomad/queues/queue/workload_watcher.go
@@ -36,7 +36,7 @@ func NewWorkloadWatcher(s Snapshotter, logger hclog.Logger, config *structs.Batc
 // TrackPlacement increments the currentPlacements counter, sets the workload
 // status, and adds a workload to the in-progress tracking map.
 func (w *WorkloadWatcher) TrackPlacement(workload Workload) {
-	workload.SetStatus("placing", "")
+	workload.SetStatus(WorkloadStatusPlacing, "")
 	w.inProgressWorkloads[workload.GetEval().ID] = workload
 }
 
@@ -118,8 +118,8 @@ func (w *WorkloadWatcher) wait(ctx context.Context, workload Workload, ws memdb.
 			continue
 		}
 
-		if w.isConstraintFailure(workload) {
-			workload.SetStatus("constrained", w.ConstraintDescription(workload))
+		if failure, reason := w.isConstraintFailure(workload); failure {
+			workload.SetStatus(WorkloadStatusBlocked, reason)
 		}
 
 		// Wait for eval update or context cancellation
@@ -138,15 +138,19 @@ func (w *WorkloadWatcher) wait(ctx context.Context, workload Workload, ws memdb.
 // isConstraintFailure checks if the evaluation failed due to non-resource constraints
 // (e.g., constraint filters) rather than resource exhaustion.
 // Returns true if the failure is constraint-related (and unlikely to resolve with time)
-func (w *WorkloadWatcher) isConstraintFailure(workload Workload) bool {
+func (w *WorkloadWatcher) isConstraintFailure(workload Workload) (bool, string) {
 	eval := workload.GetEval()
 	if eval == nil || eval.FailedTGAllocs == nil {
-		return false
+		return false, ""
 	}
 
 	for _, metric := range eval.FailedTGAllocs {
 		if metric == nil {
 			continue
+		}
+
+		if len(metric.NodesAvailable) == 0 {
+			return true, "no nodes available"
 		}
 
 		// If there are constraint filters but no resource exhaustion, it's a constraint failure
@@ -160,33 +164,21 @@ func (w *WorkloadWatcher) isConstraintFailure(workload Workload) bool {
 			w.logger.Debug("constraint failure",
 				"eval_id", eval.ID,
 				"constraint_filtered", metric.ConstraintFiltered)
-			return true
-		}
-	}
 
-	return false
-}
-
-// ConstraintDescription returns the constraint filtered causing the workload to not be placed.
-func (w *WorkloadWatcher) ConstraintDescription(workload Workload) string {
-	eval := workload.GetEval()
-
-	var s string
-	for _, metric := range eval.FailedTGAllocs {
-		if metric == nil {
-			continue
-		}
-
-		for constraint := range metric.ConstraintFiltered {
-			if s != "" {
-				s = fmt.Sprintf("%s, %s", s, constraint)
-			} else {
-				s = constraint
+			reason := ""
+			for constraint := range metric.ConstraintFiltered {
+				if reason == "" {
+					reason = constraint
+				} else {
+					reason = fmt.Sprintf("%s, %s", reason, constraint)
+				}
 			}
+
+			return true, reason
 		}
 	}
 
-	return s
+	return false, ""
 }
 
 // IsSchedulingComplete detects whether a workload was actually placed by following the

--- a/nomad/queues/queue/workload_watcher_test.go
+++ b/nomad/queues/queue/workload_watcher_test.go
@@ -1,0 +1,491 @@
+// Copyright IBM Corp. 2015, 2026
+// SPDX-License-Identifier: BUSL-1.1
+
+package queue
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/go-memdb"
+	"github.com/hashicorp/nomad/nomad/mock"
+	"github.com/hashicorp/nomad/nomad/state"
+	"github.com/hashicorp/nomad/nomad/structs"
+	"github.com/shoenig/test/must"
+	"github.com/shoenig/test/wait"
+)
+
+type testWorkload struct {
+	eval *structs.Evaluation
+	wait bool
+	s    string
+}
+
+func (w *testWorkload) GetEval() *structs.Evaluation {
+	return w.eval
+}
+func (w *testWorkload) SetEval(e *structs.Evaluation) {
+	w.eval = e
+}
+func (w *testWorkload) GetStatus() string {
+	return w.s
+}
+func (w *testWorkload) SetStatus(s, d string) {
+	w.s = fmt.Sprintf("%s %s", s, d)
+
+}
+func (w *testWorkload) WaitOnRestore() bool {
+	return w.wait
+}
+
+func TestWorkloadWatcher_WaitForPlacement(t *testing.T) {
+	t.Run("returns if eval complete", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
+
+		ws := memdb.NewWatchSet()
+		workload := &testWorkload{eval: testEval.Copy()}
+		doneCh := make(chan error)
+		go func() {
+			err := watcher.WaitForPlacement(t.Context(), workload, ws)
+			doneCh <- err
+		}()
+
+		// We want to make sure the testQueue has begun a watch on the blocked eval
+		// before continuing, which is indicated by the length of the watchset being >0.
+		must.Wait(t, wait.InitialSuccess(
+			wait.ErrorFunc(func() error {
+				if len(ws) == 0 {
+					return fmt.Errorf("blocking query not started yet")
+				}
+				return nil
+			}),
+			wait.Timeout(5*time.Second),
+			wait.Gap(100*time.Millisecond),
+		))
+
+		select {
+		case <-doneCh:
+			t.Fatal("should not have exited")
+		default:
+		}
+
+		inProgress := watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval.ID])
+		workingWorkload := inProgress[testEval.ID]
+		must.Eq(t, workingWorkload.GetStatus(), "placing ")
+
+		testEval.Status = structs.EvalStatusComplete
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
+
+		done := <-doneCh
+		must.NoError(t, done)
+
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 0, len(inProgress))
+
+	})
+
+	t.Run("continues watching blocked evals", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		blocked := mock.Eval()
+
+		testEval.Status = structs.EvalStatusComplete
+		testEval.BlockedEval = blocked.ID
+
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval, blocked})
+
+		ws := memdb.NewWatchSet()
+		workload := &testWorkload{eval: testEval.Copy()}
+		doneCh := make(chan error)
+		go func() {
+			err := watcher.WaitForPlacement(t.Context(), workload, ws)
+			doneCh <- err
+		}()
+
+		// We want to make sure the testQueue has begun a watch on the blocked eval
+		// before continuing, which is indicated by the length of the watchset being >0.
+		must.Wait(t, wait.InitialSuccess(
+			wait.ErrorFunc(func() error {
+				if len(ws) == 0 {
+					return fmt.Errorf("blocking query not started yet")
+				}
+				return nil
+			}),
+			wait.Timeout(5*time.Second),
+			wait.Gap(100*time.Millisecond),
+		))
+
+		select {
+		case <-doneCh:
+			t.Fatal("should not have exited")
+		default:
+		}
+
+		blocked.Status = structs.EvalStatusComplete
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{blocked})
+
+		done := <-doneCh
+		must.NoError(t, done)
+	})
+
+	t.Run("continues watching next evals after eval failure", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		next := mock.Eval()
+
+		testEval.Status = structs.EvalStatusFailed
+		testEval.NextEval = next.ID
+
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval, next})
+
+		ws := memdb.NewWatchSet()
+		workload := &testWorkload{eval: testEval.Copy()}
+		doneCh := make(chan error)
+		go func() {
+			err := watcher.WaitForPlacement(t.Context(), workload, ws)
+			doneCh <- err
+		}()
+
+		// We want to make sure the testQueue has begun a watch on the blocked eval
+		// before continuing, which is indicated by the length of the watchset being >0.
+		must.Wait(t, wait.InitialSuccess(
+			wait.ErrorFunc(func() error {
+				if len(ws) == 0 {
+					return fmt.Errorf("blocking query not started yet")
+				}
+				return nil
+			}),
+			wait.Timeout(5*time.Second),
+			wait.Gap(100*time.Millisecond),
+		))
+
+		select {
+		case <-doneCh:
+			t.Fatal("should not have exited")
+		default:
+		}
+
+		next.Status = structs.EvalStatusComplete
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{next})
+
+		done := <-doneCh
+		must.NoError(t, done)
+	})
+
+	t.Run("updates status when constrained", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{
+					"${attr.kernel.name} == linux": 5,
+				},
+				NodesExhausted: 0,
+			},
+		}
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		ws := memdb.NewWatchSet()
+		workload := &testWorkload{eval: testEval.Copy()}
+		doneCh := make(chan error)
+		go func() {
+			err := watcher.WaitForPlacement(t.Context(), workload, ws)
+			doneCh <- err
+		}()
+
+		// We want to make sure the testQueue has begun a watch on the blocked eval
+		// before continuing, which is indicated by the length of the watchset being >0.
+		must.Wait(t, wait.InitialSuccess(
+			wait.ErrorFunc(func() error {
+				if len(ws) == 0 {
+					return fmt.Errorf("blocking query not started yet")
+				}
+				return nil
+			}),
+			wait.Timeout(5*time.Second),
+			wait.Gap(100*time.Millisecond),
+		))
+
+		select {
+		case <-doneCh:
+			t.Fatal("should not have exited")
+		default:
+		}
+
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
+
+		// We want to make sure the testQueue has begun a watch on the blocked eval
+		// before continuing, which is indicated by the length of the watchset being >0.
+		must.Wait(t, wait.InitialSuccess(
+			wait.BoolFunc(func() bool {
+				return strings.Contains(workload.s, "constrained")
+			}),
+			wait.Timeout(5*time.Second),
+			wait.Gap(100*time.Millisecond),
+		))
+
+		inProgress := watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval.ID])
+		workingWorkload := inProgress[testEval.ID]
+		must.Eq(t, workingWorkload.GetStatus(), "constrained ${attr.kernel.name} == linux")
+
+		// Complete the eval
+		testEval.Status = structs.EvalStatusComplete
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
+
+		done := <-doneCh
+		must.NoError(t, done)
+
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 0, len(inProgress))
+	})
+
+	t.Run("continues waiting on resource exhaustion timeout", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				NodesExhausted:     10,
+				DimensionExhausted: map[string]int{"cpu": 5},
+			},
+		}
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		ws := memdb.NewWatchSet()
+		workload := &testWorkload{eval: testEval.Copy()}
+		doneCh := make(chan error)
+		go func() {
+			err := watcher.WaitForPlacement(t.Context(), workload, ws)
+			doneCh <- err
+		}()
+
+		// We want to make sure the testQueue has begun a watch on the blocked eval
+		// before continuing, which is indicated by the length of the watchset being >0.
+		must.Wait(t, wait.InitialSuccess(
+			wait.ErrorFunc(func() error {
+				if len(ws) == 0 {
+					return fmt.Errorf("blocking query not started yet")
+				}
+				return nil
+			}),
+			wait.Timeout(5*time.Second),
+			wait.Gap(100*time.Millisecond),
+		))
+
+		inProgress := watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval.ID])
+
+		// Complete the eval
+		testEval.Status = structs.EvalStatusComplete
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{testEval})
+
+		done := <-doneCh
+		must.NoError(t, done)
+
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 0, len(inProgress))
+	})
+}
+
+func TestWorkloadWatcher_isSchedulingComplete(t *testing.T) {
+	t.Run("pending eval results in false", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+		testEval := mock.Eval()
+		testEval.Status = structs.EvalStatusPending
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
+
+		workload := &testWorkload{
+			eval: testEval.Copy(),
+		}
+
+		complete, err := watcher.IsSchedulingComplete(workload)
+		must.NoError(t, err)
+		must.False(t, complete)
+	})
+
+	t.Run("eval with pending blockedEval results in false", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+		testEval := mock.Eval()
+		blocked := mock.Eval()
+
+		testEval.Status = structs.EvalStatusComplete
+		testEval.BlockedEval = blocked.ID
+		blocked.Status = structs.EvalStatusPending
+
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval, blocked})
+
+		workload := &testWorkload{
+			eval: testEval.Copy(),
+		}
+
+		complete, err := watcher.IsSchedulingComplete(workload)
+		must.NoError(t, err)
+		must.False(t, complete)
+	})
+
+	t.Run("eval with complete blockedEval results in true", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		blocked := mock.Eval()
+
+		testEval.Status = structs.EvalStatusComplete
+		testEval.BlockedEval = blocked.ID
+		blocked.Status = structs.EvalStatusComplete
+
+		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval, blocked})
+
+		workload := &testWorkload{
+			eval: testEval.Copy(),
+		}
+
+		complete, err := watcher.IsSchedulingComplete(workload)
+		must.NoError(t, err)
+		must.True(t, complete)
+	})
+}
+
+func TestWorkloadWatcher_isConstraintFailure(t *testing.T) {
+	t.Run("detects constraint failure without resource exhaustion", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{
+					"${attr.kernel.name} == linux": 5,
+				},
+				NodesExhausted:     0,
+				ClassExhausted:     map[string]int{},
+				DimensionExhausted: map[string]int{},
+				QuotaExhausted:     []string{},
+			},
+		}
+
+		workload := &testWorkload{eval: testEval}
+		must.True(t, watcher.isConstraintFailure(workload))
+	})
+
+	t.Run("does not detect constraint failure with resource exhaustion", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{
+					"${attr.kernel.name} == linux": 5,
+				},
+				NodesExhausted: 10,
+				ClassExhausted: map[string]int{"compute": 5},
+			},
+		}
+
+		workload := &testWorkload{eval: testEval}
+		must.False(t, watcher.isConstraintFailure(workload))
+	})
+
+	t.Run("detects pure resource exhaustion as not constraint failure", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{},
+				NodesExhausted:     15,
+				DimensionExhausted: map[string]int{"cpu": 10, "memory": 5},
+			},
+		}
+
+		workload := &testWorkload{eval: testEval}
+		must.False(t, watcher.isConstraintFailure(workload))
+	})
+
+	t.Run("handles nil FailedTGAllocs", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = nil
+
+		workload := &testWorkload{eval: testEval}
+		must.False(t, watcher.isConstraintFailure(workload))
+	})
+
+	t.Run("handles quota exhaustion as resource issue", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval := mock.Eval()
+		testEval.FailedTGAllocs = map[string]*structs.AllocMetric{
+			"web": {
+				ConstraintFiltered: map[string]int{
+					"${attr.kernel.name} == linux": 5,
+				},
+				QuotaExhausted: []string{"default"},
+			},
+		}
+
+		workload := &testWorkload{eval: testEval}
+		must.False(t, watcher.isConstraintFailure(workload))
+	})
+}
+
+func TestWorkloadWatcher_TrackPlacement(t *testing.T) {
+	t.Run("tracks and untracks workloads", func(t *testing.T) {
+		ss := state.TestStateStore(t)
+		watcher := NewWorkloadWatcher(ss, hclog.Default(), &structs.BatchQueue{})
+
+		testEval1 := mock.Eval()
+		testEval2 := mock.Eval()
+		workload1 := &testWorkload{eval: testEval1}
+		workload2 := &testWorkload{eval: testEval2}
+
+		inProgress := watcher.GetInProgressWorkloads()
+		must.Eq(t, 0, len(inProgress))
+
+		watcher.TrackPlacement(workload1)
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval1.ID])
+
+		watcher.TrackPlacement(workload2)
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 2, len(inProgress))
+
+		watcher.UntrackPlacement(workload1)
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 1, len(inProgress))
+		must.NotNil(t, inProgress[testEval2.ID])
+
+		watcher.UntrackPlacement(workload2)
+		inProgress = watcher.GetInProgressWorkloads()
+		must.Eq(t, 0, len(inProgress))
+	})
+}

--- a/nomad/queues/queue/workload_watcher_test.go
+++ b/nomad/queues/queue/workload_watcher_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 type testWorkload struct {
-	eval *structs.Evaluation
-	wait bool
-	s    string
+	eval   *structs.Evaluation
+	wait   bool
+	status string
 }
 
 func (w *testWorkload) GetEval() *structs.Evaluation {
@@ -31,10 +31,10 @@ func (w *testWorkload) SetEval(e *structs.Evaluation) {
 	w.eval = e
 }
 func (w *testWorkload) GetStatus() string {
-	return w.s
+	return w.status
 }
 func (w *testWorkload) SetStatus(s, d string) {
-	w.s = fmt.Sprintf("%s %s", s, d)
+	w.status = fmt.Sprintf("%s %s", s, d)
 
 }
 func (w *testWorkload) WaitOnRestore() bool {
@@ -196,6 +196,7 @@ func TestWorkloadWatcher_WaitForPlacement(t *testing.T) {
 					"${attr.kernel.name} == linux": 5,
 				},
 				NodesExhausted: 0,
+				NodesAvailable: map[string]int{"test": 5},
 			},
 		}
 		ss.UpsertEvals(structs.MsgTypeTestSetup, 0, []*structs.Evaluation{testEval})
@@ -233,7 +234,7 @@ func TestWorkloadWatcher_WaitForPlacement(t *testing.T) {
 		// before continuing, which is indicated by the length of the watchset being >0.
 		must.Wait(t, wait.InitialSuccess(
 			wait.BoolFunc(func() bool {
-				return strings.Contains(workload.s, "constrained")
+				return strings.Contains(workload.status, "blocked")
 			}),
 			wait.Timeout(5*time.Second),
 			wait.Gap(100*time.Millisecond),
@@ -243,7 +244,7 @@ func TestWorkloadWatcher_WaitForPlacement(t *testing.T) {
 		must.Eq(t, 1, len(inProgress))
 		must.NotNil(t, inProgress[testEval.ID])
 		workingWorkload := inProgress[testEval.ID]
-		must.Eq(t, workingWorkload.GetStatus(), "constrained ${attr.kernel.name} == linux")
+		must.Eq(t, workingWorkload.GetStatus(), "blocked ${attr.kernel.name} == linux")
 
 		// Complete the eval
 		testEval.Status = structs.EvalStatusComplete

--- a/nomad/queues/queue/workload_watcher_test.go
+++ b/nomad/queues/queue/workload_watcher_test.go
@@ -382,13 +382,16 @@ func TestWorkloadWatcher_isConstraintFailure(t *testing.T) {
 				},
 				NodesExhausted:     0,
 				ClassExhausted:     map[string]int{},
+				NodesAvailable:     map[string]int{"test": 15},
 				DimensionExhausted: map[string]int{},
 				QuotaExhausted:     []string{},
 			},
 		}
 
 		workload := &testWorkload{eval: testEval}
-		must.True(t, watcher.isConstraintFailure(workload))
+		failure, reason := watcher.isConstraintFailure(workload)
+		must.True(t, failure)
+		must.Eq(t, reason, "${attr.kernel.name} == linux")
 	})
 
 	t.Run("does not detect constraint failure with resource exhaustion", func(t *testing.T) {
@@ -402,12 +405,14 @@ func TestWorkloadWatcher_isConstraintFailure(t *testing.T) {
 					"${attr.kernel.name} == linux": 5,
 				},
 				NodesExhausted: 10,
+				NodesAvailable: map[string]int{"test": 5},
 				ClassExhausted: map[string]int{"compute": 5},
 			},
 		}
 
 		workload := &testWorkload{eval: testEval}
-		must.False(t, watcher.isConstraintFailure(workload))
+		failure, _ := watcher.isConstraintFailure(workload)
+		must.False(t, failure)
 	})
 
 	t.Run("detects pure resource exhaustion as not constraint failure", func(t *testing.T) {
@@ -419,12 +424,14 @@ func TestWorkloadWatcher_isConstraintFailure(t *testing.T) {
 			"web": {
 				ConstraintFiltered: map[string]int{},
 				NodesExhausted:     15,
+				NodesAvailable:     map[string]int{"test": 15},
 				DimensionExhausted: map[string]int{"cpu": 10, "memory": 5},
 			},
 		}
 
 		workload := &testWorkload{eval: testEval}
-		must.False(t, watcher.isConstraintFailure(workload))
+		failure, _ := watcher.isConstraintFailure(workload)
+		must.False(t, failure)
 	})
 
 	t.Run("handles nil FailedTGAllocs", func(t *testing.T) {
@@ -435,7 +442,8 @@ func TestWorkloadWatcher_isConstraintFailure(t *testing.T) {
 		testEval.FailedTGAllocs = nil
 
 		workload := &testWorkload{eval: testEval}
-		must.False(t, watcher.isConstraintFailure(workload))
+		failure, _ := watcher.isConstraintFailure(workload)
+		must.False(t, failure)
 	})
 
 	t.Run("handles quota exhaustion as resource issue", func(t *testing.T) {
@@ -449,11 +457,13 @@ func TestWorkloadWatcher_isConstraintFailure(t *testing.T) {
 					"${attr.kernel.name} == linux": 5,
 				},
 				QuotaExhausted: []string{"default"},
+				NodesAvailable: map[string]int{"test": 15},
 			},
 		}
 
 		workload := &testWorkload{eval: testEval}
-		must.False(t, watcher.isConstraintFailure(workload))
+		failure, _ := watcher.isConstraintFailure(workload)
+		must.False(t, failure)
 	})
 }
 

--- a/nomad/queues/queues.go
+++ b/nomad/queues/queues.go
@@ -22,7 +22,7 @@ func NewQueue(ss *state.StateStore, sconf *structs.BatchQueue, broker queue.Brok
 		}
 		return dynamic.NewDynamicPriorityQueue(ss, broker, sconf, qconf, logger), nil
 	case structs.BatchQueueTypeFifo:
-		return fifo.NewFifoQueue(ss, broker, logger), nil
+		return fifo.NewFifoQueue(ss, broker, sconf, logger), nil
 	default:
 		return passthrough.NewPassthroughQueue(broker), nil
 	}

--- a/nomad/structs/queue.go
+++ b/nomad/structs/queue.go
@@ -21,6 +21,7 @@ type DynamicPriorityWorkload struct {
 	Tenant           string
 	Namespace        string
 	Position         int
+	Status           string
 	AdjustedPriority int
 	BasePriority     int
 	UsageAdjustment  int
@@ -54,6 +55,7 @@ type Workload struct {
 	JobID       string
 	Namespace   string
 	Position    int
+	Status      string
 	CreatedAt   int64
 	CreateIndex uint64
 }


### PR DESCRIPTION
### Description
When running `nomad queue jobs`, the placing workloads will show at the top of the output, along with a status indicating if it is being placed or is "constrained", along with the constraint blocking the queue. 

```
Batch Queue Workloads
JobID     Tenant  Status   Adjusted Priority  Base Priority  Position  Usage  Age  Size  CreatedAt
baz_0     baz     placing  130                50             0         80     0    0     2026-09-02T15:34:40-07:00
baz_1     baz     queued   130                50             1         80     0    0     2026-09-02T15:34:40-07:00
baz_2     baz     queued   130                50             2         80     0    0     2026-09-02T15:34:40-07:00
baz_3     baz     queued   130                50             3         80     0    0     2026-09-02T15:34:40-07:00
baz_4     baz     queued   130                50             4         80     0    0     2026-09-02T15:34:41-07:00
baz_5     baz     queued   130                50             5         80     0    0     2026-09-02T15:34:41-07:00
baz_6     baz     queued   130                50             6         80     0    0     2026-09-02T15:34:41-07:00
```

```
Batch Queue Workloads
JobID   Tenant  Status                                            Adjusted Priority  Base Priority  Position  Usage  Age  Size  CreatedAt
batch3  one     constrained (${attr.kernel.name} = hannamontana)  130                50             0         80     0    0     2026-09-02T15:35:22-07:00
bar_0   bar     queued                                            130                50             1         80     0    0     2026-09-02T15:35:24-07:00
bar_1   bar     queued                                            130                50             2         80     0    0     2026-09-02T15:35:24-07:00
bar_2   bar     queued                                            130                50             3         80     0    0     2026-09-02T15:35:24-07:00
bar_3   bar     queued                                            130                50             4         80     0    0     2026-09-02T15:35:24-07:00
bar_4   bar     queued                                            130                50             5         80     0    0     2026-09-02T15:35:25-07:00
bar_5   bar     queued                                            130                50             6         80     0    0     2026-09-02T15:35:25-07:00
bar_6   bar     queued                                            130                50             7         80     0    0     2026-09-02T15:35:25-07:00
bar_7   bar     queued                                            130                50             8         80     0    0     2026-09-02T15:35:25-07:00
bar_8   bar     queued                                            130                50             9         80     0    0     2026-09-02T15:35:25-07:00
```

The changes include adding a centralized WorkloadWatcher, which handles the waiting (moved out of a helper), and monitors the waiting workload for constraints and updates the status. It holds the `inProgress` workload in a map. This is a very paired down version of the watcher from https://github.com/hashicorp/nomad/pull/28400, and doesn't include any of the config updates, but does have the basic structure for watching more workloads concurrently in the future.

Apologies for the large PR; the tests are verbose and probably could be made shorter, but I left them as-is to try to show as much context for the test scenarios

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
Added tests, output above is from running this change. 

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
