### PR TITLE
api: fix detection of no body on requests

### DIFF
--- a/.changelog/28541.txt
+++ b/.changelog/28541.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+api: Fix job statuses error when request body is empty using HTTP2
+```

--- a/command/agent/alloc_endpoint.go
+++ b/command/agent/alloc_endpoint.go
@@ -295,8 +295,7 @@ func (s *HTTPServer) allocRestart(allocID string, resp http.ResponseWriter, req 
 		TaskName string
 		AllTasks bool
 	}
-	err := json.NewDecoder(req.Body).Decode(&reqBody)
-	if err != nil && err != io.EOF {
+	if err := decodeBody(req, &reqBody); err != nil && !errors.Is(err, errNoBody) {
 		return nil, err
 	}
 	if reqBody.TaskName != "" {
@@ -459,8 +458,7 @@ func (s *HTTPServer) allocPauseSet(allocID string, resp http.ResponseWriter, req
 		Task          string
 		ScheduleState string
 	}
-	err := json.NewDecoder(req.Body).Decode(&reqBody)
-	if err != nil && err != io.EOF {
+	if err := decodeBody(req, &reqBody); err != nil && !errors.Is(err, errNoBody) {
 		return nil, err
 	}
 	args.Task = reqBody.Task

--- a/command/agent/alloc_endpoint_test.go
+++ b/command/agent/alloc_endpoint_test.go
@@ -261,7 +261,6 @@ func TestHTTP_AllocQuery_Payload(t *testing.T) {
 
 func TestHTTP_AllocRestart(t *testing.T) {
 	ci.Parallel(t)
-	require := require.New(t)
 
 	// Validates that all methods of forwarding the request are processed correctly
 	httpTest(t, nil, func(s *TestAgent) {
@@ -270,15 +269,42 @@ func TestHTTP_AllocRestart(t *testing.T) {
 			// Make the HTTP request
 			buf := encodeReq(map[string]string{})
 			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
-			if err != nil {
-				t.Fatalf("err: %v", err)
-			}
-			respW := httptest.NewRecorder()
+			must.NoError(t, err)
 
 			// Make the request
+			respW := httptest.NewRecorder()
 			_, err = s.Server.ClientAllocRequest(respW, req)
-			require.NotNil(err)
-			require.True(structs.IsErrUnknownAllocation(err))
+			must.Error(t, err)
+			must.True(t, structs.IsErrUnknownAllocation(err))
+		}
+
+		// Local node, local resp, empty body
+		{
+			// Make the HTTP request
+			body := io.NopCloser(strings.NewReader(""))
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), body)
+			must.NoError(t, err)
+			req.Body = body
+
+			// Make the request
+			respW := httptest.NewRecorder()
+			_, err = s.Server.ClientAllocRequest(respW, req)
+			must.Error(t, err)
+			must.True(t, structs.IsErrUnknownAllocation(err))
+		}
+
+		// Local node, local resp, empty body with http.NoBody
+		{
+			// Make the HTTP request
+			body := http.NoBody
+			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), body)
+			must.NoError(t, err)
+
+			// Make the request
+			respW := httptest.NewRecorder()
+			_, err = s.Server.ClientAllocRequest(respW, req)
+			must.Error(t, err)
+			must.True(t, structs.IsErrUnknownAllocation(err))
 		}
 
 		// Local node, server resp
@@ -288,12 +314,12 @@ func TestHTTP_AllocRestart(t *testing.T) {
 
 			buf := encodeReq(map[string]string{})
 			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
-			require.Nil(err)
+			must.NoError(t, err)
 
 			respW := httptest.NewRecorder()
 			_, err = s.Server.ClientAllocRequest(respW, req)
-			require.NotNil(err)
-			require.True(structs.IsErrUnknownAllocation(err))
+			must.Error(t, err)
+			must.True(t, structs.IsErrUnknownAllocation(err))
 
 			s.server = srv
 		}
@@ -315,12 +341,12 @@ func TestHTTP_AllocRestart(t *testing.T) {
 
 			buf := encodeReq(map[string]string{})
 			req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/v1/client/allocation/%s/restart", uuid.Generate()), buf)
-			require.Nil(err)
+			must.NoError(t, err)
 
 			respW := httptest.NewRecorder()
 			_, err = s.Server.ClientAllocRequest(respW, req)
-			require.NotNil(err)
-			require.True(structs.IsErrUnknownAllocation(err))
+			must.Error(t, err)
+			must.True(t, structs.IsErrUnknownAllocation(err))
 
 			s.client = c
 		}
@@ -859,6 +885,152 @@ func TestHTTP_AllocSnapshot_Atomic(t *testing.T) {
 			t.Fatalf("marker file %s empty", markerContents)
 		} else {
 			t.Logf("EXPECTED snapshot error: %s", markerContents)
+		}
+	})
+}
+
+func TestHTTP_AllocPause(t *testing.T) {
+	ci.Parallel(t)
+	path := fmt.Sprintf("/v1/client/allocation/%s/pause", uuid.Generate())
+
+	t.Run("Set", func(t *testing.T) {
+		ci.Parallel(t)
+
+		testCases := []struct {
+			name   string
+			body   io.ReadCloser
+			before func(*TestAgent) func()
+			err    string
+		}{
+			{
+				name: "empty body",
+				body: http.NoBody,
+				err:  "Not a valid task schedule state",
+			},
+			{
+				name: "empty reader",
+				body: io.NopCloser(strings.NewReader("")),
+				err:  "Not a valid task schedule state",
+			},
+			{
+				name: "local node, local response",
+				body: encodeReq(map[string]string{"ScheduleState": "pause"}),
+			},
+			{
+				name: "local node, server response",
+				body: encodeReq(map[string]string{"ScheduleState": "pause"}),
+				before: func(agent *TestAgent) func() {
+					s := agent.server
+					agent.server = nil
+					return func() { agent.server = s }
+				},
+			},
+			{
+				name: "no client, server resp",
+				body: encodeReq(map[string]string{"ScheduleState": "pause"}),
+				before: func(agent *TestAgent) func() {
+					c := agent.client
+					agent.client = nil
+
+					testutil.WaitForResult(func() (bool, error) {
+						n, err := agent.server.State().NodeByID(nil, c.NodeID())
+						if err != nil {
+							return false, err
+						}
+						return n != nil, nil
+					}, func(err error) {
+						t.Fatalf("should have client: %v", err)
+					})
+
+					return func() { agent.client = c }
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			httpTest(t, nil, func(s *TestAgent) {
+				t.Run(tc.name, func(t *testing.T) {
+					if tc.before != nil {
+						if cleanup := tc.before(s); cleanup != nil {
+							t.Cleanup(cleanup)
+						}
+					}
+					req, err := http.NewRequest(http.MethodPost, path, tc.body)
+					must.NoError(t, err)
+					req.Body = tc.body // ensure the test case defined value is set.
+
+					respW := httptest.NewRecorder()
+					_, err = s.Server.ClientAllocRequest(respW, req)
+					must.Error(t, err)
+					if tc.err != "" {
+						must.ErrorContains(t, err, tc.err)
+					} else {
+						must.True(t, structs.IsErrUnknownAllocation(err),
+							must.Sprintf("expecting ErrUnknownAllocation, got %v", err))
+					}
+				})
+			})
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		ci.Parallel(t)
+
+		testCases := []struct {
+			name   string
+			body   io.ReadCloser
+			before func(*TestAgent) func()
+		}{
+			{
+				name: "local node, local response",
+			},
+			{
+				name: "local node, server response",
+				before: func(agent *TestAgent) func() {
+					s := agent.server
+					agent.server = nil
+					return func() { agent.server = s }
+				},
+			},
+			{
+				name: "no client, server resp",
+				before: func(agent *TestAgent) func() {
+					c := agent.client
+					agent.client = nil
+
+					testutil.WaitForResult(func() (bool, error) {
+						n, err := agent.server.State().NodeByID(nil, c.NodeID())
+						if err != nil {
+							return false, err
+						}
+						return n != nil, nil
+					}, func(err error) {
+						t.Fatalf("should have client: %v", err)
+					})
+
+					return func() { agent.client = c }
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			httpTest(t, nil, func(s *TestAgent) {
+				t.Run(tc.name, func(t *testing.T) {
+					if tc.before != nil {
+						if cleanup := tc.before(s); cleanup != nil {
+							t.Cleanup(cleanup)
+						}
+					}
+					req, err := http.NewRequest(http.MethodGet, path, tc.body)
+					must.NoError(t, err)
+
+					respW := httptest.NewRecorder()
+					_, err = s.Server.ClientAllocRequest(respW, req)
+					must.Error(t, err)
+					must.True(t, structs.IsErrUnknownAllocation(err),
+						must.Sprintf("expecting ErrUnknownAllocation, got %v", err))
+				})
+			})
 		}
 	})
 }

--- a/command/agent/http.go
+++ b/command/agent/http.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/pprof"
@@ -86,6 +87,9 @@ var (
 			AllowCredentials: true,
 		})
 	}
+
+	// errNoBody is used during decoding when a request body is empty.
+	errNoBody = errors.New("Request body is empty")
 )
 
 type handlerFn func(resp http.ResponseWriter, req *http.Request) (any, error)
@@ -905,15 +909,34 @@ func isAPIClientError(code int) bool {
 	return 400 <= code && code <= 499
 }
 
-// decodeBody is used to decode a JSON request body
+// decodeBody is used to decode a JSON request body. If
+// the request does not contain a body, errNoBody will
+// be returned.
 func decodeBody(req *http.Request, out any) error {
-
-	if req.Body == http.NoBody {
-		return errors.New("Request body is empty")
+	// For HTTP/1 requests, an empty body can be set
+	// to the http.NoBody value, so check for that.
+	if req.Body == nil || req.Body == http.NoBody {
+		return errNoBody
 	}
 
 	dec := json.NewDecoder(req.Body)
-	return dec.Decode(&out)
+	err := dec.Decode(&out)
+
+	// If the decoding was successful, just return.
+	if err == nil {
+		return nil
+	}
+
+	// If the body was empty (either 0 bytes read or
+	// only whitespace read) then an EOF error will
+	// be returned. This will be the case for HTTP/2
+	// requests which set an empty reader.
+	if errors.Is(err, io.EOF) {
+		return errNoBody
+	}
+
+	// Return the actual decoding error encountered.
+	return err
 }
 
 // setIndex is used to set the index response header

--- a/command/agent/http_test.go
+++ b/command/agent/http_test.go
@@ -1689,8 +1689,18 @@ func Test_decodeBody(t *testing.T) {
 	}{
 		{
 			inputReq:      &http.Request{Body: http.NoBody},
-			expectedError: errors.New("Request body is empty"),
+			expectedError: errNoBody,
 			name:          "empty input request body",
+		},
+		{
+			inputReq:      &http.Request{Body: io.NopCloser(strings.NewReader(""))},
+			expectedError: errNoBody,
+			name:          "empty input request body - http2", // uses an empty reader instead of http.NoBody
+		},
+		{
+			inputReq:      &http.Request{},
+			expectedError: errNoBody,
+			name:          "nil input request body",
 		},
 		{
 			inputReq: &http.Request{Body: io.NopCloser(strings.NewReader(`{"foo":"bar"}`))},
@@ -1703,13 +1713,24 @@ func Test_decodeBody(t *testing.T) {
 			expectedError: nil,
 			name:          "populated request body and correct out",
 		},
+		{
+			inputReq: &http.Request{Body: io.NopCloser(strings.NewReader(`{"foo":"bar`))},
+			inputOut: &struct {
+				Foo string `json:"foo"`
+			}{},
+			expectedError: io.ErrUnexpectedEOF,
+			name:          "invalid JSON body content",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			actualError := decodeBody(tc.inputReq, tc.inputOut)
-			assert.Equal(t, tc.expectedError, actualError, tc.name)
-			assert.Equal(t, tc.expectedOut, tc.inputOut, tc.name)
+			if tc.expectedError != nil {
+				must.ErrorIs(t, tc.expectedError, actualError)
+				return
+			}
+			must.Eq(t, tc.expectedOut, tc.inputOut)
 		})
 	}
 }

--- a/command/agent/job_endpoint_statuses.go
+++ b/command/agent/job_endpoint_statuses.go
@@ -6,7 +6,6 @@ package agent
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/hashicorp/nomad/api"
@@ -37,14 +36,13 @@ func (s *HTTPServer) JobStatusesRequest(resp http.ResponseWriter, req *http.Requ
 
 	// ostensibly GETs should not accept structured body, but the HTTP spec
 	// on this is more what you'd call "guidelines" than actual rules.
-	if req.Body != nil && req.Body != http.NoBody {
-		var in api.JobStatusesRequest
-		// HTTP2 requests without a body do not assign NoBody, so check for an
-		// EOF error if an error is returned.
-		if err := decodeBody(req, &in); err != nil && !errors.Is(err, io.EOF) {
-			return nil, CodedError(http.StatusBadRequest, fmt.Sprintf("error decoding request: %v", err))
-		}
+	var in api.JobStatusesRequest
 
+	// attempt to decode the body. if the request does not have a body, do
+	// not attempt to inspect it.
+	if err := decodeBody(req, &in); err != nil && !errors.Is(err, errNoBody) {
+		return nil, CodedError(http.StatusBadRequest, fmt.Sprintf("error decoding request: %v", err))
+	} else if !errors.Is(err, errNoBody) {
 		if len(in.Jobs) == 0 {
 			return nil, CodedError(http.StatusBadRequest, "no jobs in request")
 		}

--- a/command/agent/job_endpoint_statuses_test.go
+++ b/command/agent/job_endpoint_statuses_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -55,16 +56,30 @@ func TestJobEndpoint_Statuses(t *testing.T) {
 					WriteRequest: structs.WriteRequest{Region: "global"},
 				}, &structs.GenericResponse{}))
 		}
-		buildRequest := func(t *testing.T, method, url, body string) *http.Request {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-			t.Cleanup(cancel)
-			var reqBody io.Reader = http.NoBody
-			if body != "" {
-				reqBody = bytes.NewReader([]byte(body))
+		buildRequest := func(t *testing.T, method, url, body string) []*http.Request {
+			// Always create the body even if it is empty to test HTTP/2 parsed requests.
+			bodies := []io.ReadCloser{io.NopCloser(bytes.NewReader([]byte(body)))}
+			if body == "" {
+				// If the body is empty, add an http.NoBody to test HTTP/1
+				bodies = append(bodies, http.NoBody)
 			}
-			req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
-			must.NoError(t, err)
-			return req
+
+			reqs := make([]*http.Request, len(bodies))
+			for i, reqBody := range bodies {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+				t.Cleanup(cancel)
+				req, err := http.NewRequestWithContext(ctx, method, url, reqBody)
+				must.NoError(t, err)
+				// When building the request, if the content length is 0 the body will
+				// be set to http.NoBody. Because HTTP/2 does not do this, check if
+				// the original body was an http.NoBody. If it wasn't, set it to the
+				// original.
+				if body == "" && reqBody != http.NoBody {
+					req.Body = reqBody
+				}
+				reqs[i] = req
+			}
+			return reqs
 		}
 
 		// note: this api will return jobs ordered by ModifyIndex,
@@ -198,48 +213,54 @@ func TestJobEndpoint_Statuses(t *testing.T) {
 					tc.expectCode = 200
 				}
 
-				req := buildRequest(t, tc.method, apiPath+tc.params, tc.body)
-				recorder := httptest.NewRecorder()
+				reqs := buildRequest(t, tc.method, apiPath+tc.params, tc.body)
 
-				// method under test!
-				raw, err := s.Server.JobStatusesRequest(recorder, req)
+				for i, req := range reqs {
+					t.Run(fmt.Sprintf("req#%d", i), func(t *testing.T) {
 
-				// sad path
-				if tc.expectErr != "" {
-					must.ErrorContains(t, err, tc.expectErr)
-					var coded *codedError
-					must.True(t, errors.As(err, &coded))
-					must.Eq(t, tc.expectCode, coded.code)
+						recorder := httptest.NewRecorder()
 
-					must.Nil(t, raw)
-					return
-				}
+						// method under test!
+						raw, err := s.Server.JobStatusesRequest(recorder, req)
 
-				// happy path
-				must.NoError(t, err)
-				result := recorder.Result()
-				must.Eq(t, tc.expectCode, result.StatusCode)
+						// sad path
+						if tc.expectErr != "" {
+							must.ErrorContains(t, err, tc.expectErr)
+							var coded *codedError
+							must.True(t, errors.As(err, &coded))
+							must.Eq(t, tc.expectCode, coded.code)
 
-				// check response body
-				jobs := raw.([]structs.JobStatusesJob)
-				gotIDs := make([]string, len(jobs))
-				for i, j := range jobs {
-					gotIDs[i] = j.ID
-				}
-				must.Eq(t, tc.expectIDs, gotIDs)
+							must.Nil(t, raw)
+							return
+						}
 
-				// check headers
-				expectHeaders := append(
-					[]string{
-						"X-Nomad-Index",
-						"X-Nomad-Lastcontact",
-						"X-Nomad-Knownleader",
-					},
-					tc.expectHeaders...,
-				)
-				for _, h := range expectHeaders {
-					test.NotEq(t, "", result.Header.Get(h),
-						test.Sprintf("expect '%s' header", h))
+						// happy path
+						must.NoError(t, err)
+						result := recorder.Result()
+						must.Eq(t, tc.expectCode, result.StatusCode)
+
+						// check response body
+						jobs := raw.([]structs.JobStatusesJob)
+						gotIDs := make([]string, len(jobs))
+						for i, j := range jobs {
+							gotIDs[i] = j.ID
+						}
+						must.Eq(t, tc.expectIDs, gotIDs)
+
+						// check headers
+						expectHeaders := append(
+							[]string{
+								"X-Nomad-Index",
+								"X-Nomad-Lastcontact",
+								"X-Nomad-Knownleader",
+							},
+							tc.expectHeaders...,
+						)
+						for _, h := range expectHeaders {
+							test.NotEq(t, "", result.Header.Get(h),
+								test.Sprintf("expect '%s' header", h))
+						}
+					})
 				}
 			})
 		}

--- a/command/agent/node_identity_endpoint.go
+++ b/command/agent/node_identity_endpoint.go
@@ -5,7 +5,6 @@ package agent
 
 import (
 	"errors"
-	"io"
 	"net/http"
 
 	"github.com/hashicorp/nomad/nomad/structs"
@@ -63,12 +62,8 @@ func (s *HTTPServer) NodeIdentityRenewRequest(resp http.ResponseWriter, req *htt
 
 	// If the request body is not empty, it is likely the caller is using this
 	// to indicate the node ID. Decode it.
-	if req.Body != nil && req.Body != http.NoBody {
-		// HTTP2 requests without a body do not assign NoBody, so check for an
-		// EOF error if an error is returned.
-		if err := decodeBody(req, &args); err != nil && !errors.Is(err, io.EOF) {
-			return nil, CodedError(http.StatusBadRequest, err.Error())
-		}
+	if err := decodeBody(req, &args); err != nil && !errors.Is(err, errNoBody) {
+		return nil, CodedError(http.StatusBadRequest, err.Error())
 	}
 
 	// Determine the handler to use

--- a/command/agent/node_identity_endpoint_test.go
+++ b/command/agent/node_identity_endpoint_test.go
@@ -4,6 +4,8 @@
 package agent
 
 import (
+	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -234,4 +236,50 @@ func TestHTTPServer_NodeIdentityRenewRequest(t *testing.T) {
 			must.True(t, ok)
 		})
 	})
+
+	t.Run("200 ok no body", func(t *testing.T) {
+
+		// Enable the client, so we have something to renew.
+		configFn := func(c *Config) { c.Client.Enabled = true }
+
+		httpTest(t, configFn, func(s *TestAgent) {
+
+			testutil.WaitForClient(t, s.RPC, s.client.NodeID(), s.config().Region)
+
+			respW := httptest.NewRecorder()
+
+			req, err := http.NewRequest(http.MethodPost, "/v1/client/identity/renew", http.NoBody)
+			must.NoError(t, err)
+
+			obj, err := s.Server.NodeIdentityRenewRequest(respW, req)
+			must.NoError(t, err)
+
+			_, ok := obj.(structs.NodeIdentityRenewResp)
+			must.True(t, ok)
+		})
+	})
+
+	t.Run("200 ok no body http2", func(t *testing.T) {
+
+		// Enable the client, so we have something to renew.
+		configFn := func(c *Config) { c.Client.Enabled = true }
+
+		httpTest(t, configFn, func(s *TestAgent) {
+
+			testutil.WaitForClient(t, s.RPC, s.client.NodeID(), s.config().Region)
+
+			respW := httptest.NewRecorder()
+
+			req, err := http.NewRequest(http.MethodPost, "/v1/client/identity/renew", http.NoBody)
+			must.NoError(t, err)
+			req.Body = io.NopCloser(bytes.NewReader([]byte{}))
+
+			obj, err := s.Server.NodeIdentityRenewRequest(respW, req)
+			must.NoError(t, err)
+
+			_, ok := obj.(structs.NodeIdentityRenewResp)
+			must.True(t, ok)
+		})
+	})
+
 }


### PR DESCRIPTION
### Description

The job statuses endpoint checks the decoding error for an EOF to ignore which allows empty request bodies with HTTP2, but fails to prevent it from then being treated as if a body exists.

Since `http.NoBody` will never be used with HTTP2, and thus always requires checking the request body and the decoding result, move the logic for determining if the request body is empty into the decode helper. If it is determined the request body is empty, it will return the `errNoBody` error which callers can use to determine if the request body is empty.

Tests which are exercising the behavior of a request with no body have been updated to use an `http.NoBody` value for the body as well as an empty `io.Reader` to ensure that both requests using HTTP1 and HTTP2 are tested.

### Testing & Reproduction steps

Tests have been added to force empty `io.Reader` request body values to simulate HTTP2 requests along side existing tests using `http.NoBody` as used by HTTP1 requests.

### Links

Fixes: #28537

### Contributor Checklist
- [ ] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [ ] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [ ] **Documentation** If the change impacts user-facing functionality such as the CLI, API, UI,
  and job configuration, please update the Nomad product documentation, which is stored in the
  [`web-unified-docs` repo](https://github.com/hashicorp/web-unified-docs/). Refer to the [`web-unified-docs` contributor guide](https://github.com/hashicorp/web-unified-docs/blob/main/CONTRIBUTING.md) for docs guidelines.
  Please also consider whether the change requires notes within the [upgrade
  guide](https://developer.hashicorp.com/nomad/docs/upgrade/upgrade-specific). If you would like help with the docs, tag the `nomad-docs` team in this PR.
- [ ] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).

### Reviewer Checklist
- [ ] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
