### PR TITLE
vault hook: use task kill context for vault hook

### DIFF
--- a/.changelog/28501.txt
+++ b/.changelog/28501.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+vault: fixes an issue where dead tasks continued to have their tokens renewed
+```

--- a/client/allocrunner/taskrunner/task_runner_hooks.go
+++ b/client/allocrunner/taskrunner/task_runner_hooks.go
@@ -78,7 +78,7 @@ func (tr *TaskRunner) initHooks() {
 			logger:           hookLogger,
 			alloc:            tr.Alloc(),
 			task:             tr.Task(),
-			taskCtx:          tr.shutdownCtx,
+			taskCtx:          tr.killCtx,
 			widmgr:           tr.widmgr,
 		}))
 	}

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -91,9 +91,12 @@ type vaultHook struct {
 	// logger is used to log
 	logger log.Logger
 
-	// The taskRunner's context. This is stored on the vaulHook because it
-	// cuurently is not injected via Prestart.
+	// The hook's context, derived from the taskrunner . This is stored on the
+	// vaulHook because it currently is not injected via Prestart.
 	taskCtx context.Context
+
+	// The hooks cancel func to exit the token renewal loop.
+	taskCancel context.CancelFunc
 
 	// privateDirTokenPath is the path inside the task's private directory where
 	// the Vault token is read and written.
@@ -120,6 +123,7 @@ type vaultHook struct {
 }
 
 func newVaultHook(config *vaultHookConfig) *vaultHook {
+	hookCtx, hookCancel := context.WithCancel(config.taskCtx)
 	h := &vaultHook{
 		vaultBlock:           config.vaultBlock,
 		vaultConfigsFunc:     config.vaultConfigsFunc,
@@ -128,7 +132,8 @@ func newVaultHook(config *vaultHookConfig) *vaultHook {
 		lifecycle:            config.lifecycle,
 		updater:              config.updater,
 		task:                 config.task,
-		taskCtx:              config.taskCtx,
+		taskCtx:              hookCtx,
+		taskCancel:           hookCancel,
 		firstRun:             true,
 		widmgr:               config.widmgr,
 		widName:              config.task.Vault.IdentityName(),
@@ -215,10 +220,13 @@ func (h *vaultHook) Prestart(ctx context.Context, req *interfaces.TaskPrestartRe
 }
 
 func (h *vaultHook) Stop(ctx context.Context, req *interfaces.TaskStopRequest, resp *interfaces.TaskStopResponse) error {
+	h.taskCancel()
 	return nil
 }
 
-func (h *vaultHook) Shutdown() {}
+func (h *vaultHook) Shutdown() {
+	h.taskCancel()
+}
 
 func (h *vaultHook) run(ctx context.Context, token string, lease time.Duration) {
 	var err error

--- a/client/allocrunner/taskrunner/vault_hook.go
+++ b/client/allocrunner/taskrunner/vault_hook.go
@@ -91,8 +91,8 @@ type vaultHook struct {
 	// logger is used to log
 	logger log.Logger
 
-	// The hook's context, derived from the taskrunner . This is stored on the
-	// vaulHook because it currently is not injected via Prestart.
+	// The hook's context, derived from the taskrunner's killCtx. This is stored
+	// on the vaulHook because it is not injected via Prestart.
 	taskCtx context.Context
 
 	// The hooks cancel func to exit the token renewal loop.

--- a/client/allocrunner/taskrunner/vault_hook_test.go
+++ b/client/allocrunner/taskrunner/vault_hook_test.go
@@ -339,12 +339,18 @@ func TestVaultHook_Prestart(t *testing.T) {
 		)
 
 		client := vaultclient.NewMockVaultClient()
-		client.On("DeriveTokenWithJWT", t.Context(), vaultclient.JWTLoginRequest{}).Return(
+		// On the first derive, acquire the token successfully
+		client.On("DeriveTokenWithJWT", mock.Anything, vaultclient.JWTLoginRequest{}).Return(
 			"testToken", true, 0, nil,
-		)
+		).Once()
+
+		// on renewal and subsequent derives, return permission denied
 		client.On("Renew", mock.Anything, "testToken", 0).Return(
 			time.Minute,
 			errors.New("permission denied"),
+		)
+		client.On("DeriveTokenWithJWT", mock.Anything, vaultclient.JWTLoginRequest{}).Return(
+			"testToken", false, 0, errors.New("permission denied"),
 		)
 
 		mockLifecycle := trtesting.NewMockTaskHooks()
@@ -368,7 +374,7 @@ func TestVaultHook_Prestart(t *testing.T) {
 			if mockLifecycle.KillEvent() != nil {
 				return nil
 			}
-			return errors.New("test")
+			return errors.New("no kill event yet")
 		})))
 	})
 }


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes fix an issue in the vault hook where the renewal loop is not shut down properly because it is not being passed the correct context. Instead of passing the shutdown context, which is only cancelled on client shutdown, we should pass the task's `killCtx`. In addition, these changes derive a child context that is cancelled via the defined `shutdown` and `stop` hook methods.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->
Set short vault TTL, run a short batch job with vault hook, get token accessor via `vault list auth/token/accessors`, lookup token and see it get renewed eventually.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes: https://github.com/hashicorp/nomad/issues/28502

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
