### PR TITLE
drivers: Modernize the drivers package and sub-pkgs.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,7 +68,7 @@ linters:
         text: assignOp
       - path: (.+)\.go$
         text: unlambda
-      - path-except: (^client/|^command/|^jobspec2/|^plugins/|^nomad/|^scheduler/)
+      - path-except: (^client/|^command/|^drivers/|^jobspec2/|^plugins/|^nomad/|^scheduler/)
         linters:
           - modernize
     paths:

--- a/drivers/docker/cmd/main.go
+++ b/drivers/docker/cmd/main.go
@@ -50,6 +50,6 @@ func main() {
 }
 
 // factory returns a new instance of the docker driver plugin
-func factory(ctx context.Context, log log.Logger) interface{} {
+func factory(ctx context.Context, log log.Logger) any {
 	return docker.NewDockerDriver(ctx, log)
 }

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -48,14 +48,14 @@ const (
 	dockerAuthHelperPrefix = "docker-credential-"
 )
 
-func PluginLoader(opts map[string]string) (map[string]interface{}, error) {
-	conf := map[string]interface{}{}
+func PluginLoader(opts map[string]string) (map[string]any, error) {
+	conf := map[string]any{}
 	if v, ok := opts["docker.endpoint"]; ok {
 		conf["endpoint"] = v
 	}
 
 	// dockerd auth
-	authConf := map[string]interface{}{}
+	authConf := map[string]any{}
 	if v, ok := opts["docker.auth.config"]; ok {
 		authConf["config"] = v
 	}
@@ -66,7 +66,7 @@ func PluginLoader(opts map[string]string) (map[string]interface{}, error) {
 
 	// dockerd tls
 	if _, ok := opts["docker.tls.cert"]; ok {
-		conf["tls"] = map[string]interface{}{
+		conf["tls"] = map[string]any{
 			"cert": opts["docker.tls.cert"],
 			"key":  opts["docker.tls.key"],
 			"ca":   opts["docker.tls.ca"],
@@ -74,7 +74,7 @@ func PluginLoader(opts map[string]string) (map[string]interface{}, error) {
 	}
 
 	// garbage collection
-	gcConf := map[string]interface{}{}
+	gcConf := map[string]any{}
 	if v, err := strconv.ParseBool(opts["docker.cleanup.image"]); err == nil {
 		gcConf["image"] = v
 	}
@@ -87,7 +87,7 @@ func PluginLoader(opts map[string]string) (map[string]interface{}, error) {
 	conf["gc"] = gcConf
 
 	// volume options
-	volConf := map[string]interface{}{}
+	volConf := map[string]any{}
 	if v, err := strconv.ParseBool(opts["docker.volumes.enabled"]); err == nil {
 		volConf["enabled"] = v
 	}
@@ -126,8 +126,8 @@ var (
 
 	// PluginConfig is the docker config factory function registered in the plugin catalog.
 	PluginConfig = &loader.InternalPluginConfig{
-		Config:  map[string]interface{}{},
-		Factory: func(ctx context.Context, l hclog.Logger) interface{} { return NewDockerDriver(ctx, l) },
+		Config:  map[string]any{},
+		Factory: func(ctx context.Context, l hclog.Logger) any { return NewDockerDriver(ctx, l) },
 	}
 
 	// pluginInfo is the response returned for the PluginInfo RPC.

--- a/drivers/docker/config_test.go
+++ b/drivers/docker/config_test.go
@@ -41,7 +41,6 @@ func TestConfig_ParseHCL(t *testing.T) {
 
 	parser := hclutils.NewConfigParser(taskConfigSpec)
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			var tc *TaskConfig
 
@@ -108,7 +107,6 @@ func TestConfig_ParseJSON(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			var tc TaskConfig
 			hclutils.NewConfigParser(taskConfigSpec).ParseJson(t, c.input, &tc)
@@ -805,7 +803,7 @@ func TestConfig_DriverConfig_AllowRuntimes(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			var tc map[string]interface{}
+			var tc map[string]any
 			hclutils.NewConfigParser(configSpec).ParseHCL(t, "config "+c.config, &tc)
 
 			dh := dockerDriverHarness(t, tc)

--- a/drivers/docker/coordinator.go
+++ b/drivers/docker/coordinator.go
@@ -342,7 +342,7 @@ func (d *dockerCoordinator) removeImageImpl(id string, ctx context.Context) {
 	}
 	d.imageLock.Unlock()
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		_, err := d.client.ImageRemove(d.ctx, id, mclient.ImageRemoveOptions{
 			Force: true, // necessary to GC images referenced by multiple tags
 		})

--- a/drivers/docker/coordinator_test.go
+++ b/drivers/docker/coordinator_test.go
@@ -113,7 +113,7 @@ func TestDockerCoordinator_ConcurrentPulls(t *testing.T) {
 	coordinator := newDockerCoordinator(config)
 
 	id, _, _ := coordinator.PullImage(image, nil, uuid.Generate(), nil, 5*time.Minute, 2*time.Minute)
-	for i := 0; i < 9; i++ {
+	for range 9 {
 		go func() {
 			coordinator.PullImage(image, nil, uuid.Generate(), nil, 5*time.Minute, 2*time.Minute)
 		}()
@@ -166,7 +166,7 @@ func TestDockerCoordinator_Pull_Remove(t *testing.T) {
 
 	id := ""
 	callerIDs := make([]string, 10, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		callerIDs[i] = uuid.Generate()
 		id, _, _ = coordinator.PullImage(image, nil, callerIDs[i], nil, 5*time.Minute, 2*time.Minute)
 	}
@@ -177,7 +177,7 @@ func TestDockerCoordinator_Pull_Remove(t *testing.T) {
 	}
 
 	// Remove some
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		coordinator.RemoveImage(id, callerIDs[i])
 	}
 

--- a/drivers/docker/docklog/docker_logger.go
+++ b/drivers/docker/docklog/docker_logger.go
@@ -57,7 +57,7 @@ type StartOpts struct {
 func NewDockerLogger(logger hclog.Logger) DockerLogger {
 	return &dockerLogger{
 		logger: logger,
-		doneCh: make(chan interface{}),
+		doneCh: make(chan any),
 	}
 }
 
@@ -70,7 +70,7 @@ type dockerLogger struct {
 	stdLock sync.Mutex
 
 	cancelCtx context.CancelFunc
-	doneCh    chan interface{}
+	doneCh    chan any
 }
 
 // Start log monitoring

--- a/drivers/docker/docklog/plugin.go
+++ b/drivers/docker/docklog/plugin.go
@@ -98,6 +98,6 @@ func (p *Plugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) error {
 }
 
 // GRPCClient returns a client side implementation of the plugin
-func (p *Plugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
+func (p *Plugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
 	return &dockerLoggerClient{client: proto.NewDockerLoggerClient(c)}, nil
 }

--- a/drivers/docker/driver.go
+++ b/drivers/docker/driver.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/netip"
 	"os"
@@ -1495,9 +1496,7 @@ func (d *Driver) createContainerConfig(task *drivers.TaskConfig, driverConfig *T
 	}
 
 	labels := make(map[string]string, len(driverConfig.Labels)+1)
-	for k, v := range driverConfig.Labels {
-		labels[k] = v
-	}
+	maps.Copy(labels, driverConfig.Labels)
 	// main mandatory label
 	labels[dockerLabelAllocID] = task.AllocID
 
@@ -1932,7 +1931,7 @@ func (d *Driver) ExecTaskStreaming(ctx context.Context, taskID string, opts *dri
 	defer opts.Stdout.Close()
 	defer opts.Stderr.Close()
 
-	done := make(chan interface{})
+	done := make(chan any)
 	defer close(done)
 
 	h, ok := d.tasks.Get(taskID)

--- a/drivers/docker/driver_test.go
+++ b/drivers/docker/driver_test.go
@@ -150,7 +150,7 @@ func dockerTask(t *testing.T) (*drivers.TaskConfig, *TaskConfig, []int) {
 //
 // If there is a problem during setup this function will abort or skip the test
 // and indicate the reason.
-func dockerSetup(t *testing.T, task *drivers.TaskConfig, driverCfg map[string]interface{}) (*mclient.Client, *dtestutil.DriverHarness, *taskHandle, func()) {
+func dockerSetup(t *testing.T, task *drivers.TaskConfig, driverCfg map[string]any) (*mclient.Client, *dtestutil.DriverHarness, *taskHandle, func()) {
 	client := newTestDockerClient(t)
 	driver := dockerDriverHarness(t, driverCfg)
 	cleanup := driver.MkAllocDir(task, loggingIsEnabled(&DriverConfig{}, task))
@@ -192,14 +192,14 @@ func cleanSlate(client *mclient.Client, imageID string) {
 
 // dockerDriverHarness wires up everything needed to launch a task with a docker driver.
 // A driver plugin interface and cleanup function is returned
-func dockerDriverHarness(t *testing.T, cfg map[string]interface{}) *dtestutil.DriverHarness {
+func dockerDriverHarness(t *testing.T, cfg map[string]any) *dtestutil.DriverHarness {
 	logger := testlog.HCLogger(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(func() { cancel() })
 	harness := dtestutil.NewDriverHarness(t, NewDockerDriver(ctx, logger))
 	if cfg == nil {
-		cfg = map[string]interface{}{
-			"gc": map[string]interface{}{
+		cfg = map[string]any{
+			"gc": map[string]any{
 				"image":       false,
 				"image_delay": "1s",
 			},
@@ -213,7 +213,7 @@ func dockerDriverHarness(t *testing.T, cfg map[string]interface{}) *dtestutil.Dr
 		InternalPlugins: map[loader.PluginID]*loader.InternalPluginConfig{
 			PluginID: {
 				Config: cfg,
-				Factory: func(context.Context, hclog.Logger) interface{} {
+				Factory: func(context.Context, hclog.Logger) any {
 					return harness
 				},
 			},
@@ -874,7 +874,7 @@ func TestDockerDriver_ExtraLabels(t *testing.T) {
 
 	must.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
-	dockerClientConfig := make(map[string]interface{})
+	dockerClientConfig := make(map[string]any)
 
 	dockerClientConfig["extra_labels"] = []string{"task*", "job_name"}
 	client, d, handle, cleanup := dockerSetup(t, task, dockerClientConfig)
@@ -908,7 +908,7 @@ func TestDockerDriver_LoggingConfiguration(t *testing.T) {
 
 	must.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
-	dockerClientConfig := make(map[string]interface{})
+	dockerClientConfig := make(map[string]any)
 	loggerConfig := map[string]string{"gelf-address": "udp://1.2.3.4:12201", "tag": "gelf"}
 
 	dockerClientConfig["logging"] = LoggingConfig{
@@ -939,7 +939,7 @@ func TestDockerDriver_LogCollectionDisabled(t *testing.T) {
 
 	must.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
-	dockerClientConfig := make(map[string]interface{})
+	dockerClientConfig := make(map[string]any)
 	loggerConfig := map[string]string{"gelf-address": "udp://1.2.3.4:12201", "tag": "gelf"}
 
 	dockerClientConfig["logging"] = LoggingConfig{
@@ -1227,7 +1227,7 @@ func TestDockerDriver_CreateContainerConfig_AllowedModes(t *testing.T) {
 			image := "org/repro:0.1"
 			task, config, _ := dockerTask(t)
 
-			dockerClientConfig := make(map[string]interface{})
+			dockerClientConfig := make(map[string]any)
 			dockerClientConfig["allowed_modes"] = tc.modes
 			if tc.allowPrivileged {
 				dockerClientConfig["allow_privileged"] = tc.allowPrivileged
@@ -1652,7 +1652,7 @@ func TestDockerDriver_CreateContainerConfigWithRuntimes(t *testing.T) {
 		t.Run(testCase.description, func(t *testing.T) {
 			task, cfg, _ := dockerTask(t)
 
-			dh := dockerDriverHarness(t, map[string]interface{}{
+			dh := dockerDriverHarness(t, map[string]any{
 				"allow_runtimes": []string{"runc", "nvidia", "nvidia-runtime-modified-name"},
 			})
 			driver := dh.Impl().(*Driver)
@@ -2256,8 +2256,8 @@ func TestDockerDriver_EnableImageGC(t *testing.T) {
 	must.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
 	client := newTestDockerClient(t)
-	driver := dockerDriverHarness(t, map[string]interface{}{
-		"gc": map[string]interface{}{
+	driver := dockerDriverHarness(t, map[string]any{
+		"gc": map[string]any{
 			"container":   true,
 			"image":       true,
 			"image_delay": "2s",
@@ -2324,8 +2324,8 @@ func TestDockerDriver_DisableImageGC(t *testing.T) {
 	must.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
 	client := newTestDockerClient(t)
-	driver := dockerDriverHarness(t, map[string]interface{}{
-		"gc": map[string]interface{}{
+	driver := dockerDriverHarness(t, map[string]any{
+		"gc": map[string]any{
 			"container":   true,
 			"image":       false,
 			"image_delay": "1s",
@@ -2389,8 +2389,8 @@ func TestDockerDriver_MissingContainer_Cleanup(t *testing.T) {
 	must.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
 	client := newTestDockerClient(t)
-	driver := dockerDriverHarness(t, map[string]interface{}{
-		"gc": map[string]interface{}{
+	driver := dockerDriverHarness(t, map[string]any{
+		"gc": map[string]any{
 			"container":   true,
 			"image":       true,
 			"image_delay": "0s",
@@ -2494,7 +2494,7 @@ func TestDockerDriver_Stats(t *testing.T) {
 	}
 }
 
-func setupDockerVolumes(t *testing.T, cfg map[string]interface{}, hostpath string) (*drivers.TaskConfig, *dtestutil.DriverHarness, *TaskConfig, string, func()) {
+func setupDockerVolumes(t *testing.T, cfg map[string]any, hostpath string) (*drivers.TaskConfig, *dtestutil.DriverHarness, *TaskConfig, string, func()) {
 	testutil.DockerCompatible(t)
 
 	randfn := fmt.Sprintf("test-%d", rand.Int())
@@ -2531,11 +2531,11 @@ func TestDockerDriver_VolumesDisabled(t *testing.T) {
 	ci.Parallel(t)
 	testutil.DockerCompatible(t)
 
-	cfg := map[string]interface{}{
-		"volumes": map[string]interface{}{
+	cfg := map[string]any{
+		"volumes": map[string]any{
 			"enabled": false,
 		},
-		"gc": map[string]interface{}{
+		"gc": map[string]any{
 			"image": false,
 		},
 	}
@@ -2598,11 +2598,11 @@ func TestDockerDriver_VolumesEnabled(t *testing.T) {
 	ci.Parallel(t)
 	testutil.DockerCompatible(t)
 
-	cfg := map[string]interface{}{
-		"volumes": map[string]interface{}{
+	cfg := map[string]any{
+		"volumes": map[string]any{
 			"enabled": true,
 		},
-		"gc": map[string]interface{}{
+		"gc": map[string]any{
 			"image": false,
 		},
 	}
@@ -3188,7 +3188,7 @@ func TestDockerDriver_CreateContainerConfig_CPUHardLimit(t *testing.T) {
 	schema, _ := driver.TaskConfigSchema()
 	spec, _ := hclspecutils.Convert(schema)
 
-	val, _, _ := hclutils.ParseHclInterface(map[string]interface{}{
+	val, _, _ := hclutils.ParseHclInterface(map[string]any{
 		"image":          "foo/bar",
 		"cpu_hard_limit": true,
 	}, spec, nil)
@@ -3606,7 +3606,7 @@ func Test_validateNamespace(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			dockerClientConfig := make(map[string]interface{})
+			dockerClientConfig := make(map[string]any)
 
 			if tc.allowPrivileged {
 				dockerClientConfig["allow_privileged"] = tc.allowPrivileged

--- a/drivers/docker/driver_unix_test.go
+++ b/drivers/docker/driver_unix_test.go
@@ -696,8 +696,8 @@ func TestDockerDriver_Cleanup(t *testing.T) {
 
 	must.NoError(t, task.EncodeConcreteDriverConfig(cfg))
 
-	client, driver, handle, cleanup := dockerSetup(t, task, map[string]interface{}{
-		"gc": map[string]interface{}{
+	client, driver, handle, cleanup := dockerSetup(t, task, map[string]any{
+		"gc": map[string]any{
 			"image":       true,
 			"image_delay": "1ms",
 		},

--- a/drivers/docker/fingerprint_test.go
+++ b/drivers/docker/fingerprint_test.go
@@ -4,7 +4,6 @@
 package docker
 
 import (
-	"context"
 	"testing"
 
 	"github.com/hashicorp/nomad/ci"
@@ -27,8 +26,7 @@ func TestDockerDriver_FingerprintHealth(t *testing.T) {
 	ci.Parallel(t)
 	testutil.DockerCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := NewDockerDriver(ctx, testlog.HCLogger(t)).(*Driver)
 
@@ -44,8 +42,7 @@ func TestDockerDriver_NonRoot_CGV2(t *testing.T) {
 	testutil.CgroupsCompatibleV2(t)
 	testutil.RequireNonRoot(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := NewDockerDriver(ctx, testlog.HCLogger(t)).(*Driver)
 

--- a/drivers/docker/reconcile_dangling.go
+++ b/drivers/docker/reconcile_dangling.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"sync"
 	"time"
 
@@ -69,10 +70,7 @@ func (r *containerReconciler) removeDanglingContainersGoroutine() {
 	// The initial period is a grace period for restore allocation
 	// before a driver may kill containers launched by an earlier nomad
 	// process.
-	initialDelay := period
-	if r.config.CreationGrace > initialDelay {
-		initialDelay = r.config.CreationGrace
-	}
+	initialDelay := max(r.config.CreationGrace, period)
 
 	timer := time.NewTimer(initialDelay)
 	for {
@@ -175,11 +173,7 @@ func (r *containerReconciler) untrackedContainers(tracked set.Collection[string]
 // We'll try hitting Docker API on subsequent iteration.
 func (r *containerReconciler) dockerAPIQueryContext() (context.Context, context.CancelFunc) {
 	// use a reasonable floor to avoid very small limit
-	timeout := 30 * time.Second
-
-	if timeout < r.config.period {
-		timeout = r.config.period
-	}
+	timeout := max(30*time.Second, r.config.period)
 
 	return context.WithTimeout(context.Background(), timeout)
 }
@@ -215,12 +209,7 @@ func hasMount(c container.Summary, p string) bool {
 var nomadContainerNamePattern = regexp.MustCompile(`\/.*-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)
 
 func hasNomadName(c container.Summary) bool {
-	for _, n := range c.Names {
-		if nomadContainerNamePattern.MatchString(n) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(c.Names, nomadContainerNamePattern.MatchString)
 }
 
 // trackedContainers returns the set of container IDs of containers that were

--- a/drivers/docker/utils.go
+++ b/drivers/docker/utils.go
@@ -369,10 +369,10 @@ func registryGetAuthConfigKey(index *registrytypes.IndexInfo) string {
 
 func registryConvertToHostname(rawURL string) string {
 	stripped := rawURL
-	if strings.HasPrefix(stripped, "http://") {
-		stripped = strings.TrimPrefix(stripped, "http://")
-	} else if strings.HasPrefix(stripped, "https://") {
-		stripped = strings.TrimPrefix(stripped, "https://")
+	if after, ok := strings.CutPrefix(stripped, "http://"); ok {
+		stripped = after
+	} else if after, ok := strings.CutPrefix(stripped, "https://"); ok {
+		stripped = after
 	}
 	stripped, _, _ = strings.Cut(stripped, "/")
 	return stripped

--- a/drivers/exec/driver.go
+++ b/drivers/exec/driver.go
@@ -53,8 +53,8 @@ var (
 	// PluginConfig is the exec driver factory function registered in the
 	// plugin catalog.
 	PluginConfig = &loader.InternalPluginConfig{
-		Config:  map[string]interface{}{},
-		Factory: func(ctx context.Context, l hclog.Logger) interface{} { return NewExecDriver(ctx, l) },
+		Config:  map[string]any{},
+		Factory: func(ctx context.Context, l hclog.Logger) any { return NewExecDriver(ctx, l) },
 	}
 
 	// pluginInfo is the response returned for the PluginInfo RPC

--- a/drivers/exec/driver_test.go
+++ b/drivers/exec/driver_test.go
@@ -90,8 +90,7 @@ func TestExecDriver_Fingerprint_NonLinux(t *testing.T) {
 		t.Skip("Test only available not on Linux")
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -112,8 +111,7 @@ func TestExecDriver_Fingerprint(t *testing.T) {
 
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -134,8 +132,7 @@ func TestExecDriver_WorkDir(t *testing.T) {
 
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -177,8 +174,7 @@ func TestExecDriver_StartWait(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -213,8 +209,7 @@ func TestExecDriver_StartWaitStopKill(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -278,8 +273,7 @@ func TestExecDriver_StartWaitRecover(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	dCtx, dCancel := context.WithCancel(context.Background())
-	defer dCancel()
+	dCtx := t.Context()
 
 	d := newExecDriverTest(t, dCtx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -309,12 +303,10 @@ func TestExecDriver_StartWaitRecover(t *testing.T) {
 	require.NoError(t, err)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		result := <-ch
 		require.Error(t, result.Err)
-	}()
+	})
 
 	require.NoError(t, harness.WaitUntilStarted(task.ID, 1*time.Second))
 	cancel()
@@ -352,8 +344,7 @@ func TestExecDriver_NoOrphanedExecutor(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -389,7 +380,7 @@ func TestExecDriver_NoOrphanedExecutor(t *testing.T) {
 	cleanup := harness.MkAllocDir(task, true)
 	defer cleanup()
 
-	taskConfig := map[string]interface{}{}
+	taskConfig := map[string]any{}
 	taskConfig["command"] = "force-an-error"
 	must.NoError(t, task.EncodeConcreteDriverConfig(&taskConfig))
 
@@ -415,8 +406,7 @@ func TestExecDriver_NoOrphanedTasks(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -452,7 +442,7 @@ func TestExecDriver_NoOrphanedTasks(t *testing.T) {
 	cleanup := harness.MkAllocDir(task, true)
 	defer cleanup()
 
-	taskConfig := map[string]interface{}{}
+	taskConfig := map[string]any{}
 	taskConfig["command"] = "/bin/sh"
 	// print the child PID in the task PID namespace, then sleep for 5 seconds to give us a chance to examine processes
 	taskConfig["args"] = []string{"-c", fmt.Sprintf(`sleep 3600 & sleep 20`)}
@@ -541,8 +531,7 @@ func TestExecDriver_Stats(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	dctx, dcancel := context.WithCancel(context.Background())
-	defer dcancel()
+	dctx := t.Context()
 
 	d := newExecDriverTest(t, dctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -569,8 +558,7 @@ func TestExecDriver_Stats(t *testing.T) {
 	require.NotNil(t, handle)
 
 	require.NoError(t, harness.WaitUntilStarted(task.ID, 1*time.Second))
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	statsCh, err := harness.TaskStats(ctx, task.ID, time.Second*10)
 	require.NoError(t, err)
 	select {
@@ -589,8 +577,7 @@ func TestExecDriver_Start_Wait_AllocDir(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -642,8 +629,7 @@ func TestExecDriver_User(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -680,8 +666,7 @@ func TestExecDriver_HandlerExec(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -712,7 +697,7 @@ func TestExecDriver_HandlerExec(t *testing.T) {
 	stdout := strings.TrimSpace(string(res.Stdout))
 	switch cgroupslib.GetMode() {
 	case cgroupslib.CG1:
-		for _, line := range strings.Split(stdout, "\n") {
+		for line := range strings.SplitSeq(stdout, "\n") {
 			// skip empty lines
 			if line == "" {
 				continue
@@ -750,8 +735,7 @@ func TestExecDriver_DevicesAndMounts(t *testing.T) {
 	err := os.WriteFile(filepath.Join(tmpDir, "testfile"), []byte("from-host"), 600)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -860,8 +844,7 @@ func TestExecDriver_NoPivotRoot(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -982,8 +965,7 @@ func TestDriver_Config_setDeniedIds(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			d := newExecDriverTest(t, ctx)
 

--- a/drivers/exec/driver_unix_test.go
+++ b/drivers/exec/driver_unix_test.go
@@ -29,8 +29,7 @@ func TestExecDriver_StartWaitStop(t *testing.T) {
 	ci.Parallel(t)
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -42,7 +41,7 @@ func TestExecDriver_StartWaitStop(t *testing.T) {
 		Resources: testResources(allocID, "test"),
 	}
 
-	taskConfig := map[string]interface{}{
+	taskConfig := map[string]any{
 		"command": "/bin/sleep",
 		"args":    []string{"600"},
 	}
@@ -92,8 +91,7 @@ func TestExec_ExecTaskStreaming(t *testing.T) {
 	ci.SkipTestWithoutRootAccess(t)
 	ci.Parallel(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -129,8 +127,7 @@ func TestExec_dnsConfig(t *testing.T) {
 	ctestutils.RequireRoot(t)
 	ctestutils.ExecCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newExecDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -256,8 +253,7 @@ func TestExecDriver_Capabilities(t *testing.T) {
 		},
 	} {
 		t.Run(tc.Name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			d := newExecDriverTest(t, ctx)
 			harness := dtestutil.NewDriverHarness(t, d)

--- a/drivers/java/driver.go
+++ b/drivers/java/driver.go
@@ -55,8 +55,8 @@ var (
 	// PluginConfig is the java driver factory function registered in the
 	// plugin catalog.
 	PluginConfig = &loader.InternalPluginConfig{
-		Config:  map[string]interface{}{},
-		Factory: func(ctx context.Context, l hclog.Logger) interface{} { return NewDriver(ctx, l) },
+		Config:  map[string]any{},
+		Factory: func(ctx context.Context, l hclog.Logger) any { return NewDriver(ctx, l) },
 	}
 
 	// pluginInfo is the response returned for the PluginInfo RPC

--- a/drivers/java/driver_test.go
+++ b/drivers/java/driver_test.go
@@ -87,8 +87,7 @@ func TestJavaDriver_Fingerprint(t *testing.T) {
 	ci.Parallel(t)
 	javaCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newJavaDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -110,8 +109,7 @@ func TestJavaDriver_Jar_Start_Wait(t *testing.T) {
 	ci.Parallel(t)
 	javaCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newJavaDriverTest(t, ctx)
 
@@ -152,8 +150,7 @@ func TestJavaDriver_Jar_Stop_Wait(t *testing.T) {
 	ci.Parallel(t)
 	javaCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newJavaDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -213,8 +210,7 @@ func TestJavaDriver_Class_Start_Wait(t *testing.T) {
 	ci.Parallel(t)
 	javaCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newJavaDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -252,8 +248,7 @@ func TestJavaDriver_WorkDir(t *testing.T) {
 	ci.Parallel(t)
 	javaCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newJavaDriverTest(t, ctx)
 
@@ -346,8 +341,7 @@ func TestJavaDriver_ExecTaskStreaming(t *testing.T) {
 	ci.Parallel(t)
 	javaCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newJavaDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)
@@ -453,8 +447,7 @@ func Test_dnsConfig(t *testing.T) {
 	ctestutil.RequireRoot(t)
 	javaCompatible(t)
 	require := require.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	d := newJavaDriverTest(t, ctx)
 	harness := dtestutil.NewDriverHarness(t, d)

--- a/drivers/mock/command.go
+++ b/drivers/mock/command.go
@@ -18,17 +18,13 @@ func runCommand(c Command, stdout, stderr io.WriteCloser, cancelCh <-chan struct
 	errCh := make(chan error, 1)
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		runCommandOutput(stdout, c.StdoutString, c.StdoutRepeat, c.stdoutRepeatDuration, cancelCh, logger, errCh)
-	}()
+	})
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		runCommandOutput(stderr, c.StderrString, c.StderrRepeat, c.stderrRepeatDuration, cancelCh, logger, errCh)
-	}()
+	})
 
 	timer := time.NewTimer(c.runForDuration)
 	defer timer.Stop()
@@ -80,7 +76,7 @@ func runCommandOutput(writer io.WriteCloser,
 		return
 	}
 
-	for i := 0; i < outputRepeat; i++ {
+	for i := range outputRepeat {
 		select {
 		case <-cancelCh:
 			logger.Warn("exiting before done writing output", "i", i, "total", outputRepeat)

--- a/drivers/mock/driver.go
+++ b/drivers/mock/driver.go
@@ -48,8 +48,8 @@ var (
 	// PluginConfig is the mock driver factory function registered in the
 	// plugin catalog.
 	PluginConfig = &loader.InternalPluginConfig{
-		Config:  map[string]interface{}{},
-		Factory: func(ctx context.Context, l hclog.Logger) interface{} { return NewMockDriver(ctx, l) },
+		Config:  map[string]any{},
+		Factory: func(ctx context.Context, l hclog.Logger) any { return NewMockDriver(ctx, l) },
 	}
 
 	// pluginInfo is the response returned for the PluginInfo RPC
@@ -496,7 +496,7 @@ func (d *Driver) StartTask(cfg *drivers.TaskConfig) (*drivers.TaskHandle, *drive
 		pluginExitAfter: driverConfig.pluginExitAfterDuration,
 		killAfter:       driverConfig.killAfterDuration,
 		logger:          d.logger.With("task_name", cfg.Name),
-		waitCh:          make(chan interface{}),
+		waitCh:          make(chan any),
 		killCh:          killCtx.Done(),
 		kill:            killCancel,
 		startedAt:       time.Now(),
@@ -647,7 +647,7 @@ func (d *Driver) ExecTask(taskID string, cmd []string, timeout time.Duration) (*
 	}
 
 	res := drivers.ExecTaskResult{
-		Stdout:     []byte(fmt.Sprintf("Exec(%q, %q)", h.taskConfig.Name, cmd)),
+		Stdout:     fmt.Appendf(nil, "Exec(%q, %q)", h.taskConfig.Name, cmd),
 		ExitResult: &drivers.ExitResult{},
 	}
 	return &res, nil

--- a/drivers/mock/driver_test.go
+++ b/drivers/mock/driver_test.go
@@ -72,13 +72,11 @@ func TestMockDriver_StartWaitRecoverWaitStop(t *testing.T) {
 
 	var waitDone bool
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		result := <-ch
 		must.Error(t, result.Err)
 		waitDone = true
-	}()
+	})
 
 	originalStatus, err := d.InspectTask(task.ID)
 	must.NoError(t, err)

--- a/drivers/mock/handle.go
+++ b/drivers/mock/handle.go
@@ -19,7 +19,7 @@ type taskHandle struct {
 
 	pluginExitAfter time.Duration
 	killAfter       time.Duration
-	waitCh          chan interface{}
+	waitCh          chan any
 
 	taskConfig  *drivers.TaskConfig
 	command     Command

--- a/drivers/qemu/driver.go
+++ b/drivers/qemu/driver.go
@@ -68,8 +68,8 @@ var (
 	// PluginConfig is the qemu driver factory function registered in the
 	// plugin catalog.
 	PluginConfig = &loader.InternalPluginConfig{
-		Config:  map[string]interface{}{},
-		Factory: func(ctx context.Context, l hclog.Logger) interface{} { return NewQemuDriver(ctx, l) },
+		Config:  map[string]any{},
+		Factory: func(ctx context.Context, l hclog.Logger) any { return NewQemuDriver(ctx, l) },
 	}
 
 	versionRegex = regexp.MustCompile(`version (\d[\.\d+]+)`)

--- a/drivers/qemu/driver_bsd.go
+++ b/drivers/qemu/driver_bsd.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build darwin || freebsd || netbsd || openbsd
-// +build darwin freebsd netbsd openbsd
 
 package qemu
 

--- a/drivers/qemu/driver_linux.go
+++ b/drivers/qemu/driver_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build linux
-// +build linux
 
 package qemu
 

--- a/drivers/qemu/driver_test.go
+++ b/drivers/qemu/driver_test.go
@@ -37,8 +37,7 @@ func TestQemuDriver_Start_Wait_Stop(t *testing.T) {
 	ctestutil.QemuCompatible_x86_64(t)
 	ctestutil.CgroupsCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	topology := numalib.Scan(numalib.PlatformScanners(false))
 	d := NewQemuDriver(ctx, testlog.HCLogger(t))
@@ -115,8 +114,7 @@ func TestQemuDriver_User(t *testing.T) {
 	ctestutil.QemuCompatible_x86_64(t)
 	ctestutil.CgroupsCompatible(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	topology := numalib.Scan(numalib.PlatformScanners(false))
 	d := NewQemuDriver(ctx, testlog.HCLogger(t))
@@ -242,8 +240,7 @@ func TestQemuDriver_Fingerprint(t *testing.T) {
 	ctestutil.QemuCompatible_aarch64(t)
 
 	t.Run("fingerpints all emulators", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		d := NewQemuDriver(ctx, testlog.HCLogger(t))
 		harness := dtestutil.NewDriverHarness(t, d)
@@ -265,8 +262,7 @@ func TestQemuDriver_Fingerprint(t *testing.T) {
 
 	t.Run("fingerprints only allowed emulators", func(t *testing.T) {
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		allowedEms := []string{"x86_64"}
 		d := NewQemuDriver(ctx, testlog.HCLogger(t))

--- a/drivers/rawexec/driver.go
+++ b/drivers/rawexec/driver.go
@@ -54,16 +54,16 @@ var (
 	// PluginConfig is the rawexec factory function registered in the
 	// plugin catalog.
 	PluginConfig = &loader.InternalPluginConfig{
-		Config:  map[string]interface{}{},
-		Factory: func(ctx context.Context, l hclog.Logger) interface{} { return NewRawExecDriver(ctx, l) },
+		Config:  map[string]any{},
+		Factory: func(ctx context.Context, l hclog.Logger) any { return NewRawExecDriver(ctx, l) },
 	}
 
 	errDisabledDriver = fmt.Errorf("raw_exec is disabled")
 )
 
 // PluginLoader maps pre-0.9 client driver options to post-0.9 plugin options.
-func PluginLoader(opts map[string]string) (map[string]interface{}, error) {
-	conf := map[string]interface{}{}
+func PluginLoader(opts map[string]string) (map[string]any, error) {
+	conf := map[string]any{}
 	if v, err := strconv.ParseBool(opts["driver.raw_exec.enable"]); err == nil {
 		conf["enabled"] = v
 	}

--- a/drivers/rawexec/driver_test.go
+++ b/drivers/rawexec/driver_test.go
@@ -114,8 +114,7 @@ func newEnabledRawExecDriver(t *testing.T) *Driver {
 func TestRawExecDriver_SetConfig(t *testing.T) {
 	ci.Parallel(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	logger := testlog.HCLogger(t)
 

--- a/drivers/rawexec/driver_unix_test.go
+++ b/drivers/rawexec/driver_unix_test.go
@@ -175,7 +175,7 @@ func TestRawExecDriver_StartWaitStop(t *testing.T) {
 		Resources: testResources(allocID, taskName),
 	}
 
-	taskConfig := map[string]interface{}{}
+	taskConfig := map[string]any{}
 	taskConfig["command"] = testtask.Path()
 	taskConfig["args"] = []string{"sleep", "100s"}
 
@@ -249,7 +249,7 @@ func TestRawExecDriver_DestroyKillsAll(t *testing.T) {
 
 	harness.MakeTaskCgroup(allocID, taskName)
 
-	taskConfig := map[string]interface{}{}
+	taskConfig := map[string]any{}
 	taskConfig["command"] = "/bin/sh"
 	taskConfig["args"] = []string{"-c", fmt.Sprintf(`sleep 3600 & echo "SLEEP_PID=$!"`)}
 
@@ -469,13 +469,11 @@ func TestRawExecDriver_StartWaitRecoverWaitStop(t *testing.T) {
 
 	var waitDone bool
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		result := <-ch
 		require.Error(result.Err)
 		waitDone = true
-	}()
+	})
 
 	originalStatus, err := d.InspectTask(task.ID)
 	require.NoError(err)

--- a/drivers/shared/capabilities/set.go
+++ b/drivers/shared/capabilities/set.go
@@ -5,6 +5,7 @@
 package capabilities
 
 import (
+	"maps"
 	"sort"
 	"strings"
 )
@@ -44,9 +45,7 @@ func insert(data map[string]nothing, cap string) {
 	switch name := normalize(cap); name {
 	case "":
 	case "all":
-		for k, v := range Supported().data {
-			data[k] = v
-		}
+		maps.Copy(data, Supported().data)
 		return
 	default:
 		data[name] = null

--- a/drivers/shared/eventer/eventer_test.go
+++ b/drivers/shared/eventer/eventer_test.go
@@ -19,8 +19,7 @@ func TestEventer(t *testing.T) {
 	ci.Parallel(t)
 	require := require.New(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 	e := NewEventer(ctx, testlog.HCLogger(t))
 
 	events := []*drivers.TaskEvent{
@@ -38,8 +37,7 @@ func TestEventer(t *testing.T) {
 		},
 	}
 
-	ctx1, cancel1 := context.WithCancel(context.Background())
-	defer cancel1()
+	ctx1 := t.Context()
 	consumer1, err := e.TaskEvents(ctx1)
 	require.NoError(err)
 	ctx2 := (context.Background())
@@ -102,13 +100,11 @@ func TestEventer_iterateConsumers(t *testing.T) {
 	require.Equal(1, len(e.consumers))
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		ev1, ok := <-consumer
 		require.Exactly(ev, ev1)
 		require.True(ok)
-	}()
+	})
 	e.iterateConsumers(ev)
 	wg.Wait()
 

--- a/drivers/shared/executor/executor.go
+++ b/drivers/shared/executor/executor.go
@@ -327,7 +327,7 @@ type UniversalExecutor struct {
 	command  *ExecCommand
 
 	exitState     *ProcessState
-	processExited chan interface{}
+	processExited chan any
 
 	totalCpuStats  *cpustats.Tracker
 	userCpuStats   *cpustats.Tracker
@@ -341,7 +341,7 @@ type UniversalExecutor struct {
 func NewExecutor(logger hclog.Logger, compute cpustats.Compute) Executor {
 	ue := &UniversalExecutor{
 		logger:         logger.Named("executor"),
-		processExited:  make(chan interface{}),
+		processExited:  make(chan any),
 		totalCpuStats:  cpustats.New(compute),
 		userCpuStats:   cpustats.New(compute),
 		systemCpuStats: cpustats.New(compute),

--- a/drivers/shared/executor/executor_linux_cgo.go
+++ b/drivers/shared/executor/executor_linux_cgo.go
@@ -81,7 +81,7 @@ type LibcontainerExecutor struct {
 
 	container      *libcontainer.Container
 	userProc       *libcontainer.Process
-	userProcExited chan interface{}
+	userProcExited chan any
 	exitState      *ProcessState
 	sigChan        chan os.Signal
 }
@@ -274,7 +274,7 @@ func (l *LibcontainerExecutor) Launch(command *ExecCommand) (*ProcessState, erro
 
 	// start a goroutine to wait on the process to complete, so Wait calls can
 	// be multiplexed
-	l.userProcExited = make(chan interface{})
+	l.userProcExited = make(chan any)
 	go l.wait()
 
 	return &ProcessState{

--- a/drivers/shared/executor/executor_linux_test.go
+++ b/drivers/shared/executor/executor_linux_test.go
@@ -561,7 +561,7 @@ func TestExecutor_DoesNotInheritOomScoreAdj(t *testing.T) {
 	_, err = executor.Launch(execCmd)
 	require.NoError(t, err)
 
-	ch := make(chan interface{})
+	ch := make(chan any)
 	go func() {
 		executor.Wait(context.Background())
 		close(ch)
@@ -655,7 +655,7 @@ CapAmb: 0000000000000400`,
 			_, err := executor.Launch(execCmd)
 			require.NoError(t, err)
 
-			ch := make(chan interface{})
+			ch := make(chan any)
 			go func() {
 				executor.Wait(context.Background())
 				close(ch)
@@ -713,7 +713,7 @@ func TestExecutor_ClientCleanup(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 	require.NoError(executor.Shutdown("SIGINT", 100*time.Millisecond))
 
-	ch := make(chan interface{})
+	ch := make(chan any)
 	go func() {
 		executor.Wait(context.Background())
 		close(ch)

--- a/drivers/shared/executor/executor_plugin.go
+++ b/drivers/shared/executor/executor_plugin.go
@@ -30,7 +30,7 @@ func (p *ExecutorPlugin) GRPCServer(broker *plugin.GRPCBroker, s *grpc.Server) e
 	return nil
 }
 
-func (p *ExecutorPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (interface{}, error) {
+func (p *ExecutorPlugin) GRPCClient(ctx context.Context, broker *plugin.GRPCBroker, c *grpc.ClientConn) (any, error) {
 	return &grpcExecutorClient{
 		client:  proto.NewExecutorClient(c),
 		doneCtx: ctx,

--- a/drivers/shared/executor/executor_test.go
+++ b/drivers/shared/executor/executor_test.go
@@ -526,7 +526,7 @@ func TestExecutor_Start_Kill_Immediately_NoGrace(t *testing.T) {
 			require.NoError(err)
 			require.NotZero(ps.Pid)
 
-			waitCh := make(chan interface{})
+			waitCh := make(chan any)
 			go func() {
 				defer close(waitCh)
 				executor.Wait(context.Background())
@@ -562,7 +562,7 @@ func TestExecutor_Start_Kill_Immediately_WithGrace(t *testing.T) {
 			require.NoError(err)
 			require.NotZero(ps.Pid)
 
-			waitCh := make(chan interface{})
+			waitCh := make(chan any)
 			go func() {
 				defer close(waitCh)
 				executor.Wait(context.Background())

--- a/drivers/shared/executor/pty_unix.go
+++ b/drivers/shared/executor/pty_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package executor
 

--- a/drivers/shared/executor/utils_unix.go
+++ b/drivers/shared/executor/utils_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package executor
 

--- a/drivers/shared/hostnames/mount_unix_test.go
+++ b/drivers/shared/hostnames/mount_unix_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //go:build !windows
-// +build !windows
 
 package hostnames
 
@@ -89,7 +88,6 @@ func TestGenerateEtcHostsMount(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 


### PR DESCRIPTION
### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

