### PR TITLE
client: fix nil pointer dereference when getting client allocs

### DIFF
--- a/.changelog/28522.txt
+++ b/.changelog/28522.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+client: fixes possible nil pointer dereference when getting client allocations
+```

--- a/nomad/alloc_endpoint.go
+++ b/nomad/alloc_endpoint.go
@@ -203,7 +203,7 @@ func (a *Alloc) GetAllocs(args *structs.AllocsGetRequest,
 	defer metrics.MeasureSince([]string{"nomad", "alloc", "get_allocs"}, time.Now())
 
 	// The *maximum* we'll return is the number requested.
-	allocs := make([]*structs.Allocation, len(args.AllocIDs))
+	allocs := make([]*structs.Allocation, 0, len(args.AllocIDs))
 
 	// Setup the blocking query. We wait for at least one of the requested
 	// allocations to be above the min query index. This guarantees that the
@@ -215,7 +215,7 @@ func (a *Alloc) GetAllocs(args *structs.AllocsGetRequest,
 			// Lookup the allocation
 			thresholdMet := false
 			maxIndex := uint64(0)
-			for i, alloc := range args.AllocIDs {
+			for _, alloc := range args.AllocIDs {
 				out, err := state.AllocByID(ws, alloc)
 				if err != nil {
 					return err
@@ -239,7 +239,7 @@ func (a *Alloc) GetAllocs(args *structs.AllocsGetRequest,
 				}
 
 				// Store the pointer
-				allocs[i] = out
+				allocs = append(allocs, out)
 
 				// Check if we have passed the minimum index
 				if out.ModifyIndex > args.QueryOptions.MinQueryIndex {

--- a/nomad/structs/alloc.go
+++ b/nomad/structs/alloc.go
@@ -289,6 +289,10 @@ func (a *Allocation) CopySkipJob() *Allocation {
 // Allocations or receiving Allocations from Nomad agents potentially on an
 // older version of Nomad.
 func (a *Allocation) Canonicalize() {
+	if a == nil {
+		return
+	}
+
 	if a.AllocatedResources == nil && a.TaskResources != nil {
 		ar := AllocatedResources{}
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes introduce better nil allocation pointer handling in the client and `Alloc.GetAllocs` RPC endpoint.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->
Fixes: https://github.com/hashicorp/nomad/issues/28517

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
