### PR TITLE
docker: don't use global HTTP timeout for image pulls

### DIFF
--- a/.changelog/28543.txt
+++ b/.changelog/28543.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+docker: Fixed a bug where image_pull_timeout was not respected if more than 5min
+```

--- a/drivers/docker/config.go
+++ b/drivers/docker/config.go
@@ -39,8 +39,9 @@ const (
 	// fingerprintPeriod is the interval at which the driver will send fingerprint responses
 	fingerprintPeriod = 30 * time.Second
 
-	// dockerTimeout is the length of time a request can be outstanding before
-	// it is timed out.
+	// dockerTimeout is set on the HTTP client and is the maximum length of time
+	// a request can be outstanding before it is timed out, regardless of
+	// context
 	dockerTimeout = 5 * time.Minute
 
 	// dockerAuthHelperPrefix is the prefix to attach to the credential helper
@@ -841,7 +842,10 @@ func (d *Driver) SetConfig(c *base.Config) error {
 		d.clientConfig = c.AgentConfig.Driver
 	}
 
-	dockerClient, err := d.getDockerClient()
+	// the coordinator needs to be able to pull very large images, so we don't
+	// want the default HTTP client timeout to apply and we'll only use the
+	// context from pull timeout
+	dockerClient, err := d.getInfinityClient()
 	if err != nil {
 		return fmt.Errorf("failed to get docker client: %v", err)
 	}


### PR DESCRIPTION
In #27870 we migrated to `moby/moby/client` for the `docker` driver and in doing so accidentally ended up fixing timeouts we intended to set on the HTTP client but that were ineffective. This had the further side-effect of applying those timeouts to Docker image pulls, even if `image_pull_timeout` was set to a longer duration.

Update the image pull coordinator to use the "infinity client" without a global timeout, so that we can use the `image_pull_timeout` exclusively to determine how long we wait for an image to be pulled.

Fixes: https://github.com/hashicorp/nomad/issues/28496
Ref: https://hashicorp.atlassian.net/browse/NMD-1732
Ref: https://github.com/hashicorp/nomad/pull/27870

### Testing & Reproduction steps

I set the global network timeout to 1min and ran this patch using a proxy that trickles bytes from the registry. With a 3min pull timeout I end up getting the following:

```
Recent Events:
Time                       Type            Description
2026-09-10T15:25:07-04:00  Restarting      Task restarting in 17.691747515s
2026-09-10T15:25:07-04:00  Driver Failure  Failed to pull `localhost:5000/busybox:1`: context deadline exceeded
2026-09-10T15:24:07-04:00  Driver          Docker image pull progress: Pulled 0/1 (228.4MiB/572.2MiB) layers: 0 waiting/1 pulling - est 360.6s remaining
2026-09-10T15:22:07-04:00  Driver          Docker image pull progress: Pulled 0/1 (114.2MiB/572.2MiB) layers: 0 waiting/1 pulling - est 480.6s remaining
2026-09-10T15:21:42-04:00  Driver          Downloading image
2026-09-10T15:21:42-04:00  Task Setup      Building Task Directory
2026-09-10T15:21:42-04:00  Received        Task received by client
```


### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
  * see above. Unfortunately testing this in-tree turns out to be quite a giant pile of code to maintain in lockstep with the registry, so it's value is a little rough in terms of regression testing
- [x] **Documentation** n/a
- [x] **LLM Usage** If an LLM was used to generate any code, please ensure and confirm you have read
  and followed the [AI usage guide](../contributing/ai.md).
  * used to generate the registry proxy with predictably AI-slop results, but good enough to do the test with.

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
