### PR TITLE
bjq: refactor queue locking

### DIFF
--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -23,13 +23,13 @@ type DynamicPriorityQueue struct {
 	// ability for log(n) insert and delete and allows for Top(k) lookups
 	queue queue.WorkloadQueue
 
-	// qMux locks the queue during concurrent access
-	qMux sync.Mutex
-
 	// tenants is used to keep track of cluster usage for this queue.
 	// When workloads are placed or the  configured interval is passed,
 	// cluster usage is updated for the workloads of each tenant.
 	tenants map[TenantID]*Tenant
+
+	// tMux locks the tenant map for concurrent access
+	tMux sync.Mutex
 
 	// qNotify allows for notifying the consumer that workloads
 	// have been added to the queue
@@ -67,7 +67,7 @@ func NewDynamicPriorityQueue(ss *state.StateStore, broker queue.Broker, qconf *s
 	return &DynamicPriorityQueue{
 		queue:       queue.NewWorkloadQueue(workloadSortFn()),
 		evalBroker:  broker,
-		qMux:        sync.Mutex{},
+		tMux:        sync.Mutex{},
 		tenants:     make(map[TenantID]*Tenant),
 		enqueueCh:   make(chan *dynamicPriorityWorkload, 8192),
 		qNotify:     make(chan struct{}, 1),
@@ -145,8 +145,6 @@ func (d *DynamicPriorityQueue) restore(ss *state.StateSnapshot, now time.Time) e
 	// The DPQ needs to rebuild it's internal usage state when enabled.
 	// The actual queue will be rebuilt when establishing leadership
 	// via pending eval enqueuing
-	d.qMux.Lock()
-	defer d.qMux.Unlock()
 
 	ws := memdb.NewWatchSet()
 	iter, err := ss.Evals(ws, state.SortDefault)
@@ -233,12 +231,10 @@ func (d *DynamicPriorityQueue) runProducer(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case w := <-d.enqueueCh:
-			d.qMux.Lock()
 			// use createTime so that workloads have consistent age
 			// priority calculations after restoring from state.
 			d.setWorkloadPriority(time.Unix(0, w.eval.CreateTime), w)
 			d.queue.Push(w)
-			d.qMux.Unlock()
 
 			// Notify Workload consumer of new workload
 			select {
@@ -246,9 +242,7 @@ func (d *DynamicPriorityQueue) runProducer(ctx context.Context) {
 			default:
 			}
 		case <-time.After(d.conf.CalcInterval):
-			d.qMux.Lock()
 			d.calculatePriorities(time.Now())
-			d.qMux.Unlock()
 		}
 	}
 }
@@ -264,9 +258,7 @@ func (d *DynamicPriorityQueue) runConsumer(ctx context.Context) {
 		case <-d.qNotify:
 
 			// Pop a workload off the queue if available
-			d.qMux.Lock()
 			w := d.queue.Pop()
-			d.qMux.Unlock()
 
 			// We don't need to pass the waitOnRestore workload
 			// to the eval broker, that already happened.
@@ -280,12 +272,10 @@ func (d *DynamicPriorityQueue) runConsumer(ctx context.Context) {
 				d.logger.Error("failure waiting for workload placement", "evalID", w.GetEval().ID)
 			}
 
-			d.qMux.Lock()
 			if evalHasPlacement(w.GetEval()) {
 				d.updateUsage(w)
 			}
 			l := d.queue.Len()
-			d.qMux.Unlock()
 
 			// If the queue still has work, notify self
 			// to continue.
@@ -381,6 +371,9 @@ func (d *DynamicPriorityQueue) setWorkloadPriority(now time.Time, w *dynamicPrio
 // usageAdjustment calculates the adjustment to a workload's priority based on
 // it's tenant's usage relative to the total usage, and configured weight.
 func (d *DynamicPriorityQueue) usageAdjustment(w *dynamicPriorityWorkload) int {
+	d.tMux.Lock()
+	defer d.tMux.Unlock()
+
 	if d.conf.UsageWeight == 0 {
 		return 0
 	}
@@ -403,6 +396,9 @@ func (d *DynamicPriorityQueue) usageAdjustment(w *dynamicPriorityWorkload) int {
 // half-life. If the eval no longer exists in the state store, its workload's
 // usage is removed from the calculation.
 func (d *DynamicPriorityQueue) decayUsage(now time.Time, state *state.StateSnapshot) {
+	d.tMux.Lock()
+	defer d.tMux.Unlock()
+
 	totalUsage := &ResourceUsage{}
 
 	for _, tenant := range d.tenants {
@@ -430,7 +426,6 @@ func (d *DynamicPriorityQueue) decayUsage(now time.Time, state *state.StateSnaps
 }
 
 func decayMultiplier(now, createdAt time.Time, halfLife time.Duration) float64 {
-	// elapsed := time.Unix(0, ts).Sub(time.Unix(0, createdAt)).Seconds()
 	elapsed := now.Sub(createdAt)
 	return math.Pow(0.5, elapsed.Seconds()/halfLife.Seconds())
 }
@@ -478,17 +473,14 @@ func (d *DynamicPriorityQueue) sizeAdjustment(w *dynamicPriorityWorkload) int {
 }
 
 func (d *DynamicPriorityQueue) Jobs(sortOrder structs.SortOrder) *queue.WorkloadIter {
-	d.qMux.Lock()
-	sortedWorkloads := d.queue.Slice()
-	d.qMux.Unlock()
-
 	pos := 0
 	workloads := []structs.QueueWorkload{}
-	for _, workload := range sortedWorkloads {
+
+	d.queue.Iterate(func(workload queue.Workload) {
 		w := workload.(*dynamicPriorityWorkload)
 		// waitOnRestore does not count towards position in queue
 		if w.waitOnRestore {
-			continue
+			return
 		}
 		pos++
 
@@ -505,7 +497,8 @@ func (d *DynamicPriorityQueue) Jobs(sortOrder structs.SortOrder) *queue.Workload
 			CreatedAt:        w.eval.CreateTime,
 			CreateIndex:      w.eval.CreateIndex,
 		})
-	}
+	})
+
 	iter := queue.NewWorkloadIter(workloads)
 
 	if sortOrder != structs.SortByPriority {
@@ -516,8 +509,8 @@ func (d *DynamicPriorityQueue) Jobs(sortOrder structs.SortOrder) *queue.Workload
 }
 
 func (d *DynamicPriorityQueue) Tenants() structs.QueueTenantsResponse {
-	d.qMux.Lock()
-	defer d.qMux.Unlock()
+	d.tMux.Lock()
+	defer d.tMux.Unlock()
 
 	tenants := []structs.DynamicPriorityTenant{}
 	for _, t := range d.tenants {
@@ -536,6 +529,8 @@ func (d *DynamicPriorityQueue) Tenants() structs.QueueTenantsResponse {
 
 // updateUsage updates the tenant and total usage for a given workload.
 func (d *DynamicPriorityQueue) updateUsage(w queue.Workload) {
+	d.tMux.Lock()
+	defer d.tMux.Unlock()
 
 	workload := w.(*dynamicPriorityWorkload)
 	tenant := d.tenants[workload.tid]

--- a/nomad/queues/fifo/queue.go
+++ b/nomad/queues/fifo/queue.go
@@ -48,7 +48,6 @@ func NewFifoQueue(ss *state.StateStore, broker queue.Broker, logger hclog.Logger
 		qNotify:    make(chan struct{}, 1),
 		evalBroker: broker,
 		state:      ss,
-		qMux:       sync.Mutex{},
 		logger:     logger.Named("Fifo Queue"),
 	}
 }
@@ -127,9 +126,7 @@ func (f *FifoQueue) runConsumer(ctx context.Context) {
 				f.logger.Error("failure waiting for workload placement", "evalID", w.GetEval().ID)
 			}
 
-			f.qMux.Lock()
 			l := f.queue.Len()
-			f.qMux.Unlock()
 
 			if l > 0 {
 				select {

--- a/nomad/queues/fifo/queue.go
+++ b/nomad/queues/fifo/queue.go
@@ -20,9 +20,6 @@ type FifoQueue struct {
 	// ability for log(n) insert and delete and allows for Top(k) lookups
 	queue queue.WorkloadQueue
 
-	// qMux locks the queue during concurrent access
-	qMux sync.Mutex
-
 	// evalBroker is the injected broker for passing an evaluation
 	// on to be scheduled by Nomad
 	evalBroker queue.Broker
@@ -106,9 +103,7 @@ func (f *FifoQueue) runProducer(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case w := <-f.enqueueCh:
-			f.qMux.Lock()
 			f.queue.Push(w)
-			f.qMux.Unlock()
 			select {
 			case f.qNotify <- struct{}{}:
 			default:
@@ -123,9 +118,7 @@ func (f *FifoQueue) runConsumer(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-f.qNotify:
-			f.qMux.Lock()
 			w := f.queue.Pop()
-			f.qMux.Unlock()
 
 			f.evalBroker.Enqueue(w.GetEval())
 
@@ -149,9 +142,6 @@ func (f *FifoQueue) runConsumer(ctx context.Context) {
 }
 
 func (f *FifoQueue) restore(snap *state.StateSnapshot) error {
-	f.qMux.Lock()
-	defer f.qMux.Unlock()
-
 	ws := memdb.NewWatchSet()
 	iter, err := snap.Evals(ws, state.SortDefault)
 	if err != nil {
@@ -200,13 +190,17 @@ func (f *FifoQueue) Type() structs.BatchQueueType {
 }
 
 func (f *FifoQueue) Jobs(sortOrder structs.SortOrder) *queue.WorkloadIter {
-	f.qMux.Lock()
-	sortedWorkloads := f.queue.Slice()
-	defer f.qMux.Unlock()
-
+	pos := 0
 	workloads := []structs.QueueWorkload{}
-	for pos, workload := range sortedWorkloads {
-		eval := workload.GetEval()
+	f.queue.Iterate(func(workload queue.Workload) {
+		w := workload.(*fifoWorkload)
+		// waitOnRestore does not count towards position in queue
+		if w.waitOnRestore {
+			return
+		}
+		pos++
+
+		eval := w.GetEval()
 		workloads = append(workloads, &structs.Workload{
 			JobID:       eval.JobID,
 			Namespace:   eval.Namespace,
@@ -214,7 +208,8 @@ func (f *FifoQueue) Jobs(sortOrder structs.SortOrder) *queue.WorkloadIter {
 			CreatedAt:   eval.CreateTime,
 			CreateIndex: eval.CreateIndex,
 		})
-	}
+	})
+
 	iter := queue.NewWorkloadIter(workloads)
 
 	if sortOrder != structs.SortByPriority {

--- a/nomad/queues/fifo/queue_test.go
+++ b/nomad/queues/fifo/queue_test.go
@@ -166,8 +166,8 @@ func TestFifoQueue_runConsumer_enqueueOrder(t *testing.T) {
 	ss.UpsertEvals(structs.MsgTypeTestSetup, 1, []*structs.Evaluation{eval1})
 	ss.UpsertEvals(structs.MsgTypeTestSetup, 5, []*structs.Evaluation{eval2})
 
-	q.Enqueue(eval1)
-	q.Enqueue(eval2)
+	q.Enqueue(eval1, nil)
+	q.Enqueue(eval2, nil)
 
 	must.Wait(t, wait.InitialSuccess(
 		wait.ErrorFunc(func() error {

--- a/nomad/queues/queue/workload_queue.go
+++ b/nomad/queues/queue/workload_queue.go
@@ -62,7 +62,10 @@ func (pq *WorkloadQueue) UpdateAll(updateFn func(w Workload)) {
 }
 
 // Iterate does an in order traversal of each item in the queue
-// and called the passed function on the workload.
+// and calls the passed function on the workload.
+//
+// The callback function should NOT mutate the workload, but use it
+// to construct a separate threadsafe object.
 func (pq *WorkloadQueue) Iterate(fn func(Workload)) {
 	pq.mux.Lock()
 	defer pq.mux.Unlock()

--- a/nomad/queues/queue/workload_queue.go
+++ b/nomad/queues/queue/workload_queue.go
@@ -53,12 +53,12 @@ func (pq *WorkloadQueue) UpdateAll(updateFn func(w Workload)) {
 	pq.mux.Lock()
 	defer pq.mux.Unlock()
 
-	newQueue := NewWorkloadQueue(pq.sortFn)
+	newTs := set.NewTreeSet(pq.sortFn)
 	for w := range pq.ts.Items() {
 		updateFn(w)
-		newQueue.Push(w)
+		newTs.Insert(w)
 	}
-	*pq = newQueue
+	pq.ts = newTs
 }
 
 // Iterate does an in order traversal of each item in the queue

--- a/nomad/queues/queue/workload_queue.go
+++ b/nomad/queues/queue/workload_queue.go
@@ -4,38 +4,70 @@
 package queue
 
 import (
+	"sync"
+
 	"github.com/hashicorp/go-set/v3"
 )
 
 // A WorkloadQueue implements heap.Interface and holds *Workload.
 type WorkloadQueue struct {
 	sortFn func(i, j Workload) int
-	*set.TreeSet[Workload]
+	ts     *set.TreeSet[Workload]
+	mux    *sync.Mutex
 }
 
 func NewWorkloadQueue(sortFn func(i, j Workload) int) WorkloadQueue {
-	return WorkloadQueue{sortFn: sortFn, TreeSet: set.NewTreeSet(sortFn)}
+	return WorkloadQueue{
+		sortFn: sortFn,
+		ts:     set.NewTreeSet(sortFn),
+		mux:    &sync.Mutex{},
+	}
 }
 
-func (pq WorkloadQueue) Len() int { return pq.Size() }
+func (pq WorkloadQueue) Len() int {
+	pq.mux.Lock()
+	defer pq.mux.Unlock()
+
+	return pq.ts.Size()
+}
 
 func (pq *WorkloadQueue) Push(w Workload) {
-	pq.Insert(w)
+	pq.mux.Lock()
+	defer pq.mux.Unlock()
+
+	pq.ts.Insert(w)
 }
 
 func (pq *WorkloadQueue) Pop() Workload {
-	w := pq.Min()
-	pq.Remove(w)
+	pq.mux.Lock()
+	defer pq.mux.Unlock()
+
+	w := pq.ts.Min()
+	pq.ts.Remove(w)
 	return w
 }
 
 // UpdateAll takes a function that mutates a workload and updates
 // all workloads in the queue via this function.
 func (pq *WorkloadQueue) UpdateAll(updateFn func(w Workload)) {
+	pq.mux.Lock()
+	defer pq.mux.Unlock()
+
 	newQueue := NewWorkloadQueue(pq.sortFn)
-	for _, w := range pq.Slice() {
+	for w := range pq.ts.Items() {
 		updateFn(w)
 		newQueue.Push(w)
 	}
 	*pq = newQueue
+}
+
+// Iterate does an in order traversal of each item in the queue
+// and called the passed function on the workload.
+func (pq *WorkloadQueue) Iterate(fn func(Workload)) {
+	pq.mux.Lock()
+	defer pq.mux.Unlock()
+
+	for w := range pq.ts.Items() {
+		fn(w)
+	}
 }


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes refactor the way we lock various data structures for concurrent access. Notably, all the queue locking is done within the queue object, so the caller does not need to worry about locking. And the tenant map gets its own dedicated lock, `tMux`.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
