### PR TITLE
ui: invalid list markup in task group parent component

### DIFF
--- a/ui/app/components/exec/task-group-parent.hbs
+++ b/ui/app/components/exec/task-group-parent.hbs
@@ -19,46 +19,48 @@
 {{#if this.isOpen}}
   <ul class="task-list">
     {{#each this.sortedTasks as |task|}}
-      {{#if this.shouldOpenInNewWindow}}
-        <a
-          {{on
-            "click"
-            (fn this.openInNewWindow this.taskGroup.job this.taskGroup task)
-          }}
-          href="#"
-          class="task-item"
-          data-test-task
-        >
-          <Exec::TaskContents
-            @task={{task}}
-            @active={{and
-              this.currentRouteIsThisTaskGroup
-              (eq task.name this.activeTaskName)
+      <li>
+        {{#if this.shouldOpenInNewWindow}}
+          <a
+            {{on
+              "click"
+              (fn this.openInNewWindow this.taskGroup.job this.taskGroup task)
             }}
-            @shouldOpenInNewWindow={{this.shouldOpenInNewWindow}}
-          />
-        </a>
-      {{else}}
-        <LinkTo
-          @route="exec.task-group.task"
-          @models={{array
-            this.taskGroup.job.plainId
-            this.taskGroup.name
-            task.name
-          }}
-          class="task-item"
-          data-test-task={{true}}
-        >
-          <Exec::TaskContents
-            @task={{task}}
-            @active={{and
-              this.currentRouteIsThisTaskGroup
-              (eq task.name this.activeTaskName)
+            href="#"
+            class="task-item"
+            data-test-task
+          >
+            <Exec::TaskContents
+              @task={{task}}
+              @active={{and
+                this.currentRouteIsThisTaskGroup
+                (eq task.name this.activeTaskName)
+              }}
+              @shouldOpenInNewWindow={{this.shouldOpenInNewWindow}}
+            />
+          </a>
+        {{else}}
+          <LinkTo
+            @route="exec.task-group.task"
+            @models={{array
+              this.taskGroup.job.plainId
+              this.taskGroup.name
+              task.name
             }}
-            @shouldOpenInNewWindow={{this.shouldOpenInNewWindow}}
-          />
-        </LinkTo>
-      {{/if}}
+            class="task-item"
+            data-test-task={{true}}
+          >
+            <Exec::TaskContents
+              @task={{task}}
+              @active={{and
+                this.currentRouteIsThisTaskGroup
+                (eq task.name this.activeTaskName)
+              }}
+              @shouldOpenInNewWindow={{this.shouldOpenInNewWindow}}
+            />
+          </LinkTo>
+        {{/if}}
+      </li>
     {{/each}}
   </ul>
 {{/if}}

--- a/ui/tests/acceptance/exec-test.js
+++ b/ui/tests/acceptance/exec-test.js
@@ -50,6 +50,7 @@ module('Acceptance | exec', function (hooks) {
 
   test('it passes an accessibility audit', async function (assert) {
     await Exec.visitJob({ job: this.job.id });
+    await Exec.taskGroups[0].click();
     await a11yAudit({
       include: [['#ember-testing-container']],
       exclude: [['[disabled]']],


### PR DESCRIPTION
### Description
1. This fixes the invalid markup issue, by wrapping each element in `<ul>` with `<li>`, inside the `task-group-parent.hbs`
2. Added a click in `ui/tests/acceptance/exec-test.js`, so that the task list expands before `a11y audit` runs.

### Testing & Reproduction steps
Tested via mirage data, since only markup needed to be changed. No UI changes.

### Links
[Jira](https://hashicorp.atlassian.net/browse/NMD-1489)

### Screenshots
Attached is the screen recording-

https://github.com/user-attachments/assets/8afe9e12-359a-4c9e-8e10-6c186c371122



### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
