### PR TITLE
lint: Run modernize on the remaining codebase.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,8 +8,9 @@ run:
   # Modules download mode (do not modify go.mod)
   modules-download-mode: readonly
 
-  # Exclude test files
-  tests: false
+  # Enable linting for tests, so modernize can run on them. All other linters
+  # are suppressed on tests at the moment via the exclusions section below.
+  tests: true
 
 output:
   formats:
@@ -68,9 +69,26 @@ linters:
         text: assignOp
       - path: (.+)\.go$
         text: unlambda
-      - path-except: (^client/|^command/|^drivers/|^jobspec2/|^plugins/|^nomad/|^scheduler/)
+      # Suppress all linters except modernize on test files for now. The goal
+      # is to have them run on all files.
+      - path: _test\.go
         linters:
-          - modernize
+          - asasalint
+          - asciicheck
+          - bidichk
+          - bodyclose
+          - copyloopvar
+          - dogsled
+          - durationcheck
+          - gocritic
+          - gofmt
+          - goimports
+          - govet
+          - ineffassign
+          - misspell
+          - staticcheck
+          - unconvert
+          - usestdlibvars
     paths:
       - ".*\\.generated\\.go$"
       - ".*bindata_assetfs\\.go$"

--- a/acl/acl_test.go
+++ b/acl/acl_test.go
@@ -959,7 +959,6 @@ func TestVariablesMatching(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			policy, err := Parse(tc.policy, PolicyParseStrict)
 			must.NoError(t, err)

--- a/api/nodes_test.go
+++ b/api/nodes_test.go
@@ -578,28 +578,28 @@ func TestNodeStatValueFormatting(t *testing.T) {
 		{
 			"2.718",
 			StatValue{
-				FloatNumeratorVal: float64ToPtr(2.718),
+				FloatNumeratorVal: new(2.718),
 			},
 		},
 		{
 			"2.718 / 3.14",
 			StatValue{
-				FloatNumeratorVal:   float64ToPtr(2.718),
-				FloatDenominatorVal: float64ToPtr(3.14),
+				FloatNumeratorVal:   new(2.718),
+				FloatDenominatorVal: new(3.14),
 			},
 		},
 		{
 			"2.718 MHz",
 			StatValue{
-				FloatNumeratorVal: float64ToPtr(2.718),
+				FloatNumeratorVal: new(2.718),
 				Unit:              "MHz",
 			},
 		},
 		{
 			"2.718 / 3.14 MHz",
 			StatValue{
-				FloatNumeratorVal:   float64ToPtr(2.718),
-				FloatDenominatorVal: float64ToPtr(3.14),
+				FloatNumeratorVal:   new(2.718),
+				FloatDenominatorVal: new(3.14),
 				Unit:                "MHz",
 			},
 		},

--- a/api/util_test.go
+++ b/api/util_test.go
@@ -132,11 +132,6 @@ func testQuotaSpec() *QuotaSpec {
 // conversions utils only used for testing
 // added here to avoid linter warning
 
-// float64ToPtr returns the pointer to an float64
-func float64ToPtr(f float64) *float64 {
-	return &f
-}
-
 // generateUUID generates a uuid useful for testing only
 func generateUUID() string {
 	buf := make([]byte, 16)

--- a/client/allocdir/fs_linux_test.go
+++ b/client/allocdir/fs_linux_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !windows
-// +build !windows
 
 package allocdir
 
@@ -32,7 +31,7 @@ func isMount(path string) (int, error) {
 	defer file.Close()
 	reader := bufio.NewReaderSize(file, 64*1024)
 	const max = 100000
-	for i := 0; i < max; i++ {
+	for range max {
 		line, err := reader.ReadString('\n')
 		if err != nil {
 			if err == io.EOF {

--- a/client/allocrunner/network_hook_linux_test.go
+++ b/client/allocrunner/network_hook_linux_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build linux
-// +build linux
 
 package allocrunner
 

--- a/client/allocrunner/networking_cni_test.go
+++ b/client/allocrunner/networking_cni_test.go
@@ -777,7 +777,7 @@ func TestCNI_setupTproxyArgs(t *testing.T) {
 		LocalServicePort:    0,
 		Upstreams:           []structs.ConsulUpstream{},
 		Expose:              &structs.ConsulExposeConfig{},
-		Config:              map[string]interface{}{},
+		Config:              map[string]any{},
 	}
 
 	spec := &drivers.NetworkIsolationSpec{

--- a/client/allocrunner/taskrunner/script_check_hook_test.go
+++ b/client/allocrunner/taskrunner/script_check_hook_test.go
@@ -6,7 +6,6 @@ package taskrunner
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -92,7 +91,7 @@ func TestScript_Exec_Cancel(t *testing.T) {
 
 	// The underlying ScriptExecutor (newBlockScriptExec) *cannot* be
 	// canceled. Only a wrapper around it obeys the context cancelation.
-	require.NotEqual(t, atomic.LoadInt32(&exec.exited), 1,
+	require.NotEqual(t, exec.exited.Load(), 1,
 		"expected script executor to still be running after timeout")
 }
 
@@ -122,7 +121,7 @@ func TestScript_Exec_TimeoutBasic(t *testing.T) {
 
 	// The underlying ScriptExecutor (newBlockScriptExec) *cannot* be
 	// canceled. Only a wrapper around it obeys the context cancelation.
-	require.NotEqual(t, atomic.LoadInt32(&exec.exited), 1,
+	require.NotEqual(t, exec.exited.Load(), 1,
 		"expected script executor to still be running after timeout")
 
 	// Cancel and watch for exit

--- a/client/allocrunner/taskrunner/sids_hook_test.go
+++ b/client/allocrunner/taskrunner/sids_hook_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build linux
-// +build linux
 
 // todo(shoenig): Once Connect is supported on Windows, we'll need to make this
 //  set of tests work there too.

--- a/client/allocrunner/taskrunner/stats_hook_test.go
+++ b/client/allocrunner/taskrunner/stats_hook_test.go
@@ -41,14 +41,14 @@ func (m *mockStatsUpdater) UpdateStats(ru *cstructs.TaskResourceUsage) {
 }
 
 type mockDriverStats struct {
-	called uint32
+	called atomic.Uint32
 
 	// err is returned by Stats if it is non-nil
 	err error
 }
 
 func (m *mockDriverStats) Stats(ctx context.Context, interval time.Duration) (<-chan *cstructs.TaskResourceUsage, error) {
-	atomic.AddUint32(&m.called, 1)
+	m.called.Add(1)
 
 	if m.err != nil {
 		return nil, m.err
@@ -80,7 +80,7 @@ func (m *mockDriverStats) Stats(ctx context.Context, interval time.Duration) (<-
 }
 
 func (m *mockDriverStats) Called() int {
-	return int(atomic.LoadUint32(&m.called))
+	return int(m.called.Load())
 }
 
 // TestTaskRunner_StatsHook_PoststartExited asserts the stats hook starts and

--- a/client/allocrunner/taskrunner/task_runner_linux_test.go
+++ b/client/allocrunner/taskrunner/task_runner_linux_test.go
@@ -230,7 +230,7 @@ func TestTaskRunner_BuildTaskConfig_CPU_Memory(t *testing.T) {
 			alloc.Job.TaskGroups[0].Count = 1
 			task := alloc.Job.TaskGroups[0].Tasks[0]
 			task.Driver = "mock_driver"
-			task.Config = map[string]interface{}{
+			task.Config = map[string]any{
 				"run_for": "2s",
 			}
 			res := alloc.AllocatedResources.Tasks[task.Name]
@@ -267,7 +267,7 @@ func TestTaskRunner_Stop_ExitCode(t *testing.T) {
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.KillSignal = "SIGTERM"
 	task.Driver = "raw_exec"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"command": "/bin/sleep",
 		"args":    []string{"1000"},
 	}
@@ -322,7 +322,7 @@ func TestTaskRunner_Restore_Running(t *testing.T) {
 	alloc.Job.TaskGroups[0].Count = 1
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for": "2s",
 	}
 	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, nil)
@@ -376,7 +376,7 @@ func TestTaskRunner_Restore_Dead(t *testing.T) {
 	alloc.Job.TaskGroups[0].Count = 1
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for": "2s",
 	}
 	conf, cleanup := testTaskRunnerConfig(t, alloc, task.Name, nil)
@@ -454,7 +454,7 @@ func TestTaskRunner_Restore_Dead(t *testing.T) {
 func setupRestoreFailureTest(t *testing.T, alloc *structs.Allocation) (*TaskRunner, *Config, func()) {
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "raw_exec"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"command": "sleep",
 		"args":    []string{"30"},
 	}
@@ -607,7 +607,7 @@ func TestTaskRunner_Restore_System(t *testing.T) {
 	alloc.Job.Type = structs.JobTypeSystem
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "raw_exec"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"command": "sleep",
 		"args":    []string{"30"},
 	}
@@ -747,7 +747,7 @@ func TestTaskRunner_TaskEnv_Interpolated(t *testing.T) {
 	}
 
 	// Use interpolation from both node attributes and meta vars
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for":       "1ms",
 		"stdout_string": `${node.region} ${NOMAD_META_foo} ${NOMAD_META_common_user}`,
 	}
@@ -778,7 +778,7 @@ func TestTaskRunner_TaskEnv_None(t *testing.T) {
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "raw_exec"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"command": "sh",
 		"args": []string{"-c", "echo $NOMAD_ALLOC_DIR; " +
 			"echo $NOMAD_TASK_DIR; " +
@@ -829,7 +829,7 @@ func TestTaskRunner_DevicePropogation(t *testing.T) {
 	alloc.Job.TaskGroups[0].Count = 1
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for": "100ms",
 	}
 	tRes := alloc.AllocatedResources.Tasks[task.Name]
@@ -960,7 +960,7 @@ func TestTaskRunner_RecoverFromDriverExiting(t *testing.T) {
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"plugin_exit_after": "1s",
 		"run_for":           "5s",
 	}
@@ -1032,7 +1032,7 @@ func TestTaskRunner_ShutdownDelay(t *testing.T) {
 	task.Services[0].Tags = []string{"tag1"}
 	task.Services = task.Services[:1] // only need 1 for this test
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for": "1000s",
 	}
 
@@ -1122,7 +1122,7 @@ func TestTaskRunner_NoShutdownDelay(t *testing.T) {
 	task.Services[0].Tags = []string{"tag1"}
 	task.Services = task.Services[:1] // only need 1 for this test
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for": "1000s",
 	}
 	task.ShutdownDelay = maxTestDuration
@@ -1199,7 +1199,7 @@ func TestTaskRunner_Dispatch_Payload(t *testing.T) {
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for": "1s",
 	}
 
@@ -1246,7 +1246,7 @@ func TestTaskRunner_SignalFailure(t *testing.T) {
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
 	errMsg := "test forcing failure"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for":      "10m",
 		"signal_error": errMsg,
 	}
@@ -1267,7 +1267,7 @@ func TestTaskRunner_RestartTask(t *testing.T) {
 	alloc := mock.Alloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for": "10m",
 	}
 
@@ -1327,7 +1327,7 @@ func TestTaskRunner_CheckWatcher_Restart(t *testing.T) {
 
 	task := tg.Tasks[0]
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for": "10m",
 	}
 
@@ -1443,7 +1443,7 @@ func TestTaskRunner_Download_RawExec(t *testing.T) {
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.RestartPolicy = &structs.RestartPolicy{}
 	task.Driver = "raw_exec"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"command": "noop.sh",
 	}
 	task.Env = map[string]string{
@@ -1565,7 +1565,7 @@ func TestTaskRunner_DriverNetwork(t *testing.T) {
 	alloc := mock.Alloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for":         "100s",
 		"driver_ip":       "10.1.2.3",
 		"driver_port_map": "http:80",
@@ -1704,7 +1704,7 @@ func TestTaskRunner_RestartSignalTask_NotRunning(t *testing.T) {
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for": "0s",
 	}
 
@@ -1784,7 +1784,7 @@ func TestTaskRunner_Run_RecoverableStartError(t *testing.T) {
 
 	alloc := mock.BatchAlloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"start_error":             "driver failure",
 		"start_error_recoverable": true,
 	}
@@ -2017,7 +2017,7 @@ func TestTaskRunner_TemplateWorkloadIdentity(t *testing.T) {
 	alloc.Job.TaskGroups[0].Count = 1
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"run_for": "2s",
 	}
 	task.Consul = &structs.Consul{
@@ -2098,7 +2098,7 @@ func TestTaskRunner_UnregisterConsul_Retries(t *testing.T) {
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.RestartPolicy = rp
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"exit_code": "1",
 		"run_for":   "1ns",
 	}
@@ -2163,7 +2163,7 @@ func TestTaskRunner_BaseLabels(t *testing.T) {
 	alloc.Namespace = "not-default"
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "raw_exec"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"command": "whoami",
 	}
 
@@ -2195,7 +2195,7 @@ func TestTaskRunner_BaseLabels_IncludesAllocMetadata(t *testing.T) {
 	job.Meta = map[string]string{"owner": "HashiCorp", "my-key": "my-value", "some_dynamic_value": "now()"}
 	task := job.TaskGroups[0].Tasks[0]
 	task.Driver = "raw_exec"
-	task.Config = map[string]interface{}{
+	task.Config = map[string]any{
 		"command": "whoami",
 	}
 
@@ -2304,7 +2304,7 @@ func TestTaskRunner_AllocNetworkStatus(t *testing.T) {
 	alloc := mock.Alloc()
 	task := alloc.Job.TaskGroups[0].Tasks[0]
 	task.Driver = "mock_driver"
-	task.Config = map[string]interface{}{"run_for": "2s"}
+	task.Config = map[string]any{"run_for": "2s"}
 
 	groupNetworks := []*structs.NetworkResource{{
 		Device: "eth0",

--- a/client/allocrunner/taskrunner/tasklet_test.go
+++ b/client/allocrunner/taskrunner/tasklet_test.go
@@ -77,7 +77,7 @@ func TestTasklet_Exec_Cancel(t *testing.T) {
 
 	// The underlying ScriptExecutor (newBlockScriptExec) *cannot* be
 	// canceled. Only a wrapper around it obeys the context cancelation.
-	if atomic.LoadInt32(&exec.exited) == 1 {
+	if exec.exited.Load() == 1 {
 		t.Errorf("expected script executor to still be running after timeout")
 	}
 	// No tasklets finished, so no callbacks should have gotten a
@@ -115,7 +115,7 @@ func TestTasklet_Exec_Timeout(t *testing.T) {
 
 	// The underlying ScriptExecutor (newBlockScriptExec) *cannot* be
 	// canceled. Only a wrapper around it obeys the context cancelation.
-	if atomic.LoadInt32(&exec.exited) == 1 {
+	if exec.exited.Load() == 1 {
 		t.Errorf("expected executor to still be running after timeout")
 	}
 
@@ -191,7 +191,7 @@ type blockingScriptExec struct {
 	running chan struct{}
 
 	// set to 1 with atomics if Exec is called and has exited
-	exited int32
+	exited atomic.Int32
 }
 
 // newBlockingScriptExec returns a ScriptExecutor that blocks Exec() until the
@@ -220,7 +220,7 @@ func (b *blockingScriptExec) Exec(dur time.Duration, _ string, _ []string) ([]by
 			code = 1
 		}
 	}
-	atomic.StoreInt32(&b.exited, 1)
+	b.exited.Store(1)
 	return []byte{}, code, err
 }
 

--- a/client/allocwatcher/alloc_watcher_test.go
+++ b/client/allocwatcher/alloc_watcher_test.go
@@ -70,7 +70,7 @@ type countingRPCer struct {
 	calls int
 }
 
-func (c *countingRPCer) RPC(method string, args interface{}, reply interface{}) error {
+func (c *countingRPCer) RPC(method string, args any, reply any) error {
 	c.calls++
 	return c.err
 }

--- a/e2e/client_intro/client_intro_test.go
+++ b/e2e/client_intro/client_intro_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -221,9 +222,9 @@ server {
 
 			// Iterate the stored lines backwards, as the log line we are looking
 			// for is likely to be towards the end of the output.
-			for i := len(clientWriter.lines) - 1; i >= 0; i-- {
+			for _, v := range slices.Backward(clientWriter.lines) {
 				if strings.Contains(
-					clientWriter.lines[i],
+					v,
 					`client: error registering: error="rpc error: Permission denied"`,
 				) {
 					return nil

--- a/e2e/clientstate/clientstate.go
+++ b/e2e/clientstate/clientstate.go
@@ -177,7 +177,7 @@ func (tc *ClientStateTC) TestClientState_Kill(f *framework.F) {
 
 	// Kill and restart a few times
 	tries := 10
-	for i := 0; i < tries; i++ {
+	for i := range tries {
 		t.Logf("TEST RUN %d/%d", i+1, tries)
 
 		// Kill -9 the Agent

--- a/e2e/consul/namespaces_ce.go
+++ b/e2e/consul/namespaces_ce.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !ent
-// +build !ent
 
 // Nomad OSS ignores Consul Namespace configuration in jobs, these e2e tests
 // verify everything still works and is registered into the "default" namespace,

--- a/e2e/consulcompat/shared_download_test.go
+++ b/e2e/consulcompat/shared_download_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"testing"
 	"time"
 
@@ -71,12 +72,7 @@ func getMinimumVersion(t *testing.T) *version.Version {
 }
 
 func skipVersion(v *version.Version) bool {
-	for _, sv := range skippedVersions {
-		if v.Equal(sv) {
-			return true
-		}
-	}
-	return false
+	return slices.ContainsFunc(skippedVersions, v.Equal)
 }
 
 type build struct {

--- a/e2e/disconnectedclients/disconnectedclients_test.go
+++ b/e2e/disconnectedclients/disconnectedclients_test.go
@@ -118,7 +118,6 @@ func TestDisconnectedClients(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 
 			if tc.skip {

--- a/e2e/e2eutil/cli.go
+++ b/e2e/e2eutil/cli.go
@@ -133,8 +133,8 @@ func ParseColumns(section string) ([]map[string]string, error) {
 // (ex. the Latest Deployment section of `nomad job status :id`)
 func ParseFields(section string) (map[string]string, error) {
 	parsed := map[string]string{}
-	rows := strings.Split(strings.TrimSpace(section), "\n")
-	for _, row := range rows {
+	rows := strings.SplitSeq(strings.TrimSpace(section), "\n")
+	for row := range rows {
 		kv := strings.Split(row, "=")
 		if len(kv) == 0 {
 			continue

--- a/e2e/e2eutil/utils.go
+++ b/e2e/e2eutil/utils.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -123,12 +124,13 @@ func RegisterAndWaitForAllocs(t *testing.T, nomadClient *api.Client, jobFile, jo
 
 		return true, nil
 	}, func(e error) {
-		msg := fmt.Sprintf("allocations not placed for %s", jobID)
+		var msg strings.Builder
+		msg.WriteString(fmt.Sprintf("allocations not placed for %s", jobID))
 		for _, eval := range evals {
-			msg += fmt.Sprintf("\n  %s - %s", eval.Status, eval.StatusDescription)
+			msg.WriteString(fmt.Sprintf("\n  %s - %s", eval.Status, eval.StatusDescription))
 		}
 
-		require.Fail(t, msg, "full evals: %v", pretty.Sprint(evals))
+		require.Fail(t, msg.String(), "full evals: %v", pretty.Sprint(evals))
 	})
 
 	require.NoError(t, err) // we only care about the last error
@@ -322,7 +324,7 @@ func DumpEvals(c *api.Client, jobID string) string {
 	}
 	buf := bytes.NewBuffer(nil)
 	for i, e := range evals {
-		err := EvalTemplate.Execute(buf, map[string]interface{}{
+		err := EvalTemplate.Execute(buf, map[string]any{
 			"Index": i + 1,
 			"Total": len(evals),
 			"Eval":  e,

--- a/e2e/framework/context.go
+++ b/e2e/framework/context.go
@@ -21,7 +21,7 @@ type F struct {
 	assert *assert.Assertions
 	t      *testing.T
 
-	data map[interface{}]interface{}
+	data map[any]any
 }
 
 func newF(t *testing.T) *F {
@@ -66,11 +66,11 @@ func (f *F) ID() string {
 }
 
 // Set is used to set arbitrary key/values to pass between before/after and test methods
-func (f *F) Set(key, val interface{}) {
+func (f *F) Set(key, val any) {
 	f.data[key] = val
 }
 
 // Value retrives values set by the F.Set method
-func (f *F) Value(key interface{}) interface{} {
+func (f *F) Value(key any) any {
 	return f.data[key]
 }

--- a/e2e/framework/framework.go
+++ b/e2e/framework/framework.go
@@ -100,7 +100,7 @@ func New() *Framework {
 		Arch:     *fArch,
 		Tags:     map[string]struct{}{},
 	}
-	for _, tag := range strings.Split(*fTags, ",") {
+	for tag := range strings.SplitSeq(*fTags, ",") {
 		env.Tags[tag] = struct{}{}
 	}
 	return &Framework{
@@ -247,8 +247,7 @@ func (f *Framework) runCase(t *testing.T, s *TestSuite, c TestCase) {
 		// Here we need to iterate through the methods of the case to find
 		// ones that are test functions
 		reflectC := reflect.TypeOf(c)
-		for i := 0; i < reflectC.NumMethod(); i++ {
-			method := reflectC.Method(i)
+		for method := range reflectC.Methods() {
 			if ok := isTestMethod(method.Name); !ok {
 				continue
 			}

--- a/e2e/jobsubmissions/jobsubapi_test.go
+++ b/e2e/jobsubmissions/jobsubapi_test.go
@@ -276,7 +276,7 @@ func testReversion(t *testing.T) {
 	t.Cleanup(e2eutil.MaybeCleanupJobsAndGC(&jobIDs))
 
 	// register job 3 times
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		yVar := fmt.Sprintf("-var=Y=%d", i)
 
 		// register the job
@@ -298,7 +298,7 @@ func testReversion(t *testing.T) {
 	// there should be a submission for version 3, and it should
 	// contain Y=1 as did the version 1 of the job
 	expectY := []string{"0", "1", "2", "1"}
-	for version := 0; version < 4; version++ {
+	for version := range 4 {
 		sub, _, err := nomad.Jobs().Submission(jobID, version, &api.QueryOptions{
 			Namespace: "default",
 		})

--- a/e2e/parameterized/parameterized.go
+++ b/e2e/parameterized/parameterized.go
@@ -56,7 +56,7 @@ func (tc *ParameterizedTest) TestParameterizedDispatch_Basic(f *framework.F) {
 	// force dispatch
 	dispatched := 4
 
-	for i := 0; i < dispatched; i++ {
+	for i := range dispatched {
 		require.NoError(t, e2eutil.Dispatch(jobID, map[string]string{"i": fmt.Sprintf("%v", i)}, ""))
 	}
 

--- a/e2e/quotas/quotas_ce.go
+++ b/e2e/quotas/quotas_ce.go
@@ -2,6 +2,5 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !ent
-// +build !ent
 
 package quotas

--- a/e2e/rescheduling/rescheduling_test.go
+++ b/e2e/rescheduling/rescheduling_test.go
@@ -6,6 +6,7 @@ package rescheduling
 import (
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"testing"
 	"time"
@@ -124,12 +125,7 @@ func TestRescheduling_MaxAttempts(t *testing.T) {
 		wait.BoolFunc(func() bool {
 			got, err := e2eutil.AllocStatuses(jobID, ns)
 			must.NoError(t, err)
-			for _, status := range got {
-				if status == "running" {
-					return true
-				}
-			}
-			return false
+			return slices.Contains(got, "running")
 		}),
 		wait.Timeout(10*time.Second),
 		wait.Gap(500*time.Millisecond),

--- a/helper/backoff.go
+++ b/helper/backoff.go
@@ -24,10 +24,7 @@ func Backoff(backoffBase time.Duration, backoffLimit time.Duration, attempt uint
 	}
 
 	// Compute deadline and clamp it to backoffLimit
-	deadline := 1 << attempt * backoffBase
-	if deadline > backoffLimit {
-		deadline = backoffLimit
-	}
+	deadline := min(1<<attempt*backoffBase, backoffLimit)
 
 	return deadline
 }
@@ -53,10 +50,7 @@ func WithBackoffFunc(ctx context.Context, minBackoff, maxBackoff time.Duration, 
 		}
 
 		if backoff < maxBackoff {
-			backoff = backoff*2 + RandomStagger(minBackoff/10)
-			if backoff > maxBackoff {
-				backoff = maxBackoff
-			}
+			backoff = min(backoff*2+RandomStagger(minBackoff/10), maxBackoff)
 		}
 
 		t.Reset(backoff)

--- a/helper/boltdd/boltdd.go
+++ b/helper/boltdd/boltdd.go
@@ -306,7 +306,7 @@ func newBucket(b *bucketMeta, bb *bbolt.Bucket) *Bucket {
 }
 
 // Put into boltdb iff it has changed since the last write.
-func (b *Bucket) Put(key []byte, val interface{}) error {
+func (b *Bucket) Put(key []byte, val any) error {
 	// buffer for writing serialized state to
 	var buf bytes.Buffer
 
@@ -341,7 +341,7 @@ func (b *Bucket) Put(key []byte, val interface{}) error {
 
 // Get value by key from boltdb or return an ErrNotFound error if key not
 // found.
-func (b *Bucket) Get(key []byte, obj interface{}) error {
+func (b *Bucket) Get(key []byte, obj any) error {
 	// Get the raw data from the underlying boltdb
 	data := b.boltBucket.Get(key)
 	if data == nil {

--- a/helper/broker/notify.go
+++ b/helper/broker/notify.go
@@ -16,12 +16,12 @@ type GenericNotifier struct {
 
 	// publishCh is the channel used to receive the update which will be sent
 	// to all subscribers.
-	publishCh chan interface{}
+	publishCh chan any
 
 	// subscribeCh and unsubscribeCh are the channels used to modify the
 	// subscription membership mapping.
-	subscribeCh   chan chan interface{}
-	unsubscribeCh chan chan interface{}
+	subscribeCh   chan chan any
+	unsubscribeCh chan chan any
 
 	ctx context.Context
 }
@@ -30,9 +30,9 @@ type GenericNotifier struct {
 // to notify many subscribers when a specific update is triggered.
 func NewGenericNotifier(ctx context.Context) *GenericNotifier {
 	return &GenericNotifier{
-		publishCh:     make(chan interface{}, 1),
-		subscribeCh:   make(chan chan interface{}, 1),
-		unsubscribeCh: make(chan chan interface{}, 1),
+		publishCh:     make(chan any, 1),
+		subscribeCh:   make(chan chan any, 1),
+		unsubscribeCh: make(chan chan any, 1),
 		ctx:           ctx,
 	}
 }
@@ -40,7 +40,7 @@ func NewGenericNotifier(ctx context.Context) *GenericNotifier {
 // Notify allows the implementer to notify all subscribers with a specific
 // update. There is no guarantee the order in which subscribers receive the
 // message which is sent linearly.
-func (g *GenericNotifier) Notify(msg interface{}) {
+func (g *GenericNotifier) Notify(msg any) {
 	select {
 	case g.publishCh <- msg:
 	default:
@@ -55,7 +55,7 @@ func (g *GenericNotifier) Run() {
 	// Store our subscribers inline with a map. This map can only be accessed
 	// via a single channel update at a time, meaning we can manage without
 	// using a lock.
-	subscribers := map[chan interface{}]struct{}{}
+	subscribers := map[chan any]struct{}{}
 
 	for {
 		select {
@@ -82,11 +82,11 @@ func (g *GenericNotifier) Run() {
 // WaitForChange allows a subscriber to wait until there is a notification
 // change, or the timeout is reached. The function will block until one
 // condition is met.
-func (g *GenericNotifier) WaitForChange(timeout time.Duration) interface{} {
+func (g *GenericNotifier) WaitForChange(timeout time.Duration) any {
 
 	// Create a channel and subscribe to any update. This channel is buffered
 	// to ensure we do not block the main broker process.
-	updateCh := make(chan interface{}, 1)
+	updateCh := make(chan any, 1)
 	select {
 	case <-g.ctx.Done():
 		return "shutting down"

--- a/helper/broker/notify_test.go
+++ b/helper/broker/notify_test.go
@@ -4,7 +4,6 @@
 package broker
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -17,8 +16,7 @@ func TestGenericNotifier(t *testing.T) {
 	ci.Parallel(t)
 
 	// Create the new notifier.
-	ctx, cancelFn := context.WithCancel(context.Background())
-	defer cancelFn()
+	ctx := t.Context()
 
 	notifier := NewGenericNotifier(ctx)
 	go notifier.Run()
@@ -31,7 +29,7 @@ func TestGenericNotifier(t *testing.T) {
 	// Test that the timeout works.
 	var timeoutWG sync.WaitGroup
 
-	for i := 0; i < 6; i++ {
+	for range 6 {
 		go func(wg *sync.WaitGroup) {
 			wg.Add(1)
 			msg := notifier.WaitForChange(100 * time.Millisecond)
@@ -45,13 +43,11 @@ func TestGenericNotifier(t *testing.T) {
 	// is sent.
 	var notifiedWG sync.WaitGroup
 
-	for i := 0; i < 6; i++ {
-		notifiedWG.Add(1)
-		go func() {
-			defer notifiedWG.Done()
+	for range 6 {
+		notifiedWG.Go(func() {
 			msg := notifier.WaitForChange(3 * time.Second)
 			require.Equal(t, "we got an update and not a timeout", msg)
-		}()
+		})
 	}
 
 	// Ensure the routines have had time to start before sending the notify

--- a/helper/codec/inmem.go
+++ b/helper/codec/inmem.go
@@ -12,8 +12,8 @@ import (
 // InmemCodec is used to do an RPC call without going over a network
 type InmemCodec struct {
 	Method string
-	Args   interface{}
-	Reply  interface{}
+	Args   any
+	Reply  any
 	Err    error
 }
 
@@ -22,7 +22,7 @@ func (i *InmemCodec) ReadRequestHeader(req *rpc.Request) error {
 	return nil
 }
 
-func (i *InmemCodec) ReadRequestBody(args interface{}) error {
+func (i *InmemCodec) ReadRequestBody(args any) error {
 	if args == nil {
 		return nil
 	}
@@ -32,7 +32,7 @@ func (i *InmemCodec) ReadRequestBody(args interface{}) error {
 	return nil
 }
 
-func (i *InmemCodec) WriteResponse(resp *rpc.Response, reply interface{}) error {
+func (i *InmemCodec) WriteResponse(resp *rpc.Response, reply any) error {
 	if resp.Error != "" {
 		i.Err = errors.New(resp.Error)
 		return nil

--- a/helper/eof.go
+++ b/helper/eof.go
@@ -33,8 +33,7 @@ func IsErrEOF(err error) bool {
 		return true
 	}
 
-	var serverError rpc.ServerError
-	if errors.As(err, &serverError) {
+	if _, ok := errors.AsType[rpc.ServerError](err); ok {
 		return strings.HasSuffix(err.Error(), fmt.Sprintf(": %s", io.EOF.Error()))
 	}
 

--- a/helper/escapingio/reader_test.go
+++ b/helper/escapingio/reader_test.go
@@ -143,11 +143,9 @@ func TestEscapingReader_FlushesPartialReads(t *testing.T) {
 
 	var rerr error
 	var wg sync.WaitGroup
-	wg.Add(1)
 
 	// goroutine for reading partial data
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 
 		buf := make([]byte, 1024)
 		for {
@@ -161,7 +159,7 @@ func TestEscapingReader_FlushesPartialReads(t *testing.T) {
 				break
 			}
 		}
-	}()
+	})
 
 	expected := &bytes.Buffer{}
 
@@ -377,7 +375,7 @@ func checkEquivalenceToReadOnce(t *testing.T, input string) bool {
 type readingInput string
 
 func (i readingInput) Generate(rand *rand.Rand, size int) reflect.Value {
-	v, ok := quick.Value(reflect.TypeOf(""), rand)
+	v, ok := quick.Value(reflect.TypeFor[string](), rand)
 	if !ok {
 		panic("couldn't generate a string")
 	}

--- a/helper/flags/flag_test.go
+++ b/helper/flags/flag_test.go
@@ -15,7 +15,7 @@ import (
 func TestStringFlag_implements(t *testing.T) {
 	ci.Parallel(t)
 
-	var raw interface{}
+	var raw any
 	raw = new(StringFlag)
 	if _, ok := raw.(flag.Value); !ok {
 		t.Fatalf("StringFlag should be a Value")

--- a/helper/flatmap/flatmap.go
+++ b/helper/flatmap/flatmap.go
@@ -11,7 +11,7 @@ import (
 // Flatten takes an object and returns a flat map of the object. The keys of the
 // map is the path of the field names until a primitive field is reached and the
 // value is a string representation of the terminal field.
-func Flatten(obj interface{}, filter []string, primitiveOnly bool) map[string]string {
+func Flatten(obj any, filter []string, primitiveOnly bool) map[string]string {
 	flat := make(map[string]string)
 	v := reflect.ValueOf(obj)
 	if !v.IsValid() {

--- a/helper/flatmap/flatmap_test.go
+++ b/helper/flatmap/flatmap_test.go
@@ -38,12 +38,12 @@ type containers struct {
 }
 
 type interfaceHolder struct {
-	value interface{}
+	value any
 }
 
 func TestFlatMap(t *testing.T) {
 	cases := []struct {
-		Input         interface{}
+		Input         any
 		Expected      map[string]string
 		Filter        []string
 		PrimitiveOnly bool

--- a/helper/funcs.go
+++ b/helper/funcs.go
@@ -169,9 +169,7 @@ func MergeMapStringString(m map[string]string, n map[string]string) map[string]s
 
 	result := maps.Clone(m)
 
-	for k, v := range n {
-		result[k] = v
-	}
+	maps.Copy(result, n)
 
 	return result
 }
@@ -267,7 +265,7 @@ func CheckHCLKeys(node ast.Node, valid []string) error {
 }
 
 // UnusedKeys returns a pretty-printed error if any `hcl:",unusedKeys"` is not empty
-func UnusedKeys(obj interface{}) error {
+func UnusedKeys(obj any) error {
 	val := reflect.ValueOf(obj)
 	if val.Kind() == reflect.Pointer {
 		val = reflect.Indirect(val)
@@ -298,16 +296,10 @@ func unusedKeysImpl(path []string, val reflect.Value) error {
 		}
 
 		// Search the hcl tags for "unusedKeys"
-		unusedKeys := false
-		for _, p := range tags {
-			if p == "unusedKeys" {
-				unusedKeys = true
-				break
-			}
-		}
+		unusedKeys := slices.Contains(tags, "unusedKeys")
 
 		if unusedKeys {
-			ks, ok := fval.Interface().([]string)
+			ks, ok := reflect.TypeAssert[[]string](fval)
 			if ok && len(ks) != 0 {
 				ps := ""
 				if len(path) > 0 {

--- a/helper/funcs_test.go
+++ b/helper/funcs_test.go
@@ -112,7 +112,6 @@ func TestCompareSliceSetString(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		tc := tc
 		t.Run(fmt.Sprintf("case-%da", i), func(t *testing.T) {
 			if res := SliceSetEq(tc.A, tc.B); res != tc.Result {
 				t.Fatalf("expected %t but CompareSliceSetString(%v, %v) -> %t",

--- a/helper/funcs_unix.go
+++ b/helper/funcs_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package helper
 

--- a/helper/gated-writer/writer_test.go
+++ b/helper/gated-writer/writer_test.go
@@ -109,13 +109,10 @@ func TestWriter_WithMultipleWriters(t *testing.T) {
 	wg := &sync.WaitGroup{}
 
 	for _, str := range strs {
-		str := str
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-waitCh
 			writer.Write([]byte(str))
-		}()
+		})
 	}
 
 	// synchronize calls to Write() as closely as possible

--- a/helper/group/group.go
+++ b/helper/group/group.go
@@ -16,11 +16,9 @@ type Group struct {
 
 // Go starts f in a goroutine and must be called before Wait.
 func (g *Group) Go(f func()) {
-	g.wg.Add(1)
-	go func() {
-		defer g.wg.Done()
+	g.wg.Go(func() {
 		f()
-	}()
+	})
 }
 
 func (g *Group) AddCh(ch <-chan struct{}) {

--- a/helper/grpc-middleware/logging/client_interceptors.go
+++ b/helper/grpc-middleware/logging/client_interceptors.go
@@ -16,7 +16,7 @@ import (
 // UnaryClientInterceptor returns a new unary client interceptor that logs the execution of gRPC calls.
 func UnaryClientInterceptor(logger hclog.Logger, opts ...Option) grpc.UnaryClientInterceptor {
 	o := evaluateClientOpt(opts)
-	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+	return func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 		startTime := time.Now()
 		err := invoker(ctx, method, req, reply, cc, opts...)
 		emitClientLog(logger, o, method, startTime, err, "finished client unary call")

--- a/helper/mount/mount_linux.go
+++ b/helper/mount/mount_linux.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build linux
-// +build linux
 
 package mount
 

--- a/helper/mount/mount_unsupported.go
+++ b/helper/mount/mount_unsupported.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !linux
-// +build !linux
 
 package mount
 

--- a/helper/pluginutils/catalog/catalog.go
+++ b/helper/pluginutils/catalog/catalog.go
@@ -26,7 +26,7 @@ type Registration struct {
 // ConfigFromOptions is used to retrieve a plugin config when passed a node's
 // option map. This allows upgrade pathing from the old configuration format to
 // the new config format.
-type ConfigFromOptions func(options map[string]string) (config map[string]interface{}, err error)
+type ConfigFromOptions func(options map[string]string) (config map[string]any, err error)
 
 // Register is used to register an internal plugin.
 func Register(id loader.PluginID, config *loader.InternalPluginConfig) {

--- a/helper/pluginutils/catalog/register_testing.go
+++ b/helper/pluginutils/catalog/register_testing.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !release
-// +build !release
 
 package catalog
 

--- a/helper/pluginutils/catalog/testing.go
+++ b/helper/pluginutils/catalog/testing.go
@@ -16,7 +16,7 @@ func TestPluginLoader(t testing.TB) loader.PluginCatalog {
 	driverConfigs := []*config.PluginConfig{
 		{
 			Name: "raw_exec",
-			Config: map[string]interface{}{
+			Config: map[string]any{
 				"enabled": true,
 			},
 		},

--- a/helper/pluginutils/hclutils/testing.go
+++ b/helper/pluginutils/hclutils/testing.go
@@ -45,7 +45,7 @@ func (b *HCLParser) WithVars(vars map[string]cty.Value) *HCLParser {
 //
 //	var tc *TaskConfig
 //	hclutils.NewConfigParser(spec).ParseJson(t, configString, &tc)
-func (b *HCLParser) ParseJson(t *testing.T, configStr string, out interface{}) {
+func (b *HCLParser) ParseJson(t *testing.T, configStr string, out any) {
 	config := JsonConfigToInterface(t, configStr)
 	b.parse(t, config, out)
 }
@@ -60,12 +60,12 @@ func (b *HCLParser) ParseJson(t *testing.T, configStr string, out interface{}) {
 // var tc *TaskConfig
 // hclutils.NewConfigParser(spec).ParseHCL(t, configString, &tc)
 // ```
-func (b *HCLParser) ParseHCL(t *testing.T, configStr string, out interface{}) {
+func (b *HCLParser) ParseHCL(t *testing.T, configStr string, out any) {
 	config := HclConfigToInterface(t, configStr)
 	b.parse(t, config, out)
 }
 
-func (b *HCLParser) parse(t *testing.T, config, out interface{}) {
+func (b *HCLParser) parse(t *testing.T, config, out any) {
 	decSpec, diags := hclspecutils.Convert(b.spec)
 	require.Empty(t, diags)
 
@@ -88,7 +88,7 @@ func (b *HCLParser) parse(t *testing.T, config, out interface{}) {
 	require.NoError(t, dtc.DecodeDriverConfig(out))
 }
 
-func HclConfigToInterface(t *testing.T, config string) interface{} {
+func HclConfigToInterface(t *testing.T, config string) any {
 	t.Helper()
 
 	// Parse as we do in the jobspec parser
@@ -103,12 +103,12 @@ func HclConfigToInterface(t *testing.T, config string) interface{} {
 		t.Fatalf("root should be an object")
 	}
 
-	var m map[string]interface{}
+	var m map[string]any
 	if err := hcl.DecodeObject(&m, list.Items[0]); err != nil {
 		t.Fatalf("failed to decode object: %v", err)
 	}
 
-	var m2 map[string]interface{}
+	var m2 map[string]any
 	if err := mapstructure.WeakDecode(m, &m2); err != nil {
 		t.Fatalf("failed to weak decode object: %v", err)
 	}
@@ -116,13 +116,13 @@ func HclConfigToInterface(t *testing.T, config string) interface{} {
 	return m2["config"]
 }
 
-func JsonConfigToInterface(t *testing.T, config string) interface{} {
+func JsonConfigToInterface(t *testing.T, config string) any {
 	t.Helper()
 
 	// Decode from json
 	dec := codec.NewDecoderBytes([]byte(config), structs.JsonHandle)
 
-	var m map[string]interface{}
+	var m map[string]any
 	err := dec.Decode(&m)
 	if err != nil {
 		t.Fatalf("failed to decode: %v", err)

--- a/helper/pluginutils/hclutils/types.go
+++ b/helper/pluginutils/hclutils/types.go
@@ -4,6 +4,8 @@
 package hclutils
 
 import (
+	"maps"
+
 	"github.com/hashicorp/go-msgpack/v2/codec"
 )
 
@@ -23,9 +25,7 @@ func (s *MapStrInt) CodecDecodeSelf(dec *codec.Decoder) {
 
 	r := map[string]int{}
 	for _, m := range ms {
-		for k, v := range m {
-			r[k] = v
-		}
+		maps.Copy(r, m)
 	}
 	*s = r
 }
@@ -46,9 +46,7 @@ func (s *MapStrStr) CodecDecodeSelf(dec *codec.Decoder) {
 
 	r := map[string]string{}
 	for _, m := range ms {
-		for k, v := range m {
-			r[k] = v
-		}
+		maps.Copy(r, m)
 	}
 	*s = r
 }

--- a/helper/pluginutils/hclutils/util.go
+++ b/helper/pluginutils/hclutils/util.go
@@ -25,7 +25,7 @@ import (
 // ParseHclInterface is used to convert an interface value representing a hcl2
 // body and return the interpolated value. Vars may be nil if there are no
 // variables to interpolate.
-func ParseHclInterface(val interface{}, spec hcldec.Spec, vars map[string]cty.Value) (cty.Value, hcl.Diagnostics, []error) {
+func ParseHclInterface(val any, spec hcldec.Spec, vars map[string]cty.Value) (cty.Value, hcl.Diagnostics, []error) {
 	evalCtx := &hcl.EvalContext{
 		Variables: vars,
 		Functions: GetStdlibFuncs(),
@@ -95,7 +95,7 @@ func CtyValueToMapInterface(val cty.Value) (map[string]any, error) {
 	return m, nil
 }
 
-func ctyValueToInterface(val cty.Value) (interface{}, error) {
+func ctyValueToInterface(val cty.Value) (any, error) {
 	t := val.Type()
 
 	if val.IsNull() {
@@ -126,7 +126,7 @@ func ctyValueToInterface(val cty.Value) (interface{}, error) {
 		}
 
 	case t.IsListType(), t.IsSetType(), t.IsTupleType():
-		result := []interface{}{}
+		result := []any{}
 
 		it := val.ElementIterator()
 		for it.Next() {
@@ -140,7 +140,7 @@ func ctyValueToInterface(val cty.Value) (interface{}, error) {
 		return result, nil
 
 	case t.IsMapType():
-		result := map[string]interface{}{}
+		result := map[string]any{}
 
 		it := val.ElementIterator()
 		for it.Next() {
@@ -156,7 +156,7 @@ func ctyValueToInterface(val cty.Value) (interface{}, error) {
 		return result, nil
 
 	case t.IsObjectType():
-		result := map[string]interface{}{}
+		result := map[string]any{}
 
 		for k := range t.AttributeTypes() {
 			av := val.GetAttr(k)
@@ -177,7 +177,7 @@ func ctyValueToInterface(val cty.Value) (interface{}, error) {
 	}
 }
 
-func smallestNumber(b *big.Float) interface{} {
+func smallestNumber(b *big.Float) any {
 	if v, acc := b.Int64(); acc == big.Exact {
 		if int64(int(v)) == v {
 			return int(v)

--- a/helper/pluginutils/hclutils/util_test.go
+++ b/helper/pluginutils/hclutils/util_test.go
@@ -31,11 +31,11 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 
 	cases := []struct {
 		name         string
-		config       interface{}
+		config       any
 		spec         hcldec.Spec
 		vars         map[string]cty.Value
-		expected     interface{}
-		expectedType interface{}
+		expected     any
+		expectedType any
 	}{
 		{
 			name: "single string attr",
@@ -387,7 +387,6 @@ func TestParseHclInterface_Hcl(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		c := c
 		t.Run(c.name, func(t *testing.T) {
 			t.Logf("Val: % #v", pretty.Formatter(c.config))
 			// Parse the interface
@@ -602,11 +601,11 @@ func TestCtyValueToMapInterface(t *testing.T) {
 
 	m, err := hclutils.CtyValueToMapInterface(v)
 	must.NoError(t, err)
-	must.Eq(t, map[string]interface{}{
+	must.Eq(t, map[string]any{
 		"a": "hello",
 		"b": 42,
-		"c": []interface{}{"one", "two"},
-		"d": map[string]interface{}{"x": true},
+		"c": []any{"one", "two"},
+		"d": map[string]any{"x": true},
 	}, m)
 }
 
@@ -618,7 +617,7 @@ func TestCtyValueToMapInterface_MapInput(t *testing.T) {
 
 	m, err := hclutils.CtyValueToMapInterface(v)
 	must.NoError(t, err)
-	must.Eq(t, map[string]interface{}{
+	must.Eq(t, map[string]any{
 		"first":  "value",
 		"second": "another",
 	}, m)

--- a/helper/pluginutils/loader/filter_unix.go
+++ b/helper/pluginutils/loader/filter_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !windows
-// +build !windows
 
 package loader
 

--- a/helper/pluginutils/loader/init.go
+++ b/helper/pluginutils/loader/init.go
@@ -6,6 +6,7 @@ package loader
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -411,9 +412,7 @@ func (l *PluginLoader) mergePlugins(internal, external map[PluginID]*pluginInfo)
 	finalized := make(map[PluginID]*pluginInfo, len(internal))
 
 	// Load the internal plugins
-	for k, v := range internal {
-		finalized[k] = v
-	}
+	maps.Copy(finalized, internal)
 
 	for k, extPlugin := range external {
 		internal, ok := finalized[k]
@@ -461,7 +460,7 @@ func (l *PluginLoader) validatePluginConfigs() (map[string]*InternalPluginConfig
 // validatePluginConfig is used to validate the plugin's configuration. If the
 // plugin has a config, it is parsed with the plugins config schema and
 // SetConfig is called to ensure the config is valid.
-func (l *PluginLoader) validatePluginConfig(id PluginID, info *pluginInfo) (map[string]interface{}, error) {
+func (l *PluginLoader) validatePluginConfig(id PluginID, info *pluginInfo) (map[string]any, error) {
 	var mErr multierror.Error
 
 	// Check if a config is allowed
@@ -484,7 +483,7 @@ func (l *PluginLoader) validatePluginConfig(id PluginID, info *pluginInfo) (map[
 	// If there is no config, initialize it to an empty map so we can still
 	// handle defaults
 	if info.config == nil {
-		info.config = map[string]interface{}{}
+		info.config = map[string]any{}
 	}
 
 	// Parse the config using the spec

--- a/helper/pluginutils/loader/instance.go
+++ b/helper/pluginutils/loader/instance.go
@@ -21,7 +21,7 @@ type PluginInstance interface {
 	ReattachConfig() (config *plugin.ReattachConfig, canReattach bool)
 
 	// Plugin returns the wrapped plugin instance.
-	Plugin() interface{}
+	Plugin() any
 
 	// Exited returns whether the plugin has exited
 	Exited() bool
@@ -32,7 +32,7 @@ type PluginInstance interface {
 
 // internalPluginInstance wraps an internal plugin
 type internalPluginInstance struct {
-	instance   interface{}
+	instance   any
 	apiVersion string
 	killFn     func()
 }
@@ -41,21 +41,21 @@ func (p *internalPluginInstance) Internal() bool { return true }
 func (p *internalPluginInstance) Kill()          { p.killFn() }
 
 func (p *internalPluginInstance) ReattachConfig() (*plugin.ReattachConfig, bool) { return nil, false }
-func (p *internalPluginInstance) Plugin() interface{}                            { return p.instance }
+func (p *internalPluginInstance) Plugin() any                                    { return p.instance }
 func (p *internalPluginInstance) Exited() bool                                   { return false }
 func (p *internalPluginInstance) ApiVersion() string                             { return p.apiVersion }
 
 // externalPluginInstance wraps an external plugin
 type externalPluginInstance struct {
 	client     *plugin.Client
-	instance   interface{}
+	instance   any
 	apiVersion string
 }
 
-func (p *externalPluginInstance) Internal() bool      { return false }
-func (p *externalPluginInstance) Plugin() interface{} { return p.instance }
-func (p *externalPluginInstance) Exited() bool        { return p.client.Exited() }
-func (p *externalPluginInstance) ApiVersion() string  { return p.apiVersion }
+func (p *externalPluginInstance) Internal() bool     { return false }
+func (p *externalPluginInstance) Plugin() any        { return p.instance }
+func (p *externalPluginInstance) Exited() bool       { return p.client.Exited() }
+func (p *externalPluginInstance) ApiVersion() string { return p.apiVersion }
 
 func (p *externalPluginInstance) ReattachConfig() (*plugin.ReattachConfig, bool) {
 	return p.client.ReattachConfig(), true

--- a/helper/pluginutils/loader/loader.go
+++ b/helper/pluginutils/loader/loader.go
@@ -34,7 +34,7 @@ type PluginCatalog interface {
 
 // InternalPluginConfig is used to configure launching an internal plugin.
 type InternalPluginConfig struct {
-	Config  map[string]interface{}
+	Config  map[string]any
 	Factory plugins.PluginCtxFactory
 }
 
@@ -106,7 +106,7 @@ type pluginInfo struct {
 	apiVersion string
 
 	configSchema  *hclspec.Spec
-	config        map[string]interface{}
+	config        map[string]any
 	msgpackConfig []byte
 }
 

--- a/helper/pluginutils/loader/loader_test.go
+++ b/helper/pluginutils/loader/loader_test.go
@@ -312,7 +312,7 @@ func TestPluginLoader_External_Config(t *testing.T) {
 				Name: plugins[0],
 				Args: []string{"-plugin", "-name", plugins[0],
 					"-type", base.PluginTypeDevice, "-version", pluginVersions[0], "-api-version", device.ApiVersion010},
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"foo": "1",
 					"bar": "2",
 				},
@@ -321,7 +321,7 @@ func TestPluginLoader_External_Config(t *testing.T) {
 				Name: plugins[1],
 				Args: []string{"-plugin", "-name", plugins[1],
 					"-type", base.PluginTypeDevice, "-version", pluginVersions[1], "-api-version", device.ApiVersion010},
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"foo": "3",
 					"bar": "4",
 				},
@@ -378,7 +378,7 @@ func TestPluginLoader_External_Config_Bad(t *testing.T) {
 				Name: plugins[0],
 				Args: []string{"-plugin", "-name", plugins[0],
 					"-type", base.PluginTypeDevice, "-version", pluginVersions[0], "-api-version", device.ApiVersion010},
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"foo":          "1",
 					"bar":          "2",
 					"non-existent": "3",
@@ -638,7 +638,7 @@ func TestPluginLoader_Internal_Config(t *testing.T) {
 				PluginType: base.PluginTypeDevice,
 			}: {
 				Factory: mockFactory(plugins[0], base.PluginTypeDevice, pluginVersions[0], pluginApiVersions, true),
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"foo": "1",
 					"bar": "2",
 				},
@@ -648,7 +648,7 @@ func TestPluginLoader_Internal_Config(t *testing.T) {
 				PluginType: base.PluginTypeDevice,
 			}: {
 				Factory: mockFactory(plugins[1], base.PluginTypeDevice, pluginVersions[1], pluginApiVersions, true),
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"foo": "3",
 					"bar": "4",
 				},
@@ -700,7 +700,7 @@ func TestPluginLoader_Internal_ExternalConfig(t *testing.T) {
 		Name:       plugin,
 		PluginType: base.PluginTypeDevice,
 	}
-	expectedConfig := map[string]interface{}{
+	expectedConfig := map[string]any{
 		"foo": "2",
 		"bar": "3",
 	}
@@ -714,7 +714,7 @@ func TestPluginLoader_Internal_ExternalConfig(t *testing.T) {
 		InternalPlugins: map[PluginID]*InternalPluginConfig{
 			id: {
 				Factory: mockFactory(plugin, base.PluginTypeDevice, pluginVersion, pluginApiVersions, true),
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"foo": "1",
 					"bar": "2",
 				},
@@ -778,7 +778,7 @@ func TestPluginLoader_Internal_Config_Bad(t *testing.T) {
 				PluginType: base.PluginTypeDevice,
 			}: {
 				Factory: mockFactory(plugins[0], base.PluginTypeDevice, pluginVersions[0], pluginApiVersions, true),
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"foo":          "1",
 					"bar":          "2",
 					"non-existent": "3",
@@ -926,7 +926,7 @@ func TestPluginLoader_Dispense_External(t *testing.T) {
 				Name: plugin,
 				Args: []string{"-plugin", "-name", plugin,
 					"-type", base.PluginTypeDevice, "-version", pluginVersion, "-api-version", device.ApiVersion010},
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"res_key": expKey,
 				},
 			},
@@ -979,7 +979,7 @@ func TestPluginLoader_Dispense_Internal(t *testing.T) {
 				PluginType: base.PluginTypeDevice,
 			}: {
 				Factory: mockFactory(plugin, base.PluginTypeDevice, pluginVersion, pluginApiVersions, true),
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"res_key": expKey,
 				},
 			},
@@ -1030,7 +1030,7 @@ func TestPluginLoader_Dispense_NoConfigSchema_External(t *testing.T) {
 				Name: plugin,
 				Args: []string{"-plugin", "-config-schema=false", "-name", plugin,
 					"-type", base.PluginTypeDevice, "-version", pluginVersion, "-api-version", device.ApiVersion010},
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"res_key": expKey,
 				},
 			},
@@ -1080,7 +1080,7 @@ func TestPluginLoader_Dispense_NoConfigSchema_Internal(t *testing.T) {
 		InternalPlugins: map[PluginID]*InternalPluginConfig{
 			pid: {
 				Factory: mockFactory(plugin, base.PluginTypeDevice, pluginVersion, pluginApiVersions, false),
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"res_key": expKey,
 				},
 			},
@@ -1127,7 +1127,7 @@ func TestPluginLoader_Reattach_External(t *testing.T) {
 				Name: plugin,
 				Args: []string{"-plugin", "-name", plugin,
 					"-type", base.PluginTypeDevice, "-version", pluginVersion, "-api-version", device.ApiVersion010},
-				Config: map[string]interface{}{
+				Config: map[string]any{
 					"res_key": expKey,
 				},
 			},

--- a/helper/pluginutils/loader/plugin_test.go
+++ b/helper/pluginutils/loader/plugin_test.go
@@ -96,8 +96,8 @@ func pluginMain(name, pluginType, version string, apiVersions []string, config b
 
 // mockFactory returns a PluginFactory method which creates the mock plugin with
 // the passed parameters
-func mockFactory(name, ptype, version string, apiVersions []string, configSchema bool) func(context.Context, log.Logger) interface{} {
-	return func(ctx context.Context, log log.Logger) interface{} {
+func mockFactory(name, ptype, version string, apiVersions []string, configSchema bool) func(context.Context, log.Logger) any {
+	return func(ctx context.Context, log log.Logger) any {
 		return &mockPlugin{
 			name:         name,
 			ptype:        ptype,

--- a/helper/pluginutils/loader/testing.go
+++ b/helper/pluginutils/loader/testing.go
@@ -36,7 +36,7 @@ type MockInstance struct {
 	InternalPlugin  bool
 	KillF           func()
 	ReattachConfigF func() (*plugin.ReattachConfig, bool)
-	PluginF         func() interface{}
+	PluginF         func() any
 	ExitedF         func() bool
 	ApiVersionF     func() string
 }
@@ -44,14 +44,14 @@ type MockInstance struct {
 func (m *MockInstance) Internal() bool                                 { return m.InternalPlugin }
 func (m *MockInstance) Kill()                                          { m.KillF() }
 func (m *MockInstance) ReattachConfig() (*plugin.ReattachConfig, bool) { return m.ReattachConfigF() }
-func (m *MockInstance) Plugin() interface{}                            { return m.PluginF() }
+func (m *MockInstance) Plugin() any                                    { return m.PluginF() }
 func (m *MockInstance) Exited() bool                                   { return m.ExitedF() }
 func (m *MockInstance) ApiVersion() string                             { return m.ApiVersionF() }
 
 // MockBasicExternalPlugin returns a MockInstance that simulates an external
 // plugin returning it has been exited after kill is called. It returns the
 // passed inst as the plugin
-func MockBasicExternalPlugin(inst interface{}, apiVersion string) *MockInstance {
+func MockBasicExternalPlugin(inst any, apiVersion string) *MockInstance {
 	var killedLock sync.Mutex
 	killed := new(false)
 	return &MockInstance{
@@ -74,7 +74,7 @@ func MockBasicExternalPlugin(inst interface{}, apiVersion string) *MockInstance 
 			}, true
 		},
 
-		PluginF: func() interface{} {
+		PluginF: func() any {
 			return inst
 		},
 

--- a/helper/pluginutils/singleton/singleton_test.go
+++ b/helper/pluginutils/singleton/singleton_test.go
@@ -35,7 +35,7 @@ func TestSingleton_Dispense(t *testing.T) {
 		p := &base.MockPlugin{}
 		i := &loader.MockInstance{
 			ExitedF: func() bool { return false },
-			PluginF: func() interface{} { return p },
+			PluginF: func() any { return p },
 		}
 		dispenseCalled++
 		return i, nil
@@ -45,11 +45,10 @@ func TestSingleton_Dispense(t *testing.T) {
 	const count = 128
 	var l sync.Mutex
 	var wg sync.WaitGroup
-	plugins := make(map[interface{}]struct{}, 1)
+	plugins := make(map[any]struct{}, 1)
 	waitCh := make(chan struct{})
-	for i := 0; i < count; i++ {
-		wg.Add(1)
-		go func() {
+	for range count {
+		wg.Go(func() {
 			// Wait for unblock
 			<-waitCh
 
@@ -62,8 +61,7 @@ func TestSingleton_Dispense(t *testing.T) {
 			l.Lock()
 			plugins[i1] = struct{}{}
 			l.Unlock()
-			wg.Done()
-		}()
+		})
 	}
 	time.Sleep(10 * time.Millisecond)
 	close(waitCh)
@@ -85,7 +83,7 @@ func TestSingleton_Dispense_Exit_Dispense(t *testing.T) {
 		p := &base.MockPlugin{}
 		i := &loader.MockInstance{
 			ExitedF: func() bool { return exited },
-			PluginF: func() interface{} { return p },
+			PluginF: func() any { return p },
 		}
 		dispenseCalled++
 		return i, nil
@@ -133,7 +131,7 @@ func TestSingleton_DispenseError_Dispense(t *testing.T) {
 		p := &base.MockPlugin{}
 		i := &loader.MockInstance{
 			ExitedF: func() bool { return false },
-			PluginF: func() interface{} { return p },
+			PluginF: func() any { return p },
 		}
 		dispenseCalled++
 		return i, nil
@@ -177,7 +175,7 @@ func TestSingleton_ReattachError_Dispense(t *testing.T) {
 		p := &base.MockPlugin{}
 		i := &loader.MockInstance{
 			ExitedF: func() bool { return false },
-			PluginF: func() interface{} { return p },
+			PluginF: func() any { return p },
 		}
 		dispenseCalled++
 		return i, nil
@@ -221,7 +219,7 @@ func TestSingleton_Reattach_Dispense(t *testing.T) {
 		p := &base.MockPlugin{}
 		i := &loader.MockInstance{
 			ExitedF: func() bool { return false },
-			PluginF: func() interface{} { return p },
+			PluginF: func() any { return p },
 		}
 		reattachCalled++
 		return i, nil

--- a/helper/pool/pool.go
+++ b/helper/pool/pool.go
@@ -50,7 +50,7 @@ func (sc *StreamClient) Close() {
 // Conn is a pooled connection to a Nomad server
 type Conn struct {
 	refCount    int32
-	shouldClose int32
+	shouldClose atomic.Int32
 
 	addr     net.Addr
 	session  *yamux.Session
@@ -73,7 +73,7 @@ func (c *Conn) markForUse() {
 // releaseUse is the complement of `markForUse`, to free up the reference count
 func (c *Conn) releaseUse() {
 	refCount := atomic.AddInt32(&c.refCount, -1)
-	if refCount == 0 && atomic.LoadInt32(&c.shouldClose) == 1 {
+	if refCount == 0 && c.shouldClose.Load() == 1 {
 		c.Close()
 	}
 }
@@ -122,7 +122,7 @@ func (c *Conn) getRPCClient() (*StreamClient, error) {
 func (c *Conn) returnClient(client *StreamClient) {
 	didSave := false
 	c.clientLock.Lock()
-	if c.clients.Len() < c.pool.maxStreams && atomic.LoadInt32(&c.shouldClose) == 0 {
+	if c.clients.Len() < c.pool.maxStreams && c.shouldClose.Load() == 0 {
 		c.clients.PushFront(client)
 		didSave = true
 
@@ -447,7 +447,7 @@ func (p *ConnPool) getNewConn(region string, addr net.Addr) (*Conn, error) {
 // an error
 func (p *ConnPool) clearConn(conn *Conn) {
 	// Ensure returned streams are closed
-	atomic.StoreInt32(&conn.shouldClose, 1)
+	conn.shouldClose.Store(1)
 
 	// Clear from the cache
 	p.Lock()
@@ -510,7 +510,7 @@ func (p *ConnPool) StreamingRPC(region string, addr net.Addr) (net.Conn, error) 
 }
 
 // RPC is used to make an RPC call to a remote host
-func (p *ConnPool) RPC(region string, addr net.Addr, method string, args interface{}, reply interface{}) error {
+func (p *ConnPool) RPC(region string, addr net.Addr, method string, args any, reply any) error {
 	// Get a usable client
 	conn, sc, err := p.getRPCClient(region, addr)
 	if err != nil {

--- a/helper/raftutil/fsm.go
+++ b/helper/raftutil/fsm.go
@@ -194,13 +194,13 @@ func (f *FSMHelper) State() *state.StateStore {
 	return f.fsm.State()
 }
 
-func (f *FSMHelper) StateAsMap() map[string][]interface{} {
+func (f *FSMHelper) StateAsMap() map[string][]any {
 	return StateAsMap(f.fsm.State())
 }
 
 // StateAsMap returns a json-able representation of the state
-func StateAsMap(store *state.StateStore) map[string][]interface{} {
-	result := map[string][]interface{}{
+func StateAsMap(store *state.StateStore) map[string][]any {
+	result := map[string][]any{
 		"ACLPolicies":      toArray(store.ACLPolicies(nil)),
 		"ACLTokens":        toArray(store.ACLTokens(nil, state.SortDefault)),
 		"Allocs":           toArray(store.Allocs(nil, state.SortDefault)),
@@ -252,12 +252,12 @@ func (f *FSMHelper) restoreFromSnapshot() (index uint64, term uint64, err error)
 	return 0, 0, nil
 }
 
-func toArray(iter memdb.ResultIterator, err error) []interface{} {
+func toArray(iter memdb.ResultIterator, err error) []any {
 	if err != nil {
-		return []interface{}{err}
+		return []any{err}
 	}
 
-	r := []interface{}{}
+	r := []any{}
 
 	if iter != nil {
 		item := iter.Next()

--- a/helper/raftutil/fsm_ce.go
+++ b/helper/raftutil/fsm_ce.go
@@ -2,11 +2,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build !ent
-// +build !ent
 
 package raftutil
 
 import "github.com/hashicorp/nomad/nomad/state"
 
-func insertEnterpriseState(m map[string][]interface{}, state *state.StateStore) {
+func insertEnterpriseState(m map[string][]any, state *state.StateStore) {
 }

--- a/helper/raftutil/msgpack.go
+++ b/helper/raftutil/msgpack.go
@@ -14,9 +14,9 @@ import (
 )
 
 // fixTime converts any suspected time.Time binary string representation to time.Time
-func fixTime(v interface{}) {
+func fixTime(v any) {
 	switch v2 := v.(type) {
-	case map[string]interface{}:
+	case map[string]any:
 		for ek, ev := range v2 {
 			if s, ok := ev.(string); ok {
 				t, err := maybeDecodeTime(s)
@@ -27,7 +27,7 @@ func fixTime(v interface{}) {
 				fixTime(ev)
 			}
 		}
-	case []interface{}:
+	case []any:
 		for _, e := range v2 {
 			fixTime(e)
 		}

--- a/helper/raftutil/msgpack_test.go
+++ b/helper/raftutil/msgpack_test.go
@@ -48,7 +48,7 @@ func TestDecodesTime(t *testing.T) {
 	err := codec.NewEncoder(&buf, structs.MsgpackHandle).Encode(v)
 	require.NoError(t, err)
 
-	var r map[string]interface{}
+	var r map[string]any
 	err = codec.NewDecoder(&buf, structs.MsgpackHandle).Decode(&r)
 	require.NoError(t, err)
 
@@ -57,7 +57,7 @@ func TestDecodesTime(t *testing.T) {
 
 	fixTime(r)
 
-	expected := map[string]interface{}{
+	expected := map[string]any{
 		"CreateTime": now,
 		"Mode":       "host",
 	}

--- a/helper/raftutil/state.go
+++ b/helper/raftutil/state.go
@@ -102,13 +102,13 @@ func raftStateInfoWAL(p string) (store RaftStore, firstIdx uint64, lastIdx uint6
 // the path `p`, and returns a channel of logs, and a channel of
 // warnings. If opening the raft state returns an error, both channels
 // will be nil.
-func LogEntries(p string) (<-chan interface{}, <-chan error, error) {
+func LogEntries(p string) (<-chan any, <-chan error, error) {
 	store, firstIdx, lastIdx, err := RaftStateInfo(p)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to open raft logs: %v", err)
 	}
 
-	entries := make(chan interface{})
+	entries := make(chan any)
 	warnings := make(chan error)
 
 	go func() {
@@ -143,9 +143,9 @@ type logMessage struct {
 	Term    uint64
 	Index   uint64
 
-	CommandType           string      `json:",omitempty"`
-	IgnoreUnknownTypeFlag bool        `json:",omitempty"`
-	Body                  interface{} `json:",omitempty"`
+	CommandType           string `json:",omitempty"`
+	IgnoreUnknownTypeFlag bool   `json:",omitempty"`
+	Body                  any    `json:",omitempty"`
 }
 
 func decode(e *raft.Log) (*logMessage, error) {
@@ -178,14 +178,14 @@ func decode(e *raft.Log) (*logMessage, error) {
 	if len(data) != 0 {
 		decoder := codec.NewDecoder(bytes.NewReader(data), structs.MsgpackHandle)
 
-		var v interface{}
+		var v any
 		var err error
 		if m.CommandType == commandName(structs.JobBatchDeregisterRequestType) {
 			var vr structs.JobBatchDeregisterRequest
 			err = decoder.Decode(&vr)
 			v = jsonifyJobBatchDeregisterRequest(&vr)
 		} else {
-			var vr interface{}
+			var vr any
 			err = decoder.Decode(&vr)
 			v = vr
 		}
@@ -203,7 +203,7 @@ func decode(e *raft.Log) (*logMessage, error) {
 
 // jsonifyJobBatchDeregisterRequest special case JsonBatchDeregisterRequest object
 // as the actual type is not json friendly.
-func jsonifyJobBatchDeregisterRequest(v *structs.JobBatchDeregisterRequest) interface{} {
+func jsonifyJobBatchDeregisterRequest(v *structs.JobBatchDeregisterRequest) any {
 	var data struct {
 		Jobs  map[string]*structs.JobDeregisterOptions
 		Evals []*structs.Evaluation

--- a/helper/snapshot/archive_test.go
+++ b/helper/snapshot/archive_test.go
@@ -115,7 +115,7 @@ func TestArchive_BadData(t *testing.T) {
 
 func TestArchive_hashList(t *testing.T) {
 	hl := newHashList()
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		h := hl.Add(fmt.Sprintf("file-%d", i))
 		if _, err := io.CopyN(h, rand.Reader, 32); err != nil {
 			t.Fatalf("err: %v", err)

--- a/helper/snapshot/snapshot_test.go
+++ b/helper/snapshot/snapshot_test.go
@@ -39,7 +39,7 @@ type MockSnapshot struct {
 }
 
 // See raft.FSM.
-func (m *MockFSM) Apply(log *raft.Log) interface{} {
+func (m *MockFSM) Apply(log *raft.Log) any {
 	m.Lock()
 	defer m.Unlock()
 	m.logs = append(m.logs, log.Data)
@@ -139,7 +139,7 @@ func TestSnapshot(t *testing.T) {
 	entries := 64 * 1024
 	before, _ := makeRaft(t, filepath.Join(dir, "before"))
 	defer before.Shutdown()
-	for i := 0; i < entries; i++ {
+	for range entries {
 		var log bytes.Buffer
 		var copy bytes.Buffer
 		both := io.MultiWriter(&log, &copy)
@@ -184,7 +184,7 @@ func TestSnapshot(t *testing.T) {
 	defer after.Shutdown()
 
 	// Put some initial data in there that the snapshot should overwrite.
-	for i := 0; i < 16; i++ {
+	for range 16 {
 		var log bytes.Buffer
 		if _, err := io.CopyN(&log, rand.Reader, 256); err != nil {
 			t.Fatalf("err: %v", err)
@@ -248,7 +248,7 @@ func TestSnapshot_TruncatedVerify(t *testing.T) {
 	entries := 64 * 1024
 	before, _ := makeRaft(t, filepath.Join(dir, "before"))
 	defer before.Shutdown()
-	for i := 0; i < entries; i++ {
+	for range entries {
 		var log bytes.Buffer
 		var copy bytes.Buffer
 		both := io.MultiWriter(&log, &copy)
@@ -293,7 +293,7 @@ func TestSnapshot_BadRestore(t *testing.T) {
 	// Make a Raft and populate it with some data.
 	before, _ := makeRaft(t, filepath.Join(dir, "before"))
 	defer before.Shutdown()
-	for i := 0; i < 16*1024; i++ {
+	for range 16 * 1024 {
 		var log bytes.Buffer
 		if _, err := io.CopyN(&log, rand.Reader, 256); err != nil {
 			t.Fatalf("err: %v", err)
@@ -318,7 +318,7 @@ func TestSnapshot_BadRestore(t *testing.T) {
 	// Put some initial data in there that should not be harmed by the
 	// failed restore attempt.
 	var expected []bytes.Buffer
-	for i := 0; i < 16; i++ {
+	for range 16 {
 		var log bytes.Buffer
 		var copy bytes.Buffer
 		both := io.MultiWriter(&log, &copy)
@@ -363,7 +363,7 @@ func TestSnapshot_FromFSM(t *testing.T) {
 	entries := 64 * 1024
 	before, fsm := makeRaft(t, filepath.Join(dir, "before"))
 	defer before.Shutdown()
-	for i := 0; i < entries; i++ {
+	for range entries {
 		var log bytes.Buffer
 		var copy bytes.Buffer
 		both := io.MultiWriter(&log, &copy)
@@ -399,7 +399,7 @@ func TestSnapshot_FromFSM(t *testing.T) {
 	defer after.Shutdown()
 
 	// Put some initial data in there that the snapshot should overwrite.
-	for i := 0; i < 16; i++ {
+	for range 16 {
 		var log bytes.Buffer
 		_, err := io.CopyN(&log, rand.Reader, 256)
 		must.NoError(t, err)

--- a/helper/subproc/subproc.go
+++ b/helper/subproc/subproc.go
@@ -51,13 +51,13 @@ func Print(format string, args ...any) {
 // f should be an HCLogger Print method (e.g. log.Debug)
 func Log(r io.Reader, f func(msg string, args ...any)) string {
 	scanner := bufio.NewScanner(r)
-	lines := ""
+	var lines strings.Builder
 	for scanner.Scan() {
 		line := scanner.Text()
-		lines += line + "\n"
+		lines.WriteString(line + "\n")
 		f("sub-process", "OUTPUT", line)
 	}
-	return strings.TrimSpace(lines)
+	return strings.TrimSpace(lines.String())
 }
 
 // Context creates a context setup with the given timeout.

--- a/helper/testlog/testlog.go
+++ b/helper/testlog/testlog.go
@@ -20,7 +20,7 @@ import (
 // LogPrinter is the methods of testing.T (or testing.B) needed by the test
 // logger.
 type LogPrinter interface {
-	Logf(format string, args ...interface{})
+	Logf(format string, args ...any)
 }
 
 // NewWriter creates a new io.Writer backed by a Logger.

--- a/helper/testtask/testtask_unix.go
+++ b/helper/testtask/testtask_unix.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package testtask
 

--- a/helper/tlsutil/generate.go
+++ b/helper/tlsutil/generate.go
@@ -259,7 +259,7 @@ func GenerateCert(opts CertOpts) (string, string, error) {
 }
 
 // KeyId returns a x509 KeyId from the given signing key.
-func keyID(raw interface{}) ([]byte, error) {
+func keyID(raw any) ([]byte, error) {
 	switch raw.(type) {
 	case *ecdsa.PublicKey:
 	case *rsa.PublicKey:

--- a/helper/tlsutil/generate_test.go
+++ b/helper/tlsutil/generate_test.go
@@ -53,7 +53,7 @@ func TestGeneratePrivateKey(t *testing.T) {
 }
 
 type TestSigner struct {
-	public interface{}
+	public any
 }
 
 func (s *TestSigner) Public() crypto.PublicKey {

--- a/helper/users/dynamic/pool.go
+++ b/helper/users/dynamic/pool.go
@@ -155,7 +155,7 @@ func (p *pool) random() UGID {
 	const maxAttempts = 10
 	size := int64(p.max - p.min)
 	tries := int(min(maxAttempts, size))
-	for attempt := 0; attempt < tries; attempt++ {
+	for range tries {
 		id := UGID(rand.Int63n(size)) + p.min
 		if p.used.Insert(id) {
 			return id

--- a/helper/users/dynamic/pool_test.go
+++ b/helper/users/dynamic/pool_test.go
@@ -72,7 +72,7 @@ func TestPool_Acquire_random(t *testing.T) {
 	p2 := New(testPoolConfig)
 
 	// acquire all 10 UGIDs and record the order of each
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		v1, err1 := p1.Acquire()
 		must.NoError(t, err1)
 

--- a/helper/uuid/uuid_test.go
+++ b/helper/uuid/uuid_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestGenerate(t *testing.T) {
 	prev := Generate()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		id := Generate()
 		if prev == id {
 			t.Fatalf("Should get a new ID!")

--- a/internal/testing/apitests/acl_test.go
+++ b/internal/testing/apitests/acl_test.go
@@ -121,7 +121,7 @@ func TestACLOIDC_CompleteAuth(t *testing.T) {
 	oidcTestProvider.SetExpectedAuthNonce("fpSPuaodKevKfDU3IeXb")
 	oidcTestProvider.SetExpectedAuthCode("codeABC")
 	oidcTestProvider.SetCustomAudience("mock")
-	oidcTestProvider.SetCustomClaims(map[string]interface{}{
+	oidcTestProvider.SetCustomClaims(map[string]any{
 		"azp":                            "mock",
 		"http://nomad.internal/policies": []string{"engineering"},
 		"http://nomad.internal/roles":    []string{"engineering"},

--- a/internal/testing/apitests/structsync_test.go
+++ b/internal/testing/apitests/structsync_test.go
@@ -105,7 +105,7 @@ func toStructsResource(t *testing.T, in *api.Resources) structs.Resources {
 	return out
 }
 
-func toStructs(t *testing.T, out, in interface{}) {
+func toStructs(t *testing.T, out, in any) {
 	bytes, err := json.Marshal(in)
 	require.NoError(t, err)
 

--- a/internal/testing/apitests/util_test.go
+++ b/internal/testing/apitests/util_test.go
@@ -55,11 +55,15 @@ func testJob() *api.Job {
 // added here to avoid linter warning
 
 // int64ToPtr returns the pointer to an int
+//
+//go:fix inline
 func int64ToPtr(i int64) *int64 {
-	return &i
+	return new(i)
 }
 
 // float64ToPtr returns the pointer to an float64
+//
+//go:fix inline
 func float64ToPtr(f float64) *float64 {
-	return &f
+	return new(f)
 }

--- a/lib/auth/binder.go
+++ b/lib/auth/binder.go
@@ -163,7 +163,7 @@ func computeBindName(bindType, bindName string, claimMappings map[string]string)
 }
 
 // doesSelectorMatch checks that a single selector matches the provided vars.
-func doesSelectorMatch(selector string, selectableVars interface{}) bool {
+func doesSelectorMatch(selector string, selectableVars any) bool {
 	if selector == "" {
 		return true // catch-all
 	}

--- a/lib/auth/binder_test.go
+++ b/lib/auth/binder_test.go
@@ -184,7 +184,7 @@ func Test_doesSelectorMatch(t *testing.T) {
 	tests := []struct {
 		name           string
 		selector       string
-		selectableVars interface{}
+		selectableVars any
 		want           bool
 	}{
 		{

--- a/lib/auth/claims.go
+++ b/lib/auth/claims.go
@@ -6,6 +6,7 @@ package auth
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -16,7 +17,7 @@ import (
 
 // SelectorData returns the data for go-bexpr for selector evaluation.
 func SelectorData(
-	am *structs.ACLAuthMethod, idClaims, userClaims map[string]interface{}) (*structs.ACLAuthClaims, error) {
+	am *structs.ACLAuthMethod, idClaims, userClaims map[string]any) (*structs.ACLAuthClaims, error) {
 
 	// Ensure the issuer and subscriber data does not get overwritten.
 	if len(userClaims) > 0 {
@@ -24,9 +25,7 @@ func SelectorData(
 		iss, issOk := idClaims["iss"]
 		sub, subOk := idClaims["sub"]
 
-		for k, v := range userClaims {
-			idClaims[k] = v
-		}
+		maps.Copy(idClaims, userClaims)
 
 		if issOk {
 			idClaims["iss"] = iss
@@ -43,7 +42,7 @@ func SelectorData(
 // extracts the claims, and returns a map of data that can be used with
 // go-bexpr.
 func extractClaims(
-	am *structs.ACLAuthMethod, all map[string]interface{}) (*structs.ACLAuthClaims, error) {
+	am *structs.ACLAuthMethod, all map[string]any) (*structs.ACLAuthClaims, error) {
 
 	values, err := extractMappings(all, am.Config.ClaimMappings)
 	if err != nil {
@@ -63,7 +62,7 @@ func extractClaims(
 
 // extractMappings extracts the string value mappings.
 func extractMappings(
-	all map[string]interface{}, mapping map[string]string) (map[string]string, error) {
+	all map[string]any, mapping map[string]string) (map[string]string, error) {
 
 	result := make(map[string]string)
 	for source, target := range mapping {
@@ -94,7 +93,7 @@ func extractMappings(
 //	     ...
 //	}
 func extractListMappings(
-	all map[string]interface{}, mappings map[string]string) (map[string][]string, error) {
+	all map[string]any, mappings map[string]string) (map[string][]string, error) {
 
 	result := make(map[string][]string)
 	for source, target := range mappings {
@@ -134,7 +133,7 @@ func extractListMappings(
 //
 // There is no fixup done to the returned data type here. That happens a layer
 // up in the caller.
-func getClaim(all map[string]interface{}, claim string) interface{} {
+func getClaim(all map[string]any, claim string) any {
 	if !strings.HasPrefix(claim, "/") {
 		return all[claim]
 	}
@@ -161,9 +160,9 @@ func getClaim(all map[string]interface{}, claim string) interface{} {
 //
 // If successful the string value and true are returned. otherwise an empty
 // string and false are returned.
-func stringifyClaimValue(rawValue interface{}) (string, bool) {
+func stringifyClaimValue(rawValue any) (string, bool) {
 	switch v := rawValue.(type) {
-	case []interface{}:
+	case []any:
 		b, err := json.Marshal(v)
 		if err != nil {
 			return "", false
@@ -216,9 +215,9 @@ func stringifyClaimValue(rawValue interface{}) (string, bool) {
 //
 // There is no fixup done to elements of the returned slice here. That happens
 // a layer up in the caller.
-func normalizeList(raw interface{}) ([]interface{}, bool) {
+func normalizeList(raw any) ([]any, bool) {
 	switch v := raw.(type) {
-	case []interface{}:
+	case []any:
 		return v, true
 	case string, // note: this list should be the same as stringifyClaimValue
 		bool,
@@ -235,7 +234,7 @@ func normalizeList(raw interface{}) ([]interface{}, bool) {
 		uint32,
 		uint64,
 		uint:
-		return []interface{}{v}, true
+		return []any{v}, true
 	default:
 		return nil, false
 	}

--- a/lib/auth/claims_test.go
+++ b/lib/auth/claims_test.go
@@ -16,14 +16,14 @@ func TestSelectorData(t *testing.T) {
 		Name        string
 		Mapping     map[string]string
 		ListMapping map[string]string
-		Data        map[string]interface{}
+		Data        map[string]any
 		Expected    *structs.ACLAuthClaims
 	}{
 		{
 			"no mappings",
 			nil,
 			nil,
-			map[string]interface{}{"iss": "https://hashicorp.com"},
+			map[string]any{"iss": "https://hashicorp.com"},
 			&structs.ACLAuthClaims{
 				Value: map[string]string{},
 				List:  map[string][]string{},
@@ -34,7 +34,7 @@ func TestSelectorData(t *testing.T) {
 			"key",
 			map[string]string{"iss": "issuer"},
 			nil,
-			map[string]interface{}{"iss": "https://hashicorp.com"},
+			map[string]any{"iss": "https://hashicorp.com"},
 			&structs.ACLAuthClaims{
 				Value: map[string]string{"issuer": "https://hashicorp.com"},
 				List:  map[string][]string{},
@@ -45,7 +45,7 @@ func TestSelectorData(t *testing.T) {
 			"key doesn't exist",
 			map[string]string{"iss": "issuer"},
 			nil,
-			map[string]interface{}{"nope": "https://hashicorp.com"},
+			map[string]any{"nope": "https://hashicorp.com"},
 			&structs.ACLAuthClaims{
 				Value: map[string]string{},
 				List:  map[string][]string{},
@@ -56,8 +56,8 @@ func TestSelectorData(t *testing.T) {
 			"list",
 			nil,
 			map[string]string{"groups": "g"},
-			map[string]interface{}{
-				"groups": []interface{}{
+			map[string]any{
+				"groups": []any{
 					"A", 42, false,
 				},
 			},
@@ -85,7 +85,6 @@ func TestSelectorData(t *testing.T) {
 				},
 			},
 		},
-
 	}
 
 	for _, tt := range cases {

--- a/lib/auth/identity.go
+++ b/lib/auth/identity.go
@@ -10,7 +10,7 @@ import (
 type Identity struct {
 	// Claims is the format of this Identity suitable for selection
 	// with a binding rule.
-	Claims interface{}
+	Claims any
 
 	// ClaimMappings is the format of this Identity suitable for interpolation in a
 	// bind name within a binding rule.

--- a/lib/auth/jwt/validator_test.go
+++ b/lib/auth/jwt/validator_test.go
@@ -78,7 +78,7 @@ func TestValidate(t *testing.T) {
 		name    string
 		token   string
 		conf    *structs.ACLAuthMethodConfig
-		want    map[string]interface{}
+		want    map[string]any
 		wantErr bool
 	}{
 		{

--- a/lib/delayheap/delay_heap.go
+++ b/lib/delayheap/delay_heap.go
@@ -20,7 +20,7 @@ type DelayHeap struct {
 
 // HeapNode is an interface type implemented by objects stored in the DelayHeap
 type HeapNode interface {
-	Data() interface{} // The data object
+	Data() any         // The data object
 	ID() string        // ID of the object, used in conjunction with namespace for deduplication
 	Namespace() string // Namespace of the object, can be empty
 }
@@ -65,14 +65,14 @@ func (h delayedHeapImp) Swap(i, j int) {
 	h[j].index = j
 }
 
-func (h *delayedHeapImp) Push(x interface{}) {
+func (h *delayedHeapImp) Push(x any) {
 	node := x.(*delayHeapNode)
 	n := len(*h)
 	node.index = n
 	*h = append(*h, node)
 }
 
-func (h *delayedHeapImp) Pop() interface{} {
+func (h *delayedHeapImp) Pop() any {
 	old := *h
 	n := len(old)
 	node := old[n-1]

--- a/lib/delayheap/delay_heap_test.go
+++ b/lib/delayheap/delay_heap_test.go
@@ -13,12 +13,12 @@ import (
 
 // HeapNodeImpl satisfies the HeapNode interface
 type heapNodeImpl struct {
-	dataObject interface{}
+	dataObject any
 	id         string
 	namespace  string
 }
 
-func (d *heapNodeImpl) Data() interface{} {
+func (d *heapNodeImpl) Data() any {
 	return d.dataObject
 }
 

--- a/lib/kheap/score_heap.go
+++ b/lib/kheap/score_heap.go
@@ -9,8 +9,8 @@ import (
 
 // HeapItem is an interface type implemented by objects stored in the ScoreHeap
 type HeapItem interface {
-	Data() interface{} // The data object
-	Score() float64    // Score to use as the sort criteria
+	Data() any      // The data object
+	Score() float64 // Score to use as the sort criteria
 }
 
 // A ScoreHeap implements heap.Interface and is a min heap
@@ -37,7 +37,7 @@ func (pq ScoreHeap) Swap(i, j int) {
 
 // Push implements heap.Interface and only stores
 // the top K elements by Score
-func (pq *ScoreHeap) Push(x interface{}) {
+func (pq *ScoreHeap) Push(x any) {
 	item := x.(HeapItem)
 	if len(pq.items) < pq.capacity {
 		pq.items = append(pq.items, item)
@@ -57,7 +57,7 @@ func (pq *ScoreHeap) Push(x interface{}) {
 // Pop implements heap.Interface and returns the top K scoring elements in
 // increasing order of Score. Callers must reverse the order of returned
 // elements to get the top K scoring elements in descending order.
-func (pq *ScoreHeap) Pop() interface{} {
+func (pq *ScoreHeap) Pop() any {
 	old := pq.items
 	n := len(old)
 	item := old[n-1]
@@ -67,8 +67,8 @@ func (pq *ScoreHeap) Pop() interface{} {
 
 // GetItemsReverse returns the items in this min heap in reverse order
 // sorted by score descending
-func (pq *ScoreHeap) GetItemsReverse() []interface{} {
-	ret := make([]interface{}, pq.Len())
+func (pq *ScoreHeap) GetItemsReverse() []any {
+	ret := make([]any, pq.Len())
 	i := pq.Len() - 1
 	for pq.Len() > 0 {
 		item := heap.Pop(pq)

--- a/lib/kheap/score_heap_test.go
+++ b/lib/kheap/score_heap_test.go
@@ -16,7 +16,7 @@ type heapItem struct {
 	ScoreVal float64
 }
 
-func (h *heapItem) Data() interface{} {
+func (h *heapItem) Data() any {
 	return h.Value
 }
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -132,19 +133,10 @@ func groupedHelpFunc(f cli.HelpFunc) cli.HelpFunc {
 		// commands output
 		otherCommands := make([]string, 0, len(commands))
 		for k := range commands {
-			found := false
-			for _, v := range commonCommands {
-				if k == v {
-					found = true
-					break
-				}
-			}
+			found := slices.Contains(commonCommands, k)
 
-			for _, v := range aliases {
-				if k == v {
-					found = true
-					break
-				}
+			if slices.Contains(aliases, k) {
+				found = true
 			}
 
 			if !found {

--- a/scheduler/feasible/feasible_test.go
+++ b/scheduler/feasible/feasible_test.go
@@ -33,7 +33,7 @@ func TestStaticIterator_Reset(t *testing.T) {
 
 	for i := range 6 {
 		static.Reset()
-		for j := 0; j < i; j++ {
+		for range i {
 			static.Next()
 		}
 		static.Reset()

--- a/testutil/server.go
+++ b/testutil/server.go
@@ -362,7 +362,7 @@ func (s *TestServer) waitForServers() {
 		}
 
 		jwks := struct {
-			Keys []interface{} `json:"keys"`
+			Keys []any `json:"keys"`
 		}{}
 		if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
 			return false, fmt.Errorf("error decoding jwks response: %w", err)
@@ -469,7 +469,7 @@ func (s *TestServer) get(path string) *http.Response {
 
 // encodePayload returns a new io.Reader wrapping the encoded contents
 // of the payload, suitable for passing directly to a new request.
-func (s *TestServer) encodePayload(payload interface{}) io.Reader {
+func (s *TestServer) encodePayload(payload any) io.Reader {
 	var encoded bytes.Buffer
 	enc := json.NewEncoder(&encoded)
 	if err := enc.Encode(payload); err != nil {

--- a/testutil/wait.go
+++ b/testutil/wait.go
@@ -132,7 +132,7 @@ func IsAppVeyor() bool {
 	return ok
 }
 
-type rpcFn func(string, interface{}, interface{}) error
+type rpcFn func(string, any, any) error
 
 // WaitForLeader blocks until a leader is elected.
 func WaitForLeader(t testing.TB, rpc rpcFn) {
@@ -152,7 +152,7 @@ func WaitForLeaders(t testing.TB, rpcs ...rpcFn) string {
 	t.Helper()
 
 	var leader string
-	for i := 0; i < len(rpcs); i++ {
+	for i := range rpcs {
 		ok := func() (bool, error) {
 			leader = ""
 			args := &structs.GenericRequest{}


### PR DESCRIPTION
Run modernize on the remaining codebase and update golangci-lint, so that modernize linting is run on all files including tests.

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

