### PR TITLE
leader: Fix potential race condition in cancelable eval reaper.

### DIFF
--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -455,7 +455,7 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 	go s.reapDupBlockedEvaluations(stopCh)
 
 	// Reap any cancelable evaluations
-	s.reapCancelableEvalsCh = s.reapCancelableEvaluations(stopCh)
+	go s.reapCancelableEvaluations(stopCh)
 
 	// Periodically unblock failed allocations
 	go s.periodicUnblockFailedEvals(stopCh)
@@ -1186,29 +1186,24 @@ func (s *Server) reapDupBlockedEvaluations(stopCh chan struct{}) {
 // reapCancelableEvaluations is used to reap evaluations that were marked
 // cancelable by the eval broker and should be canceled. These get swept up
 // whenever an eval Acks, but this ensures that we don't have a straggling batch
-// when the cluster doesn't have any more work to do. Returns a wake-up channel
-// that can be used to trigger a new reap without waiting for the timer
-func (s *Server) reapCancelableEvaluations(stopCh chan struct{}) chan struct{} {
+// when the cluster doesn't have any more work to do. Wakes up whenever
+// s.reapCancelableEvalsCh is signalled or the configured interval elapses.
+func (s *Server) reapCancelableEvaluations(stopCh chan struct{}) {
 
-	wakeCh := make(chan struct{}, 1)
-	go func() {
+	timer, cancel := helper.NewSafeTimer(s.config.EvalReapCancelableInterval)
+	defer cancel()
 
-		timer, cancel := helper.NewSafeTimer(s.config.EvalReapCancelableInterval)
-		defer cancel()
-		for {
-			select {
-			case <-stopCh:
-				return
-			case <-wakeCh:
-				cancelCancelableEvals(s)
-			case <-timer.C:
-				cancelCancelableEvals(s)
-				timer.Reset(s.config.EvalReapCancelableInterval)
-			}
+	for {
+		select {
+		case <-stopCh:
+			return
+		case <-s.reapCancelableEvalsCh:
+			_ = cancelCancelableEvals(s)
+		case <-timer.C:
+			_ = cancelCancelableEvals(s)
+			timer.Reset(s.config.EvalReapCancelableInterval)
 		}
-	}()
-
-	return wakeCh
+	}
 }
 
 const cancelableEvalsBatchSize = 728 // structs.MaxUUIDsPerWriteRequest / 10

--- a/nomad/server.go
+++ b/nomad/server.go
@@ -222,7 +222,9 @@ type Server struct {
 	// transitions to collide and create inconsistent state.
 	brokerLock sync.Mutex
 
-	// reapCancelableEvalsCh is used to signal the cancelable evals reaper to wake up
+	// reapCancelableEvalsCh is used to signal the cancelable evals reaper
+	// goroutine to wake up. It is initialised once in NewServer and must not be
+	// reassigned.
 	reapCancelableEvalsCh chan struct{}
 
 	// deploymentWatcher is used to watch deployments and their allocations and
@@ -373,7 +375,7 @@ func NewServer(config *Config, consulCatalog consul.CatalogAPI, consulConfigFunc
 		reconcileCh:             make(chan serf.Member, 32),
 		readyForConsistentReads: &atomic.Bool{},
 		eventCh:                 make(chan serf.Event, 256),
-		reapCancelableEvalsCh:   make(chan struct{}),
+		reapCancelableEvalsCh:   make(chan struct{}, 1),
 		rpcTLS:                  incomingTLS,
 		workersEventCh:          make(chan any, 1),
 		lockTTLTimer:            lock.NewTTLTimer(),


### PR DESCRIPTION
When leadership was being established, the cancelable eval reaper was started which returned a buffered channel for use in triggering a reap. This returned channel is then stored on the server object for use in the eval ack RCP handler. In a tight timing situation we can hit a race condition with the leader writing the channel to the server object and the eval handler sending to the channel.

The change has the reaper now use the existing channel for notification rather than generate a new one. The RPC handler requires a buffered channel which means a slight change to the server build function. The reaper has also been moved from running a go routine itself, to having the caller perform this, which is standard on other leader routines.

Changelog: seeing as this is a potential condition with no reports, I'm initially not adding a changelog. If reviewers think otherwise, please let me know.

Found in some local testing:

<details>
  <summary>race condition stack</summary>
  
```
==================
WARNING: DATA RACE
Read at 0x00c0007e29a0 by goroutine 54838:
  github.com/hashicorp/nomad/nomad.(*Eval).Ack()
      /Users/jrasell/Projects/Go/nomad/nomad/eval_endpoint.go:252 +0x450
  runtime.call32()
      /Users/jrasell/.local/share/mise/installs/go/1.27.1/src/runtime/asm_arm64.s:650 +0x6c
  reflect.Value.Call()
      /Users/jrasell/.local/share/mise/installs/go/1.27.1/src/reflect/value.go:369 +0x90
  net/rpc.(*service).call()
      /Users/jrasell/.local/share/mise/installs/go/1.27.1/src/net/rpc/server.go:383 +0x1d8
  net/rpc.(*Server).ServeRequest()
      /Users/jrasell/.local/share/mise/installs/go/1.27.1/src/net/rpc/server.go:504 +0x114
  github.com/hashicorp/nomad/nomad.(*rpcHandler).handleNomadConn()
      /Users/jrasell/Projects/Go/nomad/nomad/rpc.go:469 +0x230
  github.com/hashicorp/nomad/nomad.(*rpcHandler).handleConn()
      /Users/jrasell/Projects/Go/nomad/nomad/rpc.go:317 +0x794
  github.com/hashicorp/nomad/nomad.(*rpcHandler).listen.gowrap2()
      /Users/jrasell/Projects/Go/nomad/nomad/rpc.go:237 +0x5c

Previous write at 0x00c0007e29a0 by goroutine 55112:
  github.com/hashicorp/nomad/nomad.(*Server).establishLeadership()
      /Users/jrasell/Projects/Go/nomad/nomad/leader.go:458 +0x8e4
  github.com/hashicorp/nomad/nomad.(*Server).leaderLoop()
      /Users/jrasell/Projects/Go/nomad/nomad/leader.go:268 +0x368
  github.com/hashicorp/nomad/nomad.(*Server).monitorLeadership.func1.1()
      /Users/jrasell/Projects/Go/nomad/nomad/leader.go:128 +0x80
  github.com/hashicorp/nomad/nomad.(*Server).monitorLeadership.func1.gowrap1()
      /Users/jrasell/Projects/Go/nomad/nomad/leader.go:129 +0x38

Goroutine 54838 (running) created at:
  github.com/hashicorp/nomad/nomad.(*rpcHandler).listen()
      /Users/jrasell/Projects/Go/nomad/nomad/rpc.go:237 +0x61c
  github.com/hashicorp/nomad/nomad.(*Server).startRPCListener.gowrap1()
      /Users/jrasell/Projects/Go/nomad/nomad/server.go:592 +0x40

Goroutine 55112 (running) created at:
  github.com/hashicorp/nomad/nomad.(*Server).monitorLeadership.func1()
      /Users/jrasell/Projects/Go/nomad/nomad/leader.go:126 +0x218
  github.com/hashicorp/nomad/nomad.(*Server).monitorLeadership()
      /Users/jrasell/Projects/Go/nomad/nomad/leader.go:153 +0x224
  github.com/hashicorp/nomad/nomad.NewServer.gowrap2()
      /Users/jrasell/Projects/Go/nomad/nomad/server.go:539 +0x2c
==================
```
</details>


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

