### PR TITLE
scheduler: normalize node affinity by the larger of the pos/neg weight sums

### DIFF
--- a/.changelog/11130.txt
+++ b/.changelog/11130.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+scheduler: Fixed a bug where mixing positive and negative node affinity weights squashed the affinity score range
+```

--- a/scheduler/feasible/rank.go
+++ b/scheduler/feasible/rank.go
@@ -974,10 +974,21 @@ func (iter *NodeAffinityIterator) Next() *RankedNode {
 		return option
 	}
 	// TODO(preetha): we should calculate normalized weights once and reuse it here
-	sumWeight := 0.0
+	// Normalize by the larger of the total positive and total negative weight
+	// rather than the sum of all absolute weights. Using the sum would let an
+	// anti-affinity on one node shrink the score of a node that only matches a
+	// positive affinity (and vice versa), squashing the usable [-1, 1] range
+	// whenever positive and negative weights are mixed.
+	sumPosWeight := 0.0
+	sumNegWeight := 0.0
 	for _, affinity := range iter.affinities {
-		sumWeight += math.Abs(float64(affinity.Weight))
+		if affinity.Weight >= 0 {
+			sumPosWeight += float64(affinity.Weight)
+		} else {
+			sumNegWeight += math.Abs(float64(affinity.Weight))
+		}
 	}
+	sumWeight := math.Max(sumPosWeight, sumNegWeight)
 
 	totalAffinityScore := 0.0
 	for _, affinity := range iter.affinities {
@@ -985,7 +996,10 @@ func (iter *NodeAffinityIterator) Next() *RankedNode {
 			totalAffinityScore += float64(affinity.Weight)
 		}
 	}
-	normScore := totalAffinityScore / sumWeight
+	normScore := 0.0
+	if sumWeight > 0 {
+		normScore = totalAffinityScore / sumWeight
+	}
 	option.Scores = append(option.Scores, normScore)
 	iter.ctx.Metrics().ScoreNode(option.Node, "node-affinity", normScore)
 	return option

--- a/scheduler/feasible/rank_test.go
+++ b/scheduler/feasible/rank_test.go
@@ -2621,18 +2621,19 @@ func TestNodeAffinityIterator(t *testing.T) {
 		scoreNorm := NewScoreNormalizationIterator(ctx, nodeAffinity)
 		out := collectRanked(scoreNorm)
 
-		// Total weight = 300
+		// Denominator = max(sum of positive weights, sum of negative weights)
+		// = max(100+50+50, 100) = 200
 		// Node 0 matches two affinities(dc and kernel version), total weight = 150
-		test.Eq(t, 0.5, out[0].FinalScore)
+		test.Eq(t, 0.75, out[0].FinalScore)
 
 		// Node 1 matches an anti affinity, weight = -100
-		test.Eq(t, -(1.0 / 3.0), out[1].FinalScore)
+		test.Eq(t, -0.5, out[1].FinalScore)
 
-		// Node 2 matches one affinity(node class) with weight 50
-		test.Eq(t, -(1.0 / 6.0), out[2].FinalScore)
+		// Node 2 matches dc anti affinity and node class, total weight = -50
+		test.Eq(t, -0.25, out[2].FinalScore)
 
 		// Node 3 matches one affinity (dc) with weight = 100
-		test.Eq(t, 1.0/3.0, out[3].FinalScore)
+		test.Eq(t, 0.5, out[3].FinalScore)
 
 		// Node 4 matches no affinities but should still generate a score
 		test.Eq(t, 0, out[4].FinalScore)
@@ -2663,18 +2664,18 @@ func TestNodeAffinityIterator(t *testing.T) {
 		scoreNorm := NewScoreNormalizationIterator(ctx, nodeAffinity)
 		out := collectRanked(scoreNorm)
 
-		// Total weight = 300
+		// Denominator = max(100+50+50, 100) = 200
 		// Node 0 matches two affinities(dc and kernel version), total weight = 150
-		test.Eq(t, (0.5+bp)/2, out[0].FinalScore)
+		test.Eq(t, (0.75+bp)/2, out[0].FinalScore)
 
 		// Node 1 matches an anti affinity, weight = -100
-		test.Eq(t, (-(1.0/3.0)+bp)/2, out[1].FinalScore)
+		test.Eq(t, (-0.5+bp)/2, out[1].FinalScore)
 
-		// Node 2 matches one affinity(node class) with weight 50
-		test.Eq(t, (-(1.0/6.0)+bp)/2, out[2].FinalScore)
+		// Node 2 matches dc anti affinity and node class, total weight = -50
+		test.Eq(t, (-0.25+bp)/2, out[2].FinalScore)
 
 		// Node 3 matches one affinity (dc) with weight = 100
-		test.Eq(t, ((1.0/3.0)+bp)/2, out[3].FinalScore)
+		test.Eq(t, (0.5+bp)/2, out[3].FinalScore)
 
 		// Node 4 matches no affinities but should still generate a score and
 		// the final score should be lower than any positive score
@@ -2682,5 +2683,32 @@ func TestNodeAffinityIterator(t *testing.T) {
 		test.Len(t, 2, out[4].Scores)
 		test.Less(t, out[0].FinalScore, out[4].FinalScore)
 		test.Less(t, out[3].FinalScore, out[4].FinalScore)
+	})
+
+	t.Run("mixed sign weights preserve full range", func(t *testing.T) {
+		// Regression for #11130: an anti-affinity targeting an unrelated node
+		// must not shrink a matching node's affinity score. With a +100 and a
+		// -100 affinity on different datacenters, a node matching only the +100
+		// should score the full 1.0 and a node matching only the -100 should
+		// score -1.0, rather than the squashed 0.5/-0.5 produced when the
+		// denominator sums the absolute value of every weight.
+		nodeA := &RankedNode{Node: mock.Node()} // datacenter dc1
+		nodeB := &RankedNode{Node: mock.Node()}
+		nodeB.Node.Datacenter = "dc2"
+
+		rangeJob := mock.Job()
+		rangeJob.TaskGroups[0].Affinities = []*structs.Affinity{
+			{Operand: "=", LTarget: "${node.datacenter}", RTarget: "dc1", Weight: 100},
+			{Operand: "=", LTarget: "${node.datacenter}", RTarget: "dc2", Weight: -100},
+		}
+
+		static := NewStaticRankIterator(ctx, []*RankedNode{nodeA, nodeB})
+		nodeAffinity := NewNodeAffinityIterator(ctx, static)
+		nodeAffinity.SetTaskGroup(rangeJob.TaskGroups[0])
+		scoreNorm := NewScoreNormalizationIterator(ctx, nodeAffinity)
+		out := collectRanked(scoreNorm)
+
+		test.Eq(t, 1.0, out[0].FinalScore)  // nodeA matches only the +100 affinity
+		test.Eq(t, -1.0, out[1].FinalScore) // nodeB matches only the -100 anti-affinity
 	})
 }


### PR DESCRIPTION
### Description

NodeAffinityIterator normalized a node's affinity score by the sum of the absolute value of every affinity weight. When a job mixed positive and negative weights, an anti-affinity on one node inflated the denominator for an unrelated node that only matched a positive affinity (and vice versa), the score does not reached the [-1, 1] range. 

For example a +100 affinity on node A plus a -100 anti-affinity on node B scored node A at 0.5 instead of 1.0.

This divides by the larger of the total positive weight and the total negative weight instead. This restores the range while still keeping scores within [-1, 1], since the matched total is bounded by the positive sum above and the negative sum below.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links

Fixes #11130

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
