### PR TITLE
bjq: separate cpu and memory adjustments instead of generic size

### DIFF
--- a/api/batch_job_queue.go
+++ b/api/batch_job_queue.go
@@ -43,7 +43,8 @@ type DynamicPriorityWorkload struct {
 	BasePriority     int
 	UsageAdjustment  int
 	AgeAdjustment    int
-	SizeAdjustment   int
+	CpuAdjustment    int
+	MemoryAdjustment int
 	CreatedAt        int64
 }
 

--- a/command/queue_jobs.go
+++ b/command/queue_jobs.go
@@ -181,10 +181,10 @@ func (c *QueueJobsCommand) printDynamicQueueFormatted(resp []api.DynamicPriority
 	}
 
 	out := make([]string, len(resp)+1)
-	out[0] = "JobID|Tenant|Adjusted Priority|Base Priority|Position|Usage|Age|Size|CreatedAt"
+	out[0] = "JobID|Tenant|Adjusted Priority|Base Priority|Position|Usage|Age|Cpu|Memory|CreatedAt"
 
 	for i, v := range resp {
-		out[i+1] = fmt.Sprintf("%s|%s|%d|%d|%d|%d|%d|%d|%s",
+		out[i+1] = fmt.Sprintf("%s|%s|%d|%d|%d|%d|%d|%d|%d|%s",
 			v.JobID,
 			v.Tenant,
 			v.AdjustedPriority,
@@ -192,7 +192,8 @@ func (c *QueueJobsCommand) printDynamicQueueFormatted(resp []api.DynamicPriority
 			v.Position,
 			v.UsageAdjustment,
 			v.AgeAdjustment,
-			v.SizeAdjustment,
+			v.CpuAdjustment,
+			v.MemoryAdjustment,
 			formatUnixNanoTime(v.CreatedAt),
 		)
 	}

--- a/command/queue_jobs_test.go
+++ b/command/queue_jobs_test.go
@@ -33,15 +33,16 @@ func TestQueueJobsCommand_printDynamicQueueFormatted(t *testing.T) {
 			BasePriority:     10,
 			UsageAdjustment:  10,
 			AgeAdjustment:    5,
-			SizeAdjustment:   6,
+			CpuAdjustment:    5,
+			MemoryAdjustment: 5,
 			CreatedAt:        time.Now().UnixNano(),
 		},
 	}
 	cmd.printDynamicQueueFormatted(testResp)
 
 	expect := "Batch Queue Workloads\n" +
-		"JobID  Tenant       Adjusted Priority  Base Priority  Position  Usage  Age  Size  CreatedAt\n" +
-		fmt.Sprintf("123    testTenant1  10                 10             1         10     5    6     %v\n", formatUnixNanoTime(testResp[0].CreatedAt))
+		"JobID  Tenant       Adjusted Priority  Base Priority  Position  Usage  Age  Cpu  Memory  CreatedAt\n" +
+		"123    testTenant1  10                 10             1         10     5    5    5       " + fmt.Sprintf("%v\n", formatUnixNanoTime(testResp[0].CreatedAt))
 
 	must.Eq(t, expect, ui.OutputWriter.String())
 }
@@ -60,7 +61,8 @@ func TestQueueJobsCommand_printDynamicQueueJSON(t *testing.T) {
 			BasePriority:     10,
 			UsageAdjustment:  10,
 			AgeAdjustment:    5,
-			SizeAdjustment:   6,
+			CpuAdjustment:    5,
+			MemoryAdjustment: 5,
 			CreatedAt:        time.Now().UnixNano(),
 		},
 	}

--- a/command/queue_jobs_test.go
+++ b/command/queue_jobs_test.go
@@ -68,7 +68,7 @@ func TestQueueJobsCommand_printDynamicQueueJSON(t *testing.T) {
 	}
 	cmd.printDynamicQueueJSON(testResp)
 
-	expect := `[{"JobID":"123","Tenant":"testTenant1","Position":1,"AdjustedPriority":10,"BasePriority":10,"UsageAdjustment":10,"AgeAdjustment":5,"SizeAdjustment":6,"CreatedAt":` + fmt.Sprintf("%d", testResp[0].CreatedAt) + `}]` + "\n"
+	expect := `[{"JobID":"123","Tenant":"testTenant1","Position":1,"AdjustedPriority":10,"BasePriority":10,"UsageAdjustment":10,"AgeAdjustment":5,"CpuAdjustment":5,"MemoryAdjustment":5,"CreatedAt":` + fmt.Sprintf("%d", testResp[0].CreatedAt) + `}]` + "\n"
 
 	must.Eq(t, expect, ui.OutputWriter.String())
 }

--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -375,7 +375,8 @@ func (d *DynamicPriorityQueue) setWorkloadPriority(now time.Time, w *dynamicPrio
 	w.priority = w.eval.Priority +
 		d.usageAdjustment(w) +
 		d.ageAdjustment(now, w) +
-		d.sizeAdjustment(w)
+		d.cpuAdjustment(w) +
+		d.memAdjustment(w)
 }
 
 // usageAdjustment calculates the adjustment to a workload's priority based on
@@ -465,16 +466,28 @@ func (d *DynamicPriorityQueue) ageAdjustment(now time.Time, w *dynamicPriorityWo
 	return w.ageAdjustment
 }
 
-func (d *DynamicPriorityQueue) sizeAdjustment(w *dynamicPriorityWorkload) int {
-	if d.conf.SizeWeight == 0 {
+func (d *DynamicPriorityQueue) cpuAdjustment(w *dynamicPriorityWorkload) int {
+	if d.conf.CpuWeight == 0 {
 		return 0
 	}
 
-	size := w.requestedResources.resources.Total() / float64(d.conf.MaxSize)
+	size := w.requestedResources.resources.CPU / float64(d.conf.MaxCpu)
 	sizeClamped := min(1.0, max(0.0, size))
 
-	w.sizeAdjustment = int((1 - sizeClamped) * float64(d.conf.SizeWeight))
-	return w.sizeAdjustment
+	w.cpuAdjustment = int((1 - sizeClamped) * float64(d.conf.CpuWeight))
+	return w.cpuAdjustment
+}
+
+func (d *DynamicPriorityQueue) memAdjustment(w *dynamicPriorityWorkload) int {
+	if d.conf.MemWeight == 0 {
+		return 0
+	}
+
+	size := w.requestedResources.resources.Memory / float64(d.conf.MaxMemory)
+	sizeClamped := min(1.0, max(0.0, size))
+
+	w.memAdjustment = int((1 - sizeClamped) * float64(d.conf.MemWeight))
+	return w.memAdjustment
 }
 
 func (d *DynamicPriorityQueue) Jobs(sortOrder structs.SortOrder) *queue.WorkloadIter {
@@ -501,7 +514,8 @@ func (d *DynamicPriorityQueue) Jobs(sortOrder structs.SortOrder) *queue.Workload
 			BasePriority:     w.eval.Priority,
 			UsageAdjustment:  w.usageAdjustment,
 			AgeAdjustment:    w.ageAdjustment,
-			SizeAdjustment:   w.sizeAdjustment,
+			CpuAdjustment:    w.cpuAdjustment,
+			MemoryAdjustment: w.memAdjustment,
 			CreatedAt:        w.eval.CreateTime,
 			CreateIndex:      w.eval.CreateIndex,
 		})

--- a/nomad/queues/dynamic_priority/queue_test.go
+++ b/nomad/queues/dynamic_priority/queue_test.go
@@ -421,7 +421,7 @@ func TestDynamicPriorityQueue_calculatePriorities(t *testing.T) {
 	}
 }
 
-func TestDynamicPriorityQueue_sizeAdjustment(t *testing.T) {
+func TestDynamicPriorityQueue_resourceAdjustments(t *testing.T) {
 	testCases := []struct {
 		name     string
 		conf     *structs.DynamicQueueConfig
@@ -429,24 +429,28 @@ func TestDynamicPriorityQueue_sizeAdjustment(t *testing.T) {
 		exp      int
 	}{
 		{
-			name: "larger size results in 0 adjustment",
+			name: "larger requests results in 0 adjustment",
 			conf: &structs.DynamicQueueConfig{
-				SizeWeight: 10,
-				MaxSize:    1000,
+				CpuWeight: 10,
+				MaxCpu:    1000,
+				MemWeight: 10,
+				MaxMemory: 1000,
 			},
 			workload: &dynamicPriorityWorkload{requestedResources: &UsageList{
 				resources: &ResourceUsage{
-					CPU:    500,
-					Memory: 500,
+					CPU:    1000,
+					Memory: 1000,
 				},
 			}},
 			exp: 0,
 		},
 		{
-			name: "smaller sized job results in expected adjustment",
+			name: "smaller requests results in expected adjustment",
 			conf: &structs.DynamicQueueConfig{
-				SizeWeight: 10,
-				MaxSize:    1000,
+				CpuWeight: 10,
+				MaxCpu:    1000,
+				MemWeight: 10,
+				MaxMemory: 1000,
 			},
 			workload: &dynamicPriorityWorkload{requestedResources: &UsageList{
 				resources: &ResourceUsage{
@@ -459,8 +463,10 @@ func TestDynamicPriorityQueue_sizeAdjustment(t *testing.T) {
 		{
 			name: "negative weight results in negative adjustment",
 			conf: &structs.DynamicQueueConfig{
-				SizeWeight: -10,
-				MaxSize:    1000,
+				CpuWeight: -10,
+				MaxCpu:    1000,
+				MemWeight: -10,
+				MaxMemory: 1000,
 			},
 			workload: &dynamicPriorityWorkload{requestedResources: &UsageList{
 				resources: &ResourceUsage{
@@ -476,7 +482,8 @@ func TestDynamicPriorityQueue_sizeAdjustment(t *testing.T) {
 		testQueue := &DynamicPriorityQueue{
 			conf: tc.conf,
 		}
-		must.Eq(t, tc.exp, testQueue.sizeAdjustment(tc.workload), must.Sprint(tc.name))
+		must.Eq(t, tc.exp, testQueue.cpuAdjustment(tc.workload), must.Sprint(tc.name))
+		must.Eq(t, tc.exp, testQueue.memAdjustment(tc.workload), must.Sprint(tc.name))
 	}
 }
 
@@ -563,7 +570,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						CreateIndex: 10,
 					},
 					priority:        59,
-					sizeAdjustment:  2,
 					ageAdjustment:   3,
 					usageAdjustment: 4,
 				},
@@ -576,7 +582,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						Position:         1,
 						AdjustedPriority: 59,
 						BasePriority:     50,
-						SizeAdjustment:   2,
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 						CreatedAt:        time.Unix(20, 0).UnixNano(),
@@ -599,7 +604,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						CreateIndex: 14,
 					},
 					priority:        59,
-					sizeAdjustment:  2,
 					ageAdjustment:   3,
 					usageAdjustment: 4,
 				},
@@ -613,7 +617,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						CreateIndex: 12,
 					},
 					priority:        66,
-					sizeAdjustment:  12,
 					ageAdjustment:   3,
 					usageAdjustment: 4,
 				},
@@ -627,7 +630,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						CreateIndex: 10,
 					},
 					priority:        51,
-					sizeAdjustment:  0,
 					ageAdjustment:   0,
 					usageAdjustment: 1,
 				},
@@ -640,7 +642,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						Position:         3,
 						AdjustedPriority: 51,
 						BasePriority:     50,
-						SizeAdjustment:   0,
 						AgeAdjustment:    0,
 						UsageAdjustment:  1,
 						CreateIndex:      10,
@@ -651,7 +652,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						Position:         1,
 						AdjustedPriority: 66,
 						BasePriority:     50,
-						SizeAdjustment:   12,
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 						CreateIndex:      12,
@@ -662,7 +662,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						Position:         2,
 						AdjustedPriority: 59,
 						BasePriority:     50,
-						SizeAdjustment:   2,
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 						CreateIndex:      14,
@@ -684,7 +683,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						CreateIndex: 14,
 					},
 					priority:        59,
-					sizeAdjustment:  2,
 					ageAdjustment:   3,
 					usageAdjustment: 4,
 				},
@@ -698,7 +696,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						CreateIndex: 12,
 					},
 					priority:        66,
-					sizeAdjustment:  12,
 					ageAdjustment:   3,
 					usageAdjustment: 4,
 				},
@@ -712,7 +709,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						CreateIndex: 10,
 					},
 					priority:        51,
-					sizeAdjustment:  0,
 					ageAdjustment:   0,
 					usageAdjustment: 1,
 				},
@@ -725,7 +721,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						Position:         1,
 						AdjustedPriority: 66,
 						BasePriority:     50,
-						SizeAdjustment:   12,
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 						CreateIndex:      12,
@@ -736,7 +731,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						Position:         2,
 						AdjustedPriority: 59,
 						BasePriority:     50,
-						SizeAdjustment:   2,
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 						CreateIndex:      14,
@@ -747,7 +741,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						Position:         3,
 						AdjustedPriority: 51,
 						BasePriority:     50,
-						SizeAdjustment:   0,
 						AgeAdjustment:    0,
 						UsageAdjustment:  1,
 						CreateIndex:      10,
@@ -770,7 +763,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						CreateIndex: 12,
 					},
 					priority:        59,
-					sizeAdjustment:  2,
 					ageAdjustment:   3,
 					usageAdjustment: 4,
 				},
@@ -785,7 +777,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						CreateIndex: 10,
 					},
 					priority:        59,
-					sizeAdjustment:  2,
 					ageAdjustment:   3,
 					usageAdjustment: 4,
 				},
@@ -798,7 +789,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						Position:         1,
 						AdjustedPriority: 59,
 						BasePriority:     50,
-						SizeAdjustment:   2,
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 						CreatedAt:        time.Unix(10, 0).UnixNano(),
@@ -810,7 +800,6 @@ func TestDynamicPriorityQueue_Jobs(t *testing.T) {
 						Position:         2,
 						AdjustedPriority: 59,
 						BasePriority:     50,
-						SizeAdjustment:   2,
 						AgeAdjustment:    3,
 						UsageAdjustment:  4,
 						CreatedAt:        time.Unix(20, 0).UnixNano(),

--- a/nomad/queues/dynamic_priority/workload.go
+++ b/nomad/queues/dynamic_priority/workload.go
@@ -15,7 +15,8 @@ type dynamicPriorityWorkload struct {
 	eval               *structs.Evaluation
 	requestedResources *UsageList
 
-	sizeAdjustment  int
+	cpuAdjustment   int
+	memAdjustment   int
 	ageAdjustment   int
 	usageAdjustment int
 

--- a/nomad/queues/fifo/queue_test.go
+++ b/nomad/queues/fifo/queue_test.go
@@ -166,8 +166,8 @@ func TestFifoQueue_runConsumer_enqueueOrder(t *testing.T) {
 	ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{eval1})
 	ss.UpsertEvals(structs.MsgTypeTestSetup, 5, []*structs.Evaluation{eval2})
 
-	q.Enqueue(eval1)
-	q.Enqueue(eval2)
+	q.Enqueue(eval1, nil)
+	q.Enqueue(eval2, nil)
 
 	must.Wait(t, wait.InitialSuccess(
 		wait.ErrorFunc(func() error {

--- a/nomad/structs/operator.go
+++ b/nomad/structs/operator.go
@@ -395,10 +395,12 @@ type DynamicQueueConfig struct {
 	CalcInterval time.Duration `mapstructure:"calc_interval" json:"calc_interval"`
 	MaxAge       time.Duration `mapstructure:"max_age" json:"max_age"`
 	HalfLife     time.Duration `mapstructure:"half_life" json:"half_life"`
-	MaxSize      int           `mapstructure:"max_size" json:"max_size"`
+	MaxCpu       int           `mapstructure:"max_cpu" json:"max_cpu"`
+	MaxMemory    int           `mapstructure:"max_memory" json:"max_memory"`
 	AgeWeight    int           `mapstructure:"age_weight" json:"age_weight"`
 	UsageWeight  int           `mapstructure:"usage_weight" json:"usage_weight"`
-	SizeWeight   int           `mapstructure:"size_weight" json:"size_weight"`
+	CpuWeight    int           `mapstructure:"cpu_weight" json:"cpu_weight"`
+	MemWeight    int           `mapstructure:"memory_weight" json:"memory_weight"`
 }
 
 func (d *DynamicQueueConfig) Validate() error {

--- a/nomad/structs/queue.go
+++ b/nomad/structs/queue.go
@@ -25,7 +25,8 @@ type DynamicPriorityWorkload struct {
 	BasePriority     int
 	UsageAdjustment  int
 	AgeAdjustment    int
-	SizeAdjustment   int
+	CpuAdjustment    int
+	MemoryAdjustment int
 	CreatedAt        int64
 	CreateIndex      uint64
 }


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes introduce separate configuration and weights for CPU and Memory reservations for a job in the Dynamic Priority Queue. These allow operators to weight these resources differently dependent on what may be more important.

Note: These do not affect the "usage" computation, which is still `cpu + memory`.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
