### PR TITLE
core: ignore NomadTokenID when comparing job specs (#26810)

### DIFF
--- a/.changelog/26810.txt
+++ b/.changelog/26810.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+core: Fixed a bug where re-submitting an otherwise unchanged job with a different ACL token created a new job version and deployment
+```

--- a/nomad/structs/structs.go
+++ b/nomad/structs/structs.go
@@ -5278,6 +5278,7 @@ func (j *Job) SpecChanged(new *Job) bool {
 	c.ModifyIndex = j.ModifyIndex
 	c.JobModifyIndex = j.JobModifyIndex
 	c.SubmitTime = j.SubmitTime
+	c.NomadTokenID = j.NomadTokenID
 
 	// cgbaker: FINISH: probably need some consideration of scaling policy ID here
 

--- a/nomad/structs/structs_test.go
+++ b/nomad/structs/structs_test.go
@@ -813,6 +813,11 @@ func TestJob_SpecChanged(t *testing.T) {
 	change := base.Copy()
 	change.Priority = 99
 
+	// tokenChange only differs by the accessor ID of the ACL token used to
+	// submit the job, which is not part of the functional spec
+	tokenChange := base.Copy()
+	tokenChange.NomadTokenID = "6c3c6c3c-e4b8-4d3a-9f21-0b1c2d3e4f50"
+
 	cases := []struct {
 		Name     string
 		Original *Job
@@ -830,6 +835,12 @@ func TestJob_SpecChanged(t *testing.T) {
 			Changed:  true,
 			Original: base,
 			New:      change,
+		},
+		{
+			Name:     "Same job except NomadTokenID",
+			Changed:  false,
+			Original: base,
+			New:      tokenChange,
 		},
 		{
 			Name:     "With Constraints",


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->

`Job.SpecChanged()` does a `reflect.DeepEqual` on two jobs after scrubbing the bookkeeping fields (`Status`, `Version`, `ModifyIndex`, `SubmitTime`), but it never scrubs `NomadTokenID`, which holds the accessor ID of the token that submitted the job. So re-running `nomad job run` on a file you haven't touched with a different `NOMAD_TOKEN` reads as a spec change, and you get a new job version and a deployment out of it.

Not multiregion specific. The field is only there for MRD, but `SpecChanged()` sits on the normal register path, so this hits any cluster with ACLs on.

`diff.go` already excludes the same field for the plan diff, so the two disagree right now: `nomad plan` says nothing changed while the register path deploys anyway.

`SpecChanged()` also backs `deploymentwatcher.handleRollbackValidity`, which decides whether a rollback target is actually different from what's running. A token-only difference makes an identical target look changed, so you get one extra rollback and job version before the guard catches it on the next pass.

Two things this changes:
1. A token-only resubmit stops writing a version, so the stored `NomadTokenID` sticks with the accessor from the last real spec change until the next one re-stamps it. Confirmed fine in #26810, a token rotated mid-deployment fails the deployment anyway.
2. `nomad job revert` to an older version with the same spec is now a real no-op. `Job.Revert` goes through `doRegister`, so before this the reverting user's token on its own was enough to make a new version.

One thing I can't check from the OSS side: the CE `multiregionSpecChanged` just forwards to `SpecChanged`, so this should land under the ENT override too, but someone with ENT access should confirm.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

Reproduction steps are in #26810.

Added `TestJob_SpecChanged/Same_job_except_NomadTokenID`, checked it fails without the scrub line.

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

Fixes #26810

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI, and job configuration, please update the Nomad product documentation, which is stored in the [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines. Please also consider whether the change requires notes within the [upgrade guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge" in the majority of situations. The main exceptions are long-lived feature branches or merges where history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

None.
