### PR TITLE
testing: fix panic in fuzzy search test

### DIFF
--- a/nomad/search_endpoint_test.go
+++ b/nomad/search_endpoint_test.go
@@ -2591,6 +2591,9 @@ func TestSearch_FuzzySearch_Job(t *testing.T) {
 			},
 		}},
 	}}
+	// we added partial Task objects, so ensure they're canonicalized manually
+	// for anything that might read them in the agent, like reporting
+	job.Canonicalize()
 
 	ns := mock.Namespace()
 	ns.Name = job.Namespace


### PR DESCRIPTION
In one of our search endpoint tests, we mutate the job in such a way that its tasks have nil `Resource` blocks. In the Enterprise code base we have Census reporting, which runs async during server startup. It's possible for this to come up just slowly enough that we've written this invalid job to state first and then tried to do reporting on it. This results in a nil pointer panic when we count devices.

Canonicalize the job before writing it to the state store, as we would if it were coming in via RPC.

Fixes: https://hashicorp.atlassian.net/browse/NMD-1671

### Contributor Checklist
- [x] **Changelog Entry** test-only code
- [x] **Testing** test-only code
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
