### PR TITLE
avoid overwriting initial namespace/node pools when federated

### DIFF
--- a/.changelog/28552.txt
+++ b/.changelog/28552.txt
@@ -1,0 +1,19 @@
+```release-note:bug
+node pools: Fixed a bug where node pools could stop replicating between federated regions
+```
+
+```release-note:bug
+node pools: Fixed a bug where an invalid replication token could delete node pools in a federated follower region
+```
+
+```release-note:bug
+node pools: Fixed a bug where blocking queries would not unblock if a node pool was added automatically by registering a node
+```
+
+```release-note:bug
+namespaces: Fixed a bug where namespaces could stop replicating between federated regions
+```
+
+```release-note:bug
+namespaces: Fixed a bug where an invalid replication token could delete namespaces in a federated follower region
+```

--- a/nomad/leader.go
+++ b/nomad/leader.go
@@ -526,8 +526,9 @@ func (s *Server) establishLeadership(stopCh chan struct{}) error {
 func (s *Server) replicateNamespaces(stopCh chan struct{}) {
 	req := structs.NamespaceListRequest{
 		QueryOptions: structs.QueryOptions{
-			Region:     s.config.AuthoritativeRegion,
-			AllowStale: true,
+			Region:        s.config.AuthoritativeRegion,
+			AllowStale:    true,
+			MinQueryIndex: 1,
 		},
 	}
 	limiter := rate.NewLimiter(replicationRateLimit, int(replicationRateLimit))
@@ -632,6 +633,9 @@ func diffNamespaces(state *state.StateStore, minIndex uint64, remoteList []*stru
 	// Construct a set of the local and remote namespaces
 	local := make(map[string][]byte)
 	remote := make(map[string]struct{})
+	if len(remoteList) == 0 {
+		return // prevent auth issues from wiping local state
+	}
 
 	// Add all the local namespaces
 	iter, err := state.Namespaces(nil)
@@ -676,8 +680,9 @@ func diffNamespaces(state *state.StateStore, minIndex uint64, remoteList []*stru
 func (s *Server) replicateNodePools(stopCh chan struct{}) {
 	req := structs.NodePoolListRequest{
 		QueryOptions: structs.QueryOptions{
-			Region:     s.config.AuthoritativeRegion,
-			AllowStale: true,
+			Region:        s.config.AuthoritativeRegion,
+			AllowStale:    true,
+			MinQueryIndex: 1,
 		},
 	}
 	limiter := rate.NewLimiter(replicationRateLimit, int(replicationRateLimit))
@@ -768,9 +773,13 @@ func (s *Server) replicateNodePools(stopCh chan struct{}) {
 // and the remote node pools to determine which node pools need to be deleted or
 // updated.
 func diffNodePools(store *state.StateStore, minIndex uint64, remoteList []*structs.NodePool) (delete []string, update []*structs.NodePool) {
+
 	// Construct a set of the local and remote node pools
 	local := make(map[string][]byte)
 	remote := make(map[string]struct{})
+	if len(remoteList) == 0 {
+		return // prevent auth issues from wiping local state
+	}
 
 	// Add all the local node pools
 	iter, err := store.NodePools(nil, state.SortDefault)

--- a/nomad/leader_test.go
+++ b/nomad/leader_test.go
@@ -1575,6 +1575,14 @@ func TestLeader_ReplicateNamespaces(t *testing.T) {
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
 
+	must.Wait(t, wait.ContinualSuccess(
+		wait.BoolFunc(func() bool {
+			idx, _ := s1.State().Index(state.TableNamespaces)
+			return idx == 1
+		}),
+		wait.Timeout(time.Second),
+	), must.Sprint("build-in namespaces must not be replicated"))
+
 	// Write a namespace to the authoritative region
 	ns1 := mock.Namespace()
 	assert.Nil(s1.State().UpsertNamespaces(100, []*structs.Namespace{ns1}))
@@ -1610,9 +1618,15 @@ func TestLeader_DiffNamespaces(t *testing.T) {
 	ns1 := mock.Namespace()
 	ns2 := mock.Namespace()
 	ns3 := mock.Namespace()
-	assert.Nil(t, state.UpsertNamespaces(100, []*structs.Namespace{ns1, ns2, ns3}))
+	must.NoError(t, state.UpsertNamespaces(100, []*structs.Namespace{ns1, ns2, ns3}))
 
 	// Simulate a remote list
+	rDefault := &structs.Namespace{
+		Name:        "default",
+		CreateIndex: 1,
+		ModifyIndex: 1,
+	}
+	rDefault.SetHash()
 	rns2 := ns2.Copy()
 	rns2.ModifyIndex = 50 // Ignored, same index
 	rns3 := ns3.Copy()
@@ -1623,15 +1637,26 @@ func TestLeader_DiffNamespaces(t *testing.T) {
 		rns2,
 		rns3,
 		ns4,
+		rDefault,
 	}
+
+	// our initial query is with MinQueryIndex 1 so that we ignore built-ins
 	delete, update := diffNamespaces(state, 50, remoteList)
 	sort.Strings(delete)
+	test.Eq(t, []string{ns1.Name}, delete)
+	test.Eq(t, []string{ns3.Name, ns4.Name}, update)
 
-	// ns1 does not exist on the remote side, should delete
-	assert.Equal(t, []string{structs.DefaultNamespace, ns1.Name}, delete)
+	// a later query
+	delete, update = diffNamespaces(state, 50, remoteList)
+	sort.Strings(delete)
+
+	// ns1 does not exist on the remote side, should delete.
+	// don't touch built-in
+	test.Eq(t, []string{ns1.Name}, delete)
 
 	// ns2 is un-modified - ignore. ns3 modified, ns4 new.
-	assert.Equal(t, []string{ns3.Name, ns4.Name}, update)
+	// Built-in ns has not been modified, so not updated.
+	test.Eq(t, []string{ns3.Name, ns4.Name}, update)
 }
 
 func TestLeader_ReplicateNodePools(t *testing.T) {
@@ -1654,6 +1679,14 @@ func TestLeader_ReplicateNodePools(t *testing.T) {
 	TestJoin(t, s1, s2)
 	testutil.WaitForLeader(t, s1.RPC)
 	testutil.WaitForLeader(t, s2.RPC)
+
+	must.Wait(t, wait.ContinualSuccess(
+		wait.BoolFunc(func() bool {
+			idx, _ := s1.State().Index(state.TableNodePools)
+			return idx == 1
+		}),
+		wait.Timeout(time.Second),
+	), must.Sprint("build-in pools must not be replicated"))
 
 	// Write a node pool to the authoritative region
 	np1 := mock.NodePool()
@@ -1692,7 +1725,13 @@ func TestLeader_DiffNodePools(t *testing.T) {
 	must.NoError(t, state.UpsertNodePools(
 		structs.MsgTypeTestSetup, 100, []*structs.NodePool{np1, np2, np3}))
 
-	// Simulate a remote list
+	// Simulate a remote list that includes the built-in pools as they would be
+	// returned from cluster that's taken at least one snapshot (ModifyIndex: 1
+	// but hashed)
+	rAll := &structs.NodePool{Name: structs.NodePoolAll, ModifyIndex: 1}
+	rAll.SetHash()
+	rDefault := &structs.NodePool{Name: structs.NodePoolDefault, ModifyIndex: 1}
+	rDefault.SetHash()
 	rnp2 := np2.Copy()
 	rnp2.ModifyIndex = 50 // Ignored, same index
 	rnp3 := np3.Copy()
@@ -1701,17 +1740,29 @@ func TestLeader_DiffNodePools(t *testing.T) {
 	rnp3.SetHash()
 	rnp4 := mock.NodePool()
 	remoteList := []*structs.NodePool{
+		rAll,
+		rDefault,
 		rnp2,
 		rnp3,
 		rnp4,
 	}
-	delete, update := diffNodePools(state, 50, remoteList)
+
+	// our initial query is with MinQueryIndex 1 so that we ignore built-ins
+	delete, update := diffNodePools(state, 1, remoteList)
+	sort.Strings(delete)
+	test.Eq(t, []string{np1.Name}, delete)
+	test.Eq(t, []*structs.NodePool{rnp3, rnp4}, update)
+
+	// a later query
+	delete, update = diffNodePools(state, 50, remoteList)
 	sort.Strings(delete)
 
-	// np1 does not exist on the remote side, should delete
-	test.Eq(t, []string{structs.NodePoolAll, structs.NodePoolDefault, np1.Name}, delete)
+	// np1 does not exist on the remote side, should delete.
+	// Don't touch built-in pools.
+	test.Eq(t, []string{np1.Name}, delete)
 
 	// np2 is un-modified - ignore. np3 modified, np4 new.
+	// Built-in pools have not been modified, so they're not updated.
 	test.Eq(t, []*structs.NodePool{rnp3, rnp4}, update)
 }
 

--- a/nomad/state/state_store_node_pools.go
+++ b/nomad/state/state_store_node_pools.go
@@ -169,6 +169,9 @@ func (s *StateStore) fetchOrCreateNodePoolTxn(txn *txn, index uint64, name strin
 		if err != nil {
 			return nil, err
 		}
+		if err := txn.Insert("index", &IndexEntry{TableNodePools, index}); err != nil {
+			return nil, fmt.Errorf("index update failed: %w", err)
+		}
 	}
 
 	return pool, nil


### PR DESCRIPTION
When we replicate node pools from the authoritative region, we make a blocking query without a minimum index. This ends up immediately unblocking because the built-in pools `"all"` and `"default"` have an index of 1. The diff logic checks that the pools modify index is higher than the `MinQueryIndex` (it is) and then checks the hash. When the pools are first created, the hash is empty. But starting in Nomad 1.11 when we restore a server from snapshot we set the hash as part of upgrading the object. This can result in a window where a follower that has never restarted will attempt to update the built-in pools and fail, which blocks further replication.

Because in the future we may want to allow adding more state to the built-in node pools, we still want to be able to replicate these if they've been modified. Start the replication query at `MinQueryIndex: 1` to avoid trying to overwrite with the default definition from the remote.

This same logic applies to namespaces with the built-in `"default"` namespace.

In the process of testing this change, I also discovered that we were not updating the index of the node pools table when a pool was created automatically via a node upsert. This stalls blocking queries and replication for one timeout period (5 min). And I also discovered that it was possible to wipe out follower state, which there was already an open issue for (#17536). Because this is a small PR and the tests don't pass without these fixes, I've fixed both of these along the way.

Fixes: https://github.com/hashicorp/nomad/issues/28526
Fixes: https://github.com/hashicorp/nomad/issues/17536
Ref: https://hashicorp.atlassian.net/browse/NMD-1740
Ref: https://github.com/hashicorp/nomad/pull/17456

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** n/a
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** Please add the correct backport labels as described by the internal
  backporting document.
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
