### PR TITLE
e2e: Fix template path test due to change in secrets reading.

### DIFF
--- a/e2e/consultemplate/consultemplate_test.go
+++ b/e2e/consultemplate/consultemplate_test.go
@@ -4,6 +4,7 @@
 package consultemplate
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -233,14 +234,23 @@ func TestTemplatePathInterpolation_Ok(t *testing.T) {
 	t.Cleanup(cleanupJob)
 	allocID := submission.AllocID("template-paths")
 
-	mustWaitTemplateRender(t, allocID, "task/secrets/foo/dst",
-		func(out string) error {
-			if len(out) == 0 {
-				return fmt.Errorf("expected file to have contents")
+	// Ensure we are not able to read the secrets file from the alloc FS
+	// command.
+	must.Wait(t, wait.InitialSuccess(
+		wait.ErrorFunc(func() error {
+			_, err := e2eutil.Command("nomad", "alloc", "fs", allocID, "task/secrets/foo/dst")
+			if err == nil {
+				return errors.New("expected an error, got nil")
 			}
-			return nil
-		},
-		time.Second*10)
+
+			if strings.Contains(err.Error(), "Reading secret file prohibited") {
+				return nil
+			}
+			return fmt.Errorf("unexpected error: %v", err)
+		}),
+		wait.Gap(time.Millisecond*500),
+		wait.Timeout(5*time.Second),
+	))
 
 	mustWaitTemplateRender(t, allocID, "alloc/shared.txt",
 		func(out string) error {


### PR DESCRIPTION
PR#28468 updated the guards around the allocations FS capabilities meaning the secrets directories are blocked. This change breaks an existing e2e test which therefore needs updating.

### Testing
Tested on a local Linux VM with 2.0.6:
```console
❯ go test -v -run TestTemplatePathInterpolation_Ok
=== RUN   TestTemplatePathInterpolation_Ok
    consultemplate_test.go:233: submitting job: "./input/template_paths.nomad"
--- PASS: TestTemplatePathInterpolation_Ok (15.26s)
PASS
ok      github.com/hashicorp/nomad/e2e/consultemplate   15.698s
```

### Links
#28468

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [x] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [x] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.

