### PR TITLE
client: track cpuset reservations per allocation

### DIFF
--- a/.changelog/28521.txt
+++ b/.changelog/28521.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: Fixed a bug where allocations on a node would fail to start with `cpuparts_hook` errors (`no space left on device` or `device or resource busy`) after an allocation's reserved cores were released while another allocation still held them
+```

--- a/client/allocrunner/alloc_runner.go
+++ b/client/allocrunner/alloc_runner.go
@@ -26,8 +26,6 @@ import (
 	"github.com/hashicorp/nomad/client/devicemanager"
 	"github.com/hashicorp/nomad/client/dynamicplugins"
 	cinterfaces "github.com/hashicorp/nomad/client/interfaces"
-	"github.com/hashicorp/nomad/client/lib/idset"
-	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 	"github.com/hashicorp/nomad/client/lib/proclib"
 	"github.com/hashicorp/nomad/client/pluginmanager/csimanager"
 	"github.com/hashicorp/nomad/client/pluginmanager/drivermanager"
@@ -508,23 +506,15 @@ func (ar *allocRunner) Restore() error {
 
 		// restore process wrangler for task
 		ar.wranglers.Setup(proclib.Task{AllocID: tr.Alloc().ID, Task: tr.Task().Name})
-
-		// restore cpuset partition state
-		ar.restoreCores(tr.Alloc().AllocatedResources)
 	}
+
+	// restore cpuset partition state
+	alloc := ar.Alloc()
+	ar.partitions.Restore(alloc.ID, alloc.ReservedCores())
 
 	ar.taskCoordinator.Restore(states)
 
 	return nil
-}
-
-// restoreCores will restore the cpuset partitions with the reserved core
-// data for each task in the alloc
-func (ar *allocRunner) restoreCores(res *structs.AllocatedResources) {
-	for _, taskRes := range res.Tasks {
-		s := idset.From[hw.CoreID](taskRes.Cpu.ReservedCores)
-		ar.partitions.Restore(s)
-	}
 }
 
 // persistDeploymentStatus stores AllocDeploymentStatus.

--- a/client/allocrunner/cpuparts_hook.go
+++ b/client/allocrunner/cpuparts_hook.go
@@ -55,9 +55,9 @@ var (
 )
 
 func (h *cpuPartsHook) Prerun(_ *taskenv.TaskEnv) error {
-	return h.partitions.Reserve(h.reservations)
+	return h.partitions.Reserve(h.allocID, h.reservations)
 }
 
 func (h *cpuPartsHook) Postrun() error {
-	return h.partitions.Release(h.reservations)
+	return h.partitions.Release(h.allocID)
 }

--- a/client/interfaces/client.go
+++ b/client/interfaces/client.go
@@ -52,7 +52,7 @@ type ProcessWranglers interface {
 
 // CPUPartitions is an interface satisfied by the cgroupslib package.
 type CPUPartitions interface {
-	Restore(*idset.Set[hw.CoreID])
-	Reserve(*idset.Set[hw.CoreID]) error
-	Release(*idset.Set[hw.CoreID]) error
+	Restore(allocID string, cores *idset.Set[hw.CoreID])
+	Reserve(allocID string, cores *idset.Set[hw.CoreID]) error
+	Release(allocID string) error
 }

--- a/client/lib/cgroupslib/partition.go
+++ b/client/lib/cgroupslib/partition.go
@@ -8,11 +8,18 @@ import (
 	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 )
 
-// A Partition is used to track reserved vs. shared cpu cores.
+// A Partition is used to track reserved vs. shared cpu cores. Reservations
+// are tracked per allocation, identified by allocation ID, so that the cores
+// of one allocation are only returned to the shared pool once no other
+// allocation holds them.
 type Partition interface {
-	Restore(*idset.Set[hw.CoreID])
-	Reserve(*idset.Set[hw.CoreID]) error
-	Release(*idset.Set[hw.CoreID]) error
+	// Restore records the cores held by an allocation that was already
+	// running when the client started, without touching the cgroups.
+	Restore(allocID string, cores *idset.Set[hw.CoreID])
+	// Reserve records the cores held by an allocation and updates the cgroups.
+	Reserve(allocID string, cores *idset.Set[hw.CoreID]) error
+	// Release forgets the cores held by an allocation and updates the cgroups.
+	Release(allocID string) error
 }
 
 // SharePartition is the name of the cgroup containing cgroups for tasks

--- a/client/lib/cgroupslib/partition_linux.go
+++ b/client/lib/cgroupslib/partition_linux.go
@@ -6,10 +6,12 @@
 package cgroupslib
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/lib/idset"
@@ -43,12 +45,11 @@ func NewPartition(log hclog.Logger, cores *idset.Set[hw.CoreID]) Partition {
 	}
 
 	return &partition{
-		usableCores: cores.Copy(),
-		log:         log,
-		sharePath:   sharePath,
-		reservePath: reservePath,
-		share:       cores.Copy(),
-		reserve:     idset.Empty[hw.CoreID](),
+		usableCores:  cores.Copy(),
+		log:          log,
+		sharePath:    sharePath,
+		reservePath:  reservePath,
+		reservations: make(map[string]*idset.Set[hw.CoreID]),
 	}
 }
 
@@ -58,63 +59,132 @@ type partition struct {
 	reservePath string
 	usableCores *idset.Set[hw.CoreID]
 
-	lock    sync.Mutex
-	share   *idset.Set[hw.CoreID]
-	reserve *idset.Set[hw.CoreID]
+	lock sync.Mutex
+
+	// reservations tracks the cores held by each allocation, keyed by
+	// allocation ID. The reserve cpuset is the union of these sets and the
+	// share cpuset is whatever is left of usableCores.
+	//
+	// The books are kept per allocation rather than as a single set of
+	// reserved cores so that releasing one allocation never removes a core
+	// still held by another. Two allocations can briefly hold the same core
+	// when the scheduler places a replacement before the client has finished
+	// stopping the allocation it replaces, and a Release may arrive without a
+	// matching Reserve when an earlier prerun hook fails. With a single set
+	// either case empties the reserve cpuset while a task still lives in it,
+	// which the kernel refuses (ENOSPC on cgroups v2, EBUSY on v1), and every
+	// allocation on the node then fails until that task exits.
+	reservations map[string]*idset.Set[hw.CoreID]
 }
 
-func (p *partition) Restore(cores *idset.Set[hw.CoreID]) {
+// reserved returns the union of all reserved cores. Must be called with the
+// lock held.
+func (p *partition) reserved() *idset.Set[hw.CoreID] {
+	reserve := idset.Empty[hw.CoreID]()
+	for _, cores := range p.reservations {
+		reserve.InsertSet(cores)
+	}
+	return reserve
+}
 
+// shared returns the usable cores not reserved by any allocation. Must be
+// called with the lock held.
+func (p *partition) shared() *idset.Set[hw.CoreID] {
+	share := p.usableCores.Copy()
+	share.RemoveSet(p.reserved())
+	return share
+}
+
+func (p *partition) Restore(allocID string, cores *idset.Set[hw.CoreID]) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	p.share.RemoveSet(cores)
-	// Use the intersection with the usable cores to avoid adding more cores than available.
-	p.reserve.InsertSet(p.usableCores.Intersect(cores))
-
+	p.add(allocID, cores)
 }
 
-func (p *partition) Reserve(cores *idset.Set[hw.CoreID]) error {
-
+func (p *partition) Reserve(allocID string, cores *idset.Set[hw.CoreID]) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
 	// Use the intersection with the usable cores to avoid adding more cores than available.
 	usableCores := p.usableCores.Intersect(cores)
 
-	overlappingCores := p.reserve.Intersect(usableCores)
+	// The same allocation may reserve its cores more than once (e.g. after a
+	// client restart) which is not an overlap; only consider other allocations.
+	overlappingCores := idset.Empty[hw.CoreID]()
+	for id, held := range p.reservations {
+		if id != allocID {
+			overlappingCores.InsertSet(held.Intersect(usableCores))
+		}
+	}
 	if overlappingCores.Size() > 0 {
 		// COMPAT: prior to Nomad 1.9.X this would silently happen, this should probably return an error instead
-		p.log.Warn("Unable to exclusively reserve the requested cores", "cores", cores.Slice(), "overlapping_cores", overlappingCores.Slice())
+		p.log.Warn("Unable to exclusively reserve the requested cores", "alloc_id", allocID, "cores", cores.Slice(), "overlapping_cores", overlappingCores.Slice())
 	}
 
-	p.share.RemoveSet(cores)
-	p.reserve.InsertSet(usableCores)
+	p.add(allocID, usableCores)
 
 	return p.write()
 }
 
-func (p *partition) Release(cores *idset.Set[hw.CoreID]) error {
-
+func (p *partition) Release(allocID string) error {
 	p.lock.Lock()
 	defer p.lock.Unlock()
 
-	p.reserve.RemoveSet(cores)
+	delete(p.reservations, allocID)
 
-	// Use the intersection with the usable cores to avoid removing more cores than available.
-	p.share.InsertSet(p.usableCores.Intersect(cores))
 	return p.write()
 }
 
+// add records cores as held by the allocation, keeping the books free of
+// empty entries so that allocations without reserved cores are not tracked.
+// Must be called with the lock held.
+func (p *partition) add(allocID string, cores *idset.Set[hw.CoreID]) {
+	usableCores := p.usableCores.Intersect(cores)
+	if usableCores.Size() == 0 {
+		return
+	}
+	held, ok := p.reservations[allocID]
+	if !ok {
+		held = idset.Empty[hw.CoreID]()
+		p.reservations[allocID] = held
+	}
+	held.InsertSet(usableCores)
+}
+
 func (p *partition) write() error {
-	shareStr := p.share.String()
-	if err := os.WriteFile(p.sharePath, []byte(shareStr), 0644); err != nil {
-		return fmt.Errorf("cgroupslib: unable to update share cpuset with %q: %w", shareStr, err)
+	if err := p.writeCpuset(p.sharePath, p.shared()); err != nil {
+		return fmt.Errorf("cgroupslib: unable to update share cpuset: %w", err)
 	}
 
-	reserveStr := p.reserve.String()
-	if err := os.WriteFile(p.reservePath, []byte(reserveStr), 0644); err != nil {
-		return fmt.Errorf("cgroupslib: unable to update reserve cpuset with %q: %w", reserveStr, err)
+	if err := p.writeCpuset(p.reservePath, p.reserved()); err != nil {
+		return fmt.Errorf("cgroupslib: unable to update reserve cpuset: %w", err)
 	}
 	return nil
+}
+
+func (p *partition) writeCpuset(path string, cores *idset.Set[hw.CoreID]) error {
+	value := cores.String()
+	err := os.WriteFile(path, []byte(value), 0644)
+	if err == nil {
+		return nil
+	}
+
+	// The kernel refuses to empty the cpuset of a cgroup that still has tasks
+	// in it or in any of its descendants (validate_change in
+	// kernel/cgroup/cpuset.c returns ENOSPC). This happens when the last
+	// reservation on the node is released while a task lingers in the reserve
+	// cgroup, or when every usable core is reserved while a task lingers in
+	// the share cgroup. Failing here would fail the allocation being started
+	// or stopped, and every allocation after it until the lingering task
+	// exits. Keeping the previous cpuset is harmless: on cgroups v2 an empty
+	// cpuset would fall back to the parent's cores anyway, so the tasks in the
+	// cgroup are no more exclusive than they would have been had the write
+	// succeeded. The next write will set the cpuset once it is non-empty again.
+	if cores.Size() == 0 && errors.Is(err, syscall.ENOSPC) {
+		p.log.Warn("Unable to empty cpuset of a cgroup that still has tasks; leaving previous value", "path", path, "error", err)
+		return nil
+	}
+
+	return fmt.Errorf("write %q to %s: %w", value, path, err)
 }

--- a/client/lib/cgroupslib/partition_noop.go
+++ b/client/lib/cgroupslib/partition_noop.go
@@ -14,12 +14,12 @@ func NoopPartition() Partition {
 
 type noop struct{}
 
-func (p *noop) Reserve(*idset.Set[hw.CoreID]) error {
+func (p *noop) Reserve(string, *idset.Set[hw.CoreID]) error {
 	return nil
 }
 
-func (p *noop) Release(*idset.Set[hw.CoreID]) error {
+func (p *noop) Release(string) error {
 	return nil
 }
 
-func (p *noop) Restore(*idset.Set[hw.CoreID]) {}
+func (p *noop) Restore(string, *idset.Set[hw.CoreID]) {}

--- a/client/lib/cgroupslib/partition_test.go
+++ b/client/lib/cgroupslib/partition_test.go
@@ -9,22 +9,23 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/nomad/client/lib/idset"
 	"github.com/hashicorp/nomad/client/lib/numalib/hw"
 	"github.com/shoenig/test/must"
 )
 
-// testPartition creates a fresh partition configured with cores 10-20.
+// testPartition creates a fresh partition configured with cores 10-19.
 func testPartition(t *testing.T) *partition {
 	dir := t.TempDir()
 	shareFile := filepath.Join(dir, "share.cpus")
 	reserveFile := filepath.Join(dir, "reserve.cpus")
 	return &partition{
-		usableCores: idset.From[hw.CoreID]([]hw.CoreID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19}),
-		sharePath:   shareFile,
-		reservePath: reserveFile,
-		share:       idset.From[hw.CoreID]([]hw.CoreID{10, 11, 12, 13, 14, 15, 16, 17, 18, 19}),
-		reserve:     idset.Empty[hw.CoreID](),
+		log:          hclog.NewNullLogger(),
+		usableCores:  idset.From[hw.CoreID]([]hw.CoreID{10, 11, 12, 13, 14, 15, 16, 17, 18, 19}),
+		sharePath:    shareFile,
+		reservePath:  reserveFile,
+		reservations: make(map[string]*idset.Set[hw.CoreID]),
 	}
 }
 
@@ -35,69 +36,171 @@ func coreset(ids ...hw.CoreID) *idset.Set[hw.CoreID] {
 func TestPartition_Restore(t *testing.T) {
 	p := testPartition(t)
 
-	must.NotEmpty(t, p.share)
-	must.Empty(t, p.reserve)
+	must.NotEmpty(t, p.shared())
+	must.Empty(t, p.reserved())
 
-	p.Restore(coreset(11, 13))
-	p.Restore(coreset(15, 16, 17))
-	p.Restore(coreset(10, 19))
+	p.Restore("a", coreset(11, 13))
+	p.Restore("b", coreset(15, 16, 17))
+	p.Restore("c", coreset(10, 19))
 
 	expShare := idset.From[hw.CoreID]([]hw.CoreID{12, 14, 18})
 	expReserve := idset.From[hw.CoreID]([]hw.CoreID{11, 13, 15, 16, 17, 10, 19})
 
-	must.Eq(t, expShare, p.share)
-	must.Eq(t, expReserve, p.reserve)
+	must.Eq(t, expShare, p.shared())
+	must.Eq(t, expReserve, p.reserved())
 
 	// restore does not write to the cgroup interface
 	must.FileNotExists(t, p.sharePath)
 	must.FileNotExists(t, p.reservePath)
 }
 
+func TestPartition_Restore_multipleTasks(t *testing.T) {
+	p := testPartition(t)
+
+	// each task of an alloc is restored separately; the alloc holds the union
+	p.Restore("a", coreset(11, 13))
+	p.Restore("a", coreset(15))
+	p.Restore("b", coreset())
+
+	must.Eq(t, coreset(11, 13, 15), p.reserved())
+	must.MapContainsKey(t, p.reservations, "a")
+	must.MapNotContainsKey(t, p.reservations, "b")
+}
+
 func TestPartition_Reserve(t *testing.T) {
 	p := testPartition(t)
 
-	p.Reserve(coreset(10, 15, 19))
-	p.Reserve(coreset(12, 13))
+	must.NoError(t, p.Reserve("a", coreset(10, 15, 19)))
+	must.NoError(t, p.Reserve("b", coreset(12, 13)))
 
 	expShare := idset.From[hw.CoreID]([]hw.CoreID{11, 14, 16, 17, 18})
 	expReserve := idset.From[hw.CoreID]([]hw.CoreID{10, 12, 13, 15, 19})
 
-	must.Eq(t, expShare, p.share)
-	must.Eq(t, expReserve, p.reserve)
+	must.Eq(t, expShare, p.shared())
+	must.Eq(t, expReserve, p.reserved())
 
 	must.FileContains(t, p.sharePath, "11,14,16-18")
 	must.FileContains(t, p.reservePath, "10,12-13,15,19")
+}
+
+func TestPartition_Reserve_unusableCores(t *testing.T) {
+	p := testPartition(t)
+
+	// cores outside the usable set are ignored
+	must.NoError(t, p.Reserve("a", coreset(18, 19, 20, 21)))
+	must.FileContains(t, p.sharePath, "10-17")
+	must.FileContains(t, p.reservePath, "18-19")
+
+	// an alloc with no usable cores is not tracked
+	must.NoError(t, p.Reserve("b", coreset()))
+	must.NoError(t, p.Reserve("c", coreset(20, 21)))
+	must.MapLen(t, 1, p.reservations)
+}
+
+func TestPartition_Reserve_afterRestore(t *testing.T) {
+	p := testPartition(t)
+
+	// a restored alloc runs its prerun hooks again; the books do not change
+	p.Restore("a", coreset(10, 11))
+	must.NoError(t, p.Reserve("a", coreset(10, 11)))
+
+	must.MapLen(t, 1, p.reservations)
+	must.FileContains(t, p.sharePath, "12-19")
+	must.FileContains(t, p.reservePath, "10-11")
+
+	must.NoError(t, p.Release("a"))
+	must.FileContains(t, p.sharePath, "10-19")
+	must.FileContains(t, p.reservePath, "")
 }
 
 func TestPartition_Release(t *testing.T) {
 	p := testPartition(t)
 
 	// some reservations
-	p.Reserve(coreset(10, 15, 19))
-	p.Reserve(coreset(12, 13))
-	p.Reserve(coreset(11, 18))
+	must.NoError(t, p.Reserve("a", coreset(10, 15, 19)))
+	must.NoError(t, p.Reserve("b", coreset(12, 13)))
+	must.NoError(t, p.Reserve("c", coreset(11, 18)))
 
 	must.FileContains(t, p.sharePath, "14,16-17")
 	must.FileContains(t, p.reservePath, "10-13,15,18-19")
 
 	// release 1
-	p.Release(coreset(12, 13))
+	must.NoError(t, p.Release("b"))
 	must.FileContains(t, p.sharePath, "12-14,16-17")
 	must.FileContains(t, p.reservePath, "10-11,15,18-19")
 
 	// release 2
-	p.Release(coreset(10, 15, 19))
+	must.NoError(t, p.Release("a"))
 	must.FileContains(t, p.sharePath, "10,12-17,19")
 	must.FileContains(t, p.reservePath, "11,18")
 
 	// release 3
-	p.Release(coreset(11, 18))
+	must.NoError(t, p.Release("c"))
 	must.FileContains(t, p.sharePath, "10-19")
 	must.FileContains(t, p.reservePath, "")
+	must.MapEmpty(t, p.reservations)
 
-	// release more cores than the usable ones
-	// test partition only has 20 usable cores.
-	p.Release(coreset(11, 18, 19, 20, 21))
+	// releasing again is a no-op
+	must.NoError(t, p.Release("c"))
 	must.FileContains(t, p.sharePath, "10-19")
 	must.FileContains(t, p.reservePath, "")
+}
+
+func TestPartition_Release_overlapping(t *testing.T) {
+	p := testPartition(t)
+
+	// the scheduler can place a replacement alloc on the cores of the alloc
+	// it replaces before the client has stopped the old one
+	must.NoError(t, p.Reserve("old", coreset(10, 11, 12, 13)))
+	must.NoError(t, p.Reserve("new", coreset(10, 11, 12, 13)))
+	must.FileContains(t, p.sharePath, "14-19")
+	must.FileContains(t, p.reservePath, "10-13")
+
+	// stopping the old alloc must not take the cores away from the new one
+	must.NoError(t, p.Release("old"))
+	must.FileContains(t, p.sharePath, "14-19")
+	must.FileContains(t, p.reservePath, "10-13")
+
+	must.NoError(t, p.Release("new"))
+	must.FileContains(t, p.sharePath, "10-19")
+	must.FileContains(t, p.reservePath, "")
+}
+
+func TestPartition_Release_partialOverlap(t *testing.T) {
+	p := testPartition(t)
+
+	must.NoError(t, p.Reserve("a", coreset(10, 11, 12)))
+	must.NoError(t, p.Reserve("b", coreset(12, 13, 14)))
+	must.FileContains(t, p.sharePath, "15-19")
+	must.FileContains(t, p.reservePath, "10-14")
+
+	// only the cores held by no other alloc go back to the share
+	must.NoError(t, p.Release("a"))
+	must.FileContains(t, p.sharePath, "10-11,15-19")
+	must.FileContains(t, p.reservePath, "12-14")
+}
+
+func TestPartition_Release_withoutReserve(t *testing.T) {
+	p := testPartition(t)
+
+	must.NoError(t, p.Reserve("a", coreset(10, 11)))
+
+	// an earlier prerun hook failing means postrun runs without a matching
+	// reserve; the cores of other allocs must be untouched
+	must.NoError(t, p.Release("b"))
+	must.FileContains(t, p.sharePath, "12-19")
+	must.FileContains(t, p.reservePath, "10-11")
+}
+
+func TestPartition_write_error(t *testing.T) {
+	p := testPartition(t)
+	p.reservePath = filepath.Join(t.TempDir(), "missing", "cpuset.cpus")
+
+	// errors other than ENOSPC on an empty set are returned
+	err := p.Reserve("a", coreset(10))
+	must.ErrorContains(t, err, "unable to update reserve cpuset")
+	must.ErrorContains(t, err, p.reservePath)
+
+	err = p.Release("a")
+	must.ErrorContains(t, err, "unable to update reserve cpuset")
 }


### PR DESCRIPTION
The cpuset partition manager keeps the reserve and share cpusets as two plain sets of cores. `Reserve` adds an allocation's cores to the reserve set and `Release` removes them again. This bookkeeping breaks whenever the calls are not perfectly paired:

- **Overlapping reservations.** The scheduler treats an allocation with `DesiredStatus = stop` as freed before the client has finished stopping it, so a replacement can be placed on the same cores while the old allocation is still running. When the old allocation stops, its `Release` removes cores the new allocation still holds.
- **Release without a matching Reserve.** When a prerun hook that runs before `cpuparts_hook` fails, the alloc runner still runs every postrun hook, so `Release` runs for cores that were never reserved by that allocation and may be held by another.

In both cases Nomad ends up writing a reserve cpuset that is smaller than the set of cores live tasks are still pinned to. When the last reservation goes, that write is an empty cpuset on a cgroup that still has tasks in it. The kernel refuses that, the hook fails, and because every `Reserve`/`Release` rewrites both files, every allocation on the node fails in `cpuparts_hook` until the lingering task exits.

```
pre-run hook "cpuparts_hook" failed: cgroupslib: unable to update reserve cpuset with " ": write /sys/fs/cgroup/nomad.slice/reserve.slice/cpuset.cpus: no space left on device
```

This PR:

1. Tracks cgroup reservations by allocation ID: 

   The reserve cpuset is the union of every live allocation's cores and the share cpuset is what remains of the usable cores. Releasing an allocation only returns cores no other allocation holds. Reserving twice for the same allocation is idempotent.

2. And tolerates `ENOSPC` when the desired cgroup is empty:

   That is the one write the kernel can refuse for a populated cgroup, and it can still happen with correct tracking when a task lingers after its allocation was released, or when all usable cores are reserved while a `cpu`-resource task is still stopping. Keeping the previous cpuset is no less exclusive than the empty cpuset would have been, and the next write sets it once the set is non-empty again. Previously that write failed the allocation being started or stopped.

### Testing & Reproduction steps

Unit tests in cover the previous behaviour plus the two failure modes above.

To reproduce the original failure on a cgroups v2 client without this patch:

   run a job with `resources { cores = N }`, then submit an update that forces a replacement onto the same node (the replacement is often placed on the same cores while the old allocation is still stopping). Once the old allocation finishes, `reserve.slice/cpuset.cpus` is written as empty while the new allocation's task is in it, and every subsequent allocation on the node fails with the error above.

### Links

- Fixes #23405
- Fixes #23965 (same bug, `EBUSY` on cgroups v1)
- Related: #24297, #24304

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

  Claude Code was used to trace the failure from the kernel `ENOSPC` path and for the tests. The author reviewed and takes responsibility for every line.

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.
