### PR TITLE
agent: remove unauthenticated server join

### DIFF
--- a/.changelog/28553.txt
+++ b/.changelog/28553.txt
@@ -1,0 +1,3 @@
+```release-note:breaking-change
+agent: Server join via the CLI or API now requires `agent:write` permission
+```

--- a/command/agent/agent_endpoint.go
+++ b/command/agent/agent_endpoint.go
@@ -116,12 +116,8 @@ func (s *HTTPServer) AgentJoinRequest(resp http.ResponseWriter, req *http.Reques
 	var secret string
 	s.parseToken(req, &secret)
 
-	// COMPAT(2.1.0): this will return an error in Nomad 2.1
-	// ref https://hashicorp.atlassian.net/browse/NMD-1507
-	var warning string
 	if err := aclPermissionCheckHelper(srv, secret, func(aclObj *acl.ACL) bool { return aclObj.AllowAgentWrite() }); err != nil {
-		warning = "anonymous server join is deprecated and will be removed in a future version of Nomad"
-		s.logger.Warn(warning)
+		return nil, err
 	}
 
 	// Get the join addresses
@@ -140,7 +136,6 @@ func (s *HTTPServer) AgentJoinRequest(resp http.ResponseWriter, req *http.Reques
 	return joinResult{
 		NumJoined: num,
 		Error:     errStr,
-		Warning:   warning,
 	}, nil
 }
 

--- a/command/agent/agent_endpoint_test.go
+++ b/command/agent/agent_endpoint_test.go
@@ -158,12 +158,17 @@ func TestHTTP_AgentJoin(t *testing.T) {
 		respW := httptest.NewRecorder()
 
 		obj, err := s.Server.AgentJoinRequest(respW, req)
-		must.NoError(t, err)
+		must.EqError(t, err, "Permission denied")
+		must.Nil(t, obj)
 
+		token := mock.CreatePolicyAndToken(t, s.server.State(), 1001, "invalid",
+			mock.AgentPolicy(acl.PolicyWrite))
+		setToken(req, token)
+
+		obj, err = s.Server.AgentJoinRequest(respW, req)
+		must.NoError(t, err)
 		join := obj.(joinResult)
 		must.Eq(t, 2, join.NumJoined)
-		must.Eq(t, "", join.Error)
-		must.Eq(t, "anonymous server join is deprecated and will be removed in a future version of Nomad", join.Warning)
 	})
 }
 


### PR DESCRIPTION
As foretold in the 2.0.4 release notes, remove unauthenticated server join.

Ref: https://developer.hashicorp.com/nomad/docs/release-notes/v2-0-x#server-join-deprecations
Ref: https://github.com/hashicorp/nomad/pull/28176
Ref: https://hashicorp.atlassian.net/browse/NMD-1507

### Contributor Checklist
- [x] **Changelog Entry** If this PR changes user-facing behavior, please generate and add a
  changelog entry using the `make cl` command.
- [x] **Testing** Please add tests to cover any new functionality or to demonstrate bug fixes and
  ensure regressions will be caught.
- [x] **Documentation** https://github.com/hashicorp/web-unified-docs/pull/3392
- [x] **LLM Usage** n/a

### Reviewer Checklist
- [x] **Backport Labels** n/a as this is 2.1.0 only, which will be cut from main
- [ ] **Commit Type** Ensure the correct merge method is selected which should be "squash and merge"
  in the majority of situations. The main exceptions are long-lived feature branches or merges where
  history should be preserved.
- [ ] **Enterprise PRs** If this is an enterprise only PR, please add any required changelog entry
  within the public repository.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.


[NMD-1508]: https://hashicorp.atlassian.net/browse/NMD-1508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ