### PR TITLE
bjq: remove evals from queue when jobs are stopped.

### DIFF
--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -880,6 +880,19 @@ func (n *nomadFSM) handleJobDeregister(index uint64, jobID, namespace string, pu
 		return fmt.Errorf("periodicDispatcher.Remove failed: %w", err)
 	}
 
+	// Get the current job and mark it as stopped and re-insert it.
+	ws := memdb.NewWatchSet()
+	current, err := n.state.JobByIDTxn(ws, namespace, jobID, tx)
+	if err != nil {
+		return fmt.Errorf("JobByID lookup failed: %w", err)
+	}
+
+	if current == nil {
+		return fmt.Errorf("job %q in namespace %q doesn't exist to be deregistered", jobID, namespace)
+	}
+
+	n.batchQueue.Dequeue(current)
+
 	if noShutdownDelay {
 		ws := memdb.NewWatchSet()
 		allocs, err := n.state.AllocsByJob(ws, namespace, jobID, false)
@@ -909,17 +922,6 @@ func (n *nomadFSM) handleJobDeregister(index uint64, jobID, namespace string, pu
 		// doesn't ensure we clean it up properly.
 		n.state.DeletePeriodicLaunchTxn(index, namespace, jobID, tx)
 		return nil
-	}
-
-	// Get the current job and mark it as stopped and re-insert it.
-	ws := memdb.NewWatchSet()
-	current, err := n.state.JobByIDTxn(ws, namespace, jobID, tx)
-	if err != nil {
-		return fmt.Errorf("JobByID lookup failed: %w", err)
-	}
-
-	if current == nil {
-		return fmt.Errorf("job %q in namespace %q doesn't exist to be deregistered", jobID, namespace)
 	}
 
 	stopped := current.Copy()

--- a/nomad/fsm.go
+++ b/nomad/fsm.go
@@ -880,19 +880,6 @@ func (n *nomadFSM) handleJobDeregister(index uint64, jobID, namespace string, pu
 		return fmt.Errorf("periodicDispatcher.Remove failed: %w", err)
 	}
 
-	// Get the current job and mark it as stopped and re-insert it.
-	ws := memdb.NewWatchSet()
-	current, err := n.state.JobByIDTxn(ws, namespace, jobID, tx)
-	if err != nil {
-		return fmt.Errorf("JobByID lookup failed: %w", err)
-	}
-
-	if current == nil {
-		return fmt.Errorf("job %q in namespace %q doesn't exist to be deregistered", jobID, namespace)
-	}
-
-	n.batchQueue.Dequeue(current)
-
 	if noShutdownDelay {
 		ws := memdb.NewWatchSet()
 		allocs, err := n.state.AllocsByJob(ws, namespace, jobID, false)
@@ -922,6 +909,17 @@ func (n *nomadFSM) handleJobDeregister(index uint64, jobID, namespace string, pu
 		// doesn't ensure we clean it up properly.
 		n.state.DeletePeriodicLaunchTxn(index, namespace, jobID, tx)
 		return nil
+	}
+
+	// Get the current job
+	ws := memdb.NewWatchSet()
+	current, err := n.state.JobByIDTxn(ws, namespace, jobID, tx)
+	if err != nil {
+		return fmt.Errorf("JobByID lookup failed: %w", err)
+	}
+
+	if current == nil {
+		return fmt.Errorf("job %q in namespace %q doesn't exist to be deregistered", jobID, namespace)
 	}
 
 	stopped := current.Copy()

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -850,7 +850,7 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 			ID:          uuid.Generate(),
 			Namespace:   args.RequestNamespace(),
 			Priority:    priority,
-			Type:        structs.JobTypeService,
+			Type:        job.Type,
 			TriggeredBy: structs.EvalTriggerJobDeregister,
 			JobID:       args.JobID,
 			Status:      structs.EvalStatusPending,

--- a/nomad/job_endpoint.go
+++ b/nomad/job_endpoint.go
@@ -829,6 +829,22 @@ func (j *Job) Deregister(args *structs.JobDeregisterRequest, reply *structs.JobD
 	// priority even if the job was.
 	now := time.Now().UnixNano()
 
+	// During job deregistration, the original job register eval may be sitting
+	// in a batch queue. If so, we cancel it here so it can be GC'd.
+	//
+	// TODO: this functionality will move into the BQM via a closure
+	if e := j.srv.batchQueueMgr.Dequeue(job); e != nil {
+		e = e.Copy()
+		e.Status = structs.EvalStatusCancelled
+
+		_, _, err := j.srv.raftApply(structs.EvalUpdateRequestType, &structs.EvalUpdateRequest{
+			Evals: []*structs.Evaluation{e},
+		})
+		if err != nil {
+			j.logger.Error("failed to cancel batch queue evaluation")
+		}
+	}
+
 	// If the job is periodic or parameterized, we don't create an eval.
 	if !(job.IsPeriodic() || job.IsParameterized()) {
 

--- a/nomad/queues/batch_queue_manager.go
+++ b/nomad/queues/batch_queue_manager.go
@@ -91,6 +91,14 @@ func (b *BatchQueueManager) Enqueue(e *structs.Evaluation) {
 	q.Enqueue(e, job)
 }
 
+func (b *BatchQueueManager) Dequeue(job *structs.Job) {
+	q, ok := b.queues[job.NodePool]
+	if !ok {
+		return
+	}
+	q.Dequeue(job)
+}
+
 // SetEnabled is called during leadership transfers and is responsible for starting
 // and stopping queues.
 func (b *BatchQueueManager) SetEnabled(enabled bool, state *state.StateStore) {

--- a/nomad/queues/batch_queue_manager.go
+++ b/nomad/queues/batch_queue_manager.go
@@ -91,12 +91,21 @@ func (b *BatchQueueManager) Enqueue(e *structs.Evaluation) {
 	q.Enqueue(e, job)
 }
 
-func (b *BatchQueueManager) Dequeue(job *structs.Job) {
+func (b *BatchQueueManager) Dequeue(job *structs.Job) *structs.Evaluation {
+	if job == nil {
+		return nil
+	}
+
+	if !b.enabled.Load() {
+		return nil
+	}
+
 	q, ok := b.queues[job.NodePool]
 	if !ok {
-		return
+		return nil
 	}
-	q.Dequeue(job)
+
+	return q.Dequeue(job)
 }
 
 // SetEnabled is called during leadership transfers and is responsible for starting

--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -223,6 +223,14 @@ func (d *DynamicPriorityQueue) Enqueue(e *structs.Evaluation, j *structs.Job) {
 	d.enqueueCh <- w
 }
 
+func (d *DynamicPriorityQueue) Dequeue(j *structs.Job) {
+	wl := d.queue.Remove(j)
+
+	if wl != nil {
+		d.evalBroker.Enqueue(wl.GetEval())
+	}
+}
+
 // runProducer pushes workloads onto the queue and notifies the consumer
 // goroutine. It also updates priorities on the configured interval.
 func (d *DynamicPriorityQueue) runProducer(ctx context.Context) {

--- a/nomad/queues/dynamic_priority/queue.go
+++ b/nomad/queues/dynamic_priority/queue.go
@@ -223,12 +223,14 @@ func (d *DynamicPriorityQueue) Enqueue(e *structs.Evaluation, j *structs.Job) {
 	d.enqueueCh <- w
 }
 
-func (d *DynamicPriorityQueue) Dequeue(j *structs.Job) {
+func (d *DynamicPriorityQueue) Dequeue(j *structs.Job) *structs.Evaluation {
 	wl := d.queue.Remove(j)
 
 	if wl != nil {
-		d.evalBroker.Enqueue(wl.GetEval())
+		return wl.GetEval()
 	}
+
+	return nil
 }
 
 // runProducer pushes workloads onto the queue and notifies the consumer

--- a/nomad/queues/fifo/queue.go
+++ b/nomad/queues/fifo/queue.go
@@ -67,12 +67,14 @@ func (f *FifoQueue) Enqueue(e *structs.Evaluation, _ *structs.Job) {
 	f.enqueueCh <- newFifoWorkload(e)
 }
 
-func (f *FifoQueue) Dequeue(j *structs.Job) {
+func (f *FifoQueue) Dequeue(j *structs.Job) *structs.Evaluation {
 	wl := f.queue.Remove(j)
 
 	if wl != nil {
-		f.evalBroker.Enqueue(wl.GetEval())
+		return wl.GetEval()
 	}
+
+	return nil
 }
 
 func (f *FifoQueue) Start(ctx context.Context) error {

--- a/nomad/queues/fifo/queue.go
+++ b/nomad/queues/fifo/queue.go
@@ -67,6 +67,14 @@ func (f *FifoQueue) Enqueue(e *structs.Evaluation, _ *structs.Job) {
 	f.enqueueCh <- newFifoWorkload(e)
 }
 
+func (f *FifoQueue) Dequeue(j *structs.Job) {
+	wl := f.queue.Remove(j)
+
+	if wl != nil {
+		f.evalBroker.Enqueue(wl.GetEval())
+	}
+}
+
 func (f *FifoQueue) Start(ctx context.Context) error {
 	rCtx, cancel := context.WithCancel(ctx)
 	f.cancel = cancel

--- a/nomad/queues/passthrough/queue.go
+++ b/nomad/queues/passthrough/queue.go
@@ -33,7 +33,7 @@ func (p *PassthroughQueue) Stop() {}
 
 func (p *PassthroughQueue) Enqueue(e *structs.Evaluation, _ *structs.Job) { p.evalBroker.Enqueue(e) }
 
-func (p *PassthroughQueue) Dequeue(*structs.Job) {}
+func (p *PassthroughQueue) Dequeue(*structs.Job) *structs.Evaluation { return nil }
 
 func (p *PassthroughQueue) Jobs(structs.SortOrder) *queue.WorkloadIter {
 	return &queue.WorkloadIter{}

--- a/nomad/queues/passthrough/queue.go
+++ b/nomad/queues/passthrough/queue.go
@@ -33,6 +33,8 @@ func (p *PassthroughQueue) Stop() {}
 
 func (p *PassthroughQueue) Enqueue(e *structs.Evaluation, _ *structs.Job) { p.evalBroker.Enqueue(e) }
 
+func (p *PassthroughQueue) Dequeue(*structs.Job) {}
+
 func (p *PassthroughQueue) Jobs(structs.SortOrder) *queue.WorkloadIter {
 	return &queue.WorkloadIter{}
 }

--- a/nomad/queues/queue/interface.go
+++ b/nomad/queues/queue/interface.go
@@ -13,7 +13,7 @@ type Queue interface {
 	Start(context.Context) error
 	Stop()
 	Enqueue(*structs.Evaluation, *structs.Job)
-	Dequeue(*structs.Job)
+	Dequeue(*structs.Job) *structs.Evaluation
 	Jobs(structs.SortOrder) *WorkloadIter
 	Tenants() structs.QueueTenantsResponse
 	Type() structs.BatchQueueType

--- a/nomad/queues/queue/interface.go
+++ b/nomad/queues/queue/interface.go
@@ -13,6 +13,7 @@ type Queue interface {
 	Start(context.Context) error
 	Stop()
 	Enqueue(*structs.Evaluation, *structs.Job)
+	Dequeue(*structs.Job)
 	Jobs(structs.SortOrder) *WorkloadIter
 	Tenants() structs.QueueTenantsResponse
 	Type() structs.BatchQueueType

--- a/nomad/queues/queue/workload_queue.go
+++ b/nomad/queues/queue/workload_queue.go
@@ -7,19 +7,34 @@ import (
 	"sync"
 
 	"github.com/hashicorp/go-set/v3"
+	"github.com/hashicorp/nomad/nomad/structs"
 )
 
 // A WorkloadQueue implements heap.Interface and holds *Workload.
 type WorkloadQueue struct {
+	// sortFn is the function used to compare workloads in the treeset. It is stored
+	// in order to easily create a new treeset during UpdateAll.
 	sortFn func(i, j Workload) int
-	ts     *set.TreeSet[Workload]
-	mux    *sync.Mutex
+
+	// ts is the underlying datastructure for storing workloads.
+	ts *set.TreeSet[Workload]
+
+	// wl is a k/v store of workloads used to remove or check or existence
+	// of a workload via it's namespaced JobID
+	//
+	// TODO: Golang maps never shrink capacity, maybe need to recreate this
+	// when the queue shrinks
+	wl map[structs.NamespacedID]Workload
+
+	// mux is the lock for the queue, making it safe for concurrent access.
+	mux *sync.Mutex
 }
 
 func NewWorkloadQueue(sortFn func(i, j Workload) int) WorkloadQueue {
 	return WorkloadQueue{
 		sortFn: sortFn,
 		ts:     set.NewTreeSet(sortFn),
+		wl:     map[structs.NamespacedID]Workload{},
 		mux:    &sync.Mutex{},
 	}
 }
@@ -34,6 +49,10 @@ func (pq WorkloadQueue) Len() int {
 func (pq *WorkloadQueue) Push(w Workload) {
 	pq.mux.Lock()
 	defer pq.mux.Unlock()
+
+	e := w.GetEval()
+
+	pq.wl[structs.NewNamespacedID(e.JobID, e.Namespace)] = w
 
 	pq.ts.Insert(w)
 }
@@ -73,4 +92,17 @@ func (pq *WorkloadQueue) Iterate(fn func(Workload)) {
 	for w := range pq.ts.Items() {
 		fn(w)
 	}
+}
+
+func (pq *WorkloadQueue) Remove(j *structs.Job) Workload {
+	pq.mux.Lock()
+	defer pq.mux.Unlock()
+
+	if wl, ok := pq.wl[j.NamespacedID()]; ok {
+		pq.ts.Remove(wl)
+		delete(pq.wl, j.NamespacedID())
+		return wl
+	}
+
+	return nil
 }

--- a/nomad/queues/testing.go
+++ b/nomad/queues/testing.go
@@ -38,8 +38,10 @@ func (m *MockQueue) Enqueue(e *structs.Evaluation, j *structs.Job) {
 	m.Called(e, j)
 }
 
-func (m *MockQueue) Dequeue(j *structs.Job) {
-	m.Called(j)
+func (m *MockQueue) Dequeue(j *structs.Job) *structs.Evaluation {
+	args := m.Called(j)
+
+	return args.Get(0).(*structs.Evaluation)
 }
 
 func (m *MockQueue) Jobs(sortOrder structs.SortOrder) *queue.WorkloadIter {

--- a/nomad/queues/testing.go
+++ b/nomad/queues/testing.go
@@ -38,6 +38,10 @@ func (m *MockQueue) Enqueue(e *structs.Evaluation, j *structs.Job) {
 	m.Called(e, j)
 }
 
+func (m *MockQueue) Dequeue(j *structs.Job) {
+	m.Called(j)
+}
+
 func (m *MockQueue) Jobs(sortOrder structs.SortOrder) *queue.WorkloadIter {
 	args := m.Called(sortOrder)
 


### PR DESCRIPTION
### Description
<!-- Please describe why you're making this change and point out any important details the reviewers
should be aware of.-->
These changes add the ability for for queues to dequeue jobs/evaluations from a queue when jobs are deregistered. The Nomad scheduler always handled this gracefully but this change provides a better UX for the queues.

### Testing & Reproduction steps
<!--
* In the case of bugs, please describe how to reproduce it.
* If any manual tests were done, document the steps and the conditions to reproduce them.
-->

### Links
<!--
Please include links to GitHub issues, documentation, or similar which is relevant to this PR. If
this is a bug fix, please ensure related issues are linked so they will close when this PR is
merged.
-->

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
